### PR TITLE
docs: add doc examples as tests for redact, module-key, math, path, exclude

### DIFF
--- a/crates/tokmd-exclude/src/lib.rs
+++ b/crates/tokmd-exclude/src/lib.rs
@@ -12,6 +12,17 @@ use tokmd_path::normalize_rel_path;
 /// - if `path` is absolute and under `root`, strip the `root` prefix
 /// - convert backslashes to `/`
 /// - strip one leading `./`
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+/// use tokmd_exclude::normalize_exclude_pattern;
+///
+/// let root = Path::new("/project");
+/// let relative = Path::new("./out/bundle.js");
+/// assert_eq!(normalize_exclude_pattern(root, relative), "out/bundle.js");
+/// ```
 #[must_use]
 pub fn normalize_exclude_pattern(root: &Path, path: &Path) -> String {
     let rel = if path.is_absolute() {
@@ -23,6 +34,16 @@ pub fn normalize_exclude_pattern(root: &Path, path: &Path) -> String {
 }
 
 /// Return `true` when `existing` already contains `pattern` after normalization.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_exclude::has_exclude_pattern;
+///
+/// let existing = vec!["out/bundle".to_string()];
+/// assert!(has_exclude_pattern(&existing, "./out/bundle"));
+/// assert!(!has_exclude_pattern(&existing, "dist/app"));
+/// ```
 #[must_use]
 pub fn has_exclude_pattern(existing: &[String], pattern: &str) -> bool {
     let normalized = normalize_rel_path(pattern);
@@ -34,6 +55,18 @@ pub fn has_exclude_pattern(existing: &[String], pattern: &str) -> bool {
 /// Add a pattern only when non-empty and not already present (after normalization).
 ///
 /// Returns `true` when the pattern was inserted.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_exclude::add_exclude_pattern;
+///
+/// let mut patterns = vec![];
+/// assert!(add_exclude_pattern(&mut patterns, "out/bundle".to_string()));
+/// assert!(!add_exclude_pattern(&mut patterns, "./out/bundle".to_string())); // duplicate
+/// assert!(!add_exclude_pattern(&mut patterns, String::new())); // empty
+/// assert_eq!(patterns.len(), 1);
+/// ```
 pub fn add_exclude_pattern(existing: &mut Vec<String>, pattern: String) -> bool {
     if pattern.is_empty() || has_exclude_pattern(existing, &pattern) {
         return false;

--- a/crates/tokmd-math/src/lib.rs
+++ b/crates/tokmd-math/src/lib.rs
@@ -3,6 +3,16 @@
 #![forbid(unsafe_code)]
 
 /// Round a floating point value to `decimals` decimal places.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_math::round_f64;
+///
+/// assert_eq!(round_f64(12.34567, 2), 12.35);
+/// assert_eq!(round_f64(12.34567, 4), 12.3457);
+/// assert_eq!(round_f64(1.5, 0), 2.0);
+/// ```
 #[must_use]
 pub fn round_f64(value: f64, decimals: u32) -> f64 {
     let factor = 10f64.powi(decimals as i32);
@@ -10,6 +20,15 @@ pub fn round_f64(value: f64, decimals: u32) -> f64 {
 }
 
 /// Return a 4-decimal ratio and guard division by zero.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_math::safe_ratio;
+///
+/// assert_eq!(safe_ratio(1, 4), 0.25);
+/// assert_eq!(safe_ratio(5, 0), 0.0); // division by zero returns 0
+/// ```
 #[must_use]
 pub fn safe_ratio(numer: usize, denom: usize) -> f64 {
     if denom == 0 {
@@ -20,6 +39,17 @@ pub fn safe_ratio(numer: usize, denom: usize) -> f64 {
 }
 
 /// Return the `pct` percentile from an ascending-sorted integer slice.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_math::percentile;
+///
+/// let values = [10, 20, 30, 40, 50];
+/// assert_eq!(percentile(&values, 0.0), 10.0);
+/// assert_eq!(percentile(&values, 0.9), 50.0);
+/// assert_eq!(percentile(&[], 0.5), 0.0); // empty slice returns 0
+/// ```
 #[must_use]
 pub fn percentile(sorted: &[usize], pct: f64) -> f64 {
     if sorted.is_empty() {
@@ -30,6 +60,21 @@ pub fn percentile(sorted: &[usize], pct: f64) -> f64 {
 }
 
 /// Return the Gini coefficient for an ascending-sorted integer slice.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_math::gini_coefficient;
+///
+/// // Perfectly equal distribution has a Gini of 0
+/// assert!((gini_coefficient(&[5, 5, 5, 5]) - 0.0).abs() < 1e-10);
+///
+/// // Empty slice returns 0
+/// assert_eq!(gini_coefficient(&[]), 0.0);
+///
+/// // Unequal distribution produces a positive Gini
+/// assert!(gini_coefficient(&[1, 1, 1, 100]) > 0.0);
+/// ```
 #[must_use]
 pub fn gini_coefficient(sorted: &[usize]) -> f64 {
     if sorted.is_empty() {

--- a/crates/tokmd-module-key/src/lib.rs
+++ b/crates/tokmd-module-key/src/lib.rs
@@ -7,6 +7,22 @@
 /// - If the first directory segment is in `module_roots`, include up to
 ///   `module_depth` directory segments.
 /// - Otherwise, the module key is the first directory segment.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_module_key::module_key;
+///
+/// // Root-level files map to "(root)"
+/// assert_eq!(module_key("Cargo.toml", &[], 2), "(root)");
+///
+/// // Files under a module root include deeper segments
+/// let roots = vec!["crates".into()];
+/// assert_eq!(module_key("crates/foo/src/lib.rs", &roots, 2), "crates/foo");
+///
+/// // Non-root directories use only the first segment
+/// assert_eq!(module_key("src/lib.rs", &roots, 2), "src");
+/// ```
 #[must_use]
 pub fn module_key(path: &str, module_roots: &[String], module_depth: usize) -> String {
     let mut p = path.replace('\\', "/");
@@ -24,6 +40,24 @@ pub fn module_key(path: &str, module_roots: &[String], module_depth: usize) -> S
 /// - forward slashes only
 /// - no leading `./`
 /// - no leading `/`
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_module_key::module_key_from_normalized;
+///
+/// let roots = vec!["crates".into()];
+/// assert_eq!(
+///     module_key_from_normalized("crates/foo/src/lib.rs", &roots, 2),
+///     "crates/foo"
+/// );
+///
+/// // Root-level files return "(root)"
+/// assert_eq!(
+///     module_key_from_normalized("README.md", &roots, 2),
+///     "(root)"
+/// );
+/// ```
 #[must_use]
 pub fn module_key_from_normalized(
     path: &str,

--- a/crates/tokmd-path/src/lib.rs
+++ b/crates/tokmd-path/src/lib.rs
@@ -1,6 +1,15 @@
 //! Single-responsibility path normalization for deterministic matching.
 
 /// Normalize path separators to `/`.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_path::normalize_slashes;
+///
+/// assert_eq!(normalize_slashes("src\\lib.rs"), "src/lib.rs");
+/// assert_eq!(normalize_slashes("already/forward"), "already/forward");
+/// ```
 #[must_use]
 pub fn normalize_slashes(path: &str) -> String {
     if path.contains('\\') {
@@ -13,6 +22,16 @@ pub fn normalize_slashes(path: &str) -> String {
 /// Normalize a relative path for matching:
 /// - converts `\` to `/`
 /// - strips one leading `./`
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_path::normalize_rel_path;
+///
+/// assert_eq!(normalize_rel_path("./src/main.rs"), "src/main.rs");
+/// assert_eq!(normalize_rel_path(".\\src\\main.rs"), "src/main.rs");
+/// assert_eq!(normalize_rel_path("../lib.rs"), "../lib.rs");
+/// ```
 #[must_use]
 pub fn normalize_rel_path(path: &str) -> String {
     let normalized = normalize_slashes(path);


### PR DESCRIPTION
## Summary

Add \/// # Examples\ doc comments with runnable code examples to key public functions across five utility crates. Doc tests serve as both documentation and tests.

### Crates updated

| Crate | Functions | New doc tests |
|-------|-----------|---------------|
| **tokmd-module-key** | \module_key()\, \module_key_from_normalized()\ | 2 |
| **tokmd-math** | \ound_f64()\, \safe_ratio()\, \percentile()\, \gini_coefficient()\ | 4 |
| **tokmd-path** | \
ormalize_slashes()\, \
ormalize_rel_path()\ | 2 |
| **tokmd-exclude** | \
ormalize_exclude_pattern()\, \has_exclude_pattern()\, \dd_exclude_pattern()\ | 3 |
| **tokmd-redact** | \short_hash()\, \edact_path()\ | *(already had examples)* |

### Verification

All 13 doc tests pass:
\\\
cargo test --doc -p tokmd-redact -p tokmd-module-key -p tokmd-math -p tokmd-path -p tokmd-exclude
\\\

### Changes

- 4 files changed, 131 insertions(+), 0 deletions(-)