### PR TITLE
test: lock deterministic aggregation against report shuffling 🧪 Gatekeeper

### DIFF
--- a/.jules/quality/envelopes/1770029725.json
+++ b/.jules/quality/envelopes/1770029725.json
@@ -1,0 +1,13 @@
+{
+  "run_id": "1770029725",
+  "persona": "Gatekeeper",
+  "target": "crates/tokmd-model/tests/determinism.rs",
+  "lane": "B",
+  "goal": "Verify deterministic aggregation logic in tokmd-model against shuffled input",
+  "gates": {
+    "build": "PASS",
+    "test": "PASS",
+    "fmt": "PASS",
+    "clippy": "PASS"
+  }
+}

--- a/.jules/quality/runs/2026-02-02.md
+++ b/.jules/quality/runs/2026-02-02.md
@@ -1,0 +1,14 @@
+# Run 1770029725 - Gatekeeper
+
+## Context
+Targeting `tokmd-model` aggregation logic to ensure determinism regardless of input order (Tokei parallelism).
+
+## Discovery
+- `tokmd-model` handles `Languages` -> `Report` transformation.
+- `tokei` parallel execution means `reports` order is unstable.
+- `create_module_report` and `create_lang_report` sort outputs, but we need to prove that intermediate aggregation doesn't depend on order.
+- Plan: Add a property-based/randomized test to shuffle `reports` and assert output identity.
+
+## Execution
+- Creating `crates/tokmd-model/tests/determinism.rs`.
+- Using `simple_shuffle` (LCG) to avoid new dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,8 @@ dependencies = [
  "anyhow",
  "proptest",
  "serde",
+ "serde_json",
+ "tempfile",
  "tokei",
  "tokmd-config",
  "tokmd-types",

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -20,3 +20,5 @@ tokmd-types.workspace = true
 
 [dev-dependencies]
 proptest = "1.9.0"
+serde_json = "1.0.149"
+tempfile = "3.24.0"

--- a/crates/tokmd-model/tests/determinism.rs
+++ b/crates/tokmd-model/tests/determinism.rs
@@ -1,0 +1,163 @@
+use std::fs;
+use tokei::{Config, Languages};
+use tokmd_model::{create_export_data, create_lang_report, create_module_report};
+use tokmd_types::{ChildIncludeMode, ChildrenMode};
+
+fn simple_shuffle<T>(vec: &mut [T], seed: u64) {
+    let len = vec.len();
+    if len <= 1 {
+        return;
+    }
+    let mut rng = seed;
+    for i in (1..len).rev() {
+        // Linear Congruential Generator
+        rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let j = (rng as usize) % (i + 1);
+        vec.swap(i, j);
+    }
+}
+
+// Helper to shuffle reports in languages
+fn shuffle_languages(languages: &mut Languages, seed: u64) {
+    for (_lang_type, lang) in languages.iter_mut() {
+        simple_shuffle(&mut lang.reports, seed);
+    }
+}
+
+#[test]
+fn test_aggregation_determinism() {
+    // 1. Setup temp dir with files
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    // Create a rich structure of files to ensure multiple aggregation paths
+    let files = vec![
+        // Root files
+        ("src/main.rs", "fn main() { println!(\"Hello\"); }"),
+        ("src/lib.rs", "pub fn foo() {}"),
+        ("src/utils.rs", "pub fn bar() {}"),
+        ("src/common.rs", "pub fn baz() {}"),
+        // Deep nesting
+        ("src/modules/mod.rs", "pub mod a; pub mod b;"),
+        ("src/modules/a.rs", "pub fn a() { /* comment */ }"),
+        ("src/modules/b.rs", "pub fn b() { let x = 1; }"),
+        // Other languages
+        (
+            "Cargo.toml",
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"",
+        ),
+        ("README.md", "# Test\n\nThis is a test."),
+        ("build.rs", "fn main() {}"),
+        // Tests
+        ("tests/foo.rs", "fn test_foo() {}"),
+        ("tests/bar.rs", "fn test_bar() {}"),
+        ("tests/baz.rs", "fn test_baz() {}"),
+        // Scripts
+        ("scripts/run.sh", "#!/bin/bash\necho hello"),
+        ("scripts/setup.py", "print('setup')"),
+    ];
+
+    for (path, content) in files {
+        let p = root.join(path);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, content).unwrap();
+    }
+
+    // 2. Scan with tokei
+    let mut languages = Languages::new();
+    let config = Config::default();
+    languages.get_statistics(&[root.to_path_buf()], &[], &config);
+
+    // Verify we have enough data
+    assert!(!languages.is_empty());
+
+    // 3. Define params
+    let module_roots = vec![
+        "src".to_string(),
+        "tests".to_string(),
+        "scripts".to_string(),
+    ];
+    let module_depth = 1;
+    let top = 10;
+
+    // 4. Baseline Runs
+    // Generate baseline reports from the initial scan order (whatever tokei returned)
+    let base_module = create_module_report(
+        &languages,
+        &module_roots,
+        module_depth,
+        ChildIncludeMode::Separate,
+        top,
+    );
+    let base_lang = create_lang_report(&languages, top, true, ChildrenMode::Separate);
+    let base_export = create_export_data(
+        &languages,
+        &module_roots,
+        module_depth,
+        ChildIncludeMode::Separate,
+        None,
+        0,
+        100,
+    );
+
+    // 5. Shuffle and Compare
+    // Run 50 iterations with different shuffle seeds
+    for seed in 1..=50 {
+        // Tokei::Languages does not implement Clone directly (it derefs to BTreeMap),
+        // so calling .clone() returns a BTreeMap, which is not a Languages struct.
+        // We must reconstruct the Languages struct manually.
+        let mut shuffled = Languages::new();
+        for (k, v) in languages.iter() {
+            shuffled.insert(*k, v.clone());
+        }
+
+        shuffle_languages(&mut shuffled, seed);
+
+        let mod_rep = create_module_report(
+            &shuffled,
+            &module_roots,
+            module_depth,
+            ChildIncludeMode::Separate,
+            top,
+        );
+        let lang_rep = create_lang_report(&shuffled, top, true, ChildrenMode::Separate);
+        let export = create_export_data(
+            &shuffled,
+            &module_roots,
+            module_depth,
+            ChildIncludeMode::Separate,
+            None,
+            0,
+            100,
+        );
+
+        // Assert Module Report Determinism
+        let base_json = serde_json::to_string_pretty(&base_module).unwrap();
+        let shuf_json = serde_json::to_string_pretty(&mod_rep).unwrap();
+        assert_eq!(
+            base_json, shuf_json,
+            "Seed {}: Module report mismatch. Aggregation must be independent of input order.",
+            seed
+        );
+
+        // Assert Lang Report Determinism
+        let base_l_json = serde_json::to_string_pretty(&base_lang).unwrap();
+        let shuf_l_json = serde_json::to_string_pretty(&lang_rep).unwrap();
+        assert_eq!(
+            base_l_json, shuf_l_json,
+            "Seed {}: Lang report mismatch. Aggregation must be independent of input order.",
+            seed
+        );
+
+        // Assert Export Data Determinism
+        let base_e_json = serde_json::to_string_pretty(&base_export).unwrap();
+        let shuf_e_json = serde_json::to_string_pretty(&export).unwrap();
+        assert_eq!(
+            base_e_json, shuf_e_json,
+            "Seed {}: Export data mismatch. Sorting must be stable.",
+            seed
+        );
+    }
+}


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Added a regression test (`crates/tokmd-model/tests/determinism.rs`) to ensure `tokmd-model` aggregation logic produces deterministic outputs regardless of the order of input reports (simulating `tokei` parallel execution).

## 🎯 Why (user/dev pain)
`tokei` scans files in parallel, meaning the order of `Report` structs in `Languages` is non-deterministic. If `tokmd` relies on input order for aggregation, users would see unstable receipts (hashes changing) for identical codebases. We claimed determinism but lacked a test proving robust aggregation against shuffled inputs.

## 🔎 Evidence (before/after)
- **Before:** No test explicitly verified that shuffling `tokei` reports produced identical module/lang receipts.
- **After:** `tests/determinism.rs` runs 50 iterations of shuffled inputs and asserts bit-for-bit JSON identity of outputs.

## 🧭 Options considered
### Option A (recommended)
- Add property-style test with LCG shuffling.
- Adds `tempfile` and `serde_json` to `dev-dependencies`.
- **Trade-off:** Minimal blast radius (only test deps), high confidence.

### Option B
- Use `proptest` fully.
- **Trade-off:** More complex setup for deep structure generation, LCG is sufficient for shuffling existing data.

## ✅ Decision
Option A. Simple, effective, low overhead.

## 🧱 Changes made (SRP)
- `crates/tokmd-model/Cargo.toml`: Added `tempfile`, `serde_json` (dev-deps).
- `crates/tokmd-model/tests/determinism.rs`: New test file.

## 🧪 Verification receipts
```bash
cargo test -p tokmd-model --test determinism
# running 1 test
# test test_aggregation_determinism ... ok
```

## 🧭 Telemetry
- **Risk:** Low (test only).
- **Blast radius:** `tokmd-model` dev-dependencies.
- **Merge-confidence:** High (new test passes, existing tests pass).

## 🗂️ .jules updates
- Updated `.jules/quality/envelopes/1770029725.json`.


---
*PR created automatically by Jules for task [11627595801605132432](https://jules.google.com/task/11627595801605132432) started by @EffortlessSteven*