### PR TITLE
test: add unit tests to 8 crates missing #[cfg(test)] in lib.rs

### DIFF
--- a/crates/tokmd-context-git/src/lib.rs
+++ b/crates/tokmd-context-git/src/lib.rs
@@ -71,6 +71,35 @@ pub fn compute_git_scores(
     None
 }
 
+#[cfg(test)]
+mod tests_no_feature {
+    use super::*;
+
+    #[test]
+    fn git_scores_can_be_constructed() {
+        let scores = GitScores {
+            hotspots: BTreeMap::new(),
+            commit_counts: BTreeMap::new(),
+        };
+        assert!(scores.hotspots.is_empty());
+        assert!(scores.commit_counts.is_empty());
+    }
+
+    #[test]
+    fn git_scores_btreemap_is_sorted() {
+        let mut hotspots = BTreeMap::new();
+        hotspots.insert("z/file.rs".to_string(), 100);
+        hotspots.insert("a/file.rs".to_string(), 50);
+        let scores = GitScores {
+            hotspots,
+            commit_counts: BTreeMap::new(),
+        };
+        let keys: Vec<&String> = scores.hotspots.keys().collect();
+        assert_eq!(keys[0], "a/file.rs");
+        assert_eq!(keys[1], "z/file.rs");
+    }
+}
+
 #[cfg(all(test, feature = "git"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Adds \#[cfg(test)] mod tests\ with basic unit tests to 8 crates that lacked them in their \lib.rs\.

## Changes

| Crate | Tests Added | Key Coverage |
|-------|-------------|-------------|
| \	okmd-types\ | 25 | ToolInfo, TokenEstimationMeta invariants, TokenAudit overhead, enum serde roundtrips, schema constants, proptest |
| \	okmd-analysis-types\ | 16 | Schema version, enum serde roundtrips, ComplexityBaseline, histogram ASCII, timestamp conversion, proptest |
| \	okmd-config\ | 11 | UserConfig/Profile defaults, GlobalArgs -> ScanOptions conversion, enum serde roundtrips |
| \	okmd-walk\ | 8 | license_candidates detection/empty/case-insensitive/sorted, file_size, list_files zero limit |
| \	okmd-fun\ | 7 | render_obj empty/single/multi, sanitize_name, render_midi empty/single/channel clamping |
| \	okmd-tokeignore\ | 6 | print mode, creates file, overwrite protection, force overwrite, nonexistent dir, all templates |
| \	okmd-gate\ | 3 | resolve_pointer via public API, evaluate_policy pass/fail |
| \	okmd-context-git\ | 2 | GitScores construction, BTreeMap sorting |

**Total: 78 new unit tests across 8 crates.**

## Verification

- All 78 new tests pass
- \cargo clippy --tests -- -D warnings\ clean on all 8 crates
- No existing tests broken
- No changes to production code