### PR TITLE
Fix Docker Rust version and xtask publish ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # =============================================================================
 # Stage 1: Build
 # =============================================================================
-FROM rust:1.85-alpine AS builder
+FROM rust:1.92-alpine AS builder
 
 # Install build dependencies for musl-based static linking
 RUN apk add --no-cache musl-dev

--- a/xtask/src/tasks/publish.rs
+++ b/xtask/src/tasks/publish.rs
@@ -491,7 +491,10 @@ fn execute_publish(crates: &[String], args: &PublishArgs) -> Result<(Vec<String>
 fn is_publish_dependency(kind: &DependencyKind) -> bool {
     matches!(
         kind,
-        DependencyKind::Normal | DependencyKind::Build | DependencyKind::Unknown
+        DependencyKind::Normal
+            | DependencyKind::Build
+            | DependencyKind::Development
+            | DependencyKind::Unknown
     )
 }
 
@@ -1011,6 +1014,6 @@ mod tests {
     fn test_is_publish_dependency() {
         assert!(is_publish_dependency(&DependencyKind::Normal));
         assert!(is_publish_dependency(&DependencyKind::Build));
-        assert!(!is_publish_dependency(&DependencyKind::Development));
+        assert!(is_publish_dependency(&DependencyKind::Development));
     }
 }


### PR DESCRIPTION
## Summary
- **Dockerfile**: Bump `rust:1.85-alpine` → `rust:1.92-alpine` to match workspace MSRV (`rust-version = "1.92"`)
- **xtask publish**: Include `DependencyKind::Development` in `is_publish_dependency()` so dev-deps are respected in topological publish ordering — fixes `tokmd-analysis-format` being scheduled before its dev-dep `tokmd-analysis`

## Test plan
- [x] `cargo test --verbose` — full workspace passes (0 failures)
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test -p xtask --verbose` — updated unit test passes