### PR TITLE
fix(tests): update redaction tests and improve scan error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/tokmd-format/src/lib.rs
+++ b/crates/tokmd-format/src/lib.rs
@@ -1194,7 +1194,7 @@ mod tests {
     #[test]
     fn redact_rows_none_mode() {
         let rows = sample_file_rows();
-        let redacted = redact_rows(&rows, RedactMode::None);
+        let redacted: Vec<_> = redact_rows(&rows, RedactMode::None).collect();
 
         // Should be identical
         assert_eq!(redacted.len(), rows.len());
@@ -1205,7 +1205,7 @@ mod tests {
     #[test]
     fn redact_rows_paths_mode() {
         let rows = sample_file_rows();
-        let redacted = redact_rows(&rows, RedactMode::Paths);
+        let redacted: Vec<_> = redact_rows(&rows, RedactMode::Paths).collect();
 
         // Paths should be redacted (16 char hash + extension)
         assert_ne!(redacted[0].path, "src/lib.rs");
@@ -1219,7 +1219,7 @@ mod tests {
     #[test]
     fn redact_rows_all_mode() {
         let rows = sample_file_rows();
-        let redacted = redact_rows(&rows, RedactMode::All);
+        let redacted: Vec<_> = redact_rows(&rows, RedactMode::All).collect();
 
         // Paths should be redacted
         assert_ne!(redacted[0].path, "src/lib.rs");
@@ -1233,7 +1233,7 @@ mod tests {
     #[test]
     fn redact_rows_preserves_other_fields() {
         let rows = sample_file_rows();
-        let redacted = redact_rows(&rows, RedactMode::All);
+        let redacted: Vec<_> = redact_rows(&rows, RedactMode::All).collect();
 
         // All other fields should be preserved
         assert_eq!(redacted[0].lang, "Rust");
@@ -1317,7 +1317,7 @@ mod tests {
             }];
 
             for mode in [RedactMode::None, RedactMode::Paths, RedactMode::All] {
-                let redacted = redact_rows(&rows, mode);
+                let redacted: Vec<_> = redact_rows(&rows, mode).collect();
                 prop_assert_eq!(redacted.len(), 1);
                 prop_assert_eq!(redacted[0].code, code);
                 prop_assert_eq!(redacted[0].comments, comments);
@@ -1341,7 +1341,7 @@ mod tests {
                 tokens: 250,
             }];
 
-            let redacted = redact_rows(&rows, RedactMode::Paths);
+            let redacted: Vec<_> = redact_rows(&rows, RedactMode::Paths).collect();
             prop_assert!(redacted[0].path.ends_with(&format!(".{}", ext)),
                 "Redacted path '{}' should end with .{}", redacted[0].path, ext);
         }

--- a/crates/tokmd-scan/src/lib.rs
+++ b/crates/tokmd-scan/src/lib.rs
@@ -101,12 +101,13 @@ mod tests {
     }
 
     #[test]
-    fn scan_with_nonexistent_path_returns_empty() {
+    fn scan_with_nonexistent_path_returns_error() {
         let args = default_global_args();
         let paths = vec![PathBuf::from("/nonexistent/path/that/does/not/exist")];
-        let result = scan(&paths, &args).unwrap();
-        // Tokei returns empty for nonexistent paths
-        assert!(result.is_empty());
+        let result = scan(&paths, &args);
+        // Should return an error for nonexistent paths
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Path not found"));
     }
 
     // ========================

--- a/crates/tokmd/tests/schema_validation.rs
+++ b/crates/tokmd/tests/schema_validation.rs
@@ -21,7 +21,7 @@ fn load_schema() -> Result<Value> {
     let schema_content =
         std::fs::read_to_string(&schema_path).context("Failed to read schema.json")?;
 
-    Ok(serde_json::from_str(&schema_content).context("Failed to parse schema.json")?)
+    serde_json::from_str(&schema_content).context("Failed to parse schema.json")
 }
 
 /// Build a validator for a specific definition in the schema


### PR DESCRIPTION
## Summary
- Fix `tokmd-format` tests to collect iterator results into Vec before indexing (iterator changed to `impl Iterator`)
- Update `tokmd-scan` test to expect error for nonexistent paths (behavior change from empty result to error)
- Fix clippy `needless_question_mark` warning in schema validation test

## Context
These fixes are needed for the v1.2.0 release. All tests pass with `cargo test --all-features`.

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes
- [x] `cargo ws publish --from-git --dry-run` succeeds (with expected dependency warnings)