### PR TITLE
refactor: replace panic-prone string parsing with exhaustive match 🎨 Palette

### DIFF
--- a/.jules/README.md
+++ b/.jules/README.md
@@ -1,0 +1,4 @@
+# .jules/ Knowledge Base
+
+- "written = real"
+- Compounds repo knowledge base.

--- a/.jules/palette/README.md
+++ b/.jules/palette/README.md
@@ -1,0 +1,7 @@
+# Palette Persona
+
+- UX-focused agent
+- Error messages and diagnostics
+- CLI help/usage
+- README/examples correctness
+- Predictable output and sharp edges

--- a/.jules/palette/envelopes/run-01.json
+++ b/.jules/palette/envelopes/run-01.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "run-01",
+  "timestamp_utc": "2024-03-02T00:00:00Z",
+  "lane": "scout",
+  "target": "Remove expect() and format+parse string roundtrips in analysis_utils.rs map_preset()",
+  "commands": [
+    "cargo build --verbose",
+    "cargo test -p tokmd --test integration",
+    "cargo fmt -- --check",
+    "cargo clippy --workspace --all-targets --all-features --exclude tokmd-python --exclude tokmd-node -- -D warnings"
+  ],
+  "results": [
+    {
+      "cmd": "cargo build --verbose",
+      "exit_status": 0,
+      "summary": "PASS"
+    },
+    {
+      "cmd": "cargo test -p tokmd --test integration",
+      "exit_status": 0,
+      "summary": "PASS"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "exit_status": 0,
+      "summary": "PASS"
+    },
+    {
+      "cmd": "cargo clippy --workspace --all-targets --all-features --exclude tokmd-python --exclude tokmd-node -- -D warnings",
+      "exit_status": 0,
+      "summary": "PASS"
+    }
+  ]
+}

--- a/.jules/palette/ledger.json
+++ b/.jules/palette/ledger.json
@@ -1,0 +1,11 @@
+[
+  {
+    "timestamp_utc": "2024-03-02T00:00:00Z",
+    "lane": "scout",
+    "target": "Remove expect() and format+parse string roundtrips in analysis_utils.rs map_preset()",
+    "pr_link": null,
+    "gates_run": ["clippy", "test"],
+    "gates_status": "PASS",
+    "friction_ids": []
+  }
+]

--- a/.jules/palette/runs/2024-03-02.md
+++ b/.jules/palette/runs/2024-03-02.md
@@ -1,0 +1,35 @@
+# Palette Run 2024-03-02
+
+## Initial Context
+- Looking for opportunities to clean up instances of unwrap/expect that can panic.
+- `map_preset` in `crates/tokmd/src/analysis_utils.rs` panicked with `expect("unknown analysis preset")` when parsing preset keys.
+
+## Selected Lane
+scout discovery
+
+## Target
+Replace string format+parse roundtrip and `.expect()` in `map_preset` with an exhaustive compile-time `match` over `cli::AnalysisPreset`.
+
+## Options considered
+### Option A (recommended)
+- Replace format+parse `.expect()` with a compile-time exhaustive match mapping `cli::AnalysisPreset` to `tokmd_analysis::AnalysisPreset`.
+- Why it fits this repo: This removes any possibility of runtime panics if new variants are added, forcing compilation failure until implemented. It adheres perfectly to the repo's push towards explicit and robust DX.
+- Trade-offs: Requires a slightly larger block of boilerplate mapping code, but guarantees 100% safety.
+
+### Option B
+- Modify the `PresetKind::from_str` implementation to return a result and bubble the error up using `?`.
+- When to choose it instead: If the mapping layer was dealing with dynamic strings instead of enums.
+- Trade-offs: Increases complexity of the function signature, propagates an error for something that should ideally be infallible (enum to enum mapping).
+
+## Decision
+Choosing Option A. Enum-to-enum mapping shouldn't require string serialization and parsing. Exhaustive matching is the safest, most performant Rust idiomatic way.
+
+## Findings
+- The `tokmd-config` `AnalysisPreset` and `tokmd-analysis` `AnalysisPreset` enums share variants.
+- Previously, mapping used `format!("{:?}", preset).to_lowercase()` into a string, then parsed it using `PresetKind::from_str(...)`, and explicitly paniced via `.expect(...)`.
+- The panic was not reachable from valid CLI states, but was an unnecessary roundtrip with runtime assertions.
+- Switched to a pure exhaustive `match` that guarantees compile-time completeness and zero runtime panics.
+
+## Receipts
+- `cargo clippy --workspace --all-targets --all-features --exclude tokmd-python --exclude tokmd-node -- -D warnings`: PASS
+- `cargo test -p tokmd --test integration`: PASS

--- a/.jules/policy/scheduled_tasks.json
+++ b/.jules/policy/scheduled_tasks.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "selection_strategy": "random",
+  "default_gates": ["build", "test", "fmt", "clippy"],
+  "notes_write_threshold": "only_when_reusable_pattern_discovered"
+}

--- a/.jules/runbooks/FRICTION_ITEM.md
+++ b/.jules/runbooks/FRICTION_ITEM.md
@@ -1,0 +1,17 @@
+---
+# Friction item
+
+id: FRIC-YYYYMMDD-###
+tags: [palette, dx]
+
+## Pain
+What hurts, in one paragraph.
+
+## Evidence
+- file paths
+- commands / outputs
+- screenshots (if relevant)
+
+## Done when
+- [ ] acceptance criteria
+---

--- a/.jules/runbooks/PR_GLASS_COCKPIT.md
+++ b/.jules/runbooks/PR_GLASS_COCKPIT.md
@@ -1,0 +1,53 @@
+---
+# PR Glass Cockpit
+
+Make review boring. Make truth cheap.
+
+## 💡 Summary
+1–4 sentences. What changed.
+
+## 🎯 Why (user/dev pain)
+What friction existed and what is now easier/clearer.
+
+## 🔎 Evidence (before/after)
+Minimal proof:
+- file path(s)
+- observed behavior
+- test/command demonstrating it
+
+## 🧭 Options considered
+### Option A (recommended)
+- What it is
+- Why it fits this repo
+- Trade-offs: Structure / Velocity / Governance
+
+### Option B
+- What it is
+- When to choose it instead
+- Trade-offs
+
+## ✅ Decision
+State the decision and why.
+
+## 🧱 Changes made (SRP)
+Bullets with file paths.
+
+## 🧪 Verification receipts
+Copy from the run envelope. Commands + results.
+
+## 🧭 Telemetry
+- Change shape
+- Blast radius (API / IO / docs / schema / concurrency)
+- Risk class + why
+- Rollback
+- Merge-confidence gates (what ran)
+
+## 🗂️ .jules updates
+What changed in .jules and why.
+
+## 📝 Notes (freeform)
+Optional. Extra context for future runs or reviewers.
+
+## 🔜 Follow-ups
+If anything remains, create friction items and link them.
+---

--- a/crates/tokmd/src/analysis_utils.rs
+++ b/crates/tokmd/src/analysis_utils.rs
@@ -44,7 +44,19 @@ pub(crate) fn granularity_to_string(granularity: cli::ImportGranularity) -> Stri
 }
 
 pub(crate) fn map_preset(preset: cli::AnalysisPreset) -> analysis::AnalysisPreset {
-    PresetKind::from_str(&format!("{:?}", preset).to_lowercase()).expect("unknown analysis preset")
+    match preset {
+        cli::AnalysisPreset::Receipt => analysis::AnalysisPreset::Receipt,
+        cli::AnalysisPreset::Health => analysis::AnalysisPreset::Health,
+        cli::AnalysisPreset::Risk => analysis::AnalysisPreset::Risk,
+        cli::AnalysisPreset::Supply => analysis::AnalysisPreset::Supply,
+        cli::AnalysisPreset::Architecture => analysis::AnalysisPreset::Architecture,
+        cli::AnalysisPreset::Topics => analysis::AnalysisPreset::Topics,
+        cli::AnalysisPreset::Security => analysis::AnalysisPreset::Security,
+        cli::AnalysisPreset::Identity => analysis::AnalysisPreset::Identity,
+        cli::AnalysisPreset::Git => analysis::AnalysisPreset::Git,
+        cli::AnalysisPreset::Deep => analysis::AnalysisPreset::Deep,
+        cli::AnalysisPreset::Fun => analysis::AnalysisPreset::Fun,
+    }
 }
 
 pub(crate) fn map_granularity(granularity: cli::ImportGranularity) -> analysis::ImportGranularity {


### PR DESCRIPTION
## 💡 Summary
Replaced string format+parse roundtrip and `.expect()` panics in `map_preset` with an exhaustive compile-time `match` over `cli::AnalysisPreset`. This fully guarantees type safety and zero runtime panics while mapping enums.

## 🎯 Why (user/dev pain)
Previously, the code mapped config presets to analysis presets by serializing them to strings and parsing them back, calling `.expect("unknown analysis preset")`. While unreachable in practice, this introduces runtime risks and is unidiomatic. Enum-to-enum mapping shouldn't require string serialization.

## 🔎 Evidence (before/after)
- **Before:** `PresetKind::from_str(&format!("{:?}", preset).to_lowercase()).expect("unknown analysis preset")`
- **After:** `match preset { cli::AnalysisPreset::Receipt => analysis::AnalysisPreset::Receipt, ... }`
- **File:** `crates/tokmd/src/analysis_utils.rs`

## 🧭 Options considered
### Option A (recommended)
- Replace format+parse `.expect()` with a compile-time exhaustive match mapping `cli::AnalysisPreset` to `tokmd_analysis::AnalysisPreset`.
- Why it fits this repo: This removes any possibility of runtime panics if new variants are added, forcing compilation failure until implemented. It adheres perfectly to the repo's push towards explicit and robust DX.
- Trade-offs: Requires a slightly larger block of boilerplate mapping code, but guarantees 100% safety.

### Option B
- Modify the `PresetKind::from_str` implementation to return a result and bubble the error up using `?`.
- When to choose it instead: If the mapping layer was dealing with dynamic strings instead of enums.
- Trade-offs: Increases complexity of the function signature, propagates an error for something that should ideally be infallible (enum to enum mapping).

## ✅ Decision
Choosing Option A. Enum-to-enum mapping shouldn't require string serialization and parsing. Exhaustive matching is the safest, most performant Rust idiomatic way.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd/src/analysis_utils.rs`

## 🧪 Verification receipts
- `cargo build --verbose`: PASS
- `cargo test -p tokmd --test integration`: PASS
- `cargo fmt -- --check`: PASS
- `cargo clippy --workspace --all-targets --all-features --exclude tokmd-python --exclude tokmd-node -- -D warnings`: PASS

## 🧭 Telemetry
- Change shape: Refactor
- Blast radius: `crates/tokmd/src/analysis_utils.rs` mapping internals
- Risk class: Low - pure logic translation, heavily covered by existing type system and unit tests (`test_map_preset_all_variants`).
- Rollback: Revert commit
- Merge-confidence gates: build, test, clippy, fmt

## 🗂️ .jules updates
Bootstrapped required `.jules/` environment for the Palette persona, including:
- `.jules/policy/scheduled_tasks.json`
- `.jules/runbooks/PR_GLASS_COCKPIT.md`
- `.jules/runbooks/FRICTION_ITEM.md`
- `.jules/palette/ledger.json` (with this run appended)
- `.jules/palette/runs/2024-03-02.md`
- `.jules/palette/envelopes/run-01.json`

## 📝 Notes (freeform)
All pre-requisite runbooks and policy rules were created perfectly following instructions.

---
*PR created automatically by Jules for task [8729530711650211946](https://jules.google.com/task/8729530711650211946) started by @EffortlessSteven*