### PR TITLE
test: lock deterministic ordering for TomlConfig views 🧪 Gatekeeper

### DIFF
--- a/.jules/quality/envelopes/20260222-213627.json
+++ b/.jules/quality/envelopes/20260222-213627.json
@@ -1,0 +1,15 @@
+{
+  "id": "20260222-213627",
+  "agent": "Gatekeeper",
+  "target": "crates/tokmd-settings",
+  "goal": "Enforce deterministic ordering in TomlConfig serialization for view profiles",
+  "decision": "Replace HashMap with BTreeMap for TomlConfig.view",
+  "files_changed": [
+    "crates/tokmd-settings/src/lib.rs",
+    "crates/tokmd-settings/tests/determinism.rs"
+  ],
+  "verification": {
+    "new_test": "crates/tokmd-settings/tests/determinism.rs",
+    "status": "passed"
+  }
+}

--- a/.jules/quality/ledger.json
+++ b/.jules/quality/ledger.json
@@ -8,5 +8,10 @@
     "run_id": "2026-01-30-gatekeeper-analysis-determinism",
     "timestamp": "2026-01-30T11:00:00Z",
     "summary": "Added determinism regression test for analysis reports."
+  },
+  {
+    "run_id": "20260222-213627",
+    "timestamp": "2026-02-22T21:36:27Z",
+    "summary": "Switched TomlConfig to BTreeMap for deterministic serialization of view profiles."
   }
 ]

--- a/crates/tokmd-settings/src/lib.rs
+++ b/crates/tokmd-settings/src/lib.rs
@@ -16,7 +16,7 @@
 //! * I/O operations
 //! * Business logic
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -393,7 +393,7 @@ pub struct TomlConfig {
 
     /// Named view profiles (e.g., [view.llm], [view.ci]).
     #[serde(default)]
-    pub view: HashMap<String, ViewProfile>,
+    pub view: BTreeMap<String, ViewProfile>,
 }
 
 /// Scan settings shared by all commands.

--- a/crates/tokmd-settings/tests/determinism.rs
+++ b/crates/tokmd-settings/tests/determinism.rs
@@ -1,0 +1,26 @@
+use std::collections::BTreeMap;
+use tokmd_settings::{TomlConfig, ViewProfile};
+
+#[test]
+fn test_toml_config_determinism() {
+    let mut view = BTreeMap::new();
+    // Insert in reverse order to test sorting
+    view.insert("zebra".to_string(), ViewProfile::default());
+    view.insert("beta".to_string(), ViewProfile::default());
+    view.insert("alpha".to_string(), ViewProfile::default());
+
+    let config = TomlConfig {
+        view,
+        ..Default::default()
+    };
+
+    let json = serde_json::to_string(&config).expect("failed to serialize");
+
+    // Check view keys order
+    let p_alpha = json.find("\"alpha\":").expect("alpha profile missing");
+    let p_beta = json.find("\"beta\":").expect("beta profile missing");
+    let p_zebra = json.find("\"zebra\":").expect("zebra profile missing");
+
+    assert!(p_alpha < p_beta, "alpha should be before beta");
+    assert!(p_beta < p_zebra, "beta should be before zebra");
+}


### PR DESCRIPTION
## 💡 Summary
Enforced deterministic ordering for `TomlConfig.view` by replacing `HashMap` with `BTreeMap`. This ensures that configuration serialization (e.g., `tokmd.toml`) is stable and sorted by profile name.

## 🎯 Why (user/dev pain)
Non-deterministic ordering in configuration files can cause unnecessary diff noise when files are regenerated or modified by tools.

## 🔎 Evidence (before/after)
- Before: `HashMap` iteration order is arbitrary.
- After: `BTreeMap` ensures keys are sorted alphabetically.
- Verified by new test `crates/tokmd-settings/tests/determinism.rs`.

## 🧭 Options considered
### Option A (recommended)
- Replace `HashMap` with `BTreeMap`.
- Fits this repo as `BTreeMap` is already used in `tokmd-config` for `UserConfig`.
- Trade-offs: negligible performance impact for config files.

## ✅ Decision
Option A.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd-settings/src/lib.rs` to use `BTreeMap`.
- Added `crates/tokmd-settings/tests/determinism.rs`.
- Updated `.jules/quality/ledger.json` and created envelope.

## 🧪 Verification receipts
- `cargo check -p tokmd-settings` passed.
- `cargo test -p tokmd-settings` passed (including new test).
- `cargo test -p tokmd-config` passed.


---
*PR created automatically by Jules for task [16729127158539051677](https://jules.google.com/task/16729127158539051677) started by @EffortlessSteven*