### PR TITLE
test: add fuzz targets for JSON parsing, gate, redact, badge

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -53,6 +53,8 @@ tokmd-settings = { workspace = true, optional = true }
 tokmd-analysis-imports = { workspace = true, optional = true }
 tokmd-ffi-envelope = { workspace = true, optional = true }
 tokmd-export-tree = { workspace = true, optional = true }
+tokmd-core = { workspace = true, optional = true }
+tokmd-badge = { workspace = true, optional = true }
 
 # ============================================================================
 # Features
@@ -125,6 +127,20 @@ ffi_envelope = ["dep:tokmd-ffi-envelope", "dep:serde_json"]
 # ExportData tree rendering helpers (tokmd-export-tree)
 # Targets: fuzz_export_tree
 export_tree = ["dep:tokmd-export-tree", "dep:tokmd-types"]
+
+# FFI run_json entrypoint (tokmd-core)
+# Targets: fuzz_run_json
+# Needs serde_json for envelope validation
+core = ["dep:tokmd-core", "dep:serde_json"]
+
+# Ratchet policy evaluation (tokmd-gate)
+# Targets: fuzz_gate_ratchet
+# Needs serde_json for JSON document handling
+gate_ratchet = ["dep:tokmd-gate", "dep:serde_json"]
+
+# SVG badge rendering (tokmd-badge)
+# Targets: fuzz_badge_svg
+badge = ["dep:tokmd-badge"]
 
 # ============================================================================
 # Fuzz Targets - Path/Module Functions
@@ -289,3 +305,42 @@ path = "fuzz_targets/fuzz_import_parser.rs"
 test = false
 doc = false
 required-features = ["analysis_imports"]
+
+# ============================================================================
+# Fuzz Targets - FFI run_json Entrypoint
+# ============================================================================
+# Tests the single-entrypoint FFI function with arbitrary mode/args pairs.
+# Validates no-panic behavior and JSON envelope well-formedness.
+
+[[bin]]
+name = "fuzz_run_json"
+path = "fuzz_targets/fuzz_run_json.rs"
+test = false
+doc = false
+required-features = ["core"]
+
+# ============================================================================
+# Fuzz Targets - Ratchet Gate Evaluation
+# ============================================================================
+# Tests evaluate_ratchet_policy() with arbitrary JSON docs and TOML configs.
+# Complements fuzz_policy_evaluate which targets evaluate_policy().
+
+[[bin]]
+name = "fuzz_gate_ratchet"
+path = "fuzz_targets/fuzz_gate_ratchet.rs"
+test = false
+doc = false
+required-features = ["gate_ratchet"]
+
+# ============================================================================
+# Fuzz Targets - SVG Badge Rendering
+# ============================================================================
+# Tests badge_svg() with arbitrary label/value strings for no-panic
+# behavior, determinism, and basic SVG well-formedness.
+
+[[bin]]
+name = "fuzz_badge_svg"
+path = "fuzz_targets/fuzz_badge_svg.rs"
+test = false
+doc = false
+required-features = ["badge"]

--- a/fuzz/fuzz_targets/fuzz_badge_svg.rs
+++ b/fuzz/fuzz_targets/fuzz_badge_svg.rs
@@ -1,0 +1,47 @@
+//! Fuzz target for SVG badge rendering.
+//!
+//! Tests `badge_svg()` with arbitrary label and value strings to verify:
+//! - No panics on any valid UTF-8 input
+//! - Deterministic output (same inputs → same SVG)
+//! - Output is well-formed (starts with `<svg` and ends with `</svg>`)
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use tokmd_badge::badge_svg;
+
+/// Cap input size — badge rendering is fast but we focus on realistic lengths.
+const MAX_INPUT_SIZE: usize = 4 * 1024; // 4 KB
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() || data.len() > MAX_INPUT_SIZE {
+        return;
+    }
+    let Ok(input) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // Split on first newline: label\nvalue
+    let (label, value) = match input.find('\n') {
+        Some(pos) => (&input[..pos], &input[pos + 1..]),
+        None => (input, ""),
+    };
+
+    // Generate badge — must never panic
+    let svg = badge_svg(label, value);
+
+    // Invariant: deterministic output
+    let svg2 = badge_svg(label, value);
+    assert_eq!(svg, svg2, "badge_svg must be deterministic");
+
+    // Invariant: output is non-empty and looks like SVG
+    assert!(!svg.is_empty(), "badge_svg must not return empty string");
+    assert!(
+        svg.starts_with("<svg"),
+        "badge_svg must start with <svg, got: {}",
+        &svg[..svg.len().min(40)]
+    );
+    assert!(
+        svg.ends_with("</svg>"),
+        "badge_svg must end with </svg>"
+    );
+});

--- a/fuzz/fuzz_targets/fuzz_gate_ratchet.rs
+++ b/fuzz/fuzz_targets/fuzz_gate_ratchet.rs
@@ -1,0 +1,68 @@
+//! Fuzz target for ratchet policy evaluation.
+//!
+//! Tests `evaluate_ratchet_policy()` with arbitrary TOML configs and
+//! JSON baseline/current documents to find panics or invariant violations.
+//!
+//! Corpus format: `baseline_json\ncurrent_json\nratchet_toml`
+//! The input is split on the first two newlines.
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use serde_json::Value;
+use tokmd_gate::{RatchetConfig, evaluate_ratchet_policy};
+
+/// Max input sizes to prevent pathological parse times
+const MAX_JSON_SIZE: usize = 64 * 1024; // 64 KB per JSON doc
+const MAX_TOML_SIZE: usize = 16 * 1024; // 16 KB for TOML config
+
+fuzz_target!(|data: &[u8]| {
+    // Split into three sections on newlines: baseline\ncurrent\nconfig
+    let Some(first_nl) = data.iter().position(|&b| b == b'\n') else {
+        return;
+    };
+    let (baseline_bytes, rest) = data.split_at(first_nl);
+    let rest = &rest[1..]; // skip newline
+
+    let Some(second_nl) = rest.iter().position(|&b| b == b'\n') else {
+        return;
+    };
+    let (current_bytes, config_bytes) = rest.split_at(second_nl);
+    let config_bytes = &config_bytes[1..]; // skip newline
+
+    if baseline_bytes.len() > MAX_JSON_SIZE
+        || current_bytes.len() > MAX_JSON_SIZE
+        || config_bytes.len() > MAX_TOML_SIZE
+    {
+        return;
+    }
+
+    let Ok(baseline_str) = std::str::from_utf8(baseline_bytes) else {
+        return;
+    };
+    let Ok(current_str) = std::str::from_utf8(current_bytes) else {
+        return;
+    };
+    let Ok(config_str) = std::str::from_utf8(config_bytes) else {
+        return;
+    };
+
+    let Ok(baseline) = serde_json::from_str::<Value>(baseline_str) else {
+        return;
+    };
+    let Ok(current) = serde_json::from_str::<Value>(current_str) else {
+        return;
+    };
+    let Ok(config) = RatchetConfig::from_toml(config_str) else {
+        return;
+    };
+
+    // Evaluate — must never panic
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+
+    // Invariant: number of results matches number of rules
+    assert_eq!(
+        result.ratchet_results.len(),
+        config.rules.len(),
+        "result count must equal rule count"
+    );
+});

--- a/fuzz/fuzz_targets/fuzz_run_json.rs
+++ b/fuzz/fuzz_targets/fuzz_run_json.rs
@@ -1,0 +1,42 @@
+//! Fuzz target for the FFI `run_json` entrypoint.
+//!
+//! Feeds arbitrary mode strings and JSON argument payloads into the
+//! single-entrypoint FFI function to verify it never panics and always
+//! returns a well-formed JSON envelope.
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use serde_json::Value;
+use tokmd_core::ffi::run_json;
+
+/// Cap input size to keep iterations fast.
+const MAX_INPUT_SIZE: usize = 64 * 1024; // 64 KB
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() || data.len() > MAX_INPUT_SIZE {
+        return;
+    }
+    let Ok(input) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // Split on first newline: mode\nargs_json
+    let (mode, args_json) = match input.find('\n') {
+        Some(pos) => (&input[..pos], &input[pos + 1..]),
+        None => (input, "{}"),
+    };
+
+    // Call the FFI entrypoint — must never panic
+    let result = run_json(mode, args_json);
+
+    // Invariant: result is always valid JSON
+    let envelope: Value =
+        serde_json::from_str(&result).expect("run_json must always return valid JSON");
+
+    // Invariant: envelope always contains an "ok" boolean field
+    assert!(
+        envelope.get("ok").and_then(Value::as_bool).is_some(),
+        "envelope must have boolean 'ok' field, got: {}",
+        result
+    );
+});


### PR DESCRIPTION
Expand fuzzing coverage with new targets:

- `fuzz_run_json`: FFI `run_json` entrypoint with arbitrary mode/args
- `fuzz_gate_ratchet`: ratchet policy evaluation with random rules/values
- `fuzz_badge_svg`: SVG badge rendering with arbitrary labels/values

Existing `fuzz_redact` and `fuzz_policy_evaluate` already cover path redaction and gate rule evaluation.