### PR TITLE
test: add insta snapshot tests for format crate output rendering

### DIFF
--- a/crates/tokmd-format/tests/snapshots/snapshots__diff_md_no_changes.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__diff_md_no_changes.snap
@@ -1,0 +1,31 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 930
+expression: md
+---
+## Diff: v1.0.0 → v1.0.0
+
+### Summary
+
+|Metric|From|To|Delta|Change|
+|---|---:|---:|---:|---:|
+|LOC|0|0|0|+0.0%|
+|Lines|0|0|0|+0.0%|
+|Files|0|0|0|+0.0%|
+|Bytes|0|0|0|+0.0%|
+|Tokens|0|0|0|+0.0%|
+
+### Language Movement
+
+|Type|Count|
+|---|---:|
+|Changed|0|
+|Added|0|
+|Removed|0|
+|Modified|0|
+
+### Language Breakdown
+
+|Language|Old LOC|New LOC|Delta|
+|---|---:|---:|---:|
+|**Total**|0|0|0|

--- a/crates/tokmd-format/tests/snapshots/snapshots__export_csv_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__export_csv_empty.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 694
+expression: output
+---
+path,module,lang,kind,code,comments,blanks,lines,bytes,tokens

--- a/crates/tokmd-format/tests/snapshots/snapshots__export_jsonl_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__export_jsonl_single_file.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 972
+expression: output
+---
+{"type":"row","path":"main.rs","module":".","lang":"Rust","kind":"parent","code":42,"comments":5,"blanks":3,"lines":50,"bytes":500,"tokens":100}

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_json_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_json_empty.snap
@@ -1,0 +1,47 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 615
+expression: pretty
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": false
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [],
+  "scan": {
+    "config": "auto",
+    "excluded": [],
+    "hidden": false,
+    "no_ignore": false,
+    "no_ignore_dot": false,
+    "no_ignore_parent": false,
+    "no_ignore_vcs": false,
+    "paths": [
+      "."
+    ],
+    "treat_doc_strings_as_comments": false
+  },
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 0,
+    "bytes": 0,
+    "code": 0,
+    "files": 0,
+    "lines": 0,
+    "tokens": 0
+  },
+  "warnings": [],
+  "with_files": false
+}

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_json_many.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_json_many.snap
@@ -1,0 +1,120 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 917
+expression: pretty
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": false
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [
+    {
+      "avg_lines": 120,
+      "bytes": 250000,
+      "code": 5000,
+      "files": 50,
+      "lang": "Rust",
+      "lines": 6000,
+      "tokens": 12500
+    },
+    {
+      "avg_lines": 120,
+      "bytes": 150000,
+      "code": 3000,
+      "files": 30,
+      "lang": "Python",
+      "lines": 3600,
+      "tokens": 7500
+    },
+    {
+      "avg_lines": 120,
+      "bytes": 100000,
+      "code": 2000,
+      "files": 20,
+      "lang": "JavaScript",
+      "lines": 2400,
+      "tokens": 5000
+    },
+    {
+      "avg_lines": 120,
+      "bytes": 75000,
+      "code": 1500,
+      "files": 15,
+      "lang": "TypeScript",
+      "lines": 1800,
+      "tokens": 3750
+    },
+    {
+      "avg_lines": 120,
+      "bytes": 50000,
+      "code": 1000,
+      "files": 10,
+      "lang": "Go",
+      "lines": 1200,
+      "tokens": 2500
+    },
+    {
+      "avg_lines": 30,
+      "bytes": 10000,
+      "code": 200,
+      "files": 8,
+      "lang": "TOML",
+      "lines": 240,
+      "tokens": 500
+    },
+    {
+      "avg_lines": 36,
+      "bytes": 7500,
+      "code": 150,
+      "files": 5,
+      "lang": "YAML",
+      "lines": 180,
+      "tokens": 375
+    },
+    {
+      "avg_lines": 30,
+      "bytes": 5000,
+      "code": 100,
+      "files": 4,
+      "lang": "Markdown",
+      "lines": 120,
+      "tokens": 250
+    }
+  ],
+  "scan": {
+    "config": "auto",
+    "excluded": [],
+    "hidden": false,
+    "no_ignore": false,
+    "no_ignore_dot": false,
+    "no_ignore_parent": false,
+    "no_ignore_vcs": false,
+    "paths": [
+      "."
+    ],
+    "treat_doc_strings_as_comments": false
+  },
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 109,
+    "bytes": 647500,
+    "code": 12950,
+    "files": 142,
+    "lines": 15540,
+    "tokens": 32375
+  },
+  "warnings": [],
+  "with_files": false
+}

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_json_single.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_json_single.snap
@@ -1,0 +1,57 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 772
+expression: pretty
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": false
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [
+    {
+      "avg_lines": 120,
+      "bytes": 25000,
+      "code": 500,
+      "files": 5,
+      "lang": "Rust",
+      "lines": 600,
+      "tokens": 1250
+    }
+  ],
+  "scan": {
+    "config": "auto",
+    "excluded": [],
+    "hidden": false,
+    "no_ignore": false,
+    "no_ignore_dot": false,
+    "no_ignore_parent": false,
+    "no_ignore_vcs": false,
+    "paths": [
+      "."
+    ],
+    "treat_doc_strings_as_comments": false
+  },
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 120,
+    "bytes": 25000,
+    "code": 500,
+    "files": 5,
+    "lines": 600,
+    "tokens": 1250
+  },
+  "warnings": [],
+  "with_files": false
+}

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_md_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_md_empty.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 581
+expression: output
+---
+|Lang|Code|Lines|Bytes|Tokens|
+|---|---:|---:|---:|---:|
+|**Total**|0|0|0|0|

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_md_many.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_md_many.snap
@@ -1,0 +1,16 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 883
+expression: output
+---
+|Lang|Code|Lines|Bytes|Tokens|
+|---|---:|---:|---:|---:|
+|Rust|5000|6000|250000|12500|
+|Python|3000|3600|150000|7500|
+|JavaScript|2000|2400|100000|5000|
+|TypeScript|1500|1800|75000|3750|
+|Go|1000|1200|50000|2500|
+|TOML|200|240|10000|500|
+|YAML|150|180|7500|375|
+|Markdown|100|120|5000|250|
+|**Total**|12950|15540|647500|32375|

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_md_single.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_md_single.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 738
+expression: output
+---
+|Lang|Code|Lines|Bytes|Tokens|
+|---|---:|---:|---:|---:|
+|Rust|500|600|25000|1250|
+|**Total**|500|600|25000|1250|

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_tsv_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_tsv_empty.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 596
+expression: output
+---
+Lang	Code	Lines	Bytes	Tokens
+Total	0	0	0	0

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_tsv_many.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_tsv_many.snap
@@ -1,0 +1,15 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 898
+expression: output
+---
+Lang	Code	Lines	Bytes	Tokens
+Rust	5000	6000	250000	12500
+Python	3000	3600	150000	7500
+JavaScript	2000	2400	100000	5000
+TypeScript	1500	1800	75000	3750
+Go	1000	1200	50000	2500
+TOML	200	240	10000	500
+YAML	150	180	7500	375
+Markdown	100	120	5000	250
+Total	12950	15540	647500	32375

--- a/crates/tokmd-format/tests/snapshots/snapshots__lang_tsv_single.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__lang_tsv_single.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 753
+expression: output
+---
+Lang	Code	Lines	Bytes	Tokens
+Rust	500	600	25000	1250
+Total	500	600	25000	1250

--- a/crates/tokmd-format/tests/snapshots/snapshots__module_json_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__module_json_empty.snap
@@ -1,0 +1,49 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 667
+expression: pretty
+---
+{
+  "args": {
+    "children": "separate",
+    "format": "json",
+    "module_depth": 1,
+    "module_roots": [],
+    "top": 0
+  },
+  "children": "separate",
+  "generated_at_ms": 0,
+  "mode": "module",
+  "module_depth": 1,
+  "module_roots": [],
+  "rows": [],
+  "scan": {
+    "config": "auto",
+    "excluded": [],
+    "hidden": false,
+    "no_ignore": false,
+    "no_ignore_dot": false,
+    "no_ignore_parent": false,
+    "no_ignore_vcs": false,
+    "paths": [
+      "."
+    ],
+    "treat_doc_strings_as_comments": false
+  },
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 0,
+    "bytes": 0,
+    "code": 0,
+    "files": 0,
+    "lines": 0,
+    "tokens": 0
+  },
+  "warnings": []
+}

--- a/crates/tokmd-format/tests/snapshots/snapshots__module_md_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__module_md_empty.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 631
+expression: output
+---
+|Module|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|**Total**|0|0|0|0|0|0|

--- a/crates/tokmd-format/tests/snapshots/snapshots__module_tsv_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__module_tsv_empty.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+assertion_line: 647
+expression: output
+---
+Module	Code	Lines	Files	Bytes	Tokens	Avg
+Total	0	0	0	0	0	0


### PR DESCRIPTION
## Summary

Adds 15 new insta snapshot tests for the \	okmd-format\ crate covering edge cases in output rendering. These complement the existing 15 snapshot tests that cover standard scenarios.

## New Test Coverage

### Empty Results (7 tests)
- \snapshot_lang_md_empty\ / \snapshot_lang_tsv_empty\ / \snapshot_lang_json_empty\
- \snapshot_module_md_empty\ / \snapshot_module_tsv_empty\ / \snapshot_module_json_empty\
- \snapshot_export_csv_empty\

### Single Language (3 tests)
- \snapshot_lang_md_single\ / \snapshot_lang_tsv_single\ / \snapshot_lang_json_single\

### Many Languages — 8 languages (3 tests)
- \snapshot_lang_md_many\ / \snapshot_lang_tsv_many\ / \snapshot_lang_json_many\

### Behavioral Edge Cases (2 tests)
- \snapshot_diff_md_no_changes\ — diff of identical reports
- \snapshot_export_jsonl_single_file\ — single-file JSONL export

## Verification

All 30 snapshot tests pass (\cargo test -p tokmd-format --test snapshots\).