### PR TITLE
deps: remove redundant serde_json/tokmd-model dev-dependencies 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/20260224-125928.json
+++ b/.jules/deps/envelopes/20260224-125928.json
@@ -1,0 +1,11 @@
+{
+  "id": "20260224-125928",
+  "start_time": "2026-02-24T12:59:28Z",
+  "target": "dev-dependencies",
+  "lane": "B",
+  "decision": "Remove redundant `serde_json` and `tokmd-model` entries from `[dev-dependencies]` where they are already present in `[dependencies]`.",
+  "receipts": [
+    "cargo check --workspace: passed",
+    "cargo test --workspace --exclude tokmd-python: passed (tokmd-python tests failed due to environment issues unrelated to changes)"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -19,5 +19,12 @@
     "target": "dev-dependencies",
     "action": "sync-proptest",
     "status": "success"
+  },
+  {
+    "run_id": "20260224-125928",
+    "timestamp": "2026-02-24T12:59:28Z",
+    "target": "dev-dependencies",
+    "action": "remove-redundant-deps",
+    "status": "success"
   }
 ]

--- a/crates/tokmd-analysis-types/Cargo.toml
+++ b/crates/tokmd-analysis-types/Cargo.toml
@@ -19,5 +19,4 @@ tokmd-types.workspace = true
 
 [dev-dependencies]
 proptest = "1.10.0"
-serde_json = "1.0.149"
 

--- a/crates/tokmd-config/Cargo.toml
+++ b/crates/tokmd-config/Cargo.toml
@@ -22,5 +22,4 @@ tokmd-types = { workspace = true, features = ["clap"] }
 
 [dev-dependencies]
 proptest = "1.10.0"
-serde_json = "1.0.149"
 tempfile = "3.25.0"

--- a/crates/tokmd-envelope/Cargo.toml
+++ b/crates/tokmd-envelope/Cargo.toml
@@ -18,5 +18,4 @@ serde_json = "1.0.149"
 
 [dev-dependencies]
 proptest = "1.10.0"
-serde_json = "1.0.149"
 

--- a/crates/tokmd-sensor/Cargo.toml
+++ b/crates/tokmd-sensor/Cargo.toml
@@ -28,6 +28,5 @@ tokmd-types.workspace = true
 tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.149"
 tempfile = "3.25.0"
 

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -98,6 +98,4 @@ tempfile = "3.25.0"
 insta = { workspace = true }
 regex = "1.12.3"
 proptest = "1.10.0"
-serde_json = "1.0.149"
-tokmd-model.workspace = true
 jsonschema = "0.42.0"


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Removed redundant `serde_json` and `tokmd-model` entries from `[dev-dependencies]` in 5 crates (`tokmd`, `tokmd-sensor`, `tokmd-envelope`, `tokmd-config`, `tokmd-analysis-types`) where they were already present in `[dependencies]`.

## 🎯 Why (user/dev pain)
Redundant dependencies add noise to `Cargo.toml`, potentially confuse dependency resolution or human readers, and violate DRY principles.

## 🔎 Evidence (before/after)
- Before: `serde_json` appeared in both sections.
- After: `serde_json` only appears in `[dependencies]`.
- Tests: `cargo check --workspace` and `cargo test --workspace` passed (excluding unrelated `tokmd-python` env issues).

## 🧭 Options considered
### Option A (recommended)
- Remove redundant dev-deps.
- Fits "Scout discovery" lane for Auditor.
- Low risk, high hygiene.

## ✅ Decision
Option A.

## 🧱 Changes made (SRP)
- `crates/tokmd-analysis-types/Cargo.toml`
- `crates/tokmd-config/Cargo.toml`
- `crates/tokmd-envelope/Cargo.toml`
- `crates/tokmd-sensor/Cargo.toml`
- `crates/tokmd/Cargo.toml`

## 🧪 Verification receipts
- `cargo check --workspace`: passed
- `cargo test --workspace --exclude tokmd-python`: passed

## 🗂️ .jules updates
- Created `.jules/deps/envelopes/20260224-125928.json`
- Updated `.jules/deps/ledger.json`

---
*PR created automatically by Jules for task [696053457634771350](https://jules.google.com/task/696053457634771350) started by @EffortlessSteven*