### PR TITLE
compat: fix no-default-features build warnings in cockpit 🧷 Compat

### DIFF
--- a/crates/tokmd/src/commands/cockpit/mod.rs
+++ b/crates/tokmd/src/commands/cockpit/mod.rs
@@ -1,0 +1,16 @@
+#[cfg(not(feature = "git"))]
+use anyhow::Result;
+#[cfg(not(feature = "git"))]
+use tokmd_config as cli;
+
+#[cfg(feature = "git")]
+mod impl_git;
+
+#[cfg(feature = "git")]
+pub(crate) use impl_git::*;
+
+#[cfg(not(feature = "git"))]
+pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Result<()> {
+    let _ = args;
+    anyhow::bail!("The cockpit command requires the 'git' feature. Rebuild with --features git");
+}

--- a/crates/tokmd/src/commands/sensor.rs
+++ b/crates/tokmd/src/commands/sensor.rs
@@ -7,11 +7,18 @@
 //! 2. **extras/cockpit_receipt.json** — Full cockpit receipt sidecar
 //! 3. **comment.md** — Markdown summary for PR comments
 
+#[cfg(feature = "git")]
 use std::io::Write;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
+#[cfg(feature = "git")]
+use anyhow::Context;
+
 use tokmd_config as cli;
+
+#[cfg(feature = "git")]
 use tokmd_envelope::findings;
+#[cfg(feature = "git")]
 use tokmd_envelope::{
     Artifact, Finding, FindingSeverity, GateItem, GateResults, SensorReport, ToolMeta, Verdict,
 };
@@ -383,6 +390,7 @@ fn emit_gate_findings(report: &mut SensorReport, evidence: &super::cockpit::Evid
     }
 }
 
+#[cfg(feature = "git")]
 fn render_sensor_md(report: &SensorReport) -> String {
     use std::fmt::Write;
     let mut s = String::new();
@@ -420,6 +428,7 @@ fn render_sensor_md(report: &SensorReport) -> String {
     s
 }
 
+#[cfg(feature = "git")]
 fn now_iso8601() -> String {
     time::OffsetDateTime::now_utc()
         .format(&time::format_description::well_known::Rfc3339)


### PR DESCRIPTION
Refactored `crates/tokmd/src/commands/cockpit.rs` into `crates/tokmd/src/commands/cockpit/` directory to cleanly separate git-dependent logic.
- Moved `cockpit.rs` to `cockpit/impl_git.rs`.
- Created `cockpit/mod.rs` to conditionally include `impl_git` when `feature = "git"`.
- Cleaned up redundant `cfg` attributes in `impl_git.rs`.
- Fixed warnings in `sensor.rs` and `cockpit/mod.rs` by gating imports that are unused when `git` feature is disabled.
- Verified build with `--no-default-features` (0 warnings) and `--all-features` (0 warnings).

---
*PR created automatically by Jules for task [16682293972455012633](https://jules.google.com/task/16682293972455012633) started by @EffortlessSteven*