### PR TITLE
refactor: move legacy profile config types into tokmd-settings

### DIFF
--- a/crates/tokmd-config/src/lib.rs
+++ b/crates/tokmd-config/src/lib.rs
@@ -18,11 +18,11 @@
 //! ## Future Direction
 //! * Split into `tokmd-settings` (pure config) and `tokmd-cli` (Clap parsing)
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
+pub use tokmd_settings::{Profile, UserConfig};
 pub use tokmd_tool_schema::ToolSchemaFormat;
 pub use tokmd_types::{
     AnalysisFormat, ChildIncludeMode, ChildrenMode, ConfigMode, ExportFormat, RedactMode,
@@ -156,33 +156,6 @@ pub enum Commands {
 
     /// Run as a conforming sensor, producing a SensorReport.
     Sensor(SensorArgs),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct UserConfig {
-    pub profiles: BTreeMap<String, Profile>,
-    pub repos: BTreeMap<String, String>, // "owner/repo" -> "profile_name"
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct Profile {
-    // Shared
-    pub format: Option<String>, // "json", "md", "tsv", "csv", "jsonl"
-    pub top: Option<usize>,
-
-    // Lang
-    pub files: Option<bool>,
-
-    // Module / Export
-    pub module_roots: Option<Vec<String>>,
-    pub module_depth: Option<usize>,
-    pub min_code: Option<usize>,
-    pub max_rows: Option<usize>,
-    pub redact: Option<RedactMode>,
-    pub meta: Option<bool>,
-
-    // "children" can be ChildrenMode or ChildIncludeMode string
-    pub children: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/tokmd-settings/src/lib.rs
+++ b/crates/tokmd-settings/src/lib.rs
@@ -24,6 +24,37 @@ use serde::{Deserialize, Serialize};
 // Re-export types from tokmd_types for convenience
 pub use tokmd_types::{ChildIncludeMode, ChildrenMode, ConfigMode, ExportFormat, RedactMode};
 
+/// Legacy JSON configuration used by early `tokmd` profile workflows.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserConfig {
+    /// Named profile map.
+    pub profiles: BTreeMap<String, Profile>,
+    /// Repository-to-profile mapping (`owner/repo` -> `profile_name`).
+    pub repos: BTreeMap<String, String>,
+}
+
+/// Legacy per-profile settings consumed by `tokmd` profile resolution.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Profile {
+    // Shared
+    pub format: Option<String>, // "json", "md", "tsv", "csv", "jsonl"
+    pub top: Option<usize>,
+
+    // Lang
+    pub files: Option<bool>,
+
+    // Module / Export
+    pub module_roots: Option<Vec<String>>,
+    pub module_depth: Option<usize>,
+    pub min_code: Option<usize>,
+    pub max_rows: Option<usize>,
+    pub redact: Option<RedactMode>,
+    pub meta: Option<bool>,
+
+    // "children" can be ChildrenMode or ChildIncludeMode string
+    pub children: Option<String>,
+}
+
 /// Scan options shared by all commands that invoke the scanner.
 ///
 /// This mirrors the scan-relevant fields of `GlobalArgs` without any


### PR DESCRIPTION
### Motivation

- Keep single-responsibility microcrates by placing pure Serde-only configuration data in the clap-free settings layer rather than the CLI crate. 
- Reduce duplication and tighten boundaries so `tokmd-config` focuses on Clap/CLI parsing while `tokmd-settings` owns pure configuration types.

### Description

- Added the legacy profile types `UserConfig` and `Profile` (Serde derives only) to `crates/tokmd-settings/src/lib.rs` so settings are Clap-free and consumable by lower-tier crates.
- Removed the duplicated `UserConfig`/`Profile` struct definitions from `crates/tokmd-config/src/lib.rs` and re-exported them from `tokmd-settings` via `pub use tokmd_settings::{Profile, UserConfig};` to preserve the existing public API.
- Ran formatting to keep code consistent with the repository style (`cargo fmt`).

### Testing

- Ran `cargo fmt` to format changes successfully.
- Ran `cargo test -p tokmd-settings -p tokmd-config --verbose` and the test suites for both crates completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3680668c88333afc138f4ace07e30)