### PR TITLE
test: add integration tests for analysis enricher crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ version = "1.7.2"
 dependencies = [
  "anyhow",
  "proptest",
+ "tempfile",
  "tokmd-analysis-maintainability",
  "tokmd-analysis-types",
  "tokmd-analysis-util",

--- a/crates/tokmd-analysis-complexity/Cargo.toml
+++ b/crates/tokmd-analysis-complexity/Cargo.toml
@@ -21,3 +21,4 @@ tokmd-types.workspace = true
 
 [dev-dependencies]
 proptest = "1.10.0"
+tempfile = "3.25.0"

--- a/crates/tokmd-analysis-complexity/tests/integration.rs
+++ b/crates/tokmd-analysis-complexity/tests/integration.rs
@@ -1,0 +1,479 @@
+//! Integration tests for `build_complexity_report`.
+//!
+//! Each test writes source files to a temp directory and feeds matching
+//! `ExportData` rows to exercise the end-to-end complexity pipeline.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tokmd_analysis_complexity::build_complexity_report;
+use tokmd_analysis_types::ComplexityRisk;
+use tokmd_analysis_util::AnalysisLimits;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_row(path: &str, module: &str, lang: &str, code: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments: 0,
+        blanks: 0,
+        lines: code,
+        bytes: code * 40,
+        tokens: code * 8,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn default_limits() -> AnalysisLimits {
+    AnalysisLimits::default()
+}
+
+fn write_temp_files(files: &[(&str, &str)]) -> (tempfile::TempDir, Vec<PathBuf>) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let mut paths = Vec::new();
+    for (rel, content) in files {
+        let full = dir.path().join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&full, content).unwrap();
+        paths.push(PathBuf::from(rel));
+    }
+    (dir, paths)
+}
+
+// ===========================================================================
+// Scenario: Empty input
+// ===========================================================================
+
+#[test]
+fn given_no_files_report_has_zero_totals() {
+    let dir = tempfile::tempdir().unwrap();
+    let export = make_export(vec![]);
+    let report =
+        build_complexity_report(dir.path(), &[], &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.total_functions, 0);
+    assert_eq!(report.avg_cyclomatic, 0.0);
+    assert_eq!(report.max_cyclomatic, 0);
+    assert_eq!(report.high_risk_files, 0);
+    assert!(report.files.is_empty());
+}
+
+// ===========================================================================
+// Scenario: Single Rust file with simple functions
+// ===========================================================================
+
+#[test]
+fn given_rust_file_detects_functions_and_cyclomatic() {
+    let code = "\
+fn simple() {
+    println!(\"hello\");
+}
+
+pub fn with_branch(x: i32) -> &'static str {
+    if x > 0 {
+        \"positive\"
+    } else {
+        \"non-positive\"
+    }
+}
+";
+    let (dir, paths) = write_temp_files(&[("src/lib.rs", code)]);
+    let export = make_export(vec![make_row("src/lib.rs", "src", "Rust", 12)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.total_functions, 2);
+    assert!(
+        report.max_cyclomatic >= 2,
+        "branching should add complexity"
+    );
+    assert_eq!(report.files.len(), 1);
+    assert_eq!(report.files[0].function_count, 2);
+}
+
+// ===========================================================================
+// Scenario: Function details when detail_functions=true
+// ===========================================================================
+
+#[test]
+fn given_detail_flag_then_function_details_present() {
+    let code = "\
+fn alpha() {
+    let x = 1;
+}
+
+fn beta(a: i32, b: i32) {
+    if a > b {
+        println!(\"a\");
+    }
+}
+";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", ".", "Rust", 10)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), true).unwrap();
+
+    assert_eq!(report.files.len(), 1);
+    let functions = report.files[0].functions.as_ref().expect("details present");
+    assert_eq!(functions.len(), 2);
+
+    let names: Vec<&str> = functions.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"alpha"));
+    assert!(names.contains(&"beta"));
+}
+
+// ===========================================================================
+// Scenario: detail_functions=false omits function details
+// ===========================================================================
+
+#[test]
+fn given_no_detail_flag_then_function_details_none() {
+    let code = "fn foo() { let x = 1; }\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", ".", "Rust", 1)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert!(report.files[0].functions.is_none());
+}
+
+// ===========================================================================
+// Scenario: Unsupported language is skipped
+// ===========================================================================
+
+#[test]
+fn given_unsupported_lang_file_is_skipped() {
+    let code = "# Markdown heading\nSome text.\n";
+    let (dir, paths) = write_temp_files(&[("README.md", code)]);
+    let export = make_export(vec![make_row("README.md", ".", "Markdown", 2)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.total_functions, 0);
+    assert!(report.files.is_empty());
+}
+
+// ===========================================================================
+// Scenario: Child rows are excluded
+// ===========================================================================
+
+#[test]
+fn given_child_rows_they_are_excluded() {
+    let code = "pub fn visible() {}\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let mut row = make_row("lib.rs", ".", "Rust", 1);
+    row.kind = FileKind::Child;
+    let export = make_export(vec![row]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.total_functions, 0);
+    assert!(report.files.is_empty());
+}
+
+// ===========================================================================
+// Scenario: Multiple files sorted by complexity descending
+// ===========================================================================
+
+#[test]
+fn given_multiple_files_sorted_by_complexity_desc() {
+    let simple = "fn a() { let x = 1; }\n";
+    let complex = "\
+fn branchy(x: i32) -> i32 {
+    if x > 0 {
+        if x > 10 {
+            for i in 0..x {
+                if i % 2 == 0 {
+                    println!(\"{}\", i);
+                }
+            }
+            42
+        } else {
+            x
+        }
+    } else {
+        0
+    }
+}
+";
+    let (dir, paths) = write_temp_files(&[("src/simple.rs", simple), ("src/complex.rs", complex)]);
+    let export = make_export(vec![
+        make_row("src/simple.rs", "src", "Rust", 1),
+        make_row("src/complex.rs", "src", "Rust", 18),
+    ]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.files.len(), 2);
+    // First file should have higher complexity
+    assert!(
+        report.files[0].cyclomatic_complexity >= report.files[1].cyclomatic_complexity,
+        "files should be sorted by cyclomatic desc"
+    );
+}
+
+// ===========================================================================
+// Scenario: Histogram is included
+// ===========================================================================
+
+#[test]
+fn given_files_then_histogram_is_present() {
+    let code = "fn f() { let x = 1; }\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", ".", "Rust", 1)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    let hist = report.histogram.as_ref().expect("histogram present");
+    assert_eq!(hist.total, 1);
+    assert_eq!(hist.counts.iter().sum::<u32>(), 1);
+}
+
+// ===========================================================================
+// Scenario: Python file analysis
+// ===========================================================================
+
+#[test]
+fn given_python_file_detects_functions() {
+    let code = "\
+def greet(name):
+    if name:
+        print(f'Hello, {name}!')
+    else:
+        print('Hello!')
+
+def add(a, b):
+    return a + b
+";
+    let (dir, paths) = write_temp_files(&[("main.py", code)]);
+    let export = make_export(vec![make_row("main.py", ".", "Python", 8)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.total_functions, 2);
+    assert!(report.max_cyclomatic >= 2);
+}
+
+// ===========================================================================
+// Scenario: Go file analysis
+// ===========================================================================
+
+#[test]
+fn given_go_file_detects_functions() {
+    let code = "\
+package main
+
+func hello() {
+    fmt.Println(\"hello\")
+}
+
+func decide(x int) int {
+    if x > 0 {
+        return x
+    }
+    return 0
+}
+";
+    let (dir, paths) = write_temp_files(&[("main.go", code)]);
+    let export = make_export(vec![make_row("main.go", ".", "Go", 12)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.total_functions, 2);
+    assert!(report.max_cyclomatic >= 2);
+}
+
+// ===========================================================================
+// Scenario: Max bytes limit stops scanning early
+// ===========================================================================
+
+#[test]
+fn given_max_bytes_limit_scanning_stops() {
+    let code_a = "fn a() { let x = 1; }\n";
+    let code_b = "fn b() { let y = 2; }\nfn c() { let z = 3; }\n";
+    let (dir, paths) = write_temp_files(&[("a.rs", code_a), ("b.rs", code_b)]);
+    let export = make_export(vec![
+        make_row("a.rs", ".", "Rust", 1),
+        make_row("b.rs", ".", "Rust", 2),
+    ]);
+    let limits = AnalysisLimits {
+        max_bytes: Some(code_a.len() as u64),
+        ..Default::default()
+    };
+    let report = build_complexity_report(dir.path(), &paths, &export, &limits, false).unwrap();
+
+    // Only the first file should be scanned
+    assert!(
+        report.files.len() <= 1,
+        "expected at most 1 file, got {}",
+        report.files.len()
+    );
+}
+
+// ===========================================================================
+// Scenario: Aggregates are consistent
+// ===========================================================================
+
+#[test]
+fn given_files_then_aggregates_are_consistent() {
+    let code_a = "\
+fn one() {
+    if true { println!(\"a\"); }
+}
+";
+    let code_b = "\
+fn two() {
+    for i in 0..10 {
+        if i > 5 {
+            println!(\"{}\", i);
+        }
+    }
+}
+
+fn three() {
+    match 1 {
+        1 => println!(\"one\"),
+        _ => println!(\"other\"),
+    }
+}
+";
+    let (dir, paths) = write_temp_files(&[("a.rs", code_a), ("b.rs", code_b)]);
+    let export = make_export(vec![
+        make_row("a.rs", ".", "Rust", 3),
+        make_row("b.rs", ".", "Rust", 16),
+    ]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    // total_functions is sum across files
+    let fn_sum: usize = report.files.iter().map(|f| f.function_count).sum();
+    assert_eq!(report.total_functions, fn_sum);
+
+    // max_cyclomatic >= avg_cyclomatic
+    assert!(report.max_cyclomatic as f64 >= report.avg_cyclomatic);
+
+    // high_risk_files <= files.len()
+    assert!(report.high_risk_files <= report.files.len());
+}
+
+// ===========================================================================
+// Scenario: Risk classification
+// ===========================================================================
+
+#[test]
+fn given_simple_function_risk_is_low() {
+    let code = "fn simple() { let x = 1; }\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", ".", "Rust", 1)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.files[0].risk_level, ComplexityRisk::Low);
+}
+
+// ===========================================================================
+// Scenario: Technical debt ratio
+// ===========================================================================
+
+#[test]
+fn given_files_with_code_then_technical_debt_present() {
+    let code = "\
+fn complex(x: i32) -> i32 {
+    if x > 0 {
+        if x > 10 {
+            for i in 0..x {
+                if i % 2 == 0 {
+                    return i;
+                }
+            }
+        }
+    }
+    0
+}
+";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", ".", "Rust", 12)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    let debt = report
+        .technical_debt
+        .as_ref()
+        .expect("debt should be present");
+    assert!(debt.ratio > 0.0);
+    assert!(debt.complexity_points > 0);
+    assert!(debt.code_kloc > 0.0);
+}
+
+// ===========================================================================
+// Scenario: Cognitive complexity is populated
+// ===========================================================================
+
+#[test]
+fn given_branchy_code_cognitive_complexity_populated() {
+    let code = "\
+fn branchy(x: i32) -> i32 {
+    if x > 0 {
+        if x > 10 {
+            42
+        } else {
+            x
+        }
+    } else {
+        0
+    }
+}
+";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", ".", "Rust", 12)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert!(
+        report.files[0].cognitive_complexity.is_some(),
+        "cognitive complexity should be populated for branchy code"
+    );
+}
+
+// ===========================================================================
+// Scenario: JavaScript file analysis
+// ===========================================================================
+
+#[test]
+fn given_javascript_file_detects_functions() {
+    let code = "\
+function greet(name) {
+    if (name) {
+        console.log('Hello, ' + name);
+    }
+}
+
+function add(a, b) {
+    return a + b;
+}
+";
+    let (dir, paths) = write_temp_files(&[("index.js", code)]);
+    let export = make_export(vec![make_row("index.js", ".", "JavaScript", 10)]);
+    let report =
+        build_complexity_report(dir.path(), &paths, &export, &default_limits(), false).unwrap();
+
+    assert_eq!(report.total_functions, 2);
+    assert!(report.avg_cyclomatic > 0.0);
+}

--- a/crates/tokmd-analysis-derived/tests/integration_subreports.rs
+++ b/crates/tokmd-analysis-derived/tests/integration_subreports.rs
@@ -1,0 +1,270 @@
+//! Integration tests for derived sub-reports: boilerplate, verbosity,
+//! lang purity, top offenders, and test density edge cases.
+
+use tokmd_analysis_derived::derive_report;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn make_row(
+    path: &str,
+    module: &str,
+    lang: &str,
+    code: usize,
+    comments: usize,
+    blanks: usize,
+    bytes: usize,
+    tokens: usize,
+) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments,
+        blanks,
+        lines: code + comments + blanks,
+        bytes,
+        tokens,
+    }
+}
+
+fn export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+// ── Boilerplate ─────────────────────────────────────────────────
+
+mod boilerplate {
+    use super::*;
+
+    #[test]
+    fn given_only_logic_langs_then_boilerplate_ratio_is_zero() {
+        let rows = vec![
+            make_row("src/lib.rs", "src", "Rust", 200, 10, 5, 8000, 1600),
+            make_row("src/app.py", "src", "Python", 100, 5, 3, 4000, 800),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.boilerplate.ratio, 0.0);
+        assert_eq!(report.boilerplate.infra_lines, 0);
+        assert!(report.boilerplate.infra_langs.is_empty());
+    }
+
+    #[test]
+    fn given_infra_files_then_boilerplate_ratio_is_positive() {
+        let rows = vec![
+            make_row("src/lib.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+            make_row("Cargo.toml", ".", "TOML", 50, 5, 5, 2000, 400),
+            make_row("config.json", ".", "JSON", 30, 0, 0, 1200, 240),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert!(report.boilerplate.ratio > 0.0);
+        assert!(report.boilerplate.infra_lines > 0);
+        assert!(report.boilerplate.logic_lines > 0);
+        assert!(!report.boilerplate.infra_langs.is_empty());
+    }
+
+    #[test]
+    fn given_only_infra_files_then_ratio_is_one() {
+        let rows = vec![
+            make_row("Cargo.toml", ".", "TOML", 50, 0, 0, 2000, 400),
+            make_row("package.json", ".", "JSON", 30, 0, 0, 1200, 240),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.boilerplate.ratio, 1.0);
+        assert_eq!(report.boilerplate.logic_lines, 0);
+    }
+
+    #[test]
+    fn given_empty_input_then_boilerplate_is_zeroed() {
+        let report = derive_report(&export(vec![]), None);
+        assert_eq!(report.boilerplate.ratio, 0.0);
+        assert_eq!(report.boilerplate.infra_lines, 0);
+        assert_eq!(report.boilerplate.logic_lines, 0);
+    }
+}
+
+// ── Verbosity ───────────────────────────────────────────────────
+
+mod verbosity {
+    use super::*;
+
+    #[test]
+    fn given_files_then_verbosity_rate_is_bytes_per_line() {
+        // 4000 bytes / 110 lines ≈ 36.36
+        let rows = vec![make_row("src/lib.rs", "src", "Rust", 100, 5, 5, 4000, 800)];
+        let report = derive_report(&export(rows), None);
+        let expected_rate = 4000.0 / 110.0;
+        assert!(
+            (report.verbosity.total.rate - expected_rate).abs() < 0.1,
+            "verbosity rate should be ~{expected_rate}, got {}",
+            report.verbosity.total.rate
+        );
+    }
+
+    #[test]
+    fn given_multi_lang_files_then_verbosity_has_lang_breakdown() {
+        let rows = vec![
+            make_row("a.rs", "src", "Rust", 100, 0, 0, 8000, 1600),
+            make_row("b.py", "src", "Python", 100, 0, 0, 3000, 600),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.verbosity.by_lang.len(), 2);
+        // Rust has higher bytes-per-line → should be first (sorted desc by rate)
+        assert_eq!(report.verbosity.by_lang[0].key, "Rust");
+    }
+
+    #[test]
+    fn given_zero_lines_then_verbosity_rate_is_zero() {
+        let report = derive_report(&export(vec![]), None);
+        assert_eq!(report.verbosity.total.rate, 0.0);
+    }
+}
+
+// ── Lang Purity ─────────────────────────────────────────────────
+
+mod lang_purity {
+    use super::*;
+
+    #[test]
+    fn given_single_lang_module_then_purity_is_one() {
+        let rows = vec![
+            make_row("src/a.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+            make_row("src/b.rs", "src", "Rust", 200, 0, 0, 8000, 1600),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.lang_purity.rows.len(), 1);
+        assert_eq!(report.lang_purity.rows[0].module, "src");
+        assert_eq!(report.lang_purity.rows[0].lang_count, 1);
+        assert_eq!(report.lang_purity.rows[0].dominant_pct, 1.0);
+    }
+
+    #[test]
+    fn given_mixed_lang_module_then_purity_reflects_dominant() {
+        let rows = vec![
+            make_row("src/lib.rs", "src", "Rust", 300, 0, 0, 12000, 2400),
+            make_row("src/helper.py", "src", "Python", 100, 0, 0, 4000, 800),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.lang_purity.rows.len(), 1);
+        let row = &report.lang_purity.rows[0];
+        assert_eq!(row.lang_count, 2);
+        assert_eq!(row.dominant_lang, "Rust");
+        // Rust: 300 lines, Python: 100 lines → 300/400 = 0.75
+        assert_eq!(row.dominant_pct, 0.75);
+    }
+
+    #[test]
+    fn given_multiple_modules_then_purity_rows_per_module() {
+        let rows = vec![
+            make_row("src/a.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+            make_row("lib/b.py", "lib", "Python", 100, 0, 0, 4000, 800),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.lang_purity.rows.len(), 2);
+        // Sorted by module name
+        assert_eq!(report.lang_purity.rows[0].module, "lib");
+        assert_eq!(report.lang_purity.rows[1].module, "src");
+    }
+
+    #[test]
+    fn given_empty_input_then_purity_is_empty() {
+        let report = derive_report(&export(vec![]), None);
+        assert!(report.lang_purity.rows.is_empty());
+    }
+}
+
+// ── Top Offenders ───────────────────────────────────────────────
+
+mod top_offenders {
+    use super::*;
+
+    #[test]
+    fn given_files_then_largest_by_lines_sorted_desc() {
+        let rows = vec![
+            make_row("small.rs", "src", "Rust", 10, 0, 0, 400, 80),
+            make_row("big.rs", "src", "Rust", 500, 0, 0, 20000, 4000),
+            make_row("medium.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.top.largest_lines[0].path, "big.rs");
+        assert_eq!(report.top.largest_lines[1].path, "medium.rs");
+        assert_eq!(report.top.largest_lines[2].path, "small.rs");
+    }
+
+    #[test]
+    fn given_files_then_largest_by_tokens_sorted_desc() {
+        let rows = vec![
+            make_row("low_tok.rs", "src", "Rust", 100, 0, 0, 4000, 100),
+            make_row("high_tok.rs", "src", "Rust", 100, 0, 0, 4000, 5000),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.top.largest_tokens[0].path, "high_tok.rs");
+        assert_eq!(report.top.largest_tokens[1].path, "low_tok.rs");
+    }
+
+    #[test]
+    fn given_more_than_ten_files_then_top_bounded_at_ten() {
+        let rows: Vec<FileRow> = (0..15)
+            .map(|i| {
+                make_row(
+                    &format!("f{i:02}.rs"),
+                    "src",
+                    "Rust",
+                    (i + 1) * 10,
+                    0,
+                    0,
+                    (i + 1) * 400,
+                    (i + 1) * 80,
+                )
+            })
+            .collect();
+        let report = derive_report(&export(rows), None);
+        assert!(report.top.largest_lines.len() <= 10);
+        assert!(report.top.largest_tokens.len() <= 10);
+        assert!(report.top.largest_bytes.len() <= 10);
+    }
+
+    #[test]
+    fn given_undocumented_large_files_then_least_documented_populated() {
+        // Files >= 50 lines with zero comments show up in least_documented
+        let rows = vec![
+            make_row("nodoc.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+            make_row("doc.rs", "src", "Rust", 50, 50, 0, 4000, 800),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert!(!report.top.least_documented.is_empty());
+        // nodoc.rs has 0% documentation
+        assert_eq!(report.top.least_documented[0].path, "nodoc.rs");
+    }
+
+    #[test]
+    fn given_dense_files_then_most_dense_populated() {
+        // Files >= 10 lines with high bytes-per-line
+        let rows = vec![
+            make_row("sparse.rs", "src", "Rust", 50, 0, 0, 500, 100),
+            make_row("dense.rs", "src", "Rust", 50, 0, 0, 50000, 10000),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert!(!report.top.most_dense.is_empty());
+        // dense.rs has 50000/50=1000 bytes per line
+        assert_eq!(report.top.most_dense[0].path, "dense.rs");
+    }
+
+    #[test]
+    fn given_empty_input_then_all_top_offenders_empty() {
+        let report = derive_report(&export(vec![]), None);
+        assert!(report.top.largest_lines.is_empty());
+        assert!(report.top.largest_tokens.is_empty());
+        assert!(report.top.largest_bytes.is_empty());
+        assert!(report.top.least_documented.is_empty());
+        assert!(report.top.most_dense.is_empty());
+    }
+}


### PR DESCRIPTION
Add integration tests for analysis enricher crates with coverage gaps. 16 new tests for tokmd-analysis-complexity (build_complexity_report). 17 new tests for tokmd-analysis-derived (boilerplate, verbosity, lang purity, top offenders sub-reports).