### PR TITLE
chore: add .jules/ to .gitignore to prevent stale agent metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ mutants.out.old/
 # Claude Code (local overrides)
 .claude/settings.local.json
 
+# Jules agent metadata (stale run logs, envelopes)
+.jules/
+
 # Windows artifacts
 nul


### PR DESCRIPTION
## Summary

The `.jules/` directory was fully cleaned up in commit 29c7156 (merged via PR #219). This PR adds `.jules/` to `.gitignore` to prevent automated agent run logs, envelopes, and ledgers from being accidentally re-committed in the future.

## What was cleaned

Commit 29c7156 already removed **all** `.jules/` contents (2,348 lines) including:
- `.jules/bolt/` — old bolt agent run logs and envelopes
- `.jules/palette/` — palette agent runs
- `.jules/quality/` — quality gatekeeper runs
- `.jules/security/` — security sentinel runs
- `.jules/docs/` — librarian doc runs
- `.jules/deps/` — dependency audit ledger
- `.jules/compat/` — compatibility matrix runs
- `.jules/commands/` — scheduled task prompts, runbooks, and scaffolding
- `.jules/policy/` — scheduled task config
- `.jules/runbooks/` — runbook templates
- `.jules/README.md` — top-level readme

## What this PR adds

Adds `.jules/` to `.gitignore` so these files cannot be re-committed.