### PR TITLE
Refactor sensor/cockpit wiring to explicit microcrate boundaries

### DIFF
--- a/crates/tokmd/src/commands/cockpit.rs
+++ b/crates/tokmd/src/commands/cockpit.rs
@@ -13,14 +13,6 @@ use anyhow::Context;
 use anyhow::{Result, bail};
 use tokmd_config as cli;
 
-// Re-export all cockpit types for backwards compatibility with sensor.rs
-#[cfg(feature = "git")]
-pub use tokmd_types::cockpit::*;
-
-// Re-export computation functions used by sensor.rs
-#[cfg(feature = "git")]
-pub use tokmd_cockpit::compute_cockpit;
-
 /// Handle the cockpit command.
 pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Result<()> {
     #[cfg(not(feature = "git"))]


### PR DESCRIPTION
### Motivation
- Reduce cross-command coupling by enforcing SRP: commands should not re-export behavior/types for other commands to consume. 
- Make ownership explicit: `tokmd-cockpit` provides behavior, `tokmd-types` owns cockpit data contracts, and the CLI command layer remains a thin dispatcher.

### Description
- Removed `tokmd::commands::cockpit` re-exports that implicitly exposed cockpit types/functions to other command modules. 
- Updated `tokmd` `sensor` command to invoke `tokmd_cockpit::compute_cockpit` directly instead of calling into the `cockpit` command module. 
- Switched sensor helper signatures, gate/finding logic, and tests to reference cockpit types from `tokmd_types::cockpit` explicitly (e.g. `tokmd_types::cockpit::CockpitReceipt`, `GateStatus`, `Evidence`, etc.).
- Adjusted unit tests in the sensor module to import and construct cockpit types from `tokmd_types::cockpit` to match the new explicit boundaries.

### Testing
- Ran formatting via `cargo fmt` and applied results successfully. 
- Executed the targeted unit test with: `cargo test -p tokmd --all-features -- tests::render_sensor_md_includes_findings_and_gates` and it passed (1 test OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a367fabc4483339ef3de7c12b6790a)