### PR TITLE
feat(cli): make markdown the default format for 'tokmd cockpit' 🎨 Palette

### DIFF
--- a/.jules/palette/envelopes/20260201-130435.json
+++ b/.jules/palette/envelopes/20260201-130435.json
@@ -1,0 +1,17 @@
+{
+  "run_id": "20260201-130435",
+  "timestamp_utc": "2026-02-01T13:04:35Z",
+  "lane": "scout",
+  "target": "tokmd cockpit default format",
+  "commands": [
+    {
+      "cmd": "cargo test --test cockpit_integration",
+      "exit_code": 0,
+      "summary": "PASS"
+    }
+  ],
+  "results_summary": [
+    "Changed default format of tokmd cockpit to markdown",
+    "Updated docs and tests"
+  ]
+}

--- a/.jules/palette/ledger.json
+++ b/.jules/palette/ledger.json
@@ -1,8 +1,9 @@
 [
   {
-    "date": "2026-01-30T13:18:35Z",
+    "run_id": "20260201-130435",
+    "timestamp_utc": "2026-02-01T13:04:35Z",
     "lane": "scout",
-    "target": "cli-help-defaults",
+    "target": "tokmd cockpit default format",
     "pr_link": null,
     "gates": {
       "build": "PASS",

--- a/.jules/palette/runs/2026-02-01.md
+++ b/.jules/palette/runs/2026-02-01.md
@@ -1,0 +1,24 @@
+# Run 2026-02-01
+
+## 20260201-130435 (Palette)
+
+### 📚 Read
+- CI (workflows)
+- CONTRIBUTING.md
+- CLAUDE.md
+- AGENTS.md (if present)
+
+### 🎯 Selection
+- Lane: Scout (Lane B)
+- Target: `tokmd cockpit` default format
+
+### 🔎 Findings
+- `tokmd cockpit` defaults to JSON output, which is unfriendly for developers running it locally.
+- The "Glass Cockpit" concept implies a human-readable dashboard.
+- Automation use cases can easily use `--format json`.
+
+### 🧾 Receipts
+- Updated `crates/tokmd-config/src/lib.rs` to change default format to `Md`.
+- Updated `crates/tokmd/tests/cockpit_integration.rs` to fix tests.
+- Updated documentation to reflect the change.
+- Verified with `cargo test` and local run.

--- a/crates/tokmd-config/src/lib.rs
+++ b/crates/tokmd-config/src/lib.rs
@@ -705,7 +705,7 @@ pub struct CockpitArgs {
     pub head: String,
 
     /// Output format.
-    #[arg(long, value_enum, default_value_t = CockpitFormat::Json)]
+    #[arg(long, value_enum, default_value_t = CockpitFormat::Md)]
     pub format: CockpitFormat,
 
     /// Output file (stdout if omitted).
@@ -717,9 +717,9 @@ pub struct CockpitArgs {
 #[serde(rename_all = "kebab-case")]
 pub enum CockpitFormat {
     /// JSON output with full metrics.
-    #[default]
     Json,
     /// Markdown output for human readability.
+    #[default]
     Md,
     /// Section-based output for PR template filling.
     Sections,

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -309,6 +309,8 @@ fn test_cockpit_output_file() {
         .arg("cockpit")
         .arg("--base")
         .arg("main")
+        .arg("--format")
+        .arg("json")
         .arg("--output")
         .arg(&output_file)
         .assert()

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -353,13 +353,13 @@ Generate comprehensive PR metrics for code review automation with evidence gates
 
 ```bash
 # Generate JSON metrics for CI parsing
-tokmd cockpit
+tokmd cockpit --format json
 
 # Markdown summary for PR description
-tokmd cockpit --format md
+tokmd cockpit
 
 # Compare specific refs
-tokmd cockpit --base origin/main --head feature-branch --format md
+tokmd cockpit --base origin/main --head feature-branch
 
 # Generate sections for PR template filling
 tokmd cockpit --format sections --output pr-metrics.txt
@@ -392,7 +392,7 @@ jobs:
 
       - name: Generate cockpit metrics
         run: |
-          tokmd cockpit --base origin/${{ github.base_ref }} --head HEAD --format md > cockpit.md
+          tokmd cockpit --base origin/${{ github.base_ref }} --head HEAD > cockpit.md
 
       - name: Post PR comment
         uses: actions/github-script@v7

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -385,7 +385,7 @@ Generates comprehensive PR metrics for code review automation. This command anal
 | :--- | :--- | :--- |
 | `--base <REF>` | Base reference to compare from (e.g., `main`, commit SHA). | `main` |
 | `--head <REF>` | Head reference to compare to (e.g., `HEAD`, branch name). | `HEAD` |
-| `--format <FMT>` | Output format: `json`, `md`, `sections`. | `json` |
+| `--format <FMT>` | Output format: `json`, `md`, `sections`. | `md` |
 | `--output <PATH>` | Write output to file instead of stdout. | `(stdout)` |
 | `--no-progress` | Disable progress spinners. | `false` |
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -323,7 +323,7 @@ tokmd cockpit --base develop --head feature/my-branch
 
 **Output in Markdown for PR descriptions**:
 ```bash
-tokmd cockpit --format md --output pr-metrics.md
+tokmd cockpit --output pr-metrics.md
 ```
 
 **What you get**:


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Changed the default output format of `tokmd cockpit` from JSON to Markdown.

## 🎯 Why (user/dev pain)
The `tokmd cockpit` command is designed for "PR Glass Cockpit" usage, which implies a human-readable dashboard. Defaulting to JSON (machine-readable) created friction for developers running the command locally to see the metrics.

## 🔎 Evidence (before/after)
Before:
`tokmd cockpit` -> outputs JSON blob.

After:
`tokmd cockpit` -> outputs Markdown report (Glass Cockpit).

## 🧭 Options considered
### Option A (recommended)
- Change default to Markdown.
- Fits the "Glass Cockpit" metaphor.
- Requires automation scripts to explicit use `--format json`.

### Option B
- Keep JSON default.
- Users must type `--format md` every time.
- Higher friction for interactive use.

## ✅ Decision
Option A. Interactive use (DX) prioritizes human readability. CI/Automation should be explicit about formats anyway.

## 🧱 Changes made (SRP)
- `crates/tokmd-config/src/lib.rs`: Changed default value for `CockpitFormat`.
- `crates/tokmd/tests/cockpit_integration.rs`: Updated tests to expect JSON only when requested.
- `docs/*.md`: Updated documentation to reflect the new default.

## 🧪 Verification receipts
- `cargo test --test cockpit_integration` PASSED.
- Local run of `tokmd cockpit` outputs Markdown.

## 🗂️ .jules updates
- Created run envelope and log.
- Updated ledger.


---
*PR created automatically by Jules for task [3665091999032471273](https://jules.google.com/task/3665091999032471273) started by @EffortlessSteven*