### PR TITLE
refactor: replace remaining HashMap/HashSet with BTreeMap/BTreeSet

### DIFF
--- a/crates/tokmd-analysis-near-dup/src/lib.rs
+++ b/crates/tokmd-analysis-near-dup/src/lib.rs
@@ -8,7 +8,7 @@
 //! 5. Compute Jaccard similarity for candidate pairs
 //! 6. Emit pairs exceeding the similarity threshold
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
 
@@ -147,7 +147,7 @@ pub fn build_near_dup_report(
         }
 
         // Build inverted index: fingerprint -> list of (local_idx) into file_fingerprints
-        let mut inverted: HashMap<u64, Vec<usize>> = HashMap::new();
+        let mut inverted: BTreeMap<u64, Vec<usize>> = BTreeMap::new();
         for (local_idx, (_, fps)) in file_fingerprints.iter().enumerate() {
             for &fp in fps {
                 inverted.entry(fp).or_default().push(local_idx);
@@ -310,7 +310,7 @@ fn build_clusters(pairs: &[NearDupPairRow]) -> Vec<NearDupCluster> {
     let mut ds = DisjointSets::new(names.len());
 
     // Track per-file connection counts for representative selection
-    let mut connection_count: HashMap<usize, usize> = HashMap::new();
+    let mut connection_count: BTreeMap<usize, usize> = BTreeMap::new();
 
     for pair in pairs {
         let a = name_to_idx[pair.left.as_str()];
@@ -328,8 +328,8 @@ fn build_clusters(pairs: &[NearDupPairRow]) -> Vec<NearDupCluster> {
     }
 
     // Track max similarity and pair count per component
-    let mut comp_max_sim: HashMap<usize, f64> = HashMap::new();
-    let mut comp_pair_count: HashMap<usize, usize> = HashMap::new();
+    let mut comp_max_sim: BTreeMap<usize, f64> = BTreeMap::new();
+    let mut comp_pair_count: BTreeMap<usize, usize> = BTreeMap::new();
     for pair in pairs {
         let a = name_to_idx[pair.left.as_str()];
         let root = ds.find(a);

--- a/crates/tokmd-sensor/src/substrate_builder.rs
+++ b/crates/tokmd-sensor/src/substrate_builder.rs
@@ -45,7 +45,7 @@ pub fn build_substrate(
                 .collect()
         })
         .unwrap_or_default();
-    let changed_set: std::collections::HashSet<&str> =
+    let changed_set: std::collections::BTreeSet<&str> =
         normalized_changed.iter().map(|s| s.as_str()).collect();
 
     // Convert file rows to substrate files

--- a/crates/tokmd/src/context_pack.rs
+++ b/crates/tokmd/src/context_pack.rs
@@ -481,7 +481,7 @@ pub fn select_files_with_options(
     }
 
     // Step 3: Build pack candidates (excluding policy-skipped files, adjusting tokens for HeadTail)
-    let excluded_paths: std::collections::HashSet<&str> =
+    let excluded_paths: std::collections::BTreeSet<&str> =
         excluded_by_policy.iter().map(|e| e.path.as_str()).collect();
 
     let pack_rows: Vec<FileRow> = candidate_rows
@@ -521,7 +521,7 @@ pub fn select_files_with_options(
 
     let mut spine_files: Vec<ContextFileRow> = Vec::new();
     let mut spine_used = 0;
-    let mut spine_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut spine_paths: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
 
     let mut spine_candidates: Vec<&FileRow> = parents
         .iter()


### PR DESCRIPTION
## Summary

Replace all remaining HashMap/HashSet usage in production code with BTreeMap/BTreeSet to enforce the project convention of deterministic collection ordering everywhere.

## Changes

### tokmd-analysis-near-dup/src/lib.rs
- Convert `inverted` index from `HashMap<u64, Vec<usize>>` to `BTreeMap`
- Convert `connection_count` from `HashMap<usize, usize>` to `BTreeMap`
- Convert `comp_max_sim` from `HashMap<usize, f64>` to `BTreeMap`
- Convert `comp_pair_count` from `HashMap<usize, usize>` to `BTreeMap`
- Remove `HashMap` from import (only `BTreeMap` needed now)

### tokmd/src/context_pack.rs
- Convert `excluded_paths` from `HashSet<&str>` to `BTreeSet`
- Convert `spine_paths` from `HashSet<String>` to `BTreeSet`

### tokmd-sensor/src/substrate_builder.rs
- Convert `changed_set` from `HashSet<&str>` to `BTreeSet`

## Analysis

While these collections were previously safe (outputs were stabilized by downstream BTreeMaps and explicit sorting), using ordered collections throughout provides defense-in-depth against future regressions and aligns with the project's deterministic-output-first principle documented in CLAUDE.md.

### Intentionally skipped
- **Test code**: HashSet in `#[cfg(test)]` modules across sensor.rs, sensor_integration.rs, properties.rs, bdd.rs — no impact on output determinism
- No FxHashMap/FxHashSet/IndexMap usage found in production code

## Verification
- `cargo build --workspace` ✅
- `cargo test -p tokmd-analysis-near-dup -p tokmd-sensor -p tokmd` ✅ (23 tests passed)
- `cargo clippy --workspace -- -D warnings` ✅
- Pre-existing test failure in tokmd-context-git (unrelated unwrap on None) noted
