### PR TITLE
test: add unit tests for types, analysis-types, config, gate, fun

### DIFF
--- a/crates/tokmd-fun/src/lib.rs
+++ b/crates/tokmd-fun/src/lib.rs
@@ -153,3 +153,178 @@ pub fn render_midi(notes: &[MidiNote], tempo_bpm: u16) -> Result<Vec<u8>> {
     smf.write_std(&mut out)?;
     Ok(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── sanitize_name ─────────────────────────────────────────────────
+    #[test]
+    fn sanitize_name_replaces_non_alphanumeric() {
+        assert_eq!(sanitize_name("hello world"), "hello_world");
+        assert_eq!(sanitize_name("src/main.rs"), "src_main_rs");
+        assert_eq!(sanitize_name("foo-bar_baz"), "foo_bar_baz");
+    }
+
+    #[test]
+    fn sanitize_name_preserves_alphanumeric() {
+        assert_eq!(sanitize_name("abc123"), "abc123");
+    }
+
+    #[test]
+    fn sanitize_name_empty() {
+        assert_eq!(sanitize_name(""), "");
+    }
+
+    // ── render_obj ────────────────────────────────────────────────────
+    #[test]
+    fn render_obj_empty_input() {
+        let result = render_obj(&[]);
+        assert_eq!(result, "# tokmd code city\n");
+    }
+
+    #[test]
+    fn render_obj_single_building() {
+        let buildings = vec![ObjBuilding {
+            name: "main".into(),
+            x: 0.0,
+            y: 0.0,
+            w: 1.0,
+            d: 1.0,
+            h: 2.0,
+        }];
+        let result = render_obj(&buildings);
+        assert!(result.starts_with("# tokmd code city\n"));
+        assert!(result.contains("o main\n"));
+        // 8 vertices per building
+        assert_eq!(result.matches("\nv ").count(), 8);
+        // 6 faces per building
+        assert_eq!(result.matches("\nf ").count(), 6);
+    }
+
+    #[test]
+    fn render_obj_multiple_buildings() {
+        let buildings = vec![
+            ObjBuilding {
+                name: "a".into(),
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                d: 1.0,
+                h: 1.0,
+            },
+            ObjBuilding {
+                name: "b".into(),
+                x: 2.0,
+                y: 0.0,
+                w: 1.0,
+                d: 1.0,
+                h: 3.0,
+            },
+        ];
+        let result = render_obj(&buildings);
+        assert!(result.contains("o a\n"));
+        assert!(result.contains("o b\n"));
+        // 16 vertices total (2 × 8)
+        assert_eq!(result.matches("\nv ").count(), 16);
+        // 12 faces total (2 × 6)
+        assert_eq!(result.matches("\nf ").count(), 12);
+    }
+
+    #[test]
+    fn render_obj_sanitizes_names() {
+        let buildings = vec![ObjBuilding {
+            name: "src/main.rs".into(),
+            x: 0.0,
+            y: 0.0,
+            w: 1.0,
+            d: 1.0,
+            h: 1.0,
+        }];
+        let result = render_obj(&buildings);
+        assert!(result.contains("o src_main_rs\n"));
+        assert!(!result.contains("o src/main.rs\n"));
+    }
+
+    // ── render_midi ───────────────────────────────────────────────────
+    #[test]
+    fn render_midi_empty_notes() {
+        let result = render_midi(&[], 120).unwrap();
+        // Should produce valid MIDI even with no notes (header + tempo + end-of-track)
+        assert!(!result.is_empty());
+        // MIDI files start with "MThd"
+        assert_eq!(&result[..4], b"MThd");
+    }
+
+    #[test]
+    fn render_midi_single_note() {
+        let notes = vec![MidiNote {
+            key: 60,
+            velocity: 100,
+            start: 0,
+            duration: 480,
+            channel: 0,
+        }];
+        let result = render_midi(&notes, 120).unwrap();
+        assert_eq!(&result[..4], b"MThd");
+        // Should contain track data
+        assert!(result.len() > 14); // Header is 14 bytes minimum
+    }
+
+    #[test]
+    fn render_midi_multiple_notes() {
+        let notes = vec![
+            MidiNote {
+                key: 60,
+                velocity: 100,
+                start: 0,
+                duration: 480,
+                channel: 0,
+            },
+            MidiNote {
+                key: 64,
+                velocity: 80,
+                start: 480,
+                duration: 480,
+                channel: 0,
+            },
+            MidiNote {
+                key: 67,
+                velocity: 60,
+                start: 960,
+                duration: 480,
+                channel: 1,
+            },
+        ];
+        let result = render_midi(&notes, 120).unwrap();
+        assert_eq!(&result[..4], b"MThd");
+    }
+
+    #[test]
+    fn render_midi_channel_clamped_to_15() {
+        let notes = vec![MidiNote {
+            key: 60,
+            velocity: 100,
+            start: 0,
+            duration: 480,
+            channel: 255, // Should be clamped to 15
+        }];
+        // Should not panic or error
+        let result = render_midi(&notes, 120).unwrap();
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn render_midi_tempo_min_clamped() {
+        let notes = vec![MidiNote {
+            key: 60,
+            velocity: 100,
+            start: 0,
+            duration: 480,
+            channel: 0,
+        }];
+        // tempo_bpm = 0 should be clamped via max(1)
+        let result = render_midi(&notes, 0).unwrap();
+        assert!(!result.is_empty());
+    }
+}

--- a/crates/tokmd-gate/src/lib.rs
+++ b/crates/tokmd-gate/src/lib.rs
@@ -31,3 +31,227 @@ pub use types::{
     GateError, GateResult, PolicyConfig, PolicyRule, RatchetConfig, RatchetGateResult,
     RatchetResult, RatchetRule, RuleLevel, RuleOperator, RuleResult,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── resolve_pointer (public API) ──────────────────────────────────
+    #[test]
+    fn resolve_pointer_simple_path() {
+        let doc = json!({"a": {"b": 42}});
+        assert_eq!(resolve_pointer(&doc, "/a/b"), Some(&json!(42)));
+    }
+
+    #[test]
+    fn resolve_pointer_missing_path() {
+        let doc = json!({"a": 1});
+        assert_eq!(resolve_pointer(&doc, "/b"), None);
+    }
+
+    #[test]
+    fn resolve_pointer_empty_is_whole_doc() {
+        let doc = json!({"x": 1});
+        assert_eq!(resolve_pointer(&doc, ""), Some(&doc));
+    }
+
+    // ── evaluate_policy (public API) ──────────────────────────────────
+    #[test]
+    fn evaluate_policy_all_pass() {
+        let receipt = json!({"tokens": 100, "files": 5});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "max_tokens".into(),
+                pointer: "/tokens".into(),
+                op: RuleOperator::Lte,
+                value: Some(json!(1000)),
+                values: None,
+                negate: false,
+                level: RuleLevel::Error,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let result = evaluate_policy(&receipt, &policy);
+        assert!(result.passed);
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn evaluate_policy_with_failure() {
+        let receipt = json!({"tokens": 2000});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "max_tokens".into(),
+                pointer: "/tokens".into(),
+                op: RuleOperator::Lte,
+                value: Some(json!(1000)),
+                values: None,
+                negate: false,
+                level: RuleLevel::Error,
+                message: Some("Too many tokens".into()),
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let result = evaluate_policy(&receipt, &policy);
+        assert!(!result.passed);
+        assert_eq!(result.errors, 1);
+    }
+
+    #[test]
+    fn evaluate_policy_warn_does_not_fail() {
+        let receipt = json!({"tokens": 2000});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "token_warning".into(),
+                pointer: "/tokens".into(),
+                op: RuleOperator::Lte,
+                value: Some(json!(1000)),
+                values: None,
+                negate: false,
+                level: RuleLevel::Warn,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let result = evaluate_policy(&receipt, &policy);
+        assert!(result.passed); // Warnings don't fail
+        assert_eq!(result.warnings, 1);
+    }
+
+    // ── evaluate_ratchet_policy (public API) ──────────────────────────
+    #[test]
+    fn ratchet_policy_pass() {
+        let baseline = json!({"complexity": 10.0});
+        let current = json!({"complexity": 10.5}); // 5% increase
+        let config = RatchetConfig {
+            rules: vec![RatchetRule {
+                pointer: "/complexity".into(),
+                max_increase_pct: Some(10.0),
+                max_value: None,
+                level: RuleLevel::Error,
+                description: None,
+            }],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.errors, 0);
+    }
+
+    #[test]
+    fn ratchet_policy_fail_regression() {
+        let baseline = json!({"complexity": 10.0});
+        let current = json!({"complexity": 15.0}); // 50% increase
+        let config = RatchetConfig {
+            rules: vec![RatchetRule {
+                pointer: "/complexity".into(),
+                max_increase_pct: Some(10.0),
+                max_value: None,
+                level: RuleLevel::Error,
+                description: None,
+            }],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+        assert_eq!(result.errors, 1);
+    }
+
+    // ── PolicyConfig parsing ──────────────────────────────────────────
+    #[test]
+    fn policy_config_from_toml() {
+        let toml = r#"
+fail_fast = false
+allow_missing = true
+
+[[rules]]
+name = "check_tokens"
+pointer = "/tokens"
+op = "lte"
+value = 500000
+"#;
+        let policy = PolicyConfig::from_toml(toml).unwrap();
+        assert!(!policy.fail_fast);
+        assert!(policy.allow_missing);
+        assert_eq!(policy.rules.len(), 1);
+        assert_eq!(policy.rules[0].name, "check_tokens");
+    }
+
+    #[test]
+    fn policy_config_default_is_empty() {
+        let policy = PolicyConfig::default();
+        assert!(policy.rules.is_empty());
+        assert!(!policy.fail_fast);
+        assert!(!policy.allow_missing);
+    }
+
+    #[test]
+    fn ratchet_config_from_toml() {
+        let toml = r#"
+fail_fast = true
+allow_missing_baseline = true
+
+[[rules]]
+pointer = "/complexity/avg"
+max_increase_pct = 5.0
+level = "error"
+"#;
+        let config = RatchetConfig::from_toml(toml).unwrap();
+        assert!(config.fail_fast);
+        assert!(config.allow_missing_baseline);
+        assert_eq!(config.rules.len(), 1);
+    }
+
+    // ── GateResult construction ───────────────────────────────────────
+    #[test]
+    fn gate_result_from_empty_results() {
+        let result = GateResult::from_results(vec![]);
+        assert!(result.passed);
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn ratchet_gate_result_from_empty_results() {
+        let result = RatchetGateResult::from_results(vec![]);
+        assert!(result.passed);
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+
+    // ── RuleOperator Display ──────────────────────────────────────────
+    #[test]
+    fn rule_operator_display() {
+        assert_eq!(RuleOperator::Gt.to_string(), ">");
+        assert_eq!(RuleOperator::Lte.to_string(), "<=");
+        assert_eq!(RuleOperator::Eq.to_string(), "==");
+        assert_eq!(RuleOperator::In.to_string(), "in");
+        assert_eq!(RuleOperator::Exists.to_string(), "exists");
+    }
+
+    // ── RuleOperator/RuleLevel defaults ───────────────────────────────
+    #[test]
+    fn rule_operator_default_is_eq() {
+        assert_eq!(RuleOperator::default(), RuleOperator::Eq);
+    }
+
+    #[test]
+    fn rule_level_default_is_error() {
+        assert_eq!(RuleLevel::default(), RuleLevel::Error);
+    }
+}


### PR DESCRIPTION
## Summary

Adds \#[cfg(test)] mod tests\ unit test modules to five crates that were missing them, improving test coverage across the codebase.

## Crates covered

| Crate | Tests added | Focus areas |
|-------|------------|-------------|
| \	okmd-types\ | ~20 tests | Schema constants, Default impls, serde roundtrips, TokenEstimationMeta, TokenAudit |
| \	okmd-analysis-types\ | ~15 tests | Schema constants, defaults, enum serde, ComplexityBaseline, ComplexityHistogram::to_ascii |
| \	okmd-config\ | ~11 tests | Defaults, enum serde roundtrips, UserConfig serde, GlobalArgs→ScanOptions conversion |
| \	okmd-gate\ | ~17 tests | Integration tests for evaluate_policy, resolve_pointer, evaluate_ratchet_policy, TOML parsing |
| \	okmd-fun\ | ~15 tests | sanitize_name, render_obj geometry validation, render_midi encoding |

## Approach

- Tests exercise the **public API surface** of each crate
- Serde roundtrip tests verify JSON serialization/deserialization stability
- Default impl tests ensure contract stability
- Gate tests provide integration-level coverage through the public API (submodules already had unit tests)
- All tests are deterministic with no external dependencies