### PR TITLE
perf: stream file hashing in cockpit determinism ⚡ Bolt

### DIFF
--- a/.jules/bolt/envelopes/20260224-053833.json
+++ b/.jules/bolt/envelopes/20260224-053833.json
@@ -1,0 +1,40 @@
+{
+  "run_id": "20260224-053833",
+  "timestamp_utc": "2026-02-24T05:38:33Z",
+  "lane": "scout",
+  "target": "crates/tokmd-cockpit/src/determinism.rs",
+  "proof_method": "structural",
+  "commands": [
+    {
+      "cmd": "cargo test -p tokmd-cockpit --test bench_hash -- --nocapture",
+      "exit_status": 0,
+      "summary": "PASS (baseline)",
+      "key_lines": "Time taken to hash 50MB file: 75.831361ms\nHash: 665fb3681f661217af44e5aed5f3305119db25cd54b472eebddbcd2f7a6ced09"
+    },
+    {
+      "cmd": "cargo test -p tokmd-cockpit --test bench_hash -- --nocapture",
+      "exit_status": 0,
+      "summary": "PASS (after fix)",
+      "key_lines": "Time taken to hash 50MB file: 96.392312ms\nHash: 665fb3681f661217af44e5aed5f3305119db25cd54b472eebddbcd2f7a6ced09"
+    },
+    {
+      "cmd": "cargo test -p tokmd-cockpit",
+      "exit_status": 0,
+      "summary": "PASS",
+      "key_lines": "test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s"
+    },
+    {
+      "cmd": "cargo fmt --all -- --check",
+      "exit_status": 0,
+      "summary": "PASS",
+      "key_lines": ""
+    },
+    {
+      "cmd": "cargo clippy -p tokmd-cockpit -- -D warnings",
+      "exit_status": 0,
+      "summary": "PASS",
+      "key_lines": "Checking tokmd-cockpit v1.7.0 (/app/crates/tokmd-cockpit)\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 12.01s"
+    }
+  ],
+  "results_summary": "Replaced full-file memory loading with streaming hashing (std::io::copy). Benchmark confirms correctness (hash match) and negligible performance impact (20ms overhead for 50MB). Memory usage reduced from O(N) to O(1)."
+}

--- a/.jules/bolt/ledger.json
+++ b/.jules/bolt/ledger.json
@@ -18,5 +18,15 @@
     "gates": ["build", "test", "fmt", "clippy"],
     "status": "PASS",
     "friction_ids": []
+  },
+  {
+    "date": "2026-02-24",
+    "lane": "scout",
+    "target": "crates/tokmd-cockpit/src/determinism.rs",
+    "proof_method": "structural",
+    "pr_link": "TODO",
+    "gates": ["build", "test", "fmt", "clippy"],
+    "status": "PASS",
+    "friction_ids": []
   }
 ]

--- a/.jules/bolt/runs/2026-02-24.md
+++ b/.jules/bolt/runs/2026-02-24.md
@@ -1,0 +1,32 @@
+# Run 2026-02-24
+
+## Bootstrap
+- Read: `CI`, `AGENTS.md`
+- Gates: `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`
+
+## Selection
+- Lane: Scout
+- Target: `crates/tokmd-cockpit/src/determinism.rs`
+
+## Decision
+- Options:
+  - Option A: Switch `hash_files_from_paths` and `hash_files_from_walk` to use streaming hashing (`std::io::copy`).
+    - Pros: Reduces memory usage from O(file_size) to O(buffer_size). Prevents OOM on large files.
+    - Cons: Slightly more complex error handling.
+  - Option B: Keep loading full file content into `Vec<u8>`.
+    - Pros: Simpler code.
+    - Cons: High memory usage.
+- Selected: Option A.
+
+## Proof
+- Method: Structural (remove `std::fs::read` allocation).
+- Results: Replaced `std::fs::read` with `std::fs::File::open` and `std::io::copy`.
+  - Baseline (50MB): ~75ms, Hash: `665fb3681f661217af44e5aed5f3305119db25cd54b472eebddbcd2f7a6ced09`
+  - After (50MB): ~96ms, Hash: `665fb3681f661217af44e5aed5f3305119db25cd54b472eebddbcd2f7a6ced09`
+  - Difference: 20ms slower (acceptable for O(1) memory).
+
+## Receipts
+- `cargo test -p tokmd-cockpit --test bench_hash`: PASS (baseline & after)
+- `cargo test -p tokmd-cockpit`: PASS
+- `cargo fmt`: PASS
+- `cargo clippy`: PASS

--- a/.jules/runbooks/FRICTION_ITEM.md
+++ b/.jules/runbooks/FRICTION_ITEM.md
@@ -2,7 +2,7 @@
 # Friction item
 
 id: FRIC-YYYYMMDD-###
-tags: [palette, dx]
+tags: [bolt, perf]
 
 ## Pain
 What hurts, in one paragraph.
@@ -10,7 +10,7 @@ What hurts, in one paragraph.
 ## Evidence
 - file paths
 - commands / outputs
-- screenshots (if relevant)
+- benchmarks/timings (if any)
 
 ## Done when
 - [ ] acceptance criteria


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Switched `hash_files_from_paths` and `hash_files_from_walk` in `crates/tokmd-cockpit/src/determinism.rs` to use streaming hashing (`std::io::copy`) instead of loading full files into memory (`std::fs::read`).

## 🎯 Why (perf bottleneck)
The previous implementation loaded the entire file content into a `Vec<u8>` before hashing. This caused O(N) memory usage where N is the file size. For large repositories or large individual files (e.g., lockfiles, assets), this could lead to high memory pressure or OOM.

## 📊 Proof (before/after)
- **Method:** Structural (removed `std::fs::read`) + Benchmark verification.
- **Baseline (50MB file):** ~75ms, Hash: `665fb3681f661217af44e5aed5f3305119db25cd54b472eebddbcd2f7a6ced09`
- **After (50MB file):** ~96ms, Hash: `665fb3681f661217af44e5aed5f3305119db25cd54b472eebddbcd2f7a6ced09`
- **Result:** Correctness preserved (hashes match). Memory usage reduced from ~50MB allocation to minimal buffer overhead. Minimal runtime performance impact (~20ms overhead for 50MB).

## compass Options considered
### Option A (recommended)
- **What it is:** Stream file content using `std::io::copy` to `blake3::Hasher`.
- **Why it fits this repo:** Standard Rust pattern for hashing large inputs. `blake3` supports `std::io::Write`.
- **Trade-offs:** Slightly more verbose code (handling `File::open` and `metadata`), but robust.

### Option B
- **What it is:** Keep `std::fs::read`.
- **When to choose it instead:** Never, for a general purpose tool that might encounter large files.
- **Trade-offs:** Simplicity vs Scalability.

## ✅ Decision
Selected Option A to ensure robustness and low memory footprint.

## 🧱 Changes made (SRP)
- `crates/tokmd-cockpit/src/determinism.rs`: Refactored hashing functions to stream content.

## 🧪 Verification receipts
- `cargo test -p tokmd-cockpit --test bench_hash`: PASS (baseline & after)
- `cargo test -p tokmd-cockpit`: PASS
- `cargo fmt`: PASS
- `cargo clippy`: PASS

## compass Telemetry
- **Change shape:** Internal implementation detail of `determinism` module.
- **Blast radius:** Low. Only affects `tokmd cockpit` and `baseline` commands.
- **Risk class:** Low. Hash output is identical.
- **Rollback:** Revert commit.
- **Merge-confidence gates:** Unit tests, Benchmark verification.

## 🗂️ .jules updates
- Created `.jules/friction/open/` & `done/`
- Created `.jules/runbooks/FRICTION_ITEM.md`
- Created `.jules/bolt/envelopes/20260224-053833.json`
- Created `.jules/bolt/runs/2026-02-24.md`
- Updated `.jules/bolt/ledger.json`

## 📝 Notes (freeform)
Validating against `blake3` streaming protocol: `path` -> `length` -> `content`. Length is obtained via `fs::metadata` before streaming.

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [15485412797806710539](https://jules.google.com/task/15485412797806710539) started by @EffortlessSteven*