### PR TITLE
test: add tests for tokmd-tool-schema and expand config tests

### DIFF
--- a/crates/tokmd-config/tests/toml_parsing.rs
+++ b/crates/tokmd-config/tests/toml_parsing.rs
@@ -1,0 +1,464 @@
+//! Extended TOML parsing tests for tokmd-config.
+//!
+//! Tests cover profile inheritance semantics, default values, invalid config
+//! handling, and edge cases in tokmd.toml parsing.
+
+use std::io::Write;
+use tempfile::NamedTempFile;
+use tokmd_config::TomlConfig;
+
+// ── 1. Profile inheritance: view profile inherits from section defaults ──
+
+#[test]
+fn view_profile_fields_override_section_defaults_independently() {
+    let toml_str = r#"
+[export]
+format = "jsonl"
+min_code = 10
+
+[view.ci]
+format = "csv"
+min_code = 0
+
+[view.llm]
+format = "json"
+"#;
+    let config = TomlConfig::parse(toml_str).expect("valid TOML");
+
+    // Export section keeps its values
+    assert_eq!(config.export.format, Some("jsonl".to_string()));
+    assert_eq!(config.export.min_code, Some(10));
+
+    // ci profile has its own values
+    let ci = config.view.get("ci").expect("ci profile");
+    assert_eq!(ci.format, Some("csv".to_string()));
+    assert_eq!(ci.min_code, Some(0));
+
+    // llm profile only has format, no min_code
+    let llm = config.view.get("llm").expect("llm profile");
+    assert_eq!(llm.format, Some("json".to_string()));
+    assert_eq!(llm.min_code, None);
+}
+
+// ── 2. Multiple profiles with distinct settings ─────────────────────────
+
+#[test]
+fn multiple_view_profiles_are_independent() {
+    let toml_str = r#"
+[view.quick]
+format = "md"
+top = 5
+compress = false
+
+[view.deep]
+format = "json"
+top = 100
+preset = "deep"
+window = 256000
+compress = true
+"#;
+    let config = TomlConfig::parse(toml_str).expect("valid TOML");
+
+    let quick = config.view.get("quick").unwrap();
+    let deep = config.view.get("deep").unwrap();
+
+    assert_eq!(quick.format, Some("md".to_string()));
+    assert_eq!(quick.top, Some(5));
+    assert_eq!(quick.compress, Some(false));
+    assert_eq!(quick.preset, None);
+
+    assert_eq!(deep.format, Some("json".to_string()));
+    assert_eq!(deep.top, Some(100));
+    assert_eq!(deep.compress, Some(true));
+    assert_eq!(deep.preset, Some("deep".to_string()));
+    assert_eq!(deep.window, Some(256000));
+}
+
+// ── 3. Default values: empty TOML yields all-None config ────────────────
+
+#[test]
+fn empty_toml_yields_all_none_defaults() {
+    let config = TomlConfig::parse("").expect("valid");
+
+    assert_eq!(config.scan.hidden, None);
+    assert_eq!(config.scan.no_ignore, None);
+    assert_eq!(config.scan.paths, None);
+    assert_eq!(config.scan.exclude, None);
+    assert_eq!(config.module.depth, None);
+    assert_eq!(config.module.roots, None);
+    assert_eq!(config.export.format, None);
+    assert_eq!(config.export.min_code, None);
+    assert_eq!(config.analyze.preset, None);
+    assert_eq!(config.analyze.window, None);
+    assert_eq!(config.context.budget, None);
+    assert_eq!(config.context.strategy, None);
+    assert_eq!(config.badge.metric, None);
+    assert_eq!(config.gate.fail_fast, None);
+    assert!(config.gate.rules.is_none());
+    assert!(config.gate.ratchet.is_none());
+    assert!(config.view.is_empty());
+}
+
+// ── 4. Invalid TOML syntax is rejected ──────────────────────────────────
+
+#[test]
+fn invalid_toml_syntax_returns_error() {
+    let cases = [
+        "[scan\nhidden = true",               // missing closing bracket
+        "scan.hidden = [true, false",         // unclosed array
+        "[module]\ndepth = \"not a number\"", // wrong type (string → usize)
+    ];
+
+    for case in &cases {
+        let result = TomlConfig::parse(case);
+        assert!(result.is_err(), "Should fail for: {}", case);
+    }
+}
+
+// ── 5. Type mismatch errors ─────────────────────────────────────────────
+
+#[test]
+fn type_mismatches_return_errors() {
+    // String where bool expected
+    assert!(TomlConfig::parse("[scan]\nhidden = \"yes\"").is_err());
+    // Bool where usize expected
+    assert!(TomlConfig::parse("[module]\ndepth = true").is_err());
+    // Float where usize expected
+    assert!(TomlConfig::parse("[analyze]\nwindow = 3.14").is_err());
+    // Array where string expected
+    assert!(TomlConfig::parse("[context]\nbudget = [\"128k\"]").is_err());
+    // String where array expected
+    assert!(TomlConfig::parse("[module]\nroots = \"crates\"").is_err());
+    // Negative where unsigned expected
+    assert!(TomlConfig::parse("[export]\nmin_code = -1").is_err());
+}
+
+// ── 6. Gate rules parsing ───────────────────────────────────────────────
+
+#[test]
+fn gate_rules_with_all_fields_are_parsed_correctly() {
+    let toml_str = r#"
+[gate]
+fail_fast = true
+
+[[gate.rules]]
+name = "max-lines"
+pointer = "/summary/total_code"
+op = "lt"
+value = 100000
+level = "error"
+message = "Too many lines of code"
+
+[[gate.rules]]
+name = "lang-check"
+pointer = "/summary/languages"
+op = "in"
+values = ["Rust", "Python"]
+negate = true
+"#;
+    let config = TomlConfig::parse(toml_str).expect("valid");
+    assert_eq!(config.gate.fail_fast, Some(true));
+
+    let rules = config.gate.rules.unwrap();
+    assert_eq!(rules.len(), 2);
+
+    assert_eq!(rules[0].name, "max-lines");
+    assert_eq!(rules[0].op, "lt");
+    assert_eq!(rules[0].level, Some("error".to_string()));
+    assert_eq!(rules[0].message, Some("Too many lines of code".to_string()));
+    assert!(!rules[0].negate);
+
+    assert_eq!(rules[1].name, "lang-check");
+    assert!(rules[1].negate);
+    assert!(rules[1].values.is_some());
+}
+
+// ── 7. Ratchet rules parsing ────────────────────────────────────────────
+
+#[test]
+fn ratchet_rules_with_mixed_constraints() {
+    let toml_str = r#"
+[[gate.ratchet]]
+pointer = "/complexity/avg_cyclomatic"
+max_increase_pct = 5.0
+level = "error"
+description = "Complexity must not increase by more than 5%"
+
+[[gate.ratchet]]
+pointer = "/summary/total_code"
+max_value = 100000.0
+level = "warn"
+"#;
+    let config = TomlConfig::parse(toml_str).expect("valid");
+    let ratchet = config.gate.ratchet.unwrap();
+    assert_eq!(ratchet.len(), 2);
+
+    assert_eq!(ratchet[0].pointer, "/complexity/avg_cyclomatic");
+    assert_eq!(ratchet[0].max_increase_pct, Some(5.0));
+    assert_eq!(ratchet[0].max_value, None);
+    assert_eq!(ratchet[0].level, Some("error".to_string()));
+
+    assert_eq!(ratchet[1].pointer, "/summary/total_code");
+    assert_eq!(ratchet[1].max_increase_pct, None);
+    assert_eq!(ratchet[1].max_value, Some(100_000.0));
+    assert_eq!(ratchet[1].level, Some("warn".to_string()));
+}
+
+// ── 8. from_file with valid and invalid files ───────────────────────────
+
+#[test]
+fn from_file_parses_valid_toml() {
+    let content = r#"
+[scan]
+hidden = true
+exclude = ["target"]
+
+[module]
+depth = 3
+
+[view.test]
+format = "json"
+"#;
+    let mut tmp = NamedTempFile::new().unwrap();
+    tmp.write_all(content.as_bytes()).unwrap();
+
+    let config = TomlConfig::from_file(tmp.path()).expect("load from file");
+    assert_eq!(config.scan.hidden, Some(true));
+    assert_eq!(config.scan.exclude, Some(vec!["target".to_string()]));
+    assert_eq!(config.module.depth, Some(3));
+    assert!(config.view.contains_key("test"));
+}
+
+#[test]
+fn from_file_nonexistent_path_returns_error() {
+    let result = TomlConfig::from_file(std::path::Path::new("/no/such/path/tokmd.toml"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn from_file_invalid_toml_returns_error() {
+    let mut tmp = NamedTempFile::new().unwrap();
+    tmp.write_all(b"[broken\nhidden = true").unwrap();
+
+    let result = TomlConfig::from_file(tmp.path());
+    assert!(result.is_err());
+}
+
+// ── 9. View profiles: BTreeMap ordering ─────────────────────────────────
+
+#[test]
+fn view_profiles_are_stored_in_sorted_order() {
+    let toml_str = r#"
+[view.zulu]
+format = "md"
+
+[view.alpha]
+format = "json"
+
+[view.mike]
+format = "tsv"
+"#;
+    let config = TomlConfig::parse(toml_str).expect("valid");
+    let keys: Vec<&String> = config.view.keys().collect();
+    assert_eq!(keys, vec!["alpha", "mike", "zulu"]);
+}
+
+// ── 10. JSON round-trip: parse → serialize → re-parse ───────────────────
+
+#[test]
+fn toml_config_roundtrips_through_json() {
+    let toml_str = r#"
+[scan]
+hidden = true
+no_ignore = false
+exclude = ["dist", "*.lock"]
+
+[module]
+depth = 4
+roots = ["crates", "packages"]
+
+[export]
+format = "csv"
+min_code = 5
+max_rows = 1000
+
+[analyze]
+preset = "risk"
+window = 200000
+git = true
+
+[context]
+budget = "256k"
+strategy = "spread"
+compress = true
+
+[badge]
+metric = "tokens"
+
+[gate]
+fail_fast = true
+
+[view.ci]
+format = "tsv"
+top = 50
+"#;
+    let config1 = TomlConfig::parse(toml_str).expect("parse");
+    let json = serde_json::to_string(&config1).expect("to json");
+    let config2: TomlConfig = serde_json::from_str(&json).expect("from json");
+
+    // Spot-check all sections survived the round-trip
+    assert_eq!(config1.scan.hidden, config2.scan.hidden);
+    assert_eq!(config1.scan.no_ignore, config2.scan.no_ignore);
+    assert_eq!(config1.scan.exclude, config2.scan.exclude);
+    assert_eq!(config1.module.depth, config2.module.depth);
+    assert_eq!(config1.module.roots, config2.module.roots);
+    assert_eq!(config1.export.format, config2.export.format);
+    assert_eq!(config1.export.min_code, config2.export.min_code);
+    assert_eq!(config1.analyze.preset, config2.analyze.preset);
+    assert_eq!(config1.analyze.window, config2.analyze.window);
+    assert_eq!(config1.analyze.git, config2.analyze.git);
+    assert_eq!(config1.context.budget, config2.context.budget);
+    assert_eq!(config1.context.strategy, config2.context.strategy);
+    assert_eq!(config1.context.compress, config2.context.compress);
+    assert_eq!(config1.badge.metric, config2.badge.metric);
+    assert_eq!(config1.gate.fail_fast, config2.gate.fail_fast);
+    assert_eq!(
+        config1.view.get("ci").unwrap().format,
+        config2.view.get("ci").unwrap().format,
+    );
+    assert_eq!(
+        config1.view.get("ci").unwrap().top,
+        config2.view.get("ci").unwrap().top,
+    );
+}
+
+// ── 11. Unknown top-level keys are silently ignored ─────────────────────
+
+#[test]
+fn unknown_keys_are_silently_ignored() {
+    let toml_str = r#"
+unknown_section = "ignored"
+
+[scan]
+hidden = true
+"#;
+    let config = TomlConfig::parse(toml_str).expect("valid");
+    assert_eq!(config.scan.hidden, Some(true));
+}
+
+// ── 12. Boundary values ─────────────────────────────────────────────────
+
+#[test]
+fn zero_and_large_values_are_accepted() {
+    let toml_str = r#"
+[export]
+min_code = 0
+max_rows = 0
+
+[analyze]
+window = 0
+max_bytes = 9999999999999
+
+[view.extremes]
+top = 0
+"#;
+    let config = TomlConfig::parse(toml_str).expect("valid");
+    assert_eq!(config.export.min_code, Some(0));
+    assert_eq!(config.export.max_rows, Some(0));
+    assert_eq!(config.analyze.window, Some(0));
+    assert_eq!(config.analyze.max_bytes, Some(9_999_999_999_999));
+    assert_eq!(config.view.get("extremes").unwrap().top, Some(0));
+}
+
+// ── 13. Full kitchen-sink config ────────────────────────────────────────
+
+#[test]
+fn full_kitchen_sink_config_parses() {
+    let toml_str = r#"
+[scan]
+hidden = false
+no_ignore = false
+no_ignore_parent = true
+no_ignore_dot = false
+no_ignore_vcs = true
+doc_comments = true
+paths = ["src", "crates", "tests"]
+exclude = ["target", "node_modules", "**/*.min.js"]
+
+[module]
+roots = ["crates", "packages"]
+depth = 2
+children = "collapse"
+
+[export]
+format = "jsonl"
+min_code = 1
+max_rows = 10000
+redact = "paths"
+children = "separate"
+
+[analyze]
+preset = "health"
+window = 128000
+format = "json"
+git = false
+max_files = 2000
+max_bytes = 10000000
+max_file_bytes = 100000
+max_commits = 500
+max_commit_files = 50
+granularity = "file"
+
+[context]
+budget = "128k"
+strategy = "greedy"
+rank_by = "code"
+output = "list"
+compress = false
+
+[badge]
+metric = "lines"
+
+[gate]
+fail_fast = true
+
+[[gate.rules]]
+name = "max-lines"
+pointer = "/summary/total_code"
+op = "lt"
+value = 100000
+
+[[gate.ratchet]]
+pointer = "/complexity/avg_cyclomatic"
+max_increase_pct = 5.0
+level = "error"
+description = "Keep complexity in check"
+
+[view.llm]
+format = "json"
+redact = "all"
+top = 25
+compress = true
+preset = "deep"
+
+[view.ci]
+format = "tsv"
+min_code = 1
+max_rows = 50
+"#;
+    let config = TomlConfig::parse(toml_str).expect("full config");
+
+    // Spot-check a few fields from each section
+    assert_eq!(config.scan.doc_comments, Some(true));
+    assert_eq!(config.scan.no_ignore_parent, Some(true));
+    assert_eq!(config.module.children, Some("collapse".to_string()));
+    assert_eq!(config.export.redact, Some("paths".to_string()));
+    assert_eq!(config.analyze.granularity, Some("file".to_string()));
+    assert_eq!(config.analyze.max_file_bytes, Some(100_000));
+    assert_eq!(config.context.rank_by, Some("code".to_string()));
+    assert_eq!(config.badge.metric, Some("lines".to_string()));
+    assert_eq!(config.gate.rules.as_ref().map(|r| r.len()), Some(1));
+    assert_eq!(config.gate.ratchet.as_ref().map(|r| r.len()), Some(1));
+    assert_eq!(config.view.len(), 2);
+    assert_eq!(config.view.get("llm").unwrap().compress, Some(true));
+}

--- a/crates/tokmd-tool-schema/tests/unit.rs
+++ b/crates/tokmd-tool-schema/tests/unit.rs
@@ -1,0 +1,346 @@
+//! Unit tests for tokmd-tool-schema.
+//!
+//! Tests cover schema generation from clap command trees, JSON output format
+//! correctness, and OpenAI/Anthropic/JSON Schema format variants.
+
+use clap::{Arg, ArgAction, Command};
+use serde_json::Value;
+use tokmd_tool_schema::{
+    ParameterSchema, TOOL_SCHEMA_VERSION, ToolDefinition, ToolSchemaFormat, ToolSchemaOutput,
+    build_tool_schema, render_output,
+};
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+fn simple_cmd() -> Command {
+    Command::new("simple").version("1.0.0").about("Simple app")
+}
+
+fn nested_cmd() -> Command {
+    Command::new("cli")
+        .version("2.0.0")
+        .about("CLI with nested commands")
+        .subcommand(
+            Command::new("scan")
+                .about("Scan files")
+                .arg(
+                    Arg::new("path")
+                        .long("path")
+                        .required(true)
+                        .help("Path to scan"),
+                )
+                .arg(
+                    Arg::new("verbose")
+                        .short('v')
+                        .long("verbose")
+                        .action(ArgAction::Count)
+                        .help("Verbosity level"),
+                )
+                .arg(
+                    Arg::new("format")
+                        .long("format")
+                        .value_parser(["json", "csv", "md"])
+                        .default_value("json")
+                        .help("Output format"),
+                )
+                .arg(
+                    Arg::new("dry-run")
+                        .long("dry-run")
+                        .action(ArgAction::SetTrue)
+                        .help("Dry run mode"),
+                )
+                .arg(
+                    Arg::new("tags")
+                        .long("tags")
+                        .action(ArgAction::Append)
+                        .help("Add tags"),
+                ),
+        )
+        .subcommand(
+            Command::new("export").about("Export data").arg(
+                Arg::new("output")
+                    .long("output")
+                    .required(true)
+                    .help("Output file"),
+            ),
+        )
+}
+
+// ── 1. Schema envelope metadata ─────────────────────────────────────────
+
+#[test]
+fn schema_envelope_has_correct_metadata() {
+    let cmd = simple_cmd();
+    let schema = build_tool_schema(&cmd);
+
+    assert_eq!(schema.schema_version, TOOL_SCHEMA_VERSION);
+    assert_eq!(schema.name, "simple");
+    assert_eq!(schema.version, "1.0.0");
+    assert_eq!(schema.description, "Simple app");
+}
+
+// ── 2. Root command appears as first tool ────────────────────────────────
+
+#[test]
+fn root_command_is_always_first_tool() {
+    let schema = build_tool_schema(&nested_cmd());
+    assert_eq!(schema.tools[0].name, "cli");
+}
+
+// ── 3. Subcommands are included ─────────────────────────────────────────
+
+#[test]
+fn all_subcommands_appear_in_tools() {
+    let schema = build_tool_schema(&nested_cmd());
+    let names: Vec<&str> = schema.tools.iter().map(|t| t.name.as_str()).collect();
+    assert!(names.contains(&"scan"));
+    assert!(names.contains(&"export"));
+    // help subcommand should be filtered out
+    assert!(!names.contains(&"help"));
+}
+
+// ── 4. Parameter type inference ─────────────────────────────────────────
+
+#[test]
+fn parameter_types_are_correctly_inferred() {
+    let schema = build_tool_schema(&nested_cmd());
+    let scan = schema.tools.iter().find(|t| t.name == "scan").unwrap();
+
+    let find_param = |name: &str| -> &ParameterSchema {
+        scan.parameters.iter().find(|p| p.name == name).unwrap()
+    };
+
+    // String arg
+    assert_eq!(find_param("path").param_type, "string");
+    // Count arg → integer
+    assert_eq!(find_param("verbose").param_type, "integer");
+    // SetTrue arg → boolean
+    assert_eq!(find_param("dry-run").param_type, "boolean");
+    // Append arg → array
+    assert_eq!(find_param("tags").param_type, "array");
+}
+
+// ── 5. Required and optional flags ──────────────────────────────────────
+
+#[test]
+fn required_and_optional_params_are_distinguished() {
+    let schema = build_tool_schema(&nested_cmd());
+    let scan = schema.tools.iter().find(|t| t.name == "scan").unwrap();
+
+    let path = scan.parameters.iter().find(|p| p.name == "path").unwrap();
+    assert!(path.required, "path should be required");
+
+    let dry_run = scan
+        .parameters
+        .iter()
+        .find(|p| p.name == "dry-run")
+        .unwrap();
+    assert!(!dry_run.required, "dry-run should be optional");
+}
+
+// ── 6. Default values and enum values ───────────────────────────────────
+
+#[test]
+fn default_and_enum_values_are_captured() {
+    let schema = build_tool_schema(&nested_cmd());
+    let scan = schema.tools.iter().find(|t| t.name == "scan").unwrap();
+    let format = scan.parameters.iter().find(|p| p.name == "format").unwrap();
+
+    assert_eq!(format.default.as_deref(), Some("json"));
+    let enums = format.enum_values.as_ref().unwrap();
+    assert_eq!(enums, &["json", "csv", "md"]);
+}
+
+// ── 7. OpenAI format structure ──────────────────────────────────────────
+
+#[test]
+fn openai_format_has_correct_structure() {
+    let schema = build_tool_schema(&nested_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    // Top-level has "functions" array
+    assert!(v["functions"].is_array());
+    let functions = v["functions"].as_array().unwrap();
+    assert!(!functions.is_empty());
+
+    // Each function has name, description, parameters
+    for func in functions {
+        assert!(func["name"].is_string());
+        assert!(func["description"].is_string());
+        assert_eq!(func["parameters"]["type"].as_str(), Some("object"));
+        assert!(func["parameters"]["properties"].is_object());
+        assert!(func["parameters"]["required"].is_array());
+    }
+
+    // OpenAI should NOT have top-level "tools" key
+    assert!(v.get("tools").is_none());
+}
+
+// ── 8. Anthropic format structure ───────────────────────────────────────
+
+#[test]
+fn anthropic_format_uses_input_schema() {
+    let schema = build_tool_schema(&nested_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Anthropic, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    // Top-level has "tools" array
+    assert!(v["tools"].is_array());
+    let tools = v["tools"].as_array().unwrap();
+    assert!(!tools.is_empty());
+
+    // Each tool has name, description, input_schema (not "parameters")
+    for tool in tools {
+        assert!(tool["name"].is_string());
+        assert!(tool["description"].is_string());
+        assert!(tool["input_schema"].is_object());
+        assert_eq!(tool["input_schema"]["type"].as_str(), Some("object"));
+        // Anthropic format should NOT have "parameters" key on tools
+        assert!(tool.get("parameters").is_none());
+    }
+}
+
+// ── 9. JSON Schema format structure ─────────────────────────────────────
+
+#[test]
+fn jsonschema_format_has_draft_reference_and_envelope() {
+    let schema = build_tool_schema(&nested_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Jsonschema, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(
+        v["$schema"].as_str(),
+        Some("https://json-schema.org/draft-07/schema#")
+    );
+    assert_eq!(
+        v["schema_version"].as_u64(),
+        Some(TOOL_SCHEMA_VERSION as u64)
+    );
+    assert_eq!(v["name"].as_str(), Some("cli"));
+    assert_eq!(v["version"].as_str(), Some("2.0.0"));
+    assert!(v["tools"].is_array());
+
+    // JSON Schema format should include default values in properties
+    let scan = v["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == "scan")
+        .unwrap();
+    let format_prop = &scan["parameters"]["properties"]["format"];
+    assert_eq!(format_prop["default"].as_str(), Some("json"));
+}
+
+// ── 10. Clap format round-trip ──────────────────────────────────────────
+
+#[test]
+fn clap_format_round_trips_through_serde() {
+    let schema = build_tool_schema(&nested_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Clap, false).unwrap();
+
+    let deserialized: ToolSchemaOutput = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(deserialized.name, schema.name);
+    assert_eq!(deserialized.version, schema.version);
+    assert_eq!(deserialized.schema_version, schema.schema_version);
+    assert_eq!(deserialized.tools.len(), schema.tools.len());
+
+    // Verify tool names match
+    let orig_names: Vec<&str> = schema.tools.iter().map(|t| t.name.as_str()).collect();
+    let deser_names: Vec<&str> = deserialized.tools.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(orig_names, deser_names);
+}
+
+// ── 11. Pretty vs compact output ────────────────────────────────────────
+
+#[test]
+fn pretty_and_compact_produce_equivalent_values() {
+    let schema = build_tool_schema(&nested_cmd());
+
+    for fmt in [
+        ToolSchemaFormat::Openai,
+        ToolSchemaFormat::Anthropic,
+        ToolSchemaFormat::Jsonschema,
+        ToolSchemaFormat::Clap,
+    ] {
+        let pretty_str = render_output(&schema, fmt, true).unwrap();
+        let compact_str = render_output(&schema, fmt, false).unwrap();
+
+        // Pretty has newlines, compact does not
+        assert!(pretty_str.contains('\n'), "Pretty should contain newlines");
+        assert!(
+            !compact_str.contains('\n'),
+            "Compact should not contain newlines"
+        );
+
+        // Both parse to the same JSON value
+        let pretty_val: Value = serde_json::from_str(&pretty_str).unwrap();
+        let compact_val: Value = serde_json::from_str(&compact_str).unwrap();
+        assert_eq!(pretty_val, compact_val, "Mismatch for format {:?}", fmt);
+    }
+}
+
+// ── 12. OpenAI required array correctness ───────────────────────────────
+
+#[test]
+fn openai_required_array_only_contains_required_params() {
+    let schema = build_tool_schema(&nested_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    let scan = v["functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["name"] == "scan")
+        .unwrap();
+
+    let required: Vec<&str> = scan["parameters"]["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+
+    assert!(required.contains(&"path"), "path should be required");
+    assert!(
+        !required.contains(&"verbose"),
+        "verbose should not be required"
+    );
+    assert!(
+        !required.contains(&"dry-run"),
+        "dry-run should not be required"
+    );
+    assert!(!required.contains(&"tags"), "tags should not be required");
+}
+
+// ── 13. ToolDefinition and ParameterSchema are serializable ─────────────
+
+#[test]
+fn tool_definition_and_parameter_schema_serde_roundtrip() {
+    let param = ParameterSchema {
+        name: "input".to_string(),
+        description: Some("Input file".to_string()),
+        param_type: "string".to_string(),
+        required: true,
+        default: None,
+        enum_values: Some(vec!["a".to_string(), "b".to_string()]),
+    };
+
+    let tool = ToolDefinition {
+        name: "my-tool".to_string(),
+        description: "Does things".to_string(),
+        parameters: vec![param],
+    };
+
+    let json = serde_json::to_string(&tool).unwrap();
+    let deser: ToolDefinition = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.name, "my-tool");
+    assert_eq!(deser.parameters.len(), 1);
+    assert_eq!(deser.parameters[0].name, "input");
+    assert!(deser.parameters[0].required);
+    assert_eq!(
+        deser.parameters[0].enum_values,
+        Some(vec!["a".to_string(), "b".to_string()])
+    );
+}


### PR DESCRIPTION
Add tests for AI tool schema generation and expand config parsing tests.

## tokmd-tool-schema (13 tests in \	ests/unit.rs\)
- Schema envelope metadata
- Root command and subcommand inclusion
- Parameter type inference (string, boolean, integer, array)
- Required/optional parameter distinction
- Default and enum value capture
- OpenAI format structure and required array correctness
- Anthropic format with input_schema key
- JSON Schema format with draft reference and envelope
- Clap format serde round-trip
- Pretty vs compact output equivalence
- ToolDefinition/ParameterSchema serde round-trip

## tokmd-config (15 tests in \	ests/toml_parsing.rs\)
- View profile independence from section defaults
- Multiple profiles with distinct settings
- Empty TOML yields all-None defaults
- Invalid TOML syntax rejection
- Type mismatch error handling
- Gate rules with all fields
- Ratchet rules with mixed constraints
- from_file with valid/invalid files
- View profile BTreeMap ordering
- JSON round-trip (parse → serialize → re-parse)
- Unknown keys silently ignored
- Boundary values (zero, large)
- Full kitchen-sink config parsing