### PR TITLE
docs: add doctests to module and export workflows 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/20260224-105905.json
+++ b/.jules/docs/envelopes/20260224-105905.json
@@ -1,0 +1,14 @@
+{
+  "id": "20260224-105905",
+  "type": "scout",
+  "target": "doctests",
+  "status": "complete",
+  "lane": "B",
+  "receipts": [
+    {
+      "command": "cargo test -p tokmd-core --doc",
+      "result": "success",
+      "details": "Added doctests for module_workflow and export_workflow"
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -10,5 +10,11 @@
     "date": "2026-01-30",
     "persona": "Librarian",
     "description": "Documented configuration files and profiles in README, removed misleading scan config from reference"
+  },
+  {
+    "run_id": "20260224-105905",
+    "date": "2026-02-24",
+    "persona": "Librarian",
+    "description": "Added doctests to `module_workflow` and `export_workflow` in `tokmd-core`"
   }
 ]

--- a/.jules/docs/runs/2026-02-24.md
+++ b/.jules/docs/runs/2026-02-24.md
@@ -1,0 +1,6 @@
+# Run Log: 2026-02-24
+
+## 20260224-105905
+- Status: Complete
+- Persona: Librarian
+- Change: Added doctest examples to `module_workflow` and `export_workflow` in `tokmd-core`.

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -137,6 +137,24 @@ pub fn lang_workflow(scan: &ScanSettings, lang: &LangSettings) -> Result<LangRec
 /// # Returns
 ///
 /// A `ModuleReceipt` containing the module breakdown.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tokmd_core::{module_workflow, settings::{ScanSettings, ModuleSettings}};
+///
+/// // Configure scan
+/// let scan = ScanSettings::current_dir();
+/// let module = ModuleSettings {
+///     module_roots: vec!["crates".to_string()],
+///     module_depth: 1,
+///     ..Default::default()
+/// };
+///
+/// // Run pipeline
+/// let receipt = module_workflow(&scan, &module).expect("Scan failed");
+/// println!("Scanned {} modules", receipt.report.rows.len());
+/// ```
 pub fn module_workflow(scan: &ScanSettings, module: &ModuleSettings) -> Result<ModuleReceipt> {
     let scan_opts = settings_to_scan_options(scan);
     let paths: Vec<PathBuf> = scan.paths.iter().map(PathBuf::from).collect();
@@ -185,6 +203,24 @@ pub fn module_workflow(scan: &ScanSettings, module: &ModuleSettings) -> Result<M
 /// # Returns
 ///
 /// An `ExportReceipt` containing file-level data.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tokmd_core::{export_workflow, settings::{ScanSettings, ExportSettings}};
+///
+/// // Configure scan
+/// let scan = ScanSettings::current_dir();
+/// let export = ExportSettings {
+///     min_code: 10,
+///     max_rows: 50,
+///     ..Default::default()
+/// };
+///
+/// // Run pipeline
+/// let receipt = export_workflow(&scan, &export).expect("Export failed");
+/// println!("Exported {} file rows", receipt.data.rows.len());
+/// ```
 pub fn export_workflow(scan: &ScanSettings, export: &ExportSettings) -> Result<ExportReceipt> {
     let scan_opts = settings_to_scan_options(scan);
     let paths: Vec<PathBuf> = scan.paths.iter().map(PathBuf::from).collect();


### PR DESCRIPTION
This PR adds doctest examples to the `module_workflow` and `export_workflow` functions in `tokmd-core`. This improves documentation coverage for the public API and ensures that these workflows are easy to use for library consumers.

Changes:
- Added `Example` section to `module_workflow` doc comment.
- Added `Example` section to `export_workflow` doc comment.
- Created run envelope `.jules/docs/envelopes/20260224-105905.json`.
- Created run log `.jules/docs/runs/2026-02-24.md`.
- Updated `.jules/docs/ledger.json`.

---
*PR created automatically by Jules for task [4307385533443966216](https://jules.google.com/task/4307385533443966216) started by @EffortlessSteven*