### PR TITLE
deps: remove redundant dev-dependencies 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/20260226-125734.json
+++ b/.jules/deps/envelopes/20260226-125734.json
@@ -1,0 +1,10 @@
+{
+  "id": "20260226-125734",
+  "start_time": "2026-02-26T12:57:34Z",
+  "target": "tokmd",
+  "lane": "B",
+  "decision": "Remove redundant dev-dependencies",
+  "receipts": [
+    "cargo audit: not available"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -19,5 +19,12 @@
     "target": "dev-dependencies",
     "action": "sync-proptest",
     "status": "success"
+  },
+  {
+    "run_id": "20260226-125734",
+    "timestamp": "2026-02-26T12:57:34Z",
+    "target": "tokmd",
+    "action": "remove-redundant-dev-deps",
+    "status": "success"
   }
 ]

--- a/.jules/deps/runs/2026-02-26.md
+++ b/.jules/deps/runs/2026-02-26.md
@@ -1,0 +1,25 @@
+# Run 20260226-125734: Remove Redundant Dev-Dependencies
+
+**Date:** 2026-02-26
+**Persona:** Auditor
+**Target:** `tokmd` (and `tokmd-config`)
+
+## Summary
+
+Removed redundant dependencies from `[dev-dependencies]` that were already present in `[dependencies]`.
+
+## Changes
+
+- **crates/tokmd/Cargo.toml**: Removed `serde_json` and `tokmd-model` from `[dev-dependencies]`.
+- **crates/tokmd-config/Cargo.toml**: Removed `serde_json` from `[dev-dependencies]`.
+
+## Verification
+
+- `cargo check -p tokmd -p tokmd-config`: Passed.
+- `cargo test -p tokmd -p tokmd-config`: Passed.
+- `cargo fmt`: No changes needed.
+- `cargo audit`: Not available.
+
+## Receipts
+
+See `.jules/deps/envelopes/20260226-125734.json`.

--- a/crates/tokmd-config/Cargo.toml
+++ b/crates/tokmd-config/Cargo.toml
@@ -22,5 +22,4 @@ tokmd-types = { workspace = true, features = ["clap"] }
 
 [dev-dependencies]
 proptest = "1.10.0"
-serde_json = "1.0.149"
 tempfile = "3.25.0"

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -98,6 +98,4 @@ tempfile = "3.25.0"
 insta = { workspace = true }
 regex = "1.12.3"
 proptest = "1.10.0"
-serde_json = "1.0.149"
-tokmd-model.workspace = true
 jsonschema = "0.42.0"


### PR DESCRIPTION
Removes `serde_json` and `tokmd-model` from `[dev-dependencies]` in `crates/tokmd/Cargo.toml` and `serde_json` from `[dev-dependencies]` in `crates/tokmd-config/Cargo.toml`, as they are already declared in `[dependencies]`.

This is a scheduled dependency hygiene run (Auditor).

**Receipts:**
- Run ID: 20260226-125734
- Envelope: `.jules/deps/envelopes/20260226-125734.json`
- Log: `.jules/deps/runs/2026-02-26.md`
- Verification: `cargo check`, `cargo test`, `cargo fmt` passed.

---
*PR created automatically by Jules for task [2490072483337501472](https://jules.google.com/task/2490072483337501472) started by @EffortlessSteven*