### PR TITLE
test: expand insta snapshot tests across key crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,7 @@ name = "tokmd-tokeignore"
 version = "1.7.2"
 dependencies = [
  "anyhow",
+ "insta",
  "proptest",
  "tempfile",
  "tokmd-config",

--- a/crates/tokmd-analysis-format/tests/snapshots.rs
+++ b/crates/tokmd-analysis-format/tests/snapshots.rs
@@ -1,0 +1,446 @@
+//! Insta snapshot tests for analysis format rendering.
+//!
+//! Pins the exact output of each text format so regressions are caught
+//! at review time. Uses the same fixture helpers as render_formats.rs.
+
+use tokmd_analysis_format::{RenderedOutput, render};
+use tokmd_analysis_types::*;
+use tokmd_types::{AnalysisFormat, ScanStatus, ToolInfo};
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirrors render_formats.rs)
+// ---------------------------------------------------------------------------
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: ToolInfo {
+            name: "tokmd".into(),
+            version: "0.0.0-test".into(),
+        },
+        mode: "analyze".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec![".".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "md".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_file_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 5,
+            code: 500,
+            comments: 80,
+            blanks: 40,
+            lines: 620,
+            bytes: 5000,
+            tokens: 1200,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 80,
+                denominator: 580,
+                ratio: 0.1379,
+            },
+            by_lang: vec![RatioRow {
+                key: "Rust".into(),
+                numerator: 70,
+                denominator: 470,
+                ratio: 0.1489,
+            }],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 40,
+                denominator: 620,
+                ratio: 0.0645,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 5000,
+                denominator: 620,
+                rate: 8.06,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: FileStatRow {
+                path: "src/main.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 200,
+                comments: 30,
+                blanks: 15,
+                lines: 245,
+                bytes: 2000,
+                tokens: 500,
+                doc_pct: Some(0.13),
+                bytes_per_line: Some(8.16),
+                depth: 1,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 4,
+            avg: 2.0,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 100,
+            prod_lines: 400,
+            test_files: 2,
+            prod_files: 3,
+            ratio: 0.25,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 50,
+            logic_lines: 570,
+            ratio: 0.0877,
+            infra_langs: vec!["TOML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 2,
+            entropy: 0.72,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 450,
+            dominant_pct: 0.9,
+        },
+        distribution: DistributionReport {
+            count: 5,
+            min: 25,
+            max: 245,
+            mean: 124.0,
+            median: 100.0,
+            p90: 245.0,
+            p99: 245.0,
+            gini: 0.32,
+        },
+        histogram: vec![
+            HistogramBucket {
+                label: "Small".into(),
+                min: 0,
+                max: Some(100),
+                files: 3,
+                pct: 0.6,
+            },
+            HistogramBucket {
+                label: "Medium".into(),
+                min: 101,
+                max: Some(500),
+                files: 2,
+                pct: 0.4,
+            },
+        ],
+        top: TopOffenders {
+            largest_lines: vec![FileStatRow {
+                path: "src/main.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 200,
+                comments: 30,
+                blanks: 15,
+                lines: 245,
+                bytes: 2000,
+                tokens: 500,
+                doc_pct: Some(0.13),
+                bytes_per_line: Some(8.16),
+                depth: 1,
+            }],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 31.0,
+            lines_per_minute: 20,
+            basis_lines: 620,
+        },
+        context_window: None,
+        cocomo: None,
+        todo: None,
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "a".repeat(64),
+            entries: 5,
+        },
+    }
+}
+
+fn text(output: RenderedOutput) -> String {
+    match output {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_md_minimal() {
+    let receipt = minimal_receipt();
+    let rendered = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("analysis_md_minimal", rendered);
+}
+
+#[test]
+fn snapshot_analysis_md_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let rendered = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("analysis_md_with_derived", rendered);
+}
+
+#[test]
+fn snapshot_analysis_md_full() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    receipt.archetype = Some(Archetype {
+        kind: "cli-tool".into(),
+        evidence: vec!["main.rs".into(), "Cargo.toml".into()],
+    });
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![
+            ImportEdge {
+                from: "src/a".into(),
+                to: "src/b".into(),
+                count: 3,
+            },
+            ImportEdge {
+                from: "src/b".into(),
+                to: "src/c".into(),
+                count: 1,
+            },
+        ],
+    });
+    receipt.entropy = Some(EntropyReport {
+        suspects: vec![EntropyFinding {
+            path: "secrets.bin".into(),
+            module: "data".into(),
+            entropy_bits_per_byte: 7.8,
+            sample_bytes: 1024,
+            class: EntropyClass::High,
+        }],
+    });
+    receipt.license = Some(LicenseReport {
+        effective: Some("MIT".into()),
+        findings: vec![LicenseFinding {
+            spdx: "MIT".into(),
+            confidence: 0.95,
+            source_path: "LICENSE".into(),
+            source_kind: LicenseSourceKind::Text,
+        }],
+    });
+    let rendered = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("analysis_md_full", rendered);
+}
+
+// ---------------------------------------------------------------------------
+// JSON snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_json_minimal() {
+    let receipt = minimal_receipt();
+    let rendered = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("analysis_json_minimal", rendered);
+}
+
+#[test]
+fn snapshot_analysis_json_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let rendered = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("analysis_json_with_derived", rendered);
+}
+
+// ---------------------------------------------------------------------------
+// JSON-LD snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_jsonld_minimal() {
+    let receipt = minimal_receipt();
+    let rendered = text(render(&receipt, AnalysisFormat::Jsonld).unwrap());
+    insta::assert_snapshot!("analysis_jsonld_minimal", rendered);
+}
+
+#[test]
+fn snapshot_analysis_jsonld_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let rendered = text(render(&receipt, AnalysisFormat::Jsonld).unwrap());
+    insta::assert_snapshot!("analysis_jsonld_with_derived", rendered);
+}
+
+// ---------------------------------------------------------------------------
+// XML snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_xml_minimal() {
+    let receipt = minimal_receipt();
+    let rendered = text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    insta::assert_snapshot!("analysis_xml_minimal", rendered);
+}
+
+#[test]
+fn snapshot_analysis_xml_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let rendered = text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    insta::assert_snapshot!("analysis_xml_with_derived", rendered);
+}
+
+// ---------------------------------------------------------------------------
+// SVG snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_svg_minimal() {
+    let receipt = minimal_receipt();
+    let rendered = text(render(&receipt, AnalysisFormat::Svg).unwrap());
+    insta::assert_snapshot!("analysis_svg_minimal", rendered);
+}
+
+#[test]
+fn snapshot_analysis_svg_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let rendered = text(render(&receipt, AnalysisFormat::Svg).unwrap());
+    insta::assert_snapshot!("analysis_svg_with_derived", rendered);
+}
+
+// ---------------------------------------------------------------------------
+// Mermaid snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_mermaid_no_imports() {
+    let receipt = minimal_receipt();
+    let rendered = text(render(&receipt, AnalysisFormat::Mermaid).unwrap());
+    insta::assert_snapshot!("analysis_mermaid_no_imports", rendered);
+}
+
+#[test]
+fn snapshot_analysis_mermaid_with_imports() {
+    let mut receipt = minimal_receipt();
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![
+            ImportEdge {
+                from: "mod-a".into(),
+                to: "mod-b".into(),
+                count: 5,
+            },
+            ImportEdge {
+                from: "mod-b".into(),
+                to: "mod-c".into(),
+                count: 2,
+            },
+        ],
+    });
+    let rendered = text(render(&receipt, AnalysisFormat::Mermaid).unwrap());
+    insta::assert_snapshot!("analysis_mermaid_with_imports", rendered);
+}
+
+// ---------------------------------------------------------------------------
+// Tree snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_tree_unavailable() {
+    let receipt = minimal_receipt();
+    let rendered = text(render(&receipt, AnalysisFormat::Tree).unwrap());
+    insta::assert_snapshot!("analysis_tree_unavailable", rendered);
+}
+
+#[test]
+fn snapshot_analysis_tree_with_data() {
+    let mut receipt = minimal_receipt();
+    let mut d = sample_derived();
+    d.tree = Some("root\n  src/\n    lib.rs (500 lines)\n    main.rs (245 lines)\n  tests/\n    smoke.rs (65 lines)".into());
+    receipt.derived = Some(d);
+    let rendered = text(render(&receipt, AnalysisFormat::Tree).unwrap());
+    insta::assert_snapshot!("analysis_tree_with_data", rendered);
+}
+
+// ---------------------------------------------------------------------------
+// HTML snapshot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analysis_html_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let rendered = text(render(&receipt, AnalysisFormat::Html).unwrap());
+    // Normalize the embedded timestamp so the snapshot is deterministic.
+    let rendered = regex_replace_timestamp(&rendered);
+    insta::assert_snapshot!("analysis_html_with_derived", rendered);
+}
+
+/// Replace the HTML timestamp line with a fixed value for determinism.
+fn regex_replace_timestamp(s: &str) -> String {
+    s.lines()
+        .map(|line| {
+            if line.contains("class=\"timestamp\"") && line.contains("Generated:") {
+                "        <div class=\"timestamp\">Generated: 1970-01-01 00:00:00 UTC</div>"
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_html_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_html_with_derived.snap
@@ -1,0 +1,401 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tokmd Analysis Report</title>
+    <style>
+        :root {
+            --bg-primary: #1a1a2e;
+            --bg-secondary: #16213e;
+            --bg-card: #0f3460;
+            --text-primary: #e6e6e6;
+            --text-secondary: #a0a0a0;
+            --accent: #4c9aff;
+            --accent-hover: #357abd;
+            --success: #4caf50;
+            --warning: #ff9800;
+            --danger: #f44336;
+            --border: #2a2a4a;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
+        header {
+            text-align: center;
+            padding: 40px 20px;
+            background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card));
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 30px;
+        }
+        header h1 { font-size: 2.5rem; margin-bottom: 10px; }
+        header .timestamp { color: var(--text-secondary); font-size: 0.9rem; }
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .metric-card {
+            background: var(--bg-card);
+            border-radius: 12px;
+            padding: 20px;
+            text-align: center;
+            border: 1px solid var(--border);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .metric-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 20px rgba(76, 154, 255, 0.2);
+        }
+        .metric-card .value {
+            font-size: 2rem;
+            font-weight: bold;
+            color: var(--accent);
+            display: block;
+        }
+        .metric-card .label {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .section {
+            background: var(--bg-secondary);
+            border-radius: 12px;
+            padding: 24px;
+            margin-bottom: 24px;
+            border: 1px solid var(--border);
+        }
+        .section h2 {
+            font-size: 1.3rem;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--accent);
+            display: inline-block;
+        }
+        #treemap {
+            width: 100%;
+            height: 400px;
+            background: var(--bg-primary);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        .treemap-cell {
+            position: absolute;
+            overflow: hidden;
+            border: 1px solid var(--bg-primary);
+            transition: opacity 0.2s;
+            cursor: pointer;
+        }
+        .treemap-cell:hover { opacity: 0.85; }
+        .treemap-label {
+            padding: 4px 6px;
+            font-size: 11px;
+            color: white;
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .search-box {
+            width: 100%;
+            padding: 12px 16px;
+            font-size: 1rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text-primary);
+            margin-bottom: 16px;
+        }
+        .search-box:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(76, 154, 255, 0.2);
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+        th, td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        th {
+            background: var(--bg-card);
+            color: var(--accent);
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+        }
+        th:hover { background: var(--accent); color: white; }
+        tr:hover { background: rgba(76, 154, 255, 0.1); }
+        .num { text-align: right; font-family: 'SF Mono', Monaco, monospace; }
+        .path { font-family: 'SF Mono', Monaco, monospace; font-size: 0.85rem; }
+        .lang-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+        .hidden { display: none; }
+        footer {
+            text-align: center;
+            padding: 30px;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+        }
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>tokmd Analysis Report</h1>
+        <div class="timestamp">Generated: 1970-01-01 00:00:00 UTC</div>
+    </header>
+
+    <div class="container">
+        <div class="metrics-grid">
+            <div class="metric-card"><span class="value">5</span><span class="label">Files</span></div><div class="metric-card"><span class="value">620</span><span class="label">Lines</span></div><div class="metric-card"><span class="value">500</span><span class="label">Code</span></div><div class="metric-card"><span class="value">1.2K</span><span class="label">Tokens</span></div><div class="metric-card"><span class="value">13.8%</span><span class="label">Doc%</span></div>
+        </div>
+
+        <div class="section">
+            <h2>Code Distribution</h2>
+            <div id="treemap"></div>
+        </div>
+
+        <div class="section">
+            <h2>Files</h2>
+            <input type="text" class="search-box" id="search" placeholder="Filter by path, module, or language...">
+            <table id="files-table">
+                <thead>
+                    <tr>
+                        <th data-sort="path">Path</th>
+                        <th data-sort="module">Module</th>
+                        <th data-sort="lang">Lang</th>
+                        <th data-sort="lines" class="num">Lines</th>
+                        <th data-sort="code" class="num">Code</th>
+                        <th data-sort="tokens" class="num">Tokens</th>
+                        <th data-sort="bytes" class="num">Bytes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td class="path" data-path="src/main.rs">src/main.rs</td><td data-module="src">src</td><td data-lang="Rust"><span class="lang-badge">Rust</span></td><td class="num" data-lines="245">245</td><td class="num" data-code="200">200</td><td class="num" data-tokens="500">500</td><td class="num" data-bytes="2000">2.0K</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <footer>
+        Generated by <a href="https://github.com/EffortlessMetrics/tokmd">tokmd</a>
+    </footer>
+
+    <script>
+    const REPORT_DATA = {"files":[{"code":200,"lang":"Rust","lines":245,"module":"src","path":"src/main.rs","tokens":500}]};
+
+    // Language colors
+    const LANG_COLORS = {
+        'Rust': '#dea584',
+        'JavaScript': '#f1e05a',
+        'TypeScript': '#3178c6',
+        'Python': '#3572A5',
+        'Go': '#00ADD8',
+        'Java': '#b07219',
+        'C': '#555555',
+        'C++': '#f34b7d',
+        'C#': '#178600',
+        'Ruby': '#701516',
+        'PHP': '#4F5D95',
+        'Swift': '#F05138',
+        'Kotlin': '#A97BFF',
+        'Scala': '#c22d40',
+        'HTML': '#e34c26',
+        'CSS': '#563d7c',
+        'SCSS': '#c6538c',
+        'JSON': '#292929',
+        'YAML': '#cb171e',
+        'TOML': '#9c4221',
+        'Markdown': '#083fa1',
+        'Shell': '#89e051',
+        'SQL': '#e38c00',
+    };
+
+    function getLangColor(lang) {
+        return LANG_COLORS[lang] || '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+    }
+
+    // Treemap implementation (squarify algorithm)
+    function squarify(data, x, y, width, height) {
+        if (data.length === 0 || width <= 0 || height <= 0) return [];
+
+        const total = data.reduce((sum, d) => sum + d.value, 0);
+        if (total === 0) return [];
+
+        const rects = [];
+        let remaining = [...data];
+        let cx = x, cy = y, cw = width, ch = height;
+
+        while (remaining.length > 0) {
+            const vertical = ch > cw;
+            const side = vertical ? ch : cw;
+            const scale = (cw * ch) / total;
+
+            let row = [];
+            let rowArea = 0;
+            let worst = Infinity;
+
+            for (const item of remaining) {
+                const testRow = [...row, item];
+                const testArea = rowArea + item.value * scale;
+                const testWorst = getWorst(testRow, testArea, side, scale);
+
+                if (testWorst <= worst) {
+                    row = testRow;
+                    rowArea = testArea;
+                    worst = testWorst;
+                } else {
+                    break;
+                }
+            }
+
+            // Layout row
+            const rowSide = rowArea / side;
+            let offset = 0;
+
+            for (const item of row) {
+                const itemSize = (item.value * scale) / rowSide;
+                if (vertical) {
+                    rects.push({ ...item, x: cx, y: cy + offset, w: rowSide, h: itemSize });
+                } else {
+                    rects.push({ ...item, x: cx + offset, y: cy, w: itemSize, h: rowSide });
+                }
+                offset += itemSize;
+            }
+
+            // Update remaining area
+            if (vertical) {
+                cx += rowSide;
+                cw -= rowSide;
+            } else {
+                cy += rowSide;
+                ch -= rowSide;
+            }
+
+            remaining = remaining.slice(row.length);
+        }
+
+        return rects;
+    }
+
+    function getWorst(row, area, side, scale) {
+        if (row.length === 0) return Infinity;
+        const s2 = side * side;
+        let min = Infinity, max = 0;
+        for (const item of row) {
+            const v = item.value * scale;
+            min = Math.min(min, v);
+            max = Math.max(max, v);
+        }
+        return Math.max((s2 * max) / (area * area), (area * area) / (s2 * min));
+    }
+
+    function renderTreemap() {
+        const container = document.getElementById('treemap');
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
+        container.innerHTML = '';
+        container.style.position = 'relative';
+
+        // Aggregate by module
+        const moduleData = {};
+        for (const file of REPORT_DATA.files || []) {
+            const mod = file.module || '(root)';
+            if (!moduleData[mod]) moduleData[mod] = { name: mod, value: 0, lang: file.lang };
+            moduleData[mod].value += file.code || file.lines || 1;
+        }
+
+        const data = Object.values(moduleData).sort((a, b) => b.value - a.value).slice(0, 50);
+        const rects = squarify(data, 0, 0, width, height);
+
+        for (const rect of rects) {
+            const div = document.createElement('div');
+            div.className = 'treemap-cell';
+            div.style.left = rect.x + 'px';
+            div.style.top = rect.y + 'px';
+            div.style.width = rect.w + 'px';
+            div.style.height = rect.h + 'px';
+            div.style.background = getLangColor(rect.lang);
+
+            const label = document.createElement('div');
+            label.className = 'treemap-label';
+            label.textContent = rect.name + ' (' + rect.value.toLocaleString() + ')';
+            div.appendChild(label);
+
+            div.title = rect.name + ': ' + rect.value.toLocaleString() + ' lines';
+            container.appendChild(div);
+        }
+    }
+
+    // Table filtering
+    document.getElementById('search').addEventListener('input', function(e) {
+        const filter = e.target.value.toLowerCase();
+        const rows = document.querySelectorAll('#files-table tbody tr');
+        rows.forEach(row => {
+            const text = row.textContent.toLowerCase();
+            row.classList.toggle('hidden', filter && !text.includes(filter));
+        });
+    });
+
+    // Table sorting
+    let sortCol = null, sortAsc = true;
+    document.querySelectorAll('#files-table th').forEach(th => {
+        th.addEventListener('click', function() {
+            const col = this.dataset.sort;
+            if (sortCol === col) sortAsc = !sortAsc;
+            else { sortCol = col; sortAsc = true; }
+
+            const tbody = document.querySelector('#files-table tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+
+            rows.sort((a, b) => {
+                const aVal = a.querySelector(`[data-${col}]`)?.dataset[col] || a.cells[getColIndex(col)].textContent;
+                const bVal = b.querySelector(`[data-${col}]`)?.dataset[col] || b.cells[getColIndex(col)].textContent;
+                const aNum = parseFloat(aVal.replace(/,/g, ''));
+                const bNum = parseFloat(bVal.replace(/,/g, ''));
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return sortAsc ? aNum - bNum : bNum - aNum;
+                }
+                return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+            });
+
+            rows.forEach(row => tbody.appendChild(row));
+        });
+    });
+
+    function getColIndex(col) {
+        const map = { path: 0, module: 1, lang: 2, lines: 3, code: 4, tokens: 5, bytes: 6 };
+        return map[col] || 0;
+    }
+
+    // Initialize
+    window.addEventListener('load', renderTreemap);
+    window.addEventListener('resize', renderTreemap);
+    </script>
+</body>
+</html>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_json_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_json_minimal.snap
@@ -1,0 +1,55 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "md",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": null,
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": null
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_json_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_json_with_derived.snap
@@ -1,0 +1,212 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "md",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": {
+    "totals": {
+      "files": 5,
+      "code": 500,
+      "comments": 80,
+      "blanks": 40,
+      "lines": 620,
+      "bytes": 5000,
+      "tokens": 1200
+    },
+    "doc_density": {
+      "total": {
+        "key": "total",
+        "numerator": 80,
+        "denominator": 580,
+        "ratio": 0.1379
+      },
+      "by_lang": [
+        {
+          "key": "Rust",
+          "numerator": 70,
+          "denominator": 470,
+          "ratio": 0.1489
+        }
+      ],
+      "by_module": []
+    },
+    "whitespace": {
+      "total": {
+        "key": "total",
+        "numerator": 40,
+        "denominator": 620,
+        "ratio": 0.0645
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "verbosity": {
+      "total": {
+        "key": "total",
+        "numerator": 5000,
+        "denominator": 620,
+        "rate": 8.06
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "max_file": {
+      "overall": {
+        "path": "src/main.rs",
+        "module": "src",
+        "lang": "Rust",
+        "code": 200,
+        "comments": 30,
+        "blanks": 15,
+        "lines": 245,
+        "bytes": 2000,
+        "tokens": 500,
+        "doc_pct": 0.13,
+        "bytes_per_line": 8.16,
+        "depth": 1
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "lang_purity": {
+      "rows": []
+    },
+    "nesting": {
+      "max": 4,
+      "avg": 2.0,
+      "by_module": []
+    },
+    "test_density": {
+      "test_lines": 100,
+      "prod_lines": 400,
+      "test_files": 2,
+      "prod_files": 3,
+      "ratio": 0.25
+    },
+    "boilerplate": {
+      "infra_lines": 50,
+      "logic_lines": 570,
+      "ratio": 0.0877,
+      "infra_langs": [
+        "TOML"
+      ]
+    },
+    "polyglot": {
+      "lang_count": 2,
+      "entropy": 0.72,
+      "dominant_lang": "Rust",
+      "dominant_lines": 450,
+      "dominant_pct": 0.9
+    },
+    "distribution": {
+      "count": 5,
+      "min": 25,
+      "max": 245,
+      "mean": 124.0,
+      "median": 100.0,
+      "p90": 245.0,
+      "p99": 245.0,
+      "gini": 0.32
+    },
+    "histogram": [
+      {
+        "label": "Small",
+        "min": 0,
+        "max": 100,
+        "files": 3,
+        "pct": 0.6
+      },
+      {
+        "label": "Medium",
+        "min": 101,
+        "max": 500,
+        "files": 2,
+        "pct": 0.4
+      }
+    ],
+    "top": {
+      "largest_lines": [
+        {
+          "path": "src/main.rs",
+          "module": "src",
+          "lang": "Rust",
+          "code": 200,
+          "comments": 30,
+          "blanks": 15,
+          "lines": 245,
+          "bytes": 2000,
+          "tokens": 500,
+          "doc_pct": 0.13,
+          "bytes_per_line": 8.16,
+          "depth": 1
+        }
+      ],
+      "largest_tokens": [],
+      "largest_bytes": [],
+      "least_documented": [],
+      "most_dense": []
+    },
+    "tree": null,
+    "reading_time": {
+      "minutes": 31.0,
+      "lines_per_minute": 20,
+      "basis_lines": 620
+    },
+    "context_window": null,
+    "cocomo": null,
+    "todo": null,
+    "integrity": {
+      "algo": "blake3",
+      "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "entries": 5
+    }
+  },
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": null
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_jsonld_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_jsonld_minimal.snap
@@ -1,0 +1,18 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "codeLines": 0,
+  "commentCount": 0,
+  "fileSize": 0,
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "http://schema.org/ReadAction",
+    "userInteractionCount": 0
+  },
+  "lineCount": 0,
+  "name": "."
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_jsonld_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_jsonld_with_derived.snap
@@ -1,0 +1,18 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "codeLines": 500,
+  "commentCount": 80,
+  "fileSize": 5000,
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "http://schema.org/ReadAction",
+    "userInteractionCount": 1200
+  },
+  "lineCount": 620,
+  "name": "."
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_md_full.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_md_full.snap
@@ -1,0 +1,143 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Archetype
+
+- Kind: `cli-tool`
+- Evidence: `main.rs`, `Cargo.toml`
+
+## Entropy profiling
+
+|Path|Module|Entropy|Sample bytes|Class|
+|---|---|---:|---:|---|
+|secrets.bin|data|7.80|1024|High|
+
+## License radar
+
+- Effective: `MIT`
+- Heuristic detection; not legal advice.
+
+|SPDX|Confidence|Source|Kind|
+|---|---:|---|---|
+|MIT|0.95|LICENSE|Text|
+
+## Totals
+
+|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|
+|---:|---:|---:|---:|---:|---:|---:|
+|5|500|80|40|620|5000|1200|
+
+## Ratios
+
+|Metric|Value|
+|---|---:|
+|Doc density|13.8%|
+|Whitespace ratio|6.5%|
+|Bytes per line|8.06|
+
+### Doc density by language
+
+|Lang|Doc%|Comments|Code|
+|---|---:|---:|---:|
+|Rust|14.9%|70|400|
+
+### Whitespace ratio by language
+
+|Lang|Blank%|Blanks|Code+Comments|
+|---|---:|---:|---:|
+
+### Verbosity by language
+
+|Lang|Bytes/Line|Bytes|Lines|
+|---|---:|---:|---:|
+
+## Distribution
+
+|Count|Min|Max|Mean|Median|P90|P99|Gini|
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|5|25|245|124.00|100.00|245.00|245.00|0.3200|
+
+## File size histogram
+
+|Bucket|Min|Max|Files|Pct|
+|---|---:|---:|---:|---:|
+|Small|0|100|3|60.0%|
+|Medium|101|500|2|40.0%|
+
+## Top offenders
+
+### Largest files by lines
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|src/main.rs|Rust|245|200|2000|500|13.0%|8.16|
+
+### Largest files by tokens
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Largest files by bytes
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Least documented (min LOC)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Most dense (bytes/line)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+## Structure
+
+- Max depth: `4`
+- Avg depth: `2.00`
+
+## Test density
+
+- Test lines: `100`
+- Prod lines: `400`
+- Test ratio: `25.0%`
+
+## Boilerplate ratio
+
+- Infra lines: `50`
+- Logic lines: `570`
+- Infra ratio: `8.8%`
+
+## Polyglot
+
+- Languages: `2`
+- Dominant: `Rust` (90.0%)
+- Entropy: `0.7200`
+
+## Reading time
+
+- Minutes: `31.00` (20 lines/min)
+
+## Integrity
+
+- Hash: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` (`blake3`)
+- Entries: `5`
+
+## Imports
+
+- Granularity: `module`
+
+|From|To|Count|
+|---|---|---:|
+|src/a|src/b|3|
+|src/b|src/c|1|

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_md_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_md_minimal.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_md_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_md_with_derived.snap
@@ -1,0 +1,114 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Totals
+
+|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|
+|---:|---:|---:|---:|---:|---:|---:|
+|5|500|80|40|620|5000|1200|
+
+## Ratios
+
+|Metric|Value|
+|---|---:|
+|Doc density|13.8%|
+|Whitespace ratio|6.5%|
+|Bytes per line|8.06|
+
+### Doc density by language
+
+|Lang|Doc%|Comments|Code|
+|---|---:|---:|---:|
+|Rust|14.9%|70|400|
+
+### Whitespace ratio by language
+
+|Lang|Blank%|Blanks|Code+Comments|
+|---|---:|---:|---:|
+
+### Verbosity by language
+
+|Lang|Bytes/Line|Bytes|Lines|
+|---|---:|---:|---:|
+
+## Distribution
+
+|Count|Min|Max|Mean|Median|P90|P99|Gini|
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|5|25|245|124.00|100.00|245.00|245.00|0.3200|
+
+## File size histogram
+
+|Bucket|Min|Max|Files|Pct|
+|---|---:|---:|---:|---:|
+|Small|0|100|3|60.0%|
+|Medium|101|500|2|40.0%|
+
+## Top offenders
+
+### Largest files by lines
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|src/main.rs|Rust|245|200|2000|500|13.0%|8.16|
+
+### Largest files by tokens
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Largest files by bytes
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Least documented (min LOC)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Most dense (bytes/line)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+## Structure
+
+- Max depth: `4`
+- Avg depth: `2.00`
+
+## Test density
+
+- Test lines: `100`
+- Prod lines: `400`
+- Test ratio: `25.0%`
+
+## Boilerplate ratio
+
+- Infra lines: `50`
+- Logic lines: `570`
+- Infra ratio: `8.8%`
+
+## Polyglot
+
+- Languages: `2`
+- Dominant: `Rust` (90.0%)
+- Entropy: `0.7200`
+
+## Reading time
+
+- Minutes: `31.00` (20 lines/min)
+
+## Integrity
+
+- Hash: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` (`blake3`)
+- Entries: `5`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_mermaid_no_imports.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_mermaid_no_imports.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+graph TD

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_mermaid_with_imports.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_mermaid_with_imports.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+graph TD
+  mod_a -->|5| mod_b
+  mod_b -->|2| mod_c

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_svg_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_svg_minimal.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="32" role="img"><rect width="80" height="32" fill="#555"/><rect x="80" width="160" height="32" fill="#4c9aff"/><text x="40" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">tokens</text><text x="160" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">0</text></svg>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_svg_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_svg_with_derived.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="32" role="img"><rect width="80" height="32" fill="#555"/><rect x="80" width="160" height="32" fill="#4c9aff"/><text x="40" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">tokens</text><text x="160" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">1200</text></svg>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_tree_unavailable.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_tree_unavailable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+(tree unavailable)

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_tree_with_data.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_tree_with_data.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+root
+  src/
+    lib.rs (500 lines)
+    main.rs (245 lines)
+  tests/
+    smoke.rs (65 lines)

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_xml_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_xml_minimal.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+<analysis></analysis>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_xml_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshots__analysis_xml_with_derived.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshots.rs
+expression: rendered
+---
+<analysis><totals files="5" code="500" comments="80" blanks="40" lines="620" bytes="5000" tokens="1200"/></analysis>

--- a/crates/tokmd-badge/tests/snapshots.rs
+++ b/crates/tokmd-badge/tests/snapshots.rs
@@ -50,6 +50,36 @@ fn snapshot_minimum_width_badge() {
     insta::assert_snapshot!("minimum_width_badge", svg);
 }
 
+#[test]
+fn snapshot_large_number_badge() {
+    let svg = badge_svg("total lines", "1,234,567");
+    insta::assert_snapshot!("large_number_badge", svg);
+}
+
+#[test]
+fn snapshot_emoji_badge() {
+    let svg = badge_svg("status", "✅ pass");
+    insta::assert_snapshot!("emoji_badge", svg);
+}
+
+#[test]
+fn snapshot_empty_value_badge() {
+    let svg = badge_svg("label", "");
+    insta::assert_snapshot!("empty_value_badge", svg);
+}
+
+#[test]
+fn snapshot_both_empty_badge() {
+    let svg = badge_svg("", "");
+    insta::assert_snapshot!("both_empty_badge", svg);
+}
+
+#[test]
+fn snapshot_numeric_label_badge() {
+    let svg = badge_svg("42", "100%");
+    insta::assert_snapshot!("numeric_label_badge", svg);
+}
+
 // ── Property: badge always produces valid SVG structure ──────────────
 
 mod properties {

--- a/crates/tokmd-badge/tests/snapshots/snapshots__both_empty_badge.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshots__both_empty_badge.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshots.rs
+expression: svg
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="60" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle"></text><text x="90" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle"></text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshots__emoji_badge.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshots__emoji_badge.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshots.rs
+expression: svg
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="124" height="24" role="img"><rect width="62" height="24" fill="#555"/><rect x="62" width="62" height="24" fill="#4c9aff"/><text x="31" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">status</text><text x="93" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">✅ pass</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshots__empty_value_badge.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshots__empty_value_badge.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshots.rs
+expression: svg
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="60" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">label</text><text x="90" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle"></text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshots__large_number_badge.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshots__large_number_badge.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshots.rs
+expression: svg
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="24" role="img"><rect width="97" height="24" fill="#555"/><rect x="97" width="83" height="24" fill="#4c9aff"/><text x="48" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">total lines</text><text x="138" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">1,234,567</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshots__numeric_label_badge.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshots__numeric_label_badge.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshots.rs
+expression: svg
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="60" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">42</text><text x="90" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">100%</text></svg>

--- a/crates/tokmd-format/tests/snapshots.rs
+++ b/crates/tokmd-format/tests/snapshots.rs
@@ -971,3 +971,144 @@ fn snapshot_export_jsonl_single_file() {
     let output = String::from_utf8(buf).unwrap();
     insta::assert_snapshot!("export_jsonl_single_file", output);
 }
+
+// ---------------------------------------------------------------------------
+// Export — JSONL with meta
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_export_jsonl_with_meta() {
+    let mut buf = Vec::new();
+    let args = ExportArgs {
+        paths: vec![PathBuf::from(".")],
+        format: ExportFormat::Jsonl,
+        output: None,
+        module_roots: vec!["src".into()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+        min_code: 0,
+        max_rows: 0,
+        redact: RedactMode::None,
+        meta: true,
+        strip_prefix: None,
+    };
+    write_export_jsonl_to(&mut buf, &export_data(), &global(), &args).unwrap();
+    let raw = String::from_utf8(buf).unwrap();
+    // Normalise non-deterministic meta fields
+    let normalised = raw
+        .lines()
+        .map(|line| {
+            if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(line) {
+                if v.get("generated_at_ms").is_some() {
+                    v["generated_at_ms"] = serde_json::json!(0);
+                }
+                if v.pointer("/tool/version").is_some() {
+                    v["tool"]["version"] = serde_json::json!("0.0.0");
+                }
+                serde_json::to_string(&v).unwrap()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    insta::assert_snapshot!("export_jsonl_with_meta", normalised);
+}
+
+// ---------------------------------------------------------------------------
+// Export — JSON with meta envelope
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_export_json_with_meta() {
+    let mut buf = Vec::new();
+    let args = ExportArgs {
+        paths: vec![PathBuf::from(".")],
+        format: ExportFormat::Json,
+        output: None,
+        module_roots: vec!["src".into()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+        min_code: 0,
+        max_rows: 0,
+        redact: RedactMode::None,
+        meta: true,
+        strip_prefix: None,
+    };
+    write_export_json_to(&mut buf, &export_data(), &global(), &args).unwrap();
+    let raw = String::from_utf8(buf).unwrap();
+    let mut v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    if v.get("generated_at_ms").is_some() {
+        v["generated_at_ms"] = serde_json::json!(0);
+    }
+    if v.pointer("/tool/version").is_some() {
+        v["tool"]["version"] = serde_json::json!("0.0.0");
+    }
+    let pretty = serde_json::to_string_pretty(&v).unwrap();
+    insta::assert_snapshot!("export_json_with_meta", pretty);
+}
+
+// ---------------------------------------------------------------------------
+// Module — single module row
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_module_md_single() {
+    let report = ModuleReport {
+        rows: vec![ModuleRow {
+            module: "src".into(),
+            code: 500,
+            lines: 600,
+            files: 5,
+            bytes: 25000,
+            tokens: 1250,
+            avg_lines: 120,
+        }],
+        total: Totals {
+            code: 500,
+            lines: 600,
+            files: 5,
+            bytes: 25000,
+            tokens: 1250,
+            avg_lines: 120,
+        },
+        module_roots: vec!["src".into()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+        top: 0,
+    };
+    let mut buf = Vec::new();
+    let args = ModuleArgs {
+        paths: vec![PathBuf::from(".")],
+        format: TableFormat::Md,
+        top: 0,
+        module_roots: vec!["src".into()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+    write_module_report_to(&mut buf, &report, &global(), &args).unwrap();
+    let output = String::from_utf8(buf).unwrap();
+    insta::assert_snapshot!("module_md_single", output);
+}
+
+// ---------------------------------------------------------------------------
+// Diff — color mode ANSI
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_diff_md_ansi_color() {
+    let (from, to) = diff_reports();
+    let rows = compute_diff_rows(&from, &to);
+    let totals = compute_diff_totals(&rows);
+    let md = render_diff_md_with_options(
+        "v1.0.0",
+        "v2.0.0",
+        &rows,
+        &totals,
+        DiffRenderOptions {
+            compact: false,
+            color: DiffColorMode::Ansi,
+        },
+    );
+    insta::assert_snapshot!("diff_md_ansi_color", md);
+}

--- a/crates/tokmd-format/tests/snapshots/snapshots__diff_md_ansi_color.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__diff_md_ansi_color.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+expression: md
+---
+## Diff: v1.0.0 → v2.0.0
+
+### Summary
+
+|Metric|From|To|Delta|Change|
+|---|---:|---:|---:|---:|
+|LOC|700|750|[32m+50[0m|[32m+7.1%[0m|
+|Lines|840|900|[32m+60[0m|[32m+7.1%[0m|
+|Files|8|10|[32m+2[0m|[32m+25.0%[0m|
+|Bytes|33000|37500|[32m+4500[0m|[32m+13.6%[0m|
+|Tokens|1750|1875|[32m+125[0m|[32m+7.1%[0m|
+
+### Language Movement
+
+|Type|Count|
+|---|---:|
+|Changed|3|
+|Added|1|
+|Removed|1|
+|Modified|1|
+
+### Language Breakdown
+
+|Language|Old LOC|New LOC|Delta|
+|---|---:|---:|---:|
+|Go|200|0|[31m-200[0m|
+|Python|0|150|[32m+150[0m|
+|Rust|500|600|[32m+100[0m|
+|**Total**|700|750|[32m+50[0m|

--- a/crates/tokmd-format/tests/snapshots/snapshots__export_json_with_meta.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__export_json_with_meta.snap
@@ -1,0 +1,85 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+expression: pretty
+---
+{
+  "args": {
+    "children": "separate",
+    "format": "json",
+    "max_rows": 0,
+    "min_code": 0,
+    "module_depth": 1,
+    "module_roots": [
+      "src",
+      "tests"
+    ],
+    "redact": "none",
+    "strip_prefix": null
+  },
+  "children": "separate",
+  "generated_at_ms": 0,
+  "mode": "export",
+  "module_depth": 1,
+  "module_roots": [
+    "src",
+    "tests"
+  ],
+  "rows": [
+    {
+      "blanks": 10,
+      "bytes": 1000,
+      "code": 100,
+      "comments": 20,
+      "kind": "parent",
+      "lang": "Rust",
+      "lines": 130,
+      "module": "src",
+      "path": "src/lib.rs",
+      "tokens": 250
+    },
+    {
+      "blanks": 5,
+      "bytes": 600,
+      "code": 60,
+      "comments": 5,
+      "kind": "parent",
+      "lang": "Rust",
+      "lines": 70,
+      "module": "src",
+      "path": "src/util.rs",
+      "tokens": 150
+    },
+    {
+      "blanks": 3,
+      "bytes": 400,
+      "code": 40,
+      "comments": 2,
+      "kind": "parent",
+      "lang": "Rust",
+      "lines": 45,
+      "module": "tests",
+      "path": "tests/smoke.rs",
+      "tokens": 100
+    }
+  ],
+  "scan": {
+    "config": "auto",
+    "excluded": [],
+    "hidden": false,
+    "no_ignore": false,
+    "no_ignore_dot": false,
+    "no_ignore_parent": false,
+    "no_ignore_vcs": false,
+    "paths": [
+      "."
+    ],
+    "treat_doc_strings_as_comments": false
+  },
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0"
+  },
+  "warnings": []
+}

--- a/crates/tokmd-format/tests/snapshots/snapshots__export_jsonl_with_meta.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__export_jsonl_with_meta.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+expression: normalised
+---
+{"args":{"children":"separate","format":"jsonl","max_rows":0,"min_code":0,"module_depth":1,"module_roots":["src","tests"],"redact":"none","strip_prefix":null},"generated_at_ms":0,"mode":"export","scan":{"config":"auto","excluded":[],"hidden":false,"no_ignore":false,"no_ignore_dot":false,"no_ignore_parent":false,"no_ignore_vcs":false,"paths":["."],"treat_doc_strings_as_comments":false},"schema_version":2,"status":"complete","tool":{"name":"tokmd","version":"0.0.0"},"type":"meta","warnings":[]}
+{"blanks":10,"bytes":1000,"code":100,"comments":20,"kind":"parent","lang":"Rust","lines":130,"module":"src","path":"src/lib.rs","tokens":250,"type":"row"}
+{"blanks":5,"bytes":600,"code":60,"comments":5,"kind":"parent","lang":"Rust","lines":70,"module":"src","path":"src/util.rs","tokens":150,"type":"row"}
+{"blanks":3,"bytes":400,"code":40,"comments":2,"kind":"parent","lang":"Rust","lines":45,"module":"tests","path":"tests/smoke.rs","tokens":100,"type":"row"}

--- a/crates/tokmd-format/tests/snapshots/snapshots__module_md_single.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshots__module_md_single.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshots.rs
+expression: output
+---
+|Module|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|src|500|600|5|25000|1250|120|
+|**Total**|500|600|5|25000|1250|120|

--- a/crates/tokmd-tokeignore/Cargo.toml
+++ b/crates/tokmd-tokeignore/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.101"
 tokmd-config.workspace = true
 
 [dev-dependencies]
+insta = { workspace = true }
 proptest = "1.10.0"
 tempfile = "3.25.0"
 

--- a/crates/tokmd-tokeignore/tests/snapshots.rs
+++ b/crates/tokmd-tokeignore/tests/snapshots.rs
@@ -1,0 +1,63 @@
+//! Insta snapshot tests for tokmd-tokeignore template generation.
+//!
+//! Pins the exact content of each profile template so regressions
+//! in ignore patterns are caught at review time.
+
+use tempfile::TempDir;
+use tokmd_config::{InitArgs, InitProfile};
+use tokmd_tokeignore::init_tokeignore;
+
+fn generate_template(profile: InitProfile) -> String {
+    let temp = TempDir::new().unwrap();
+    let args = InitArgs {
+        dir: temp.path().to_path_buf(),
+        template: profile,
+        force: false,
+        print: false,
+        non_interactive: true,
+    };
+    init_tokeignore(&args).unwrap();
+    std::fs::read_to_string(temp.path().join(".tokeignore")).unwrap()
+}
+
+#[test]
+fn snapshot_template_default() {
+    let content = generate_template(InitProfile::Default);
+    insta::assert_snapshot!("template_default", content);
+}
+
+#[test]
+fn snapshot_template_rust() {
+    let content = generate_template(InitProfile::Rust);
+    insta::assert_snapshot!("template_rust", content);
+}
+
+#[test]
+fn snapshot_template_node() {
+    let content = generate_template(InitProfile::Node);
+    insta::assert_snapshot!("template_node", content);
+}
+
+#[test]
+fn snapshot_template_mono() {
+    let content = generate_template(InitProfile::Mono);
+    insta::assert_snapshot!("template_mono", content);
+}
+
+#[test]
+fn snapshot_template_python() {
+    let content = generate_template(InitProfile::Python);
+    insta::assert_snapshot!("template_python", content);
+}
+
+#[test]
+fn snapshot_template_go() {
+    let content = generate_template(InitProfile::Go);
+    insta::assert_snapshot!("template_go", content);
+}
+
+#[test]
+fn snapshot_template_cpp() {
+    let content = generate_template(InitProfile::Cpp);
+    insta::assert_snapshot!("template_cpp", content);
+}

--- a/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_cpp.snap
+++ b/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_cpp.snap
@@ -1,0 +1,17 @@
+---
+source: crates/tokmd-tokeignore/tests/snapshots.rs
+expression: content
+---
+# .tokeignore (C++)
+build/
+**/build/
+cmake-build-*/
+**/cmake-build-*/
+out/
+**/out/
+.cache/
+**/.cache/
+
+# tokmd outputs
+.runs/
+**/.runs/

--- a/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_default.snap
+++ b/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_default.snap
@@ -1,0 +1,61 @@
+---
+source: crates/tokmd-tokeignore/tests/snapshots.rs
+expression: content
+---
+# .tokeignore
+# Patterns here use gitignore syntax.
+#
+# Goal: keep LOC summaries focused on *your* code, not build artifacts or vendored blobs.
+# Tune aggressively for your repos.
+
+# --- Rust / Cargo ---
+target/
+**/target/
+
+# --- Node / JS tooling ---
+node_modules/
+**/node_modules/
+dist/
+out/
+build/
+**/build/
+
+# --- Python ---
+__pycache__/
+**/__pycache__/
+.venv/
+**/.venv/
+venv/
+**/venv/
+.tox/
+**/.tox/
+
+# --- Common vendored / third-party dirs ---
+vendor/
+**/vendor/
+third_party/
+**/third_party/
+external/
+**/external/
+
+# --- Generated code ---
+generated/
+**/generated/
+*.generated.*
+*.gen.*
+
+# --- Coverage / reports ---
+coverage/
+**/coverage/
+.coverage
+lcov.info
+
+# --- tokmd outputs ---
+.runs/
+**/.runs/
+
+# --- Tree-sitter (common "big files" when vendored) ---
+# Adjust to match your vendor layout.
+**/tree-sitter*/src/parser.c
+**/tree-sitter*/src/scanner.c
+**/tree-sitter*/src/*_scanner.c

--- a/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_go.snap
+++ b/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_go.snap
@@ -1,0 +1,13 @@
+---
+source: crates/tokmd-tokeignore/tests/snapshots.rs
+expression: content
+---
+# .tokeignore (Go)
+vendor/
+**/vendor/
+bin/
+**/bin/
+
+# tokmd outputs
+.runs/
+**/.runs/

--- a/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_mono.snap
+++ b/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_mono.snap
@@ -1,0 +1,59 @@
+---
+source: crates/tokmd-tokeignore/tests/snapshots.rs
+expression: content
+---
+# .tokeignore (Monorepo)
+# A conservative monorepo template. Tune to your reality.
+
+# Rust
+target/
+**/target/
+
+# Node
+node_modules/
+**/node_modules/
+dist/
+**/dist/
+out/
+**/out/
+build/
+**/build/
+
+# Python
+__pycache__/
+**/__pycache__/
+.venv/
+**/.venv/
+venv/
+**/venv/
+.tox/
+**/.tox/
+
+# Common vendored / third-party
+vendor/
+**/vendor/
+third_party/
+**/third_party/
+external/
+**/external/
+
+# Generated code
+generated/
+**/generated/
+*.generated.*
+*.gen.*
+
+# Coverage / reports
+coverage/
+**/coverage/
+.coverage
+lcov.info
+
+# tokmd outputs
+.runs/
+**/.runs/
+
+# Tree-sitter vendoring (common big files)
+**/tree-sitter*/src/parser.c
+**/tree-sitter*/src/scanner.c
+**/tree-sitter*/src/*_scanner.c

--- a/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_node.snap
+++ b/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_node.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tokmd-tokeignore/tests/snapshots.rs
+expression: content
+---
+# .tokeignore (Node)
+node_modules/
+**/node_modules/
+dist/
+**/dist/
+out/
+**/out/
+build/
+**/build/
+coverage/
+**/coverage/
+
+# tokmd outputs
+.runs/
+**/.runs/

--- a/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_python.snap
+++ b/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_python.snap
@@ -1,0 +1,23 @@
+---
+source: crates/tokmd-tokeignore/tests/snapshots.rs
+expression: content
+---
+# .tokeignore (Python)
+__pycache__/
+**/__pycache__/
+*.pyc
+.venv/
+**/.venv/
+venv/
+**/venv/
+.tox/
+**/.tox/
+.pytest_cache/
+**/.pytest_cache/
+htmlcov/
+**/htmlcov/
+.coverage
+
+# tokmd outputs
+.runs/
+**/.runs/

--- a/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_rust.snap
+++ b/crates/tokmd-tokeignore/tests/snapshots/snapshots__template_rust.snap
@@ -1,0 +1,19 @@
+---
+source: crates/tokmd-tokeignore/tests/snapshots.rs
+expression: content
+---
+# .tokeignore (Rust)
+# Focus: ignore build outputs and generated artifacts.
+
+target/
+**/target/
+
+**/*.rs.bk
+
+# Coverage
+coverage/
+**/coverage/
+
+# tokmd outputs
+.runs/
+**/.runs/


### PR DESCRIPTION
## Summary

Add 32 new insta snapshot tests across four crates for comprehensive regression coverage.

### Changes by crate

| Crate | New Snapshots | Coverage |
|-------|--------------|----------|
| **tokmd-tokeignore** | 7 | All template profiles (Default, Rust, Node, Mono, Python, Go, Cpp) |
| **tokmd-analysis-format** | 16 | MD, JSON, JSON-LD, XML, SVG, Mermaid, Tree, HTML — minimal and with-derived variants |
| **tokmd-badge** | 5 | Edge cases: large numbers, emoji, empty values, numeric labels |
| **tokmd-format** | 4 | JSONL/JSON with meta envelope, single-module MD, ANSI-color diff |

### Details

- Added \insta\ dev-dependency to \	okmd-tokeignore\ (was missing)
- All new tests use deterministic fixtures (\generated_at_ms: 0\, fixed version strings)
- HTML analysis test normalizes the embedded timestamp for reproducibility
- All existing tests continue to pass (0 regressions)
