### PR TITLE
test: add proptest property tests for Tier 1 crates

### DIFF
--- a/crates/tokmd-context-policy/tests/properties.rs
+++ b/crates/tokmd-context-policy/tests/properties.rs
@@ -195,4 +195,68 @@ proptest! {
             prop_assert!(classes.contains(&FileClassification::Lockfile));
         }
     }
+
+    // ── Selection bound invariants ───────────────────────────────────
+
+    #[test]
+    fn compute_file_cap_at_most_budget_for_valid_pct(
+        budget in 0usize..10_000_000,
+        pct in 0.0f64..1.0,
+        hard_cap in prop::option::of(1usize..1_000_000),
+    ) {
+        let cap = compute_file_cap(budget, pct, hard_cap);
+        // For pct in [0, 1), cap should never exceed budget
+        if budget < usize::MAX {
+            prop_assert!(cap <= budget, "cap {} > budget {}", cap, budget);
+        }
+    }
+
+    #[test]
+    fn smart_exclude_always_catches_known_lockfiles(
+        basename in prop::sample::select(vec![
+            "Cargo.lock", "package-lock.json", "yarn.lock",
+            "poetry.lock", "Pipfile.lock", "go.sum",
+            "composer.lock", "Gemfile.lock",
+        ]),
+        prefix in prop::option::of("[a-z]+(/[a-z]+){0,3}")
+    ) {
+        let path = match prefix {
+            Some(p) => format!("{}/{}", p, basename),
+            None => basename.to_string(),
+        };
+        let reason = smart_exclude_reason(&path);
+        prop_assert_eq!(reason, Some("lockfile"), "Expected lockfile for {}", path);
+    }
+
+    #[test]
+    fn smart_exclude_always_catches_known_minified(
+        stem in "[a-z][a-z0-9]{0,20}",
+        ext in prop::sample::select(vec!["js", "css"]),
+        prefix in prop::option::of("[a-z]+(/[a-z]+){0,2}")
+    ) {
+        let filename = format!("{}.min.{}", stem, ext);
+        let path = match prefix {
+            Some(p) => format!("{}/{}", p, filename),
+            None => filename,
+        };
+        let reason = smart_exclude_reason(&path);
+        prop_assert_eq!(reason, Some("minified"), "Expected minified for {}", path);
+    }
+
+    #[test]
+    fn assign_policy_never_returns_full_above_cap_with_skip_class(
+        tokens in 1usize..200_000,
+        cap in 0usize..200_000,
+        class in prop::sample::select(vec![
+            FileClassification::Generated,
+            FileClassification::DataBlob,
+            FileClassification::Vendored,
+        ]),
+    ) {
+        let (policy, _) = assign_policy(tokens, cap, &[class]);
+        if tokens > cap {
+            prop_assert_ne!(policy, InclusionPolicy::Full,
+                "tokens={}, cap={}: should not be Full", tokens, cap);
+        }
+    }
 }

--- a/crates/tokmd-model/tests/properties.rs
+++ b/crates/tokmd-model/tests/properties.rs
@@ -216,3 +216,152 @@ proptest! {
 
 // Note: fold_other_* property tests are in lib.rs where they can access
 // the private functions directly instead of reimplementing them.
+
+// ========================
+// Aggregation Invariants
+// ========================
+
+/// Generate an arbitrary `LangRow` with consistent avg_lines.
+fn arb_lang_row() -> impl Strategy<Value = tokmd_types::LangRow> {
+    (
+        "[A-Z][a-z]+",
+        0usize..10_000,
+        0usize..20_000,
+        0usize..500,
+        0usize..1_000_000,
+        0usize..250_000,
+    )
+        .prop_map(|(lang, code, lines, files, bytes, tokens)| {
+            let avg_lines = avg(lines, files);
+            tokmd_types::LangRow {
+                lang,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            }
+        })
+}
+
+/// Generate an arbitrary `ModuleRow` with consistent avg_lines.
+fn arb_module_row() -> impl Strategy<Value = tokmd_types::ModuleRow> {
+    (
+        "[a-z][a-z0-9_/]+",
+        0usize..10_000,
+        0usize..20_000,
+        0usize..500,
+        0usize..1_000_000,
+        0usize..250_000,
+    )
+        .prop_map(|(module, code, lines, files, bytes, tokens)| {
+            let avg_lines = avg(lines, files);
+            tokmd_types::ModuleRow {
+                module,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            }
+        })
+}
+
+proptest! {
+    // ── LangRow aggregation invariants ───────────────────────────────
+
+    #[test]
+    fn lang_row_sum_code_equals_total(rows in prop::collection::vec(arb_lang_row(), 0..20)) {
+        let sum_code: usize = rows.iter().map(|r| r.code).sum();
+        let sum_lines: usize = rows.iter().map(|r| r.lines).sum();
+        let sum_files: usize = rows.iter().map(|r| r.files).sum();
+        let sum_bytes: usize = rows.iter().map(|r| r.bytes).sum();
+        let sum_tokens: usize = rows.iter().map(|r| r.tokens).sum();
+
+        // The total should equal the sum of all row fields
+        prop_assert_eq!(sum_code, rows.iter().map(|r| r.code).sum::<usize>());
+        prop_assert_eq!(sum_lines, rows.iter().map(|r| r.lines).sum::<usize>());
+        prop_assert_eq!(sum_files, rows.iter().map(|r| r.files).sum::<usize>());
+        prop_assert_eq!(sum_bytes, rows.iter().map(|r| r.bytes).sum::<usize>());
+        prop_assert_eq!(sum_tokens, rows.iter().map(|r| r.tokens).sum::<usize>());
+    }
+
+    #[test]
+    fn lang_row_sorting_is_descending_by_code_then_name(
+        rows in prop::collection::vec(arb_lang_row(), 0..20)
+    ) {
+        let mut sorted = rows.clone();
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+
+        // Verify the sort order: descending by code, ascending by name
+        for window in sorted.windows(2) {
+            let (a, b) = (&window[0], &window[1]);
+            prop_assert!(
+                a.code > b.code || (a.code == b.code && a.lang <= b.lang),
+                "Sort violated: {:?} should come before {:?}", a, b
+            );
+        }
+    }
+
+    #[test]
+    fn lang_row_sorting_is_idempotent(rows in prop::collection::vec(arb_lang_row(), 0..20)) {
+        let mut once = rows.clone();
+        once.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+
+        let mut twice = once.clone();
+        twice.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+
+        prop_assert_eq!(once, twice, "Sorting should be idempotent");
+    }
+
+    #[test]
+    fn lang_row_sorting_preserves_count(rows in prop::collection::vec(arb_lang_row(), 0..20)) {
+        let mut sorted = rows.clone();
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+        prop_assert_eq!(sorted.len(), rows.len(), "Sorting should preserve row count");
+    }
+
+    // ── ModuleRow aggregation invariants ─────────────────────────────
+
+    #[test]
+    fn module_row_sum_code_equals_total(rows in prop::collection::vec(arb_module_row(), 0..20)) {
+        let sum_code: usize = rows.iter().map(|r| r.code).sum();
+        let sum_lines: usize = rows.iter().map(|r| r.lines).sum();
+        let sum_bytes: usize = rows.iter().map(|r| r.bytes).sum();
+        let sum_tokens: usize = rows.iter().map(|r| r.tokens).sum();
+
+        prop_assert_eq!(sum_code, rows.iter().map(|r| r.code).sum::<usize>());
+        prop_assert_eq!(sum_lines, rows.iter().map(|r| r.lines).sum::<usize>());
+        prop_assert_eq!(sum_bytes, rows.iter().map(|r| r.bytes).sum::<usize>());
+        prop_assert_eq!(sum_tokens, rows.iter().map(|r| r.tokens).sum::<usize>());
+    }
+
+    #[test]
+    fn module_row_sorting_is_descending_by_code_then_module(
+        rows in prop::collection::vec(arb_module_row(), 0..20)
+    ) {
+        let mut sorted = rows.clone();
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+
+        for window in sorted.windows(2) {
+            let (a, b) = (&window[0], &window[1]);
+            prop_assert!(
+                a.code > b.code || (a.code == b.code && a.module <= b.module),
+                "Sort violated: {:?} should come before {:?}", a, b
+            );
+        }
+    }
+
+    #[test]
+    fn module_row_sorting_is_idempotent(rows in prop::collection::vec(arb_module_row(), 0..20)) {
+        let mut once = rows.clone();
+        once.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+
+        let mut twice = once.clone();
+        twice.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+
+        prop_assert_eq!(once, twice, "Sorting should be idempotent");
+    }
+}

--- a/crates/tokmd-scan-args/tests/properties.rs
+++ b/crates/tokmd-scan-args/tests/properties.rs
@@ -250,4 +250,65 @@ proptest! {
         prop_assert_eq!(&args_none.excluded, &excluded);
         prop_assert_eq!(&args_opt_none.excluded, &excluded);
     }
+
+    // ── Redacted paths never contain original path segments ──────────
+
+    #[test]
+    fn scan_args_redacted_paths_do_not_contain_original_segments(
+        path_segments in prop::collection::vec("[a-z]{4,12}", 1..5),
+    ) {
+        let path_str = path_segments.join("/") + ".rs";
+        let paths = vec![PathBuf::from(&path_str)];
+        let scan_options = ScanOptions::default();
+
+        let args = scan_args(&paths, &scan_options, Some(RedactMode::Paths));
+        let redacted = &args.paths[0];
+
+        // Each original segment (≥4 chars) should not appear in the redacted output
+        for seg in &path_segments {
+            prop_assert!(
+                !redacted.contains(seg.as_str()),
+                "Redacted path '{}' still contains original segment '{}'",
+                redacted, seg
+            );
+        }
+    }
+
+    #[test]
+    fn scan_args_redacted_exclusions_do_not_contain_originals(
+        excluded_items in prop::collection::vec("[a-z]{4,12}", 1..5),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let scan_options = ScanOptions {
+            excluded: excluded_items.clone(),
+            ..Default::default()
+        };
+
+        let args = scan_args(&paths, &scan_options, Some(RedactMode::Paths));
+
+        for (original, redacted) in excluded_items.iter().zip(args.excluded.iter()) {
+            prop_assert!(
+                !redacted.contains(original.as_str()),
+                "Redacted exclusion '{}' still contains original '{}'",
+                redacted, original
+            );
+        }
+    }
+
+    #[test]
+    fn scan_args_all_output_paths_use_forward_slashes(
+        path_segments in prop::collection::vec("[a-zA-Z0-9_]+", 1..5),
+        redact in redact_mode_strategy(),
+    ) {
+        // Build a path using OS separator
+        let path_str = path_segments.join("\\");
+        let paths = vec![PathBuf::from(&path_str)];
+        let scan_options = ScanOptions::default();
+
+        let args = scan_args(&paths, &scan_options, redact);
+        for p in &args.paths {
+            prop_assert!(!p.contains('\\'),
+                "Output path '{}' contains backslash", p);
+        }
+    }
 }

--- a/crates/tokmd-sensor/tests/properties.rs
+++ b/crates/tokmd-sensor/tests/properties.rs
@@ -1,0 +1,197 @@
+//! Property-based tests for tokmd-sensor types and invariants.
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use tokmd_envelope::{SENSOR_REPORT_SCHEMA, SensorReport, ToolMeta, Verdict};
+use tokmd_substrate::{LangSummary, RepoSubstrate, SubstrateFile};
+
+/// Generate an arbitrary `SubstrateFile`.
+fn arb_substrate_file() -> impl Strategy<Value = SubstrateFile> {
+    (
+        "[a-z]+(/[a-z]+){0,3}\\.[a-z]{1,4}",
+        "[A-Z][a-z]+",
+        0usize..10_000,
+        0usize..20_000,
+        0usize..1_000_000,
+        0usize..250_000,
+        "[a-z]+(/[a-z]+){0,2}",
+        any::<bool>(),
+    )
+        .prop_map(
+            |(path, lang, code, lines, bytes, tokens, module, in_diff)| SubstrateFile {
+                path,
+                lang,
+                code,
+                lines,
+                bytes,
+                tokens,
+                module,
+                in_diff,
+            },
+        )
+}
+
+/// Build a `RepoSubstrate` from a vec of files with correct aggregates.
+fn substrate_from_files(files: Vec<SubstrateFile>) -> RepoSubstrate {
+    let mut lang_summary: BTreeMap<String, LangSummary> = BTreeMap::new();
+    let mut total_tokens = 0usize;
+    let mut total_bytes = 0usize;
+    let mut total_code_lines = 0usize;
+
+    for f in &files {
+        let entry = lang_summary.entry(f.lang.clone()).or_insert(LangSummary {
+            files: 0,
+            code: 0,
+            lines: 0,
+            bytes: 0,
+            tokens: 0,
+        });
+        entry.files += 1;
+        entry.code += f.code;
+        entry.lines += f.lines;
+        entry.bytes += f.bytes;
+        entry.tokens += f.tokens;
+
+        total_tokens += f.tokens;
+        total_bytes += f.bytes;
+        total_code_lines += f.code;
+    }
+
+    RepoSubstrate {
+        repo_root: ".".to_string(),
+        files,
+        lang_summary,
+        diff_range: None,
+        total_tokens,
+        total_bytes,
+        total_code_lines,
+    }
+}
+
+proptest! {
+    // ── SensorReport schema invariants ───────────────────────────────
+
+    #[test]
+    fn sensor_report_always_has_valid_schema(
+        name in "[a-z][a-z0-9_-]{0,20}",
+        version in "[0-9]+\\.[0-9]+\\.[0-9]+",
+        mode in "[a-z]+",
+        verdict in prop::sample::select(vec![
+            Verdict::Pass, Verdict::Fail, Verdict::Warn,
+            Verdict::Skip, Verdict::Pending,
+        ]),
+    ) {
+        let report = SensorReport::new(
+            ToolMeta::new(&name, &version, &mode),
+            "2024-01-01T00:00:00Z".to_string(),
+            verdict,
+            "test summary".to_string(),
+        );
+        prop_assert_eq!(&report.schema, SENSOR_REPORT_SCHEMA,
+            "Schema must be '{}'", SENSOR_REPORT_SCHEMA);
+    }
+
+    #[test]
+    fn sensor_report_tool_meta_preserves_inputs(
+        name in "[a-z][a-z0-9_-]{1,20}",
+        version in "[0-9]+\\.[0-9]+\\.[0-9]+",
+        mode in "[a-z]+",
+    ) {
+        let report = SensorReport::new(
+            ToolMeta::new(&name, &version, &mode),
+            "2024-01-01T00:00:00Z".to_string(),
+            Verdict::Pass,
+            "test".to_string(),
+        );
+        prop_assert_eq!(&report.tool.name, &name);
+        prop_assert_eq!(&report.tool.version, &version);
+        prop_assert_eq!(&report.tool.mode, &mode);
+        prop_assert!(!report.tool.name.is_empty(), "Sensor name must not be empty");
+        prop_assert!(!report.tool.version.is_empty(), "Version must not be empty");
+    }
+
+    #[test]
+    fn sensor_report_serde_roundtrip_preserves_schema(
+        name in "[a-z][a-z0-9_-]{1,20}",
+        version in "[0-9]+\\.[0-9]+\\.[0-9]+",
+    ) {
+        let report = SensorReport::new(
+            ToolMeta::new(&name, &version, "check"),
+            "2024-01-01T00:00:00Z".to_string(),
+            Verdict::Pass,
+            "roundtrip test".to_string(),
+        );
+        let json = serde_json::to_string(&report).unwrap();
+        let back: SensorReport = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(&back.schema, SENSOR_REPORT_SCHEMA);
+        prop_assert_eq!(&back.tool.name, &name);
+        prop_assert_eq!(&back.tool.version, &version);
+    }
+
+    // ── Substrate consistency invariants ──────────────────────────────
+
+    #[test]
+    fn substrate_totals_equal_sum_of_files(
+        files in prop::collection::vec(arb_substrate_file(), 0..30)
+    ) {
+        let substrate = substrate_from_files(files);
+
+        let sum_tokens: usize = substrate.files.iter().map(|f| f.tokens).sum();
+        let sum_bytes: usize = substrate.files.iter().map(|f| f.bytes).sum();
+        let sum_code: usize = substrate.files.iter().map(|f| f.code).sum();
+
+        prop_assert_eq!(substrate.total_tokens, sum_tokens,
+            "total_tokens mismatch");
+        prop_assert_eq!(substrate.total_bytes, sum_bytes,
+            "total_bytes mismatch");
+        prop_assert_eq!(substrate.total_code_lines, sum_code,
+            "total_code_lines mismatch");
+    }
+
+    #[test]
+    fn substrate_lang_summary_matches_file_aggregates(
+        files in prop::collection::vec(arb_substrate_file(), 0..30)
+    ) {
+        let substrate = substrate_from_files(files);
+
+        // Recompute lang summary from files
+        let mut expected: BTreeMap<String, (usize, usize, usize, usize, usize)> = BTreeMap::new();
+        for f in &substrate.files {
+            let e = expected.entry(f.lang.clone()).or_default();
+            e.0 += 1;      // files
+            e.1 += f.code;  // code
+            e.2 += f.lines; // lines
+            e.3 += f.bytes; // bytes
+            e.4 += f.tokens; // tokens
+        }
+
+        prop_assert_eq!(substrate.lang_summary.len(), expected.len(),
+            "Language count mismatch");
+
+        for (lang, summary) in &substrate.lang_summary {
+            let (files, code, lines, bytes, tokens) = expected.get(lang)
+                .expect("Language should exist");
+            prop_assert_eq!(summary.files, *files, "files mismatch for {}", lang);
+            prop_assert_eq!(summary.code, *code, "code mismatch for {}", lang);
+            prop_assert_eq!(summary.lines, *lines, "lines mismatch for {}", lang);
+            prop_assert_eq!(summary.bytes, *bytes, "bytes mismatch for {}", lang);
+            prop_assert_eq!(summary.tokens, *tokens, "tokens mismatch for {}", lang);
+        }
+    }
+
+    #[test]
+    fn substrate_serde_roundtrip_preserves_totals(
+        files in prop::collection::vec(arb_substrate_file(), 0..15)
+    ) {
+        let substrate = substrate_from_files(files);
+        let json = serde_json::to_string(&substrate).unwrap();
+        let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+
+        prop_assert_eq!(back.total_tokens, substrate.total_tokens);
+        prop_assert_eq!(back.total_bytes, substrate.total_bytes);
+        prop_assert_eq!(back.total_code_lines, substrate.total_code_lines);
+        prop_assert_eq!(back.files.len(), substrate.files.len());
+        prop_assert_eq!(back.lang_summary.len(), substrate.lang_summary.len());
+    }
+}


### PR DESCRIPTION
Add property-based tests verifying invariants for model, context-policy, scan-args, and sensor crates.