### PR TITLE
deps: remove redundant dev-dependencies in tokmd crate 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/20260225-125847.json
+++ b/.jules/deps/envelopes/20260225-125847.json
@@ -1,0 +1,12 @@
+{
+  "id": "20260225-125847",
+  "start_time": "2026-02-25T12:58:47Z",
+  "target": "tokmd",
+  "lane": "B",
+  "decision": "Remove redundant dev-dependencies in tokmd crate",
+  "receipts": [
+    "cargo check: passed",
+    "cargo test -p tokmd: passed",
+    "cargo clippy -- -D warnings: passed"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -19,5 +19,12 @@
     "target": "dev-dependencies",
     "action": "sync-proptest",
     "status": "success"
+  },
+  {
+    "run_id": "20260225-125847",
+    "timestamp": "2026-02-25T12:58:47Z",
+    "target": "tokmd",
+    "action": "remove-redundant-dev-deps",
+    "status": "success"
   }
 ]

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -98,6 +98,4 @@ tempfile = "3.25.0"
 insta = { workspace = true }
 regex = "1.12.3"
 proptest = "1.10.0"
-serde_json = "1.0.149"
-tokmd-model.workspace = true
 jsonschema = "0.42.0"


### PR DESCRIPTION
## 💡 Summary
Removed `tokmd-model` and `serde_json` from `[dev-dependencies]` in `crates/tokmd/Cargo.toml` as they are already present in `[dependencies]`.

## 🎯 Why (user/dev pain)
Redundant dependencies clutter the manifest and can potentially cause version confusion, although in this case they were using the same versions/workspace references. Cleaning them up improves hygiene.

## 🔎 Evidence (before/after)
Before:
```toml
[dependencies]
tokmd-model.workspace = true
serde_json = "1.0.149"

[dev-dependencies]
tokmd-model.workspace = true
serde_json = "1.0.149"
```

After: `[dev-dependencies]` no longer contains these entries.

## 🧭 Options considered
### Option A (recommended)
Remove them. They are available to tests via `[dependencies]`.
### Option B
Leave them. No harm, just noise.

## ✅ Decision
Option A. Keeps the manifest clean.

## 🧱 Changes made (SRP)
- `crates/tokmd/Cargo.toml`: Removed redundant dev-deps.

## 🧪 Verification receipts
- `cargo check`: passed
- `cargo test -p tokmd`: passed
- `cargo clippy -- -D warnings`: passed

## 🧭 Telemetry
- Risk class: Low (manifest change only)

## 🗂️ .jules updates
- Created `.jules/deps/envelopes/20260225-125847.json`
- Updated `.jules/deps/ledger.json`

---
*PR created automatically by Jules for task [8245501851348666883](https://jules.google.com/task/8245501851348666883) started by @EffortlessSteven*