### PR TITLE
compat: fix unused import warning in run_diff tests when git feature disabled 🧷 Compat

### DIFF
--- a/.jules/compat/envelopes/run-20260131-compat-init.json
+++ b/.jules/compat/envelopes/run-20260131-compat-init.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "run-20260131-compat-init",
+  "date": "2026-01-31",
+  "persona": "compat",
+  "status": "in_progress",
+  "gates": {
+      "build": "PASS",
+      "test": "PASS",
+      "fmt": "PENDING",
+      "clippy": "PENDING"
+  },
+  "receipts": [
+    {
+      "command": "cargo check --package tokmd --test run_diff --no-default-features",
+      "result": "Success"
+    },
+    {
+      "command": "cargo check --package tokmd --test run_diff",
+      "result": "Success"
+    }
+  ]
+}

--- a/.jules/compat/ledger.json
+++ b/.jules/compat/ledger.json
@@ -11,5 +11,11 @@
     "date": "2024-05-24",
     "target": "tokmd-analysis",
     "improvement": "fixed unused fields warning in no-default-features build"
+  },
+  {
+    "run_id": "run-20260131-compat-init",
+    "date": "2026-01-31",
+    "target": "tokmd",
+    "improvement": "fixed unused import warning in run_diff tests when git feature disabled"
   }
 ]

--- a/.jules/compat/runs/2026-01-31.md
+++ b/.jules/compat/runs/2026-01-31.md
@@ -1,0 +1,14 @@
+# Run Log - 2026-01-31
+
+**Run ID**: run-20260131-compat-init
+
+## Task
+Fix unused import warning in `crates/tokmd/tests/run_diff.rs` when `git` feature is disabled.
+
+## Actions
+1. Discovered warning via `cargo check --test run_diff --no-default-features`.
+2. Gated `use std::process::Command as ProcessCommand;` with `#[cfg(feature = "git")]`.
+3. Verified with both minimal and default feature sets.
+
+## Outcome
+Tests pass without warnings in both configurations.

--- a/crates/tokmd/tests/run_diff.rs
+++ b/crates/tokmd/tests/run_diff.rs
@@ -4,6 +4,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use std::path::PathBuf;
+#[cfg(feature = "git")]
 use std::process::Command as ProcessCommand;
 use tempfile::tempdir;
 


### PR DESCRIPTION
Fixes an unused import warning when building with `--no-default-features` (disabling `git` feature).

### Changes
- `crates/tokmd/tests/run_diff.rs`: Gated `use std::process::Command as ProcessCommand;` with `#[cfg(feature = "git")]`.

### Verification
- `cargo check --package tokmd --test run_diff --no-default-features`: Success (no warnings).
- `cargo check --package tokmd --test run_diff`: Success.
- `cargo test --package tokmd --test run_diff`: Success.

### Artifacts
- Updated `.jules/compat/ledger.json`.
- Created `.jules/compat/runs/2026-01-31.md`.
- Created `.jules/compat/envelopes/run-20260131-compat-init.json`.


---
*PR created automatically by Jules for task [15278301521114995364](https://jules.google.com/task/15278301521114995364) started by @EffortlessSteven*