### PR TITLE
docs: fix CLI help text drift for tokmd run 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/run_librarian_task.json
+++ b/.jules/docs/envelopes/run_librarian_task.json
@@ -1,0 +1,24 @@
+{
+  "run_id": "run_librarian_task",
+  "persona": "Librarian",
+  "status": "complete",
+  "target_lane": "B",
+  "receipts": [
+    {
+      "type": "verification",
+      "description": "Verified `tokmd run` CLI flags and output files via reproduction",
+      "command": "cargo run --package tokmd -- run ...",
+      "result": "Confirmed --analysis flag and conditional analysis.json output"
+    },
+    {
+      "type": "change",
+      "description": "Updated docs/reference-cli.md to fix `tokmd run` documentation",
+      "files": ["docs/reference-cli.md"]
+    },
+    {
+      "type": "change",
+      "description": "Updated docs/tutorial.md to fix `tokmd run` output list",
+      "files": ["docs/tutorial.md"]
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -10,5 +10,11 @@
     "date": "2026-01-30",
     "persona": "Librarian",
     "description": "Documented configuration files and profiles in README, removed misleading scan config from reference"
+  },
+  {
+    "run_id": "run_librarian_task",
+    "date": "2026-02-01",
+    "persona": "Librarian",
+    "description": "Fixed CLI help text drift for `tokmd run` (flags and output files)"
   }
 ]

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -103,14 +103,15 @@ Executes a full scan and saves all artifacts to a run directory.
 | `--module-roots <DIRS>` | Comma-separated list of root directories. | `.` |
 | `--module-depth <N>` | How deep to group modules. | `1` |
 | `--children <MODE>` | Handling of embedded languages. | `collapse` |
-| `--preset <PRESET>` | Analysis preset to include. | `receipt` |
+| `--analysis <PRESET>` | Analysis preset to include (e.g., `receipt`, `deep`). | `(none)` |
 | `--git` / `--no-git` | Force-enable or disable git metrics. | auto |
 
 **Output files**:
+- `receipt.json` — Run manifest (index)
 - `lang.json` — Language summary receipt
 - `module.json` — Module summary receipt
 - `export.jsonl` — File-level inventory
-- `analysis.json` — Derived metrics and enrichments
+- `analysis.json` — Derived metrics (only if `--analysis` is used)
 
 **Example**:
 ```bash
@@ -118,7 +119,7 @@ Executes a full scan and saves all artifacts to a run directory.
 tokmd run --output-dir .runs/baseline
 
 # Full run with deep analysis
-tokmd run --output-dir .runs/full --preset deep
+tokmd run --output-dir .runs/full --analysis deep
 ```
 
 ### `tokmd analyze`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -210,10 +210,10 @@ tokmd run --output-dir .runs/baseline
 ```
 
 This creates:
+- `receipt.json` — Run manifest
 - `lang.json` — Language summary
 - `module.json` — Module breakdown
 - `export.jsonl` — File inventory
-- `analysis.json` — Derived metrics
 
 Later, you can diff against this baseline:
 


### PR DESCRIPTION
Fixed documentation for `tokmd run` command to match actual behavior:
- Corrected flag from `--preset` to `--analysis`.
- Clarified that `analysis.json` is only produced when `--analysis` is used.
- Added `receipt.json` to the list of output files.
- Updated `reference-cli.md` and `tutorial.md`.

---
*PR created automatically by Jules for task [13022325521935517336](https://jules.google.com/task/13022325521935517336) started by @EffortlessSteven*