### PR TITLE
docs: fix incorrect flag --output to --mode for tokmd context 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/20260226-105348.json
+++ b/.jules/docs/envelopes/20260226-105348.json
@@ -1,0 +1,29 @@
+{
+  "run_id": "20260226-105348",
+  "persona": "Librarian",
+  "lane": "B",
+  "target": "docs",
+  "summary": "Fix incorrect flag --output to --mode for tokmd context in documentation",
+  "receipts": [
+    {
+      "command": "sed -i 's/--output bundle/--mode bundle/g' README.md docs/reference-cli.md docs/recipes.md docs/tutorial.md docs/troubleshooting.md crates/tokmd/README.md",
+      "result": "success"
+    },
+    {
+      "command": "sed -i 's/--output list/--mode list/g' README.md docs/reference-cli.md docs/recipes.md docs/tutorial.md docs/troubleshooting.md crates/tokmd/README.md",
+      "result": "success"
+    },
+    {
+      "command": "sed -i 's/--output json/--mode json/g' docs/reference-cli.md",
+      "result": "success"
+    },
+    {
+      "command": "sed -i 's/| --output <MODE> |/| --mode <MODE> |/g' docs/reference-cli.md",
+      "result": "success"
+    },
+    {
+      "command": "sed -i 's/--mode bundle.txt/--output bundle.txt/g' docs/reference-cli.md",
+      "result": "success"
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -10,5 +10,11 @@
     "date": "2026-01-30",
     "persona": "Librarian",
     "description": "Documented configuration files and profiles in README, removed misleading scan config from reference"
+  },
+  {
+    "run_id": "20260226-105348",
+    "date": "2026-02-26",
+    "persona": "Librarian",
+    "description": "Fix incorrect flag --output to --mode for tokmd context in documentation"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tokmd > summary.md
 tokmd module --module-roots crates,packages
 
 # 3. Pack for LLM context (smart selection)
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # 4. Analysis report (derived metrics)
 tokmd analyze --preset receipt --format md
@@ -65,9 +65,9 @@ tokmd diff main HEAD
 Pack files into an LLM context window with budget-aware selection:
 
 ```bash
-tokmd context --budget 128k --output bundle --output context.txt  # Ready to paste
+tokmd context --budget 128k --mode bundle --output context.txt  # Ready to paste
 tokmd context --budget 200k --strategy spread                  # Coverage across modules
-tokmd context --budget 100k --output bundle --compress --output context.txt  # Strip blank lines for density
+tokmd context --budget 100k --mode bundle --compress --output context.txt  # Strip blank lines for density
 ```
 
 ### LLM Context Planning
@@ -76,10 +76,10 @@ Smartly select files to fit your context window:
 
 ```bash
 # Pack top files by code volume into 128k tokens
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Or generate a manifest to see what fits
-tokmd context --budget 128k --output list
+tokmd context --budget 128k --mode list
 ```
 
 ### PR Summaries

--- a/crates/tokmd/README.md
+++ b/crates/tokmd/README.md
@@ -29,7 +29,7 @@ tokmd
 tokmd module --module-roots crates,packages
 
 # Pack for LLM context
-tokmd context --budget 128k --output bundle > context.txt
+tokmd context --budget 128k --mode bundle > context.txt
 
 # Analysis report
 tokmd analyze --preset risk --format md

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -10,13 +10,13 @@ When you need to feed actual code to an LLM (not just metadata), use the `contex
 
 ```bash
 # Pack files into 128k tokens (Claude's context window)
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Spread coverage across modules instead of just largest files
-tokmd context --budget 128k --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --strategy spread --mode bundle --output context.txt
 
 # Strip blank lines for maximum density
-tokmd context --budget 128k --output bundle --compress --output context.txt
+tokmd context --budget 128k --mode bundle --compress --output context.txt
 
 # Use module roots for better organization
 tokmd context --budget 128k --module-roots crates,src --strategy spread --output context.txt

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -442,16 +442,16 @@ Packs files into an LLM context window within a token budget. Intelligently sele
 tokmd context --budget 128k
 
 # Create a bundle ready to paste into Claude
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Spread coverage across modules instead of taking largest files
 tokmd context --budget 200k --strategy spread
 
 # Compressed bundle (no blank lines)
-tokmd context --budget 100k --output bundle --compress --output bundle.txt
+tokmd context --budget 100k --mode bundle --compress --output bundle.txt
 
 # JSON receipt for programmatic use
-tokmd context --budget 128k --output json --output selection.json
+tokmd context --budget 128k --mode json --output selection.json
 
 # Bundle to directory for large outputs
 tokmd context --budget 200k --bundle-dir ./ctx-bundle

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -133,7 +133,7 @@ Files with different encodings may report different sizes.
 **Check what's selected**:
 ```bash
 # List mode shows what would be packed
-tokmd context --budget 128k --output list
+tokmd context --budget 128k --mode list
 ```
 
 **Check token estimates**:
@@ -150,7 +150,7 @@ tokmd export --format csv | head -20
 **Workaround**: Use a smaller budget than your actual context window:
 ```bash
 # For 128k context, use 100k budget
-tokmd context --budget 100k --output bundle
+tokmd context --budget 100k --mode bundle
 ```
 
 **2. Wrong files selected with greedy strategy**
@@ -164,7 +164,7 @@ tokmd context --budget 128k --strategy spread
 
 Strip them for maximum density:
 ```bash
-tokmd context --budget 128k --output bundle --compress
+tokmd context --budget 128k --mode bundle --compress
 ```
 
 ---

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,25 +100,25 @@ You want to paste actual code into an LLM, but your repo is too large. Use `cont
 
 ```bash
 # Pack the most valuable files into 128k tokens
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 ```
 
 **What happened?**
 - `--budget 128k`: Set a token limit matching Claude's context window.
-- `--output bundle`: Concatenated selected files into a single text file.
+- `--mode bundle`: Concatenated selected files into a single text file.
 - `--output context.txt`: Write output to a file instead of stdout.
 - Files are selected by size (largest = most valuable) until the budget is exhausted.
 
 **Alternative strategies**:
 ```bash
 # Spread coverage across all modules
-tokmd context --budget 128k --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --strategy spread --mode bundle --output context.txt
 
 # Strip blank lines for maximum density
-tokmd context --budget 128k --output bundle --compress --output context.txt
+tokmd context --budget 128k --mode bundle --compress --output context.txt
 
 # Use module roots for better organization
-tokmd context --budget 128k --module-roots src,crates --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --module-roots src,crates --strategy spread --mode bundle --output context.txt
 ```
 
 ## Step 5: Creating a File Inventory for AI


### PR DESCRIPTION
## 💡 Summary
Replaced incorrect usage of `--output` for specifying the operation mode in `tokmd context` documentation with the correct flag `--mode`. The `--output` flag is reserved for specifying the output file path.

## 🎯 Why (user/dev pain)
Users following the documentation for `tokmd context` would encounter errors or unexpected behavior because the examples used `--output bundle` or `--output list` instead of `--mode bundle` or `--mode list`.

## 🔎 Evidence (before/after)
Before:
`tokmd context --budget 128k --output bundle --output context.txt`

After:
`tokmd context --budget 128k --mode bundle --output context.txt`

## ✅ Decision
Option B (Scout Discovery): Found high-signal docs drift in CLI help text vs documentation.

## 🧱 Changes made (SRP)
- `README.md`
- `crates/tokmd/README.md`
- `docs/reference-cli.md`
- `docs/recipes.md`
- `docs/tutorial.md`
- `docs/troubleshooting.md`

## 🧪 Verification receipts
- Verified against `crates/tokmd-config/src/lib.rs` which defines `output_mode` as `--mode` and `output` as `--output`.
- Grepped codebase to ensure all incorrect usages were replaced and correct usages (file paths) were preserved.

## 🗂️ .jules updates
- Added run envelope `20260226-105348`
- Updated `docs/ledger.json`

---
*PR created automatically by Jules for task [8206029423455064619](https://jules.google.com/task/8206029423455064619) started by @EffortlessSteven*