### PR TITLE
test: add BDD edge-case tests for analysis crates

### DIFF
--- a/crates/tokmd-analysis-complexity/tests/edge_cases.rs
+++ b/crates/tokmd-analysis-complexity/tests/edge_cases.rs
@@ -1,0 +1,410 @@
+//! Edge-case and language-coverage tests for `tokmd-analysis-complexity`.
+//!
+//! Supplements the existing BDD, integration, and property tests with
+//! scenarios for deeply nested code, additional languages, and report
+//! aggregate invariants.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tokmd_analysis_complexity::build_complexity_report;
+use tokmd_analysis_types::ComplexityRisk;
+use tokmd_analysis_util::AnalysisLimits;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn make_row(path: &str, module: &str, lang: &str, code: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments: 0,
+        blanks: 0,
+        lines: code,
+        bytes: code * 40,
+        tokens: code * 8,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn write_temp_files(files: &[(&str, &str)]) -> (tempfile::TempDir, Vec<PathBuf>) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let mut paths = Vec::new();
+    for (rel, content) in files {
+        let full = dir.path().join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&full, content).unwrap();
+        paths.push(PathBuf::from(rel));
+    }
+    (dir, paths)
+}
+
+// ── Deeply nested code ──────────────────────────────────────────
+
+mod deeply_nested {
+    use super::*;
+
+    #[test]
+    fn given_deeply_nested_rust_when_analyzed_then_high_cyclomatic() {
+        let code = "\
+fn deep(x: i32, y: i32, z: i32) -> i32 {
+    if x > 0 {
+        if y > 0 {
+            if z > 0 {
+                if x > y {
+                    if y > z {
+                        for i in 0..x {
+                            if i % 2 == 0 {
+                                return i;
+                            }
+                        }
+                    }
+                }
+            } else {
+                match z {
+                    0 => return 0,
+                    1 => return 1,
+                    _ => return -1,
+                }
+            }
+        }
+    }
+    42
+}
+";
+        let (dir, paths) = write_temp_files(&[("nested.rs", code)]);
+        let export = make_export(vec![make_row("nested.rs", "src", "Rust", 25)]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(report.files.len(), 1);
+        assert!(
+            report.files[0].cyclomatic_complexity >= 7,
+            "deeply nested code should have high cyclomatic, got {}",
+            report.files[0].cyclomatic_complexity
+        );
+        assert!(matches!(
+            report.files[0].risk_level,
+            ComplexityRisk::Moderate | ComplexityRisk::High | ComplexityRisk::Critical
+        ));
+    }
+
+    #[test]
+    fn given_deeply_nested_rust_when_analyzed_then_nesting_depth_detected() {
+        let code = "\
+fn deep_nest() {
+    if true {
+        if true {
+            if true {
+                if true {
+                    println!(\"deep\");
+                }
+            }
+        }
+    }
+}
+";
+        let (dir, paths) = write_temp_files(&[("deep.rs", code)]);
+        let export = make_export(vec![make_row("deep.rs", "src", "Rust", 12)]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(report.files.len(), 1);
+        if let Some(nesting) = report.files[0].max_nesting {
+            assert!(nesting >= 4, "expected nesting depth >= 4, got {nesting}");
+        }
+    }
+}
+
+// ── Ruby and C# language support ────────────────────────────────
+
+mod language_support {
+    use super::*;
+
+    #[test]
+    fn given_ruby_file_when_analyzed_then_functions_detected() {
+        let code = "\
+def greet(name)
+  if name
+    puts \"Hello, #{name}!\"
+  else
+    puts \"Hello!\"
+  end
+end
+
+def add(a, b)
+  a + b
+end
+";
+        let (dir, paths) = write_temp_files(&[("app.rb", code)]);
+        let export = make_export(vec![make_row("app.rb", ".", "Ruby", 12)]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(report.total_functions, 2);
+        assert_eq!(report.files.len(), 1);
+    }
+
+    #[test]
+    fn given_c_sharp_file_when_analyzed_then_functions_detected() {
+        let code = "\
+public class Program {
+    static void Main(string[] args) {
+        if (args.Length > 0) {
+            Console.WriteLine(args[0]);
+        }
+    }
+
+    static int Add(int a, int b) {
+        return a + b;
+    }
+}
+";
+        let (dir, paths) = write_temp_files(&[("Program.cs", code)]);
+        let export = make_export(vec![make_row("Program.cs", ".", "C#", 12)]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            report.total_functions >= 2,
+            "C# file should detect functions, got {}",
+            report.total_functions
+        );
+    }
+
+    #[test]
+    fn given_typescript_file_when_analyzed_then_functions_detected() {
+        let code = "\
+function greet(name: string): void {
+    if (name) {
+        console.log(`Hello, ${name}!`);
+    } else {
+        console.log('Hello!');
+    }
+}
+
+function add(a: number, b: number): number {
+    return a + b;
+}
+";
+        let (dir, paths) = write_temp_files(&[("app.ts", code)]);
+        let export = make_export(vec![make_row("app.ts", ".", "TypeScript", 12)]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(report.total_functions, 2);
+        assert!(report.avg_cyclomatic > 0.0);
+    }
+}
+
+// ── Aggregate invariants ────────────────────────────────────────
+
+mod aggregate_invariants {
+    use super::*;
+
+    #[test]
+    fn given_multiple_files_when_analyzed_then_avg_cyclomatic_between_min_and_max() {
+        let code_simple = "fn simple() { let x = 1; }\n";
+        let code_branchy = "\
+fn branchy(x: i32) -> i32 {
+    if x > 0 {
+        if x > 10 {
+            for i in 0..x {
+                if i % 2 == 0 { return i; }
+            }
+        }
+    }
+    0
+}
+";
+        let (dir, paths) =
+            write_temp_files(&[("simple.rs", code_simple), ("branchy.rs", code_branchy)]);
+        let export = make_export(vec![
+            make_row("simple.rs", "src", "Rust", 1),
+            make_row("branchy.rs", "src", "Rust", 12),
+        ]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        let min_cyclo = report
+            .files
+            .iter()
+            .map(|f| f.cyclomatic_complexity)
+            .min()
+            .unwrap_or(0);
+        let max_cyclo = report.max_cyclomatic;
+        assert!(
+            report.avg_cyclomatic >= min_cyclo as f64,
+            "avg {} should be >= min {}",
+            report.avg_cyclomatic,
+            min_cyclo
+        );
+        assert!(
+            report.avg_cyclomatic <= max_cyclo as f64,
+            "avg {} should be <= max {}",
+            report.avg_cyclomatic,
+            max_cyclo
+        );
+    }
+
+    #[test]
+    fn given_files_when_analyzed_then_high_risk_count_le_total_files() {
+        let code = "\
+fn moderate(x: i32) -> i32 {
+    if x > 0 { if x > 10 { 42 } else { x } } else { 0 }
+}
+";
+        let (dir, paths) = write_temp_files(&[("a.rs", code), ("b.rs", code)]);
+        let export = make_export(vec![
+            make_row("a.rs", "src", "Rust", 3),
+            make_row("b.rs", "src", "Rust", 3),
+        ]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        assert!(report.high_risk_files <= report.files.len());
+    }
+}
+
+// ── Determinism ─────────────────────────────────────────────────
+
+mod determinism {
+    use super::*;
+
+    #[test]
+    fn given_same_input_when_analyzed_twice_then_output_is_identical() {
+        let code = "\
+fn branchy(x: i32) -> i32 {
+    if x > 0 { if x > 10 { 42 } else { x } } else { 0 }
+}
+fn simple() { let y = 1; }
+";
+        let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+        let export = make_export(vec![make_row("lib.rs", "src", "Rust", 5)]);
+
+        let r1 = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            true,
+        )
+        .unwrap();
+        let r2 = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(r1.total_functions, r2.total_functions);
+        assert_eq!(r1.max_cyclomatic, r2.max_cyclomatic);
+        assert_eq!(r1.avg_cyclomatic, r2.avg_cyclomatic);
+        assert_eq!(r1.files.len(), r2.files.len());
+        for (f1, f2) in r1.files.iter().zip(r2.files.iter()) {
+            assert_eq!(f1.path, f2.path);
+            assert_eq!(f1.cyclomatic_complexity, f2.cyclomatic_complexity);
+            assert_eq!(f1.function_count, f2.function_count);
+        }
+    }
+}
+
+// ── Empty / minimal ─────────────────────────────────────────────
+
+mod empty_minimal {
+    use super::*;
+
+    #[test]
+    fn given_file_with_no_functions_when_analyzed_then_zero_function_count() {
+        let code = "// Just a comment, no functions\nlet x = 42;\n";
+        let (dir, paths) = write_temp_files(&[("nofn.rs", code)]);
+        let export = make_export(vec![make_row("nofn.rs", "src", "Rust", 2)]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        // File is analyzed but has no functions
+        if !report.files.is_empty() {
+            assert_eq!(report.files[0].function_count, 0);
+        }
+    }
+
+    #[test]
+    fn given_empty_file_when_analyzed_then_no_crash() {
+        let (dir, paths) = write_temp_files(&[("empty.rs", "")]);
+        let export = make_export(vec![make_row("empty.rs", "src", "Rust", 0)]);
+        let report = build_complexity_report(
+            dir.path(),
+            &paths,
+            &export,
+            &AnalysisLimits::default(),
+            false,
+        )
+        .unwrap();
+
+        // Should not panic; may or may not include the file
+        assert!(report.total_functions == 0);
+    }
+}

--- a/crates/tokmd-analysis-derived/tests/edge_cases.rs
+++ b/crates/tokmd-analysis-derived/tests/edge_cases.rs
@@ -1,0 +1,229 @@
+//! Edge-case and determinism tests for `tokmd-analysis-derived`.
+//!
+//! Supplements the existing BDD, integration, and property tests with
+//! scenarios that exercise max_file, lang_purity tie-breaking, and
+//! output determinism.
+
+use tokmd_analysis_derived::derive_report;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn make_row(
+    path: &str,
+    module: &str,
+    lang: &str,
+    code: usize,
+    comments: usize,
+    blanks: usize,
+    bytes: usize,
+    tokens: usize,
+) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments,
+        blanks,
+        lines: code + comments + blanks,
+        bytes,
+        tokens,
+    }
+}
+
+fn export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+// ── Max-file report ─────────────────────────────────────────────
+
+mod max_file {
+    use super::*;
+
+    #[test]
+    fn given_single_file_when_derived_then_max_file_overall_matches() {
+        let rows = vec![make_row(
+            "src/only.rs",
+            "src",
+            "Rust",
+            100,
+            10,
+            5,
+            4000,
+            800,
+        )];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.max_file.overall.path, "src/only.rs");
+        assert_eq!(report.max_file.overall.lines, 115);
+    }
+
+    #[test]
+    fn given_two_files_when_derived_then_overall_max_is_largest_by_lines() {
+        let rows = vec![
+            make_row("small.rs", "src", "Rust", 10, 0, 0, 400, 80),
+            make_row("big.rs", "src", "Rust", 500, 0, 0, 20000, 4000),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.max_file.overall.path, "big.rs");
+        assert_eq!(report.max_file.overall.lines, 500);
+    }
+
+    #[test]
+    fn given_tie_in_lines_when_derived_then_max_file_is_deterministic() {
+        let rows = vec![
+            make_row("z.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+            make_row("a.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+        ];
+        let r1 = derive_report(&export(rows.clone()), None);
+        let r2 = derive_report(&export(rows), None);
+        // Tie-breaking is deterministic across runs
+        assert_eq!(r1.max_file.overall.path, r2.max_file.overall.path);
+        assert_eq!(r1.max_file.overall.lines, 100);
+    }
+
+    #[test]
+    fn given_multi_lang_files_when_derived_then_max_file_has_by_lang_entries() {
+        let rows = vec![
+            make_row("lib.rs", "src", "Rust", 200, 0, 0, 8000, 1600),
+            make_row("app.py", "src", "Python", 300, 0, 0, 12000, 2400),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.max_file.by_lang.len(), 2);
+        let rust_entry = report
+            .max_file
+            .by_lang
+            .iter()
+            .find(|e| e.key == "Rust")
+            .unwrap();
+        assert_eq!(rust_entry.file.path, "lib.rs");
+    }
+
+    #[test]
+    fn given_multi_module_files_when_derived_then_max_file_has_by_module_entries() {
+        let rows = vec![
+            make_row("src/a.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+            make_row("lib/b.rs", "lib", "Rust", 300, 0, 0, 12000, 2400),
+        ];
+        let report = derive_report(&export(rows), None);
+        assert_eq!(report.max_file.by_module.len(), 2);
+        let lib_entry = report
+            .max_file
+            .by_module
+            .iter()
+            .find(|e| e.key == "lib")
+            .unwrap();
+        assert_eq!(lib_entry.file.path, "lib/b.rs");
+    }
+
+    #[test]
+    fn given_empty_input_when_derived_then_max_file_overall_is_empty() {
+        let report = derive_report(&export(vec![]), None);
+        assert!(report.max_file.overall.path.is_empty());
+        assert_eq!(report.max_file.overall.lines, 0);
+        assert!(report.max_file.by_lang.is_empty());
+        assert!(report.max_file.by_module.is_empty());
+    }
+}
+
+// ── Lang purity tie-breaking ────────────────────────────────────
+
+mod lang_purity_tiebreak {
+    use super::*;
+
+    #[test]
+    fn given_equal_lang_lines_when_derived_then_dominant_is_alphabetically_first() {
+        let rows = vec![
+            make_row("a.rs", "src", "Rust", 100, 0, 0, 4000, 800),
+            make_row("a.py", "src", "Python", 100, 0, 0, 4000, 800),
+        ];
+        let report = derive_report(&export(rows), None);
+        let purity = &report.lang_purity.rows[0];
+        // Equal lines → alphabetically first lang wins
+        assert_eq!(purity.dominant_lang, "Python");
+        assert_eq!(purity.dominant_pct, 0.5);
+        assert_eq!(purity.lang_count, 2);
+    }
+}
+
+// ── Determinism ─────────────────────────────────────────────────
+
+mod determinism {
+    use super::*;
+
+    #[test]
+    fn given_same_input_when_derived_twice_then_output_is_identical() {
+        let rows = vec![
+            make_row("src/lib.rs", "src", "Rust", 200, 50, 20, 10000, 2000),
+            make_row("src/app.ts", "src", "TypeScript", 150, 30, 10, 7000, 1500),
+            make_row("tests/test.rs", "tests", "Rust", 80, 10, 5, 3500, 700),
+        ];
+        let r1 = derive_report(&export(rows.clone()), Some(128_000));
+        let r2 = derive_report(&export(rows), Some(128_000));
+
+        assert_eq!(r1.totals.code, r2.totals.code);
+        assert_eq!(r1.totals.files, r2.totals.files);
+        assert_eq!(r1.integrity.hash, r2.integrity.hash);
+        assert_eq!(r1.distribution.gini, r2.distribution.gini);
+        assert_eq!(r1.polyglot.entropy, r2.polyglot.entropy);
+        assert_eq!(
+            r1.cocomo.as_ref().unwrap().effort_pm,
+            r2.cocomo.as_ref().unwrap().effort_pm
+        );
+    }
+
+    #[test]
+    fn given_rows_in_different_order_when_derived_then_integrity_hash_is_same() {
+        let row_a = make_row("a.rs", "src", "Rust", 100, 10, 5, 4000, 800);
+        let row_b = make_row("b.rs", "src", "Rust", 200, 20, 10, 8000, 1600);
+
+        let r1 = derive_report(&export(vec![row_a.clone(), row_b.clone()]), None);
+        let r2 = derive_report(&export(vec![row_b, row_a]), None);
+
+        assert_eq!(
+            r1.integrity.hash, r2.integrity.hash,
+            "integrity hash must be order-independent"
+        );
+    }
+}
+
+// ── COCOMO edge cases ───────────────────────────────────────────
+
+mod cocomo_edges {
+    use super::*;
+
+    #[test]
+    fn given_very_small_code_when_derived_then_cocomo_kloc_is_fractional() {
+        let rows = vec![make_row("tiny.rs", "src", "Rust", 50, 0, 0, 2000, 400)];
+        let report = derive_report(&export(rows), None);
+        let cocomo = report.cocomo.as_ref().unwrap();
+        assert_eq!(cocomo.kloc, 0.05);
+        assert!(cocomo.effort_pm > 0.0);
+    }
+
+    #[test]
+    fn given_large_codebase_when_derived_then_cocomo_scales_superlinearly() {
+        let small = vec![make_row("s.rs", "src", "Rust", 1000, 0, 0, 40000, 8000)];
+        let big = vec![make_row(
+            "b.rs", "src", "Rust", 100_000, 0, 0, 4_000_000, 800_000,
+        )];
+        let r_small = derive_report(&export(small), None);
+        let r_big = derive_report(&export(big), None);
+
+        let small_effort = r_small.cocomo.as_ref().unwrap().effort_pm;
+        let big_effort = r_big.cocomo.as_ref().unwrap().effort_pm;
+
+        // With b=1.05, effort scales superlinearly: 100x code should give >100x effort
+        assert!(
+            big_effort / small_effort > 100.0,
+            "effort should scale superlinearly: small={small_effort}, big={big_effort}"
+        );
+    }
+}

--- a/crates/tokmd-analysis-entropy/tests/determinism.rs
+++ b/crates/tokmd-analysis-entropy/tests/determinism.rs
@@ -1,0 +1,308 @@
+//! Determinism and threshold boundary tests for `tokmd-analysis-entropy`.
+//!
+//! Supplements existing BDD and unit tests with explicit determinism
+//! verification and entropy classification threshold boundary tests.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+use tokmd_analysis_entropy::build_entropy_report;
+use tokmd_analysis_types::EntropyClass;
+use tokmd_analysis_util::AnalysisLimits;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn export_for_paths(paths: &[&str]) -> ExportData {
+    let rows = paths
+        .iter()
+        .map(|p| FileRow {
+            path: (*p).to_string(),
+            module: "(root)".to_string(),
+            lang: "Text".to_string(),
+            kind: FileKind::Parent,
+            code: 1,
+            comments: 0,
+            blanks: 0,
+            lines: 1,
+            bytes: 10,
+            tokens: 2,
+        })
+        .collect();
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn write_repeated(path: &Path, byte: u8, len: usize) {
+    fs::write(path, vec![byte; len]).unwrap();
+}
+
+fn write_pseudorandom(path: &Path, seed: u32, len: usize) {
+    let mut data = Vec::with_capacity(len);
+    let mut x = seed;
+    for _ in 0..len {
+        x = x.wrapping_mul(1664525).wrapping_add(1013904223);
+        data.push((x >> 16) as u8);
+    }
+    fs::write(path, data).unwrap();
+}
+
+// ── Determinism ─────────────────────────────────────────────────
+
+mod determinism {
+    use super::*;
+
+    #[test]
+    fn given_same_input_when_scanned_twice_then_identical_results() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("data.bin");
+        write_pseudorandom(&f, 0xDEAD, 2048);
+
+        let export = export_for_paths(&["data.bin"]);
+        let files = vec![PathBuf::from("data.bin")];
+
+        let r1 =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+        let r2 =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        assert_eq!(r1.suspects.len(), r2.suspects.len());
+        for (s1, s2) in r1.suspects.iter().zip(r2.suspects.iter()) {
+            assert_eq!(s1.path, s2.path);
+            assert_eq!(s1.class, s2.class);
+            assert!(
+                (s1.entropy_bits_per_byte - s2.entropy_bits_per_byte).abs() < f32::EPSILON,
+                "entropy should be identical across runs"
+            );
+            assert_eq!(s1.sample_bytes, s2.sample_bytes);
+        }
+    }
+
+    #[test]
+    fn given_multiple_files_when_scanned_twice_then_order_is_identical() {
+        let dir = tempdir().unwrap();
+
+        let lo = dir.path().join("low.bin");
+        let hi = dir.path().join("high.bin");
+        write_repeated(&lo, 0x00, 1024);
+        write_pseudorandom(&hi, 0xBEEF, 4096);
+
+        let export = export_for_paths(&["low.bin", "high.bin"]);
+        let files = vec![PathBuf::from("low.bin"), PathBuf::from("high.bin")];
+
+        let r1 =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+        let r2 =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        let paths1: Vec<&str> = r1.suspects.iter().map(|s| s.path.as_str()).collect();
+        let paths2: Vec<&str> = r2.suspects.iter().map(|s| s.path.as_str()).collect();
+        assert_eq!(paths1, paths2, "suspect order must be deterministic");
+    }
+
+    #[test]
+    fn given_files_in_different_order_when_scanned_then_sorted_output_is_same() {
+        let dir = tempdir().unwrap();
+
+        let a = dir.path().join("a.bin");
+        let b = dir.path().join("b.bin");
+        write_pseudorandom(&a, 0x1111, 2048);
+        write_pseudorandom(&b, 0x2222, 2048);
+
+        let export = export_for_paths(&["a.bin", "b.bin"]);
+        let files_ab = vec![PathBuf::from("a.bin"), PathBuf::from("b.bin")];
+        let files_ba = vec![PathBuf::from("b.bin"), PathBuf::from("a.bin")];
+
+        let r_ab = build_entropy_report(dir.path(), &files_ab, &export, &AnalysisLimits::default())
+            .unwrap();
+        let r_ba = build_entropy_report(dir.path(), &files_ba, &export, &AnalysisLimits::default())
+            .unwrap();
+
+        // Output is sorted by entropy desc then path asc, so order should be same
+        assert_eq!(r_ab.suspects.len(), r_ba.suspects.len());
+        for (a, b) in r_ab.suspects.iter().zip(r_ba.suspects.iter()) {
+            assert_eq!(a.path, b.path);
+            assert_eq!(a.class, b.class);
+        }
+    }
+}
+
+// ── Threshold boundaries ────────────────────────────────────────
+
+mod threshold_boundaries {
+    use super::*;
+
+    #[test]
+    fn given_all_zero_bytes_then_entropy_near_zero_classified_low() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("zeros.bin");
+        write_repeated(&f, 0x00, 2048);
+
+        let export = export_for_paths(&["zeros.bin"]);
+        let files = vec![PathBuf::from("zeros.bin")];
+        let report =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        assert_eq!(report.suspects.len(), 1);
+        assert_eq!(report.suspects[0].class, EntropyClass::Low);
+        assert!(
+            report.suspects[0].entropy_bits_per_byte < 2.0,
+            "all-zero file should have entropy < 2.0, got {}",
+            report.suspects[0].entropy_bits_per_byte
+        );
+    }
+
+    #[test]
+    fn given_pseudorandom_data_then_entropy_above_7_5_classified_high() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("rand.bin");
+        write_pseudorandom(&f, 0xABCDEF, 8192);
+
+        let export = export_for_paths(&["rand.bin"]);
+        let files = vec![PathBuf::from("rand.bin")];
+        let report =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        assert_eq!(report.suspects.len(), 1);
+        assert_eq!(report.suspects[0].class, EntropyClass::High);
+        assert!(
+            report.suspects[0].entropy_bits_per_byte > 7.5,
+            "pseudorandom should have entropy > 7.5, got {}",
+            report.suspects[0].entropy_bits_per_byte
+        );
+    }
+
+    #[test]
+    fn given_normal_text_then_not_in_suspects_entropy_between_2_and_6_5() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("normal.txt");
+        let text = "The quick brown fox jumps over the lazy dog. \
+                     Hello world, this is a normal text file with moderate entropy.\n"
+            .repeat(30);
+        fs::write(&f, text).unwrap();
+
+        let export = export_for_paths(&["normal.txt"]);
+        let files = vec![PathBuf::from("normal.txt")];
+        let report =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        // Normal text should have entropy in [2.0, 6.5) → classified Normal → not in suspects
+        assert!(
+            report.suspects.is_empty(),
+            "normal text should not be a suspect"
+        );
+    }
+}
+
+// ── Multiple classifications in one report ──────────────────────
+
+mod mixed_classifications {
+    use super::*;
+
+    #[test]
+    fn given_low_and_high_entropy_files_then_both_classified_correctly() {
+        let dir = tempdir().unwrap();
+
+        let lo = dir.path().join("constant.bin");
+        let hi = dir.path().join("random.bin");
+        write_repeated(&lo, b'X', 1024);
+        write_pseudorandom(&hi, 0x9999, 4096);
+
+        let export = export_for_paths(&["constant.bin", "random.bin"]);
+        let files = vec![PathBuf::from("constant.bin"), PathBuf::from("random.bin")];
+        let report =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        assert_eq!(report.suspects.len(), 2);
+        let low_finding = report
+            .suspects
+            .iter()
+            .find(|s| s.path == "constant.bin")
+            .unwrap();
+        let high_finding = report
+            .suspects
+            .iter()
+            .find(|s| s.path == "random.bin")
+            .unwrap();
+        assert_eq!(low_finding.class, EntropyClass::Low);
+        assert_eq!(high_finding.class, EntropyClass::High);
+    }
+
+    #[test]
+    fn given_normal_among_abnormal_then_normal_excluded_from_suspects() {
+        let dir = tempdir().unwrap();
+
+        let lo = dir.path().join("lo.bin");
+        let hi = dir.path().join("hi.bin");
+        let normal = dir.path().join("code.rs");
+        write_repeated(&lo, 0x00, 1024);
+        write_pseudorandom(&hi, 0x4444, 4096);
+        let code = "fn main() { println!(\"hello\"); }\n".repeat(20);
+        fs::write(&normal, code).unwrap();
+
+        let export = export_for_paths(&["lo.bin", "hi.bin", "code.rs"]);
+        let files = vec![
+            PathBuf::from("lo.bin"),
+            PathBuf::from("hi.bin"),
+            PathBuf::from("code.rs"),
+        ];
+        let report =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        // code.rs should not be a suspect
+        assert!(
+            report.suspects.iter().all(|s| s.path != "code.rs"),
+            "normal source code should be excluded from suspects"
+        );
+        // lo.bin and hi.bin should both be suspects
+        assert!(report.suspects.iter().any(|s| s.path == "lo.bin"));
+        assert!(report.suspects.iter().any(|s| s.path == "hi.bin"));
+    }
+}
+
+// ── Child row filtering ─────────────────────────────────────────
+
+mod child_filtering {
+    use super::*;
+
+    #[test]
+    fn given_child_row_for_high_entropy_file_then_module_is_unknown() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("secret.bin");
+        write_pseudorandom(&f, 0xFACE, 2048);
+
+        // Export has only a child row for this file
+        let rows = vec![FileRow {
+            path: "secret.bin".to_string(),
+            module: "embedded".to_string(),
+            lang: "Text".to_string(),
+            kind: FileKind::Child,
+            code: 1,
+            comments: 0,
+            blanks: 0,
+            lines: 1,
+            bytes: 10,
+            tokens: 2,
+        }];
+        let export = ExportData {
+            rows,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+        };
+        let files = vec![PathBuf::from("secret.bin")];
+        let report =
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        assert_eq!(report.suspects.len(), 1);
+        assert_eq!(
+            report.suspects[0].module, "(unknown)",
+            "child row should not be used for module lookup"
+        );
+    }
+}

--- a/crates/tokmd-analysis-near-dup/tests/determinism.rs
+++ b/crates/tokmd-analysis-near-dup/tests/determinism.rs
@@ -1,0 +1,393 @@
+//! Determinism and additional edge-case tests for `tokmd-analysis-near-dup`.
+//!
+//! Supplements the existing BDD and unit tests with explicit determinism
+//! verification, stats validation, and eligible_files reporting.
+
+use std::io::Write;
+
+use tempfile::TempDir;
+use tokmd_analysis_near_dup::{NearDupLimits, build_near_dup_report};
+use tokmd_analysis_types::NearDupScope;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn source_text(n: usize, seed: usize) -> String {
+    (0..n)
+        .map(|i| format!("tok_{}_{}", seed, i))
+        .collect::<Vec<_>>()
+        .join(" + ")
+}
+
+fn make_file_row(path: &str, module: &str, lang: &str, code: usize, bytes: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments: 0,
+        blanks: 0,
+        lines: code,
+        bytes,
+        tokens: code * 5,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+fn write_file(dir: &TempDir, path: &str, content: &str) {
+    let full = dir.path().join(path);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut f = std::fs::File::create(&full).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+// ── Determinism ─────────────────────────────────────────────────
+
+mod determinism {
+    use super::*;
+
+    #[test]
+    fn given_same_input_when_run_three_times_then_all_outputs_identical() {
+        let dir = TempDir::new().unwrap();
+        let content = source_text(100, 42);
+        write_file(&dir, "a.rs", &content);
+        write_file(&dir, "b.rs", &content);
+
+        let rows = vec![
+            make_file_row("a.rs", "root", "Rust", 100, content.len()),
+            make_file_row("b.rs", "root", "Rust", 100, content.len()),
+        ];
+        let export = make_export(rows);
+
+        let results: Vec<_> = (0..3)
+            .map(|_| {
+                build_near_dup_report(
+                    dir.path(),
+                    &export,
+                    NearDupScope::Global,
+                    0.5,
+                    1000,
+                    None,
+                    &NearDupLimits::default(),
+                    &[],
+                )
+                .unwrap()
+            })
+            .collect();
+
+        for i in 1..3 {
+            assert_eq!(results[0].pairs.len(), results[i].pairs.len());
+            for (p0, pi) in results[0].pairs.iter().zip(results[i].pairs.iter()) {
+                assert_eq!(p0.left, pi.left);
+                assert_eq!(p0.right, pi.right);
+                assert!(
+                    (p0.similarity - pi.similarity).abs() < 1e-10,
+                    "similarity should be identical across runs"
+                );
+                assert_eq!(p0.shared_fingerprints, pi.shared_fingerprints);
+            }
+        }
+    }
+
+    #[test]
+    fn given_files_with_different_code_order_then_pairs_are_deterministic() {
+        let dir = TempDir::new().unwrap();
+        let content = source_text(100, 7);
+        write_file(&dir, "x.rs", &content);
+        write_file(&dir, "y.rs", &content);
+
+        let rows_xy = vec![
+            make_file_row("x.rs", "root", "Rust", 100, content.len()),
+            make_file_row("y.rs", "root", "Rust", 100, content.len()),
+        ];
+        let rows_yx = vec![
+            make_file_row("y.rs", "root", "Rust", 100, content.len()),
+            make_file_row("x.rs", "root", "Rust", 100, content.len()),
+        ];
+
+        let r1 = build_near_dup_report(
+            dir.path(),
+            &make_export(rows_xy),
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+        let r2 = build_near_dup_report(
+            dir.path(),
+            &make_export(rows_yx),
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(r1.pairs.len(), r2.pairs.len());
+        for (p1, p2) in r1.pairs.iter().zip(r2.pairs.iter()) {
+            assert_eq!(p1.left, p2.left);
+            assert_eq!(p1.right, p2.right);
+        }
+    }
+}
+
+// ── Stats field ─────────────────────────────────────────────────
+
+mod stats_validation {
+    use super::*;
+
+    #[test]
+    fn given_report_then_stats_timing_is_present_and_non_negative() {
+        let dir = TempDir::new().unwrap();
+        let content = source_text(100, 0);
+        write_file(&dir, "a.rs", &content);
+        write_file(&dir, "b.rs", &content);
+
+        let rows = vec![
+            make_file_row("a.rs", "root", "Rust", 100, content.len()),
+            make_file_row("b.rs", "root", "Rust", 100, content.len()),
+        ];
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(rows),
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        let stats = report.stats.as_ref().expect("stats should be present");
+        // Timing values should exist (may be 0 for very fast runs)
+        assert!(stats.bytes_processed > 0, "bytes_processed should be > 0");
+    }
+
+    #[test]
+    fn given_empty_input_then_stats_has_zero_bytes() {
+        let dir = TempDir::new().unwrap();
+        let export = make_export(vec![]);
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &export,
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        let stats = report.stats.as_ref().expect("stats should be present");
+        assert_eq!(stats.bytes_processed, 0);
+    }
+}
+
+// ── Eligible files count ────────────────────────────────────────
+
+mod eligible_files {
+    use super::*;
+
+    #[test]
+    fn given_all_files_eligible_then_eligible_equals_analyzed() {
+        let dir = TempDir::new().unwrap();
+        let content = source_text(100, 0);
+        write_file(&dir, "a.rs", &content);
+        write_file(&dir, "b.rs", &content);
+
+        let rows = vec![
+            make_file_row("a.rs", "root", "Rust", 100, content.len()),
+            make_file_row("b.rs", "root", "Rust", 100, content.len()),
+        ];
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(rows),
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(report.eligible_files, Some(2));
+        assert_eq!(report.files_analyzed, 2);
+        assert_eq!(report.files_skipped, 0);
+    }
+
+    #[test]
+    fn given_some_files_oversized_then_eligible_less_than_total_rows() {
+        let dir = TempDir::new().unwrap();
+        let content = source_text(100, 0);
+        write_file(&dir, "small.rs", &content);
+        write_file(&dir, "big.rs", &content);
+
+        let rows = vec![
+            make_file_row("small.rs", "root", "Rust", 100, content.len()),
+            make_file_row("big.rs", "root", "Rust", 100, 600_000), // exceeds default 512KB
+        ];
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(rows),
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(report.eligible_files, Some(1));
+        assert_eq!(report.files_analyzed, 1);
+    }
+
+    #[test]
+    fn given_max_files_caps_then_eligible_greater_than_analyzed() {
+        let dir = TempDir::new().unwrap();
+        let content = source_text(100, 0);
+        for i in 0..5 {
+            write_file(&dir, &format!("f{i}.rs"), &content);
+        }
+
+        let rows: Vec<FileRow> = (0..5)
+            .map(|i| make_file_row(&format!("f{i}.rs"), "root", "Rust", 100, content.len()))
+            .collect();
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(rows),
+            NearDupScope::Global,
+            0.5,
+            3, // only analyze 3
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(report.eligible_files, Some(5));
+        assert_eq!(report.files_analyzed, 3);
+        assert_eq!(report.files_skipped, 2);
+    }
+}
+
+// ── Cluster completeness ────────────────────────────────────────
+
+mod cluster_completeness {
+    use super::*;
+
+    #[test]
+    fn given_identical_files_then_cluster_files_are_sorted_alphabetically() {
+        let dir = TempDir::new().unwrap();
+        let content = source_text(100, 0);
+        write_file(&dir, "c.rs", &content);
+        write_file(&dir, "a.rs", &content);
+        write_file(&dir, "b.rs", &content);
+
+        let rows = vec![
+            make_file_row("c.rs", "root", "Rust", 100, content.len()),
+            make_file_row("a.rs", "root", "Rust", 100, content.len()),
+            make_file_row("b.rs", "root", "Rust", 100, content.len()),
+        ];
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(rows),
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        let clusters = report.clusters.as_ref().unwrap();
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(
+            clusters[0].files,
+            vec!["a.rs", "b.rs", "c.rs"],
+            "cluster files should be sorted alphabetically"
+        );
+    }
+
+    #[test]
+    fn given_two_separate_groups_then_two_clusters_sorted_by_max_similarity() {
+        let dir = TempDir::new().unwrap();
+
+        // Group 1: identical pair
+        let content1 = source_text(100, 1);
+        write_file(&dir, "g1_a.rs", &content1);
+        write_file(&dir, "g1_b.rs", &content1);
+
+        // Group 2: identical pair with different content
+        let content2 = source_text(100, 2);
+        write_file(&dir, "g2_a.rs", &content2);
+        write_file(&dir, "g2_b.rs", &content2);
+
+        let rows = vec![
+            make_file_row("g1_a.rs", "root", "Rust", 100, content1.len()),
+            make_file_row("g1_b.rs", "root", "Rust", 100, content1.len()),
+            make_file_row("g2_a.rs", "root", "Rust", 100, content2.len()),
+            make_file_row("g2_b.rs", "root", "Rust", 100, content2.len()),
+        ];
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(rows),
+            NearDupScope::Global,
+            0.5,
+            1000,
+            None,
+            &NearDupLimits::default(),
+            &[],
+        )
+        .unwrap();
+
+        let clusters = report.clusters.as_ref().unwrap();
+        assert_eq!(clusters.len(), 2, "should have two distinct clusters");
+
+        // Both clusters should have max_similarity ~1.0
+        for c in clusters {
+            assert!(
+                c.max_similarity >= 0.99,
+                "identical pairs should yield ~1.0 similarity"
+            );
+            assert_eq!(c.files.len(), 2);
+            assert_eq!(c.pair_count, 1);
+        }
+
+        // Verify sorted by max_similarity desc, then representative alphabetically
+        for window in clusters.windows(2) {
+            assert!(
+                window[0].max_similarity >= window[1].max_similarity
+                    || window[0].representative <= window[1].representative,
+                "clusters should be sorted"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Add 39 new BDD-style tests for 4 analysis crates covering determinism, edge cases, and language support:
- tokmd-analysis-derived: 11 tests (COCOMO, purity, integrity hash)
- tokmd-analysis-complexity: 10 tests (deep nesting, multilang, aggregates)
- tokmd-analysis-entropy: 9 tests (determinism, thresholds, classification)
- tokmd-analysis-near-dup: 9 tests (determinism, order-independence, cluster completeness)