### PR TITLE
test(tier4): expand facade crate tests for config, core, and gate

### DIFF
--- a/crates/tokmd-config/tests/edge_cases.rs
+++ b/crates/tokmd-config/tests/edge_cases.rs
@@ -1,0 +1,659 @@
+//! Edge-case and coverage-gap tests for tokmd-config.
+//!
+//! Focuses on areas not covered by existing test files:
+//! - CLI parsing for newer subcommands (Handoff, Sensor, Baseline, Gate, Cockpit)
+//! - Serde roundtrip for newer enums added after properties.rs
+//! - TomlConfig with gate allow_missing fields
+//! - ViewProfile with full field coverage
+
+use tokmd_config::{
+    AnalysisPreset, Cli, CockpitFormat, ColorMode, ContextOutput, ContextStrategy, DiffFormat,
+    DiffRangeMode, GateFormat, HandoffPreset, NearDupScope, SensorFormat, TomlConfig, ValueMetric,
+    ViewProfile,
+};
+
+// =========================================================================
+// Scenario: Serde roundtrip for newer enums not covered in properties.rs
+// =========================================================================
+
+mod newer_enum_roundtrips {
+    use super::*;
+
+    #[test]
+    fn context_strategy_roundtrip() {
+        for variant in [ContextStrategy::Greedy, ContextStrategy::Spread] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: ContextStrategy = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "ContextStrategy roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn value_metric_roundtrip() {
+        for variant in [
+            ValueMetric::Code,
+            ValueMetric::Tokens,
+            ValueMetric::Churn,
+            ValueMetric::Hotspot,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: ValueMetric = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "ValueMetric roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn context_output_roundtrip() {
+        for variant in [
+            ContextOutput::List,
+            ContextOutput::Bundle,
+            ContextOutput::Json,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: ContextOutput = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "ContextOutput roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn gate_format_roundtrip() {
+        for variant in [GateFormat::Text, GateFormat::Json] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: GateFormat = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "GateFormat roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn cockpit_format_roundtrip() {
+        for variant in [
+            CockpitFormat::Json,
+            CockpitFormat::Md,
+            CockpitFormat::Sections,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: CockpitFormat = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "CockpitFormat roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn handoff_preset_roundtrip() {
+        for variant in [
+            HandoffPreset::Minimal,
+            HandoffPreset::Standard,
+            HandoffPreset::Risk,
+            HandoffPreset::Deep,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: HandoffPreset = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "HandoffPreset roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn sensor_format_roundtrip() {
+        for variant in [SensorFormat::Json, SensorFormat::Md] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: SensorFormat = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "SensorFormat roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn near_dup_scope_roundtrip() {
+        for variant in [
+            NearDupScope::Module,
+            NearDupScope::Lang,
+            NearDupScope::Global,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: NearDupScope = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "NearDupScope roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn diff_range_mode_roundtrip() {
+        for variant in [DiffRangeMode::TwoDot, DiffRangeMode::ThreeDot] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: DiffRangeMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "DiffRangeMode roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn diff_format_roundtrip() {
+        for variant in [DiffFormat::Md, DiffFormat::Json] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: DiffFormat = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "DiffFormat roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn color_mode_roundtrip() {
+        for variant in [ColorMode::Auto, ColorMode::Always, ColorMode::Never] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: ColorMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, variant,
+                "ColorMode roundtrip failed for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn newer_enums_use_kebab_case() {
+        // All newer enums must serialize to kebab-case (no underscores, no uppercase)
+        let cases: Vec<String> = vec![
+            serde_json::to_string(&ContextStrategy::Greedy).unwrap(),
+            serde_json::to_string(&ValueMetric::Hotspot).unwrap(),
+            serde_json::to_string(&ContextOutput::List).unwrap(),
+            serde_json::to_string(&GateFormat::Text).unwrap(),
+            serde_json::to_string(&CockpitFormat::Sections).unwrap(),
+            serde_json::to_string(&HandoffPreset::Minimal).unwrap(),
+            serde_json::to_string(&SensorFormat::Json).unwrap(),
+            serde_json::to_string(&NearDupScope::Global).unwrap(),
+            serde_json::to_string(&DiffRangeMode::TwoDot).unwrap(),
+            serde_json::to_string(&DiffFormat::Md).unwrap(),
+            serde_json::to_string(&ColorMode::Always).unwrap(),
+        ];
+
+        for json in &cases {
+            let inner = json.trim_matches('"');
+            assert!(
+                !inner.contains('_') || inner.contains('-'),
+                "Expected kebab-case (no bare underscores), got: {}",
+                inner
+            );
+            assert!(
+                !inner.chars().any(|c| c.is_uppercase()),
+                "Expected lowercase, got: {}",
+                inner
+            );
+        }
+    }
+}
+
+// =========================================================================
+// Scenario: CLI parsing for newer subcommands via try_parse_from
+// =========================================================================
+
+mod cli_parsing {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn handoff_subcommand_parses_with_defaults() {
+        let cli = Cli::try_parse_from(["tokmd", "handoff"]).unwrap();
+        let cmd = cli.command.expect("should have subcommand");
+        match cmd {
+            tokmd_config::Commands::Handoff(args) => {
+                assert_eq!(args.budget, "128k");
+                assert!(!args.force);
+                assert!(!args.compress);
+                assert!(!args.no_smart_exclude);
+                assert!(!args.no_git);
+            }
+            other => panic!("Expected Handoff, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn handoff_subcommand_with_custom_flags() {
+        let cli = Cli::try_parse_from([
+            "tokmd",
+            "handoff",
+            "--budget",
+            "256k",
+            "--preset",
+            "deep",
+            "--force",
+            "--compress",
+            "--no-smart-exclude",
+            "--no-git",
+        ])
+        .unwrap();
+
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Handoff(args) => {
+                assert_eq!(args.budget, "256k");
+                assert_eq!(args.preset, HandoffPreset::Deep);
+                assert!(args.force);
+                assert!(args.compress);
+                assert!(args.no_smart_exclude);
+                assert!(args.no_git);
+            }
+            other => panic!("Expected Handoff, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sensor_subcommand_parses_with_defaults() {
+        let cli = Cli::try_parse_from(["tokmd", "sensor"]).unwrap();
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Sensor(args) => {
+                assert_eq!(args.base, "main");
+                assert_eq!(args.head, "HEAD");
+                assert_eq!(args.format, SensorFormat::Json);
+            }
+            other => panic!("Expected Sensor, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sensor_subcommand_with_custom_refs() {
+        let cli = Cli::try_parse_from([
+            "tokmd",
+            "sensor",
+            "--base",
+            "v1.0",
+            "--head",
+            "feature-branch",
+            "--format",
+            "md",
+        ])
+        .unwrap();
+
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Sensor(args) => {
+                assert_eq!(args.base, "v1.0");
+                assert_eq!(args.head, "feature-branch");
+                assert_eq!(args.format, SensorFormat::Md);
+            }
+            other => panic!("Expected Sensor, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn baseline_subcommand_parses_with_defaults() {
+        let cli = Cli::try_parse_from(["tokmd", "baseline"]).unwrap();
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Baseline(args) => {
+                assert_eq!(args.path.to_str().unwrap(), ".");
+                assert_eq!(args.output.to_str().unwrap(), ".tokmd/baseline.json");
+                assert!(!args.determinism);
+                assert!(!args.force);
+            }
+            other => panic!("Expected Baseline, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn gate_subcommand_parses_with_defaults() {
+        let cli = Cli::try_parse_from(["tokmd", "gate"]).unwrap();
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Gate(args) => {
+                assert!(args.input.is_none());
+                assert!(args.policy.is_none());
+                assert!(args.baseline.is_none());
+                assert!(args.ratchet_config.is_none());
+                assert!(args.preset.is_none());
+                assert_eq!(args.format, GateFormat::Text);
+                assert!(!args.fail_fast);
+            }
+            other => panic!("Expected Gate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn gate_subcommand_with_all_options() {
+        let cli = Cli::try_parse_from([
+            "tokmd",
+            "gate",
+            "receipt.json",
+            "--policy",
+            "policy.toml",
+            "--baseline",
+            "baseline.json",
+            "--ratchet-config",
+            "ratchet.toml",
+            "--preset",
+            "health",
+            "--format",
+            "json",
+            "--fail-fast",
+        ])
+        .unwrap();
+
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Gate(args) => {
+                assert_eq!(args.input.unwrap().to_str().unwrap(), "receipt.json");
+                assert_eq!(args.policy.unwrap().to_str().unwrap(), "policy.toml");
+                assert_eq!(args.baseline.unwrap().to_str().unwrap(), "baseline.json");
+                assert_eq!(
+                    args.ratchet_config.unwrap().to_str().unwrap(),
+                    "ratchet.toml"
+                );
+                assert_eq!(args.preset, Some(AnalysisPreset::Health));
+                assert_eq!(args.format, GateFormat::Json);
+                assert!(args.fail_fast);
+            }
+            other => panic!("Expected Gate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cockpit_subcommand_with_sensor_mode() {
+        let cli = Cli::try_parse_from([
+            "tokmd",
+            "cockpit",
+            "--base",
+            "v2.0",
+            "--head",
+            "feature",
+            "--diff-range",
+            "three-dot",
+            "--sensor-mode",
+        ])
+        .unwrap();
+
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Cockpit(args) => {
+                assert_eq!(args.base, "v2.0");
+                assert_eq!(args.head, "feature");
+                assert_eq!(args.diff_range, DiffRangeMode::ThreeDot);
+                assert!(args.sensor_mode);
+            }
+            other => panic!("Expected Cockpit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn context_subcommand_with_advanced_options() {
+        let cli = Cli::try_parse_from([
+            "tokmd",
+            "context",
+            "--budget",
+            "1m",
+            "--strategy",
+            "spread",
+            "--rank-by",
+            "churn",
+            "--mode",
+            "bundle",
+            "--compress",
+            "--no-smart-exclude",
+            "--max-file-pct",
+            "0.25",
+            "--require-git-scores",
+        ])
+        .unwrap();
+
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Context(args) => {
+                assert_eq!(args.budget, "1m");
+                assert_eq!(args.strategy, ContextStrategy::Spread);
+                assert_eq!(args.rank_by, ValueMetric::Churn);
+                assert_eq!(args.output_mode, ContextOutput::Bundle);
+                assert!(args.compress);
+                assert!(args.no_smart_exclude);
+                assert!((args.max_file_pct - 0.25).abs() < f64::EPSILON);
+                assert!(args.require_git_scores);
+            }
+            other => panic!("Expected Context, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn analyze_subcommand_with_near_dup_options() {
+        let cli = Cli::try_parse_from([
+            "tokmd",
+            "analyze",
+            "--near-dup",
+            "--near-dup-threshold",
+            "0.90",
+            "--near-dup-max-files",
+            "5000",
+            "--near-dup-scope",
+            "global",
+            "--near-dup-max-pairs",
+            "500",
+            "--near-dup-exclude",
+            "*.generated.*",
+        ])
+        .unwrap();
+
+        match cli.command.unwrap() {
+            tokmd_config::Commands::Analyze(args) => {
+                assert!(args.near_dup);
+                assert!((args.near_dup_threshold - 0.90).abs() < f64::EPSILON);
+                assert_eq!(args.near_dup_max_files, 5000);
+                assert_eq!(args.near_dup_scope, Some(NearDupScope::Global));
+                assert_eq!(args.near_dup_max_pairs, 500);
+                assert_eq!(args.near_dup_exclude, vec!["*.generated.*"]);
+            }
+            other => panic!("Expected Analyze, got {:?}", other),
+        }
+    }
+}
+
+// =========================================================================
+// Scenario: TomlConfig with gate allow_missing fields
+// =========================================================================
+
+mod toml_gate_config {
+    use super::*;
+
+    #[test]
+    fn gate_config_with_allow_missing_baseline() {
+        let toml_str = r#"
+[gate]
+allow_missing_baseline = true
+allow_missing_current = false
+"#;
+        let config = TomlConfig::parse(toml_str).expect("valid");
+        assert_eq!(config.gate.allow_missing_baseline, Some(true));
+        assert_eq!(config.gate.allow_missing_current, Some(false));
+    }
+
+    #[test]
+    fn gate_config_with_both_allow_missing_true() {
+        let toml_str = r#"
+[gate]
+allow_missing_baseline = true
+allow_missing_current = true
+fail_fast = false
+"#;
+        let config = TomlConfig::parse(toml_str).expect("valid");
+        assert_eq!(config.gate.allow_missing_baseline, Some(true));
+        assert_eq!(config.gate.allow_missing_current, Some(true));
+        assert_eq!(config.gate.fail_fast, Some(false));
+    }
+
+    #[test]
+    fn gate_config_with_preset_and_policy() {
+        let toml_str = r#"
+[gate]
+policy = "policy.toml"
+baseline = "baseline.json"
+preset = "health"
+"#;
+        let config = TomlConfig::parse(toml_str).expect("valid");
+        assert_eq!(config.gate.policy, Some("policy.toml".to_string()));
+        assert_eq!(config.gate.baseline, Some("baseline.json".to_string()));
+        assert_eq!(config.gate.preset, Some("health".to_string()));
+    }
+
+    #[test]
+    fn gate_config_defaults_are_none_when_absent() {
+        let toml_str = r#"
+[gate]
+fail_fast = true
+"#;
+        let config = TomlConfig::parse(toml_str).expect("valid");
+        assert_eq!(config.gate.fail_fast, Some(true));
+        assert!(config.gate.allow_missing_baseline.is_none());
+        assert!(config.gate.allow_missing_current.is_none());
+        assert!(config.gate.policy.is_none());
+        assert!(config.gate.baseline.is_none());
+        assert!(config.gate.preset.is_none());
+    }
+}
+
+// =========================================================================
+// Scenario: ViewProfile with all fields populated
+// =========================================================================
+
+mod view_profile_coverage {
+    use super::*;
+
+    #[test]
+    fn view_profile_with_all_fields_set() {
+        let toml_str = r#"
+[view.full]
+format = "json"
+top = 25
+files = true
+module_roots = ["crates", "packages"]
+module_depth = 3
+min_code = 10
+max_rows = 500
+redact = "all"
+meta = true
+children = "collapse"
+preset = "deep"
+window = 256000
+budget = "128k"
+strategy = "greedy"
+rank_by = "code"
+output = "list"
+compress = true
+metric = "tokens"
+"#;
+        let config = TomlConfig::parse(toml_str).expect("valid");
+        let full = config.view.get("full").expect("full profile");
+
+        assert_eq!(full.format, Some("json".to_string()));
+        assert_eq!(full.top, Some(25));
+        assert_eq!(full.files, Some(true));
+        assert_eq!(
+            full.module_roots,
+            Some(vec!["crates".to_string(), "packages".to_string()])
+        );
+        assert_eq!(full.module_depth, Some(3));
+        assert_eq!(full.min_code, Some(10));
+        assert_eq!(full.max_rows, Some(500));
+        assert_eq!(full.redact, Some("all".to_string()));
+        assert_eq!(full.meta, Some(true));
+        assert_eq!(full.children, Some("collapse".to_string()));
+        assert_eq!(full.preset, Some("deep".to_string()));
+        assert_eq!(full.window, Some(256000));
+        assert_eq!(full.budget, Some("128k".to_string()));
+        assert_eq!(full.strategy, Some("greedy".to_string()));
+        assert_eq!(full.rank_by, Some("code".to_string()));
+        assert_eq!(full.output, Some("list".to_string()));
+        assert_eq!(full.compress, Some(true));
+        assert_eq!(full.metric, Some("tokens".to_string()));
+    }
+
+    #[test]
+    fn view_profile_json_roundtrip_with_all_fields() {
+        let profile = ViewProfile {
+            format: Some("json".to_string()),
+            top: Some(10),
+            files: Some(true),
+            module_roots: Some(vec!["src".to_string()]),
+            module_depth: Some(2),
+            min_code: Some(5),
+            max_rows: Some(100),
+            redact: Some("paths".to_string()),
+            meta: Some(false),
+            children: Some("separate".to_string()),
+            preset: Some("health".to_string()),
+            window: Some(128000),
+            budget: Some("64k".to_string()),
+            strategy: Some("spread".to_string()),
+            rank_by: Some("tokens".to_string()),
+            output: Some("bundle".to_string()),
+            compress: Some(false),
+            metric: Some("lines".to_string()),
+        };
+
+        let json = serde_json::to_string(&profile).unwrap();
+        let back: ViewProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.format, profile.format);
+        assert_eq!(back.top, profile.top);
+        assert_eq!(back.files, profile.files);
+        assert_eq!(back.module_roots, profile.module_roots);
+        assert_eq!(back.module_depth, profile.module_depth);
+        assert_eq!(back.min_code, profile.min_code);
+        assert_eq!(back.max_rows, profile.max_rows);
+        assert_eq!(back.redact, profile.redact);
+        assert_eq!(back.meta, profile.meta);
+        assert_eq!(back.children, profile.children);
+        assert_eq!(back.preset, profile.preset);
+        assert_eq!(back.window, profile.window);
+        assert_eq!(back.budget, profile.budget);
+        assert_eq!(back.strategy, profile.strategy);
+        assert_eq!(back.rank_by, profile.rank_by);
+        assert_eq!(back.output, profile.output);
+        assert_eq!(back.compress, profile.compress);
+        assert_eq!(back.metric, profile.metric);
+    }
+
+    #[test]
+    fn view_profile_default_is_all_none() {
+        let profile = ViewProfile::default();
+        assert!(profile.format.is_none());
+        assert!(profile.top.is_none());
+        assert!(profile.files.is_none());
+        assert!(profile.module_roots.is_none());
+        assert!(profile.module_depth.is_none());
+        assert!(profile.min_code.is_none());
+        assert!(profile.max_rows.is_none());
+        assert!(profile.redact.is_none());
+        assert!(profile.meta.is_none());
+        assert!(profile.children.is_none());
+        assert!(profile.preset.is_none());
+        assert!(profile.window.is_none());
+        assert!(profile.budget.is_none());
+        assert!(profile.strategy.is_none());
+        assert!(profile.rank_by.is_none());
+        assert!(profile.output.is_none());
+        assert!(profile.compress.is_none());
+        assert!(profile.metric.is_none());
+    }
+}

--- a/crates/tokmd-core/Cargo.toml
+++ b/crates/tokmd-core/Cargo.toml
@@ -47,4 +47,5 @@ tokmd-cockpit = { workspace = true, optional = true }
 tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
+anyhow = "1.0.101"
 proptest = "1.10.0"

--- a/crates/tokmd-core/tests/error_types.rs
+++ b/crates/tokmd-core/tests/error_types.rs
@@ -1,0 +1,446 @@
+//! BDD-style tests for the tokmd-core error module.
+//!
+//! Focuses on areas not covered by existing test files:
+//! - ErrorCode serde roundtrip for ALL variants
+//! - TokmdError factory methods and conversion traits
+//! - ResponseEnvelope serialization contract and fallbacks
+//! - CORE_SCHEMA_VERSION constant validation
+//! - version() format validation
+
+use serde_json::json;
+use tokmd_core::error::{ErrorCode, ErrorDetails, ErrorResponse, ResponseEnvelope, TokmdError};
+
+// =========================================================================
+// Scenario: ErrorCode serde roundtrip for all variants
+// =========================================================================
+
+mod error_code_serde {
+    use super::*;
+
+    const ALL_CODES: &[ErrorCode] = &[
+        ErrorCode::PathNotFound,
+        ErrorCode::InvalidPath,
+        ErrorCode::ScanError,
+        ErrorCode::AnalysisError,
+        ErrorCode::InvalidJson,
+        ErrorCode::UnknownMode,
+        ErrorCode::InvalidSettings,
+        ErrorCode::IoError,
+        ErrorCode::InternalError,
+        ErrorCode::NotImplemented,
+        ErrorCode::GitNotAvailable,
+        ErrorCode::NotGitRepository,
+        ErrorCode::GitOperationFailed,
+        ErrorCode::ConfigNotFound,
+        ErrorCode::ConfigInvalid,
+    ];
+
+    #[test]
+    fn all_error_codes_roundtrip_through_json() {
+        for code in ALL_CODES {
+            let json = serde_json::to_string(code).unwrap();
+            let back: ErrorCode = serde_json::from_str(&json).unwrap();
+            assert_eq!(*code, back, "ErrorCode roundtrip failed for {:?}", code);
+        }
+    }
+
+    #[test]
+    fn all_error_codes_serialize_to_snake_case() {
+        for code in ALL_CODES {
+            let json = serde_json::to_string(code).unwrap();
+            let inner = json.trim_matches('"');
+            assert!(
+                !inner.chars().any(|c| c.is_uppercase()),
+                "ErrorCode should serialize to snake_case, got: {}",
+                inner
+            );
+        }
+    }
+
+    #[test]
+    fn error_code_display_matches_serde() {
+        // Display impl should produce the same string as serde serialization
+        for code in ALL_CODES {
+            let display = code.to_string();
+            let serde = serde_json::to_string(code).unwrap();
+            let serde_inner = serde.trim_matches('"');
+            assert_eq!(
+                display, serde_inner,
+                "Display and serde disagree for {:?}",
+                code
+            );
+        }
+    }
+}
+
+// =========================================================================
+// Scenario: TokmdError factory methods produce correct codes and messages
+// =========================================================================
+
+mod error_factory_methods {
+    use super::*;
+
+    #[test]
+    fn path_not_found_error() {
+        let err = TokmdError::path_not_found("/some/missing/path");
+        assert_eq!(err.code, ErrorCode::PathNotFound);
+        assert!(err.message.contains("/some/missing/path"));
+        assert!(err.details.is_none());
+        assert!(err.suggestions.is_none());
+    }
+
+    #[test]
+    fn path_not_found_with_suggestions_error() {
+        let err = TokmdError::path_not_found_with_suggestions("/bad/path");
+        assert_eq!(err.code, ErrorCode::PathNotFound);
+        assert!(err.message.contains("/bad/path"));
+        assert!(err.details.is_some());
+        assert!(err.suggestions.is_some());
+        assert!(!err.suggestions.unwrap().is_empty());
+    }
+
+    #[test]
+    fn invalid_json_error() {
+        let err = TokmdError::invalid_json("unexpected token");
+        assert_eq!(err.code, ErrorCode::InvalidJson);
+        assert!(err.message.contains("unexpected token"));
+    }
+
+    #[test]
+    fn unknown_mode_error() {
+        let err = TokmdError::unknown_mode("bogus");
+        assert_eq!(err.code, ErrorCode::UnknownMode);
+        assert!(err.message.contains("bogus"));
+    }
+
+    #[test]
+    fn scan_error() {
+        let err = TokmdError::scan_error("permission denied");
+        assert_eq!(err.code, ErrorCode::ScanError);
+        assert!(err.message.contains("permission denied"));
+    }
+
+    #[test]
+    fn analysis_error() {
+        let err = TokmdError::analysis_error("out of memory");
+        assert_eq!(err.code, ErrorCode::AnalysisError);
+        assert!(err.message.contains("out of memory"));
+    }
+
+    #[test]
+    fn io_error() {
+        let err = TokmdError::io_error("disk full");
+        assert_eq!(err.code, ErrorCode::IoError);
+        assert!(err.message.contains("disk full"));
+    }
+
+    #[test]
+    fn internal_error() {
+        let err = TokmdError::internal("unexpected state");
+        assert_eq!(err.code, ErrorCode::InternalError);
+        assert!(err.message.contains("unexpected state"));
+    }
+
+    #[test]
+    fn not_implemented_error() {
+        let err = TokmdError::not_implemented("streaming mode");
+        assert_eq!(err.code, ErrorCode::NotImplemented);
+        assert_eq!(err.message, "streaming mode");
+    }
+
+    #[test]
+    fn invalid_field_error() {
+        let err = TokmdError::invalid_field("format", "'md' or 'json'");
+        assert_eq!(err.code, ErrorCode::InvalidSettings);
+        assert!(err.message.contains("format"));
+        assert!(err.message.contains("'md' or 'json'"));
+    }
+
+    #[test]
+    fn git_not_available_has_suggestions() {
+        let err = TokmdError::git_not_available();
+        assert_eq!(err.code, ErrorCode::GitNotAvailable);
+        let suggestions = err.suggestions.expect("should have suggestions");
+        assert!(suggestions.len() >= 2, "should have multiple suggestions");
+    }
+
+    #[test]
+    fn not_git_repository_includes_path() {
+        let err = TokmdError::not_git_repository("/tmp/not-a-repo");
+        assert_eq!(err.code, ErrorCode::NotGitRepository);
+        assert!(err.message.contains("/tmp/not-a-repo"));
+        assert!(err.details.is_some());
+        assert!(err.suggestions.is_some());
+    }
+
+    #[test]
+    fn git_operation_failed_includes_details() {
+        let err = TokmdError::git_operation_failed("git log", "fatal: not a repository");
+        assert_eq!(err.code, ErrorCode::GitOperationFailed);
+        assert!(err.message.contains("git log"));
+        assert!(
+            err.details
+                .as_ref()
+                .unwrap()
+                .contains("fatal: not a repository")
+        );
+    }
+
+    #[test]
+    fn config_not_found_has_suggestions() {
+        let err = TokmdError::config_not_found("tokmd.toml");
+        assert_eq!(err.code, ErrorCode::ConfigNotFound);
+        assert!(err.message.contains("tokmd.toml"));
+        let suggestions = err.suggestions.expect("should have suggestions");
+        assert!(suggestions.iter().any(|s| s.contains("tokmd init")));
+    }
+
+    #[test]
+    fn config_invalid_includes_reason() {
+        let err = TokmdError::config_invalid("tokmd.toml", "bad syntax");
+        assert_eq!(err.code, ErrorCode::ConfigInvalid);
+        assert!(err.details.as_ref().unwrap().contains("bad syntax"));
+        assert!(err.suggestions.is_some());
+    }
+}
+
+// =========================================================================
+// Scenario: TokmdError conversion traits
+// =========================================================================
+
+mod error_conversions {
+    use super::*;
+
+    #[test]
+    fn from_anyhow_error() {
+        let anyhow_err = anyhow::anyhow!("something broke");
+        let err: TokmdError = anyhow_err.into();
+        assert_eq!(err.code, ErrorCode::InternalError);
+        assert!(err.message.contains("something broke"));
+    }
+
+    #[test]
+    fn from_serde_json_error() {
+        let json_err = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let err: TokmdError = json_err.into();
+        assert_eq!(err.code, ErrorCode::InvalidJson);
+    }
+
+    #[test]
+    fn from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let err: TokmdError = io_err.into();
+        assert_eq!(err.code, ErrorCode::IoError);
+        assert!(err.message.contains("file missing"));
+    }
+
+    #[test]
+    fn error_display_without_details() {
+        let err = TokmdError::new(ErrorCode::ScanError, "scan failed");
+        let display = err.to_string();
+        assert!(display.contains("[scan_error]"));
+        assert!(display.contains("scan failed"));
+        // Without details, no colon separator for details
+        assert!(!display.ends_with(": "));
+    }
+
+    #[test]
+    fn error_display_with_details() {
+        let err = TokmdError::with_details(ErrorCode::ScanError, "scan failed", "timeout");
+        let display = err.to_string();
+        assert!(display.contains("[scan_error]"));
+        assert!(display.contains("scan failed"));
+        assert!(display.contains("timeout"));
+    }
+
+    #[test]
+    fn error_implements_std_error() {
+        let err = TokmdError::new(ErrorCode::ScanError, "test");
+        // Verify std::error::Error is implemented
+        let _: &dyn std::error::Error = &err;
+    }
+}
+
+// =========================================================================
+// Scenario: TokmdError to_json serialization
+// =========================================================================
+
+mod error_json_serialization {
+    use super::*;
+
+    #[test]
+    fn to_json_includes_code_and_message() {
+        let err = TokmdError::path_not_found("/path");
+        let json = err.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["code"], "path_not_found");
+        assert!(parsed["message"].as_str().unwrap().contains("/path"));
+    }
+
+    #[test]
+    fn to_json_skips_none_details() {
+        let err = TokmdError::new(ErrorCode::ScanError, "msg");
+        let json = err.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("details").is_none());
+        assert!(parsed.get("suggestions").is_none());
+    }
+
+    #[test]
+    fn to_json_includes_details_when_present() {
+        let err = TokmdError::with_details(ErrorCode::ScanError, "msg", "detail");
+        let json = err.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["details"], "detail");
+    }
+
+    #[test]
+    fn to_json_includes_suggestions_when_present() {
+        let err = TokmdError::git_not_available();
+        let json = err.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["suggestions"].is_array());
+        assert!(!parsed["suggestions"].as_array().unwrap().is_empty());
+    }
+}
+
+// =========================================================================
+// Scenario: ResponseEnvelope contract
+// =========================================================================
+
+mod response_envelope {
+    use super::*;
+
+    #[test]
+    fn success_envelope_has_correct_shape() {
+        let data = json!({"rows": [1, 2, 3]});
+        let envelope = ResponseEnvelope::success(data.clone());
+        assert!(envelope.ok);
+        assert_eq!(envelope.data, Some(data));
+        assert!(envelope.error.is_none());
+    }
+
+    #[test]
+    fn error_envelope_has_correct_shape() {
+        let err = TokmdError::unknown_mode("bogus");
+        let envelope = ResponseEnvelope::error(&err);
+        assert!(!envelope.ok);
+        assert!(envelope.data.is_none());
+        let error_details = envelope.error.as_ref().unwrap();
+        assert_eq!(error_details.code, "unknown_mode");
+        assert!(error_details.message.contains("bogus"));
+    }
+
+    #[test]
+    fn success_envelope_to_json_is_valid() {
+        let envelope = ResponseEnvelope::success(json!({"count": 42}));
+        let json = envelope.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["ok"], true);
+        assert_eq!(parsed["data"]["count"], 42);
+        // error should not be present
+        assert!(parsed.get("error").is_none());
+    }
+
+    #[test]
+    fn error_envelope_to_json_is_valid() {
+        let err = TokmdError::scan_error("timeout");
+        let envelope = ResponseEnvelope::error(&err);
+        let json = envelope.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["ok"], false);
+        assert!(parsed.get("data").is_none());
+        assert_eq!(parsed["error"]["code"], "scan_error");
+    }
+
+    #[test]
+    fn error_details_from_tokmd_error() {
+        let err = TokmdError::with_details(ErrorCode::ConfigInvalid, "bad config", "syntax error");
+        let details: ErrorDetails = ErrorDetails::from(&err);
+        assert_eq!(details.code, "config_invalid");
+        assert_eq!(details.message, "bad config");
+        assert_eq!(details.details, Some("syntax error".to_string()));
+    }
+
+    #[test]
+    fn error_response_from_tokmd_error() {
+        let err = TokmdError::unknown_mode("xyz");
+        let resp: ErrorResponse = err.into();
+        assert!(resp.error);
+        assert_eq!(resp.code, "unknown_mode");
+        assert!(resp.message.contains("xyz"));
+    }
+
+    #[test]
+    fn error_response_to_json_is_valid() {
+        let err = TokmdError::path_not_found("/missing");
+        let resp: ErrorResponse = err.into();
+        let json = resp.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["error"], true);
+        assert_eq!(parsed["code"], "path_not_found");
+    }
+
+    #[test]
+    fn envelope_roundtrip_through_json() {
+        // Success envelope
+        let success = ResponseEnvelope::success(json!({"x": 1}));
+        let json = serde_json::to_string(&success).unwrap();
+        let back: ResponseEnvelope = serde_json::from_str(&json).unwrap();
+        assert!(back.ok);
+        assert_eq!(back.data, Some(json!({"x": 1})));
+
+        // Error envelope
+        let err = TokmdError::scan_error("oops");
+        let error = ResponseEnvelope::error(&err);
+        let json = serde_json::to_string(&error).unwrap();
+        let back: ResponseEnvelope = serde_json::from_str(&json).unwrap();
+        assert!(!back.ok);
+        assert_eq!(back.error.unwrap().code, "scan_error");
+    }
+}
+
+// =========================================================================
+// Scenario: CORE_SCHEMA_VERSION and version() constants
+// =========================================================================
+
+mod constants {
+    use tokmd_core::CORE_SCHEMA_VERSION;
+    use tokmd_types::SCHEMA_VERSION;
+
+    #[test]
+    fn core_schema_version_matches_types() {
+        assert_eq!(
+            CORE_SCHEMA_VERSION, SCHEMA_VERSION,
+            "CORE_SCHEMA_VERSION should re-export SCHEMA_VERSION from tokmd-types"
+        );
+    }
+
+    #[test]
+    fn core_schema_version_is_positive() {
+        assert!(CORE_SCHEMA_VERSION > 0, "Schema version should be > 0");
+    }
+
+    #[test]
+    fn version_is_valid_semver() {
+        let v = tokmd_core::version();
+        assert!(!v.is_empty());
+        let parts: Vec<&str> = v.split('.').collect();
+        assert!(
+            parts.len() >= 2,
+            "Version should be semver-like (at least major.minor), got: {}",
+            v
+        );
+        // Major and minor should be numeric
+        assert!(
+            parts[0].parse::<u32>().is_ok(),
+            "Major version should be numeric, got: {}",
+            parts[0]
+        );
+        assert!(
+            parts[1].parse::<u32>().is_ok(),
+            "Minor version should be numeric, got: {}",
+            parts[1]
+        );
+    }
+}

--- a/crates/tokmd-gate/tests/edge_cases.rs
+++ b/crates/tokmd-gate/tests/edge_cases.rs
@@ -1,0 +1,568 @@
+//! Edge-case tests for tokmd-gate.
+//!
+//! Focuses on areas not covered by existing test files:
+//! - Operators with missing or invalid value fields
+//! - Contains on non-container types
+//! - GateError variant Display strings
+//! - RatchetConfig from_file error paths
+//! - RuleOperator and RuleLevel defaults
+//! - Combined policy + ratchet evaluation scenarios
+//! - PolicyConfig and RatchetConfig serialization roundtrips
+
+use serde_json::json;
+use tokmd_gate::{
+    GateResult, PolicyConfig, PolicyRule, RatchetConfig, RatchetGateResult, RatchetRule, RuleLevel,
+    RuleOperator, RuleResult, evaluate_policy, evaluate_ratchet_policy, resolve_pointer,
+};
+
+// =========================================================================
+// Scenario: Operators with missing or invalid value fields
+// =========================================================================
+
+mod operator_edge_cases {
+    use super::*;
+
+    #[test]
+    fn comparison_on_non_numeric_actual_fails_gracefully() {
+        // Given a string value at the pointer
+        let receipt = json!({"name": "hello"});
+        let rule = make_rule("test", "/name", RuleOperator::Gt, json!(10));
+
+        // When evaluated
+        let result = evaluate_single(&receipt, &rule);
+
+        // Then it fails (can't compare string > number)
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn eq_on_null_vs_null() {
+        let receipt = json!({"val": null});
+        let rule = make_rule("test", "/val", RuleOperator::Eq, json!(null));
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(result.passed, "null == null should pass");
+    }
+
+    #[test]
+    fn eq_on_boolean_values() {
+        let receipt = json!({"active": true});
+
+        let rule_true = make_rule("test", "/active", RuleOperator::Eq, json!(true));
+        assert!(evaluate_single(&receipt, &rule_true).passed);
+
+        let rule_false = make_rule("test", "/active", RuleOperator::Eq, json!(false));
+        assert!(!evaluate_single(&receipt, &rule_false).passed);
+    }
+
+    #[test]
+    fn contains_on_numeric_value_fails_gracefully() {
+        // Contains should fail on non-string, non-array
+        let receipt = json!({"count": 42});
+        let rule = make_rule("test", "/count", RuleOperator::Contains, json!(4));
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn contains_on_null_fails_gracefully() {
+        let receipt = json!({"val": null});
+        let rule = make_rule("test", "/val", RuleOperator::Contains, json!("x"));
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn contains_on_object_fails_gracefully() {
+        let receipt = json!({"obj": {"key": "value"}});
+        let rule = make_rule("test", "/obj", RuleOperator::Contains, json!("key"));
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn contains_empty_string_in_any_string() {
+        // Empty string is contained in any string
+        let receipt = json!({"text": "hello"});
+        let rule = make_rule("test", "/text", RuleOperator::Contains, json!(""));
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(result.passed, "empty string is always contained");
+    }
+
+    #[test]
+    fn contains_in_empty_array() {
+        let receipt = json!({"arr": []});
+        let rule = make_rule("test", "/arr", RuleOperator::Contains, json!(1));
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(!result.passed, "empty array contains nothing");
+    }
+
+    #[test]
+    fn in_operator_empty_values_list() {
+        let receipt = json!({"val": "x"});
+        let rule = PolicyRule {
+            name: "test".into(),
+            pointer: "/val".into(),
+            op: RuleOperator::In,
+            value: None,
+            values: Some(vec![]),
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(!result.passed, "no value is in an empty list");
+    }
+
+    #[test]
+    fn in_operator_numeric_values() {
+        let receipt = json!({"count": 42});
+        let rule = PolicyRule {
+            name: "test".into(),
+            pointer: "/count".into(),
+            op: RuleOperator::In,
+            value: None,
+            values: Some(vec![json!(10), json!(42), json!(100)]),
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(result.passed, "42 should be in [10, 42, 100]");
+    }
+
+    #[test]
+    fn numeric_comparison_with_string_coercion() {
+        // String "42.5" should be coerced to f64 for comparison
+        let receipt = json!({"val": "42.5"});
+        let rule = make_rule("test", "/val", RuleOperator::Gt, json!(40));
+
+        let result = evaluate_single(&receipt, &rule);
+        assert!(result.passed, "string '42.5' > 40 via coercion");
+    }
+}
+
+// =========================================================================
+// Scenario: RuleOperator and RuleLevel defaults
+// =========================================================================
+
+mod type_defaults {
+    use super::*;
+
+    #[test]
+    fn rule_operator_default_is_eq() {
+        assert_eq!(RuleOperator::default(), RuleOperator::Eq);
+    }
+
+    #[test]
+    fn rule_level_default_is_error() {
+        assert_eq!(RuleLevel::default(), RuleLevel::Error);
+    }
+
+    #[test]
+    fn policy_config_default_has_empty_rules() {
+        let config = PolicyConfig::default();
+        assert!(config.rules.is_empty());
+        assert!(!config.fail_fast);
+        assert!(!config.allow_missing);
+    }
+
+    #[test]
+    fn ratchet_config_default_has_empty_rules() {
+        let config = RatchetConfig::default();
+        assert!(config.rules.is_empty());
+        assert!(!config.fail_fast);
+        assert!(!config.allow_missing_baseline);
+        assert!(!config.allow_missing_current);
+    }
+}
+
+// =========================================================================
+// Scenario: GateError Display formatting
+// =========================================================================
+
+mod gate_error_display {
+    use tokmd_gate::GateError;
+
+    #[test]
+    fn io_error_display() {
+        let err = GateError::IoError(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "file not found",
+        ));
+        let msg = err.to_string();
+        assert!(msg.contains("read policy file"), "got: {}", msg);
+        assert!(msg.contains("file not found"), "got: {}", msg);
+    }
+
+    #[test]
+    fn invalid_pointer_display() {
+        let err = GateError::InvalidPointer("bad/pointer".to_string());
+        let msg = err.to_string();
+        assert!(msg.contains("bad/pointer"), "got: {}", msg);
+    }
+
+    #[test]
+    fn type_mismatch_display() {
+        let err = GateError::TypeMismatch {
+            expected: "number".to_string(),
+            actual: "string".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("number"), "got: {}", msg);
+        assert!(msg.contains("string"), "got: {}", msg);
+    }
+
+    #[test]
+    fn invalid_operator_display() {
+        let err = GateError::InvalidOperator {
+            op: "gt".to_string(),
+            value_type: "string".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("gt"), "got: {}", msg);
+        assert!(msg.contains("string"), "got: {}", msg);
+    }
+
+    #[test]
+    fn missing_field_display() {
+        let err = GateError::MissingField {
+            name: "rule1".to_string(),
+            field: "pointer".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("rule1"), "got: {}", msg);
+        assert!(msg.contains("pointer"), "got: {}", msg);
+    }
+}
+
+// =========================================================================
+// Scenario: Config from_file error paths
+// =========================================================================
+
+mod config_file_errors {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn policy_from_nonexistent_file_returns_error() {
+        let result = PolicyConfig::from_file(Path::new("/no/such/policy.toml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn ratchet_from_nonexistent_file_returns_error() {
+        let result = RatchetConfig::from_file(Path::new("/no/such/ratchet.toml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn policy_from_invalid_toml_returns_error() {
+        let result = PolicyConfig::from_toml("[broken\nfoo = bar");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn ratchet_from_invalid_toml_returns_error() {
+        let result = RatchetConfig::from_toml("[broken\nfoo = bar");
+        assert!(result.is_err());
+    }
+}
+
+// =========================================================================
+// Scenario: PolicyConfig and result serde roundtrips
+// =========================================================================
+
+mod serde_roundtrips {
+    use super::*;
+
+    #[test]
+    fn policy_config_roundtrip_through_json() {
+        let config = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "max_code".into(),
+                pointer: "/summary/total_code".into(),
+                op: RuleOperator::Lte,
+                value: Some(json!(100000)),
+                values: None,
+                negate: false,
+                level: RuleLevel::Error,
+                message: Some("Code exceeds limit".into()),
+            }],
+            fail_fast: true,
+            allow_missing: false,
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let back: PolicyConfig = serde_json::from_str(&json).unwrap();
+        assert!(back.fail_fast);
+        assert!(!back.allow_missing);
+        assert_eq!(back.rules.len(), 1);
+        assert_eq!(back.rules[0].name, "max_code");
+        assert_eq!(back.rules[0].op, RuleOperator::Lte);
+    }
+
+    #[test]
+    fn gate_result_roundtrip_through_json() {
+        let gate = GateResult::from_results(vec![
+            RuleResult {
+                name: "r1".into(),
+                passed: true,
+                level: RuleLevel::Error,
+                actual: Some(json!(42)),
+                expected: "/count > 10".into(),
+                message: None,
+            },
+            RuleResult {
+                name: "r2".into(),
+                passed: false,
+                level: RuleLevel::Warn,
+                actual: Some(json!("MIT")),
+                expected: "/license in [GPL]".into(),
+                message: Some("License mismatch".into()),
+            },
+        ]);
+
+        let json = serde_json::to_string(&gate).unwrap();
+        let back: GateResult = serde_json::from_str(&json).unwrap();
+        assert!(back.passed); // Only warns
+        assert_eq!(back.errors, 0);
+        assert_eq!(back.warnings, 1);
+        assert_eq!(back.rule_results.len(), 2);
+    }
+
+    #[test]
+    fn ratchet_config_roundtrip_through_json() {
+        let config = RatchetConfig {
+            rules: vec![RatchetRule {
+                pointer: "/complexity/avg".into(),
+                max_increase_pct: Some(10.0),
+                max_value: Some(50.0),
+                level: RuleLevel::Error,
+                description: Some("Keep complexity low".into()),
+            }],
+            fail_fast: true,
+            allow_missing_baseline: true,
+            allow_missing_current: false,
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let back: RatchetConfig = serde_json::from_str(&json).unwrap();
+        assert!(back.fail_fast);
+        assert!(back.allow_missing_baseline);
+        assert!(!back.allow_missing_current);
+        assert_eq!(back.rules.len(), 1);
+        assert_eq!(back.rules[0].max_increase_pct, Some(10.0));
+        assert_eq!(back.rules[0].max_value, Some(50.0));
+    }
+
+    #[test]
+    fn ratchet_gate_result_roundtrip() {
+        let result = RatchetGateResult::from_results(vec![]);
+        let json = serde_json::to_string(&result).unwrap();
+        let back: RatchetGateResult = serde_json::from_str(&json).unwrap();
+        assert!(back.passed);
+        assert_eq!(back.errors, 0);
+        assert_eq!(back.warnings, 0);
+    }
+}
+
+// =========================================================================
+// Scenario: Combined policy + ratchet evaluation
+// =========================================================================
+
+mod combined_evaluation {
+    use super::*;
+
+    #[test]
+    fn policy_and_ratchet_both_pass() {
+        let receipt = json!({
+            "summary": {"total_code": 5000},
+            "complexity": {"avg": 8.0}
+        });
+        let baseline = json!({
+            "complexity": {"avg": 7.5}
+        });
+
+        // Policy rules
+        let policy = PolicyConfig {
+            rules: vec![make_rule(
+                "max_code",
+                "/summary/total_code",
+                RuleOperator::Lte,
+                json!(100000),
+            )],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let policy_result = evaluate_policy(&receipt, &policy);
+        assert!(policy_result.passed);
+
+        // Ratchet rules
+        let ratchet = RatchetConfig {
+            rules: vec![RatchetRule {
+                pointer: "/complexity/avg".into(),
+                max_increase_pct: Some(20.0),
+                max_value: None,
+                level: RuleLevel::Error,
+                description: None,
+            }],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+
+        let ratchet_result = evaluate_ratchet_policy(&ratchet, &baseline, &receipt);
+        assert!(ratchet_result.passed);
+
+        // Combined verdict: both pass
+        assert!(policy_result.passed && ratchet_result.passed);
+    }
+
+    #[test]
+    fn policy_passes_but_ratchet_fails() {
+        let receipt = json!({
+            "summary": {"total_code": 5000},
+            "complexity": {"avg": 15.0}
+        });
+        let baseline = json!({
+            "complexity": {"avg": 7.0}
+        });
+
+        let policy = PolicyConfig {
+            rules: vec![make_rule(
+                "max_code",
+                "/summary/total_code",
+                RuleOperator::Lte,
+                json!(100000),
+            )],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let ratchet = RatchetConfig {
+            rules: vec![RatchetRule {
+                pointer: "/complexity/avg".into(),
+                max_increase_pct: Some(10.0),
+                max_value: None,
+                level: RuleLevel::Error,
+                description: None,
+            }],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+
+        let policy_result = evaluate_policy(&receipt, &policy);
+        let ratchet_result = evaluate_ratchet_policy(&ratchet, &baseline, &receipt);
+
+        assert!(policy_result.passed);
+        assert!(!ratchet_result.passed, "complexity increased >10%");
+        assert!(!(policy_result.passed && ratchet_result.passed)); // Combined fails
+    }
+
+    #[test]
+    fn ratchet_with_both_constraints_failing() {
+        let baseline = json!({"value": 100.0});
+        let current = json!({"value": 200.0}); // 100% increase AND over max_value
+
+        let config = RatchetConfig {
+            rules: vec![RatchetRule {
+                pointer: "/value".into(),
+                max_increase_pct: Some(10.0),
+                max_value: Some(150.0),
+                level: RuleLevel::Error,
+                description: None,
+            }],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+        assert_eq!(result.errors, 1);
+        // max_value is checked first, so message should be about exceeding max
+        assert!(
+            result.ratchet_results[0]
+                .message
+                .contains("exceeds maximum")
+        );
+    }
+}
+
+// =========================================================================
+// Scenario: Pointer edge cases not covered by existing tests
+// =========================================================================
+
+mod pointer_edge_cases {
+    use super::*;
+
+    #[test]
+    fn pointer_to_empty_string_key() {
+        // RFC 6901: "/" refers to key ""
+        let doc = json!({"": "empty key"});
+        assert_eq!(resolve_pointer(&doc, "/"), Some(&json!("empty key")));
+    }
+
+    #[test]
+    fn pointer_to_deeply_nested_value() {
+        let doc = json!({"a": {"b": {"c": {"d": {"e": 99}}}}});
+        assert_eq!(resolve_pointer(&doc, "/a/b/c/d/e"), Some(&json!(99)));
+    }
+
+    #[test]
+    fn pointer_through_mixed_objects_and_arrays() {
+        let doc = json!({
+            "data": [
+                {"name": "first", "scores": [10, 20]},
+                {"name": "second", "scores": [30, 40]}
+            ]
+        });
+        assert_eq!(resolve_pointer(&doc, "/data/1/scores/0"), Some(&json!(30)));
+        assert_eq!(resolve_pointer(&doc, "/data/0/name"), Some(&json!("first")));
+    }
+
+    #[test]
+    fn pointer_with_numeric_key_on_object() {
+        // Numeric token on an object should look up the string key "0"
+        let doc = json!({"0": "zero", "1": "one"});
+        assert_eq!(resolve_pointer(&doc, "/0"), Some(&json!("zero")));
+        assert_eq!(resolve_pointer(&doc, "/1"), Some(&json!("one")));
+    }
+}
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+fn make_rule(name: &str, pointer: &str, op: RuleOperator, value: serde_json::Value) -> PolicyRule {
+    PolicyRule {
+        name: name.into(),
+        pointer: pointer.into(),
+        op,
+        value: Some(value),
+        values: None,
+        negate: false,
+        level: RuleLevel::Error,
+        message: None,
+    }
+}
+
+fn evaluate_single(receipt: &serde_json::Value, rule: &PolicyRule) -> RuleResult {
+    let policy = PolicyConfig {
+        rules: vec![rule.clone()],
+        fail_fast: false,
+        allow_missing: false,
+    };
+    let result = evaluate_policy(receipt, &policy);
+    result.rule_results.into_iter().next().unwrap()
+}


### PR DESCRIPTION
## Summary

Adds **103 new BDD-style integration tests** across three facade-tier crates, targeting genuinely untested areas identified by reviewing existing test coverage.

### tokmd-config — \dge_cases.rs\ (29 tests)
- **Newer enum serde roundtrips**: ContextStrategy, ValueMetric, ContextOutput, GateFormat, CockpitFormat, HandoffPreset, SensorFormat, NearDupScope, DiffRangeMode, DiffFormat, ColorMode
- **CLI parsing**: try_parse_from for newer subcommands (Handoff, Sensor, Baseline, Gate, Cockpit, Context with advanced options, Analyze with near-dup options)
- **TomlConfig gate fields**: allow_missing_baseline, allow_missing_current
- **ViewProfile**: full field coverage with all fields populated

### tokmd-core — \rror_types.rs\ (39 tests)
- **ErrorCode serde**: roundtrip all 15 variants, snake_case validation, Display consistency
- **Factory methods**: all TokmdError constructors with code/message/details validation
- **Conversions**: From\<anyhow::Error\>, From\<serde_json::Error\>, From\<std::io::Error\>
- **JSON serialization**: to_json with/without details and suggestions
- **ResponseEnvelope**: success/error contract, JSON validity, serde roundtrip
- **ErrorDetails/ErrorResponse**: from TokmdError conversion and to_json
- **Constants**: CORE_SCHEMA_VERSION matches tokmd-types, version() semver format

### tokmd-gate — \dge_cases.rs\ (35 tests)
- **Operator edge cases**: comparison on non-numeric/null/boolean, contains on non-containers and empty containers, In with empty/numeric values, string coercion
- **GateError Display**: all variant formatting (IoError, InvalidPointer, TypeMismatch, InvalidOperator, MissingField)
- **Config error paths**: from_file with nonexistent files, from_toml with invalid TOML
- **Type defaults**: RuleOperator::Eq, RuleLevel::Error, PolicyConfig/RatchetConfig defaults
- **Serde roundtrips**: PolicyConfig, GateResult, RatchetConfig, RatchetGateResult
- **Combined evaluation**: policy + ratchet both pass, policy passes but ratchet fails, both constraints failing
- **Pointer edge cases**: empty string key, deep nesting, mixed objects/arrays, numeric keys on objects

### Changes
- 3 new test files (1674 lines)
- Added \nyhow\ to tokmd-core dev-dependencies (already a regular dependency)