### PR TITLE
fix: remove unwrap and optimize normalization in scan input 🛡️ Sentinel

### DIFF
--- a/.jules/security/envelopes/run-20260201-01.json
+++ b/.jules/security/envelopes/run-20260201-01.json
@@ -1,0 +1,46 @@
+{
+  "run_id": "run-20260201-01",
+  "timestamp_utc": "2026-02-01T12:00:00Z",
+  "lane": "scout",
+  "target": "crates/tokmd-format/src/lib.rs:normalize_scan_input",
+  "commands": [
+    {
+      "cmd": "cargo test -p tokmd-format",
+      "result": "PASS",
+      "details": "38 passed + 40 passed"
+    },
+    {
+      "cmd": "cargo test -p tokmd-format",
+      "result": "PASS",
+      "details": "38 passed + 40 passed"
+    },
+    {
+      "cmd": "cargo build --verbose",
+      "result": "PASS",
+      "details": "Build successful"
+    },
+    {
+      "cmd": "CI=true cargo test",
+      "result": "PASS",
+      "details": "Full suite passed"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "result": "PASS",
+      "details": "Format check passed"
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "result": "PASS",
+      "details": "Clippy passed"
+    }
+  ],
+  "results": {
+    "gates": {
+      "build": "PASS",
+      "test": "PASS",
+      "fmt": "PASS",
+      "clippy": "PASS"
+    }
+  }
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -16,5 +16,14 @@
     "gates_run": ["test"],
     "status": "PASS",
     "friction_ids_created": []
+  },
+  {
+    "timestamp_utc": "2026-02-01T12:00:00Z",
+    "lane": "scout",
+    "target": "crates/tokmd-format/src/lib.rs:normalize_scan_input",
+    "pr_link": "tbd",
+    "gates_run": ["build", "test", "fmt", "clippy"],
+    "status": "PASS",
+    "friction_ids_created": []
   }
 ]

--- a/.jules/security/runs/2026-02-01.md
+++ b/.jules/security/runs/2026-02-01.md
@@ -1,0 +1,24 @@
+# Run Log: 2026-02-01
+
+## Metadata
+- **Run ID:** run-20260201-01
+- **Lane:** Scout
+- **Target:** `crates/tokmd-format/src/lib.rs` (normalize_scan_input)
+
+## Findings
+- Identified `unwrap()` usage in `normalize_scan_input` within `crates/tokmd-format/src/lib.rs`.
+- Code loops `s.strip_prefix("./").unwrap().to_string()` which is safe by invariant but inefficient (allocates in loop) and unhygienic (unwrap).
+
+## Options Considered
+### Option A (Recommended)
+Refactor to operate on `&str` slice and allocate only once.
+- **Pros:** Removes `unwrap()`, reduces allocations, cleaner code.
+- **Cons:** None.
+
+### Option B
+Keep logic, replace `unwrap()` with `expect()`.
+- **Pros:** clear panic message.
+- **Cons:** Still allocates in loop, still panics if invariant breaks (unlikely).
+
+## Decision
+Choosing **Option A**.

--- a/crates/tokmd-format/src/lib.rs
+++ b/crates/tokmd-format/src/lib.rs
@@ -49,11 +49,16 @@ fn now_ms() -> u128 {
 /// This is the canonical normalization function for scan inputs. Use this
 /// before storing paths in receipts to ensure consistent output across OS.
 pub fn normalize_scan_input(p: &Path) -> String {
-    let mut s = p.display().to_string().replace('\\', "/");
-    while s.starts_with("./") {
-        s = s.strip_prefix("./").unwrap().to_string();
+    let s = p.display().to_string().replace('\\', "/");
+    let mut trimmed = s.as_str();
+    while let Some(t) = trimmed.strip_prefix("./") {
+        trimmed = t;
     }
-    if s.is_empty() { ".".to_string() } else { s }
+    if trimmed.is_empty() {
+        ".".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 /// Construct `ScanArgs` with optional redaction applied.


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Replaced `unwrap()` usage in `normalize_scan_input` with a safer, allocation-minimized loop. This ensures robust handling of path normalization and improves performance by reducing intermediate `String` allocations.

## 🎯 Why / Threat model
- **Safety:** `unwrap()` is a panic risk. While the logic `while s.starts_with` guarantees safety, explicit handling is more hygienic and robust against future refactors.
- **Performance:** The previous implementation allocated a new `String` in every iteration of the loop. The new implementation works on `&str` slices and allocates only once at the end.

## 🔎 Finding (evidence)
`crates/tokmd-format/src/lib.rs`:
```rust
    let mut s = p.display().to_string().replace('\\', "/");
    while s.starts_with("./") {
        s = s.strip_prefix("./").unwrap().to_string(); // Allocates + unwrap
    }
```

## 🧭 Options considered
### Option A (recommended)
Refactor to use `strip_prefix` on `&str` in a loop.
- Zero intermediate allocations.
- No `unwrap()`.
- Fits repo hygiene goals.

### Option B
Just replace `unwrap()` with `expect()`.
- Keeps allocations.
- Only solves hygiene, not perf.

## ✅ Decision
Option A.

## 🧱 Changes made (SRP)
- `crates/tokmd-format/src/lib.rs`: Refactored `normalize_scan_input`.

## 🧪 Verification receipts
- `cargo test -p tokmd-format`: PASS (38 tests)
- `cargo build`: PASS
- `cargo test`: PASS (Full suite)
- `cargo fmt`: PASS
- `cargo clippy`: PASS

## 🧭 Telemetry
- Change shape: Internal logic of 1 function.
- Blast radius: `normalize_scan_input` is used by all scan operations. However, existing tests cover this extensively.
- Risk class: Low. Logic is equivalent.

## 🗂️ .jules updates
- Updated `security/ledger.json`
- Created `security/envelopes/run-20260201-01.json`
- Created `security/runs/2026-02-01.md`

---
*PR created automatically by Jules for task [1589080352446875258](https://jules.google.com/task/1589080352446875258) started by @EffortlessSteven*