### PR TITLE
docs: add PR Cockpit to README Use Cases 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/run-docs-001.json
+++ b/.jules/docs/envelopes/run-docs-001.json
@@ -1,0 +1,21 @@
+{
+  "run_id": "run-docs-001",
+  "persona": "Librarian",
+  "status": "done",
+  "gates": {
+    "build": "PASS",
+    "test": "PASS",
+    "fmt": "PASS",
+    "clippy": "PASS"
+  },
+  "receipts": [
+    {
+      "command": "tokmd cockpit --help",
+      "output": "Generate PR cockpit metrics for code review"
+    },
+    {
+      "command": "cargo test --doc",
+      "output": "all doctests ran in 0.59s"
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -10,5 +10,11 @@
     "date": "2026-01-30",
     "persona": "Librarian",
     "description": "Documented configuration files and profiles in README, removed misleading scan config from reference"
+  },
+  {
+    "run_id": "run-docs-001",
+    "date": "2026-02-01",
+    "persona": "Librarian",
+    "description": "Added 'Automated Code Review' section to README highlighting `tokmd cockpit`"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ tokmd badge --metric lines --out badge.svg
 
 # 7. Diff two states
 tokmd diff main HEAD
+
+# 8. PR Cockpit (code review metrics)
+tokmd cockpit --format md
 ```
 
 ## Use Cases
@@ -79,6 +82,20 @@ Add a `tokmd` summary to show reviewers the repo shape:
 ```bash
 tokmd --format md --top 5
 ```
+
+### Automated Code Review
+Generate a "glass cockpit" report for your Pull Requests with evidence gates, risk analysis, and review prioritization.
+
+```bash
+# Generate a Markdown report for the PR description
+tokmd cockpit --format md
+```
+
+**Includes**:
+*   **Change Surface**: Net lines, file churn, concentration.
+*   **Risk**: Hotspots, coupling, and "freshness" of touched files.
+*   **Evidence Gates**: Integration with mutation testing and test coverage.
+*   **Review Plan**: Prioritized list of files that need human attention.
 
 ### CI Artifacts & Diffs
 Track changes over time:


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Added a dedicated "Automated Code Review" section to README.md showcasing the `tokmd cockpit` command.

## 🎯 Why (user/dev pain)
The `tokmd cockpit` command is a major feature for PR workflows (released in 1.3.0) but was buried in the command reference. Users missed the value of "glass cockpit" metrics for their PRs.

## 🔎 Evidence (before/after)
Before: `tokmd cockpit` only appeared in the commands table.
After: Dedicated "Quickstart" entry and "Use Cases" section explaining the value.

## 🧭 Options considered
### Option A (recommended)
Add to README.md Use Cases.
Why: High visibility, aligns with "Product" section goals.

## ✅ Decision
Option A.

## 🧱 Changes made (SRP)
- README.md: Added "PR Cockpit" to Quickstart and Use Cases.

## 🧪 Verification receipts
- `tokmd cockpit --help` verified command existence.
- `tokmd cockpit --format md` verified output format.
- `cargo test --doc` passed.

## 🗂️ .jules updates
Appended run `run-docs-001` to ledger.


---
*PR created automatically by Jules for task [4390755321507397111](https://jules.google.com/task/4390755321507397111) started by @EffortlessSteven*