### PR TITLE
docs: document configuration and profiles, remove misleading scan config 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/20260130-librarian.json
+++ b/.jules/docs/envelopes/20260130-librarian.json
@@ -1,0 +1,30 @@
+{
+  "run_id": "20260130-librarian",
+  "persona": "Librarian",
+  "status": "complete",
+  "target_lane": "B",
+  "receipts": [
+    {
+      "type": "verification",
+      "description": "Verified [export] config works",
+      "command": "tokmd export --format jsonl | wc -l (with min_code=1000)",
+      "result": "3 (filtered count)"
+    },
+    {
+      "type": "verification",
+      "description": "Verified [scan] config ignored",
+      "command": "tokmd --format json (with hidden=true in tokmd.toml)",
+      "result": "hidden: false (config ignored)"
+    },
+    {
+      "type": "change",
+      "description": "Updated README.md to document configuration and profiles",
+      "files": ["README.md"]
+    },
+    {
+      "type": "change",
+      "description": "Updated docs/reference-cli.md to remove misleading scan config",
+      "files": ["docs/reference-cli.md"]
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -4,5 +4,11 @@
     "date": "2026-01-29",
     "persona": "Librarian",
     "description": "Updated README to feature `tokmd context` for LLM workflows"
+  },
+  {
+    "run_id": "20260130-librarian",
+    "date": "2026-01-30",
+    "persona": "Librarian",
+    "description": "Documented configuration files and profiles in README, removed misleading scan config from reference"
   }
 ]

--- a/.jules/docs/runs/2026-01-30.md
+++ b/.jules/docs/runs/2026-01-30.md
@@ -1,0 +1,7 @@
+# Run Log: 2026-01-30
+
+## 20260130-librarian
+- Status: Complete
+- Persona: Librarian
+- Change: Documented configuration files and profiles in README.
+- Change: Removed misleading [scan] config from reference-cli.md (it is ignored by the app).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ tokmd analyze --preset risk    # Hotspots, coupling, freshness
 | `tokmd analyze` | Derived metrics and enrichments. |
 | `tokmd badge` | SVG badge for a metric (lines, tokens, doc%). |
 | `tokmd diff` | Compare two runs, receipts, or git refs. |
-| `tokmd init` | Generate a `.tokeignore` file. |
+| `tokmd init` | Generate a `.tokeignore` file (supports templates). |
 | `tokmd check-ignore` | Explain why files are being ignored (troubleshooting). |
 | `tokmd completions` | Generate shell completions (bash, zsh, fish, powershell). |
 
@@ -168,6 +168,29 @@ Analyze git history for risk signals:
 | **LLM Ready** | No | Token estimates, context fit analysis |
 | **Git Analysis** | No | Hotspots, freshness, coupling |
 | **Derived Metrics** | No | Doc density, COCOMO, distribution |
+
+## Configuration
+
+You can persist settings in a `tokmd.toml` file in your project root or home directory.
+
+```toml
+# tokmd.toml
+[view.llm]
+format = "jsonl"
+redact = "paths"
+min_code = 10
+max_rows = 500
+
+[export]
+format = "jsonl"
+```
+
+Use profiles with the `--profile` flag:
+```bash
+tokmd export --profile llm > context.jsonl
+```
+
+See the [CLI Reference](docs/reference-cli.md#configuration-file) for full configuration options.
 
 ## Installation
 

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -396,37 +396,6 @@ Configuration is loaded from the first file found (highest to lowest priority):
 
 ```toml
 # =============================================================================
-# Scan Settings (applies to all commands)
-# =============================================================================
-[scan]
-# Paths to scan (default: current directory)
-paths = ["."]
-
-# Glob patterns to exclude (can also use --exclude on CLI)
-exclude = ["target", "node_modules", "*.lock", "vendor/"]
-
-# Include hidden files and directories (default: false)
-hidden = false
-
-# Config file strategy for tokei: "auto" or "none" (default: "auto")
-config = "auto"
-
-# Disable all ignore files (default: false)
-no_ignore = false
-
-# Disable parent directory ignore file traversal (default: false)
-no_ignore_parent = false
-
-# Disable .ignore/.tokeignore files (default: false)
-no_ignore_dot = false
-
-# Disable .gitignore files (default: false)
-no_ignore_vcs = false
-
-# Treat doc comments as comments instead of code (default: false)
-doc_comments = false
-
-# =============================================================================
 # Module Command Settings
 # =============================================================================
 [module]
@@ -560,9 +529,6 @@ tokmd --profile llm export --format csv
 
 **Monorepo with multiple package roots**:
 ```toml
-[scan]
-exclude = ["node_modules", "dist", "coverage", "*.lock"]
-
 [module]
 roots = ["packages", "apps", "libs"]
 depth = 2
@@ -570,9 +536,6 @@ depth = 2
 
 **Rust project with strict filtering**:
 ```toml
-[scan]
-exclude = ["target", "*.lock"]
-
 [export]
 min_code = 20
 redact = "paths"


### PR DESCRIPTION
## 💡 Summary
Added documentation for `tokmd.toml` configuration files and profiles to `README.md`. Removed misleading documentation about `[scan]` configuration in `docs/reference-cli.md` as it is currently ignored by the application.

## 🎯 Why
Users were unaware of the powerful configuration and profile features because they were undocumented in the main README. Additionally, the reference documentation claimed `[scan]` settings worked in `tokmd.toml`, which was incorrect and led to confusion.

## 🔎 Evidence
- Verified that `[export]` settings in `tokmd.toml` work correctly (filtering files).
- Verified that `[scan]` settings in `tokmd.toml` are ignored by `tokmd-scan`.

## 🧭 Options considered
### Option A (Selected)
Document `tokmd.toml` and profiles, and remove `[scan]` from docs to reflect reality.
- Fits "Librarian" persona (docs/examples).
- High signal win (enables users to use config).

### Option B
Fix the code to make `[scan]` work.
- Out of scope for this run (requires code changes in `tokmd-scan` and `tokmd` CLI wiring).

## ✅ Decision
Option A: Document what works, remove what doesn't.

## 🧱 Changes made
- `README.md`: Added "Configuration" section.
- `docs/reference-cli.md`: Removed `[scan]` section from schema and examples.
- `.jules/`: Updated docs ledger and run logs.

## 🧪 Verification receipts
- `tokmd export --format jsonl | wc -l` with `min_code=1000` in `tokmd.toml` -> returned 3 (correctly filtered).
- `tokmd --format json` with `hidden=true` in `tokmd.toml` -> `hidden: false` (confirmed ignored).

---
*PR created automatically by Jules for task [14408120299120803160](https://jules.google.com/task/14408120299120803160) started by @EffortlessSteven*