### PR TITLE
test: add tests for analysis-content, git, format

### DIFF
--- a/crates/tokmd-analysis-content/tests/bdd_extended.rs
+++ b/crates/tokmd-analysis-content/tests/bdd_extended.rs
@@ -1,0 +1,329 @@
+//! Extended BDD-style tests for tokmd-analysis-content.
+//!
+//! Additional coverage for TODO density, duplicate density metrics,
+//! and import report edge cases.
+
+use std::path::PathBuf;
+
+use tokmd_analysis_content::{
+    ContentLimits, ImportGranularity, build_duplicate_report, build_import_report,
+    build_todo_report,
+};
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+fn file_row(path: &str, module: &str, lang: &str, bytes: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code: 10,
+        comments: 2,
+        blanks: 1,
+        lines: 13,
+        bytes,
+        tokens: 80,
+    }
+}
+
+fn empty_export() -> ExportData {
+    ExportData {
+        rows: vec![],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ── TODO report: all lines are TODOs ─────────────────────────────────
+
+#[test]
+fn given_file_with_all_todo_lines_when_building_todo_report_then_high_density() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    // Every line contains a TODO tag
+    let content =
+        "// TODO: first\n// TODO: second\n// TODO: third\n// TODO: fourth\n// TODO: fifth\n";
+    std::fs::write(root.join("todos.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("todos.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 5);
+    // 5 TODOs / 1.0 kLOC = 5.0 density
+    assert_eq!(report.density_per_kloc, 5.0);
+    // Only TODO tag should have non-zero count
+    let todo_count = report
+        .tags
+        .iter()
+        .find(|t| t.tag == "TODO")
+        .map(|t| t.count)
+        .unwrap_or(0);
+    assert_eq!(todo_count, 5);
+    assert!(
+        report
+            .tags
+            .iter()
+            .filter(|t| t.count > 0)
+            .all(|t| t.tag == "TODO"),
+        "only TODO should have non-zero count"
+    );
+}
+
+// ── TODO report: only FIXME tags ─────────────────────────────────────
+
+#[test]
+fn given_file_with_only_fixme_tags_when_building_todo_report_then_only_fixme_counted() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    std::fs::write(
+        root.join("fixmes.rs"),
+        "// FIXME: bug1\n// FIXME: bug2\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("fixmes.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 2000).unwrap();
+
+    assert_eq!(report.total, 2);
+    let fixme_count = report
+        .tags
+        .iter()
+        .find(|t| t.tag == "FIXME")
+        .map(|t| t.count)
+        .unwrap_or(0);
+    assert_eq!(fixme_count, 2);
+    // No other tags should have non-zero counts
+    assert!(
+        report
+            .tags
+            .iter()
+            .filter(|t| t.tag != "FIXME")
+            .all(|t| t.count == 0)
+    );
+}
+
+// ── TODO report: large codebase density ──────────────────────────────
+
+#[test]
+fn given_10_todos_and_10000_code_lines_when_building_todo_report_then_density_is_1() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    let mut content = String::new();
+    for i in 0..10 {
+        content.push_str(&format!("// TODO: item {}\n", i));
+    }
+    content.push_str("fn main() {}\n");
+    std::fs::write(root.join("big.rs"), &content).unwrap();
+
+    let files = vec![PathBuf::from("big.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 10_000).unwrap();
+
+    assert_eq!(report.total, 10);
+    assert_eq!(report.density_per_kloc, 1.0);
+}
+
+// ── TODO report: mixed tags ──────────────────────────────────────────
+
+#[test]
+fn given_file_with_all_tag_types_when_building_todo_report_then_tags_sorted_by_name() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    std::fs::write(
+        root.join("mixed.rs"),
+        "// XXX: review\n// HACK: workaround\n// FIXME: broken\n// TODO: implement\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("mixed.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 4);
+    // Tags should be from BTreeMap iteration (alphabetical)
+    let tag_names: Vec<&str> = report.tags.iter().map(|t| t.tag.as_str()).collect();
+    let mut sorted = tag_names.clone();
+    sorted.sort();
+    assert_eq!(tag_names, sorted, "tags should be in alphabetical order");
+}
+
+// ── Duplicate report: single file no duplicates ──────────────────────
+
+#[test]
+fn given_single_file_when_building_duplicate_report_then_no_groups() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    std::fs::write(root.join("only.rs"), "fn only() { 42 }\n").unwrap();
+
+    let files = vec![PathBuf::from("only.rs")];
+    let export = ExportData {
+        rows: vec![file_row("only.rs", "root", "Rust", 18)],
+        module_roots: vec!["root".to_string()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    assert!(report.groups.is_empty());
+    assert_eq!(report.wasted_bytes, 0);
+    assert_eq!(report.strategy, "exact-blake3");
+}
+
+// ── Duplicate report: density wasted_pct_of_codebase ─────────────────
+
+#[test]
+fn given_duplicates_when_building_report_then_wasted_pct_is_correct_ratio() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    // 100-byte content duplicated across two files
+    let content = "x".repeat(100);
+    std::fs::write(root.join("d1.rs"), &content).unwrap();
+    std::fs::write(root.join("d2.rs"), &content).unwrap();
+    // One unique file
+    std::fs::write(root.join("unique.rs"), "y".repeat(100)).unwrap();
+
+    let files = vec![
+        PathBuf::from("d1.rs"),
+        PathBuf::from("d2.rs"),
+        PathBuf::from("unique.rs"),
+    ];
+    let export = ExportData {
+        rows: vec![
+            file_row("d1.rs", "root", "Rust", 100),
+            file_row("d2.rs", "root", "Rust", 100),
+            file_row("unique.rs", "root", "Rust", 100),
+        ],
+        module_roots: vec!["root".to_string()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    assert_eq!(report.groups.len(), 1);
+    assert_eq!(report.wasted_bytes, 100);
+    let density = report.density.as_ref().expect("density present");
+    // module_bytes for "root" = 10+10+10 = 30 (from file_row bytes field)
+    // wasted_pct_of_codebase = wasted_bytes / total_codebase_bytes
+    assert!(
+        density.wasted_pct_of_codebase > 0.0,
+        "wasted_pct should be positive"
+    );
+}
+
+// ── Duplicate report: multiple distinct groups ───────────────────────
+
+#[test]
+fn given_two_distinct_duplicate_groups_when_building_report_then_both_detected() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    let content_a = "fn alpha() { 1 }\n";
+    let content_b = "fn beta() { 2 }\n";
+    std::fs::write(root.join("a1.rs"), content_a).unwrap();
+    std::fs::write(root.join("a2.rs"), content_a).unwrap();
+    std::fs::write(root.join("b1.rs"), content_b).unwrap();
+    std::fs::write(root.join("b2.rs"), content_b).unwrap();
+
+    let files = vec![
+        PathBuf::from("a1.rs"),
+        PathBuf::from("a2.rs"),
+        PathBuf::from("b1.rs"),
+        PathBuf::from("b2.rs"),
+    ];
+    let export = empty_export();
+
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    // Both content_a and content_b are the same length so they could form groups
+    // If same length & same hash → 1 group; different hash → 2 groups
+    // content_a != content_b so we get 2 groups (they have the same byte count
+    // but different hashes)
+    assert_eq!(report.groups.len(), 2);
+    assert!(report.groups.iter().all(|g| g.files.len() == 2));
+}
+
+// ── Import report: Rust use statements produce edges ─────────────────
+
+#[test]
+fn given_rust_file_with_use_statements_when_file_granularity_then_from_is_file_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("src/main.rs"),
+        "use std::collections::HashMap;\nuse anyhow::Result;\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("src/main.rs")];
+    let export = ExportData {
+        rows: vec![file_row("src/main.rs", "src", "Rust", 60)],
+        module_roots: vec!["src".to_string()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::File,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert_eq!(report.granularity, "file");
+    // All edges should have from == file path
+    assert!(
+        report.edges.iter().all(|e| e.from == "src/main.rs"),
+        "all edges should reference the file path"
+    );
+    assert!(
+        !report.edges.is_empty(),
+        "Rust use statements should produce import edges"
+    );
+}
+
+// ── Import report: per-file byte limit respected ─────────────────────
+
+#[test]
+fn given_per_file_byte_limit_when_building_import_report_then_large_file_truncated() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    // Write a file with imports near the top, then lots of content
+    let mut content = "import os\nimport sys\n".to_string();
+    content.push_str(&"x = 1\n".repeat(5000));
+    std::fs::write(root.join("big.py"), &content).unwrap();
+
+    let files = vec![PathBuf::from("big.py")];
+    let export = ExportData {
+        rows: vec![file_row("big.py", "root", "Python", content.len())],
+        module_roots: vec!["root".to_string()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+
+    let limits = ContentLimits {
+        max_bytes: None,
+        max_file_bytes: Some(256),
+    };
+    let report =
+        build_import_report(root, &files, &export, ImportGranularity::Module, &limits).unwrap();
+
+    // Even with truncation, imports at the top should still be parsed
+    assert!(
+        report.edges.len() >= 1,
+        "imports near file top should still be found"
+    );
+}

--- a/crates/tokmd-analysis-format/tests/bdd_extended.rs
+++ b/crates/tokmd-analysis-format/tests/bdd_extended.rs
@@ -1,0 +1,509 @@
+//! Extended BDD-style tests for tokmd-analysis-format rendering.
+//!
+//! Additional coverage for HTML output, JSON with git section, markdown
+//! consistency, and format dispatch edge cases.
+
+use std::collections::BTreeMap;
+
+use tokmd_analysis_format::{RenderedOutput, render};
+use tokmd_analysis_types::*;
+use tokmd_types::{AnalysisFormat, ScanStatus, ToolInfo};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: ToolInfo {
+            name: "tokmd".into(),
+            version: "test".into(),
+        },
+        mode: "analyze".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec![".".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "md".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_file_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn extract_text(output: RenderedOutput) -> String {
+    match output {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text output"),
+    }
+}
+
+// ===========================================================================
+// Scenario: HTML format produces valid HTML structure
+// ===========================================================================
+#[test]
+fn given_minimal_receipt_when_rendering_html_then_produces_html_tags() {
+    let receipt = minimal_receipt();
+    let output = render(&receipt, AnalysisFormat::Html).unwrap();
+    let text = extract_text(output);
+
+    assert!(text.contains("<html"), "should contain opening html tag");
+    assert!(text.contains("</html>"), "should contain closing html tag");
+    assert!(text.contains("tokmd"), "should reference tokmd");
+}
+
+// ===========================================================================
+// Scenario: HTML with derived data includes totals
+// ===========================================================================
+#[test]
+fn given_receipt_with_derived_when_rendering_html_then_includes_totals() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let output = render(&receipt, AnalysisFormat::Html).unwrap();
+    let text = extract_text(output);
+
+    assert!(text.contains("500"), "should include code line count");
+    assert!(text.contains("html"), "should be HTML format");
+}
+
+// ===========================================================================
+// Scenario: JSON with git section roundtrips correctly
+// ===========================================================================
+#[test]
+fn given_receipt_with_git_section_when_json_roundtrip_then_data_preserved() {
+    let mut receipt = minimal_receipt();
+    receipt.git = Some(GitReport {
+        commits_scanned: 42,
+        files_seen: 10,
+        hotspots: vec![HotspotRow {
+            path: "src/main.rs".into(),
+            commits: 15,
+            lines: 200,
+            score: 3000,
+        }],
+        bus_factor: vec![BusFactorRow {
+            module: "src".into(),
+            authors: 3,
+        }],
+        freshness: FreshnessReport {
+            threshold_days: 365,
+            stale_files: 2,
+            total_files: 10,
+            stale_pct: 0.2,
+            by_module: vec![],
+        },
+        coupling: vec![],
+        age_distribution: None,
+        intent: None,
+    });
+
+    let output = render(&receipt, AnalysisFormat::Json).unwrap();
+    let text = extract_text(output);
+    let parsed: AnalysisReceipt = serde_json::from_str(&text).unwrap();
+
+    let git = parsed.git.expect("git section should be present");
+    assert_eq!(git.commits_scanned, 42);
+    assert_eq!(git.files_seen, 10);
+    assert_eq!(git.hotspots.len(), 1);
+    assert_eq!(git.hotspots[0].score, 3000);
+    assert_eq!(git.bus_factor[0].authors, 3);
+}
+
+// ===========================================================================
+// Scenario: JSON with imports section preserved in roundtrip
+// ===========================================================================
+#[test]
+fn given_receipt_with_imports_when_json_roundtrip_then_edges_preserved() {
+    let mut receipt = minimal_receipt();
+    receipt.imports = Some(ImportReport {
+        granularity: "file".into(),
+        edges: vec![
+            ImportEdge {
+                from: "src/main.rs".into(),
+                to: "serde".into(),
+                count: 5,
+            },
+            ImportEdge {
+                from: "src/main.rs".into(),
+                to: "anyhow".into(),
+                count: 2,
+            },
+        ],
+    });
+
+    let output = render(&receipt, AnalysisFormat::Json).unwrap();
+    let text = extract_text(output);
+    let parsed: AnalysisReceipt = serde_json::from_str(&text).unwrap();
+
+    let imports = parsed.imports.expect("imports section present");
+    assert_eq!(imports.granularity, "file");
+    assert_eq!(imports.edges.len(), 2);
+    assert_eq!(imports.edges[0].count, 5);
+}
+
+// ===========================================================================
+// Scenario: Markdown with git section renders hotspots table
+// ===========================================================================
+#[test]
+fn given_receipt_with_git_when_rendering_md_then_hotspot_table_present() {
+    let mut receipt = minimal_receipt();
+    receipt.git = Some(GitReport {
+        commits_scanned: 10,
+        files_seen: 3,
+        hotspots: vec![
+            HotspotRow {
+                path: "src/main.rs".into(),
+                commits: 8,
+                lines: 100,
+                score: 800,
+            },
+            HotspotRow {
+                path: "src/lib.rs".into(),
+                commits: 5,
+                lines: 50,
+                score: 250,
+            },
+        ],
+        bus_factor: vec![BusFactorRow {
+            module: "src".into(),
+            authors: 2,
+        }],
+        freshness: FreshnessReport {
+            threshold_days: 365,
+            stale_files: 0,
+            total_files: 3,
+            stale_pct: 0.0,
+            by_module: vec![],
+        },
+        coupling: vec![CouplingRow {
+            left: "api".into(),
+            right: "db".into(),
+            count: 5,
+            jaccard: Some(0.75),
+            lift: Some(1.2),
+            n_left: Some(6),
+            n_right: Some(7),
+        }],
+        age_distribution: None,
+        intent: None,
+    });
+
+    let output = render(&receipt, AnalysisFormat::Md).unwrap();
+    let text = extract_text(output);
+
+    assert!(text.contains("## Git"), "should have Git section header");
+    assert!(text.contains("src/main.rs"), "should list hotspot path");
+    assert!(text.contains("|src|2|"), "should render bus factor row");
+    assert!(text.contains("|api|db|5|"), "should render coupling row");
+}
+
+// ===========================================================================
+// Scenario: Markdown renders dup density by_module table
+// ===========================================================================
+#[test]
+fn given_receipt_with_dup_density_when_rendering_md_then_module_table_present() {
+    let mut receipt = minimal_receipt();
+    receipt.dup = Some(DuplicateReport {
+        groups: vec![DuplicateGroup {
+            hash: "abc123def".into(),
+            bytes: 500,
+            files: vec!["a.rs".into(), "b.rs".into()],
+        }],
+        wasted_bytes: 500,
+        strategy: "exact-blake3".into(),
+        density: Some(DuplicationDensityReport {
+            duplicate_groups: 1,
+            duplicate_files: 2,
+            duplicated_bytes: 1000,
+            wasted_bytes: 500,
+            wasted_pct_of_codebase: 0.05,
+            by_module: vec![ModuleDuplicationDensityRow {
+                module: "core".into(),
+                duplicate_files: 2,
+                wasted_files: 1,
+                duplicated_bytes: 1000,
+                wasted_bytes: 500,
+                module_bytes: 10_000,
+                density: 0.05,
+            }],
+        }),
+        near: None,
+    });
+
+    let output = render(&receipt, AnalysisFormat::Md).unwrap();
+    let text = extract_text(output);
+
+    assert!(
+        text.contains("## Duplicates"),
+        "should have Duplicates header"
+    );
+    assert!(
+        text.contains("### Duplication density"),
+        "should have density subsection"
+    );
+    assert!(text.contains("|core|"), "should render module row");
+    assert!(text.contains("exact-blake3"), "should show strategy");
+}
+
+// ===========================================================================
+// Scenario: Mermaid without imports shows no graph edges
+// ===========================================================================
+#[test]
+fn given_receipt_without_imports_when_rendering_mermaid_then_no_edge_arrows() {
+    let receipt = minimal_receipt();
+    let output = render(&receipt, AnalysisFormat::Mermaid).unwrap();
+    let text = extract_text(output);
+
+    assert!(text.contains("graph"), "mermaid should produce a graph");
+    assert!(
+        !text.contains("-->"),
+        "should not have edge arrows without imports"
+    );
+}
+
+// ===========================================================================
+// Scenario: Mermaid with imports includes edge arrows
+// ===========================================================================
+#[test]
+fn given_receipt_with_imports_when_rendering_mermaid_then_edges_shown() {
+    let mut receipt = minimal_receipt();
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![ImportEdge {
+            from: "api".into(),
+            to: "utils".into(),
+            count: 3,
+        }],
+    });
+
+    let output = render(&receipt, AnalysisFormat::Mermaid).unwrap();
+    let text = extract_text(output);
+
+    assert!(text.contains("graph"), "should produce mermaid graph");
+    assert!(text.contains("-->"), "should have edge arrow");
+    assert!(text.contains("api"), "should reference source module");
+    assert!(text.contains("utils"), "should reference target module");
+}
+
+// ===========================================================================
+// Scenario: XML format renders analysis tags even without derived
+// ===========================================================================
+#[test]
+fn given_minimal_receipt_when_rendering_xml_then_has_analysis_tags() {
+    let receipt = minimal_receipt();
+    let output = render(&receipt, AnalysisFormat::Xml).unwrap();
+    let text = extract_text(output);
+
+    assert!(
+        text.contains("<analysis>"),
+        "should have opening analysis tag"
+    );
+    assert!(
+        text.contains("</analysis>"),
+        "should have closing analysis tag"
+    );
+}
+
+// ===========================================================================
+// Scenario: XML with derived data includes totals attributes
+// ===========================================================================
+#[test]
+fn given_receipt_with_derived_when_rendering_xml_then_totals_present() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let output = render(&receipt, AnalysisFormat::Xml).unwrap();
+    let text = extract_text(output);
+
+    assert!(text.contains("files=\"5\""), "should include file count");
+    assert!(text.contains("code=\"500\""), "should include code count");
+}
+
+// ===========================================================================
+// Scenario: JSON output is valid JSON for all optional section combos
+// ===========================================================================
+#[test]
+fn given_receipt_with_multiple_sections_when_json_then_valid_json() {
+    let mut receipt = minimal_receipt();
+    receipt.archetype = Some(Archetype {
+        kind: "monorepo".into(),
+        evidence: vec!["Cargo.toml".into(), "package.json".into()],
+    });
+    receipt.dup = Some(DuplicateReport {
+        groups: vec![],
+        wasted_bytes: 0,
+        strategy: "exact-blake3".into(),
+        density: None,
+        near: None,
+    });
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![],
+    });
+
+    let output = render(&receipt, AnalysisFormat::Json).unwrap();
+    let text = extract_text(output);
+
+    // Verify it's valid JSON by parsing it
+    let val: serde_json::Value = serde_json::from_str(&text).expect("should be valid JSON");
+    assert_eq!(val["archetype"]["kind"], "monorepo");
+    assert_eq!(val["dup"]["strategy"], "exact-blake3");
+    assert_eq!(val["imports"]["granularity"], "module");
+}
+
+// ---------------------------------------------------------------------------
+// Helper: minimal DerivedReport for tests that need it
+// ---------------------------------------------------------------------------
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 5,
+            code: 500,
+            comments: 80,
+            blanks: 40,
+            lines: 620,
+            bytes: 5000,
+            tokens: 1200,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 80,
+                denominator: 580,
+                ratio: 0.1379,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 40,
+                denominator: 620,
+                ratio: 0.0645,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 5000,
+                denominator: 620,
+                rate: 8.06,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: FileStatRow {
+                path: "src/main.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 200,
+                comments: 30,
+                blanks: 15,
+                lines: 245,
+                bytes: 2000,
+                tokens: 500,
+                doc_pct: Some(0.13),
+                bytes_per_line: Some(8.16),
+                depth: 1,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 3,
+            avg: 1.5,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 100,
+            prod_lines: 400,
+            test_files: 2,
+            prod_files: 3,
+            ratio: 0.25,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 50,
+            logic_lines: 570,
+            ratio: 0.0877,
+            infra_langs: vec!["TOML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 2,
+            entropy: 0.72,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 450,
+            dominant_pct: 0.9,
+        },
+        distribution: DistributionReport {
+            count: 5,
+            min: 25,
+            max: 245,
+            mean: 124.0,
+            median: 100.0,
+            p90: 245.0,
+            p99: 245.0,
+            gini: 0.32,
+        },
+        histogram: vec![],
+        top: TopOffenders {
+            largest_lines: vec![],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 31.0,
+            lines_per_minute: 20,
+            basis_lines: 620,
+        },
+        context_window: None,
+        cocomo: None,
+        todo: None,
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "a".repeat(64),
+            entries: 5,
+        },
+    }
+}

--- a/crates/tokmd-analysis-git/tests/bdd_extended.rs
+++ b/crates/tokmd-analysis-git/tests/bdd_extended.rs
@@ -1,0 +1,282 @@
+//! Extended BDD-style scenario tests for `tokmd-analysis-git`.
+//!
+//! Additional coverage for churn falling trend, coupling sort order,
+//! intent unknown percentage, bus factor sorting, and freshness edge cases.
+
+use std::path::Path;
+
+use tokmd_analysis_git::{build_git_report, build_predictive_churn_report};
+use tokmd_analysis_types::TrendClass;
+use tokmd_git::GitCommit;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+const DAY: i64 = 86_400;
+const WEEK: i64 = 7 * DAY;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn file_row(path: &str, module: &str, lines: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: "Rust".to_string(),
+        kind: FileKind::Parent,
+        code: lines,
+        comments: 0,
+        blanks: 0,
+        lines,
+        bytes: lines * 40,
+        tokens: lines * 3,
+    }
+}
+
+fn export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn commit(ts: i64, author: &str, subject: &str, files: &[&str]) -> GitCommit {
+    GitCommit {
+        timestamp: ts,
+        author: author.to_string(),
+        hash: None,
+        subject: subject.to_string(),
+        files: files.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+// ===========================================================================
+// Scenario: Churn with decreasing activity has falling trend
+// ===========================================================================
+#[test]
+fn scenario_churn_decreasing_activity_falling() {
+    // Given: decreasing commits per week: 5, 4, 3, 2, 1
+    let exp = export(vec![file_row("src/lib.rs", "src", 100)]);
+    let mut commits = Vec::new();
+    for w in 1..=5i64 {
+        let count = 6 - w; // 5, 4, 3, 2, 1
+        for _ in 0..count {
+            commits.push(commit(w * WEEK, "alice", "feat: less", &["src/lib.rs"]));
+        }
+    }
+
+    // When
+    let report = build_predictive_churn_report(&exp, &commits, Path::new("."));
+
+    // Then: negative slope → falling
+    let trend = report.per_module.get("src").expect("module present");
+    assert!(
+        trend.slope < 0.0,
+        "decreasing activity should have negative slope, got {}",
+        trend.slope
+    );
+    assert_eq!(trend.classification, TrendClass::Falling);
+}
+
+// ===========================================================================
+// Scenario: Churn with multiple modules tracks each independently
+// ===========================================================================
+#[test]
+fn scenario_churn_multiple_modules_independent() {
+    // Given: two modules, one active and one dormant
+    let exp = export(vec![
+        file_row("api/handler.rs", "api", 100),
+        file_row("db/query.rs", "db", 80),
+    ]);
+    let commits = vec![
+        commit(1 * WEEK, "alice", "feat: api1", &["api/handler.rs"]),
+        commit(2 * WEEK, "alice", "feat: api2", &["api/handler.rs"]),
+        commit(3 * WEEK, "alice", "feat: api3", &["api/handler.rs"]),
+        commit(1 * WEEK, "bob", "feat: db", &["db/query.rs"]),
+    ];
+
+    // When
+    let report = build_predictive_churn_report(&exp, &commits, Path::new("."));
+
+    // Then: both modules tracked
+    assert!(report.per_module.contains_key("api"));
+    assert!(report.per_module.contains_key("db"));
+    // db has only 1 data point → flat
+    let db_trend = report.per_module.get("db").unwrap();
+    assert_eq!(db_trend.slope, 0.0);
+    assert_eq!(db_trend.classification, TrendClass::Flat);
+}
+
+// ===========================================================================
+// Scenario: Coupling rows sorted by count descending
+// ===========================================================================
+#[test]
+fn scenario_coupling_sorted_by_count_desc() {
+    // Given: three modules with different coupling strengths
+    let exp = export(vec![
+        file_row("a/f.rs", "a", 50),
+        file_row("b/f.rs", "b", 50),
+        file_row("c/f.rs", "c", 50),
+    ]);
+    let commits = vec![
+        // a+b coupled 3 times
+        commit(1000, "alice", "feat: ab1", &["a/f.rs", "b/f.rs"]),
+        commit(2000, "alice", "feat: ab2", &["a/f.rs", "b/f.rs"]),
+        commit(3000, "alice", "feat: ab3", &["a/f.rs", "b/f.rs"]),
+        // a+c coupled 1 time
+        commit(4000, "bob", "feat: ac1", &["a/f.rs", "c/f.rs"]),
+        // b+c coupled 2 times
+        commit(5000, "bob", "feat: bc1", &["b/f.rs", "c/f.rs"]),
+        commit(6000, "bob", "feat: bc2", &["b/f.rs", "c/f.rs"]),
+    ];
+
+    // When
+    let report = build_git_report(Path::new("."), &exp, &commits).unwrap();
+
+    // Then: coupling sorted by count desc: a-b(3), b-c(2), a-c(1)
+    assert_eq!(report.coupling.len(), 3);
+    assert_eq!(report.coupling[0].count, 3);
+    assert_eq!(report.coupling[1].count, 2);
+    assert_eq!(report.coupling[2].count, 1);
+}
+
+// ===========================================================================
+// Scenario: Intent with unconventional messages yields high unknown_pct
+// ===========================================================================
+#[test]
+fn scenario_intent_unconventional_messages_high_unknown_pct() {
+    // Given: commits with non-conventional messages
+    let exp = export(vec![file_row("src/lib.rs", "src", 100)]);
+    let commits = vec![
+        commit(1000, "alice", "updated the thing", &["src/lib.rs"]),
+        commit(2000, "bob", "misc changes", &["src/lib.rs"]),
+        commit(3000, "charlie", "wip", &["src/lib.rs"]),
+        commit(4000, "alice", "feat: one conventional", &["src/lib.rs"]),
+    ];
+
+    // When
+    let report = build_git_report(Path::new("."), &exp, &commits).unwrap();
+
+    // Then: 3 out of 4 are "other" → unknown_pct = 0.75
+    let intent = report.intent.as_ref().expect("intent present");
+    assert_eq!(intent.overall.other, 3);
+    assert_eq!(intent.overall.feat, 1);
+    assert_eq!(intent.overall.total, 4);
+    assert_eq!(intent.unknown_pct, 0.75);
+}
+
+// ===========================================================================
+// Scenario: Bus factor sorted by authors ascending then module name
+// ===========================================================================
+#[test]
+fn scenario_bus_factor_sort_order() {
+    // Given: three modules with varying author counts
+    let exp = export(vec![
+        file_row("z/f.rs", "z", 50),
+        file_row("a/f.rs", "a", 50),
+        file_row("m/f.rs", "m", 50),
+    ]);
+    let commits = vec![
+        // z: 2 authors
+        commit(1000, "alice", "feat: z", &["z/f.rs"]),
+        commit(2000, "bob", "fix: z", &["z/f.rs"]),
+        // a: 2 authors (same count as z, but "a" < "z" alphabetically)
+        commit(3000, "charlie", "feat: a", &["a/f.rs"]),
+        commit(4000, "dave", "fix: a", &["a/f.rs"]),
+        // m: 1 author
+        commit(5000, "eve", "feat: m", &["m/f.rs"]),
+    ];
+
+    // When
+    let report = build_git_report(Path::new("."), &exp, &commits).unwrap();
+
+    // Then: sorted by authors asc, then module name asc
+    assert_eq!(report.bus_factor.len(), 3);
+    assert_eq!(report.bus_factor[0].module, "m"); // 1 author
+    assert_eq!(report.bus_factor[0].authors, 1);
+    assert_eq!(report.bus_factor[1].module, "a"); // 2 authors, "a" < "z"
+    assert_eq!(report.bus_factor[1].authors, 2);
+    assert_eq!(report.bus_factor[2].module, "z"); // 2 authors, "z" > "a"
+    assert_eq!(report.bus_factor[2].authors, 2);
+}
+
+// ===========================================================================
+// Scenario: Freshness all stale files yields 100% stale
+// ===========================================================================
+#[test]
+fn scenario_freshness_all_stale() {
+    // Given: all files changed over 365 days ago
+    let now = 1000 * DAY;
+    let exp = export(vec![
+        file_row("src/a.rs", "src", 50),
+        file_row("src/b.rs", "src", 50),
+    ]);
+    let commits = vec![
+        commit(now - 500 * DAY, "alice", "feat: a", &["src/a.rs"]),
+        commit(now - 400 * DAY, "bob", "feat: b", &["src/b.rs"]),
+        // Add a recent commit on an untracked file to set max_ts to now
+        commit(now, "charlie", "feat: other", &["untracked.rs"]),
+    ];
+
+    // When
+    let report = build_git_report(Path::new("."), &exp, &commits).unwrap();
+
+    // Then: all tracked files are stale
+    assert_eq!(report.freshness.stale_files, 2);
+    assert_eq!(report.freshness.total_files, 2);
+    assert_eq!(report.freshness.stale_pct, 1.0);
+}
+
+// ===========================================================================
+// Scenario: Freshness module p90 and avg reflect data
+// ===========================================================================
+#[test]
+fn scenario_freshness_module_p90_positive() {
+    // Given: a module with files of different ages
+    let now = 500 * DAY;
+    let exp = export(vec![
+        file_row("src/a.rs", "src", 50),
+        file_row("src/b.rs", "src", 50),
+        file_row("src/c.rs", "src", 50),
+    ]);
+    let commits = vec![
+        commit(now, "alice", "feat: fresh", &["src/a.rs"]),
+        commit(now - 100 * DAY, "bob", "feat: medium", &["src/b.rs"]),
+        commit(now - 200 * DAY, "charlie", "feat: old", &["src/c.rs"]),
+    ];
+
+    // When
+    let report = build_git_report(Path::new("."), &exp, &commits).unwrap();
+
+    // Then: module freshness has positive avg_days and p90
+    assert_eq!(report.freshness.by_module.len(), 1);
+    let module = &report.freshness.by_module[0];
+    assert_eq!(module.module, "src");
+    assert!(module.avg_days > 0.0, "avg_days should be positive");
+    assert!(module.p90_days > 0.0, "p90_days should be positive");
+    assert!(module.p90_days >= module.avg_days, "p90 should be >= avg");
+}
+
+// ===========================================================================
+// Scenario: Churn r2 is between 0.0 and 1.0
+// ===========================================================================
+#[test]
+fn scenario_churn_r2_bounded() {
+    // Given: multiple commits over several weeks
+    let exp = export(vec![file_row("src/lib.rs", "src", 100)]);
+    let commits: Vec<GitCommit> = (1..=10)
+        .map(|i| commit(i * WEEK, "alice", "feat: weekly", &["src/lib.rs"]))
+        .collect();
+
+    // When
+    let report = build_predictive_churn_report(&exp, &commits, Path::new("."));
+
+    // Then: r2 is in [0.0, 1.0]
+    let trend = report.per_module.get("src").expect("module present");
+    assert!(
+        trend.r2 >= 0.0 && trend.r2 <= 1.0,
+        "r2 should be bounded [0,1], got {}",
+        trend.r2
+    );
+}


### PR DESCRIPTION
Add BDD-style tests for 3 analysis adapter crates:

- **tokmd-analysis-content**: TODO density edge cases, duplicate detection with density metrics, import report with file granularity
- **tokmd-analysis-git**: Falling churn trend, coupling sort order, intent unknown percentage, bus factor sorting, freshness edge cases
- **tokmd-analysis-format**: HTML rendering, JSON roundtrip with git/imports, markdown git/dup sections, mermaid with/without imports, XML structure

10 new tests for content, 8 for git, 11 for format (29 total).