### PR TITLE
fix: filter dot segments in module keys 🧪 Gatekeeper

### DIFF
--- a/.jules/quality/envelopes/20260225-110140.json
+++ b/.jules/quality/envelopes/20260225-110140.json
@@ -1,0 +1,14 @@
+{
+  "run_id": "20260225-110140",
+  "goal": "Verify and lock deterministic module keys against dot segments",
+  "lane": "scout",
+  "decision": "Option A (Filter dot segments)",
+  "changes": [
+    "crates/tokmd-module-key/src/lib.rs",
+    "crates/tokmd-module-key/tests/bdd_module_key.rs"
+  ],
+  "verification": {
+    "test": "cargo test -p tokmd-module-key",
+    "workspace": "cargo test --workspace"
+  }
+}

--- a/.jules/quality/ledger.json
+++ b/.jules/quality/ledger.json
@@ -8,5 +8,10 @@
     "run_id": "2026-01-30-gatekeeper-analysis-determinism",
     "timestamp": "2026-01-30T11:00:00Z",
     "summary": "Added determinism regression test for analysis reports."
+  },
+  {
+    "run_id": "20260225-110140",
+    "timestamp": "2026-02-25T11:01:40Z",
+    "summary": "Filtered dot segments in module keys to prevent incorrect grouping."
   }
 ]

--- a/crates/tokmd-module-key/src/lib.rs
+++ b/crates/tokmd-module-key/src/lib.rs
@@ -34,7 +34,7 @@ pub fn module_key_from_normalized(
         return "(root)".to_string();
     };
 
-    let mut dirs = dir_part.split('/').filter(|s| !s.is_empty());
+    let mut dirs = dir_part.split('/').filter(|s| !s.is_empty() && *s != ".");
     let first = match dirs.next() {
         Some(s) => s,
         None => return "(root)".to_string(),

--- a/crates/tokmd-module-key/tests/bdd_module_key.rs
+++ b/crates/tokmd-module-key/tests/bdd_module_key.rs
@@ -41,3 +41,16 @@ fn given_windows_style_path_when_module_key_computed_then_result_is_forward_slas
     assert_eq!(win_key, unix_key);
     assert_eq!(win_key, "crates/tokmd");
 }
+
+#[test]
+fn given_path_with_dot_segments_when_module_key_computed_then_dots_are_filtered() {
+    // Given: a path with dot segments
+    let roots = vec!["crates".to_string()];
+    let path = "crates/./tokmd-model/src/lib.rs";
+
+    // When: module key is computed
+    let key = module_key(path, &roots, 2);
+
+    // Then: key ignores the dot segments
+    assert_eq!(key, "crates/tokmd-model");
+}


### PR DESCRIPTION
This change updates `tokmd-module-key` to explicitly filter out `.` segments during path processing. This improves the determinism of module key generation by treating `crates/./tokmd-model` identically to `crates/tokmd-model`.

- Modified `crates/tokmd-module-key/src/lib.rs` to ignore `.` path components.
- Added regression test `given_path_with_dot_segments_when_module_key_computed_then_dots_are_filtered` in `crates/tokmd-module-key/tests/bdd_module_key.rs`.
- Created run envelope `.jules/quality/envelopes/20260225-110140.json`.
- Updated `.jules/quality/ledger.json`.

Verified with `cargo test -p tokmd-module-key` and workspace tests.

---
*PR created automatically by Jules for task [6519824692251421342](https://jules.google.com/task/6519824692251421342) started by @EffortlessSteven*