### PR TITLE
compat: fix no-default-features build for tokmd binary 🧷 Compat

### DIFF
--- a/.jules/compat/envelopes/run-20260224-compat-001.json
+++ b/.jules/compat/envelopes/run-20260224-compat-001.json
@@ -1,0 +1,21 @@
+{
+  "run_id": "run-20260224-compat-001",
+  "lane": "scout",
+  "target": "tokmd",
+  "proof_method": "structural",
+  "decision": "Option A (fix gating)",
+  "changes": [
+    "crates/tokmd/src/commands/baseline.rs",
+    "crates/tokmd/src/commands/cockpit.rs",
+    "crates/tokmd/src/commands/sensor.rs",
+    "crates/tokmd/tests/baseline_integration.rs",
+    "crates/tokmd/tests/cockpit_integration.rs",
+    "crates/tokmd/tests/sensor_integration.rs",
+    "crates/tokmd/tests/docs.rs"
+  ],
+  "verification": {
+    "no-default-features": "passed",
+    "all-features": "passed",
+    "tests": "passed (including no-default-features)"
+  }
+}

--- a/.jules/compat/ledger.json
+++ b/.jules/compat/ledger.json
@@ -11,5 +11,11 @@
     "date": "2024-05-24",
     "target": "tokmd-analysis",
     "improvement": "fixed unused fields warning in no-default-features build"
+  },
+  {
+    "run_id": "run-20260224-compat-001",
+    "date": "2026-02-24",
+    "target": "tokmd",
+    "improvement": "fixed no-default-features build for tokmd binary"
   }
 ]

--- a/.jules/compat/runs/2026-02-24.md
+++ b/.jules/compat/runs/2026-02-24.md
@@ -1,0 +1,33 @@
+# Compat Run 2026-02-24
+
+## run-20260224-compat-001 (tokmd)
+
+**Goal**: Fix `--no-default-features` build failure in `tokmd` binary.
+
+**Target**: `crates/tokmd/src/commands/`
+**Proof Method**: `cargo build --no-default-features` and `cargo test --no-default-features -p tokmd`
+
+**Before**:
+- `cargo build --no-default-features` failed due to unresolved import `tokmd_cockpit` in `baseline.rs` and unused imports in `cockpit.rs` and `sensor.rs`.
+- Integration tests failed because they expected `git` and `content` features to be present.
+
+**After**:
+- `cargo build --no-default-features` passes.
+- `cargo build --all-features` passes.
+- `cargo test -p tokmd` passes.
+- `cargo test --no-default-features -p tokmd` passes (irrelevant tests skipped).
+
+**Changes**:
+- `crates/tokmd/src/commands/baseline.rs`: Gated `tokmd_cockpit` usage behind `git` feature.
+- `crates/tokmd/src/commands/cockpit.rs`: Gated imports and re-exports behind `git` feature.
+- `crates/tokmd/src/commands/sensor.rs`: Gated imports and functions behind `git` feature. Gated tests module.
+- `crates/tokmd/tests/baseline_integration.rs`: Gated determinism test behind `git` feature.
+- `crates/tokmd/tests/cockpit_integration.rs`: Gated entire file behind `git` feature.
+- `crates/tokmd/tests/sensor_integration.rs`: Gated entire file behind `git` feature.
+- `crates/tokmd/tests/docs.rs`: Gated `recipe_gate_with_baseline` behind `content` feature (as it depends on complexity metrics).
+
+**Verification**:
+- `cargo build --no-default-features` -> OK
+- `cargo build --all-features` -> OK
+- `cargo test -p tokmd` -> OK
+- `cargo test --no-default-features -p tokmd` -> OK

--- a/crates/tokmd/src/commands/baseline.rs
+++ b/crates/tokmd/src/commands/baseline.rs
@@ -7,12 +7,15 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use tokmd_analysis as analysis;
 use tokmd_analysis_types::{
-    AnalysisArgsMeta, AnalysisSource, ComplexityBaseline, DeterminismBaseline,
+    AnalysisArgsMeta, AnalysisSource, ComplexityBaseline,
 };
+#[cfg(feature = "git")]
+use tokmd_analysis_types::DeterminismBaseline;
 use tokmd_config::{BaselineArgs, GlobalArgs};
 
 use crate::analysis_utils;
 use crate::export_bundle;
+#[cfg(feature = "git")]
 use tokmd_cockpit::determinism;
 use tokmd_progress::Progress;
 
@@ -33,7 +36,9 @@ pub(crate) fn handle(args: BaselineArgs, global: &GlobalArgs) -> Result<()> {
     let bundle = export_bundle::load_export_from_inputs(&inputs, global)?;
 
     // Save file paths and root before the bundle is consumed by analysis
+    #[cfg(feature = "git")]
     let scan_root = bundle.root.clone();
+    #[cfg(feature = "git")]
     let file_paths: Vec<String> = if args.determinism {
         bundle.export.rows.iter().map(|r| r.path.clone()).collect()
     } else {
@@ -101,8 +106,16 @@ pub(crate) fn handle(args: BaselineArgs, global: &GlobalArgs) -> Result<()> {
 
     // Compute determinism baseline if requested
     if args.determinism {
-        progress.set_message("Computing determinism hashes...");
-        baseline.determinism = Some(compute_determinism_baseline(&scan_root, &file_paths)?);
+        #[cfg(feature = "git")]
+        {
+            progress.set_message("Computing determinism hashes...");
+            baseline.determinism = Some(compute_determinism_baseline(&scan_root, &file_paths)?);
+        }
+        #[cfg(not(feature = "git"))]
+        {
+            // Determinism checks require the git feature
+            progress.set_message("Skipping determinism checks (requires 'git' feature)...");
+        }
     }
 
     // Create output directory if needed
@@ -153,6 +166,7 @@ pub(crate) fn handle(args: BaselineArgs, global: &GlobalArgs) -> Result<()> {
 ///
 /// Hashes all source files and optionally `Cargo.lock` to create a
 /// reproducibility fingerprint.
+#[cfg(feature = "git")]
 fn compute_determinism_baseline(root: &Path, file_paths: &[String]) -> Result<DeterminismBaseline> {
     let path_refs: Vec<&str> = file_paths.iter().map(|s| s.as_str()).collect();
     let source_hash = determinism::hash_files_from_paths(root, &path_refs)?;

--- a/crates/tokmd/src/commands/cockpit.rs
+++ b/crates/tokmd/src/commands/cockpit.rs
@@ -3,13 +3,18 @@
 //! This is a thin CLI handler that delegates to `tokmd-cockpit` for computation
 //! and rendering. Types are re-exported from `tokmd_types::cockpit`.
 
+#[cfg(feature = "git")]
 use std::io::Write;
+#[cfg(feature = "git")]
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
+#[cfg(feature = "git")]
+use anyhow::Context;
 use tokmd_config as cli;
 
 // Re-export all cockpit types for backwards compatibility with sensor.rs
+#[cfg(feature = "git")]
 pub use tokmd_types::cockpit::*;
 
 // Re-export computation functions used by sensor.rs
@@ -109,6 +114,7 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
 }
 
 #[cfg(test)]
+#[cfg(feature = "git")]
 mod tests {
     #[cfg(feature = "git")]
     use anyhow::Result;

--- a/crates/tokmd/src/commands/sensor.rs
+++ b/crates/tokmd/src/commands/sensor.rs
@@ -7,11 +7,16 @@
 //! 2. **extras/cockpit_receipt.json** — Full cockpit receipt sidecar
 //! 3. **comment.md** — Markdown summary for PR comments
 
+#[cfg(feature = "git")]
 use std::io::Write;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
+#[cfg(feature = "git")]
+use anyhow::Context;
 use tokmd_config as cli;
+#[cfg(feature = "git")]
 use tokmd_envelope::findings;
+#[cfg(feature = "git")]
 use tokmd_envelope::{
     Artifact, Finding, FindingSeverity, GateItem, GateResults, SensorReport, ToolMeta, Verdict,
 };
@@ -402,6 +407,7 @@ fn emit_gate_findings(report: &mut SensorReport, evidence: &super::cockpit::Evid
     }
 }
 
+#[cfg(feature = "git")]
 fn render_sensor_md(report: &SensorReport) -> String {
     use std::fmt::Write;
     let mut s = String::new();
@@ -446,6 +452,7 @@ fn now_iso8601() -> String {
 }
 
 #[cfg(test)]
+#[cfg(feature = "git")]
 mod tests {
     use super::*;
 

--- a/crates/tokmd/tests/baseline_integration.rs
+++ b/crates/tokmd/tests/baseline_integration.rs
@@ -25,6 +25,7 @@ fn baseline_generates_output_file() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+#[cfg(feature = "git")]
 fn baseline_with_determinism_flag() -> Result<(), Box<dyn std::error::Error>> {
     let dir = tempfile::tempdir()?;
     let out_file = dir.path().join("baseline.json");

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -1,5 +1,7 @@
 //! Integration tests for the `tokmd cockpit` command.
 
+#![cfg(feature = "git")]
+
 mod common;
 
 use assert_cmd::Command;

--- a/crates/tokmd/tests/docs.rs
+++ b/crates/tokmd/tests/docs.rs
@@ -143,6 +143,7 @@ fn recipe_sensor_json() {
     assert!(report_path.exists());
 }
 
+#[cfg(feature = "content")]
 #[test]
 fn recipe_gate_with_baseline() {
     // "tokmd gate --baseline baseline.json"

--- a/crates/tokmd/tests/sensor_integration.rs
+++ b/crates/tokmd/tests/sensor_integration.rs
@@ -1,5 +1,7 @@
 //! Integration tests for the `tokmd sensor` command.
 
+#![cfg(feature = "git")]
+
 mod common;
 
 use assert_cmd::Command;


### PR DESCRIPTION
This PR fixes the build failure when compiling `tokmd` with `--no-default-features`. It gates the usage of `tokmd-cockpit` (which depends on `git` feature) and ensures that integration tests are skipped when the necessary features are missing. This improves the matrix compatibility of the crate.

---
*PR created automatically by Jules for task [1923843253777981935](https://jules.google.com/task/1923843253777981935) started by @EffortlessSteven*