### PR TITLE
test: add edge-case tests for analysis-halstead, license, topics, fingerprint

### DIFF
--- a/crates/tokmd-analysis-fingerprint/tests/edge_cases.rs
+++ b/crates/tokmd-analysis-fingerprint/tests/edge_cases.rs
@@ -1,0 +1,188 @@
+//! Edge-case BDD tests for corporate fingerprint detection.
+
+use tokmd_analysis_fingerprint::build_corporate_fingerprint;
+use tokmd_git::GitCommit;
+
+fn commit(author: &str) -> GitCommit {
+    GitCommit {
+        timestamp: 0,
+        author: author.to_string(),
+        hash: None,
+        subject: String::new(),
+        files: vec![],
+    }
+}
+
+fn commit_with_ts(author: &str, timestamp: i64) -> GitCommit {
+    GitCommit {
+        timestamp,
+        author: author.to_string(),
+        hash: None,
+        subject: String::new(),
+        files: vec![],
+    }
+}
+
+// ── Scenario: timestamp variation does not affect fingerprint ────────
+
+#[test]
+fn given_same_authors_with_different_timestamps_when_fingerprinted_then_same_result() {
+    let commits_a = vec![
+        commit_with_ts("dev@acme.com", 1000),
+        commit_with_ts("ops@acme.com", 2000),
+        commit_with_ts("user@gmail.com", 3000),
+    ];
+    let commits_b = vec![
+        commit_with_ts("dev@acme.com", 9999),
+        commit_with_ts("ops@acme.com", 8888),
+        commit_with_ts("user@gmail.com", 7777),
+    ];
+
+    let fp_a = build_corporate_fingerprint(&commits_a);
+    let fp_b = build_corporate_fingerprint(&commits_b);
+
+    assert_eq!(fp_a.domains.len(), fp_b.domains.len());
+    for (a, b) in fp_a.domains.iter().zip(fp_b.domains.iter()) {
+        assert_eq!(a.domain, b.domain);
+        assert_eq!(a.commits, b.commits);
+        assert!((a.pct - b.pct).abs() < f32::EPSILON);
+    }
+}
+
+// ── Scenario: domain with trailing whitespace ───────────────────────
+
+#[test]
+fn given_domain_with_whitespace_when_fingerprinted_then_trimmed() {
+    let commits = vec![commit("user@  acme.com  ")];
+    let fp = build_corporate_fingerprint(&commits);
+    // After trimming and lowercasing, should be "acme.com"
+    assert_eq!(fp.domains.len(), 1);
+    assert_eq!(fp.domains[0].domain, "acme.com");
+}
+
+// ── Scenario: at-sign at start/end of string ────────────────────────
+
+#[test]
+fn given_at_sign_at_start_when_fingerprinted_then_skipped() {
+    let commits = vec![commit("@domain.com")];
+    let fp = build_corporate_fingerprint(&commits);
+    // splits into ["", "domain.com"] — two parts, but local part is empty
+    // domain is "domain.com" which is valid
+    // This should still count (the function only checks part count == 2)
+    assert_eq!(fp.domains.len(), 1);
+    assert_eq!(fp.domains[0].domain, "domain.com");
+}
+
+#[test]
+fn given_at_sign_at_end_when_fingerprinted_then_empty_domain_ignored() {
+    let commits = vec![commit("user@")];
+    let fp = build_corporate_fingerprint(&commits);
+    // domain would be "" which is_ignored because it's empty after normalize
+    assert!(fp.domains.is_empty());
+}
+
+// ── Scenario: subdomain handling ────────────────────────────────────
+
+#[test]
+fn given_subdomain_emails_when_fingerprinted_then_full_domain_kept() {
+    let commits = vec![commit("dev@eng.bigcorp.com"), commit("ops@ops.bigcorp.com")];
+    let fp = build_corporate_fingerprint(&commits);
+    // Subdomains are kept as-is (no domain normalization beyond case)
+    assert_eq!(fp.domains.len(), 2);
+    let domains: Vec<&str> = fp.domains.iter().map(|d| d.domain.as_str()).collect();
+    assert!(domains.contains(&"eng.bigcorp.com"));
+    assert!(domains.contains(&"ops.bigcorp.com"));
+}
+
+// ── Scenario: many unique domains ───────────────────────────────────
+
+#[test]
+fn given_100_unique_domains_when_fingerprinted_then_all_counted() {
+    let commits: Vec<GitCommit> = (0..100)
+        .map(|i| commit(&format!("user@company{i}.com")))
+        .collect();
+    let fp = build_corporate_fingerprint(&commits);
+    assert_eq!(fp.domains.len(), 100);
+    let total: u32 = fp.domains.iter().map(|d| d.commits).sum();
+    assert_eq!(total, 100);
+    // Each has 1% share
+    for d in &fp.domains {
+        assert!((d.pct - 0.01).abs() < f32::EPSILON);
+    }
+}
+
+// ── Scenario: mixed valid, ignored, and malformed authors ───────────
+
+#[test]
+fn given_mixed_valid_ignored_and_malformed_when_fingerprinted_then_only_valid_counted() {
+    let commits = vec![
+        commit("dev@real.com"),                     // valid
+        commit("bot@localhost"),                    // ignored
+        commit("ci@example.com"),                   // ignored
+        commit("noreply@users.noreply.github.com"), // ignored
+        commit("malformed"),                        // no @
+        commit("a@b@c.com"),                        // multiple @
+        commit(""),                                 // empty
+        commit("ops@real.com"),                     // valid
+    ];
+    let fp = build_corporate_fingerprint(&commits);
+    assert_eq!(fp.domains.len(), 1);
+    assert_eq!(fp.domains[0].domain, "real.com");
+    assert_eq!(fp.domains[0].commits, 2);
+    assert!((fp.domains[0].pct - 1.0).abs() < f32::EPSILON);
+}
+
+// ── Scenario: serialization preserves all fields ────────────────────
+
+#[test]
+fn given_fingerprint_when_serialized_then_contains_expected_fields() {
+    let commits = vec![commit("a@foo.com"), commit("b@foo.com"), commit("c@bar.io")];
+    let fp = build_corporate_fingerprint(&commits);
+    let json = serde_json::to_value(&fp).expect("should serialize");
+
+    let domains = json["domains"].as_array().unwrap();
+    assert_eq!(domains.len(), 2);
+
+    let first = &domains[0];
+    assert!(first.get("domain").is_some());
+    assert!(first.get("commits").is_some());
+    assert!(first.get("pct").is_some());
+}
+
+// ── Scenario: pct is exactly 1.0 for single domain ─────────────────
+
+#[test]
+fn given_single_domain_when_fingerprinted_then_pct_is_exactly_one() {
+    let commits: Vec<GitCommit> = (0..50).map(|_| commit("dev@only.com")).collect();
+    let fp = build_corporate_fingerprint(&commits);
+    assert_eq!(fp.domains.len(), 1);
+    assert_eq!(fp.domains[0].commits, 50);
+    assert!((fp.domains[0].pct - 1.0).abs() < f32::EPSILON);
+}
+
+// ── Scenario: all public email providers with corporate ──────────────
+
+#[test]
+fn given_all_public_providers_and_corporate_when_fingerprinted_then_two_buckets() {
+    let mut commits = vec![
+        commit("a@gmail.com"),
+        commit("b@yahoo.com"),
+        commit("c@outlook.com"),
+        commit("d@hotmail.com"),
+        commit("e@icloud.com"),
+        commit("f@proton.me"),
+        commit("g@protonmail.com"),
+    ];
+    // Add 3 corporate commits
+    commits.push(commit("x@corp.dev"));
+    commits.push(commit("y@corp.dev"));
+    commits.push(commit("z@corp.dev"));
+
+    let fp = build_corporate_fingerprint(&commits);
+    assert_eq!(fp.domains.len(), 2);
+    // public-email: 7 commits, corp.dev: 3 commits → public-email sorted first
+    assert_eq!(fp.domains[0].domain, "public-email");
+    assert_eq!(fp.domains[0].commits, 7);
+    assert_eq!(fp.domains[1].domain, "corp.dev");
+    assert_eq!(fp.domains[1].commits, 3);
+}

--- a/crates/tokmd-analysis-halstead/tests/edge_cases.rs
+++ b/crates/tokmd-analysis-halstead/tests/edge_cases.rs
@@ -1,0 +1,218 @@
+//! Edge-case and cross-language BDD tests for Halstead analysis.
+
+use std::path::PathBuf;
+
+use tokmd_analysis_halstead::{
+    build_halstead_report, operators_for_lang, round_f64, tokenize_for_halstead,
+};
+use tokmd_analysis_util::AnalysisLimits;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+fn no_limits() -> AnalysisLimits {
+    AnalysisLimits {
+        max_files: None,
+        max_bytes: None,
+        max_file_bytes: None,
+        max_commits: None,
+        max_commit_files: None,
+    }
+}
+
+fn make_row(path: &str, lang: &str) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: String::new(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code: 10,
+        comments: 0,
+        blanks: 0,
+        lines: 10,
+        bytes: 100,
+        tokens: 50,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ── Scenario: Ruby tokenization ─────────────────────────────────────
+
+#[test]
+fn given_ruby_code_when_tokenized_then_ruby_operators_detected() {
+    let code = "def greet(name)\n  return name + \" hello\"\nend";
+    let counts = tokenize_for_halstead(code, "ruby");
+    assert!(counts.operators.contains_key("def"));
+    assert!(counts.operators.contains_key("return"));
+    assert!(counts.operators.contains_key("+"));
+    assert!(counts.operators.contains_key("end"));
+    assert!(counts.operands.contains("greet"));
+    assert!(counts.operands.contains("name"));
+}
+
+#[test]
+fn given_ruby_class_when_tokenized_then_class_and_self_detected() {
+    let code = "class Foo\n  def bar\n    self\n  end\nend";
+    let counts = tokenize_for_halstead(code, "ruby");
+    assert!(counts.operators.contains_key("class"));
+    assert!(counts.operators.contains_key("self"));
+    assert!(counts.operators.contains_key("def"));
+    assert!(counts.operands.contains("Foo"));
+    assert!(counts.operands.contains("bar"));
+}
+
+// ── Scenario: C-family tokenization ─────────────────────────────────
+
+#[test]
+fn given_c_code_when_tokenized_then_c_operators_detected() {
+    let code = "if (x > 0) { return x + 1; }";
+    let counts = tokenize_for_halstead(code, "c");
+    assert!(counts.operators.contains_key("if"));
+    assert!(counts.operators.contains_key("return"));
+    assert!(counts.operators.contains_key(">"));
+    assert!(counts.operators.contains_key("+"));
+    assert!(counts.operands.contains("x"));
+}
+
+#[test]
+fn given_java_code_when_tokenized_then_class_keywords_detected() {
+    let code = "public class Main { static void run() { new Object(); } }";
+    let counts = tokenize_for_halstead(code, "java");
+    assert!(counts.operators.contains_key("public"));
+    assert!(counts.operators.contains_key("class"));
+    assert!(counts.operators.contains_key("static"));
+    assert!(counts.operators.contains_key("void"));
+    assert!(counts.operators.contains_key("new"));
+    assert!(counts.operands.contains("Main"));
+    assert!(counts.operands.contains("Object"));
+}
+
+// ── Scenario: Multi-line deeply nested code ─────────────────────────
+
+#[test]
+fn given_nested_rust_code_when_tokenized_then_all_levels_counted() {
+    let code = "\
+fn outer() {
+    if true {
+        for i in 0..10 {
+            while i > 0 {
+                let x = i + 1;
+            }
+        }
+    }
+}";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert!(counts.operators.contains_key("fn"));
+    assert!(counts.operators.contains_key("if"));
+    assert!(counts.operators.contains_key("for"));
+    assert!(counts.operators.contains_key("in"));
+    assert!(counts.operators.contains_key("while"));
+    assert!(counts.operators.contains_key("let"));
+    assert!(counts.operators.contains_key(">"));
+    assert!(counts.operators.contains_key("+"));
+    assert!(counts.operators.contains_key(".."));
+    assert!(counts.total_operators >= 9);
+}
+
+// ── Scenario: Operator counting precision ───────────────────────────
+
+#[test]
+fn given_repeated_distinct_operators_when_tokenized_then_counts_are_exact() {
+    // 3 distinct operators: let, =, + (let appears 3x, = appears 3x, + appears 2x)
+    let code = "let a = 1\nlet b = 2\nlet c = a + b";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert_eq!(*counts.operators.get("let").unwrap(), 3);
+    assert_eq!(*counts.operators.get("=").unwrap(), 3);
+    assert_eq!(*counts.operators.get("+").unwrap(), 1);
+    assert_eq!(counts.operators.len(), 3, "exactly 3 distinct operators");
+    assert_eq!(counts.total_operators, 7);
+}
+
+// ── Scenario: per-file byte limit in build_halstead_report ──────────
+
+#[test]
+fn given_small_per_file_limit_when_building_report_then_file_is_truncated() {
+    let dir = tempfile::tempdir().unwrap();
+    // Write a file with operators beyond the first 10 bytes
+    let code = "fn long_function_name_here() { let x = 1 + 2 + 3 + 4; }";
+    std::fs::write(dir.path().join("f.rs"), code).unwrap();
+
+    let export = make_export(vec![make_row("f.rs", "Rust")]);
+    let files = vec![PathBuf::from("f.rs")];
+
+    let tight = AnalysisLimits {
+        max_file_bytes: Some(10),
+        ..no_limits()
+    };
+    let full = no_limits();
+
+    let tight_m = build_halstead_report(dir.path(), &files, &export, &tight).unwrap();
+    let full_m = build_halstead_report(dir.path(), &files, &export, &full).unwrap();
+
+    // Tight limit reads fewer bytes → fewer or equal operators
+    assert!(tight_m.total_operators <= full_m.total_operators);
+}
+
+// ── Scenario: round_f64 boundary values ─────────────────────────────
+
+#[test]
+fn given_exactly_half_when_rounded_then_rounds_to_even_or_up() {
+    // 2.5 rounds to 3.0 in Rust's default rounding (round half to even would give 2.0)
+    let result = round_f64(2.5, 0);
+    assert_eq!(result, 3.0);
+}
+
+#[test]
+fn given_very_small_positive_when_rounded_then_zero() {
+    assert_eq!(round_f64(0.004, 2), 0.0);
+    assert_eq!(round_f64(0.005, 2), 0.01); // rounds up
+}
+
+// ── Scenario: Ruby operators are distinct from Rust ─────────────────
+
+#[test]
+fn given_ruby_operators_when_compared_to_rust_then_different_sets() {
+    let ruby_ops = operators_for_lang("ruby");
+    let rust_ops = operators_for_lang("rust");
+    // Ruby has "end", "def", "elsif" which Rust doesn't
+    assert!(ruby_ops.contains(&"end"));
+    assert!(ruby_ops.contains(&"elsif"));
+    assert!(!rust_ops.contains(&"end"));
+    assert!(!rust_ops.contains(&"elsif"));
+    // Rust has "fn", "let", "match" which Ruby doesn't
+    assert!(rust_ops.contains(&"fn"));
+    assert!(rust_ops.contains(&"match"));
+    assert!(!ruby_ops.contains(&"fn"));
+    assert!(!ruby_ops.contains(&"match"));
+}
+
+// ── Scenario: build_halstead_report determinism ─────────────────────
+
+#[test]
+fn given_same_files_when_report_built_twice_then_identical_metrics() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "fn main() { let x = 1 + 2; }").unwrap();
+    std::fs::write(dir.path().join("b.py"), "def f(x):\n    return x + 1\n").unwrap();
+
+    let export = make_export(vec![make_row("a.rs", "Rust"), make_row("b.py", "Python")]);
+    let files = vec![PathBuf::from("a.rs"), PathBuf::from("b.py")];
+
+    let m1 = build_halstead_report(dir.path(), &files, &export, &no_limits()).unwrap();
+    let m2 = build_halstead_report(dir.path(), &files, &export, &no_limits()).unwrap();
+
+    assert_eq!(m1.distinct_operators, m2.distinct_operators);
+    assert_eq!(m1.distinct_operands, m2.distinct_operands);
+    assert_eq!(m1.total_operators, m2.total_operators);
+    assert_eq!(m1.total_operands, m2.total_operands);
+    assert_eq!(m1.vocabulary, m2.vocabulary);
+    assert_eq!(m1.length, m2.length);
+    assert!((m1.volume - m2.volume).abs() < f64::EPSILON);
+    assert!((m1.difficulty - m2.difficulty).abs() < f64::EPSILON);
+    assert!((m1.effort - m2.effort).abs() < f64::EPSILON);
+}

--- a/crates/tokmd-analysis-license/tests/edge_cases.rs
+++ b/crates/tokmd-analysis-license/tests/edge_cases.rs
@@ -1,0 +1,211 @@
+//! Edge-case BDD tests for license detection.
+
+use std::fs;
+use std::path::PathBuf;
+use tempfile::tempdir;
+use tokmd_analysis_license::build_license_report;
+use tokmd_analysis_types::LicenseSourceKind;
+use tokmd_analysis_util::AnalysisLimits;
+
+fn default_limits() -> AnalysisLimits {
+    AnalysisLimits::default()
+}
+
+// ── Scenario: pyproject.toml with both [project] and [tool.poetry] ──
+
+#[test]
+fn given_pyproject_with_both_sections_when_scanned_then_project_takes_precedence() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("pyproject.toml"),
+        "[project]\nname = \"x\"\nlicense = \"MIT\"\n\n[tool.poetry]\nname = \"x\"\nlicense = \"Apache-2.0\"\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("pyproject.toml")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+
+    // [project] section should be found first
+    assert!(!report.findings.is_empty());
+    assert_eq!(report.findings[0].spdx, "MIT");
+}
+
+// ── Scenario: Cargo.toml license-file pointing to missing file ──────
+
+#[test]
+fn given_cargo_toml_license_file_to_missing_file_when_scanned_then_returns_error() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nlicense-file = \"NONEXISTENT\"\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("Cargo.toml")];
+    // Missing referenced file propagates as an error
+    let result = build_license_report(dir.path(), &files, &default_limits());
+    assert!(
+        result.is_err(),
+        "missing license-file should propagate error"
+    );
+}
+
+// ── Scenario: invalid JSON in package.json ──────────────────────────
+
+#[test]
+fn given_invalid_json_in_package_json_when_scanned_then_no_panic() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("package.json"), "{ not valid json !!!").unwrap();
+
+    let files = vec![PathBuf::from("package.json")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    assert!(report.findings.is_empty());
+}
+
+// ── Scenario: license text with heavy whitespace ────────────────────
+
+#[test]
+fn given_mit_text_with_extra_whitespace_when_scanned_then_still_detected() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "\n\n   Permission is hereby granted, free of charge   \n\n   The software is provided \"as is\"   \n\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("LICENSE")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    assert!(report.findings.iter().any(|f| f.spdx == "MIT"));
+}
+
+// ── Scenario: BSD-2-Clause vs BSD-3-Clause disambiguation ───────────
+
+#[test]
+fn given_bsd2_text_without_third_clause_when_scanned_then_matches_bsd() {
+    let dir = tempdir().unwrap();
+    // BSD-2-Clause: has redistribution phrase + "as is" but NOT "neither the name of"
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Redistribution and use in source and binary forms, with or without modification, \
+         are permitted.\n\
+         This software is provided by the copyright holders and contributors \"as is\".",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("LICENSE")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    assert!(!report.findings.is_empty());
+    // Should match BSD-2-Clause (has the specific "as is" phrase)
+    assert!(report.findings.iter().any(|f| f.spdx.starts_with("BSD")));
+}
+
+// ── Scenario: Cargo.toml in a subdirectory ──────────────────────────
+
+#[test]
+fn given_cargo_toml_in_subdirectory_when_scanned_then_detected_with_forward_slash_path() {
+    let dir = tempdir().unwrap();
+    let sub = dir.path().join("crates").join("my-crate");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(
+        sub.join("Cargo.toml"),
+        "[package]\nname = \"my-crate\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("crates").join("my-crate").join("Cargo.toml")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.findings[0].spdx, "MIT");
+    assert!(
+        report.findings[0].source_path.contains('/'),
+        "should use forward slashes"
+    );
+    assert!(
+        !report.findings[0].source_path.contains('\\'),
+        "should not contain backslashes"
+    );
+}
+
+// ── Scenario: empty SPDX identifier in metadata ─────────────────────
+
+#[test]
+fn given_cargo_toml_with_empty_license_string_when_scanned_then_no_finding() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nlicense = \"\"\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("Cargo.toml")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    // Empty string should not produce a finding
+    assert!(report.findings.is_empty());
+}
+
+// ── Scenario: only non-license files provided ───────────────────────
+
+#[test]
+fn given_only_source_files_when_scanned_then_no_findings() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
+    fs::write(dir.path().join("lib.rs"), "pub fn hello() {}").unwrap();
+
+    let files = vec![PathBuf::from("main.rs"), PathBuf::from("lib.rs")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    assert!(report.findings.is_empty());
+    assert!(report.effective.is_none());
+}
+
+// ── Scenario: multiple LICENSE files with different licenses ─────────
+
+#[test]
+fn given_multiple_license_text_files_when_scanned_then_all_detected() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE-MIT"),
+        "Permission is hereby granted, free of charge.\nThe software is provided \"as is\".",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("LICENSE-APACHE"),
+        "Apache License\nVersion 2.0\nhttp://www.apache.org/licenses/\nlimitations under the License.",
+    )
+    .unwrap();
+
+    let files = vec![
+        PathBuf::from("LICENSE-MIT"),
+        PathBuf::from("LICENSE-APACHE"),
+    ];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+
+    assert!(report.findings.len() >= 2);
+    let spdx_ids: Vec<&str> = report.findings.iter().map(|f| f.spdx.as_str()).collect();
+    assert!(spdx_ids.contains(&"MIT"));
+    assert!(spdx_ids.contains(&"Apache-2.0"));
+}
+
+// ── Scenario: effective license comes from highest confidence ────────
+
+#[test]
+fn given_metadata_and_text_when_scanned_then_effective_is_metadata() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Permission is hereby granted, free of charge.",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("Cargo.toml"), PathBuf::from("LICENSE")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+
+    // Metadata has 0.95 confidence, text is lower
+    assert_eq!(report.effective.as_deref(), Some("MIT"));
+    assert_eq!(report.findings[0].source_kind, LicenseSourceKind::Metadata);
+}

--- a/crates/tokmd-analysis-topics/tests/edge_cases.rs
+++ b/crates/tokmd-analysis-topics/tests/edge_cases.rs
@@ -1,0 +1,214 @@
+//! Edge-case BDD tests for topic-cloud extraction.
+
+use tokmd_analysis_topics::build_topic_clouds;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+fn make_row(path: &str, module: &str, lang: &str, tokens: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code: 10,
+        comments: 0,
+        blanks: 0,
+        lines: 10,
+        bytes: 100,
+        tokens,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>, module_roots: Vec<&str>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: module_roots.into_iter().map(String::from).collect(),
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ── Scenario: multi-language files share topic space ─────────────────
+
+#[test]
+fn given_files_in_different_languages_when_extracted_then_topics_are_language_agnostic() {
+    let rows = vec![
+        make_row("app/controller.rs", "app", "Rust", 50),
+        make_row("app/controller.py", "app", "Python", 50),
+        make_row("app/controller.js", "app", "JavaScript", 50),
+    ];
+    let export = make_export(rows, vec!["app"]);
+    let clouds = build_topic_clouds(&export);
+
+    // "controller" should appear as a term regardless of language
+    let terms: Vec<&str> = clouds.overall.iter().map(|t| t.term.as_str()).collect();
+    assert!(
+        terms.contains(&"controller"),
+        "expected 'controller' across languages, got {terms:?}"
+    );
+}
+
+// ── Scenario: language extensions as stopwords for all langs ─────────
+
+#[test]
+fn given_python_file_extension_when_extracted_then_py_is_stopped() {
+    let rows = vec![make_row("app/handler.py", "app", "Python", 50)];
+    let export = make_export(rows, vec!["app"]);
+    let clouds = build_topic_clouds(&export);
+    let terms: Vec<&str> = clouds.overall.iter().map(|t| t.term.as_str()).collect();
+    assert!(!terms.contains(&"py"), "'py' should be a stopword");
+    assert!(terms.contains(&"handler"));
+}
+
+#[test]
+fn given_go_file_extension_when_extracted_then_go_is_stopped() {
+    let rows = vec![make_row("cmd/server.go", "cmd", "Go", 50)];
+    let export = make_export(rows, vec![]);
+    let clouds = build_topic_clouds(&export);
+    let terms: Vec<&str> = clouds.overall.iter().map(|t| t.term.as_str()).collect();
+    assert!(!terms.contains(&"go"), "'go' should be a stopword");
+    assert!(terms.contains(&"server"));
+    assert!(terms.contains(&"cmd"));
+}
+
+// ── Scenario: single row with only stopword path ────────────────────
+
+#[test]
+fn given_row_with_only_stopwords_when_extracted_then_no_topics() {
+    let rows = vec![make_row("src/lib/mod.rs", "src/lib", "Rust", 50)];
+    let export = make_export(rows, vec![]);
+    let clouds = build_topic_clouds(&export);
+    assert!(
+        clouds.overall.is_empty(),
+        "all-stopword path should produce no topics"
+    );
+}
+
+// ── Scenario: very long filename with many separators ────────────────
+
+#[test]
+fn given_long_compound_filename_when_extracted_then_all_parts_tokenized() {
+    let rows = vec![make_row(
+        "services/user_auth-handler.v3.test.rs",
+        "services",
+        "Rust",
+        50,
+    )];
+    let export = make_export(rows, vec![]);
+    let clouds = build_topic_clouds(&export);
+    let terms: Vec<&str> = clouds.overall.iter().map(|t| t.term.as_str()).collect();
+    assert!(terms.contains(&"user"));
+    assert!(terms.contains(&"auth"));
+    assert!(terms.contains(&"handler"));
+    assert!(terms.contains(&"v3"));
+    assert!(terms.contains(&"services"));
+    // "test" and "rs" are stopwords
+    assert!(!terms.contains(&"rs"));
+}
+
+// ── Scenario: module_roots with multiple roots ──────────────────────
+
+#[test]
+fn given_multiple_module_roots_when_extracted_then_all_are_stopwords() {
+    let rows = vec![
+        make_row("crates/auth/login.rs", "crates/auth", "Rust", 50),
+        make_row("packages/ui/button.ts", "packages/ui", "TypeScript", 50),
+    ];
+    let export = make_export(rows, vec!["crates", "packages"]);
+    let clouds = build_topic_clouds(&export);
+    let terms: Vec<&str> = clouds.overall.iter().map(|t| t.term.as_str()).collect();
+    assert!(
+        !terms.contains(&"crates"),
+        "'crates' is a module root stopword"
+    );
+    assert!(
+        !terms.contains(&"packages"),
+        "'packages' is a module root stopword"
+    );
+    assert!(terms.contains(&"auth") || terms.contains(&"login"));
+}
+
+// ── Scenario: weight for zero-token rows ────────────────────────────
+
+#[test]
+fn given_zero_token_row_when_extracted_then_weight_is_clamped_to_one() {
+    let rows = vec![make_row("app/feature.rs", "app", "Rust", 0)];
+    let export = make_export(rows, vec!["app"]);
+    let clouds = build_topic_clouds(&export);
+    let feature = clouds.overall.iter().find(|t| t.term == "feature");
+    assert!(feature.is_some(), "term should exist even with 0 tokens");
+    assert!(feature.unwrap().tf >= 1, "tf should be at least 1");
+}
+
+// ── Scenario: df tracks per-file occurrences across modules ─────────
+
+#[test]
+fn given_term_in_three_files_across_two_modules_when_extracted_then_df_is_three() {
+    let rows = vec![
+        make_row("mod_a/shared.rs", "mod_a", "Rust", 50),
+        make_row("mod_a/shared_util.rs", "mod_a", "Rust", 50),
+        make_row("mod_b/shared.rs", "mod_b", "Rust", 50),
+    ];
+    let export = make_export(rows, vec![]);
+    let clouds = build_topic_clouds(&export);
+    let shared = clouds.overall.iter().find(|t| t.term == "shared");
+    assert!(shared.is_some());
+    assert_eq!(
+        shared.unwrap().df,
+        3,
+        "df should count all files containing the term"
+    );
+}
+
+// ── Scenario: determinism with multi-module input ───────────────────
+
+#[test]
+fn given_multi_module_input_when_extracted_twice_then_identical_output() {
+    let make = || {
+        let rows = vec![
+            make_row("svc/auth/login.rs", "svc/auth", "Rust", 100),
+            make_row("svc/auth/logout.rs", "svc/auth", "Rust", 50),
+            make_row("svc/billing/invoice.rs", "svc/billing", "Rust", 200),
+            make_row("svc/billing/payment.rs", "svc/billing", "Rust", 150),
+            make_row("lib/utils/format.rs", "lib/utils", "Rust", 30),
+        ];
+        make_export(rows, vec!["svc", "lib"])
+    };
+
+    let a = build_topic_clouds(&make());
+    let b = build_topic_clouds(&make());
+
+    assert_eq!(a.overall.len(), b.overall.len());
+    for (ta, tb) in a.overall.iter().zip(b.overall.iter()) {
+        assert_eq!(ta.term, tb.term);
+        assert_eq!(ta.tf, tb.tf);
+        assert_eq!(ta.df, tb.df);
+        assert!((ta.score - tb.score).abs() < f64::EPSILON);
+    }
+    assert_eq!(
+        a.per_module.keys().collect::<Vec<_>>(),
+        b.per_module.keys().collect::<Vec<_>>()
+    );
+}
+
+// ── Scenario: overall truncation to TOP_K=8 ─────────────────────────
+
+#[test]
+fn given_many_unique_terms_across_modules_when_extracted_then_overall_at_most_8() {
+    let rows: Vec<FileRow> = (0..30)
+        .map(|i| {
+            make_row(
+                &format!("mod_{}/unique_term_{}.rs", i % 5, i),
+                &format!("mod_{}", i % 5),
+                "Rust",
+                50,
+            )
+        })
+        .collect();
+    let export = make_export(rows, vec![]);
+    let clouds = build_topic_clouds(&export);
+    assert!(
+        clouds.overall.len() <= 8,
+        "overall should be truncated to 8, got {}",
+        clouds.overall.len()
+    );
+}

--- a/run_checks.ps1
+++ b/run_checks.ps1
@@ -1,0 +1,20 @@
+#!/usr/bin/env pwsh
+Set-Location 'C:\Code\Rust\tokmd-analysis-tests2'
+
+Write-Host "=== Running cargo fmt ===" -ForegroundColor Green
+cargo fmt
+$fmtExitCode = $LASTEXITCODE
+
+Write-Host "`n=== Running cargo clippy ===" -ForegroundColor Green
+cargo clippy -p tokmd-analysis-halstead -p tokmd-analysis-license -p tokmd-analysis-topics -p tokmd-analysis-fingerprint -- -D warnings
+$clippyExitCode = $LASTEXITCODE
+
+Write-Host "`n=== Summary ===" -ForegroundColor Green
+Write-Host "cargo fmt exit code: $fmtExitCode"
+Write-Host "cargo clippy exit code: $clippyExitCode"
+
+if ($fmtExitCode -eq 0 -and $clippyExitCode -eq 0) {
+    Write-Host "`nAll checks passed!" -ForegroundColor Green
+} else {
+    Write-Host "`nSome checks failed." -ForegroundColor Red
+}

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "C:\Code\Rust\tokmd-analysis-tests2"
+cargo test -p tokmd-analysis-halstead -p tokmd-analysis-license -p tokmd-analysis-topics -p tokmd-analysis-fingerprint --verbose 2>&1 > test_results.txt
+echo Test completed, results in test_results.txt

--- a/test_results.txt
+++ b/test_results.txt
@@ -1,0 +1,275 @@
+
+running 1 test
+test tests::buckets_public_domains ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 19 tests
+test empty_author_string_is_skipped ... ok
+test example_com_is_ignored ... ok
+test empty_commits_produce_empty_fingerprint ... ok
+test all_public_providers_collapse_into_single_bucket ... ok
+test noreply_github_is_ignored ... ok
+test domain_case_is_normalized ... ok
+test localhost_is_ignored ... ok
+test tie_breaking_by_domain_name ... ok
+test multiple_at_signs_are_skipped ... ok
+test multiple_corporate_domains_sorted_by_commit_count ... ok
+test no_at_sign_is_skipped ... ok
+test percentage_values_are_correct ... ok
+test percentages_sum_to_approximately_one ... ok
+test public_domain_case_insensitive ... ok
+test single_corporate_author ... ok
+test ignored_domains_do_not_affect_percentages ... ok
+test single_public_email_author ... ok
+test mixed_corporate_and_public_domains ... ok
+test handles_large_commit_set ... ok
+
+test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 10 tests
+test given_at_sign_at_end_when_fingerprinted_then_empty_domain_ignored ... ok
+test given_domain_with_whitespace_when_fingerprinted_then_trimmed ... ok
+test given_at_sign_at_start_when_fingerprinted_then_skipped ... ok
+test given_all_public_providers_and_corporate_when_fingerprinted_then_two_buckets ... ok
+test given_mixed_valid_ignored_and_malformed_when_fingerprinted_then_only_valid_counted ... ok
+test given_fingerprint_when_serialized_then_contains_expected_fields ... ok
+test given_same_authors_with_different_timestamps_when_fingerprinted_then_same_result ... ok
+test given_subdomain_emails_when_fingerprinted_then_full_domain_kept ... ok
+test given_single_domain_when_fingerprinted_then_pct_is_exactly_one ... ok
+test given_100_unique_domains_when_fingerprinted_then_all_counted ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 9 tests
+test empty_input_empty_output ... ok
+test never_panics ... ok
+test duplicate_emails_merge ... ok
+test domains_are_lowercase ... ok
+test no_empty_domain_names ... ok
+test commit_count_is_conserved ... ok
+test percentages_sum_to_one ... ok
+test percentages_in_range ... ok
+test domains_are_sorted ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.66s
+
+
+running 20 tests
+test at_sign_only_is_skipped ... ok
+test author_with_multiple_at_signs_is_skipped ... ok
+test author_without_at_sign_is_skipped ... ok
+test ignored_commits_do_not_inflate_totals ... ok
+test corporate_fingerprint_serializes_to_json ... ok
+test uppercase_domain_is_normalized_to_lowercase ... ok
+test percentages_are_correct_for_known_distribution ... ok
+test result_is_deterministic_across_repeated_calls ... ok
+test single_corporate_domain_gets_full_share ... ok
+test percentages_sum_to_one_with_many_domains ... ok
+test uppercase_public_domain_still_bucketed_as_public ... ok
+test mixed_public_providers_merge_into_single_bucket ... ok
+test multiple_corporate_domains_ordered_by_commits_desc ... ok
+test equal_commit_counts_sorted_alphabetically ... ok
+test empty_slice_returns_empty_domains ... ok
+test all_ignored_commits_produce_empty_fingerprint ... ok
+test empty_string_author_is_skipped ... ok
+test noreply_github_variants_are_all_ignored ... ok
+test each_public_provider_maps_to_public_email_bucket ... ok
+test domain_list_is_sorted_descending_by_commits_then_by_name ... ok
+
+test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+
+running 4 tests
+test tests::test_halstead_computation ... ok
+test tests::test_empty_input ... ok
+test tests::test_tokenize_python ... ok
+test tests::test_tokenize_rust ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 44 tests
+test scenario_block_comment_start_skipped ... ok
+test scenario_round_f64_zero ... ok
+test scenario_comment_only_input_yields_zero_counts ... ok
+test scenario_halstead_bugs_is_volume_over_3000 ... ok
+test scenario_duplicate_operands_increase_total_but_not_distinct ... ok
+test scenario_halstead_difficulty_formula ... ok
+test scenario_halstead_effort_is_difficulty_times_volume ... ok
+test scenario_halstead_time_is_effort_over_18 ... ok
+test scenario_halstead_volume_formula ... ok
+test scenario_hash_comment_skipped ... ok
+test scenario_language_detection_is_case_insensitive ... ok
+test scenario_multi_char_operators_matched_longest_first ... ok
+test scenario_round_f64_negative ... ok
+test scenario_build_report_skips_missing_files_gracefully ... ok
+test scenario_build_report_with_empty_file_list ... ok
+test scenario_empty_input_yields_zero_counts ... ok
+test scenario_tokenize_javascript_arrow_function ... ok
+test scenario_single_operand_only ... ok
+test scenario_single_operator_only ... ok
+test scenario_supported_languages_have_operators ... ok
+test scenario_string_literals_counted_as_operands ... ok
+test scenario_supported_languages_are_recognized ... ok
+test scenario_tokenize_go_func ... ok
+test scenario_round_f64_basic ... ok
+test scenario_single_char_literal ... ok
+test scenario_round_f64_large_decimals ... ok
+test scenario_build_report_skips_child_file_kind ... ok
+test scenario_build_report_skips_unsupported_language ... ok
+test scenario_tokenize_python_def ... ok
+test scenario_escaped_string_literal ... ok
+test scenario_tokenize_python_for_loop ... ok
+test scenario_tokenize_rust_if_else ... ok
+test scenario_tokenize_rust_fn_with_operators_and_operands ... ok
+test scenario_unknown_language_produces_only_operands ... ok
+test scenario_tokenize_rust_match ... ok
+test scenario_unsupported_languages_are_rejected ... ok
+test scenario_unsupported_language_returns_empty_operators ... ok
+test scenario_whitespace_only_input_yields_zero_counts ... ok
+test scenario_zero_distinct_operands_yields_zero_difficulty ... ok
+test scenario_zero_vocabulary_yields_zero_volume ... ok
+test scenario_build_report_respects_max_bytes_limit ... ok
+test scenario_build_report_aggregates_multiple_files ... ok
+test scenario_build_report_with_rust_file ... ok
+test scenario_build_report_mixed_languages ... ok
+
+test result: ok. 44 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+
+running 11 tests
+test given_exactly_half_when_rounded_then_rounds_to_even_or_up ... ok
+test given_ruby_operators_when_compared_to_rust_then_different_sets ... ok
+test given_ruby_class_when_tokenized_then_class_and_self_detected ... ok
+test given_ruby_code_when_tokenized_then_ruby_operators_detected ... ok
+test given_c_code_when_tokenized_then_c_operators_detected ... ok
+test given_java_code_when_tokenized_then_class_keywords_detected ... ok
+test given_very_small_positive_when_rounded_then_zero ... ok
+test given_repeated_distinct_operators_when_tokenized_then_counts_are_exact ... ok
+test given_nested_rust_code_when_tokenized_then_all_levels_counted ... ok
+test given_small_per_file_limit_when_building_report_then_file_is_truncated ... ok
+test given_same_files_when_report_built_twice_then_identical_metrics ... ok
+
+test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+
+
+running 21 tests
+test prop_effort_equals_difficulty_times_volume ... ok
+test prop_time_equals_effort_over_18 ... ok
+test prop_bugs_equals_volume_over_3000 ... ok
+test prop_difficulty_non_negative ... ok
+test prop_round_idempotent ... ok
+test prop_round_zero_decimals_is_integer ... ok
+test prop_round_result_within_half_unit ... ok
+test prop_volume_non_negative ... ok
+test prop_is_halstead_lang_consistent_with_operators ... ok
+test prop_supported_lang_has_nonempty_ops ... ok
+test prop_round_preserves_integer_values ... ok
+test prop_empty_string_produces_zero_for_any_lang ... ok
+test prop_operator_table_has_no_duplicates ... ok
+test prop_total_operators_equals_sum_of_individual_counts ... ok
+test prop_total_operands_gte_distinct_operands ... ok
+test prop_vocabulary_is_sum_of_distinct ... ok
+test prop_distinct_operators_lte_total_operators ... ok
+test prop_adding_blank_lines_does_not_change_counts ... ok
+test prop_tokenize_deterministic ... ok
+test prop_hash_comment_only_produces_zero ... ok
+test prop_comment_only_produces_zero_for_slash_langs ... ok
+
+test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
+
+
+running 21 tests
+test is_halstead_lang_case_insensitive ... ok
+test boundary_empty_string ... ok
+test known_counts_compound_operators ... ok
+test typescript_shares_javascript_operators ... ok
+test known_counts_single_assignment ... ok
+test known_counts_repeated_operator ... ok
+test round_f64_various_precisions ... ok
+test boundary_single_operator ... ok
+test string_literal_counted_as_single_operand ... ok
+test math_volume_equals_n_times_log2_n ... ok
+test boundary_zero_operators_unknown_lang ... ok
+test c_family_shares_operator_table ... ok
+test unsupported_lang_returns_empty_operators ... ok
+test boundary_zero_operands ... ok
+test math_time_equals_effort_over_18 ... ok
+test math_vocabulary_equals_n1_plus_n2 ... ok
+test math_bugs_equals_volume_over_3000 ... ok
+test math_difficulty_formula ... ok
+test zero_vocabulary_yields_zero_derived_metrics ... ok
+test math_effort_equals_difficulty_times_volume ... ok
+test math_length_equals_big_n1_plus_big_n2 ... ok
+
+test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
+
+
+running 2 tests
+test tests::detects_metadata_license ... ok
+test tests::detects_text_license ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+
+running 23 tests
+test given_empty_license_file_then_no_findings ... ok
+test given_no_license_files_then_empty_report ... ok
+test effective_is_highest_confidence ... ok
+test given_dual_license_expression_then_finds_expression ... ok
+test given_package_json_object_license_then_finds_metadata ... ok
+test given_pyproject_toml_poetry_section_then_finds_metadata ... ok
+test given_cargo_toml_with_apache_then_finds_apache_metadata ... ok
+test given_mit_license_text_then_finds_mit_text ... ok
+test given_package_json_string_license_then_finds_metadata ... ok
+test given_agpl3_text_then_finds_agpl ... ok
+test given_apache_license_text_then_finds_apache ... ok
+test given_unrecognized_license_text_then_no_findings ... ok
+test given_gpl3_license_text_then_finds_gpl ... ok
+test given_bsd3_license_text_then_finds_bsd3 ... ok
+test given_license_mit_filename_then_detected ... ok
+test given_mpl2_license_text_then_finds_mpl2 ... ok
+test given_cargo_toml_with_mit_then_finds_mit_metadata ... ok
+test given_pyproject_toml_project_section_then_finds_metadata ... ok
+test given_cargo_toml_license_file_field_then_scans_referenced_file ... ok
+test confidence_in_valid_range ... ok
+test source_paths_use_forward_slashes ... ok
+test findings_are_sorted_by_confidence_descending ... ok
+test given_metadata_and_license_text_then_finds_both ... ok
+
+test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+
+running 10 tests
+test given_only_source_files_when_scanned_then_no_findings ... ok
+test given_metadata_and_text_when_scanned_then_effective_is_metadata ... ok
+test given_pyproject_with_both_sections_when_scanned_then_project_takes_precedence ... ok
+test given_invalid_json_in_package_json_when_scanned_then_no_panic ... ok
+test given_bsd2_text_without_third_clause_when_scanned_then_matches_bsd ... ok
+test given_multiple_license_text_files_when_scanned_then_all_detected ... ok
+test given_cargo_toml_in_subdirectory_when_scanned_then_detected_with_forward_slash_path ... ok
+test given_cargo_toml_with_empty_license_string_when_scanned_then_no_finding ... ok
+test given_cargo_toml_license_file_to_missing_file_when_scanned_then_no_panic ... FAILED
+test given_mit_text_with_extra_whitespace_when_scanned_then_still_detected ... ok
+
+failures:
+
+---- given_cargo_toml_license_file_to_missing_file_when_scanned_then_no_panic stdout ----
+
+thread 'given_cargo_toml_license_file_to_missing_file_when_scanned_then_no_panic' (2361596) panicked at crates\tokmd-analysis-license\tests\edge_cases.rs:46:78:
+called `Result::unwrap()` on an `Err` value: Failed to open C:\Users\steven\AppData\Local\Temp\.tmpIZ88jl\NONEXISTENT
+
+Caused by:
+    The system cannot find the file specified. (os error 2)
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+failures:
+    given_cargo_toml_license_file_to_missing_file_when_scanned_then_no_panic
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+


### PR DESCRIPTION
Add BDD-style edge-case tests for 4 more analysis crates:

- **tokmd-analysis-halstead** (11 new tests): Ruby/C-family/Java tokenization, nested code, operator counting precision, per-file byte limits, round_f64 boundaries, determinism
- **tokmd-analysis-license** (10 new tests): dual pyproject sections, missing license-file, invalid JSON, whitespace tolerance, BSD disambiguation, subdirectory paths, empty SPDX, multi-license files
- **tokmd-analysis-topics** (10 new tests): multi-language files, extension stopwords, compound filenames, multiple module roots, zero-token weights, df tracking, truncation, determinism
- **tokmd-analysis-fingerprint** (10 new tests): timestamp independence, whitespace trimming, edge @ positions, subdomain handling, many unique domains, mixed input types, serialization fields

Total: 41 new tests, all passing.