### PR TITLE
fix: center text in SVG badges

### DIFF
--- a/crates/tokmd-analysis-format/src/lib.rs
+++ b/crates/tokmd-analysis-format/src/lib.rs
@@ -626,7 +626,7 @@ fn render_svg(receipt: &AnalysisReceipt) -> String {
     let label_width = 80;
     let value_width = width - label_width;
     format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" role=\"img\"><rect width=\"{label_width}\" height=\"{height}\" fill=\"#555\"/><rect x=\"{label_width}\" width=\"{value_width}\" height=\"{height}\" fill=\"#4c9aff\"/><text x=\"{lx}\" y=\"{ty}\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"12\">{label}</text><text x=\"{vx}\" y=\"{ty}\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"12\">{value}</text></svg>",
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" role=\"img\"><rect width=\"{label_width}\" height=\"{height}\" fill=\"#555\"/><rect x=\"{label_width}\" width=\"{value_width}\" height=\"{height}\" fill=\"#4c9aff\"/><text x=\"{lx}\" y=\"{ty}\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"12\" text-anchor=\"middle\">{label}</text><text x=\"{vx}\" y=\"{ty}\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"12\" text-anchor=\"middle\">{value}</text></svg>",
         width = width,
         height = height,
         label_width = label_width,

--- a/crates/tokmd/src/badge.rs
+++ b/crates/tokmd/src/badge.rs
@@ -19,7 +19,7 @@ pub(crate) fn badge_svg(label: &str, value: &str) -> String {
     let label_x = label_width / 2;
     let value_x = label_width + value_width / 2;
     format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" role=\"img\"><rect width=\"{label_width}\" height=\"{height}\" fill=\"#555\"/><rect x=\"{label_width}\" width=\"{value_width}\" height=\"{height}\" fill=\"#4c9aff\"/><text x=\"{label_x}\" y=\"16\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"11\">{label}</text><text x=\"{value_x}\" y=\"16\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"11\">{value}</text></svg>",
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" role=\"img\"><rect width=\"{label_width}\" height=\"{height}\" fill=\"#555\"/><rect x=\"{label_width}\" width=\"{value_width}\" height=\"{height}\" fill=\"#4c9aff\"/><text x=\"{label_x}\" y=\"16\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"11\" text-anchor=\"middle\">{label}</text><text x=\"{value_x}\" y=\"16\" fill=\"#fff\" font-family=\"Verdana\" font-size=\"11\" text-anchor=\"middle\">{value}</text></svg>",
         width = width,
         height = height,
         label_width = label_width,


### PR DESCRIPTION
## Summary

Add `text-anchor=\"middle\"` to SVG text elements in badge generation so that text is properly centered at the x coordinate rather than starting from it.

## Changes

- `crates/tokmd/src/badge.rs`: Add text-anchor to badge command SVG output
- `crates/tokmd-analysis-format/src/lib.rs`: Add text-anchor to analysis SVG output

## Before/After

**Before:** Text starts at x position, appearing shifted right
**After:** Text is centered at x position

## Related

Replaces PR #18 with a cleaner implementation based on current main.