### PR TITLE
docs: fix incorrect 'tokmd context' CLI examples 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/20260224-041314.json
+++ b/.jules/docs/envelopes/20260224-041314.json
@@ -1,0 +1,21 @@
+{
+  "run_id": "20260224-041314",
+  "persona": "Librarian",
+  "goal": "Fix incorrect 'tokmd context' CLI examples in documentation",
+  "lane": "B",
+  "decision": "Option A (recommended)",
+  "receipts": [
+    {
+      "command": "cargo run -- context --budget 1k --mode bundle --output context.txt test_context",
+      "result": "Success: Wrote context.txt (verified content)"
+    },
+    {
+      "command": "cargo run -- context --budget 1k --mode list --output list.txt test_context",
+      "result": "Success: Wrote list.txt (verified content)"
+    },
+    {
+      "command": "cargo check --workspace",
+      "result": "Success: All checks passed (except unrelated Python binding link errors in test mode)"
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -10,5 +10,11 @@
     "date": "2026-01-30",
     "persona": "Librarian",
     "description": "Documented configuration files and profiles in README, removed misleading scan config from reference"
+  },
+  {
+    "run_id": "20260224-041314",
+    "date": "2026-02-24",
+    "persona": "Librarian",
+    "description": "Fix incorrect 'tokmd context' CLI examples in documentation"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tokmd > summary.md
 tokmd module --module-roots crates,packages
 
 # 3. Pack for LLM context (smart selection)
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # 4. Analysis report (derived metrics)
 tokmd analyze --preset receipt --format md
@@ -65,9 +65,9 @@ tokmd diff main HEAD
 Pack files into an LLM context window with budget-aware selection:
 
 ```bash
-tokmd context --budget 128k --output bundle --output context.txt  # Ready to paste
+tokmd context --budget 128k --mode bundle --output context.txt  # Ready to paste
 tokmd context --budget 200k --strategy spread                  # Coverage across modules
-tokmd context --budget 100k --output bundle --compress --output context.txt  # Strip blank lines for density
+tokmd context --budget 100k --mode bundle --compress --output context.txt  # Strip blank lines for density
 ```
 
 ### LLM Context Planning
@@ -76,10 +76,10 @@ Smartly select files to fit your context window:
 
 ```bash
 # Pack top files by code volume into 128k tokens
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Or generate a manifest to see what fits
-tokmd context --budget 128k --output list
+tokmd context --budget 128k --mode list
 ```
 
 ### PR Summaries

--- a/crates/tokmd/README.md
+++ b/crates/tokmd/README.md
@@ -29,7 +29,7 @@ tokmd
 tokmd module --module-roots crates,packages
 
 # Pack for LLM context
-tokmd context --budget 128k --output bundle > context.txt
+tokmd context --budget 128k --mode bundle > context.txt
 
 # Analysis report
 tokmd analyze --preset risk --format md

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -10,13 +10,13 @@ When you need to feed actual code to an LLM (not just metadata), use the `contex
 
 ```bash
 # Pack files into 128k tokens (Claude's context window)
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Spread coverage across modules instead of just largest files
-tokmd context --budget 128k --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --strategy spread --mode bundle --output context.txt
 
 # Strip blank lines for maximum density
-tokmd context --budget 128k --output bundle --compress --output context.txt
+tokmd context --budget 128k --mode bundle --compress --output context.txt
 
 # Use module roots for better organization
 tokmd context --budget 128k --module-roots crates,src --strategy spread --output context.txt

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -424,7 +424,7 @@ Packs files into an LLM context window within a token budget. Intelligently sele
 | `--budget <SIZE>` | Token budget with optional k/m suffix (e.g., `128k`, `1m`, `50000`). | `128k` |
 | `--strategy <STRATEGY>` | Packing strategy: `greedy` (largest first), `spread` (coverage across modules). | `greedy` |
 | `--rank-by <METRIC>` | Metric to rank files: `code`, `tokens`, `churn`, `hotspot`. | `code` |
-| `--output <MODE>` | Output mode: `list` (file stats), `bundle` (concatenated content), `json` (receipt). | `list` |
+| `--mode <MODE>` | Output mode: `list` (file stats), `bundle` (concatenated content), `json` (receipt). | `list` |
 | `--compress` | Strip blank lines from bundle output. | `false` |
 | `--module-roots <DIRS>` | Comma-separated list of root directories for module grouping. | `(none)` |
 | `--module-depth <N>` | How deep to group modules. | `2` |
@@ -442,16 +442,16 @@ Packs files into an LLM context window within a token budget. Intelligently sele
 tokmd context --budget 128k
 
 # Create a bundle ready to paste into Claude
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Spread coverage across modules instead of taking largest files
 tokmd context --budget 200k --strategy spread
 
 # Compressed bundle (no blank lines)
-tokmd context --budget 100k --output bundle --compress --output bundle.txt
+tokmd context --budget 100k --mode bundle --compress --output bundle.txt
 
 # JSON receipt for programmatic use
-tokmd context --budget 128k --output json --output selection.json
+tokmd context --budget 128k --mode json --output selection.json
 
 # Bundle to directory for large outputs
 tokmd context --budget 200k --bundle-dir ./ctx-bundle

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -133,7 +133,7 @@ Files with different encodings may report different sizes.
 **Check what's selected**:
 ```bash
 # List mode shows what would be packed
-tokmd context --budget 128k --output list
+tokmd context --budget 128k --mode list
 ```
 
 **Check token estimates**:
@@ -150,7 +150,7 @@ tokmd export --format csv | head -20
 **Workaround**: Use a smaller budget than your actual context window:
 ```bash
 # For 128k context, use 100k budget
-tokmd context --budget 100k --output bundle
+tokmd context --budget 100k --mode bundle
 ```
 
 **2. Wrong files selected with greedy strategy**
@@ -164,7 +164,7 @@ tokmd context --budget 128k --strategy spread
 
 Strip them for maximum density:
 ```bash
-tokmd context --budget 128k --output bundle --compress
+tokmd context --budget 128k --mode bundle --compress
 ```
 
 ---

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,7 +100,7 @@ You want to paste actual code into an LLM, but your repo is too large. Use `cont
 
 ```bash
 # Pack the most valuable files into 128k tokens
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 ```
 
 **What happened?**
@@ -112,13 +112,13 @@ tokmd context --budget 128k --output bundle --output context.txt
 **Alternative strategies**:
 ```bash
 # Spread coverage across all modules
-tokmd context --budget 128k --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --strategy spread --mode bundle --output context.txt
 
 # Strip blank lines for maximum density
-tokmd context --budget 128k --output bundle --compress --output context.txt
+tokmd context --budget 128k --mode bundle --compress --output context.txt
 
 # Use module roots for better organization
-tokmd context --budget 128k --module-roots src,crates --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --module-roots src,crates --strategy spread --mode bundle --output context.txt
 ```
 
 ## Step 5: Creating a File Inventory for AI


### PR DESCRIPTION
Corrects documentation where `tokmd context` examples used `--output` instead of `--mode` for the output format (list, bundle, json). The `--output` flag expects a file path, and using it for both mode and path caused CLI errors.

This change:
- Replaces `--output bundle/list/json` with `--mode bundle/list/json` in all documentation.
- Updates CLI reference table for `tokmd context`.
- Ensures examples work with the current CLI parser.

Run ID: 20260224-041314
Persona: Librarian
Lane: B (Scout Discovery)

---
*PR created automatically by Jules for task [3455536982554189103](https://jules.google.com/task/3455536982554189103) started by @EffortlessSteven*