### PR TITLE
deps: remove unused serde_json and tokmd-model from dev-dependencies 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/20260223-212918.json
+++ b/.jules/deps/envelopes/20260223-212918.json
@@ -1,0 +1,12 @@
+{
+  "id": "20260223-212918",
+  "start_time": "2026-02-23T21:29:25Z",
+  "target": "tokmd",
+  "lane": "B",
+  "decision": "Remove redundant serde_json and tokmd-model from dev-dependencies",
+  "receipts": [
+    "cargo check -p tokmd: passed",
+    "cargo clippy -p tokmd: passed",
+    "cargo test -p tokmd: passed"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -19,5 +19,12 @@
     "target": "dev-dependencies",
     "action": "sync-proptest",
     "status": "success"
+  },
+  {
+    "run_id": "20260223-212918",
+    "timestamp": "2026-02-23T21:29:25Z",
+    "target": "tokmd",
+    "action": "remove-duplicate-deps",
+    "status": "success"
   }
 ]

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -81,6 +81,4 @@ tempfile = "3.25.0"
 insta = { workspace = true }
 regex = "1.12.3"
 proptest = "1.10.0"
-serde_json = "1.0.149"
-tokmd-model.workspace = true
 jsonschema = "0.42.0"


### PR DESCRIPTION
## 💡 Summary
Removed `serde_json` and `tokmd-model` from `[dev-dependencies]` in `crates/tokmd/Cargo.toml`.

## 🎯 Why (user/dev pain)
These dependencies were duplicated in `[dependencies]` and `[dev-dependencies]`. Dependencies are automatically available to tests, so the dev-dependency entries were redundant noise.

## 🔎 Evidence (before/after)
- `crates/tokmd/Cargo.toml` before: contained duplicate entries.
- `crates/tokmd/Cargo.toml` after: removed duplicates.
- `cargo check -p tokmd`: passed.
- `cargo test -p tokmd`: passed.

## 🧭 Options considered
### Option A (recommended)
Remove them. Simplifies `Cargo.toml`.
### Option B
Leave them. Harmless but noisy.

## ✅ Decision
Option A: Remove them to keep the manifest clean.

## 🧱 Changes made (SRP)
- `crates/tokmd/Cargo.toml`: removed lines.

## 🧪 Verification receipts
- `cargo check -p tokmd: passed`
- `cargo clippy -p tokmd: passed`
- `cargo test -p tokmd: passed`

## 🗂️ .jules updates
- Updated `.jules/deps/ledger.json`.
- Created `.jules/deps/envelopes/20260223-212918.json`.

---
*PR created automatically by Jules for task [13174529908949957068](https://jules.google.com/task/13174529908949957068) started by @EffortlessSteven*