### PR TITLE
docs: clarify children CLI arg help text 🎨 Palette

### DIFF
--- a/.jules/README.md
+++ b/.jules/README.md
@@ -1,0 +1,4 @@
+# .jules/
+
+State for the "Palette" agent.
+"Written = Real".

--- a/.jules/palette/README.md
+++ b/.jules/palette/README.md
@@ -1,0 +1,2 @@
+# Palette
+UX/DX focused agent.

--- a/.jules/palette/envelopes/2024-10-26-run-01.json
+++ b/.jules/palette/envelopes/2024-10-26-run-01.json
@@ -1,0 +1,39 @@
+{
+  "run_id": "2024-10-26-run-01",
+  "timestamp_utc": "2024-10-26T00:00:00Z",
+  "lane": "scout",
+  "target": "redundant-cli-help-text",
+  "commands": [
+    {
+      "cmd": "cargo run -- lang --help",
+      "result": "PASS",
+      "summary": "Cleaned up children help text"
+    },
+    {
+      "cmd": "cargo run -- module --help",
+      "result": "PASS",
+      "summary": "Cleaned up children help text"
+    },
+    {
+      "cmd": "cargo build --verbose",
+      "result": "PASS",
+      "summary": "Built successfully"
+    },
+    {
+      "cmd": "CI=true cargo test --verbose",
+      "result": "FAIL",
+      "summary": "Failed (pre-existing issue with git/ignore)"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "result": "PASS",
+      "summary": "Formatted"
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "result": "PASS",
+      "summary": "Linted"
+    }
+  ],
+  "results_summary": "Cleaned up redundant CLI help text for --children argument in lang and module commands."
+}

--- a/.jules/palette/ledger.json
+++ b/.jules/palette/ledger.json
@@ -1,0 +1,15 @@
+[
+  {
+    "date": "2024-10-26T00:00:00Z",
+    "lane": "scout",
+    "target": "redundant-cli-help-text",
+    "pr_link": "PENDING",
+    "gates": {
+      "build": "PASS",
+      "test": "FAIL (pre-existing)",
+      "fmt": "PASS",
+      "clippy": "PASS"
+    },
+    "friction_ids_created": []
+  }
+]

--- a/.jules/palette/runs/2024-10-26.md
+++ b/.jules/palette/runs/2024-10-26.md
@@ -1,0 +1,26 @@
+# Run 2024-10-26
+
+## Readings
+- CI: Build, Test, Fmt, Clippy
+- Docs: README, CLAUDE.md
+
+## Lane Selection
+- Lane: Scout (Lane B)
+- Target: Redundant CLI help text for `--children` and others.
+
+## Findings
+- `tokmd lang --help` shows duplicate descriptions for `--children` values.
+- `tokmd module --help` shows similar redundancy.
+- Field doc comments manually list values, but `clap` with `ValueEnum` already lists them from the enum variant docs.
+
+## Decisions
+- **Option A (Chosen):** Remove manual value lists from field doc comments. Rely on `clap`'s automatic generation from `ValueEnum`.
+- **Option B:** Keep them but format them better. (Redundant and harder to maintain).
+
+## Receipts
+- `cargo run -- lang --help` -> Clean output.
+- `cargo run -- module --help` -> Clean output.
+- `cargo build` -> PASS.
+- `cargo test` -> FAIL (Pre-existing issue `test_no_ignore_implies_vcs`).
+- `cargo fmt` -> PASS.
+- `cargo clippy` -> PASS.

--- a/.jules/policy/scheduled_tasks.json
+++ b/.jules/policy/scheduled_tasks.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "selection_strategy": "random",
+  "default_gates": ["build", "test", "fmt", "clippy"],
+  "notes_write_threshold": "only_when_reusable_pattern_discovered"
+}

--- a/.jules/runbooks/FRICTION_ITEM.md
+++ b/.jules/runbooks/FRICTION_ITEM.md
@@ -1,0 +1,17 @@
+---
+# Friction item
+
+id: FRIC-YYYYMMDD-###
+tags: [palette, dx]
+
+## Pain
+What hurts, in one paragraph.
+
+## Evidence
+- file paths
+- commands / outputs
+- screenshots (if relevant)
+
+## Done when
+- [ ] acceptance criteria
+---

--- a/.jules/runbooks/PR_GLASS_COCKPIT.md
+++ b/.jules/runbooks/PR_GLASS_COCKPIT.md
@@ -1,0 +1,53 @@
+---
+# PR Glass Cockpit
+
+Make review boring. Make truth cheap.
+
+## 💡 Summary
+1–4 sentences. What changed.
+
+## 🎯 Why (user/dev pain)
+What friction existed and what is now easier/clearer.
+
+## 🔎 Evidence (before/after)
+Minimal proof:
+- file path(s)
+- observed behavior
+- test/command demonstrating it
+
+## 🧭 Options considered
+### Option A (recommended)
+- What it is
+- Why it fits this repo
+- Trade-offs: Structure / Velocity / Governance
+
+### Option B
+- What it is
+- When to choose it instead
+- Trade-offs
+
+## ✅ Decision
+State the decision and why.
+
+## 🧱 Changes made (SRP)
+Bullets with file paths.
+
+## 🧪 Verification receipts
+Copy from the run envelope. Commands + results.
+
+## 🧭 Telemetry
+- Change shape
+- Blast radius (API / IO / docs / schema / concurrency)
+- Risk class + why
+- Rollback
+- Merge-confidence gates (what ran)
+
+## 🗂️ .jules updates
+What changed in .jules and why.
+
+## 📝 Notes (freeform)
+Optional. Extra context for future runs or reviewers.
+
+## 🔜 Follow-ups
+If anything remains, create friction items and link them.
+---

--- a/crates/tokmd-config/src/lib.rs
+++ b/crates/tokmd-config/src/lib.rs
@@ -199,9 +199,6 @@ pub struct CliLangArgs {
     pub files: bool,
 
     /// How to handle embedded languages (tokei "children" / blobs).
-    ///
-    /// - collapse: merge embedded content into the parent language row.
-    /// - separate: show "(embedded)" rows for child languages.
     #[arg(long, value_enum)]
     pub children: Option<ChildrenMode>,
 }
@@ -240,9 +237,6 @@ pub struct CliModuleArgs {
     pub module_depth: Option<usize>,
 
     /// Whether to include embedded languages (tokei "children" / blobs) in module totals.
-    ///
-    /// - separate: include embedded reports alongside parent reports.
-    /// - parents-only: ignore embedded reports.
     #[arg(long, value_enum)]
     pub children: Option<ChildIncludeMode>,
 }


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Removed redundant manual descriptions of enum values for the `--children` argument in `lang` and `module` commands.

## 🎯 Why (user/dev pain)
The help text for `--children` duplicated information: the "Possible values" section generated by `clap` (from the enum doc comments) was identical to the manual list in the field doc comments. This duplication adds noise and increases the risk of documentation drift.

## 🔎 Evidence (before/after)
**Before:**
```
      --children <CHILDREN>
          How to handle embedded languages (tokei "children" / blobs).
          
          - collapse: merge embedded content into the parent language row. - separate: show "(embedded)" rows for child languages.

          Possible values:
          - collapse: Merge embedded content into the parent language totals
          - separate: Show embedded languages as separate "(embedded)" rows
```

**After:**
```
      --children <CHILDREN>
          How to handle embedded languages (tokei "children" / blobs)

          Possible values:
          - collapse: Merge embedded content into the parent language totals
          - separate: Show embedded languages as separate "(embedded)" rows
```

## 🧭 Options considered
### Option A (recommended)
- **Remove manual lists:** Rely on `clap`'s automatic generation from `ValueEnum` doc comments.
- **Why:** Reduces maintenance burden and noise. Standard `clap` pattern.
- **Trade-offs:** Less control over exact formatting, but `clap` defaults are good.

### Option B
- **Keep manual lists:** Reformat them to be cleaner.
- **Trade-offs:** Still redundant.

## ✅ Decision
Option A. It's the cleanest and most maintainable approach.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd-config/src/lib.rs` to remove manual value lists from `children` field doc comments in `CliLangArgs` and `CliModuleArgs`.

## 🧪 Verification receipts
- `cargo run -- lang --help`: PASS (Clean output)
- `cargo run -- module --help`: PASS (Clean output)
- `cargo build --verbose`: PASS
- `CI=true cargo test --verbose`: FAIL (Pre-existing failure in `test_no_ignore_implies_vcs`, unrelated to doc changes)
- `cargo fmt -- --check`: PASS
- `cargo clippy -- -D warnings`: PASS

## 🧭 Telemetry
- **Change shape:** Documentation only (doc comments).
- **Blast radius:** Tiny. Affects `--help` output only.
- **Risk class:** Low. No runtime logic change.
- **Merge-confidence gates:** `build`, `fmt`, `clippy` passed. `test` failed (pre-existing).

## 🗂️ .jules updates
- Created `.jules/` structure and initialized state.
- Added run envelope `2024-10-26-run-01`.
- Added run log `2024-10-26.md`.
- Updated `ledger.json`.

## 📝 Notes (freeform)
The pre-existing test failure seems related to gitignore logic in the test environment (`test_no_ignore_implies_vcs`). Since this PR only changes help text, I proceeded.

---
*PR created automatically by Jules for task [10571692140036118818](https://jules.google.com/task/10571692140036118818) started by @EffortlessSteven*