### PR TITLE
test(tier4): expand test coverage for tool-schema and config crates

### DIFF
--- a/crates/tokmd-config/tests/config_integration.rs
+++ b/crates/tokmd-config/tests/config_integration.rs
@@ -1,0 +1,582 @@
+//! Integration and determinism tests for tokmd-config.
+//!
+//! Focus areas:
+//! - TomlConfig determinism (parse same input → identical output)
+//! - Config with combined sections stress test
+//! - Profile name edge cases (Unicode, special chars, very long names)
+//! - from_file with concurrent-safe tempdir patterns
+//! - TomlConfig merge semantics (TOML sections vs view profiles)
+//! - Handoff/sensor/baseline CLI arg interaction with config
+
+use std::io::Write;
+use tempfile::NamedTempFile;
+use tokmd_config::TomlConfig;
+
+// =========================================================================
+// Scenario: TomlConfig determinism — same TOML always parses identically
+// =========================================================================
+
+mod toml_determinism {
+    use super::*;
+
+    #[test]
+    fn given_same_toml_when_parsed_ten_times_then_json_identical() {
+        let toml_str = r#"
+[scan]
+hidden = true
+no_ignore = false
+exclude = ["target", "node_modules"]
+
+[module]
+roots = ["crates", "packages"]
+depth = 3
+
+[export]
+format = "csv"
+min_code = 5
+max_rows = 1000
+
+[analyze]
+preset = "risk"
+window = 200000
+
+[context]
+budget = "256k"
+strategy = "spread"
+compress = true
+
+[badge]
+metric = "tokens"
+
+[gate]
+fail_fast = true
+
+[[gate.rules]]
+name = "max-lines"
+pointer = "/summary/total_code"
+op = "lt"
+value = 100000
+
+[[gate.ratchet]]
+pointer = "/complexity/avg_cyclomatic"
+max_increase_pct = 5.0
+
+[view.ci]
+format = "tsv"
+top = 50
+"#;
+        let first_json = {
+            let config = TomlConfig::parse(toml_str).unwrap();
+            serde_json::to_string(&config).unwrap()
+        };
+
+        for i in 1..10 {
+            let config = TomlConfig::parse(toml_str).unwrap();
+            let json = serde_json::to_string(&config).unwrap();
+            assert_eq!(first_json, json, "parse iteration {} diverged", i);
+        }
+    }
+
+    #[test]
+    fn given_toml_from_file_when_loaded_twice_then_identical() {
+        let toml_content = r#"
+[scan]
+hidden = true
+
+[module]
+depth = 4
+roots = ["src", "lib"]
+
+[view.test]
+format = "json"
+top = 10
+"#;
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(toml_content.as_bytes()).unwrap();
+
+        let config1 = TomlConfig::from_file(tmp.path()).unwrap();
+        let config2 = TomlConfig::from_file(tmp.path()).unwrap();
+
+        let json1 = serde_json::to_string(&config1).unwrap();
+        let json2 = serde_json::to_string(&config2).unwrap();
+        assert_eq!(json1, json2);
+    }
+}
+
+// =========================================================================
+// Scenario: Profile names with special characters
+// =========================================================================
+
+mod profile_name_edge_cases {
+    use super::*;
+
+    #[test]
+    fn given_profile_name_with_hyphens_then_parsed_correctly() {
+        let toml_str = r#"
+[view.my-ci-profile]
+format = "tsv"
+top = 25
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        let profile = config.view.get("my-ci-profile").unwrap();
+        assert_eq!(profile.format, Some("tsv".to_string()));
+        assert_eq!(profile.top, Some(25));
+    }
+
+    #[test]
+    fn given_profile_name_with_numbers_then_parsed_correctly() {
+        let toml_str = r#"
+[view.v2]
+format = "json"
+
+[view.profile123]
+format = "md"
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        assert!(config.view.contains_key("v2"));
+        assert!(config.view.contains_key("profile123"));
+    }
+
+    #[test]
+    fn given_profile_name_with_dots_quoted_then_parsed_correctly() {
+        let toml_str = r#"
+[view."org.team.config"]
+format = "json"
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        assert!(config.view.contains_key("org.team.config"));
+    }
+
+    #[test]
+    fn given_profile_name_with_unicode_then_parsed_correctly() {
+        let toml_str = "[view.\"日本語\"]\nformat = \"json\"\n";
+        let config = TomlConfig::parse(toml_str).unwrap();
+        assert!(config.view.contains_key("日本語"));
+        assert_eq!(
+            config.view.get("日本語").unwrap().format,
+            Some("json".to_string())
+        );
+    }
+
+    #[test]
+    fn given_many_profiles_then_btreemap_maintains_sorted_order() {
+        let toml_str = r#"
+[view.z_last]
+format = "md"
+
+[view.a_first]
+format = "json"
+
+[view.m_middle]
+format = "tsv"
+
+[view.b_second]
+format = "csv"
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        let keys: Vec<&String> = config.view.keys().collect();
+        assert_eq!(keys, vec!["a_first", "b_second", "m_middle", "z_last"]);
+    }
+}
+
+// =========================================================================
+// Scenario: Gate config with boundary values
+// =========================================================================
+
+mod gate_boundary_values {
+    use super::*;
+
+    #[test]
+    fn given_ratchet_with_zero_pct_then_parsed() {
+        let toml_str = r#"
+[[gate.ratchet]]
+pointer = "/complexity/avg_cyclomatic"
+max_increase_pct = 0.0
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        let ratchet = config.gate.ratchet.unwrap();
+        assert_eq!(ratchet[0].max_increase_pct, Some(0.0));
+    }
+
+    #[test]
+    fn given_ratchet_with_100_pct_then_parsed() {
+        let toml_str = r#"
+[[gate.ratchet]]
+pointer = "/summary/total_code"
+max_increase_pct = 100.0
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        let ratchet = config.gate.ratchet.unwrap();
+        assert_eq!(ratchet[0].max_increase_pct, Some(100.0));
+    }
+
+    #[test]
+    fn given_rule_with_value_zero_then_parsed() {
+        let toml_str = r#"
+[[gate.rules]]
+name = "no-code"
+pointer = "/summary/total_code"
+op = "eq"
+value = 0
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        let rules = config.gate.rules.unwrap();
+        assert_eq!(rules[0].name, "no-code");
+    }
+
+    #[test]
+    fn given_many_rules_then_all_parsed_in_order() {
+        let mut toml_str = String::from("[gate]\nfail_fast = true\n\n");
+        for i in 0..10 {
+            toml_str.push_str(&format!(
+                "[[gate.rules]]\nname = \"rule-{i}\"\npointer = \"/metric/{i}\"\nop = \"lt\"\nvalue = {}\n\n",
+                i * 100
+            ));
+        }
+        let config = TomlConfig::parse(&toml_str).unwrap();
+        let rules = config.gate.rules.unwrap();
+        assert_eq!(rules.len(), 10);
+        for (i, rule) in rules.iter().enumerate() {
+            assert_eq!(rule.name, format!("rule-{i}"));
+        }
+    }
+}
+
+// =========================================================================
+// Scenario: from_file error conditions
+// =========================================================================
+
+mod from_file_errors {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn given_nonexistent_path_then_returns_error() {
+        let result = TomlConfig::from_file(Path::new("/absolutely/nonexistent/path/tokmd.toml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn given_empty_file_then_returns_default_config() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(b"").unwrap();
+        let config = TomlConfig::from_file(tmp.path()).unwrap();
+        assert_eq!(config.scan.hidden, None);
+        assert!(config.view.is_empty());
+        assert!(config.gate.rules.is_none());
+    }
+
+    #[test]
+    fn given_file_with_only_whitespace_then_returns_default_config() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(b"   \n\n  \t  \n").unwrap();
+        let config = TomlConfig::from_file(tmp.path()).unwrap();
+        assert_eq!(config.scan.hidden, None);
+    }
+
+    #[test]
+    fn given_file_with_only_comments_then_returns_default_config() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(b"# This is a comment\n# Another comment\n")
+            .unwrap();
+        let config = TomlConfig::from_file(tmp.path()).unwrap();
+        assert_eq!(config.scan.hidden, None);
+    }
+
+    #[test]
+    fn given_file_with_invalid_toml_then_returns_error() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(b"[broken\nhidden = true").unwrap();
+        let result = TomlConfig::from_file(tmp.path());
+        assert!(result.is_err());
+    }
+}
+
+// =========================================================================
+// Scenario: Section interactions — all sections coexist
+// =========================================================================
+
+mod section_interactions {
+    use super::*;
+
+    #[test]
+    fn given_all_sections_present_then_each_parsed_independently() {
+        let toml_str = r#"
+[scan]
+hidden = true
+no_ignore = true
+no_ignore_parent = true
+no_ignore_dot = true
+no_ignore_vcs = true
+doc_comments = true
+paths = ["src"]
+exclude = ["target"]
+
+[module]
+roots = ["crates"]
+depth = 2
+children = "collapse"
+
+[export]
+format = "jsonl"
+min_code = 1
+max_rows = 10000
+redact = "paths"
+children = "separate"
+
+[analyze]
+preset = "deep"
+window = 256000
+format = "json"
+git = true
+max_files = 5000
+max_bytes = 50000000
+max_file_bytes = 500000
+max_commits = 1000
+max_commit_files = 200
+granularity = "module"
+
+[context]
+budget = "1m"
+strategy = "greedy"
+rank_by = "hotspot"
+output = "bundle"
+compress = true
+
+[badge]
+metric = "doc"
+
+[gate]
+fail_fast = false
+allow_missing_baseline = true
+allow_missing_current = false
+policy = "my-policy.toml"
+baseline = "baseline.json"
+preset = "risk"
+
+[[gate.rules]]
+name = "rule-1"
+pointer = "/summary/total_code"
+op = "lt"
+value = 100000
+
+[[gate.ratchet]]
+pointer = "/complexity/avg_cyclomatic"
+max_increase_pct = 3.0
+level = "error"
+description = "Keep complexity low"
+
+[view.llm]
+format = "json"
+redact = "all"
+top = 25
+compress = true
+preset = "deep"
+window = 256000
+
+[view.ci]
+format = "tsv"
+min_code = 1
+max_rows = 50
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+
+        // Spot-check every section
+        assert_eq!(config.scan.hidden, Some(true));
+        assert_eq!(config.scan.doc_comments, Some(true));
+        assert_eq!(config.scan.exclude, Some(vec!["target".to_string()]));
+
+        assert_eq!(config.module.depth, Some(2));
+        assert_eq!(config.module.children, Some("collapse".to_string()));
+
+        assert_eq!(config.export.format, Some("jsonl".to_string()));
+        assert_eq!(config.export.children, Some("separate".to_string()));
+
+        assert_eq!(config.analyze.preset, Some("deep".to_string()));
+        assert_eq!(config.analyze.window, Some(256000));
+        assert_eq!(config.analyze.granularity, Some("module".to_string()));
+        assert_eq!(config.analyze.max_file_bytes, Some(500000));
+
+        assert_eq!(config.context.budget, Some("1m".to_string()));
+        assert_eq!(config.context.rank_by, Some("hotspot".to_string()));
+
+        assert_eq!(config.badge.metric, Some("doc".to_string()));
+
+        assert_eq!(config.gate.fail_fast, Some(false));
+        assert_eq!(config.gate.allow_missing_baseline, Some(true));
+        assert_eq!(config.gate.allow_missing_current, Some(false));
+        assert_eq!(config.gate.policy, Some("my-policy.toml".to_string()));
+        assert_eq!(config.gate.baseline, Some("baseline.json".to_string()));
+        assert_eq!(config.gate.preset, Some("risk".to_string()));
+        assert_eq!(config.gate.rules.as_ref().map(|r| r.len()), Some(1));
+        assert_eq!(config.gate.ratchet.as_ref().map(|r| r.len()), Some(1));
+
+        assert_eq!(config.view.len(), 2);
+        assert_eq!(config.view.get("llm").unwrap().compress, Some(true));
+        assert_eq!(config.view.get("ci").unwrap().max_rows, Some(50));
+    }
+
+    #[test]
+    fn given_all_sections_when_roundtripped_through_json_then_values_preserved() {
+        let toml_str = r#"
+[scan]
+hidden = true
+paths = ["src", "tests"]
+
+[module]
+depth = 3
+roots = ["crates"]
+
+[export]
+min_code = 5
+
+[analyze]
+preset = "health"
+window = 128000
+
+[context]
+budget = "64k"
+
+[badge]
+metric = "lines"
+
+[gate]
+fail_fast = true
+
+[view.ci]
+format = "tsv"
+top = 20
+"#;
+        let config1 = TomlConfig::parse(toml_str).unwrap();
+        let json = serde_json::to_string(&config1).unwrap();
+        let config2: TomlConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(config1.scan.hidden, config2.scan.hidden);
+        assert_eq!(config1.scan.paths, config2.scan.paths);
+        assert_eq!(config1.module.depth, config2.module.depth);
+        assert_eq!(config1.module.roots, config2.module.roots);
+        assert_eq!(config1.export.min_code, config2.export.min_code);
+        assert_eq!(config1.analyze.preset, config2.analyze.preset);
+        assert_eq!(config1.analyze.window, config2.analyze.window);
+        assert_eq!(config1.context.budget, config2.context.budget);
+        assert_eq!(config1.badge.metric, config2.badge.metric);
+        assert_eq!(config1.gate.fail_fast, config2.gate.fail_fast);
+        assert_eq!(
+            config1.view.get("ci").unwrap().format,
+            config2.view.get("ci").unwrap().format
+        );
+        assert_eq!(
+            config1.view.get("ci").unwrap().top,
+            config2.view.get("ci").unwrap().top
+        );
+    }
+}
+
+// =========================================================================
+// Scenario: CLI subcommand defaults with TOML config interaction
+// =========================================================================
+
+mod cli_toml_interaction {
+    use super::*;
+    use clap::Parser;
+    use tokmd_config::Cli;
+
+    #[test]
+    fn given_toml_with_view_profile_when_cli_uses_profile_flag_then_name_captured() {
+        // This tests that the --profile flag correctly captures a profile name
+        // that can be looked up in TomlConfig
+        let toml_str = r#"
+[view.my_profile]
+format = "json"
+top = 10
+redact = "all"
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+        let cli = Cli::try_parse_from(["tokmd", "--profile", "my_profile"]).unwrap();
+
+        let profile_name = cli.profile.as_deref().unwrap();
+        let profile = config.view.get(profile_name).unwrap();
+        assert_eq!(profile.format, Some("json".to_string()));
+        assert_eq!(profile.top, Some(10));
+        assert_eq!(profile.redact, Some("all".to_string()));
+    }
+
+    #[test]
+    fn given_toml_with_multiple_profiles_when_cli_selects_one_then_correct_profile_used() {
+        let toml_str = r#"
+[view.quick]
+format = "md"
+top = 5
+
+[view.deep]
+format = "json"
+top = 100
+preset = "deep"
+"#;
+        let config = TomlConfig::parse(toml_str).unwrap();
+
+        let cli_quick = Cli::try_parse_from(["tokmd", "--profile", "quick"]).unwrap();
+        let cli_deep = Cli::try_parse_from(["tokmd", "--profile", "deep"]).unwrap();
+
+        let quick = config
+            .view
+            .get(cli_quick.profile.as_deref().unwrap())
+            .unwrap();
+        let deep = config
+            .view
+            .get(cli_deep.profile.as_deref().unwrap())
+            .unwrap();
+
+        assert_eq!(quick.format, Some("md".to_string()));
+        assert_eq!(quick.top, Some(5));
+        assert_eq!(deep.format, Some("json".to_string()));
+        assert_eq!(deep.top, Some(100));
+    }
+
+    #[test]
+    fn given_toml_config_when_cli_specifies_nonexistent_profile_then_lookup_returns_none() {
+        let config = TomlConfig::parse("[view.exists]\nformat = \"json\"\n").unwrap();
+        let cli = Cli::try_parse_from(["tokmd", "--profile", "nonexistent"]).unwrap();
+
+        let result = config.view.get(cli.profile.as_deref().unwrap());
+        assert!(result.is_none());
+    }
+}
+
+// =========================================================================
+// Scenario: TOML type strictness
+// =========================================================================
+
+mod toml_type_strictness {
+    use super::*;
+
+    #[test]
+    fn given_integer_where_boolean_expected_then_error() {
+        assert!(TomlConfig::parse("[scan]\nhidden = 1").is_err());
+    }
+
+    #[test]
+    fn given_float_where_boolean_expected_then_error() {
+        assert!(TomlConfig::parse("[scan]\nhidden = 1.0").is_err());
+    }
+
+    #[test]
+    fn given_object_where_string_expected_then_error() {
+        assert!(TomlConfig::parse("[context]\nbudget = { value = 128 }").is_err());
+    }
+
+    #[test]
+    fn given_boolean_where_string_expected_then_error() {
+        assert!(TomlConfig::parse("[export]\nformat = true").is_err());
+    }
+
+    #[test]
+    fn given_boolean_where_array_expected_then_error() {
+        assert!(TomlConfig::parse("[module]\nroots = true").is_err());
+    }
+
+    #[test]
+    fn given_integer_where_string_expected_then_error() {
+        assert!(TomlConfig::parse("[context]\nbudget = 128").is_err());
+    }
+}

--- a/crates/tokmd-tool-schema/tests/depth_and_determinism.rs
+++ b/crates/tokmd-tool-schema/tests/depth_and_determinism.rs
@@ -1,0 +1,553 @@
+//! Tests for deeply nested subcommands, determinism guarantees,
+//! and edge cases not covered by other test files.
+//!
+//! Focus areas:
+//! - Deeply nested subcommand trees (3+ levels)
+//! - Schema determinism across repeated builds
+//! - Commands with all parameter action types simultaneously
+//! - Format-specific key exclusion guarantees
+//! - Zero-tool and single-tool edge cases
+
+use clap::{Arg, ArgAction, Command};
+use serde_json::Value;
+use tokmd_tool_schema::{ToolSchemaFormat, ToolSchemaOutput, build_tool_schema, render_output};
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/// A command with a deeply nested subcommand tree (3 levels deep).
+fn deeply_nested_cmd() -> Command {
+    Command::new("deep")
+        .version("1.0.0")
+        .about("Deep nesting test")
+        .subcommand(
+            Command::new("level1")
+                .about("First level")
+                .arg(
+                    Arg::new("flag1")
+                        .long("flag1")
+                        .action(ArgAction::SetTrue)
+                        .help("Level 1 flag"),
+                )
+                .subcommand(
+                    Command::new("level2")
+                        .about("Second level")
+                        .arg(
+                            Arg::new("count")
+                                .long("count")
+                                .action(ArgAction::Count)
+                                .help("A counter"),
+                        )
+                        .subcommand(
+                            Command::new("level3").about("Third level").arg(
+                                Arg::new("value")
+                                    .long("value")
+                                    .required(true)
+                                    .help("A required value"),
+                            ),
+                        ),
+                ),
+        )
+}
+
+/// A command with every parameter action type used simultaneously.
+fn all_actions_cmd() -> Command {
+    Command::new("all-actions")
+        .version("1.0.0")
+        .about("All parameter action types")
+        .arg(
+            Arg::new("string-param")
+                .long("string-param")
+                .help("A plain string"),
+        )
+        .arg(
+            Arg::new("bool-true")
+                .long("bool-true")
+                .action(ArgAction::SetTrue)
+                .help("A SetTrue flag"),
+        )
+        .arg(
+            Arg::new("bool-false")
+                .long("bool-false")
+                .action(ArgAction::SetFalse)
+                .help("A SetFalse flag"),
+        )
+        .arg(
+            Arg::new("counter")
+                .long("counter")
+                .short('c')
+                .action(ArgAction::Count)
+                .help("A counter"),
+        )
+        .arg(
+            Arg::new("list")
+                .long("list")
+                .action(ArgAction::Append)
+                .help("An appendable list"),
+        )
+        .arg(
+            Arg::new("with-enum")
+                .long("with-enum")
+                .value_parser(["alpha", "beta", "gamma"])
+                .default_value("alpha")
+                .help("Enum with default"),
+        )
+        .arg(
+            Arg::new("required-val")
+                .long("required-val")
+                .required(true)
+                .help("A required string"),
+        )
+}
+
+/// A command with many subcommands (10+).
+fn many_subcommands_cmd() -> Command {
+    Command::new("multi")
+        .version("2.0.0")
+        .about("Many subs")
+        .subcommand(
+            Command::new("cmd-0")
+                .about("Subcommand 0")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-1")
+                .about("Subcommand 1")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-2")
+                .about("Subcommand 2")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-3")
+                .about("Subcommand 3")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-4")
+                .about("Subcommand 4")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-5")
+                .about("Subcommand 5")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-6")
+                .about("Subcommand 6")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-7")
+                .about("Subcommand 7")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-8")
+                .about("Subcommand 8")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-9")
+                .about("Subcommand 9")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-10")
+                .about("Subcommand 10")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+        .subcommand(
+            Command::new("cmd-11")
+                .about("Subcommand 11")
+                .arg(Arg::new("input").long("input").help("Input path")),
+        )
+}
+
+// ── Scenario: Deeply nested subcommands ─────────────────────────────────
+
+#[test]
+fn given_deeply_nested_cmd_when_schema_built_then_only_direct_children_included() {
+    // build_tool_schema only includes direct subcommands, not nested ones
+    let schema = build_tool_schema(&deeply_nested_cmd());
+    let names: Vec<&str> = schema.tools.iter().map(|t| t.name.as_str()).collect();
+
+    // Root + level1 (direct child) are included
+    assert!(names.contains(&"deep"), "root should be present");
+    assert!(
+        names.contains(&"level1"),
+        "direct subcommand should be present"
+    );
+    // level2 and level3 are nested — not direct subcommands of root
+    assert!(
+        !names.contains(&"level2"),
+        "nested subcommands should not appear at top level"
+    );
+    assert!(
+        !names.contains(&"level3"),
+        "deeply nested subcommands should not appear at top level"
+    );
+}
+
+#[test]
+fn given_deeply_nested_cmd_when_rendered_then_valid_json_in_all_formats() {
+    let schema = build_tool_schema(&deeply_nested_cmd());
+    for fmt in [
+        ToolSchemaFormat::Openai,
+        ToolSchemaFormat::Anthropic,
+        ToolSchemaFormat::Jsonschema,
+        ToolSchemaFormat::Clap,
+    ] {
+        let json_str = render_output(&schema, fmt, false).unwrap();
+        let _: Value = serde_json::from_str(&json_str)
+            .unwrap_or_else(|e| panic!("invalid JSON for format {:?}: {e}", fmt));
+    }
+}
+
+// ── Scenario: All action types in one command ───────────────────────────
+
+#[test]
+fn given_all_actions_cmd_when_schema_built_then_each_type_correctly_inferred() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let root = &schema.tools[0];
+
+    let find = |name: &str| root.parameters.iter().find(|p| p.name == name).unwrap();
+
+    assert_eq!(find("string-param").param_type, "string");
+    assert_eq!(find("bool-true").param_type, "boolean");
+    assert_eq!(find("bool-false").param_type, "boolean");
+    assert_eq!(find("counter").param_type, "integer");
+    assert_eq!(find("list").param_type, "array");
+    assert_eq!(find("with-enum").param_type, "string");
+    assert_eq!(find("required-val").param_type, "string");
+}
+
+#[test]
+fn given_all_actions_cmd_when_schema_built_then_required_and_optional_correct() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let root = &schema.tools[0];
+
+    let find = |name: &str| root.parameters.iter().find(|p| p.name == name).unwrap();
+
+    assert!(find("required-val").required);
+    assert!(!find("string-param").required);
+    assert!(!find("bool-true").required);
+    assert!(!find("counter").required);
+    assert!(!find("list").required);
+}
+
+#[test]
+fn given_all_actions_cmd_when_rendered_openai_then_required_array_has_only_required() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    let root_func = &v["functions"][0];
+    let required: Vec<&str> = root_func["parameters"]["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+
+    assert!(required.contains(&"required-val"));
+    assert_eq!(required.len(), 1, "only required-val should be required");
+}
+
+// ── Scenario: Many subcommands ──────────────────────────────────────────
+
+#[test]
+fn given_many_subcommands_when_schema_built_then_all_included() {
+    let schema = build_tool_schema(&many_subcommands_cmd());
+    // 12 subcommands + 1 root = 13 tools
+    assert_eq!(schema.tools.len(), 13);
+    for i in 0..12 {
+        let name = format!("cmd-{i}");
+        assert!(
+            schema.tools.iter().any(|t| t.name == name),
+            "missing subcommand {}",
+            name
+        );
+    }
+}
+
+#[test]
+fn given_many_subcommands_when_rendered_then_all_formats_produce_valid_json() {
+    let schema = build_tool_schema(&many_subcommands_cmd());
+    for fmt in [
+        ToolSchemaFormat::Openai,
+        ToolSchemaFormat::Anthropic,
+        ToolSchemaFormat::Jsonschema,
+        ToolSchemaFormat::Clap,
+    ] {
+        let json_str = render_output(&schema, fmt, false).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        // Verify structure has correct tool count
+        match fmt {
+            ToolSchemaFormat::Openai => {
+                assert_eq!(v["functions"].as_array().unwrap().len(), 13);
+            }
+            ToolSchemaFormat::Anthropic => {
+                assert_eq!(v["tools"].as_array().unwrap().len(), 13);
+            }
+            ToolSchemaFormat::Jsonschema => {
+                assert_eq!(v["tools"].as_array().unwrap().len(), 13);
+            }
+            ToolSchemaFormat::Clap => {
+                let deser: ToolSchemaOutput = serde_json::from_str(&json_str).unwrap();
+                assert_eq!(deser.tools.len(), 13);
+            }
+        }
+    }
+}
+
+// ── Scenario: Determinism — repeated builds identical ───────────────────
+
+#[test]
+fn given_same_command_when_schema_built_ten_times_then_all_identical() {
+    let outputs: Vec<String> = (0..10)
+        .map(|_| {
+            let cmd = all_actions_cmd();
+            let schema = build_tool_schema(&cmd);
+            render_output(&schema, ToolSchemaFormat::Jsonschema, false).unwrap()
+        })
+        .collect();
+
+    let first = &outputs[0];
+    for (i, output) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(first, output, "iteration {} diverged from first", i);
+    }
+}
+
+#[test]
+fn given_same_command_when_schema_rendered_in_all_formats_then_each_format_deterministic() {
+    for fmt in [
+        ToolSchemaFormat::Openai,
+        ToolSchemaFormat::Anthropic,
+        ToolSchemaFormat::Jsonschema,
+        ToolSchemaFormat::Clap,
+    ] {
+        let cmd = all_actions_cmd();
+        let schema = build_tool_schema(&cmd);
+        let a = render_output(&schema, fmt, true).unwrap();
+        let b = render_output(&schema, fmt, true).unwrap();
+        assert_eq!(a, b, "non-deterministic output for {:?}", fmt);
+    }
+}
+
+// ── Scenario: Format-specific key exclusion guarantees ──────────────────
+
+#[test]
+fn given_openai_format_then_no_tools_or_schema_or_input_schema_keys() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    assert!(v.get("tools").is_none(), "OpenAI must not have 'tools' key");
+    assert!(
+        v.get("$schema").is_none(),
+        "OpenAI must not have '$schema' key"
+    );
+    // Each function uses "parameters", not "input_schema"
+    for func in v["functions"].as_array().unwrap() {
+        assert!(
+            func.get("input_schema").is_none(),
+            "OpenAI functions must not have 'input_schema'"
+        );
+        assert!(
+            func.get("parameters").is_some(),
+            "OpenAI functions must have 'parameters'"
+        );
+    }
+}
+
+#[test]
+fn given_anthropic_format_then_no_functions_or_schema_or_parameters_keys() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Anthropic, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    assert!(
+        v.get("functions").is_none(),
+        "Anthropic must not have 'functions' key"
+    );
+    assert!(
+        v.get("$schema").is_none(),
+        "Anthropic must not have '$schema' key"
+    );
+    // Each tool uses "input_schema", not "parameters"
+    for tool in v["tools"].as_array().unwrap() {
+        assert!(
+            tool.get("parameters").is_none(),
+            "Anthropic tools must not have 'parameters'"
+        );
+        assert!(
+            tool.get("input_schema").is_some(),
+            "Anthropic tools must have 'input_schema'"
+        );
+    }
+}
+
+#[test]
+fn given_jsonschema_format_then_has_schema_draft_and_no_functions_key() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let json_str = render_output(&schema, ToolSchemaFormat::Jsonschema, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    assert!(
+        v.get("$schema").is_some(),
+        "JSON Schema must have '$schema'"
+    );
+    assert!(
+        v.get("functions").is_none(),
+        "JSON Schema must not have 'functions'"
+    );
+    // Tools use "parameters" with type: "object"
+    for tool in v["tools"].as_array().unwrap() {
+        assert_eq!(tool["parameters"]["type"].as_str(), Some("object"));
+    }
+}
+
+// ── Scenario: Enum values propagate to all formats ──────────────────────
+
+#[test]
+fn given_param_with_enums_when_rendered_in_each_format_then_enums_present() {
+    let schema = build_tool_schema(&all_actions_cmd());
+
+    // OpenAI
+    let json_str = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+    let prop = &v["functions"][0]["parameters"]["properties"]["with-enum"];
+    assert_eq!(
+        prop["enum"].as_array().unwrap().len(),
+        3,
+        "OpenAI should have enum values"
+    );
+
+    // Anthropic
+    let json_str = render_output(&schema, ToolSchemaFormat::Anthropic, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+    let prop = &v["tools"][0]["input_schema"]["properties"]["with-enum"];
+    assert_eq!(
+        prop["enum"].as_array().unwrap().len(),
+        3,
+        "Anthropic should have enum values"
+    );
+
+    // JSON Schema
+    let json_str = render_output(&schema, ToolSchemaFormat::Jsonschema, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+    let prop = &v["tools"][0]["parameters"]["properties"]["with-enum"];
+    assert_eq!(
+        prop["enum"].as_array().unwrap().len(),
+        3,
+        "JSON Schema should have enum values"
+    );
+    // JSON Schema also includes default
+    assert_eq!(prop["default"].as_str(), Some("alpha"));
+}
+
+// ── Scenario: ToolSchemaOutput clone and debug ──────────────────────────
+
+#[test]
+fn given_schema_output_when_cloned_then_identical() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let cloned = schema.clone();
+
+    let a = serde_json::to_string(&schema).unwrap();
+    let b = serde_json::to_string(&cloned).unwrap();
+    assert_eq!(a, b, "cloned schema must serialize identically");
+}
+
+#[test]
+fn given_schema_output_when_debug_printed_then_does_not_panic() {
+    let schema = build_tool_schema(&all_actions_cmd());
+    let debug = format!("{:?}", schema);
+    assert!(!debug.is_empty());
+    assert!(debug.contains("all-actions"));
+}
+
+// ── Scenario: ToolSchemaFormat serde roundtrip ──────────────────────────
+
+#[test]
+fn given_tool_schema_format_when_serialized_then_roundtrips() {
+    for fmt in [
+        ToolSchemaFormat::Openai,
+        ToolSchemaFormat::Anthropic,
+        ToolSchemaFormat::Jsonschema,
+        ToolSchemaFormat::Clap,
+    ] {
+        let json = serde_json::to_string(&fmt).unwrap();
+        let back: ToolSchemaFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, fmt, "roundtrip failed for {:?}", fmt);
+    }
+}
+
+// ── Scenario: ParameterSchema skip_serializing_if behavior ──────────────
+
+#[test]
+fn given_parameter_with_no_optional_fields_then_json_omits_them() {
+    use tokmd_tool_schema::ParameterSchema;
+
+    let param = ParameterSchema {
+        name: "bare".to_string(),
+        description: None,
+        param_type: "string".to_string(),
+        required: false,
+        default: None,
+        enum_values: None,
+    };
+
+    let json = serde_json::to_string(&param).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+
+    assert!(
+        v.get("description").is_none(),
+        "None description should be omitted"
+    );
+    assert!(v.get("default").is_none(), "None default should be omitted");
+    assert!(
+        v.get("enum_values").is_none(),
+        "None enum_values should be omitted"
+    );
+    // Required fields always present
+    assert!(v.get("name").is_some());
+    assert!(v.get("type").is_some());
+    assert!(v.get("required").is_some());
+}
+
+// ── Scenario: Command with no about text on subcommands ─────────────────
+
+#[test]
+fn given_subcommand_without_about_then_description_is_empty() {
+    let cmd = Command::new("app")
+        .version("1.0.0")
+        .about("Main app")
+        .subcommand(Command::new("bare-sub"));
+
+    let schema = build_tool_schema(&cmd);
+    let bare = schema.tools.iter().find(|t| t.name == "bare-sub").unwrap();
+    assert_eq!(bare.description, "");
+}
+
+#[test]
+fn given_subcommand_without_about_when_rendered_then_description_is_empty_string() {
+    let cmd = Command::new("app")
+        .version("1.0.0")
+        .about("Main app")
+        .subcommand(Command::new("bare-sub"));
+
+    let schema = build_tool_schema(&cmd);
+    let json_str = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let v: Value = serde_json::from_str(&json_str).unwrap();
+
+    let bare = v["functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["name"] == "bare-sub")
+        .unwrap();
+    assert_eq!(bare["description"].as_str(), Some(""));
+}


### PR DESCRIPTION
## Summary

Add 46 new BDD-style integration tests across two Tier 4 crates to cover edge cases, determinism guarantees, and integration scenarios not exercised by existing tests.

### `tokmd-tool-schema` — `depth_and_determinism.rs` (19 tests)

- **Deeply nested subcommands**: 3-level nesting verifies only direct children appear
- **All parameter action types**: SetTrue, SetFalse, Count, Append, string, enum, required
- **Many subcommands**: 12 subcommands verified across all 4 output formats
- **Determinism**: 10-iteration loop confirms identical output; per-format determinism check
- **Format-specific key exclusion**: OpenAI, Anthropic, JSON Schema mutual exclusivity
- **Enum propagation**: enum values verified present in all 3 external formats
- **Trait coverage**: Clone, Debug for ToolSchemaOutput; serde roundtrip for ToolSchemaFormat
- **skip_serializing_if**: ParameterSchema with all-None optional fields omits them in JSON
- **Missing about**: Subcommands without about produce empty description strings

### `tokmd-config` — `config_integration.rs` (27 tests)

- **Determinism**: Parse same TOML 10 times identical; from_file twice identical
- **Profile name edge cases**: hyphens, numbers, quoted dots, Unicode, BTreeMap sort order
- **Gate boundary values**: 0% and 100% ratchet, value=0 rule, 10 rules in order
- **from_file errors**: nonexistent path, empty file, whitespace-only, comments-only, invalid TOML
- **Section interactions**: All config sections simultaneously + JSON roundtrip preservation
- **CLI-TOML interaction**: --profile lookup, multiple profiles, nonexistent profile
- **Type strictness**: integer-for-bool, float-for-bool, object-for-string, bool-for-string, bool-for-array, integer-for-string

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>