### PR TITLE
docs: update NOW.md to reflect current state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ This document outlines the evolution of `tokmd` and the path forward.
 | **v1.6.3** | ✅ Complete | UX polish: colored diff, progress indicators, --explain flag.    |
 | **v1.7.0** | ✅ Complete | Near-duplicate detection, commit intent, token estimation renames. |
 | **v1.7.1** | ✅ Complete | Focused microcrate extraction (40+ crates), AnalysisFormat to Tier 0. |
+| **v1.7.2** | ✅ Complete | Near-dup enricher extraction, commit intent classification, CI fixes. |
 | **v1.8.0** | 🔭 Planned  | WASM-ready core: host ports + in-memory scan + WASM CI builds |
 | **v1.9.0** | 🔭 Planned  | WASM distribution + browser runner: zipball ingestion + receipts in-browser |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
@@ -401,7 +402,7 @@ UX work is explicitly **incremental and non-breaking**:
 - [x] Moved `AnalysisFormat` to `tokmd-types` (Tier 0) for broader reuse
 - [x] Extracted 15 focused microcrates from monolithic modules
 - [x] Analysis schema version: 7 → 8
-- [x] Total crate count: 40+ (up from 16 initial crates in v1.2.0)
+- [x] Total crate count: 56 (up from 16 initial crates in v1.2.0)
 - [x] Fixed clippy/lint across all new crates for strict `--all-targets` check coverage
 - [x] Updated CI/tooling for release and publish readiness
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,0 +1,53 @@
+# NOW.md — Current State of tokmd
+
+> Last updated: 2026-02-25
+
+## Where We Are
+
+v1.7.2 shipped. 56 crates in the workspace. ~4,350 `#[test]` annotations,
+218 `proptest!` blocks, 16 fuzz targets, mutation testing on CI.
+
+---
+
+## NOW — actively in-flight
+
+- **Massive test coverage expansion.** BDD scenarios, property tests,
+  snapshot tests, integration tests, E2E tests, fuzz targets, and mutation
+  testing being added across all crates. Most analysis-* crates now have
+  dedicated `tests/bdd.rs`, `tests/properties.rs`, and snapshot suites.
+- **CI stabilization and PR merge wave.** Multiple test-addition branches
+  open and landing. Green-lining the matrix before moving to new features.
+- **Schema/doc synchronization hardening.** CLAUDE.md, AGENTS.md, GEMINI.md,
+  ROADMAP.md, and docs/ kept in sync with actual crate topology (56 crates).
+- **Analysis crate test coverage.** Each `tokmd-analysis-*` microcrate
+  getting BDD, property, and snapshot tests. Enricher contract verification.
+
+---
+
+## NEXT — after current wave lands
+
+- **v1.8 "WASM-ready core" preparation.** Host IO abstraction (ports),
+  in-memory scan path (`Vec<(path, bytes)>`), clap-free library hardening,
+  `wasm32-unknown-unknown` CI build target.
+- **PackPlan unification.** Converge `context` and `handoff` file-selection
+  logic into a shared plan/policy layer.
+- **Cockpit accuracy improvements.** Diff coverage precision, determinism
+  gate robustness, baseline comparison fidelity.
+- **Feature-gated enricher cleanup.** Ensure `halstead`, `content`, `git`,
+  `walk` feature flags compile cleanly in isolation.
+- **Bindings fidelity.** Python and Node.js parity — all workflows
+  (`lang`, `module`, `export`, `analyze`, `diff`) returning identical
+  receipts to CLI.
+
+---
+
+## LATER — roadmap horizon
+
+- **v1.9 "Browser runner."** WASM API crate (`tokmd-wasm`), zipball
+  ingestion, in-browser receipt generation without server-side compute.
+- **Adze integration track.** AST seams for tree-sitter/Adze-based
+  complexity and function extraction (v3.0+/v4.0 horizon).
+- **Advanced analysis enrichers.** API surface coverage, architecture
+  graph visualization, semantic diff intelligence.
+- **crates.io publication readiness.** Publishability audit for all 56
+  crates, dependency ordering, `cargo xtask publish` dry-run clean.


### PR DESCRIPTION
Updates NOW/NEXT/LATER to reflect the massive test coverage expansion and current priorities.

**Changes:**
- New `docs/NOW.md` with NOW/NEXT/LATER structure
- ROADMAP.md: add v1.7.2 to status table, update crate count to 56

**NOW:** BDD, property, snapshot, integration, E2E, fuzz, mutation test buildout across all crates
**NEXT:** v1.8 WASM-ready core, PackPlan unification, cockpit accuracy, bindings fidelity
**LATER:** Browser runner, Adze AST integration, crates.io publication readiness