### PR TITLE
fix: cherry-pick Jules wave 2 — docs, strict I/O, dep cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tokmd > summary.md
 tokmd module --module-roots crates,packages
 
 # 3. Pack for LLM context (smart selection)
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # 4. Analysis report (derived metrics)
 tokmd analyze --preset receipt --format md
@@ -65,9 +65,9 @@ tokmd diff main HEAD
 Pack files into an LLM context window with budget-aware selection:
 
 ```bash
-tokmd context --budget 128k --output bundle --output context.txt  # Ready to paste
+tokmd context --budget 128k --mode bundle --output context.txt  # Ready to paste
 tokmd context --budget 200k --strategy spread                  # Coverage across modules
-tokmd context --budget 100k --output bundle --compress --output context.txt  # Strip blank lines for density
+tokmd context --budget 100k --mode bundle --compress --output context.txt  # Strip blank lines for density
 ```
 
 ### LLM Context Planning
@@ -76,10 +76,10 @@ Smartly select files to fit your context window:
 
 ```bash
 # Pack top files by code volume into 128k tokens
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Or generate a manifest to see what fits
-tokmd context --budget 128k --output list
+tokmd context --budget 128k --mode list
 ```
 
 ### PR Summaries

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -98,5 +98,4 @@ tempfile = "3.25.0"
 insta = { workspace = true }
 regex = "1.12.3"
 proptest = "1.10.0"
-tokmd-model.workspace = true
 jsonschema = "0.42.0"

--- a/crates/tokmd/README.md
+++ b/crates/tokmd/README.md
@@ -29,7 +29,7 @@ tokmd
 tokmd module --module-roots crates,packages
 
 # Pack for LLM context
-tokmd context --budget 128k --output bundle > context.txt
+tokmd context --budget 128k --mode bundle > context.txt
 
 # Analysis report
 tokmd analyze --preset risk --format md

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -10,13 +10,13 @@ When you need to feed actual code to an LLM (not just metadata), use the `contex
 
 ```bash
 # Pack files into 128k tokens (Claude's context window)
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Spread coverage across modules instead of just largest files
-tokmd context --budget 128k --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --strategy spread --mode bundle --output context.txt
 
 # Strip blank lines for maximum density
-tokmd context --budget 128k --output bundle --compress --output context.txt
+tokmd context --budget 128k --mode bundle --compress --output context.txt
 
 # Use module roots for better organization
 tokmd context --budget 128k --module-roots crates,src --strategy spread --output context.txt

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -442,16 +442,16 @@ Packs files into an LLM context window within a token budget. Intelligently sele
 tokmd context --budget 128k
 
 # Create a bundle ready to paste into Claude
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 
 # Spread coverage across modules instead of taking largest files
 tokmd context --budget 200k --strategy spread
 
 # Compressed bundle (no blank lines)
-tokmd context --budget 100k --output bundle --compress --output bundle.txt
+tokmd context --budget 100k --mode bundle --compress --output bundle.txt
 
 # JSON receipt for programmatic use
-tokmd context --budget 128k --output json --output selection.json
+tokmd context --budget 128k --mode json --output selection.json
 
 # Bundle to directory for large outputs
 tokmd context --budget 200k --bundle-dir ./ctx-bundle

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -133,7 +133,7 @@ Files with different encodings may report different sizes.
 **Check what's selected**:
 ```bash
 # List mode shows what would be packed
-tokmd context --budget 128k --output list
+tokmd context --budget 128k --mode list
 ```
 
 **Check token estimates**:
@@ -150,7 +150,7 @@ tokmd export --format csv | head -20
 **Workaround**: Use a smaller budget than your actual context window:
 ```bash
 # For 128k context, use 100k budget
-tokmd context --budget 100k --output bundle
+tokmd context --budget 100k --mode bundle
 ```
 
 **2. Wrong files selected with greedy strategy**
@@ -164,7 +164,7 @@ tokmd context --budget 128k --strategy spread
 
 Strip them for maximum density:
 ```bash
-tokmd context --budget 128k --output bundle --compress
+tokmd context --budget 128k --mode bundle --compress
 ```
 
 ---

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,25 +100,25 @@ You want to paste actual code into an LLM, but your repo is too large. Use `cont
 
 ```bash
 # Pack the most valuable files into 128k tokens
-tokmd context --budget 128k --output bundle --output context.txt
+tokmd context --budget 128k --mode bundle --output context.txt
 ```
 
 **What happened?**
 - `--budget 128k`: Set a token limit matching Claude's context window.
-- `--output bundle`: Concatenated selected files into a single text file.
+- `--mode bundle`: Concatenated selected files into a single text file.
 - `--output context.txt`: Write output to a file instead of stdout.
 - Files are selected by size (largest = most valuable) until the budget is exhausted.
 
 **Alternative strategies**:
 ```bash
 # Spread coverage across all modules
-tokmd context --budget 128k --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --strategy spread --mode bundle --output context.txt
 
 # Strip blank lines for maximum density
-tokmd context --budget 128k --output bundle --compress --output context.txt
+tokmd context --budget 128k --mode bundle --compress --output context.txt
 
 # Use module roots for better organization
-tokmd context --budget 128k --module-roots src,crates --strategy spread --output bundle --output context.txt
+tokmd context --budget 128k --module-roots src,crates --strategy spread --mode bundle --output context.txt
 ```
 
 ## Step 5: Creating a File Inventory for AI


### PR DESCRIPTION
## Summary

Cherry-picks 3 valid improvements from the remaining Jules AI PRs (#196–#202):

- **Docs fix** (from #198): All `tokmd context` examples incorrectly used `--output bundle/list` instead of `--mode bundle/list`. The `--output` flag specifies a file path, while `--mode` selects the output mode (bundle/list/json). Fixed across README.md, tutorial.md, recipes.md, reference-cli.md, and troubleshooting.md.

- **Strict determinism I/O** (from #200): `hash_files_from_paths` and `hash_files_from_walk` previously silently skipped *all* file read errors (`Err(_) => continue`). Now only `NotFound` errors are skipped (for race conditions with deleted files); other errors (permissions, I/O) are propagated to prevent false-positive hash matches.

- **Dep cleanup** (from #199): Removed redundant `tokmd-model` from `[dev-dependencies]` in `crates/tokmd/Cargo.toml` — it's already in `[dependencies]`.

### PRs evaluated but not cherry-picked

| PR | Title | Reason |
|----|-------|--------|
| #196 | compat: fix no-default-features build | Duplicate of #181, already in #203 |
| #197 | config: BTreeMap for TomlConfig | Duplicate of #168, already in #203 |
| #201 | perf: Vec+sort aggregation | Too invasive for marginal gain; model already optimized in #203 |
| #202 | feat: --write-config for init | New feature, out of scope for integration |

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo build --no-default-features -p tokmd` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass, 0 failures