### PR TITLE
fix: prevent non-deterministic redaction hashing 🛡️ Sentinel

### DIFF
--- a/.jules/security/envelopes/20250222-120000.json
+++ b/.jules/security/envelopes/20250222-120000.json
@@ -1,0 +1,19 @@
+{
+  "run_id": "20250222-120000",
+  "timestamp_utc": "2025-02-22T12:00:00Z",
+  "lane": "scout",
+  "target": "determinism",
+  "commands": [
+    {
+      "cmd": "bash reproduce_nondet.sh",
+      "exit_code": 0,
+      "output": "PASS: Hashes are identical."
+    },
+    {
+      "cmd": "cargo test -p tokmd-redact",
+      "exit_code": 0,
+      "output": "16 passed; 21 passed; 2 passed"
+    }
+  ],
+  "results_summary": "Fixed non-deterministic redaction hashing by implementing lexical path cleaning in tokmd-redact."
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -16,5 +16,14 @@
     "gates_run": ["test"],
     "status": "PASS",
     "friction_ids_created": []
+  },
+  {
+    "timestamp_utc": "2025-02-22T12:00:00Z",
+    "lane": "scout",
+    "target": "determinism",
+    "pr_link": "tbd",
+    "gates_run": ["test", "build"],
+    "status": "PASS",
+    "friction_ids_created": []
   }
 ]

--- a/.jules/security/runs/2025-02-22.md
+++ b/.jules/security/runs/2025-02-22.md
@@ -1,0 +1,12 @@
+# Run 2025-02-22
+
+**Lane:** Scout
+**Target:** Determinism (Redaction)
+**Envelope:** [.jules/security/envelopes/20250222-120000.json](../envelopes/20250222-120000.json)
+**PR:** (Pending)
+
+## Findings
+Discovered that `tokmd export --redact paths` produced different hashes for equivalent paths (e.g. `foo` vs `foo/../foo`) because `redact_path` hashed the input string directly without full normalization.
+
+Implemented `clean_path` in `tokmd-redact` to resolving `.` and `..` components before hashing.
+Verified with reproduction script and unit tests.

--- a/crates/tokmd-redact/src/lib.rs
+++ b/crates/tokmd-redact/src/lib.rs
@@ -16,13 +16,49 @@
 
 use std::path::Path;
 
+/// Lexically clean a path (resolve `.` and `..`) and normalize separators.
+///
+/// This ensures consistent hashes for equivalent paths like:
+/// - `src/lib.rs`
+/// - `./src/lib.rs`
+/// - `foo/../src/lib.rs`
+fn clean_path(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    let is_absolute = normalized.starts_with('/');
+
+    let mut components = Vec::new();
+    for component in normalized.split('/') {
+        match component {
+            "" | "." => continue,
+            ".." => {
+                if !components.is_empty() && components.last() != Some(&"..") {
+                    components.pop();
+                } else if !is_absolute {
+                    components.push("..");
+                }
+            }
+            c => components.push(c),
+        }
+    }
+
+    let result = components.join("/");
+    if is_absolute {
+        format!("/{}", result)
+    } else if result.is_empty() {
+        ".".to_string()
+    } else {
+        result
+    }
+}
+
 /// Compute a short (16-character) BLAKE3 hash of a string.
 ///
 /// This is used for redacting sensitive strings like excluded patterns
 /// or module names in receipts.
 ///
-/// Path separators are normalized to forward slashes before hashing
-/// to ensure consistent hashes across operating systems.
+/// Paths are lexically cleaned (resolving `.` and `..`) and normalized
+/// to forward slashes before hashing to ensure consistent hashes across
+/// operating systems and invocation styles.
 ///
 /// # Example
 ///
@@ -34,9 +70,12 @@ use std::path::Path;
 ///
 /// // Cross-platform consistency: same hash regardless of separator
 /// assert_eq!(short_hash("src\\lib"), short_hash("src/lib"));
+///
+/// // Path cleaning: same hash regardless of relative indirection
+/// assert_eq!(short_hash("./src/lib"), short_hash("src/lib"));
 /// ```
 pub fn short_hash(s: &str) -> String {
-    let normalized = s.replace('\\', "/");
+    let normalized = clean_path(s);
     let mut hex = blake3::hash(normalized.as_bytes()).to_hex().to_string();
     hex.truncate(16);
     hex
@@ -47,8 +86,8 @@ pub fn short_hash(s: &str) -> String {
 /// This allows redacted paths to still be recognizable by file type
 /// while hiding the actual path structure.
 ///
-/// Path separators are normalized to forward slashes before hashing
-/// to ensure consistent hashes across operating systems.
+/// Paths are lexically cleaned (resolving `.` and `..`) and normalized
+/// to forward slashes before hashing to ensure consistent hashes.
 ///
 /// # Example
 ///
@@ -59,11 +98,14 @@ pub fn short_hash(s: &str) -> String {
 /// assert!(redacted.ends_with(".json"));
 /// assert_eq!(redacted.len(), 16 + 1 + 4); // hash + dot + "json"
 ///
-/// // Cross-platform consistency: same hash regardless of separator
+/// // Cross-platform consistency
 /// assert_eq!(redact_path("src\\main.rs"), redact_path("src/main.rs"));
+///
+/// // Path cleaning
+/// assert_eq!(redact_path("./src/main.rs"), redact_path("src/main.rs"));
 /// ```
 pub fn redact_path(path: &str) -> String {
-    let normalized = path.replace('\\', "/");
+    let normalized = clean_path(path);
     let ext = Path::new(&normalized)
         .extension()
         .and_then(|e| e.to_str())
@@ -157,5 +199,42 @@ mod tests {
         let r2 = redact_path("crates\\tokmd\\src\\commands\\run.rs");
         assert_eq!(r1, r2);
         assert!(r1.ends_with(".rs"));
+    }
+
+    #[test]
+    fn test_clean_path_dots() {
+        assert_eq!(clean_path("./src/lib.rs"), "src/lib.rs");
+        assert_eq!(clean_path("src/./lib.rs"), "src/lib.rs");
+        assert_eq!(clean_path("src/lib.rs/."), "src/lib.rs");
+    }
+
+    #[test]
+    fn test_clean_path_parent() {
+        assert_eq!(clean_path("src/../lib.rs"), "lib.rs");
+        assert_eq!(clean_path("a/b/../c"), "a/c");
+        assert_eq!(clean_path("a/../../b"), "../b");
+    }
+
+    #[test]
+    fn test_clean_path_absolute() {
+        assert_eq!(clean_path("/src/lib.rs"), "/src/lib.rs");
+        assert_eq!(clean_path("/src/../lib.rs"), "/lib.rs");
+        assert_eq!(clean_path("/../lib.rs"), "/lib.rs"); // Root bounds check
+    }
+
+    #[test]
+    fn test_clean_path_empty() {
+        assert_eq!(clean_path(""), ".");
+        assert_eq!(clean_path("."), ".");
+        assert_eq!(clean_path("./."), ".");
+    }
+
+    #[test]
+    fn test_redact_path_cleans_input() {
+        let r1 = redact_path("src/lib.rs");
+        let r2 = redact_path("./src/lib.rs");
+        let r3 = redact_path("foo/../src/lib.rs");
+        assert_eq!(r1, r2);
+        assert_eq!(r1, r3);
     }
 }


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Implemented lexical path cleaning in `crates/tokmd-redact` to ensure that path redaction (hashing) is deterministic regardless of how the path is expressed (e.g., `src/lib.rs` vs `./src/lib.rs` vs `foo/../src/lib.rs`).

## 🎯 Why / Threat model
**Determinism & Integrity**: `tokmd` receipts should be identical for identical content. Previously, `tokmd export --redact paths` produced different hashes depending on the command-line path syntax (e.g. `.` vs `./`), which leaks information about the invocation environment and breaks receipt reproducibility.

## 🔎 Finding (evidence)
`tokmd export --redact paths` produced different hashes for the same file when invoked with redundant path components.
- `tokmd export dummy` -> hash A
- `tokmd export dummy/../dummy` -> hash B

This was caused by `tokmd-redact::short_hash` hashing the input string directly without resolving `.` and `..`.

## 🧭 Options considered
### Option A (recommended)
- **What it is**: Implement lexical path cleaning inside `tokmd-redact`.
- **Why it fits this repo**: `tokmd-redact` is the canonical utility for redaction. Fixing it here ensures all consumers (export, scan args, etc.) benefit from correct hashing without changing their logic. It avoids adding new dependencies by implementing a simple string-based cleaner.
- **Trade-offs**: Slightly more CPU per path (string splitting/joining), but negligible compared to filesystem I/O.

### Option B
- **What it is**: Normalize paths in `tokmd-model` or `tokmd-scan-args` before passing to redaction.
- **Trade-offs**: Distributed logic. Easy to miss call sites. `tokmd-redact` would remain "unsafe" for raw inputs.

## ✅ Decision
Chose **Option A**. Hardening the utility crate is the most robust fix.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd-redact/src/lib.rs`:
  - Added `clean_path` function.
  - Updated `short_hash` and `redact_path` to use `clean_path`.
  - Added unit tests for `clean_path` and regression tests for `redact_path`.

## 🧪 Verification receipts
- **Reproduction**: Created `reproduce_nondet.sh` which confirmed the bug (FAIL) and then confirmed the fix (PASS).
- **Tests**: Ran `cargo test -p tokmd-redact`. Result: `16 passed; 21 passed; 2 passed`.

## 🧭 Telemetry
- **Change shape**: Logic fix in Tier 0.5 utility.
- **Blast radius**: Low. Affects only redacted outputs.
- **Risk class**: Low. Pure string manipulation.
- **Rollback**: Revert commit.

## 🗂️ .jules updates
- Created `20250222-120000.json` envelope.
- Updated `ledger.json`.
- Created run log `2025-02-22.md`.

## 🔜 Follow-ups
- Consider if `RedactMode::Paths` should also redact module names to prevent structure leakage (potential separate friction item).

---
*PR created automatically by Jules for task [6956158812451862414](https://jules.google.com/task/6956158812451862414) started by @EffortlessSteven*