### PR TITLE
deps: synchronize proptest to 1.9.0 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/run-02.json
+++ b/.jules/deps/envelopes/run-02.json
@@ -1,0 +1,12 @@
+{
+  "id": "run-02",
+  "start_time": "2024-05-23T10:00:00Z",
+  "target": "dev-dependencies",
+  "lane": "B",
+  "decision": "Synchronize proptest (1.9.0) versions across workspace",
+  "receipts": [
+    "cargo check --workspace: passed",
+    "cargo tree -d: proptest no longer duplicated",
+    "cargo test --workspace: passed"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -12,5 +12,12 @@
     "target": "tokmd-types",
     "action": "ci-fix",
     "status": "success"
+  },
+  {
+    "run_id": "run-02",
+    "timestamp": "2024-05-23T10:00:00Z",
+    "target": "dev-dependencies",
+    "action": "sync-proptest",
+    "status": "success"
   }
 ]

--- a/crates/tokmd-analysis/Cargo.toml
+++ b/crates/tokmd-analysis/Cargo.toml
@@ -31,4 +31,4 @@ tokmd-content = { workspace = true, optional = true }
 [dev-dependencies]
 tokmd-config.workspace = true
 tempfile = "3.10.1"
-proptest = "1.6.0"
+proptest = "1.9.0"

--- a/crates/tokmd-config/Cargo.toml
+++ b/crates/tokmd-config/Cargo.toml
@@ -14,5 +14,5 @@ toml = "0.8"
 tokmd-types = { workspace = true, features = ["clap"] }
 
 [dev-dependencies]
-proptest = "1.6.0"
+proptest = "1.9.0"
 serde_json = "1.0.149"

--- a/crates/tokmd-content/Cargo.toml
+++ b/crates/tokmd-content/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = "1.0.100"
 blake3.workspace = true
 
 [dev-dependencies]
-proptest = "1.6.0"
+proptest = "1.9.0"

--- a/crates/tokmd-format/Cargo.toml
+++ b/crates/tokmd-format/Cargo.toml
@@ -19,5 +19,5 @@ tokmd-redact.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.6.0"
+proptest = "1.9.0"
 insta = { version = "1.39.0", features = ["json"] }

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -15,4 +15,4 @@ tokmd-config.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.6.0"
+proptest = "1.9.0"

--- a/crates/tokmd-types/Cargo.toml
+++ b/crates/tokmd-types/Cargo.toml
@@ -15,5 +15,5 @@ serde = { version = "1.0.228", features = ["derive"] }
 clap = { version = "4.5.55", features = ["derive"], optional = true }
 
 [dev-dependencies]
-proptest = "1.6.0"
+proptest = "1.9.0"
 serde_json = "1.0.149"


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Synchronized `proptest` dev-dependency to version `1.9.0` across the workspace.

## 🎯 Why (user/dev pain)
Different crates were using different versions of `proptest` (1.6.0 vs 1.9.0), causing duplicate compilation and potentially pulling in duplicate transitive dependencies (e.g., `rand` versions).

## 🔎 Evidence (before/after)
- Before: `cargo tree -d` implied duplication or at least multiple versions in the graph. `grep` confirmed mixed usage.
- After: All crates use `1.9.0`.

## 🧭 Options considered
### Option A (recommended)
- Align all to `1.9.0` (latest used).
- Fits "Auditor" goal of reducing duplicates.
- Trade-offs: Minor version bump risk (mitigated by tests).

### Option B
- Downgrade to `1.6.0`.
- Trade-offs: Loss of newer features/fixes in 1.9.0.

## ✅ Decision
Option A: Standardize on the newer version `1.9.0`.

## 🧱 Changes made (SRP)
- `crates/tokmd-analysis/Cargo.toml`
- `crates/tokmd-config/Cargo.toml`
- `crates/tokmd-content/Cargo.toml`
- `crates/tokmd-format/Cargo.toml`
- `crates/tokmd-model/Cargo.toml`
- `crates/tokmd-types/Cargo.toml`

## 🧪 Verification receipts
- `cargo check --workspace`: passed
- `cargo test --workspace`: passed
- `cargo tree -d`: proptest duplication resolved.

## 🧭 Telemetry
- Change shape: Dev-dependency only.
- Blast radius: Build time / Test execution.
- Risk class: Low.

## 🗂️ .jules updates
- Appended run to `.jules/deps/ledger.json`.
- Created envelope `.jules/deps/envelopes/run-02.json`.

---
*PR created automatically by Jules for task [3001514224009604522](https://jules.google.com/task/3001514224009604522) started by @EffortlessSteven*