### PR TITLE
perf: reduce allocations in module aggregation ⚡ Bolt

### DIFF
--- a/.jules/bolt/envelopes/20260131-01.json
+++ b/.jules/bolt/envelopes/20260131-01.json
@@ -1,0 +1,36 @@
+{
+  "run_id": "20260131-01",
+  "timestamp_utc": "2026-01-31T13:10:53Z",
+  "lane": "scout",
+  "target": "Deduplicate module key allocations in tokmd-model",
+  "proof_method": "runtime timing using custom example",
+  "commands": [
+    {
+      "cmd": "cargo run --release -p tokmd-model --example bench_module",
+      "exit_status": 0,
+      "output_summary": "Baseline: 345ms per call (100k files)"
+    },
+    {
+      "cmd": "cargo run --release -p tokmd-model --example bench_module",
+      "exit_status": 0,
+      "output_summary": "After fix: 339ms per call (100k files)"
+    },
+    {
+      "cmd": "cargo test -p tokmd-model",
+      "exit_status": 0,
+      "output_summary": "PASS"
+    },
+    {
+      "cmd": "cargo test --workspace",
+      "exit_status": 0,
+      "output_summary": "PASS"
+    }
+  ],
+  "results_summary": "Reduced allocations from O(N) to O(M) in create_module_report. Runtime improved slightly (~1.7%). Code structure improved to avoid redundant normalization and string building.",
+  "gates": {
+    "build": "PASS",
+    "test": "PASS",
+    "fmt": "PASS",
+    "clippy": "PASS"
+  }
+}

--- a/.jules/bolt/ledger.json
+++ b/.jules/bolt/ledger.json
@@ -18,5 +18,15 @@
     "gates": ["build", "test", "fmt", "clippy"],
     "status": "PASS",
     "friction_ids": []
+  },
+  {
+    "date": "2026-01-31",
+    "lane": "scout",
+    "target": "crates/tokmd-model/src/lib.rs:module_key_from_normalized",
+    "proof_method": "runtime timing using custom example",
+    "pr_link": "TODO",
+    "gates": ["build", "test", "fmt", "clippy"],
+    "status": "PASS",
+    "friction_ids": []
   }
 ]

--- a/.jules/bolt/notes/20260131T1355Z--avoid-double-scan-and-string-rebuild.md
+++ b/.jules/bolt/notes/20260131T1355Z--avoid-double-scan-and-string-rebuild.md
@@ -1,0 +1,31 @@
+# Avoid Double Scan and String Rebuild in Aggregation
+
+## Context
+In `tokmd-model`, `create_module_report` was iterating over `languages.reports` (raw Tokei output) to build `module_files` mapping. However, it had *already* called `collect_file_rows` which processed the same reports and normalized paths.
+
+## Pattern
+Reuse the processed `file_rows` vector instead of re-scanning raw inputs. This avoids:
+1. Redundant `normalize_path` calls (CPU + Allocation).
+2. Redundant `module_key_from_normalized` calls (CPU).
+
+## Optimization: Zero-Copy Keys
+`module_key_from_normalized` was refactored to return `Cow<'a, str>`.
+- If the module key is a substring of the path (common case), it returns `Cow::Borrowed`.
+- If reconstruction is needed (rare double slashes), it returns `Cow::Owned`.
+
+When inserting into `BTreeMap<String, V>`:
+```rust
+let key_cow = get_key_cow();
+if let Some(val) = map.get_mut(key_cow.as_ref()) {
+    // Found without allocating String!
+    val.update();
+} else {
+    // Must allocate String for key storage
+    map.insert(key_cow.into_owned(), initial_val);
+}
+```
+This reduces allocations from O(N) to O(M) where N is items and M is unique keys.
+
+## Evidence
+- Reduced runtime for 100k files from 345ms to 339ms.
+- Structural elimination of 100k string allocations.

--- a/.jules/bolt/runs/2026-01-31.md
+++ b/.jules/bolt/runs/2026-01-31.md
@@ -1,0 +1,22 @@
+# Run 2026-01-31 (Bolt)
+
+## Bootstrap
+- Read CI config: `.github/workflows/ci.yml`
+- Read docs: `CLAUDE.md`, `CONTRIBUTING.md`
+- Created missing directories: `.jules/friction/{open,done}`, `.jules/bolt/notes`
+
+## Plan
+- Lane: Scout
+- Target: Deduplicate module key allocations in `tokmd-model`.
+- Proof Method: Runtime timing using `crates/tokmd-model/examples/bench_module.rs`.
+
+## Execution
+- Created benchmark: `crates/tokmd-model/examples/bench_module.rs`.
+- Baseline: ~345ms for 100k files (create_module_report).
+- Identified optimization: `module_key_from_normalized` allocates String for every file.
+- Refactored `module_key_from_normalized` to return `Cow<'a, str>` (zero-copy slicing).
+- Optimized `create_module_report`:
+  1. Use `Cow` to check for module existence before allocating key.
+  2. Reuse `file_rows` (already normalized) instead of re-scanning `languages` (which involved re-normalizing paths).
+- Result: ~339ms. Saved 100k redundant normalizations and ~100k module string allocations.
+- Verification: Passed `cargo test -p tokmd-model` and `cargo test --workspace`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,6 +2831,7 @@ dependencies = [
  "anyhow",
  "proptest",
  "serde",
+ "serde_json",
  "tokei",
  "tokmd-config",
  "tokmd-types",

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -15,4 +15,5 @@ tokmd-config.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
+serde_json = "1.0"
 proptest = "1.9.0"

--- a/crates/tokmd-model/examples/bench_module.rs
+++ b/crates/tokmd-model/examples/bench_module.rs
@@ -1,0 +1,71 @@
+use std::time::Instant;
+
+use serde_json::json;
+use tokei::{Language, LanguageType, Languages, Report};
+
+fn main() {
+    // Generate synthetic data
+    // 100 modules, 1000 files each = 100,000 files
+    let modules = 100;
+    let files_per_module = 1000;
+    let iterations = 10;
+
+    println!(
+        "Generating {} files across {} modules...",
+        modules * files_per_module,
+        modules
+    );
+
+    let mut languages = Languages::new();
+    let mut reports = Vec::new();
+
+    for m in 0..modules {
+        let module_name = format!("crates/module_{}", m);
+        for f in 0..files_per_module {
+            let path_str = format!("{}/src/file_{}.rs", module_name, f);
+
+            // Construct Report via JSON because Report is non_exhaustive
+            let report_json = json!({
+                "name": path_str,
+                "stats": {
+                    "blanks": 0,
+                    "code": 100,
+                    "comments": 0,
+                    "blobs": {}
+                }
+            });
+
+            let report: Report =
+                serde_json::from_value(report_json).expect("Failed to deserialize Report");
+            reports.push(report);
+        }
+    }
+
+    let mut rust_lang = Language::new();
+    rust_lang.reports = reports;
+    languages.insert(LanguageType::Rust, rust_lang);
+
+    let module_roots = vec!["crates".to_string()];
+    let module_depth = 2;
+    let children_mode = tokmd_types::ChildIncludeMode::Separate;
+    let top = 0;
+
+    println!("Starting benchmark ({} iterations)...", iterations);
+    let start = Instant::now();
+
+    for _ in 0..iterations {
+        let _report = tokmd_model::create_module_report(
+            &languages,
+            &module_roots,
+            module_depth,
+            children_mode,
+            top,
+        );
+    }
+
+    let duration = start.elapsed();
+    let avg = duration / iterations;
+
+    println!("Total time: {:?}", duration);
+    println!("Average time per call: {:?}", avg);
+}


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Optimized `tokmd-model` to reduce string allocations during module aggregation. By using zero-copy slicing (`Cow<'a, str>`) for module keys and reusing normalized paths from `file_rows`, we eliminate O(N) redundant allocations and string operations.

## 🎯 Why (perf bottleneck)
`create_module_report` was:
1. Re-scanning `languages` (raw Tokei output) after `collect_file_rows` had already processed them.
2. Re-normalizing paths (CPU + Allocation) for every file.
3. Allocating a new `String` for the module key for every file (N allocations), even though there are only M modules.

## 🔎 Evidence (before/after)
Benchmark: `crates/tokmd-model/examples/bench_module.rs` (100k files, 100 modules).

**Before:** ~345ms per call.
**After:** ~339ms per call.

While the runtime improvement is modest (~1.7%), the structural improvement is significant:
- Eliminated 100,000 redundant `String` allocations for module keys.
- Eliminated 100,000 redundant `normalize_path` calls.

## 🧭 Options considered
### Option A (recommended)
Refactor `module_key_from_normalized` to return `Cow<'a, str>` and optimize `create_module_report` loops.
- **Why:** Solves the allocation issue at the source without changing public API (wrappers preserve `String` return).
- **Trade-offs:** Slightly more complex function signature (`Cow`).

### Option B
Change `FileRow` struct to hold `Rc<str>` or `Cow`.
- **Why:** Would reduce allocations further in `collect_file_rows`.
- **Trade-offs:** Breaking change for `tokmd-types` (Tier 0). High blast radius.

## ✅ Decision
Option A. Safe, local, SRP optimization.

## 🧱 Changes made (SRP)
- `crates/tokmd-model/src/lib.rs`:
  - Refactor `module_key_from_normalized` to return `Cow<'a, str>`.
  - Update `create_module_report` to reuse `file_rows` and use `get_mut` optimization.
  - Update `module_key` and `collect_file_rows` to adapt to `Cow`.
- `crates/tokmd-model/examples/bench_module.rs`: Added benchmark.

## 🧪 Verification receipts
- `cargo run --release -p tokmd-model --example bench_module`:
  ```
  Generating 100000 files across 100 modules...
  Starting benchmark (10 iterations)...
  Total time: 3.391770636s
  Average time per call: 339.177063ms
  ```
- `cargo test -p tokmd-model`: PASS
- `cargo test --workspace`: PASS
- `cargo clippy`: PASS

## 🧭 Telemetry
- **Change shape:** Internal logic optimization.
- **Blast radius:** Low. `module_key` public API preserved. `FileRow` struct unchanged.
- **Risk class:** Low. Covered by property tests and unit tests.
- **Merge-confidence gates:** Build, Test, Clippy, Fmt.

## 🗂️ .jules updates
- `.jules/bolt/ledger.json`: Recorded run.
- `.jules/bolt/envelopes/20260131-01.json`: Recorded receipts.
- `.jules/bolt/runs/2026-01-31.md`: Run log.
- `.jules/bolt/notes/...`: Added optimization pattern note.

---
*PR created automatically by Jules for task [6978908753449941756](https://jules.google.com/task/6978908753449941756) started by @EffortlessSteven*