### PR TITLE
config: use BTreeMap for TomlConfig views to ensure deterministic serialization

### DIFF
--- a/.jules/quality/envelopes/20250521-100000.json
+++ b/.jules/quality/envelopes/20250521-100000.json
@@ -1,0 +1,16 @@
+{
+  "id": "20250521-100000",
+  "agent": "Gatekeeper",
+  "target": "crates/tokmd-settings",
+  "goal": "Enforce deterministic ordering in TomlConfig view serialization",
+  "decision": "Replace HashMap with BTreeMap in TomlConfig",
+  "files_changed": [
+    "crates/tokmd-settings/src/lib.rs",
+    "crates/tokmd-settings/tests/determinism.rs"
+  ],
+  "verification": {
+    "new_test": "crates/tokmd-settings/tests/determinism.rs",
+    "status": "passed",
+    "receipt": "cargo test -p tokmd-settings"
+  }
+}

--- a/.jules/quality/ledger.json
+++ b/.jules/quality/ledger.json
@@ -8,5 +8,10 @@
     "run_id": "2026-01-30-gatekeeper-analysis-determinism",
     "timestamp": "2026-01-30T11:00:00Z",
     "summary": "Added determinism regression test for analysis reports."
+  },
+  {
+    "run_id": "20250521-100000",
+    "timestamp": "2025-05-21T10:00:00Z",
+    "summary": "Switched TomlConfig.view to BTreeMap for deterministic serialization."
   }
 ]

--- a/crates/tokmd-settings/src/lib.rs
+++ b/crates/tokmd-settings/src/lib.rs
@@ -16,7 +16,7 @@
 //! * I/O operations
 //! * Business logic
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -393,7 +393,7 @@ pub struct TomlConfig {
 
     /// Named view profiles (e.g., [view.llm], [view.ci]).
     #[serde(default)]
-    pub view: HashMap<String, ViewProfile>,
+    pub view: BTreeMap<String, ViewProfile>,
 }
 
 /// Scan settings shared by all commands.

--- a/crates/tokmd-settings/tests/determinism.rs
+++ b/crates/tokmd-settings/tests/determinism.rs
@@ -1,0 +1,37 @@
+use tokmd_settings::{TomlConfig, ViewProfile};
+
+#[test]
+fn test_toml_config_serialization_determinism() {
+    let mut config = TomlConfig::default();
+
+    // Add multiple view profiles with keys that are not already sorted alphabetically in insert order
+    // to ensure insert order doesn't mask the issue if HashMap preserves it by chance.
+    let keys = vec!["zebra", "apple", "mango", "banana", "cherry"];
+
+    for key in &keys {
+        config.view.insert(key.to_string(), ViewProfile::default());
+    }
+
+    let toml_output = toml::to_string_pretty(&config).unwrap();
+    println!("{}", toml_output);
+
+    let apple_pos = toml_output.find("[view.apple]").expect("should find apple");
+    let banana_pos = toml_output
+        .find("[view.banana]")
+        .expect("should find banana");
+    let cherry_pos = toml_output
+        .find("[view.cherry]")
+        .expect("should find cherry");
+    let mango_pos = toml_output.find("[view.mango]").expect("should find mango");
+    let zebra_pos = toml_output.find("[view.zebra]").expect("should find zebra");
+
+    // With BTreeMap, these must be in order.
+    // With HashMap, they MIGHT be in order, but we want to enforce BTreeMap.
+    // We can't strictly "fail" if HashMap happens to be sorted, but this test
+    // serves as a regression test once we switch to BTreeMap.
+
+    assert!(apple_pos < banana_pos, "apple should be before banana");
+    assert!(banana_pos < cherry_pos, "banana should be before cherry");
+    assert!(cherry_pos < mango_pos, "cherry should be before mango");
+    assert!(mango_pos < zebra_pos, "mango should be before zebra");
+}


### PR DESCRIPTION
`TomlConfig.view` was using `HashMap<String, ViewProfile>`, which causes non-deterministic ordering of `[view.*]` sections when the configuration is serialized to TOML (e.g., during `tokmd init` or future config writing commands).

This change replaces `HashMap` with `BTreeMap` to ensure keys are always emitted in alphabetical order, stabilizing the output and preventing noise in configuration file diffs.

A regression test `crates/tokmd-settings/tests/determinism.rs` has been added to verify this behavior.

Persona: Gatekeeper
Target: crates/tokmd-settings
Goal: Enforce deterministic ordering in TomlConfig view serialization
Receipt: cargo test -p tokmd-settings

---
*PR created automatically by Jules for task [1294967410179947375](https://jules.google.com/task/1294967410179947375) started by @EffortlessSteven*