### PR TITLE
deps: remove unused thiserror dependency 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/20260216-124716.json
+++ b/.jules/deps/envelopes/20260216-124716.json
@@ -1,0 +1,13 @@
+{
+  "id": "20260216-124716",
+  "start_time": "2026-02-16T12:47:16Z",
+  "target": "tokmd-core",
+  "lane": "B",
+  "decision": "Remove unused 'thiserror' dependency",
+  "receipts": [
+    "cargo check -p tokmd-core: passed",
+    "cargo test -p tokmd-core: passed",
+    "cargo fmt --all -- --check: passed",
+    "cargo clippy --workspace -- -D warnings: passed"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -19,5 +19,12 @@
     "target": "dev-dependencies",
     "action": "sync-proptest",
     "status": "success"
+  },
+  {
+    "run_id": "20260216-124716",
+    "timestamp": "2026-02-16T12:47:16Z",
+    "target": "tokmd-core",
+    "action": "remove-unused-dep",
+    "status": "success"
   }
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,7 +3082,6 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokmd-analysis-types",
  "tokmd-config",
  "tokmd-format",

--- a/crates/tokmd-core/Cargo.toml
+++ b/crates/tokmd-core/Cargo.toml
@@ -19,7 +19,6 @@ analysis = ["tokmd-analysis-types"]
 anyhow = "1.0.101"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-thiserror = "2.0"
 tokmd-config.workspace = true
 tokmd-format.workspace = true
 tokmd-settings.workspace = true


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Removed the unused `thiserror` dependency from `tokmd-core`. This crate manually implements `std::error::Error` for `TokmdError` and uses `anyhow` for internal error handling, making `thiserror` unnecessary.

## 🎯 Why (user/dev pain)
Unused dependencies add bloat to `Cargo.lock` and potential confusion for contributors. Keeping the dependency tree minimal reduces compilation time and security surface area.

## 🔎 Evidence (before/after)
- **Before:** `crates/tokmd-core/Cargo.toml` included `thiserror = "2.0"`.
- **After:** Dependency removed.
- **Verification:** `cargo check -p tokmd-core` passes without the dependency.

## 🧭 Options considered
### Option A (recommended)
- Remove the unused dependency.
- Fits the repo's goal of minimal dependencies.
- Trade-offs: None.

### Option B
- Leave it in case it's needed later.
- Trade-offs: Unnecessary bloat.

## ✅ Decision
Option A: Remove the unused dependency.

## 🧱 Changes made (SRP)
- `crates/tokmd-core/Cargo.toml`: Removed `thiserror`.

## 🧪 Verification receipts
- `cargo check -p tokmd-core: passed`
- `cargo test -p tokmd-core: passed`
- `cargo fmt --all -- --check: passed`
- `cargo clippy --workspace -- -D warnings: passed`

## 🧭 Telemetry
- Change shape: Dependency removal.
- Blast radius: `tokmd-core` build configuration.
- Risk class: Low.
- Rollback: Revert commit.
- Merge-confidence gates: `build`, `test`, `clippy`.

## 🗂️ .jules updates
- Appended run `20260216-124716` to `.jules/deps/ledger.json`.
- Created envelope `.jules/deps/envelopes/20260216-124716.json`.

---
*PR created automatically by Jules for task [2586748700767860924](https://jules.google.com/task/2586748700767860924) started by @EffortlessSteven*