### PR TITLE
test(cockpit): allow clippy::approx_constant for pi-like literals

### DIFF
--- a/crates/tokmd-cockpit/tests/integration_deep.rs
+++ b/crates/tokmd-cockpit/tests/integration_deep.rs
@@ -1010,6 +1010,7 @@ fn format_signed_positive() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn format_signed_negative() {
     assert_eq!(format_signed_f64(-3.14), "-3.14");
 }
@@ -1041,6 +1042,7 @@ fn trend_label_degrading() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn round_pct_basic() {
     assert!((round_pct(3.14159) - 3.14).abs() < 0.01);
 }


### PR DESCRIPTION
This PR fixes build failures in CI where Clippy throws a `clippy::approx_constant` error due to π-ish literals (`3.14159`, `-3.14`) in test functions `format_signed_negative` and `round_pct_basic` in `crates/tokmd-cockpit/tests/integration_deep.rs`. The fix adds `#[allow(clippy::approx_constant)]` to these test methods, similar to the existing practice in other tests in the repository.

---
*PR created automatically by Jules for task [13951975376364872058](https://jules.google.com/task/13951975376364872058) started by @EffortlessSteven*