### PR TITLE
test: add unit tests for tokeignore, walk, cockpit, context-git, analysis-imports

### DIFF
--- a/crates/tokmd-context-git/src/lib.rs
+++ b/crates/tokmd-context-git/src/lib.rs
@@ -377,3 +377,53 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod tests_no_git {
+    use super::*;
+
+    #[test]
+    fn test_git_scores_struct_default() {
+        let scores = GitScores {
+            hotspots: BTreeMap::new(),
+            commit_counts: BTreeMap::new(),
+        };
+        assert!(scores.hotspots.is_empty());
+        assert!(scores.commit_counts.is_empty());
+    }
+
+    #[test]
+    fn test_git_scores_struct_with_data() {
+        let mut hotspots = BTreeMap::new();
+        hotspots.insert("src/main.rs".to_string(), 100);
+        hotspots.insert("src/lib.rs".to_string(), 50);
+        let mut commit_counts = BTreeMap::new();
+        commit_counts.insert("src/main.rs".to_string(), 10);
+        commit_counts.insert("src/lib.rs".to_string(), 5);
+
+        let scores = GitScores {
+            hotspots,
+            commit_counts,
+        };
+
+        assert_eq!(scores.hotspots.len(), 2);
+        assert_eq!(scores.commit_counts.get("src/main.rs"), Some(&10));
+        assert_eq!(scores.hotspots.get("src/lib.rs"), Some(&50));
+    }
+
+    #[test]
+    fn test_git_scores_btreemap_ordering() {
+        let mut hotspots = BTreeMap::new();
+        hotspots.insert("z.rs".to_string(), 1);
+        hotspots.insert("a.rs".to_string(), 2);
+        hotspots.insert("m.rs".to_string(), 3);
+
+        let scores = GitScores {
+            hotspots,
+            commit_counts: BTreeMap::new(),
+        };
+
+        let keys: Vec<&String> = scores.hotspots.keys().collect();
+        assert_eq!(keys, vec!["a.rs", "m.rs", "z.rs"]);
+    }
+}


### PR DESCRIPTION
## Summary

Add \#[cfg(test)]\ unit test modules to 5 crates that were missing them:

### Crates tested

| Crate | Tier | Tests Added | Focus |
|-------|------|-------------|-------|
| \	okmd-tokeignore\ | 1 | 13 | Template generation, content validation, file write/overwrite/force behavior |
| \	okmd-walk\ | 2 | 11 | License candidate detection, file size queries, list_files edge cases |
| \	okmd-cockpit\ | 2 | 38 | Composition, contracts, code health, risk, review plan, trend metrics, sparkline, flush_uncovered_hunks, utility helpers |
| \	okmd-context-git\ | 2 | 3 | GitScores struct construction and BTreeMap ordering (feature-independent) |
| \	okmd-analysis-imports\ | 3 | 28 | Import parsing for Rust/JS/TS/Python/Go, target normalization, language support, extract_quoted |

### Test verification

All tests pass:
- \cargo test -p tokmd-analysis-imports\ — 42 unit + 14 property tests ✅
- \cargo test -p tokmd-tokeignore\ — 29 unit + property tests ✅
- \cargo test -p tokmd-walk --lib\ — 15 unit tests ✅
- \cargo test -p tokmd-cockpit --lib\ — 53 tests (38 new + 15 existing determinism) ✅
- \cargo test -p tokmd-context-git --lib\ — 3 new tests ✅

### Notes

- All new tests are pure unit tests with no git/filesystem side effects (except tokeignore which uses tempdir)
- Tests focus on public API coverage: pure computation functions, edge cases, and output validation
- \cargo fmt\ applied