### PR TITLE
fix: ensure context files are truncated when budget exceeded 🎨 Palette

### DIFF
--- a/.jules/palette/envelopes/20260224-132200.json
+++ b/.jules/palette/envelopes/20260224-132200.json
@@ -1,0 +1,43 @@
+{
+  "run_id": "20260224-132200",
+  "timestamp_utc": "2026-02-24T13:22:00Z",
+  "lane": "scout",
+  "target": "tokmd context budget packing logic",
+  "commands": [
+    {
+      "cmd": "tokmd context large_file.rs --budget 100 --mode bundle",
+      "exit_code": 0,
+      "summary": "FAIL: 2818 bytes (expected truncation)",
+      "details": "Included full file despite 100 token budget (15 token cap)."
+    },
+    {
+      "cmd": "tokmd context large_file.rs --budget 100 --mode bundle",
+      "exit_code": 0,
+      "summary": "PASS: 139 bytes",
+      "details": "Correctly truncated file to head/tail to fit budget."
+    },
+    {
+      "cmd": "CI=true cargo test --verbose",
+      "exit_code": 0,
+      "summary": "PASS",
+      "details": "104 tests passed"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "exit_code": 0,
+      "summary": "PASS",
+      "details": ""
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "exit_code": 0,
+      "summary": "PASS",
+      "details": ""
+    }
+  ],
+  "results": {
+    "before_bytes": 2818,
+    "after_bytes": 139,
+    "tests_passed": true
+  }
+}

--- a/.jules/palette/ledger.json
+++ b/.jules/palette/ledger.json
@@ -11,5 +11,18 @@
       "clippy": "PASS"
     },
     "friction_ids": []
+  },
+  {
+    "date": "2026-02-24T13:22:00Z",
+    "lane": "scout",
+    "target": "tokmd context budget packing logic",
+    "pr_link": "PR_GLASS_COCKPIT",
+    "gates": {
+      "build": "PASS",
+      "test": "PASS",
+      "fmt": "PASS",
+      "clippy": "PASS"
+    },
+    "friction_ids": []
   }
 ]

--- a/.jules/palette/runs/2026-02-24.md
+++ b/.jules/palette/runs/2026-02-24.md
@@ -1,0 +1,25 @@
+# Palette Run 2026-02-24
+
+**Run ID**: 20260224-132200
+**Lane**: Scout
+**Target**: `tokmd context` budget packing logic
+
+## Discovery
+Found that `tokmd context` over-packs files when they exceed the per-file budget cap.
+- `select_files_with_options` caps the token count for accounting.
+- `write_head_tail` uses the capped count to calculate density (`tpl`), which is incorrect.
+- Result: Full file is included instead of a truncated version.
+
+## Options Considered
+
+### Option A (Fix accounting)
+Pass original token counts to `ContextFileRow` or `write_head_tail`. Use original counts for density calculation.
+- Trade-off: Requires modifying `context_pack.rs`.
+
+### Option B (Fix capping)
+Actually truncate the file content in memory before packing? No, we stream/write directly.
+
+## Decision
+Option A. It's the correct fix. We need to preserve the truth about the file size.
+
+## Receipts


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Fixes a bug in `tokmd context` where files exceeding the per-file budget cap were included fully instead of being truncated to head/tail.

## 🎯 Why (user/dev pain)
When using `tokmd context` to pack files for an LLM, users expect the tool to respect the budget.
Previously, if a file exceeded the per-file cap (default 15% of budget), it was flagged for `HeadTail` truncation, but the truncation logic received the *capped* token count instead of the *original* token count.
This caused the density calculation (tokens/line) to be artificially low, leading the truncation logic to believe the whole file fit within the target token count.
Result: The user's context window would overflow.

## 🔎 Evidence (before/after)
**Before:**
`tokmd context large_file.rs --budget 100 --mode bundle` -> Output size 2818 bytes (full file).

**After:**
`tokmd context large_file.rs --budget 100 --mode bundle` -> Output size 139 bytes (truncated).

## 🧭 Options considered
### Option A (recommended)
- Track original token counts in `select_files_with_options` and restore them when finalizing `ContextFileRow`.
- Fits the existing architecture where `ContextFileRow` is the source of truth for `write_head_tail`.
- Trade-offs: Minor memory usage increase (BTreeMap of original counts).

### Option B
- Modify `ContextFileRow` to have `original_tokens` field.
- Rejected because `tokmd-types` is Tier 0 and changes are more invasive.

## ✅ Decision
Option A. It's the correct fix with minimal blast radius.

## 🧱 Changes made (SRP)
- `crates/tokmd/src/context_pack.rs`: Track `original_tokens` and restore them for `HeadTail` policy files.

## 🧪 Verification receipts
- `tokmd context large_file.rs --budget 100 --mode bundle` -> PASS (139 bytes)
- `CI=true cargo test` -> PASS
- `cargo fmt` -> PASS
- `cargo clippy` -> PASS

## 🧭 Telemetry
- Change shape: Logic fix in internal packing algorithm.
- Blast radius: Low. Affects only `context` and `handoff` commands when file caps are hit.
- Risk class: Low.
- Merge-confidence gates: Build, Test, Fmt, Clippy passed.

## 🗂️ .jules updates
- Updated `.jules/palette/ledger.json`
- Created `.jules/palette/envelopes/20260224-132200.json`
- Created `.jules/palette/runs/2026-02-24.md`


---
*PR created automatically by Jules for task [3018852466357979100](https://jules.google.com/task/3018852466357979100) started by @EffortlessSteven*