### PR TITLE
fix: redact module names in module.json when redaction is enabled 🛡️ Sentinel

### DIFF
--- a/.jules/security/envelopes/202601311307.json
+++ b/.jules/security/envelopes/202601311307.json
@@ -1,0 +1,19 @@
+{
+  "run_id": "202601311307",
+  "timestamp_utc": "2026-01-31T13:07:00Z",
+  "lane": "scout",
+  "target": "module.json redaction leakage",
+  "commands": [
+    {
+      "cmd": "cargo run -- run reproduction --output-dir output_redact_all --redact all",
+      "status": 0,
+      "result": "Before fix: module names visible. After fix: module names redacted."
+    },
+    {
+      "cmd": "cargo test --workspace",
+      "status": 0,
+      "result": "All tests passed."
+    }
+  ],
+  "results_summary": "Fixed redaction leak in module.json where module names were not hashed when using --redact all."
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -16,5 +16,14 @@
     "gates_run": ["test"],
     "status": "PASS",
     "friction_ids_created": []
+  },
+  {
+    "timestamp_utc": "2026-01-31T13:07:00Z",
+    "lane": "scout",
+    "target": "module.json redaction leakage",
+    "pr_link": "tbd",
+    "gates_run": ["build", "test", "fmt", "clippy"],
+    "status": "PASS",
+    "friction_ids_created": []
   }
 ]

--- a/.jules/security/notes/202601311330Z--redaction-of-derived-artifacts.md
+++ b/.jules/security/notes/202601311330Z--redaction-of-derived-artifacts.md
@@ -1,0 +1,14 @@
+# Redaction of Derived Artifacts
+
+**Context**: When `tokmd run` generates artifacts (`module.json`), it uses internal models (`ModuleReport`) that are computed from raw scan data. Even if `scan` inputs are normalized, the derived model fields (like `module` names) retain original values.
+
+**Pattern**: `export.jsonl` was correctly redacted because it passed through `redact_rows` during serialization. However, `module.json` was serialized directly from the model, bypassing redaction.
+
+**Guidance**:
+- Any artifact that outputs user-controlled strings (paths, module names) must have a redaction pass if `RedactMode` is active.
+- Do not assume "summary" reports are safe; module names are often directory names which can be sensitive.
+- Prefer applying redaction at the "last mile" (formatting/serialization) rather than in the core model, to keep the model clean.
+
+**Prevention**:
+- Use `format::redact_*` helpers for all reports before writing.
+- Add regression tests that inspect *all* generated artifacts for leaked strings when redaction is on.

--- a/.jules/security/runs/2026-01-31.md
+++ b/.jules/security/runs/2026-01-31.md
@@ -1,0 +1,12 @@
+# Run Log: 2026-01-31
+
+## Run 202601311307
+- **Envelope**: [.jules/security/envelopes/202601311307.json](../envelopes/202601311307.json)
+- **Lane**: Scout
+- **Target**: `module.json` redaction leakage
+- **Findings**:
+  - Confirmed that `tokmd run --redact all` produced unredacted module names in `module.json` (e.g. `reproduction`).
+  - `export.jsonl` was correctly redacted.
+  - Implemented `format::redact_module_report` and wired it into `tokmd run`.
+  - Verified fix with reproduction script.
+- **Decision**: Option A (Update `tokmd run` to redact in-place before writing).

--- a/crates/tokmd-format/src/lib.rs
+++ b/crates/tokmd-format/src/lib.rs
@@ -515,6 +515,18 @@ fn redact_rows(rows: &[FileRow], mode: RedactMode) -> impl Iterator<Item = Cow<'
     })
 }
 
+/// Redact a module report in place.
+pub fn redact_module_report(report: &mut ModuleReport, mode: RedactMode) {
+    if mode == RedactMode::All {
+        for row in &mut report.rows {
+            row.module = short_hash(&row.module);
+        }
+        for root in &mut report.module_roots {
+            *root = short_hash(root);
+        }
+    }
+}
+
 // Re-export redaction functions for backwards compatibility
 pub use tokmd_redact::{redact_path, short_hash};
 

--- a/crates/tokmd/src/commands/run.rs
+++ b/crates/tokmd/src/commands/run.rs
@@ -38,7 +38,7 @@ pub(crate) fn handle(args: cli::RunArgs, global: &cli::GlobalArgs) -> Result<()>
 
     // 3. Generate Reports
     let lang_report = model::create_lang_report(&languages, 0, false, cli::ChildrenMode::Collapse);
-    let module_report = model::create_module_report(
+    let mut module_report = model::create_module_report(
         &languages,
         &["crates".to_string(), "packages".to_string()],
         2,
@@ -57,6 +57,10 @@ pub(crate) fn handle(args: cli::RunArgs, global: &cli::GlobalArgs) -> Result<()>
 
     // Get redact mode - applies to scan args in all receipts (lang.json, module.json, export.jsonl)
     let redact_mode = args.redact.unwrap_or(cli::RedactMode::None);
+
+    // Redact module report if needed
+    format::redact_module_report(&mut module_report, redact_mode);
+
     let scan_args = format::scan_args(&args.paths, global, Some(redact_mode));
 
     // 4. Write artifacts using tokmd-format for consistency


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Ensures `module.json` produced by `tokmd run` has module names and roots redacted when `--redact all` is used. Previously, only `export.jsonl` was correctly redacted, leaving sensitive module names visible in `module.json`.

## 🎯 Why / Threat model
When a user explicitly requests redaction (e.g., to share receipts with an LLM or vendor), they expect *all* sensitive identifiers to be obscured. Module names often correspond to directory paths or internal project code names. Leaking them in `module.json` violates the user's trust and intent.

## 🔎 Finding (evidence)
Running `tokmd run --redact all` produced:
- `export.jsonl`: Redacted (Correct)
- `module.json`: Unredacted module names (e.g., `reproduction` instead of `6e1aa888293cb1cf`).

## 🧭 Options considered
### Option A (recommended)
- **What it is**: Update `tokmd run` to apply redaction to the `ModuleReport` in-place using a new helper in `tokmd-format` before writing.
- **Why it fits this repo**: `tokmd run` orchestrates artifact generation. `tokmd-format` owns redaction logic.
- **Trade-offs**: Slightly mutates the report before writing, but avoids schema changes or complex model updates.

### Option B
- **What it is**: Update `ModuleArgsMeta` schema to include `RedactMode` and rely on consumers to know it is redacted.
- **Why it fits this repo**: More explicit metadata.
- **Trade-offs**: Requires `SCHEMA_VERSION` bump and potentially breaking changes for consumers.

## ✅ Decision
Selected **Option A** to fix the leak immediately without breaking schema compatibility.

## 🧱 Changes made (SRP)
- `crates/tokmd-format/src/lib.rs`: Added `redact_module_report`.
- `crates/tokmd/src/commands/run.rs`: Called `redact_module_report` when writing `module.json`.

## 🧪 Verification receipts
From `.jules/security/envelopes/202601311307.json`:
- `cargo run -- run reproduction --output-dir output_redact_all --redact all` -> `module.json` module names are now hashes.
- `cargo test --workspace` -> PASS

## 🧭 Telemetry
- **Change shape**: Safe logic addition.
- **Blast radius**: `tokmd run` command output only.
- **Risk class**: Low (fixing a leak).
- **Rollback**: Revert commit.

## 🗂️ .jules updates
- Created `.jules/security/envelopes/202601311307.json`
- Created `.jules/security/runs/2026-01-31.md`
- Updated `.jules/security/ledger.json`
- Added `.jules/security/notes/202601311330Z--redaction-of-derived-artifacts.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [3774725396317417531](https://jules.google.com/task/3774725396317417531) started by @EffortlessSteven*