### PR TITLE
test: add tests for analysis-api-surface, archetype, assets

### DIFF
--- a/crates/tokmd-analysis-api-surface/tests/bdd.rs
+++ b/crates/tokmd-analysis-api-surface/tests/bdd.rs
@@ -476,3 +476,138 @@ fn given_file_with_only_comments_no_symbols() {
 
     assert_eq!(report.total_items, 0);
 }
+
+// ---------------------------------------------------------------------------
+// Scenario: Deterministic output — same input yields identical report
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_same_input_when_built_twice_then_reports_are_identical() {
+    let code = "pub fn a() {}\nfn b() {}\npub struct C;\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", ".", "Rust")]);
+    let r1 = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+    let r2 = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(r1.total_items, r2.total_items);
+    assert_eq!(r1.public_items, r2.public_items);
+    assert_eq!(r1.internal_items, r2.internal_items);
+    assert_eq!(r1.public_ratio, r2.public_ratio);
+    assert_eq!(r1.documented_ratio, r2.documented_ratio);
+    assert_eq!(r1.by_language.len(), r2.by_language.len());
+    assert_eq!(r1.by_module.len(), r2.by_module.len());
+    assert_eq!(r1.top_exporters.len(), r2.top_exporters.len());
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: JS/TS export async function and abstract class
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_ts_export_async_function_detected_as_public() {
+    let code = "export async function fetchData() {}\n";
+    let (dir, paths) = write_temp_files(&[("api.ts", code)]);
+    let export = make_export(vec![make_row("api.ts", ".", "TypeScript")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+}
+
+#[test]
+fn given_ts_export_abstract_class_detected_as_public() {
+    let code = "export abstract class Base {}\n";
+    let (dir, paths) = write_temp_files(&[("base.ts", code)]);
+    let export = make_export(vec![make_row("base.ts", ".", "TypeScript")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Java documented with Javadoc
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_java_file_with_javadoc_documented_ratio_correct() {
+    let code = "/** Javadoc comment */\npublic class Documented {}\npublic class Undocumented {}\n";
+    let (dir, paths) = write_temp_files(&[("App.java", code)]);
+    let export = make_export(vec![make_row("App.java", ".", "Java")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 2);
+    assert_eq!(report.documented_ratio, 0.5);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Multiple files in same module — counts aggregate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_multiple_files_in_same_module_then_module_counts_aggregate() {
+    let code_a = "pub fn a1() {}\npub fn a2() {}\n";
+    let code_b = "pub fn b1() {}\n";
+    let (dir, paths) = write_temp_files(&[("src/a.rs", code_a), ("src/b.rs", code_b)]);
+    let export = make_export(vec![
+        make_row("src/a.rs", "shared_mod", "Rust"),
+        make_row("src/b.rs", "shared_mod", "Rust"),
+    ]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.by_module.len(), 1);
+    assert_eq!(report.by_module[0].module, "shared_mod");
+    assert_eq!(report.by_module[0].total_items, 3);
+    assert_eq!(report.by_module[0].public_items, 3);
+    assert_eq!(report.by_module[0].public_ratio, 1.0);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Top exporters tiebreak by path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_equal_public_items_top_exporters_sorted_by_path() {
+    let code_a = "pub fn x() {}\n";
+    let code_b = "pub fn y() {}\n";
+    let (dir, paths) = write_temp_files(&[("b.rs", code_b), ("a.rs", code_a)]);
+    let export = make_export(vec![
+        make_row("b.rs", ".", "Rust"),
+        make_row("a.rs", ".", "Rust"),
+    ]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.top_exporters.len(), 2);
+    // Same public_items → sorted ascending by path
+    assert_eq!(report.top_exporters[0].path, "a.rs");
+    assert_eq!(report.top_exporters[1].path, "b.rs");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Go var/const detection end-to-end
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_go_file_with_var_and_const_detects_visibility() {
+    let code = "var PublicVar int = 42\nconst privateConst = 10\ntype Handler interface {}\n";
+    let (dir, paths) = write_temp_files(&[("types.go", code)]);
+    let export = make_export(vec![make_row("types.go", ".", "Go")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.total_items, 3);
+    assert_eq!(report.public_items, 2); // PublicVar, Handler
+    assert_eq!(report.internal_items, 1); // privateConst
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Python triple-quote docstring variant
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_python_file_with_single_quote_docstring_detected() {
+    let code = "def func():\n    '''Single-quote docstring.'''\n    pass\n";
+    let (dir, paths) = write_temp_files(&[("mod.py", code)]);
+    let export = make_export(vec![make_row("mod.py", ".", "Python")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+    assert_eq!(report.documented_ratio, 1.0);
+}

--- a/crates/tokmd-analysis-archetype/tests/bdd.rs
+++ b/crates/tokmd-analysis-archetype/tests/bdd.rs
@@ -457,3 +457,134 @@ fn kind_is_always_a_known_archetype() {
         }
     }
 }
+
+// ===========================================================================
+// Scenario: Deterministic — calling twice yields same result
+// ===========================================================================
+
+#[test]
+fn given_same_input_when_detect_called_twice_then_same_result() {
+    let export = export_with_paths(&["Cargo.toml", "crates/core/src/lib.rs", "src/main.rs"]);
+    let a1 = detect_archetype(&export);
+    let a2 = detect_archetype(&export);
+    assert_eq!(a1.as_ref().map(|a| &a.kind), a2.as_ref().map(|a| &a.kind));
+    assert_eq!(
+        a1.as_ref().map(|a| &a.evidence),
+        a2.as_ref().map(|a| &a.evidence)
+    );
+}
+
+// ===========================================================================
+// Scenario: Single marker file without companion
+// ===========================================================================
+
+#[test]
+fn given_only_dockerfile_then_no_archetype() {
+    let export = export_with_paths(&["Dockerfile"]);
+    assert!(
+        detect_archetype(&export).is_none(),
+        "Dockerfile alone should not match any archetype"
+    );
+}
+
+#[test]
+fn given_single_tf_file_then_iac_detected() {
+    let export = export_with_paths(&["deploy.tf"]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Infrastructure as code");
+}
+
+// ===========================================================================
+// Scenario: Rust workspace with both main.rs and bin dir
+// ===========================================================================
+
+#[test]
+fn given_rust_workspace_with_both_main_rs_and_bin_dir_then_cli_variant() {
+    let export = export_with_paths(&[
+        "Cargo.toml",
+        "crates/foo/src/lib.rs",
+        "src/main.rs",
+        "crates/foo/src/bin/tool.rs",
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Rust workspace (CLI)");
+}
+
+// ===========================================================================
+// Scenario: Evidence paths never contain backslashes
+// ===========================================================================
+
+#[test]
+fn given_any_archetype_evidence_paths_have_no_backslashes() {
+    let cases: Vec<Vec<&str>> = vec![
+        vec!["Cargo.toml", "crates/a/src/lib.rs"],
+        vec!["package.json", "next.config.js"],
+        vec!["Dockerfile", "k8s/pod.yaml"],
+        vec!["main.tf"],
+        vec!["pyproject.toml"],
+        vec!["package.json"],
+    ];
+    for paths in &cases {
+        let export = export_with_paths(paths);
+        if let Some(a) = detect_archetype(&export) {
+            for ev in &a.evidence {
+                assert!(
+                    !ev.contains('\\'),
+                    "evidence path should not contain backslashes: {:?} for kind={:?}",
+                    ev,
+                    a.kind
+                );
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// Scenario: Archetype kind is never empty string
+// ===========================================================================
+
+#[test]
+fn given_detected_archetype_kind_is_non_empty() {
+    let cases: Vec<Vec<&str>> = vec![
+        vec!["Cargo.toml", "crates/a/src/lib.rs"],
+        vec!["package.json", "next.config.mjs"],
+        vec!["Dockerfile", "kubernetes/deploy.yaml"],
+        vec!["terraform/main.tf"],
+        vec!["pyproject.toml"],
+        vec!["package.json", "src/index.js"],
+    ];
+    for paths in &cases {
+        let export = export_with_paths(paths);
+        if let Some(a) = detect_archetype(&export) {
+            assert!(
+                !a.kind.is_empty(),
+                "kind must not be empty for paths={:?}",
+                paths
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// Scenario: Multiple overlapping markers — highest priority wins
+// ===========================================================================
+
+#[test]
+fn given_all_markers_present_then_rust_workspace_wins() {
+    let export = export_with_paths(&[
+        "Cargo.toml",
+        "crates/core/src/lib.rs",
+        "package.json",
+        "next.config.js",
+        "Dockerfile",
+        "k8s/pod.yaml",
+        "main.tf",
+        "pyproject.toml",
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert!(
+        a.kind.starts_with("Rust workspace"),
+        "Rust workspace should win over all others, got: {}",
+        a.kind
+    );
+}

--- a/crates/tokmd-analysis-assets/tests/bdd.rs
+++ b/crates/tokmd-analysis-assets/tests/bdd.rs
@@ -640,3 +640,147 @@ fn given_empty_package_lock_when_dependency_report_built_then_zero_deps() {
 
     assert_eq!(report.lockfiles[0].dependencies, 0);
 }
+
+// ===========================================================================
+// build_assets_report – deterministic output
+// ===========================================================================
+
+#[test]
+fn given_same_input_when_assets_report_built_twice_then_identical() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.png", &[0u8; 100]),
+        write_file(tmp.path(), "b.mp4", &[0u8; 200]),
+        write_file(tmp.path(), "c.woff2", &[0u8; 50]),
+    ];
+    let r1 = build_assets_report(tmp.path(), &files).unwrap();
+    let r2 = build_assets_report(tmp.path(), &files).unwrap();
+
+    assert_eq!(r1.total_files, r2.total_files);
+    assert_eq!(r1.total_bytes, r2.total_bytes);
+    assert_eq!(r1.categories.len(), r2.categories.len());
+    for (c1, c2) in r1.categories.iter().zip(r2.categories.iter()) {
+        assert_eq!(c1.category, c2.category);
+        assert_eq!(c1.files, c2.files);
+        assert_eq!(c1.bytes, c2.bytes);
+    }
+    assert_eq!(r1.top_files.len(), r2.top_files.len());
+}
+
+// ===========================================================================
+// build_assets_report – total_bytes equals sum of category bytes
+// ===========================================================================
+
+#[test]
+fn given_multi_category_report_total_bytes_equals_category_sum() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.png", &[0u8; 100]),
+        write_file(tmp.path(), "b.mp4", &[0u8; 200]),
+        write_file(tmp.path(), "c.zip", &[0u8; 300]),
+        write_file(tmp.path(), "d.ttf", &[0u8; 50]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+
+    let cat_sum: u64 = report.categories.iter().map(|c| c.bytes).sum();
+    assert_eq!(
+        report.total_bytes, cat_sum,
+        "total_bytes should equal sum of category bytes"
+    );
+}
+
+// ===========================================================================
+// build_dependency_report – total equals sum of lockfile deps
+// ===========================================================================
+
+#[test]
+fn given_dependency_report_total_equals_sum_of_lockfile_deps() {
+    let tmp = TempDir::new().unwrap();
+    let cargo = write_file(
+        tmp.path(),
+        "Cargo.lock",
+        b"[[package]]\nname = \"x\"\n\n[[package]]\nname = \"y\"\n",
+    );
+    let go = write_file(tmp.path(), "go.sum", b"github.com/foo/bar v1.0.0 h1:abc=\n");
+    let report = build_dependency_report(tmp.path(), &[cargo, go]).unwrap();
+
+    let lockfile_sum: usize = report.lockfiles.iter().map(|l| l.dependencies).sum();
+    assert_eq!(
+        report.total, lockfile_sum,
+        "total should equal sum of lockfile dependencies"
+    );
+}
+
+// ===========================================================================
+// build_assets_report – zero-byte files still counted
+// ===========================================================================
+
+#[test]
+fn given_zero_byte_asset_when_report_built_then_counted_with_zero_bytes() {
+    let tmp = TempDir::new().unwrap();
+    let rel = write_file(tmp.path(), "empty.png", &[]);
+    let report = build_assets_report(tmp.path(), &[rel]).unwrap();
+
+    assert_eq!(report.total_files, 1);
+    assert_eq!(report.total_bytes, 0);
+    assert_eq!(report.categories[0].files, 1);
+    assert_eq!(report.categories[0].bytes, 0);
+}
+
+// ===========================================================================
+// build_assets_report – category tiebreak sorted by name
+// ===========================================================================
+
+#[test]
+fn given_categories_with_same_bytes_when_report_built_then_sorted_by_name() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "track.mp3", &[0u8; 100]), // audio
+        write_file(tmp.path(), "archive.zip", &[0u8; 100]), // archive
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+
+    assert_eq!(report.categories.len(), 2);
+    // Same bytes → sorted by category name ascending
+    assert_eq!(report.categories[0].category, "archive");
+    assert_eq!(report.categories[1].category, "audio");
+}
+
+// ===========================================================================
+// build_dependency_report – go.sum deduplicates same module@version
+// ===========================================================================
+
+#[test]
+fn given_go_sum_with_duplicate_entries_when_report_built_then_deduplicated() {
+    let tmp = TempDir::new().unwrap();
+    let content = "\
+github.com/pkg/errors v0.9.1 h1:abc=\n\
+github.com/pkg/errors v0.9.1 h1:xyz=\n\
+github.com/pkg/errors v0.9.1/go.mod h1:def=\n";
+    let rel = write_file(tmp.path(), "go.sum", content.as_bytes());
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+
+    // Only one unique module@version (go.mod lines excluded, duplicate hash lines deduped)
+    assert_eq!(report.lockfiles[0].dependencies, 1);
+}
+
+// ===========================================================================
+// build_dependency_report – deterministic output
+// ===========================================================================
+
+#[test]
+fn given_same_lockfiles_when_dependency_report_built_twice_then_identical() {
+    let tmp = TempDir::new().unwrap();
+    let cargo = write_file(
+        tmp.path(),
+        "Cargo.lock",
+        b"[[package]]\nname = \"a\"\n\n[[package]]\nname = \"b\"\n",
+    );
+    let r1 = build_dependency_report(tmp.path(), &[cargo.clone()]).unwrap();
+    let r2 = build_dependency_report(tmp.path(), &[cargo]).unwrap();
+
+    assert_eq!(r1.total, r2.total);
+    assert_eq!(r1.lockfiles.len(), r2.lockfiles.len());
+    assert_eq!(r1.lockfiles[0].dependencies, r2.lockfiles[0].dependencies);
+    assert_eq!(r1.lockfiles[0].kind, r2.lockfiles[0].kind);
+}


### PR DESCRIPTION
Add BDD-style tests for 3 analysis adapter crates.