### PR TITLE
fix: strict file read error handling in determinism checks 🛡️ Sentinel

### DIFF
--- a/.jules/security/envelopes/20250521-120000.json
+++ b/.jules/security/envelopes/20250521-120000.json
@@ -1,0 +1,32 @@
+{
+  "run_id": "20250521-120000",
+  "timestamp_utc": "2025-05-21T12:00:00Z",
+  "lane": "scout",
+  "target": "determinism/strict-io",
+  "commands": [
+    {
+      "cmd": "cargo build --verbose",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "cmd": "CI=true cargo test --verbose",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "exit_code": 0,
+      "result": "PASS"
+    }
+  ],
+  "results_summary": [
+    "Fixed file read error suppression in tokmd-cockpit/src/determinism.rs",
+    "Refactored tokmd-cockpit/src/determinism.rs tests to use Result<()>"
+  ]
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -16,5 +16,14 @@
     "gates_run": ["test"],
     "status": "PASS",
     "friction_ids_created": []
+  },
+  {
+    "timestamp_utc": "2025-05-21T12:00:00Z",
+    "lane": "scout",
+    "target": "determinism/strict-io",
+    "pr_link": "tbd",
+    "gates_run": ["build", "test", "fmt", "clippy"],
+    "status": "PASS",
+    "friction_ids_created": []
   }
 ]

--- a/.jules/security/runs/2025-05-21.md
+++ b/.jules/security/runs/2025-05-21.md
@@ -1,0 +1,11 @@
+# Run 20250521-120000
+
+## Status
+- [x] Lane Selected: Scout (focused sweep)
+- [x] Target Selected: Determinism/IO Strictness
+- [ ] PR Link: (placeholder)
+
+## Findings
+- Found `unwrap()` usage in `tokmd-cockpit/src/determinism.rs` tests.
+- Found potentially unsafe file read error suppression in `hash_files_from_paths` and `hash_files_from_walk`.
+- Decision: Option A (Strict Read Error Handling). Make `fs::read` errors explicit (except NotFound) to improve security posture and correctness.


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Enforce strict file read error handling in `hash_files_from_paths` and `hash_files_from_walk` within `crates/tokmd-cockpit/src/determinism.rs`. Previously, all file read errors were silently ignored. Now, only `NotFound` errors are ignored (to handle race conditions), while other errors (like permissions) are propagated.

## 🎯 Why / Threat model
Silently ignoring file read errors (e.g., due to permissions) during determinism checks can lead to false positives where a file is assumed to be part of the hash but is actually skipped. This undermines the integrity verification of the `cockpit` and `baseline` commands.

## 🔎 Finding (evidence)
In `crates/tokmd-cockpit/src/determinism.rs`:
```rust
        let content = match std::fs::read(&full) {
            Ok(c) => c,
            Err(_) => continue, // Silently ignored all errors
        };
```

## 🧭 Options considered
### Option A (recommended)
- **Strict Read Error Handling**: Propagate all errors except `NotFound`.
- Fits this repo: High correctness and security standards ("Sentinel").
- Trade-offs: Might break workflows relying on skipping unreadable files, but that is arguably a bug fix.

### Option B
- **Log Warnings**: Log a warning but continue.
- Trade-offs: Requires a logger dependency and might be missed in CI logs.

## ✅ Decision
Selected **Option A**. Correctness and security take precedence.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd-cockpit/src/determinism.rs` to propagate `fs::read` errors.
- Refactored tests in `crates/tokmd-cockpit/src/determinism.rs` to use `Result<()>` and `?` instead of `unwrap()`.

## 🧪 Verification receipts
```
test determinism::tests::test_hash_cargo_lock_absent ... ok
test determinism::tests::test_hash_files_deterministic ... ok
test determinism::tests::test_hash_cargo_lock_present ... ok
test determinism::tests::test_hash_files_changes_on_modification ... ok
test determinism::tests::test_hash_files_order_independent ... ok
test determinism::tests::test_hash_files_from_walk_deterministic ... ok
test determinism::tests::test_walk_and_paths_produce_same_hash ... ok
test determinism::tests::test_walk_excludes_specified_paths ... ok
test determinism::tests::test_walk_excludes_tokmd_directory ... ok
```

## 🧭 Telemetry
- Change shape: Logic hardening + Test refactoring.
- Blast radius: Low (affects `cockpit` and `baseline` commands).
- Risk class: Low.
- Rollback: Revert PR.
- Merge-confidence gates: Build, Test, Fmt, Clippy passed.

## 🗂️ .jules updates
- Updated `.jules/security/runs/2025-05-21.md`
- Updated `.jules/security/envelopes/20250521-120000.json`
- Updated `.jules/security/ledger.json`

## 📝 Notes (freeform)
Also cleaned up `unwrap()` usage in tests as per Sentinel policy.

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [9151504903510717130](https://jules.google.com/task/9151504903510717130) started by @EffortlessSteven*