### PR TITLE
perf: consolidated rendering and module key optimizations

### DIFF
--- a/crates/tokmd-format/src/lib.rs
+++ b/crates/tokmd-format/src/lib.rs
@@ -15,6 +15,7 @@
 //! * Business logic (calculating stats)
 //! * CLI arg parsing
 
+use std::fmt::Write as FmtWrite;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
@@ -113,33 +114,37 @@ fn render_lang_md(report: &LangReport) -> String {
         s.push_str("|Lang|Code|Lines|Files|Bytes|Tokens|Avg|\n");
         s.push_str("|---|---:|---:|---:|---:|---:|---:|\n");
         for r in &report.rows {
-            s.push_str(&format!(
-                "|{}|{}|{}|{}|{}|{}|{}|\n",
+            let _ = writeln!(
+                s,
+                "|{}|{}|{}|{}|{}|{}|{}|",
                 r.lang, r.code, r.lines, r.files, r.bytes, r.tokens, r.avg_lines
-            ));
+            );
         }
-        s.push_str(&format!(
-            "|**Total**|{}|{}|{}|{}|{}|{}|\n",
+        let _ = writeln!(
+            s,
+            "|**Total**|{}|{}|{}|{}|{}|{}|",
             report.total.code,
             report.total.lines,
             report.total.files,
             report.total.bytes,
             report.total.tokens,
             report.total.avg_lines
-        ));
+        );
     } else {
         s.push_str("|Lang|Code|Lines|Bytes|Tokens|\n");
         s.push_str("|---|---:|---:|---:|---:|\n");
         for r in &report.rows {
-            s.push_str(&format!(
-                "|{}|{}|{}|{}|{}|\n",
+            let _ = writeln!(
+                s,
+                "|{}|{}|{}|{}|{}|",
                 r.lang, r.code, r.lines, r.bytes, r.tokens
-            ));
+            );
         }
-        s.push_str(&format!(
-            "|**Total**|{}|{}|{}|{}|\n",
+        let _ = writeln!(
+            s,
+            "|**Total**|{}|{}|{}|{}|",
             report.total.code, report.total.lines, report.total.bytes, report.total.tokens
-        ));
+        );
     }
 
     s
@@ -151,32 +156,36 @@ fn render_lang_tsv(report: &LangReport) -> String {
     if report.with_files {
         s.push_str("Lang\tCode\tLines\tFiles\tBytes\tTokens\tAvg\n");
         for r in &report.rows {
-            s.push_str(&format!(
-                "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+            let _ = writeln!(
+                s,
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}",
                 r.lang, r.code, r.lines, r.files, r.bytes, r.tokens, r.avg_lines
-            ));
+            );
         }
-        s.push_str(&format!(
-            "Total\t{}\t{}\t{}\t{}\t{}\t{}\n",
+        let _ = writeln!(
+            s,
+            "Total\t{}\t{}\t{}\t{}\t{}\t{}",
             report.total.code,
             report.total.lines,
             report.total.files,
             report.total.bytes,
             report.total.tokens,
             report.total.avg_lines
-        ));
+        );
     } else {
         s.push_str("Lang\tCode\tLines\tBytes\tTokens\n");
         for r in &report.rows {
-            s.push_str(&format!(
-                "{}\t{}\t{}\t{}\t{}\n",
+            let _ = writeln!(
+                s,
+                "{}\t{}\t{}\t{}\t{}",
                 r.lang, r.code, r.lines, r.bytes, r.tokens
-            ));
+            );
         }
-        s.push_str(&format!(
-            "Total\t{}\t{}\t{}\t{}\n",
+        let _ = writeln!(
+            s,
+            "Total\t{}\t{}\t{}\t{}",
             report.total.code, report.total.lines, report.total.bytes, report.total.tokens
-        ));
+        );
     }
 
     s
@@ -227,20 +236,22 @@ fn render_module_md(report: &ModuleReport) -> String {
     s.push_str("|Module|Code|Lines|Files|Bytes|Tokens|Avg|\n");
     s.push_str("|---|---:|---:|---:|---:|---:|---:|\n");
     for r in &report.rows {
-        s.push_str(&format!(
-            "|{}|{}|{}|{}|{}|{}|{}|\n",
+        let _ = writeln!(
+            s,
+            "|{}|{}|{}|{}|{}|{}|{}|",
             r.module, r.code, r.lines, r.files, r.bytes, r.tokens, r.avg_lines
-        ));
+        );
     }
-    s.push_str(&format!(
-        "|**Total**|{}|{}|{}|{}|{}|{}|\n",
+    let _ = writeln!(
+        s,
+        "|**Total**|{}|{}|{}|{}|{}|{}|",
         report.total.code,
         report.total.lines,
         report.total.files,
         report.total.bytes,
         report.total.tokens,
         report.total.avg_lines
-    ));
+    );
     s
 }
 
@@ -248,20 +259,22 @@ fn render_module_tsv(report: &ModuleReport) -> String {
     let mut s = String::new();
     s.push_str("Module\tCode\tLines\tFiles\tBytes\tTokens\tAvg\n");
     for r in &report.rows {
-        s.push_str(&format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+        let _ = writeln!(
+            s,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
             r.module, r.code, r.lines, r.files, r.bytes, r.tokens, r.avg_lines
-        ));
+        );
     }
-    s.push_str(&format!(
-        "Total\t{}\t{}\t{}\t{}\t{}\t{}\n",
+    let _ = writeln!(
+        s,
+        "Total\t{}\t{}\t{}\t{}\t{}\t{}",
         report.total.code,
         report.total.lines,
         report.total.files,
         report.total.bytes,
         report.total.tokens,
         report.total.avg_lines
-    ));
+    );
     s
 }
 

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -255,7 +255,7 @@ pub fn create_module_report(
         let _ = lang_type; // keep the pattern explicit; we only need reports
         for report in &lang.reports {
             let path = normalize_path(&report.name, None);
-            let module = module_key(&path, module_roots, module_depth);
+            let module = module_key_from_normalized(&path, module_roots, module_depth);
             module_files.entry(module).or_default().insert(path);
         }
     }
@@ -403,7 +403,7 @@ pub fn collect_file_rows(
     for (lang_type, lang) in languages.iter() {
         for report in &lang.reports {
             let path = normalize_path(&report.name, strip_prefix);
-            let module = module_key(&path, module_roots, module_depth);
+            let module = module_key_from_normalized(&path, module_roots, module_depth);
             let st = report.stats.summarise();
             let (bytes, tokens) = get_file_metrics(&report.name);
 
@@ -426,7 +426,7 @@ pub fn collect_file_rows(
             for (child_type, reports) in &lang.children {
                 for report in reports {
                     let path = normalize_path(&report.name, strip_prefix);
-                    let module = module_key(&path, module_roots, module_depth);
+                    let module = module_key_from_normalized(&path, module_roots, module_depth);
                     let st = report.stats.summarise();
                     // Embedded children do not have bytes/tokens (they are inside the parent)
 
@@ -532,25 +532,52 @@ pub fn module_key(path: &str, module_roots: &[String], module_depth: usize) -> S
     }
     p = p.trim_start_matches('/').to_string();
 
-    let parts: Vec<&str> = p.split('/').filter(|seg| !seg.is_empty()).collect();
-    if parts.len() <= 1 {
+    module_key_from_normalized(&p, module_roots, module_depth)
+}
+
+/// Compute a "module key" from a path that has already been normalized.
+///
+/// This is an optimization for hot paths where `normalize_path` has already been called.
+/// The path should have forward slashes, no leading `./`, and no leading `/`.
+fn module_key_from_normalized(path: &str, module_roots: &[String], module_depth: usize) -> String {
+    let mut parts = path.split('/').filter(|s| !s.is_empty());
+    let first = match parts.next() {
+        Some(s) => s,
+        None => return "(root)".to_string(),
+    };
+
+    // If there are no more segments, 'first' IS the filename, so return "(root)".
+    let remaining_count = parts.clone().count();
+
+    if remaining_count == 0 {
         return "(root)".to_string();
     }
 
-    // Directory segments only (exclude the filename).
-    let dirs = &parts[..parts.len() - 1];
-    if dirs.is_empty() {
-        return "(root)".to_string();
+    // It has a directory structure. 'first' is the top-level directory.
+    // Check if it matches a module root.
+    if !module_roots.iter().any(|r| r == first) {
+        return first.to_string();
     }
 
-    let head = dirs[0];
-    let is_root = module_roots.iter().any(|r| r == head);
-    if is_root {
-        let depth = module_depth.max(1).min(dirs.len());
-        dirs[..depth].join("/")
-    } else {
-        head.to_string()
+    // It IS a root module. We need to go deeper up to `module_depth`.
+    // Total segments = 1 (first) + remaining_count
+    // Directories available = total - 1 (exclude filename)
+    let dirs_available = remaining_count; // first + remaining - 1 (filename) = remaining
+
+    let depth_needed = module_depth.max(1).min(dirs_available + 1); // +1 because 'first' counts
+
+    // Build the key by taking up to depth_needed segments
+    let mut key = String::with_capacity(path.len());
+    key.push_str(first);
+
+    for _ in 1..depth_needed {
+        if let Some(next_seg) = parts.next() {
+            key.push('/');
+            key.push_str(next_seg);
+        }
     }
+
+    key
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR consolidates the core performance optimizations from multiple open PRs into a single, clean implementation:

- **Report rendering optimization**: Replace `push_str(&format!(...))` with `writeln!(s, ...)` in `render_lang_md`, `render_lang_tsv`, `render_module_md`, and `render_module_tsv` functions to avoid temporary string allocations
- **Module key computation optimization**: Add `module_key_from_normalized` helper to skip redundant path normalization when the path has already been processed by `normalize_path`

## Performance Impact

Both optimizations target hot paths called per-file during scanning:
- Report rendering: ~31% faster for large reports (measured in PR #12)
- Module key computation: ~31% faster in micro-benchmarks (measured in PR #9)

## Changes

- `crates/tokmd-format/src/lib.rs`: Added `use std::fmt::Write as FmtWrite` and updated 4 render functions
- `crates/tokmd-model/src/lib.rs`: Added `module_key_from_normalized` helper and updated 3 call sites

## Consolidates

This PR incorporates the key optimizations from:
- PR #9 (module_key allocations)
- PR #12 (string formatting in report rendering)

## Test Plan

- [x] All existing tests pass (`cargo test --verbose`)
- [x] No clippy warnings (`cargo clippy -- -D warnings`)
- [x] Code formatted (`cargo fmt --check`)