### PR TITLE
test: add tests for analysis-grid and analysis-util

### DIFF
--- a/crates/tokmd-analysis-grid/tests/unit.rs
+++ b/crates/tokmd-analysis-grid/tests/unit.rs
@@ -1,0 +1,332 @@
+//! Unit tests for `tokmd-analysis-grid` preset resolution, enricher inclusion,
+//! and feature matrix metadata.
+
+use tokmd_analysis_grid::{
+    DisabledFeature, PRESET_GRID, PRESET_KINDS, PresetKind, PresetPlan, preset_plan_for,
+    preset_plan_for_name,
+};
+
+// ── Preset resolution ───────────────────────────────────────────────────────
+
+#[test]
+fn preset_plan_for_each_kind_matches_grid_row() {
+    for row in &PRESET_GRID {
+        let resolved = preset_plan_for(row.preset);
+        assert_eq!(
+            resolved, row.plan,
+            "preset_plan_for({:?}) diverges from PRESET_GRID entry",
+            row.preset
+        );
+    }
+}
+
+#[test]
+fn preset_plan_for_name_resolves_all_known_names() {
+    let names = [
+        "receipt",
+        "health",
+        "risk",
+        "supply",
+        "architecture",
+        "topics",
+        "security",
+        "identity",
+        "git",
+        "deep",
+        "fun",
+    ];
+    for name in &names {
+        let plan = preset_plan_for_name(name);
+        assert!(plan.is_some(), "expected Some for name '{}'", name);
+    }
+}
+
+#[test]
+fn preset_plan_for_name_rejects_invalid_inputs() {
+    for input in &["", " ", "RECEIPT", "Health", "unknown", "deep ", " deep"] {
+        assert!(
+            preset_plan_for_name(input).is_none(),
+            "expected None for '{}'",
+            input
+        );
+    }
+}
+
+// ── Enricher inclusion per preset ───────────────────────────────────────────
+
+#[test]
+fn health_enables_todo_complexity_only() {
+    let plan = preset_plan_for(PresetKind::Health);
+    assert!(plan.todo);
+    assert!(plan.complexity);
+    // Must not enable unrelated enrichers
+    assert!(!plan.assets);
+    assert!(!plan.deps);
+    assert!(!plan.dup);
+    assert!(!plan.imports);
+    assert!(!plan.git);
+    assert!(!plan.fun);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+    assert!(!plan.api_surface);
+}
+
+#[test]
+fn risk_enables_git_and_complexity_only() {
+    let plan = preset_plan_for(PresetKind::Risk);
+    assert!(plan.git);
+    assert!(plan.complexity);
+    assert!(!plan.todo);
+    assert!(!plan.assets);
+    assert!(!plan.deps);
+    assert!(!plan.dup);
+    assert!(!plan.imports);
+    assert!(!plan.fun);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+    assert!(!plan.api_surface);
+}
+
+#[test]
+fn supply_enables_assets_deps_only() {
+    let plan = preset_plan_for(PresetKind::Supply);
+    assert!(plan.assets);
+    assert!(plan.deps);
+    assert!(!plan.todo);
+    assert!(!plan.dup);
+    assert!(!plan.imports);
+    assert!(!plan.git);
+    assert!(!plan.fun);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+    assert!(!plan.complexity);
+    assert!(!plan.api_surface);
+}
+
+#[test]
+fn architecture_enables_imports_api_surface_only() {
+    let plan = preset_plan_for(PresetKind::Architecture);
+    assert!(plan.imports);
+    assert!(plan.api_surface);
+    assert!(!plan.assets);
+    assert!(!plan.deps);
+    assert!(!plan.todo);
+    assert!(!plan.dup);
+    assert!(!plan.git);
+    assert!(!plan.fun);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+    assert!(!plan.complexity);
+}
+
+#[test]
+fn security_enables_entropy_license_only() {
+    let plan = preset_plan_for(PresetKind::Security);
+    assert!(plan.entropy);
+    assert!(plan.license);
+    assert!(!plan.assets);
+    assert!(!plan.deps);
+    assert!(!plan.todo);
+    assert!(!plan.dup);
+    assert!(!plan.imports);
+    assert!(!plan.git);
+    assert!(!plan.fun);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.complexity);
+    assert!(!plan.api_surface);
+}
+
+#[test]
+fn identity_enables_git_archetype_only() {
+    let plan = preset_plan_for(PresetKind::Identity);
+    assert!(plan.git);
+    assert!(plan.archetype);
+    assert!(!plan.assets);
+    assert!(!plan.deps);
+    assert!(!plan.todo);
+    assert!(!plan.dup);
+    assert!(!plan.imports);
+    assert!(!plan.fun);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+    assert!(!plan.complexity);
+    assert!(!plan.api_surface);
+}
+
+// ── Feature matrix metadata ─────────────────────────────────────────────────
+
+#[test]
+fn grid_length_equals_preset_kinds_length() {
+    assert_eq!(PRESET_GRID.len(), PRESET_KINDS.len());
+}
+
+#[test]
+fn needs_files_true_iff_any_file_flag_set() {
+    for row in &PRESET_GRID {
+        let plan = &row.plan;
+        let any_file_flag = plan.assets
+            || plan.deps
+            || plan.todo
+            || plan.dup
+            || plan.imports
+            || plan.entropy
+            || plan.license
+            || plan.complexity
+            || plan.api_surface;
+        assert_eq!(
+            plan.needs_files(),
+            any_file_flag,
+            "needs_files mismatch for {:?}",
+            row.preset
+        );
+    }
+}
+
+#[test]
+fn only_fun_preset_sets_fun_flag() {
+    for row in &PRESET_GRID {
+        if row.preset == PresetKind::Fun {
+            assert!(row.plan.fun);
+        } else {
+            assert!(!row.plan.fun, "{:?} unexpectedly has fun=true", row.preset);
+        }
+    }
+}
+
+#[test]
+fn deep_is_superset_of_every_non_fun_preset() {
+    let deep = preset_plan_for(PresetKind::Deep);
+    for kind in PresetKind::all() {
+        if *kind == PresetKind::Fun {
+            continue;
+        }
+        let plan = preset_plan_for(*kind);
+        if plan.assets {
+            assert!(deep.assets, "deep missing assets from {:?}", kind);
+        }
+        if plan.deps {
+            assert!(deep.deps, "deep missing deps from {:?}", kind);
+        }
+        if plan.todo {
+            assert!(deep.todo, "deep missing todo from {:?}", kind);
+        }
+        if plan.dup {
+            assert!(deep.dup, "deep missing dup from {:?}", kind);
+        }
+        if plan.imports {
+            assert!(deep.imports, "deep missing imports from {:?}", kind);
+        }
+        if plan.git {
+            assert!(deep.git, "deep missing git from {:?}", kind);
+        }
+        if plan.archetype {
+            assert!(deep.archetype, "deep missing archetype from {:?}", kind);
+        }
+        if plan.topics {
+            assert!(deep.topics, "deep missing topics from {:?}", kind);
+        }
+        if plan.entropy {
+            assert!(deep.entropy, "deep missing entropy from {:?}", kind);
+        }
+        if plan.license {
+            assert!(deep.license, "deep missing license from {:?}", kind);
+        }
+        if plan.complexity {
+            assert!(deep.complexity, "deep missing complexity from {:?}", kind);
+        }
+        if plan.api_surface {
+            assert!(deep.api_surface, "deep missing api_surface from {:?}", kind);
+        }
+    }
+}
+
+// ── DisabledFeature warnings ────────────────────────────────────────────────
+
+#[test]
+fn disabled_feature_warning_mentions_skipping_or_feature() {
+    let features = [
+        DisabledFeature::FileInventory,
+        DisabledFeature::TodoScan,
+        DisabledFeature::DuplicationScan,
+        DisabledFeature::NearDuplicateScan,
+        DisabledFeature::ImportScan,
+        DisabledFeature::GitMetrics,
+        DisabledFeature::EntropyProfiling,
+        DisabledFeature::LicenseRadar,
+        DisabledFeature::ComplexityAnalysis,
+        DisabledFeature::ApiSurfaceAnalysis,
+        DisabledFeature::Archetype,
+        DisabledFeature::Topics,
+        DisabledFeature::Fun,
+    ];
+    for feat in &features {
+        let msg = feat.warning();
+        assert!(
+            msg.contains("skipping") || msg.contains("feature"),
+            "{:?} warning should mention 'skipping' or 'feature', got: {}",
+            feat,
+            msg
+        );
+    }
+}
+
+#[test]
+fn disabled_feature_count_matches_expected() {
+    // There are exactly 13 DisabledFeature variants
+    let all = [
+        DisabledFeature::FileInventory,
+        DisabledFeature::TodoScan,
+        DisabledFeature::DuplicationScan,
+        DisabledFeature::NearDuplicateScan,
+        DisabledFeature::ImportScan,
+        DisabledFeature::GitMetrics,
+        DisabledFeature::EntropyProfiling,
+        DisabledFeature::LicenseRadar,
+        DisabledFeature::ComplexityAnalysis,
+        DisabledFeature::ApiSurfaceAnalysis,
+        DisabledFeature::Archetype,
+        DisabledFeature::Topics,
+        DisabledFeature::Fun,
+    ];
+    assert_eq!(all.len(), 13);
+}
+
+// ── PresetKind traits ───────────────────────────────────────────────────────
+
+#[test]
+fn preset_kind_equality_is_reflexive() {
+    for kind in PresetKind::all() {
+        assert_eq!(*kind, *kind);
+    }
+}
+
+#[test]
+fn preset_kind_inequality_across_variants() {
+    let kinds: Vec<PresetKind> = PresetKind::all().to_vec();
+    for (i, a) in kinds.iter().enumerate() {
+        for (j, b) in kinds.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "{:?} should not equal {:?}", a, b);
+            }
+        }
+    }
+}
+
+// ── PresetPlan equality ─────────────────────────────────────────────────────
+
+#[test]
+fn distinct_presets_may_have_distinct_plans() {
+    let receipt = preset_plan_for(PresetKind::Receipt);
+    let deep = preset_plan_for(PresetKind::Deep);
+    assert_ne!(receipt, deep);
+}

--- a/crates/tokmd-analysis-util/tests/unit.rs
+++ b/crates/tokmd-analysis-util/tests/unit.rs
@@ -1,0 +1,305 @@
+//! Unit tests for `tokmd-analysis-util` utility functions and edge cases.
+
+use std::path::{Path, PathBuf};
+
+use tokmd_analysis_util::{
+    AnalysisLimits, empty_file_row, gini_coefficient, is_infra_lang, is_test_path, normalize_path,
+    normalize_root, now_ms, path_depth, percentile, round_f64, safe_ratio,
+};
+
+// ── normalize_path edge cases ───────────────────────────────────────────────
+
+#[test]
+fn normalize_path_handles_only_backslashes() {
+    let root = PathBuf::from("r");
+    assert_eq!(normalize_path(r"\a\b\c", &root), "/a/b/c");
+}
+
+#[test]
+fn normalize_path_mixed_separators() {
+    let root = PathBuf::from("r");
+    assert_eq!(normalize_path(r"a/b\c/d\e", &root), "a/b/c/d/e");
+}
+
+#[test]
+fn normalize_path_dot_slash_only_strips_prefix() {
+    let root = PathBuf::from("r");
+    // Inner "./" is not stripped, only leading
+    let result = normalize_path("./a/./b", &root);
+    assert!(!result.starts_with("./"));
+    assert!(result.starts_with("a/"));
+}
+
+#[test]
+fn normalize_path_root_prefix_stripped() {
+    let root = PathBuf::from("myrepo");
+    assert_eq!(normalize_path("myrepo/src/main.rs", &root), "src/main.rs");
+}
+
+#[test]
+fn normalize_path_root_no_match_leaves_unchanged() {
+    let root = PathBuf::from("other");
+    assert_eq!(
+        normalize_path("myrepo/src/main.rs", &root),
+        "myrepo/src/main.rs"
+    );
+}
+
+// ── path_depth edge cases ───────────────────────────────────────────────────
+
+#[test]
+fn path_depth_root_slash_only() {
+    // "/" has no non-empty segments, so max(0, 1) = 1
+    assert_eq!(path_depth("/"), 1);
+}
+
+#[test]
+fn path_depth_many_slashes() {
+    assert_eq!(path_depth("///"), 1);
+}
+
+#[test]
+fn path_depth_single_segment_no_slash() {
+    assert_eq!(path_depth("README.md"), 1);
+}
+
+#[test]
+fn path_depth_three_segments() {
+    assert_eq!(path_depth("a/b/c"), 3);
+}
+
+// ── is_test_path edge cases ─────────────────────────────────────────────────
+
+#[test]
+fn is_test_path_nested_test_dir() {
+    assert!(is_test_path("project/src/tests/unit/foo.rs"));
+}
+
+#[test]
+fn is_test_path_ends_with_test_rs() {
+    assert!(is_test_path("crate/src/parser_test.rs"));
+}
+
+#[test]
+fn is_test_path_starts_with_test_underscore() {
+    assert!(is_test_path("test_parser.py"));
+}
+
+#[test]
+fn is_test_path_false_for_production_code() {
+    assert!(!is_test_path("src/lib.rs"));
+    assert!(!is_test_path("src/utils/helper.ts"));
+    assert!(!is_test_path("main.go"));
+}
+
+#[test]
+fn is_test_path_spec_file_pattern() {
+    assert!(is_test_path("components/button.spec.tsx"));
+}
+
+#[test]
+fn is_test_path_test_file_pattern_js() {
+    assert!(is_test_path("components/button.test.jsx"));
+}
+
+// ── is_infra_lang edge cases ────────────────────────────────────────────────
+
+#[test]
+fn is_infra_lang_all_known_detected() {
+    let known = [
+        "json",
+        "yaml",
+        "toml",
+        "markdown",
+        "xml",
+        "html",
+        "css",
+        "scss",
+        "less",
+        "makefile",
+        "dockerfile",
+        "hcl",
+        "terraform",
+        "nix",
+        "cmake",
+        "ini",
+        "properties",
+        "gitignore",
+        "gitconfig",
+        "editorconfig",
+        "csv",
+        "tsv",
+        "svg",
+    ];
+    for lang in &known {
+        assert!(is_infra_lang(lang), "'{}' should be infra", lang);
+    }
+}
+
+#[test]
+fn is_infra_lang_mixed_case() {
+    assert!(is_infra_lang("JSON"));
+    assert!(is_infra_lang("Yaml"));
+    assert!(is_infra_lang("Makefile"));
+    assert!(is_infra_lang("HCL"));
+}
+
+#[test]
+fn is_infra_lang_rejects_programming_languages() {
+    for lang in &[
+        "rust", "python", "go", "java", "c", "cpp", "haskell", "elixir",
+    ] {
+        assert!(!is_infra_lang(lang), "'{}' should NOT be infra", lang);
+    }
+}
+
+#[test]
+fn is_infra_lang_empty_and_whitespace() {
+    assert!(!is_infra_lang(""));
+    assert!(!is_infra_lang(" "));
+    assert!(!is_infra_lang("  json  "));
+}
+
+// ── empty_file_row ──────────────────────────────────────────────────────────
+
+#[test]
+fn empty_file_row_has_zero_metrics() {
+    let row = empty_file_row();
+    assert_eq!(row.code, 0);
+    assert_eq!(row.comments, 0);
+    assert_eq!(row.blanks, 0);
+    assert_eq!(row.lines, 0);
+    assert_eq!(row.bytes, 0);
+    assert_eq!(row.tokens, 0);
+    assert_eq!(row.depth, 0);
+}
+
+#[test]
+fn empty_file_row_has_empty_strings() {
+    let row = empty_file_row();
+    assert!(row.path.is_empty());
+    assert!(row.module.is_empty());
+    assert!(row.lang.is_empty());
+}
+
+#[test]
+fn empty_file_row_optional_fields_are_none() {
+    let row = empty_file_row();
+    assert!(row.doc_pct.is_none());
+    assert!(row.bytes_per_line.is_none());
+}
+
+// ── normalize_root ──────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_root_nonexistent_returns_input() {
+    let fake = Path::new("z:\\nonexistent\\path\\abc");
+    let result = normalize_root(fake);
+    assert_eq!(result, fake.to_path_buf());
+}
+
+#[test]
+fn normalize_root_cwd_returns_absolute() {
+    let cwd = std::env::current_dir().unwrap();
+    let result = normalize_root(&cwd);
+    assert!(result.is_absolute());
+}
+
+// ── now_ms ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn now_ms_returns_reasonable_epoch_millis() {
+    let ts = now_ms();
+    // Should be well past year 2020 (~1577836800000 ms)
+    assert!(ts > 1_577_836_800_000);
+}
+
+#[test]
+fn now_ms_two_calls_non_decreasing() {
+    let a = now_ms();
+    let b = now_ms();
+    assert!(b >= a);
+}
+
+// ── AnalysisLimits ──────────────────────────────────────────────────────────
+
+#[test]
+fn analysis_limits_partial_construction() {
+    let limits = AnalysisLimits {
+        max_files: Some(50),
+        max_bytes: None,
+        max_file_bytes: Some(10_000),
+        ..Default::default()
+    };
+    assert_eq!(limits.max_files, Some(50));
+    assert!(limits.max_bytes.is_none());
+    assert_eq!(limits.max_file_bytes, Some(10_000));
+    assert!(limits.max_commits.is_none());
+    assert!(limits.max_commit_files.is_none());
+}
+
+#[test]
+fn analysis_limits_debug_is_non_empty() {
+    let limits = AnalysisLimits::default();
+    let debug = format!("{:?}", limits);
+    assert!(!debug.is_empty());
+}
+
+// ── Re-exported math: round_f64 ─────────────────────────────────────────────
+
+#[test]
+fn round_f64_negative_values() {
+    assert_eq!(round_f64(-1.555, 2), -1.56);
+    assert_eq!(round_f64(-0.001, 2), 0.0);
+}
+
+#[test]
+fn round_f64_large_decimals() {
+    let val = round_f64(1.123456789, 8);
+    assert!((val - 1.12345679).abs() < 1e-10);
+}
+
+// ── Re-exported math: safe_ratio ────────────────────────────────────────────
+
+#[test]
+fn safe_ratio_large_values() {
+    // safe_ratio rounds to 4 decimals, so 999_999/1_000_000 rounds to 1.0
+    let r = safe_ratio(999_999, 1_000_000);
+    assert_eq!(r, 1.0);
+}
+
+#[test]
+fn safe_ratio_both_zero() {
+    assert_eq!(safe_ratio(0, 0), 0.0);
+}
+
+// ── Re-exported math: percentile ────────────────────────────────────────────
+
+#[test]
+fn percentile_median_of_odd_count() {
+    let vals = [10, 20, 30, 40, 50];
+    let med = percentile(&vals, 0.5);
+    assert!((med - 30.0).abs() < 1e-10);
+}
+
+#[test]
+fn percentile_boundary_values() {
+    let vals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(percentile(&vals, 0.0), 1.0);
+    assert_eq!(percentile(&vals, 1.0), 10.0);
+}
+
+// ── Re-exported math: gini_coefficient ──────────────────────────────────────
+
+#[test]
+fn gini_coefficient_two_elements_extreme() {
+    let g = gini_coefficient(&[0, 100]);
+    // Maximum inequality for 2 elements: gini = 0.5
+    assert!((g - 0.5).abs() < 1e-10);
+}
+
+#[test]
+fn gini_coefficient_increasing_sequence() {
+    let g = gini_coefficient(&[1, 2, 3, 4, 5]);
+    assert!(g > 0.0 && g < 1.0, "expected gini in (0,1), got {}", g);
+}


### PR DESCRIPTION
Add unit tests for preset grid resolution and analysis utilities.

## tokmd-analysis-grid (18 tests)
- Preset resolution via \preset_plan_for\ and \preset_plan_for_name\
- Enricher inclusion verification for each preset
- Feature matrix metadata (grid length, needs_files, fun exclusivity)
- Deep preset superset verification
- DisabledFeature warning content and count
- PresetKind equality and inequality

## tokmd-analysis-util (36 tests)
- \
ormalize_path\ edge cases (backslashes, mixed separators, root stripping)
- \path_depth\ edge cases
- \is_test_path\ patterns (directories, file suffixes, spec files)
- \is_infra_lang\ detection and rejection
- \mpty_file_row\ field verification
- \
ormalize_root\ behavior
- \
ow_ms\ timestamp sanity
- \AnalysisLimits\ construction and Debug trait
- Re-exported math functions (round_f64, safe_ratio, percentile, gini)