### PR TITLE
Fold unreleased CHANGELOG items into v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **Release Guide Modernized**: `RELEASE.md` now documents the `cargo xtask publish` workflow (`--plan`, `--dry-run`, `--yes`, `--from`, `--tag`) and removes stale `scripts/publish-all.ps1` references.
-
-### Fixed
-
-- **xtask Dry-Run Reliability**: `cargo xtask publish --dry-run` now validates each crate via `cargo package --list`, avoiding false failures from crates.io dependency propagation during lockstep release preparation.
-- **Cockpit Determinism Baseline Validation**: malformed baseline JSON now fails loudly, and determinism auto-skip is limited to explicit cockpit receipts (`"mode": "cockpit"`).
-
 ## [1.6.3] - 2026-02-17
 
 ### Added
@@ -37,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Config Microcrate Extraction**: Moved `TomlConfig` schema/parsing types into `tokmd-settings`; `tokmd-config` now re-exports them for compatibility
 - **CLI Wiring**: `tokmd` now consumes `tokmd-progress` and `tokmd-badge` instead of local modules
 - **Determinism Gate Baseline Parsing**: Non-`ComplexityBaseline` files passed to `--baseline` now skip determinism gate instead of hard-failing cockpit runs
+- **Release Guide Modernized**: `RELEASE.md` now documents the `cargo xtask publish` workflow (`--plan`, `--dry-run`, `--yes`, `--from`, `--tag`) and removes stale `scripts/publish-all.ps1` references.
+
+### Fixed
+
+- **xtask Dry-Run Reliability**: `cargo xtask publish --dry-run` now validates each crate via `cargo package --list`, avoiding false failures from crates.io dependency propagation during lockstep release preparation.
+- **Cockpit Determinism Baseline Validation**: malformed baseline JSON now fails loudly, and determinism auto-skip is limited to explicit cockpit receipts (`"mode": "cockpit"`).
 
 ## [1.6.2] - 2026-02-16
 


### PR DESCRIPTION
## Summary
- Folds unreleased CHANGELOG entries into the v1.6.3 release section
- Final prep step before tagging v1.6.3

## Test plan
- No code changes; CHANGELOG formatting only