### PR TITLE
docs: fix broken doctest in tokmd-core 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/20260131-librarian.json
+++ b/.jules/docs/envelopes/20260131-librarian.json
@@ -1,0 +1,25 @@
+{
+  "run_id": "20260131-librarian",
+  "date": "2026-01-31",
+  "persona": "Librarian",
+  "lane": "B",
+  "target": "crates/tokmd-core/src/lib.rs",
+  "description": "Fix broken and non-running doctest in tokmd-core",
+  "option_selected": "A",
+  "gates": {
+      "build": "PASS",
+      "test": "PASS",
+      "fmt": "PASS",
+      "clippy": "PASS"
+  },
+  "receipts": [
+      {
+          "command": "cargo test --doc --package tokmd-core",
+          "result": "passed"
+      },
+      {
+          "command": "cargo test --workspace",
+          "result": "passed"
+      }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -10,5 +10,11 @@
     "date": "2026-01-30",
     "persona": "Librarian",
     "description": "Documented configuration files and profiles in README, removed misleading scan config from reference"
+  },
+  {
+    "run_id": "20260131-librarian",
+    "date": "2026-01-31",
+    "persona": "Librarian",
+    "description": "Fix broken and non-running doctest in tokmd-core"
   }
 ]

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -8,15 +8,16 @@
 //!
 //! ## Example
 //!
-//! ```rust,no_run
+//! ```rust
+//! use std::path::PathBuf;
 //! use tokmd_core::scan_workflow;
 //! use tokmd_config::GlobalArgs;
 //! use tokmd_types::{ChildrenMode, LangArgs, RedactMode, TableFormat};
 //!
 //! // Configure scan
-//! let global = GlobalArgs::default(); // needs proper init
+//! let global = GlobalArgs::default();
 //! let lang = LangArgs {
-//!     paths: vec![],
+//!     paths: vec![PathBuf::from(".")],
 //!     format: TableFormat::Json,
 //!     top: 10,
 //!     files: false,


### PR DESCRIPTION
## 💡 Summary
Fixed a broken `no_run` doctest in `crates/tokmd-core/src/lib.rs`. The example was panicking because it provided empty paths to `scan_workflow`, which causes `tokei` to panic.

## 🎯 Why (user/dev pain)
- The example in the documentation was marked `no_run`, so it wasn't being verified.
- Users trying to run the example would encounter a panic (`Option::unwrap()` on `None` value in `tokei`).
- Documentation should be trustworthy and copy-pasteable.

## 🔎 Evidence (before/after)
- Before: `cargo test --doc` skipped the test.
- After: `cargo test --doc` passes.

## 🧭 Options considered
### Option A (Recommended)
- Provide a valid path (`.`) to the scanner.
- Requires importing `PathBuf`.
- Makes the example actually runnable and correct.

## ✅ Decision
Option A.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd-core/src/lib.rs` to:
    - Remove `no_run`
    - Add `use std::path::PathBuf;`
    - Initialize `paths` with `vec![PathBuf::from(".")]`

## 🧪 Verification receipts
- `cargo test --doc --package tokmd-core` passed.
- `cargo test --workspace` passed.


---
*PR created automatically by Jules for task [14054560698603444422](https://jules.google.com/task/14054560698603444422) started by @EffortlessSteven*