### PR TITLE
test: add deep orchestration integration tests for tokmd-analysis

### DIFF
--- a/crates/tokmd-analysis/tests/orchestration.rs
+++ b/crates/tokmd-analysis/tests/orchestration.rs
@@ -18,6 +18,7 @@ use tokmd_analysis::{
     AnalysisContext, AnalysisLimits, AnalysisPreset, AnalysisRequest, ImportGranularity,
     NearDupScope, analyze,
 };
+use tokmd_analysis_grid::PresetKind;
 use tokmd_analysis_types::{ANALYSIS_SCHEMA_VERSION, AnalysisArgsMeta, AnalysisSource};
 use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow, ScanStatus};
 
@@ -888,4 +889,427 @@ proptest! {
         let ratio = receipt.derived.unwrap().doc_density.total.ratio;
         prop_assert!((0.0..=1.0).contains(&ratio), "doc_density={} out of [0,1]", ratio);
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Deep integration: per-preset enricher field verification
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Helper: run a preset with git disabled and return the receipt.
+fn run_preset(export: ExportData, preset: AnalysisPreset) -> tokmd_analysis_types::AnalysisReceipt {
+    let mut req = make_req(preset);
+    req.git = Some(false);
+    analyze(make_ctx(export), req).expect("analyze should not fail")
+}
+
+fn multi_lang_export() -> ExportData {
+    ExportData {
+        rows: vec![
+            row("src/main.rs", "src", "Rust", 200),
+            row("src/lib.rs", "src", "Rust", 150),
+            row("src/utils.py", "src", "Python", 100),
+            row("tests/test.rs", "tests", "Rust", 80),
+            row("Cargo.toml", "(root)", "TOML", 30),
+            row("docs/README.md", "docs", "Markdown", 60),
+        ],
+        module_roots: vec!["crates".to_string()],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+#[test]
+fn health_preset_requests_todo_and_complexity() {
+    // Health plan enables todo + complexity. Without content/walk features
+    // those will appear as warnings; the key assertion is that the preset
+    // *attempts* to run them (warnings prove the plan flag was set).
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Health);
+    assert!(receipt.derived.is_some());
+    // Receipt should NOT have git, imports, assets, deps, entropy, license
+    assert!(receipt.git.is_none());
+    assert!(receipt.imports.is_none());
+    assert!(receipt.assets.is_none());
+    assert!(receipt.deps.is_none());
+    assert!(receipt.entropy.is_none());
+    assert!(receipt.license.is_none());
+    assert!(receipt.fun.is_none());
+}
+
+#[test]
+fn supply_preset_requests_assets_and_deps() {
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Supply);
+    assert!(receipt.derived.is_some());
+    // Supply should NOT have git, imports, entropy, license, complexity
+    assert!(receipt.git.is_none());
+    assert!(receipt.imports.is_none());
+    assert!(receipt.entropy.is_none());
+    assert!(receipt.license.is_none());
+    assert!(receipt.fun.is_none());
+    // assets/deps are either populated (walk feature) or warned about
+    #[cfg(not(feature = "walk"))]
+    {
+        assert!(receipt.assets.is_none());
+        assert!(receipt.deps.is_none());
+    }
+}
+
+#[test]
+fn architecture_preset_requests_imports_and_api_surface() {
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Architecture);
+    assert!(receipt.derived.is_some());
+    // Architecture should NOT have git, assets, deps, entropy, license, todo
+    assert!(receipt.git.is_none());
+    assert!(receipt.assets.is_none());
+    assert!(receipt.deps.is_none());
+    assert!(receipt.entropy.is_none());
+    assert!(receipt.license.is_none());
+    assert!(receipt.fun.is_none());
+    // imports + api_surface are either populated (content feature) or warned
+    #[cfg(not(feature = "content"))]
+    {
+        assert!(receipt.imports.is_none());
+        assert!(receipt.api_surface.is_none());
+    }
+}
+
+#[test]
+fn security_preset_requests_entropy_and_license() {
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Security);
+    assert!(receipt.derived.is_some());
+    // Security should NOT have git, assets, deps, imports, complexity
+    assert!(receipt.git.is_none());
+    assert!(receipt.assets.is_none());
+    assert!(receipt.deps.is_none());
+    assert!(receipt.imports.is_none());
+    assert!(receipt.fun.is_none());
+    // entropy + license are either populated (content+walk) or warned
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    {
+        assert!(receipt.entropy.is_none());
+        assert!(receipt.license.is_none());
+    }
+}
+
+#[test]
+fn risk_preset_does_not_include_unrelated_enrichers() {
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Risk);
+    assert!(receipt.derived.is_some());
+    // Risk: git=true (disabled via flag), complexity=true, but no assets, deps, imports, etc.
+    assert!(receipt.assets.is_none());
+    assert!(receipt.deps.is_none());
+    assert!(receipt.imports.is_none());
+    assert!(receipt.entropy.is_none());
+    assert!(receipt.license.is_none());
+    assert!(receipt.fun.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Deep integration: deep preset is a superset of all non-fun presets
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn deep_plan_is_superset_of_all_non_fun_presets() {
+    use tokmd_analysis_grid::preset_plan_for;
+
+    let deep = preset_plan_for(PresetKind::Deep);
+
+    // Every enricher flag that is true in any non-fun preset must also be
+    // true in the deep preset.
+    for preset in PresetKind::all() {
+        if *preset == PresetKind::Fun || *preset == PresetKind::Deep {
+            continue;
+        }
+        let plan = preset_plan_for(*preset);
+        assert!(
+            !plan.assets || deep.assets,
+            "{:?} has assets but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.deps || deep.deps,
+            "{:?} has deps but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.todo || deep.todo,
+            "{:?} has todo but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.dup || deep.dup,
+            "{:?} has dup but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.imports || deep.imports,
+            "{:?} has imports but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.git || deep.git,
+            "{:?} has git but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.archetype || deep.archetype,
+            "{:?} has archetype but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.topics || deep.topics,
+            "{:?} has topics but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.entropy || deep.entropy,
+            "{:?} has entropy but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.license || deep.license,
+            "{:?} has license but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.complexity || deep.complexity,
+            "{:?} has complexity but Deep does not",
+            preset
+        );
+        assert!(
+            !plan.api_surface || deep.api_surface,
+            "{:?} has api_surface but Deep does not",
+            preset
+        );
+    }
+}
+
+#[test]
+fn deep_plan_does_not_include_fun() {
+    use tokmd_analysis_grid::preset_plan_for;
+    let deep = preset_plan_for(PresetKind::Deep);
+    assert!(!deep.fun, "Deep should not include fun");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Deep integration: full receipt determinism (compare entire JSON)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Strip volatile fields (generated_at_ms, tool version) to compare stable content.
+fn strip_volatile(receipt: &tokmd_analysis_types::AnalysisReceipt) -> serde_json::Value {
+    let mut val = serde_json::to_value(receipt).unwrap();
+    if let Some(obj) = val.as_object_mut() {
+        obj.remove("generated_at_ms");
+        obj.remove("tool");
+    }
+    val
+}
+
+#[test]
+fn full_receipt_determinism_receipt_preset() {
+    let export = multi_lang_export();
+    let r1 = run_preset(export.clone(), AnalysisPreset::Receipt);
+    let r2 = run_preset(export, AnalysisPreset::Receipt);
+    assert_eq!(strip_volatile(&r1), strip_volatile(&r2));
+}
+
+#[test]
+fn full_receipt_determinism_health_preset() {
+    let export = multi_lang_export();
+    let r1 = run_preset(export.clone(), AnalysisPreset::Health);
+    let r2 = run_preset(export, AnalysisPreset::Health);
+    assert_eq!(strip_volatile(&r1), strip_volatile(&r2));
+}
+
+#[test]
+fn full_receipt_determinism_deep_preset() {
+    let export = multi_lang_export();
+    let r1 = run_preset(export.clone(), AnalysisPreset::Deep);
+    let r2 = run_preset(export, AnalysisPreset::Deep);
+    assert_eq!(strip_volatile(&r1), strip_volatile(&r2));
+}
+
+#[test]
+fn full_receipt_determinism_across_all_presets() {
+    let export = multi_lang_export();
+    for preset in PresetKind::all() {
+        let r1 = run_preset(export.clone(), *preset);
+        let r2 = run_preset(export.clone(), *preset);
+        assert_eq!(
+            strip_volatile(&r1),
+            strip_volatile(&r2),
+            "Preset {:?} is not deterministic",
+            preset
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Deep integration: edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn only_child_rows_produces_zero_totals() {
+    let export = ExportData {
+        rows: vec![
+            child_row("src/lib.rs", "src", "JavaScript", 50),
+            child_row("src/lib.rs", "src", "CSS", 30),
+        ],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    let receipt = run_preset(export, AnalysisPreset::Receipt);
+    let derived = receipt.derived.unwrap();
+    assert_eq!(derived.totals.files, 0, "child-only should have 0 files");
+    assert_eq!(derived.totals.code, 0, "child-only should have 0 code");
+}
+
+#[test]
+fn zero_code_files_produce_valid_receipt() {
+    let export = ExportData {
+        rows: vec![FileRow {
+            path: "empty.rs".to_string(),
+            module: "src".to_string(),
+            lang: "Rust".to_string(),
+            kind: FileKind::Parent,
+            code: 0,
+            comments: 0,
+            blanks: 0,
+            lines: 0,
+            bytes: 0,
+            tokens: 0,
+        }],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    let receipt = run_preset(export, AnalysisPreset::Receipt);
+    let derived = receipt.derived.unwrap();
+    assert_eq!(derived.totals.files, 1);
+    assert_eq!(derived.totals.code, 0);
+    assert!(derived.cocomo.is_none(), "COCOMO should be None for 0 KLOC");
+    assert_eq!(derived.polyglot.lang_count, 1);
+}
+
+#[test]
+fn empty_export_with_all_presets_never_panics() {
+    let empty = ExportData {
+        rows: vec![],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    for preset in PresetKind::all() {
+        let _ = run_preset(empty.clone(), *preset);
+    }
+}
+
+#[test]
+fn single_file_repo_all_presets_produce_valid_receipt() {
+    let export = ExportData {
+        rows: vec![row("main.py", "(root)", "Python", 100)],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    for preset in PresetKind::all() {
+        let receipt = run_preset(export.clone(), *preset);
+        assert!(
+            receipt.derived.is_some(),
+            "preset {:?} should produce derived for single-file repo",
+            preset
+        );
+        assert_eq!(receipt.schema_version, ANALYSIS_SCHEMA_VERSION);
+        let derived = receipt.derived.unwrap();
+        assert_eq!(derived.totals.files, 1);
+        assert_eq!(derived.totals.code, 100);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Deep integration: preset composition semantics
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn deep_preset_warnings_are_superset_of_receipt_warnings() {
+    // Deep triggers more enrichers, so it should produce >= the number of
+    // warnings that simpler presets produce (when features are disabled).
+    let export = multi_lang_export();
+    let receipt_w = run_preset(export.clone(), AnalysisPreset::Receipt)
+        .warnings
+        .len();
+    let deep_w = run_preset(export, AnalysisPreset::Deep).warnings.len();
+    assert!(
+        deep_w >= receipt_w,
+        "Deep warnings ({}) should be >= Receipt warnings ({})",
+        deep_w,
+        receipt_w,
+    );
+}
+
+#[test]
+fn receipt_preset_produces_no_warnings_without_feature_gates() {
+    // Receipt requests only derived metrics — no file walk, no git,
+    // no content scanning — so it should produce zero warnings.
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Receipt);
+    assert!(
+        receipt.warnings.is_empty(),
+        "Receipt preset should have no warnings, got: {:?}",
+        receipt.warnings
+    );
+}
+
+#[test]
+fn derived_fields_present_for_all_presets() {
+    let export = multi_lang_export();
+    for preset in PresetKind::all() {
+        let receipt = run_preset(export.clone(), *preset);
+        let derived = receipt.derived.expect("derived always present");
+        // Every preset should produce these core derived sub-fields
+        assert!(derived.totals.files > 0, "{:?}: files > 0", preset);
+        assert!(derived.totals.code > 0, "{:?}: code > 0", preset);
+        assert!(derived.polyglot.lang_count > 0, "{:?}: langs > 0", preset);
+        assert!(
+            !derived.integrity.hash.is_empty(),
+            "{:?}: integrity hash non-empty",
+            preset
+        );
+        assert!(
+            derived.distribution.count > 0,
+            "{:?}: dist count > 0",
+            preset
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Deep integration: JSON round-trip stability
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn receipt_json_roundtrip_is_lossless() {
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Receipt);
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let deserialized: tokmd_analysis_types::AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        strip_volatile(&receipt),
+        strip_volatile(&deserialized),
+        "JSON round-trip should be lossless"
+    );
+}
+
+#[test]
+fn deep_json_roundtrip_is_lossless() {
+    let receipt = run_preset(multi_lang_export(), AnalysisPreset::Deep);
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let deserialized: tokmd_analysis_types::AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        strip_volatile(&receipt),
+        strip_volatile(&deserialized),
+        "JSON round-trip should be lossless for Deep preset"
+    );
 }


### PR DESCRIPTION
Add comprehensive integration tests for the analysis orchestration pipeline covering all presets and determinism verification.

## Tests Added (20 new tests)

### Per-preset enricher field verification
- **health_preset_requests_todo_and_complexity** — Health enables todo+complexity, not git/imports/assets
- **supply_preset_requests_assets_and_deps** — Supply enables assets+deps, not git/imports/entropy
- **architecture_preset_requests_imports_and_api_surface** — Architecture enables imports+api_surface
- **security_preset_requests_entropy_and_license** — Security enables entropy+license
- **risk_preset_does_not_include_unrelated_enrichers** — Risk doesn't include assets/deps/imports

### Deep preset superset verification
- **deep_plan_is_superset_of_all_non_fun_presets** — Every enricher flag in any non-fun preset is also set in Deep
- **deep_plan_does_not_include_fun** — Deep excludes the fun enricher

### Full receipt determinism
- **full_receipt_determinism_receipt_preset** — Run Receipt twice, compare entire JSON
- **full_receipt_determinism_health_preset** — Run Health twice, compare entire JSON
- **full_receipt_determinism_deep_preset** — Run Deep twice, compare entire JSON
- **full_receipt_determinism_across_all_presets** — All 11 presets produce identical output across runs

### Preset composition semantics
- **deep_preset_warnings_are_superset_of_receipt_warnings** — Deep warnings >= Receipt warnings
- **receipt_preset_produces_no_warnings_without_feature_gates** — Receipt produces zero warnings
- **derived_fields_present_for_all_presets** — Core derived fields populated for every preset

### Edge cases
- **only_child_rows_produces_zero_totals** — Export with only child rows yields 0 files/code
- **zero_code_files_produce_valid_receipt** — Zero-LOC file doesn't panic, COCOMO is None
- **empty_export_with_all_presets_never_panics** — Empty export works with all 11 presets
- **single_file_repo_all_presets_produce_valid_receipt** — Single file works across all presets

### JSON round-trip stability
- **receipt_json_roundtrip_is_lossless** — Serialize/deserialize Receipt without data loss
- **deep_json_roundtrip_is_lossless** — Serialize/deserialize Deep without data loss

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>