### PR TITLE
test: deep tests for near-dup, topics, and entropy analysis

### DIFF
--- a/crates/tokmd-analysis-entropy/tests/deep.rs
+++ b/crates/tokmd-analysis-entropy/tests/deep.rs
@@ -1,7 +1,7 @@
 //! Deep invariant tests for entropy detection.
 //!
-//! Focuses on classification boundary values, charset entropy ranges,
-//! truncation boundaries, PRNG seed stability, and determinism.
+//! Tests classification boundaries, charset entropy ranges,
+//! truncation, PRNG stability, determinism, and edge cases.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -52,66 +52,28 @@ fn write_pseudorandom(path: &Path, seed: u32, len: usize) {
     fs::write(path, data).unwrap();
 }
 
-// ── 1. Base64-charset data falls in Normal range (not suspect) ──
+// ── 1. All-zero file classified as Low ──────────────────────────
 
 #[test]
-fn base64_charset_falls_in_normal_range() {
+fn all_zero_file_is_low_entropy() {
     let dir = tempdir().unwrap();
-    let f = dir.path().join("secret.b64");
-    // Base64 uses 64 chars → max entropy ≈ log2(64) = 6.0 bits/byte → Normal
-    let base64_chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut data = Vec::with_capacity(2048);
-    let mut x = 0xDEADBEEFu32;
-    for _ in 0..2048 {
-        x = x.wrapping_mul(1664525).wrapping_add(1013904223);
-        data.push(base64_chars[(x >> 16) as usize % base64_chars.len()]);
-    }
-    fs::write(&f, &data).unwrap();
+    let f = dir.path().join("zeros.bin");
+    write_repeated(&f, 0x00, 1024);
 
-    let export = export_for_paths(&["secret.b64"]);
-    let files = vec![PathBuf::from("secret.b64")];
+    let export = export_for_paths(&["zeros.bin"]);
+    let files = vec![PathBuf::from("zeros.bin")];
     let report =
         build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
 
-    // 64-char alphabet → entropy ≈ 6.0 → Normal → filtered out of suspects
-    assert!(
-        report.suspects.is_empty(),
-        "base64 charset data (entropy ≈ 6.0) should be Normal, not a suspect"
-    );
+    assert_eq!(report.suspects.len(), 1);
+    assert_eq!(report.suspects[0].class, EntropyClass::Low);
+    assert!(report.suspects[0].entropy_bits_per_byte < 0.001);
 }
 
-// ── 2. Hex-charset data falls in Normal range (not suspect) ─────
+// ── 2. Full-byte-range data classified as High ──────────────────
 
 #[test]
-fn hex_charset_falls_in_normal_range() {
-    let dir = tempdir().unwrap();
-    let f = dir.path().join("apikey.hex");
-    // Hex uses 16 chars → max entropy ≈ log2(16) = 4.0 bits/byte → Normal
-    let hex_chars = b"0123456789abcdef";
-    let mut data = Vec::with_capacity(2048);
-    let mut x = 0xCAFEBABEu32;
-    for _ in 0..2048 {
-        x = x.wrapping_mul(1664525).wrapping_add(1013904223);
-        data.push(hex_chars[(x >> 16) as usize % hex_chars.len()]);
-    }
-    fs::write(&f, &data).unwrap();
-
-    let export = export_for_paths(&["apikey.hex"]);
-    let files = vec![PathBuf::from("apikey.hex")];
-    let report =
-        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
-
-    // 16-char alphabet → entropy ≈ 4.0 → Normal → filtered out of suspects
-    assert!(
-        report.suspects.is_empty(),
-        "hex charset data (entropy ≈ 4.0) should be Normal, not a suspect"
-    );
-}
-
-// ── 3. Sequential bytes (0,1,2,...,255) repeated ────────────────
-
-#[test]
-fn incrementing_byte_sequence_classified_high() {
+fn full_byte_range_is_high_entropy() {
     let dir = tempdir().unwrap();
     let f = dir.path().join("seq.bin");
     let mut data = Vec::with_capacity(2048);
@@ -127,298 +89,278 @@ fn incrementing_byte_sequence_classified_high() {
     let report =
         build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
 
-    // 256 equally-distributed byte values → entropy = 8.0 bits/byte → High
     assert_eq!(report.suspects.len(), 1);
     assert_eq!(report.suspects[0].class, EntropyClass::High);
 }
 
-// ── 4. Exactly 50 suspects: not truncated ───────────────────────
+// ── 3. PRNG data classified as High ─────────────────────────────
 
 #[test]
-fn exactly_fifty_suspects_not_truncated() {
+fn pseudorandom_data_classified_high() {
     let dir = tempdir().unwrap();
-    let mut rows = Vec::new();
-    let mut files = Vec::new();
-    // Create exactly 50 high-entropy files
-    for i in 0..50 {
-        let name = format!("f{i:03}.bin");
-        let f = dir.path().join(&name);
-        write_pseudorandom(&f, i as u32 + 1000, 2048);
-        rows.push(FileRow {
-            path: name.clone(),
-            module: "(root)".to_string(),
-            lang: "Text".to_string(),
-            kind: FileKind::Parent,
-            code: 1,
-            comments: 0,
-            blanks: 0,
-            lines: 1,
-            bytes: 10,
-            tokens: 2,
-        });
-        files.push(PathBuf::from(name));
-    }
+    let f = dir.path().join("random.bin");
+    write_pseudorandom(&f, 0xDEAD, 4096);
 
-    let export = ExportData {
-        rows,
-        module_roots: vec![],
-        module_depth: 1,
-        children: ChildIncludeMode::Separate,
-    };
-    let report =
-        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
-
-    // All 50 should be present (MAX_SUSPECTS = 50, not exceeded)
-    assert_eq!(
-        report.suspects.len(),
-        50,
-        "exactly 50 suspects should not be truncated"
-    );
-}
-
-// ── 5. 51 suspects → truncated to 50 ───────────────────────────
-
-#[test]
-fn fifty_one_suspects_truncated_to_fifty() {
-    let dir = tempdir().unwrap();
-    let mut rows = Vec::new();
-    let mut files = Vec::new();
-    for i in 0..51 {
-        let name = format!("f{i:03}.bin");
-        let f = dir.path().join(&name);
-        write_pseudorandom(&f, i as u32 + 2000, 2048);
-        rows.push(FileRow {
-            path: name.clone(),
-            module: "(root)".to_string(),
-            lang: "Text".to_string(),
-            kind: FileKind::Parent,
-            code: 1,
-            comments: 0,
-            blanks: 0,
-            lines: 1,
-            bytes: 10,
-            tokens: 2,
-        });
-        files.push(PathBuf::from(name));
-    }
-
-    let export = ExportData {
-        rows,
-        module_roots: vec![],
-        module_depth: 1,
-        children: ChildIncludeMode::Separate,
-    };
-    let report =
-        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
-
-    assert_eq!(
-        report.suspects.len(),
-        50,
-        "51 suspects should be truncated to MAX_SUSPECTS=50"
-    );
-}
-
-// ── 6. Multiple seeds produce consistent high-entropy classification
-
-#[test]
-fn different_prng_seeds_all_classify_high() {
-    let dir = tempdir().unwrap();
-    let seeds = [0xAAAAu32, 0xBBBB, 0xCCCC, 0xDDDD, 0xEEEE];
-    let mut rows = Vec::new();
-    let mut files = Vec::new();
-
-    for (i, &seed) in seeds.iter().enumerate() {
-        let name = format!("s{i}.bin");
-        let f = dir.path().join(&name);
-        write_pseudorandom(&f, seed, 4096);
-        rows.push(FileRow {
-            path: name.clone(),
-            module: "(root)".to_string(),
-            lang: "Text".to_string(),
-            kind: FileKind::Parent,
-            code: 1,
-            comments: 0,
-            blanks: 0,
-            lines: 1,
-            bytes: 10,
-            tokens: 2,
-        });
-        files.push(PathBuf::from(name));
-    }
-
-    let export = ExportData {
-        rows,
-        module_roots: vec![],
-        module_depth: 1,
-        children: ChildIncludeMode::Separate,
-    };
-    let report =
-        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
-
-    assert_eq!(report.suspects.len(), 5);
-    for suspect in &report.suspects {
-        assert_eq!(
-            suspect.class,
-            EntropyClass::High,
-            "seed-varied PRNG data should all be High, {} was {:?}",
-            suspect.path,
-            suspect.class
-        );
-    }
-}
-
-// ── 7. Classification boundary: all-same bytes → Low ────────────
-
-#[test]
-fn classification_boundary_all_same_bytes_is_low() {
-    let dir = tempdir().unwrap();
-    // Test multiple single-byte values
-    for byte in [0x00u8, 0x41, 0xFF, 0x7F] {
-        let name = format!("byte_{byte:02x}.bin");
-        let f = dir.path().join(&name);
-        write_repeated(&f, byte, 1024);
-
-        let export = export_for_paths(&[&name]);
-        let files = vec![PathBuf::from(&name)];
-        let report =
-            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
-
-        assert_eq!(report.suspects.len(), 1);
-        assert_eq!(
-            report.suspects[0].class,
-            EntropyClass::Low,
-            "all-same-byte file (0x{byte:02x}) should be Low"
-        );
-    }
-}
-
-// ── 8. Module mapping for files in subdirectories ───────────────
-
-#[test]
-fn subdirectory_file_maps_to_correct_module() {
-    let dir = tempdir().unwrap();
-    let sub = dir.path().join("sub").join("dir");
-    fs::create_dir_all(&sub).unwrap();
-    let f = sub.join("secret.bin");
-    write_pseudorandom(&f, 0x1234, 2048);
-
-    let rows = vec![FileRow {
-        path: "sub/dir/secret.bin".to_string(),
-        module: "sub/dir".to_string(),
-        lang: "Text".to_string(),
-        kind: FileKind::Parent,
-        code: 1,
-        comments: 0,
-        blanks: 0,
-        lines: 1,
-        bytes: 10,
-        tokens: 2,
-    }];
-    let export = ExportData {
-        rows,
-        module_roots: vec![],
-        module_depth: 2,
-        children: ChildIncludeMode::Separate,
-    };
-    let files = vec![PathBuf::from("sub/dir/secret.bin")];
+    let export = export_for_paths(&["random.bin"]);
+    let files = vec![PathBuf::from("random.bin")];
     let report =
         build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
 
     assert_eq!(report.suspects.len(), 1);
-    assert_eq!(report.suspects[0].module, "sub/dir");
-    assert_eq!(report.suspects[0].path, "sub/dir/secret.bin");
+    assert_eq!(report.suspects[0].class, EntropyClass::High);
 }
 
-// ── 9. max_bytes budget: zero budget scans nothing ──────────────
+// ── 4. English prose is Normal (not a suspect) ──────────────────
 
 #[test]
-fn zero_max_bytes_budget_scans_nothing() {
+fn english_prose_is_normal() {
     let dir = tempdir().unwrap();
-    let f = dir.path().join("data.bin");
-    write_pseudorandom(&f, 0xABCD, 1024);
+    let f = dir.path().join("readme.txt");
+    let text = "The quick brown fox jumps over the lazy dog. ".repeat(50);
+    fs::write(&f, text).unwrap();
 
-    let export = export_for_paths(&["data.bin"]);
-    let files = vec![PathBuf::from("data.bin")];
-    let limits = AnalysisLimits {
-        max_bytes: Some(0),
-        ..AnalysisLimits::default()
-    };
-    let report = build_entropy_report(dir.path(), &files, &export, &limits).unwrap();
+    let export = export_for_paths(&["readme.txt"]);
+    let files = vec![PathBuf::from("readme.txt")];
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
 
     assert!(
         report.suspects.is_empty(),
-        "zero budget should scan nothing"
+        "English prose should be Normal class"
     );
 }
 
-// ── 10. Determinism: same file, three runs, identical output ────
+// ── 5. Typical source code is Normal ────────────────────────────
 
 #[test]
-fn three_runs_produce_identical_results() {
+fn source_code_is_normal() {
     let dir = tempdir().unwrap();
-
-    let lo = dir.path().join("lo.bin");
-    let hi = dir.path().join("hi.bin");
-    write_repeated(&lo, 0x00, 1024);
-    write_pseudorandom(&hi, 0x9999, 4096);
-
-    let export = export_for_paths(&["lo.bin", "hi.bin"]);
-    let files = vec![PathBuf::from("lo.bin"), PathBuf::from("hi.bin")];
-
-    let results: Vec<_> = (0..3)
-        .map(|_| {
-            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap()
-        })
-        .collect();
-
-    for i in 1..3 {
-        assert_eq!(results[0].suspects.len(), results[i].suspects.len());
-        for (s0, si) in results[0].suspects.iter().zip(results[i].suspects.iter()) {
-            assert_eq!(s0.path, si.path);
-            assert_eq!(s0.class, si.class);
-            assert!(
-                (s0.entropy_bits_per_byte - si.entropy_bits_per_byte).abs() < f32::EPSILON,
-                "entropy should be identical across runs"
-            );
-            assert_eq!(s0.sample_bytes, si.sample_bytes);
-            assert_eq!(s0.module, si.module);
+    let f = dir.path().join("code.rs");
+    let code = r#"fn main() {
+    let x = 42;
+    println!("Hello, world! x = {}", x);
+    for i in 0..100 {
+        if i % 2 == 0 {
+            println!("{} is even", i);
         }
     }
 }
+"#
+    .repeat(10);
+    fs::write(&f, code).unwrap();
 
-// ── 11. Entropy value for all-zero file is exactly 0.0 ──────────
-
-#[test]
-fn all_zero_file_has_zero_entropy() {
-    let dir = tempdir().unwrap();
-    let f = dir.path().join("zeros.bin");
-    write_repeated(&f, 0x00, 2048);
-
-    let export = export_for_paths(&["zeros.bin"]);
-    let files = vec![PathBuf::from("zeros.bin")];
+    let export = export_for_paths(&["code.rs"]);
+    let files = vec![PathBuf::from("code.rs")];
     let report =
         build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
 
-    assert_eq!(report.suspects.len(), 1);
     assert!(
-        report.suspects[0].entropy_bits_per_byte < 0.001,
-        "all-zero file should have ~0.0 entropy, got {}",
-        report.suspects[0].entropy_bits_per_byte
+        report.suspects.is_empty(),
+        "typical source code should be Normal class"
     );
 }
 
-// ── 12. Mixed parent and child rows: only parent used for lookup ─
+// ── 6. Base64-charset data stays Normal ─────────────────────────
 
 #[test]
-fn parent_row_preferred_over_child_for_module_lookup() {
+fn base64_charset_is_normal() {
     let dir = tempdir().unwrap();
-    let f = dir.path().join("data.bin");
-    write_pseudorandom(&f, 0xFACE, 2048);
+    let f = dir.path().join("encoded.b64");
+    let charset = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut data = Vec::with_capacity(2048);
+    let mut x = 0xBEEFu32;
+    for _ in 0..2048 {
+        x = x.wrapping_mul(1664525).wrapping_add(1013904223);
+        data.push(charset[(x >> 16) as usize % charset.len()]);
+    }
+    fs::write(&f, &data).unwrap();
+
+    let export = export_for_paths(&["encoded.b64"]);
+    let files = vec![PathBuf::from("encoded.b64")];
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+    assert!(
+        report.suspects.is_empty(),
+        "base64 charset (~6.0 bits/byte) should be Normal"
+    );
+}
+
+// ── 7. Hex-charset data stays Normal ────────────────────────────
+
+#[test]
+fn hex_charset_is_normal() {
+    let dir = tempdir().unwrap();
+    let f = dir.path().join("hex.txt");
+    let charset = b"0123456789abcdef";
+    let mut data = Vec::with_capacity(2048);
+    let mut x = 0xCAFEu32;
+    for _ in 0..2048 {
+        x = x.wrapping_mul(1664525).wrapping_add(1013904223);
+        data.push(charset[(x >> 16) as usize % charset.len()]);
+    }
+    fs::write(&f, &data).unwrap();
+
+    let export = export_for_paths(&["hex.txt"]);
+    let files = vec![PathBuf::from("hex.txt")];
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+    assert!(report.suspects.is_empty(), "hex (~4.0 bits/byte) is Normal");
+}
+
+// ── 8. Empty file produces no suspects ──────────────────────────
+
+#[test]
+fn empty_file_no_suspects() {
+    let dir = tempdir().unwrap();
+    let f = dir.path().join("empty.txt");
+    fs::write(&f, b"").unwrap();
+
+    let export = export_for_paths(&["empty.txt"]);
+    let files = vec![PathBuf::from("empty.txt")];
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+    assert!(report.suspects.is_empty(), "empty file = no suspects");
+}
+
+// ── 9. Suspects truncated to MAX_SUSPECTS (50) ─────────────────
+
+#[test]
+fn suspects_truncated_to_max() {
+    let dir = tempdir().unwrap();
+    let mut rows = Vec::new();
+    let mut files = Vec::new();
+    for i in 0..60 {
+        let name = format!("f{i:03}.bin");
+        write_pseudorandom(&dir.path().join(&name), i as u32 + 1000, 2048);
+        rows.push(FileRow {
+            path: name.clone(),
+            module: "(root)".to_string(),
+            lang: "Text".to_string(),
+            kind: FileKind::Parent,
+            code: 1,
+            comments: 0,
+            blanks: 0,
+            lines: 1,
+            bytes: 10,
+            tokens: 2,
+        });
+        files.push(PathBuf::from(name));
+    }
+    let export = ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+    assert!(
+        report.suspects.len() <= 50,
+        "suspects should be capped at 50, got {}",
+        report.suspects.len()
+    );
+}
+
+// ── 10. Suspects sorted by entropy desc, then path asc ─────────
+
+#[test]
+fn suspects_sorted_by_entropy_desc_then_path_asc() {
+    let dir = tempdir().unwrap();
+    write_repeated(&dir.path().join("a.bin"), 0x00, 1024);
+    write_repeated(&dir.path().join("b.bin"), 0x00, 1024);
+    write_pseudorandom(&dir.path().join("c.bin"), 0xABCD, 4096);
+
+    let export = export_for_paths(&["a.bin", "b.bin", "c.bin"]);
+    let files = vec![
+        PathBuf::from("a.bin"),
+        PathBuf::from("b.bin"),
+        PathBuf::from("c.bin"),
+    ];
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+    for i in 1..report.suspects.len() {
+        let prev = &report.suspects[i - 1];
+        let curr = &report.suspects[i];
+        assert!(
+            prev.entropy_bits_per_byte >= curr.entropy_bits_per_byte
+                || (prev.entropy_bits_per_byte == curr.entropy_bits_per_byte
+                    && prev.path <= curr.path),
+            "sort violation at index {i}"
+        );
+    }
+}
+
+// ── 11. Normal class never appears in suspects ──────────────────
+
+#[test]
+fn normal_class_never_in_suspects() {
+    let dir = tempdir().unwrap();
+    write_repeated(&dir.path().join("lo.bin"), 0x00, 1024);
+    write_pseudorandom(&dir.path().join("hi.bin"), 0x5555, 4096);
+    fs::write(
+        dir.path().join("code.rs"),
+        "fn main() { println!(\"hello\"); }\n".repeat(30),
+    )
+    .unwrap();
+
+    let export = export_for_paths(&["lo.bin", "hi.bin", "code.rs"]);
+    let files = vec![
+        PathBuf::from("lo.bin"),
+        PathBuf::from("hi.bin"),
+        PathBuf::from("code.rs"),
+    ];
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+    for suspect in &report.suspects {
+        assert_ne!(suspect.class, EntropyClass::Normal);
+    }
+}
+
+// ── 12. Entropy values always in [0.0, 8.0] ────────────────────
+
+#[test]
+fn entropy_within_theoretical_bounds() {
+    let dir = tempdir().unwrap();
+    write_repeated(&dir.path().join("zeros.bin"), 0x00, 1024);
+    write_repeated(&dir.path().join("ff.bin"), 0xFF, 1024);
+    write_pseudorandom(&dir.path().join("rand.bin"), 0x42, 4096);
+
+    let export = export_for_paths(&["zeros.bin", "ff.bin", "rand.bin"]);
+    let files = vec![
+        PathBuf::from("zeros.bin"),
+        PathBuf::from("ff.bin"),
+        PathBuf::from("rand.bin"),
+    ];
+    let report =
+        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+    for suspect in &report.suspects {
+        assert!(
+            (0.0..=8.0).contains(&suspect.entropy_bits_per_byte),
+            "entropy out of bounds: {} for {}",
+            suspect.entropy_bits_per_byte,
+            suspect.path
+        );
+    }
+}
+
+// ── 13. Parent row preferred for module lookup ──────────────────
+
+#[test]
+fn parent_row_preferred_for_module_lookup() {
+    let dir = tempdir().unwrap();
+    write_pseudorandom(&dir.path().join("data.bin"), 0xFACE, 2048);
 
     let rows = vec![
         FileRow {
             path: "data.bin".to_string(),
-            module: "parent_module".to_string(),
+            module: "parent_mod".to_string(),
             lang: "Text".to_string(),
             kind: FileKind::Parent,
             code: 1,
@@ -430,7 +372,7 @@ fn parent_row_preferred_over_child_for_module_lookup() {
         },
         FileRow {
             path: "data.bin".to_string(),
-            module: "child_module".to_string(),
+            module: "child_mod".to_string(),
             lang: "Text".to_string(),
             kind: FileKind::Child,
             code: 1,
@@ -452,109 +394,71 @@ fn parent_row_preferred_over_child_for_module_lookup() {
         build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
 
     assert_eq!(report.suspects.len(), 1);
-    assert_eq!(
-        report.suspects[0].module, "parent_module",
-        "should use parent row's module, not child row's"
-    );
+    assert_eq!(report.suspects[0].module, "parent_mod");
 }
 
-// ── 13. Entropy values are always in [0.0, 8.0] ────────────────
+// ── 14. Deterministic across multiple runs ──────────────────────
 
 #[test]
-fn entropy_values_within_theoretical_bounds() {
+fn deterministic_across_runs() {
     let dir = tempdir().unwrap();
+    write_pseudorandom(&dir.path().join("a.bin"), 0x1111, 2048);
+    write_repeated(&dir.path().join("b.bin"), 0x00, 512);
 
-    let names = ["zeros.bin", "ones.bin", "random.bin", "text.txt"];
-    write_repeated(&dir.path().join("zeros.bin"), 0x00, 1024);
-    write_repeated(&dir.path().join("ones.bin"), 0xFF, 1024);
-    write_pseudorandom(&dir.path().join("random.bin"), 0x1234, 4096);
-    fs::write(
-        dir.path().join("text.txt"),
-        "hello world ".repeat(100),
-    )
-    .unwrap();
+    let export = export_for_paths(&["a.bin", "b.bin"]);
+    let files = vec![PathBuf::from("a.bin"), PathBuf::from("b.bin")];
 
-    let export = export_for_paths(&names);
-    let files: Vec<PathBuf> = names.iter().map(PathBuf::from).collect();
-    let report =
-        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+    let results: Vec<_> = (0..3)
+        .map(|_| {
+            build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap()
+        })
+        .collect();
 
-    for suspect in &report.suspects {
-        assert!(
-            suspect.entropy_bits_per_byte >= 0.0 && suspect.entropy_bits_per_byte <= 8.0,
-            "entropy should be in [0, 8], got {} for {}",
-            suspect.entropy_bits_per_byte,
-            suspect.path
-        );
+    for i in 1..3 {
+        assert_eq!(results[0].suspects.len(), results[i].suspects.len());
+        for (a, b) in results[0].suspects.iter().zip(results[i].suspects.iter()) {
+            assert_eq!(a.path, b.path);
+            assert_eq!(a.class, b.class);
+            assert!(
+                (a.entropy_bits_per_byte - b.entropy_bits_per_byte).abs() < f32::EPSILON,
+                "entropy mismatch for {}",
+                a.path
+            );
+        }
     }
 }
 
-// ── 14. Suspect sort stability: deterministic for equal entropy ──
+// ── 15. max_bytes limit stops processing early ──────────────────
 
 #[test]
-fn suspects_with_equal_entropy_sorted_by_path() {
+fn max_bytes_limit_caps_processing() {
     let dir = tempdir().unwrap();
-    // Create multiple files with identical content (same entropy)
-    for name in &["c.bin", "a.bin", "b.bin"] {
-        let f = dir.path().join(name);
-        write_repeated(&f, 0x00, 512);
-    }
-
-    let export = export_for_paths(&["c.bin", "a.bin", "b.bin"]);
-    let files = vec![
-        PathBuf::from("c.bin"),
-        PathBuf::from("a.bin"),
-        PathBuf::from("b.bin"),
-    ];
-    let report =
-        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
-
-    assert_eq!(report.suspects.len(), 3);
-    // All have same entropy (0.0), so should be sorted alphabetically
-    assert_eq!(report.suspects[0].path, "a.bin");
-    assert_eq!(report.suspects[1].path, "b.bin");
-    assert_eq!(report.suspects[2].path, "c.bin");
-}
-
-// ── 15. Normal class never appears in suspects list ─────────────
-
-#[test]
-fn normal_class_never_in_suspects() {
-    let dir = tempdir().unwrap();
-    // Create files across all entropy ranges
-    let lo = dir.path().join("lo.bin");
-    let hi = dir.path().join("hi.bin");
-    let normal = dir.path().join("code.rs");
-
-    write_repeated(&lo, 0x00, 1024);
-    write_pseudorandom(&hi, 0x5555, 4096);
-    let code = r#"fn main() {
-    let x = 42;
-    println!("Hello, world! x = {}", x);
     for i in 0..10 {
-        println!("{}", i);
+        let name = format!("f{i}.bin");
+        write_pseudorandom(&dir.path().join(&name), i as u32, 4096);
     }
-}
-"#
-    .repeat(10);
-    fs::write(&normal, code).unwrap();
 
-    let export = export_for_paths(&["lo.bin", "hi.bin", "code.rs"]);
-    let files = vec![
-        PathBuf::from("lo.bin"),
-        PathBuf::from("hi.bin"),
-        PathBuf::from("code.rs"),
-    ];
-    let report =
-        build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+    let names: Vec<String> = (0..10).map(|i| format!("f{i}.bin")).collect();
+    let name_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+    let export = export_for_paths(&name_refs);
+    let files: Vec<PathBuf> = names.iter().map(PathBuf::from).collect();
 
-    for suspect in &report.suspects {
-        assert_ne!(
-            suspect.class,
-            EntropyClass::Normal,
-            "Normal class should never appear in suspects: {} is {:?}",
-            suspect.path,
-            suspect.class
-        );
-    }
+    let limits_small = AnalysisLimits {
+        max_bytes: Some(4096),
+        max_file_bytes: None,
+        ..Default::default()
+    };
+    let limits_large = AnalysisLimits {
+        max_bytes: Some(1_000_000),
+        max_file_bytes: None,
+        ..Default::default()
+    };
+
+    let report_small = build_entropy_report(dir.path(), &files, &export, &limits_small).unwrap();
+    let report_large = build_entropy_report(dir.path(), &files, &export, &limits_large).unwrap();
+
+    assert!(
+        report_small.suspects.len() <= report_large.suspects.len(),
+        "smaller budget should find <= suspects"
+    );
 }

--- a/crates/tokmd-analysis-near-dup/tests/deep.rs
+++ b/crates/tokmd-analysis-near-dup/tests/deep.rs
@@ -1,8 +1,7 @@
 //! Deep invariant tests for near-duplicate detection.
 //!
-//! Focuses on mathematical properties (Jaccard similarity degradation,
-//! combinatorial pair counts), scope isolation, cluster representative
-//! selection, and boundary conditions.
+//! Tests Jaccard similarity semantics, scope partitioning, clustering,
+//! threshold boundaries, determinism, and edge cases.
 
 use std::io::Write;
 use tempfile::TempDir;
@@ -12,22 +11,20 @@ use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
 
 // ── Helpers ─────────────────────────────────────────────────────
 
-fn source_text(n: usize, seed: usize) -> String {
+fn make_tokens(n: usize, prefix: &str) -> String {
     (0..n)
-        .map(|i| format!("tok_{seed}_{i}"))
+        .map(|i| format!("{prefix}_{i}"))
         .collect::<Vec<_>>()
         .join(" + ")
 }
 
-fn content_with_overlap(shared: usize, unique: usize, seed: usize) -> String {
-    let shared_part: Vec<String> = (0..shared).map(|i| format!("shared_{i}")).collect();
-    let unique_part: Vec<String> = (0..unique).map(|i| format!("unique_{seed}_{i}")).collect();
-    let mut all = shared_part;
-    all.extend(unique_part);
-    all.join(" + ")
+fn overlapping_content(shared: usize, unique: usize, seed: usize) -> String {
+    let shared: Vec<String> = (0..shared).map(|i| format!("common_{i}")).collect();
+    let unique: Vec<String> = (0..unique).map(|i| format!("uniq_{seed}_{i}")).collect();
+    [shared, unique].concat().join(" + ")
 }
 
-fn make_row(path: &str, module: &str, lang: &str, code: usize, bytes: usize) -> FileRow {
+fn file_row(path: &str, module: &str, lang: &str, code: usize, bytes: usize) -> FileRow {
     FileRow {
         path: path.to_string(),
         module: module.to_string(),
@@ -42,16 +39,16 @@ fn make_row(path: &str, module: &str, lang: &str, code: usize, bytes: usize) -> 
     }
 }
 
-fn write_file(dir: &TempDir, rel: &str, content: &str) {
+fn write_to(dir: &TempDir, rel: &str, content: &str) {
     let path = dir.path().join(rel);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).unwrap();
+    if let Some(p) = path.parent() {
+        std::fs::create_dir_all(p).unwrap();
     }
     let mut f = std::fs::File::create(&path).unwrap();
     f.write_all(content.as_bytes()).unwrap();
 }
 
-fn make_export(rows: Vec<FileRow>) -> ExportData {
+fn mk_export(rows: Vec<FileRow>) -> ExportData {
     ExportData {
         rows,
         module_roots: vec![],
@@ -60,94 +57,12 @@ fn make_export(rows: Vec<FileRow>) -> ExportData {
     }
 }
 
-// ── 1. Similarity degrades with increasing divergence ───────────
+// ── 1. Empty export produces empty report ───────────────────────
 
 #[test]
-fn similarity_degrades_with_increasing_divergence() {
+fn empty_export_yields_no_pairs() {
     let dir = TempDir::new().unwrap();
-    let base = source_text(100, 0);
-
-    // File A is the base
-    write_file(&dir, "a.rs", &base);
-
-    // Files with increasing divergence: 10%, 30%, 60% unique tokens
-    let b = content_with_overlap(90, 10, 1);
-    let c = content_with_overlap(70, 30, 2);
-    let d = content_with_overlap(40, 60, 3);
-    write_file(&dir, "b.rs", &b);
-    write_file(&dir, "c.rs", &c);
-    write_file(&dir, "d.rs", &d);
-
-    let rows = vec![
-        make_row("a.rs", "(root)", "Rust", 100, 5000),
-        make_row("b.rs", "(root)", "Rust", 100, 5000),
-        make_row("c.rs", "(root)", "Rust", 100, 5000),
-        make_row("d.rs", "(root)", "Rust", 100, 5000),
-    ];
-    let export = make_export(rows);
-    let report = build_near_dup_report(
-        dir.path(),
-        &export,
-        NearDupScope::Global,
-        0.0,
-        100,
-        Some(1000),
-        &NearDupLimits::default(),
-        &[],
-    )
-    .unwrap();
-
-    // Find pairs involving a.rs
-    let sim_ab = report
-        .pairs
-        .iter()
-        .find(|p| {
-            (p.left == "a.rs" && p.right == "b.rs") || (p.left == "b.rs" && p.right == "a.rs")
-        })
-        .map(|p| p.similarity);
-    let sim_ac = report
-        .pairs
-        .iter()
-        .find(|p| {
-            (p.left == "a.rs" && p.right == "c.rs") || (p.left == "c.rs" && p.right == "a.rs")
-        })
-        .map(|p| p.similarity);
-    let sim_ad = report
-        .pairs
-        .iter()
-        .find(|p| {
-            (p.left == "a.rs" && p.right == "d.rs") || (p.left == "d.rs" && p.right == "a.rs")
-        })
-        .map(|p| p.similarity);
-
-    if let (Some(ab), Some(ac), Some(ad)) = (sim_ab, sim_ac, sim_ad) {
-        assert!(
-            ab >= ac,
-            "a-b similarity ({ab}) should be >= a-c ({ac})"
-        );
-        assert!(
-            ac >= ad,
-            "a-c similarity ({ac}) should be >= a-d ({ad})"
-        );
-    }
-}
-
-// ── 2. Four identical files produce C(4,2)=6 pairs ─────────────
-
-#[test]
-fn four_identical_files_produce_six_pairs() {
-    let dir = TempDir::new().unwrap();
-    let content = source_text(100, 42);
-
-    for name in &["w.rs", "x.rs", "y.rs", "z.rs"] {
-        write_file(&dir, name, &content);
-    }
-    let rows: Vec<FileRow> = ["w.rs", "x.rs", "y.rs", "z.rs"]
-        .iter()
-        .map(|n| make_row(n, "(root)", "Rust", 100, 5000))
-        .collect();
-    let export = make_export(rows);
-
+    let export = mk_export(vec![]);
     let report = build_near_dup_report(
         dir.path(),
         &export,
@@ -159,64 +74,90 @@ fn four_identical_files_produce_six_pairs() {
         &[],
     )
     .unwrap();
-
-    assert_eq!(
-        report.pairs.len(),
-        6,
-        "C(4,2)=6 pairs expected from 4 identical files"
+    assert!(report.pairs.is_empty());
+    assert!(
+        report.clusters.as_ref().map_or(true, |c| c.is_empty()),
+        "clusters should be empty or None"
     );
+    assert_eq!(report.files_analyzed, 0);
 }
 
-// ── 3. Threshold boundary: similarity == threshold is included ──
+// ── 2. Single file produces no pairs ────────────────────────────
 
 #[test]
-fn threshold_boundary_includes_equal_similarity() {
+fn single_file_no_pairs() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 99);
-
-    write_file(&dir, "a.rs", &content);
-    write_file(&dir, "b.rs", &content);
-    let rows = vec![
-        make_row("a.rs", "(root)", "Rust", 100, 5000),
-        make_row("b.rs", "(root)", "Rust", 100, 5000),
-    ];
-    let export = make_export(rows);
-
-    // Identical files have similarity 1.0; threshold at 1.0 should include them
+    let content = make_tokens(120, "only");
+    write_to(&dir, "solo.rs", &content);
+    let export = mk_export(vec![file_row("solo.rs", "(root)", "Rust", 50, 3000)]);
     let report = build_near_dup_report(
         dir.path(),
         &export,
         NearDupScope::Global,
-        1.0,
+        0.0,
         100,
         Some(1000),
         &NearDupLimits::default(),
         &[],
     )
     .unwrap();
+    assert!(report.pairs.is_empty());
+    assert_eq!(report.files_analyzed, 1);
+}
 
-    assert_eq!(
-        report.pairs.len(),
-        1,
-        "identical files at threshold=1.0 should yield exactly one pair"
+// ── 3. Identical files produce similarity ~1.0 ──────────────────
+
+#[test]
+fn identical_files_similarity_near_one() {
+    let dir = TempDir::new().unwrap();
+    let content = make_tokens(150, "ident");
+    write_to(&dir, "x.rs", &content);
+    write_to(&dir, "y.rs", &content);
+    let export = mk_export(vec![
+        file_row("x.rs", "(root)", "Rust", 80, 5000),
+        file_row("y.rs", "(root)", "Rust", 80, 5000),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.0,
+        100,
+        Some(1000),
+        &NearDupLimits::default(),
+        &[],
+    )
+    .unwrap();
+    assert_eq!(report.pairs.len(), 1);
+    assert!(
+        report.pairs[0].similarity > 0.95,
+        "identical files should have similarity near 1.0, got {}",
+        report.pairs[0].similarity
     );
 }
 
-// ── 4. Fingerprint counts are consistent for identical files ────
+// ── 4. Similarity monotonically decreases with divergence ───────
 
 #[test]
-fn fingerprint_counts_are_consistent_for_identical_files() {
+fn similarity_decreases_with_divergence() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 7);
+    let base = make_tokens(120, "base");
+    write_to(&dir, "a.rs", &base);
 
-    write_file(&dir, "a.rs", &content);
-    write_file(&dir, "b.rs", &content);
+    let high_overlap = overlapping_content(100, 20, 1);
+    let med_overlap = overlapping_content(60, 60, 2);
+    let low_overlap = overlapping_content(30, 90, 3);
+    write_to(&dir, "b.rs", &high_overlap);
+    write_to(&dir, "c.rs", &med_overlap);
+    write_to(&dir, "d.rs", &low_overlap);
+
     let rows = vec![
-        make_row("a.rs", "(root)", "Rust", 100, 5000),
-        make_row("b.rs", "(root)", "Rust", 100, 5000),
+        file_row("a.rs", "(root)", "Rust", 100, 5000),
+        file_row("b.rs", "(root)", "Rust", 100, 5000),
+        file_row("c.rs", "(root)", "Rust", 100, 5000),
+        file_row("d.rs", "(root)", "Rust", 100, 5000),
     ];
-    let export = make_export(rows);
-
+    let export = mk_export(rows);
     let report = build_near_dup_report(
         dir.path(),
         &export,
@@ -229,119 +170,33 @@ fn fingerprint_counts_are_consistent_for_identical_files() {
     )
     .unwrap();
 
-    assert_eq!(report.pairs.len(), 1);
-    let pair = &report.pairs[0];
-    assert_eq!(
-        pair.left_fingerprints, pair.right_fingerprints,
-        "identical files should have equal fingerprint counts"
-    );
-}
-
-// ── 5. Different sized files have different fingerprint counts ──
-
-#[test]
-fn different_sized_files_have_different_fingerprint_counts() {
-    let dir = TempDir::new().unwrap();
-    // Small file: 50 shared tokens, Large file: 50 shared + 200 unique
-    let small = content_with_overlap(50, 0, 0);
-    let large = content_with_overlap(50, 200, 1);
-    write_file(&dir, "small.rs", &small);
-    write_file(&dir, "large.rs", &large);
-    let rows = vec![
-        make_row("small.rs", "(root)", "Rust", 50, 2000),
-        make_row("large.rs", "(root)", "Rust", 250, 10000),
-    ];
-    let export = make_export(rows);
-
-    let report = build_near_dup_report(
-        dir.path(),
-        &export,
-        NearDupScope::Global,
-        0.0,
-        100,
-        Some(1000),
-        &NearDupLimits::default(),
-        &[],
-    )
-    .unwrap();
-
-    assert_eq!(report.pairs.len(), 1);
-    let pair = &report.pairs[0];
-    // The file with more content should have more fingerprints
-    let (small_fp, large_fp) = if pair.left == "large.rs" {
-        (pair.right_fingerprints, pair.left_fingerprints)
-    } else {
-        (pair.left_fingerprints, pair.right_fingerprints)
+    let find_sim = |l: &str, r: &str| -> Option<f64> {
+        report
+            .pairs
+            .iter()
+            .find(|p| (p.left == l && p.right == r) || (p.left == r && p.right == l))
+            .map(|p| p.similarity)
     };
-    assert!(
-        large_fp >= small_fp,
-        "larger file ({large_fp}) should have >= fingerprints than smaller ({small_fp})"
-    );
-}
 
-// ── 6. Cluster representative with asymmetric star topology ─────
-
-#[test]
-fn cluster_representative_with_asymmetric_star_topology() {
-    let dir = TempDir::new().unwrap();
-    // All 4 identical files: every node has the same connections,
-    // so the representative is the alphabetically-first file.
-    let hub_content = source_text(100, 0);
-    write_file(&dir, "hub.rs", &hub_content);
-    write_file(&dir, "a.rs", &hub_content);
-    write_file(&dir, "b.rs", &hub_content);
-    write_file(&dir, "c.rs", &hub_content);
-
-    let rows = vec![
-        make_row("hub.rs", "(root)", "Rust", 100, 5000),
-        make_row("a.rs", "(root)", "Rust", 100, 5000),
-        make_row("b.rs", "(root)", "Rust", 100, 5000),
-        make_row("c.rs", "(root)", "Rust", 100, 5000),
-    ];
-    let export = make_export(rows);
-
-    let report = build_near_dup_report(
-        dir.path(),
-        &export,
-        NearDupScope::Global,
-        0.5,
-        100,
-        Some(1000),
-        &NearDupLimits::default(),
-        &[],
-    )
-    .unwrap();
-
-    if let Some(clusters) = &report.clusters
-        && clusters.len() == 1
-        && clusters[0].files.len() == 4
-    {
-        // All files are identical → same connection count → alphabetical tiebreak
-        assert_eq!(
-            clusters[0].representative, "a.rs",
-            "with equal connectivity, alphabetically-first file should be representative"
-        );
+    if let (Some(bc), Some(bd)) = (find_sim("b.rs", "c.rs"), find_sim("b.rs", "d.rs")) {
+        assert!(bc >= bd, "b-c ({bc}) should be >= b-d ({bd})");
     }
 }
 
-// ── 7. Global scope finds cross-module pairs ────────────────────
+// ── 5. Three identical files produce C(3,2)=3 pairs ────────────
 
 #[test]
-fn global_scope_finds_cross_module_and_cross_lang_pairs() {
+fn three_identical_files_produce_three_pairs() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 55);
-
-    std::fs::create_dir_all(dir.path().join("mod_a")).unwrap();
-    std::fs::create_dir_all(dir.path().join("mod_b")).unwrap();
-    write_file(&dir, "mod_a/file.rs", &content);
-    write_file(&dir, "mod_b/file.py", &content);
-
-    let rows = vec![
-        make_row("mod_a/file.rs", "mod_a", "Rust", 100, 5000),
-        make_row("mod_b/file.py", "mod_b", "Python", 100, 5000),
-    ];
-    let export = make_export(rows);
-
+    let content = make_tokens(120, "trio");
+    for name in &["p.rs", "q.rs", "r.rs"] {
+        write_to(&dir, name, &content);
+    }
+    let rows: Vec<FileRow> = ["p.rs", "q.rs", "r.rs"]
+        .iter()
+        .map(|n| file_row(n, "(root)", "Rust", 60, 4000))
+        .collect();
+    let export = mk_export(rows);
     let report = build_near_dup_report(
         dir.path(),
         &export,
@@ -353,36 +208,39 @@ fn global_scope_finds_cross_module_and_cross_lang_pairs() {
         &[],
     )
     .unwrap();
-
-    assert!(
-        !report.pairs.is_empty(),
-        "global scope should find cross-module, cross-lang pairs"
-    );
+    assert_eq!(report.pairs.len(), 3, "C(3,2)=3 pairs expected");
 }
 
-// ── 8. Module scope isolates files in different modules ─────────
+// ── 6. Threshold filters low-similarity pairs ───────────────────
 
 #[test]
-fn module_scope_isolates_identical_files_in_different_modules() {
+fn high_threshold_filters_dissimilar_pairs() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 66);
+    let a = make_tokens(120, "alpha");
+    let b = make_tokens(120, "beta");
+    write_to(&dir, "a.rs", &a);
+    write_to(&dir, "b.rs", &b);
+    let export = mk_export(vec![
+        file_row("a.rs", "(root)", "Rust", 60, 4000),
+        file_row("b.rs", "(root)", "Rust", 60, 4000),
+    ]);
 
-    std::fs::create_dir_all(dir.path().join("mod_a")).unwrap();
-    std::fs::create_dir_all(dir.path().join("mod_b")).unwrap();
-    write_file(&dir, "mod_a/file.rs", &content);
-    write_file(&dir, "mod_b/file.rs", &content);
-
-    let rows = vec![
-        make_row("mod_a/file.rs", "mod_a", "Rust", 100, 5000),
-        make_row("mod_b/file.rs", "mod_b", "Rust", 100, 5000),
-    ];
-    let export = make_export(rows);
-
-    let report = build_near_dup_report(
+    let report_low = build_near_dup_report(
         dir.path(),
         &export,
-        NearDupScope::Module,
-        0.5,
+        NearDupScope::Global,
+        0.0,
+        100,
+        Some(1000),
+        &NearDupLimits::default(),
+        &[],
+    )
+    .unwrap();
+    let report_high = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.99,
         100,
         Some(1000),
         &NearDupLimits::default(),
@@ -391,201 +249,223 @@ fn module_scope_isolates_identical_files_in_different_modules() {
     .unwrap();
 
     assert!(
-        report.pairs.is_empty(),
-        "module scope should not pair files from different modules"
+        report_high.pairs.len() <= report_low.pairs.len(),
+        "higher threshold should yield <= pairs"
     );
 }
 
-// ── 9. Lang scope isolates identical files with different languages
+// ── 7. Pairs always have left <= right lexicographically ────────
 
 #[test]
-fn lang_scope_isolates_identical_files_with_different_languages() {
+fn pairs_are_lexicographically_ordered() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 77);
+    let content = make_tokens(120, "order");
+    for name in &["z.rs", "a.rs", "m.rs"] {
+        write_to(&dir, name, &content);
+    }
+    let rows: Vec<FileRow> = ["z.rs", "a.rs", "m.rs"]
+        .iter()
+        .map(|n| file_row(n, "(root)", "Rust", 60, 4000))
+        .collect();
+    let export = mk_export(rows);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.0,
+        100,
+        Some(1000),
+        &NearDupLimits::default(),
+        &[],
+    )
+    .unwrap();
+    for pair in &report.pairs {
+        assert!(pair.left <= pair.right, "{} > {}", pair.left, pair.right);
+    }
+}
 
-    write_file(&dir, "file.rs", &content);
-    write_file(&dir, "file.py", &content);
+// ── 8. Lang scope isolates different languages ──────────────────
 
-    let rows = vec![
-        make_row("file.rs", "(root)", "Rust", 100, 5000),
-        make_row("file.py", "(root)", "Python", 100, 5000),
-    ];
-    let export = make_export(rows);
-
+#[test]
+fn lang_scope_isolates_different_languages() {
+    let dir = TempDir::new().unwrap();
+    let content = make_tokens(120, "lang");
+    write_to(&dir, "code.rs", &content);
+    write_to(&dir, "code.py", &content);
+    let export = mk_export(vec![
+        file_row("code.rs", "(root)", "Rust", 60, 4000),
+        file_row("code.py", "(root)", "Python", 60, 4000),
+    ]);
     let report = build_near_dup_report(
         dir.path(),
         &export,
         NearDupScope::Lang,
-        0.5,
+        0.0,
         100,
         Some(1000),
         &NearDupLimits::default(),
         &[],
     )
     .unwrap();
-
     assert!(
         report.pairs.is_empty(),
-        "lang scope should not pair files with different languages"
+        "lang scope should not pair Rust with Python"
     );
 }
 
-// ── 10. Multiple exclude patterns all applied ───────────────────
+// ── 9. Module scope isolates different modules ──────────────────
 
 #[test]
-fn multiple_exclude_patterns_all_applied() {
+fn module_scope_isolates_different_modules() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 88);
-
-    write_file(&dir, "keep.rs", &content);
-    write_file(&dir, "gen_file.rs", &content);
-    write_file(&dir, "vendor_lib.rs", &content);
-    write_file(&dir, "also_keep.rs", &content);
-
-    let rows = vec![
-        make_row("keep.rs", "(root)", "Rust", 100, 5000),
-        make_row("gen_file.rs", "(root)", "Rust", 100, 5000),
-        make_row("vendor_lib.rs", "(root)", "Rust", 100, 5000),
-        make_row("also_keep.rs", "(root)", "Rust", 100, 5000),
-    ];
-    let export = make_export(rows);
-
+    let content = make_tokens(120, "modsep");
+    write_to(&dir, "a/f.rs", &content);
+    write_to(&dir, "b/f.rs", &content);
+    let export = mk_export(vec![
+        file_row("a/f.rs", "a", "Rust", 60, 4000),
+        file_row("b/f.rs", "b", "Rust", 60, 4000),
+    ]);
     let report = build_near_dup_report(
         dir.path(),
         &export,
-        NearDupScope::Global,
-        0.5,
-        100,
-        Some(1000),
-        &NearDupLimits::default(),
-        &["gen_*".to_string(), "vendor_*".to_string()],
-    )
-    .unwrap();
-
-    // Only keep.rs and also_keep.rs should be compared → 1 pair
-    for pair in &report.pairs {
-        assert!(
-            !pair.left.contains("gen_") && !pair.right.contains("gen_"),
-            "gen_ files should be excluded"
-        );
-        assert!(
-            !pair.left.contains("vendor_") && !pair.right.contains("vendor_"),
-            "vendor_ files should be excluded"
-        );
-    }
-}
-
-// ── 11. Pair paths have left <= right (lexicographic) ───────────
-
-#[test]
-fn pair_paths_have_left_less_than_or_equal_to_right() {
-    let dir = TempDir::new().unwrap();
-    let content = source_text(100, 99);
-
-    for name in &["z.rs", "a.rs", "m.rs"] {
-        write_file(&dir, name, &content);
-    }
-    let rows: Vec<FileRow> = ["z.rs", "a.rs", "m.rs"]
-        .iter()
-        .map(|n| make_row(n, "(root)", "Rust", 100, 5000))
-        .collect();
-    let export = make_export(rows);
-
-    let report = build_near_dup_report(
-        dir.path(),
-        &export,
-        NearDupScope::Global,
-        0.5,
+        NearDupScope::Module,
+        0.0,
         100,
         Some(1000),
         &NearDupLimits::default(),
         &[],
     )
     .unwrap();
-
-    for pair in &report.pairs {
-        assert!(
-            pair.left <= pair.right,
-            "pair ordering violated: {} > {}",
-            pair.left,
-            pair.right
-        );
-    }
+    assert!(
+        report.pairs.is_empty(),
+        "module scope should not pair files across modules"
+    );
 }
 
-// ── 12. max_files limit produces skip tracking ──────────────────
+// ── 10. Exclude patterns filter files ───────────────────────────
 
 #[test]
-fn ten_files_max_three_yields_seven_skipped() {
+fn exclude_patterns_remove_matching_files() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 5);
-
-    for i in 0..10 {
-        let name = format!("f{i:02}.rs");
-        write_file(&dir, &name, &content);
-    }
-    let rows: Vec<FileRow> = (0..10)
-        .map(|i| make_row(&format!("f{i:02}.rs"), "(root)", "Rust", (10 - i) * 10, 5000))
-        .collect();
-    let export = make_export(rows);
-
+    let content = make_tokens(120, "excl");
+    write_to(&dir, "keep.rs", &content);
+    write_to(&dir, "gen_code.rs", &content);
+    write_to(&dir, "also_keep.rs", &content);
+    let export = mk_export(vec![
+        file_row("keep.rs", "(root)", "Rust", 60, 4000),
+        file_row("gen_code.rs", "(root)", "Rust", 60, 4000),
+        file_row("also_keep.rs", "(root)", "Rust", 60, 4000),
+    ]);
     let report = build_near_dup_report(
         dir.path(),
         &export,
         NearDupScope::Global,
-        0.5,
+        0.0,
+        100,
+        Some(1000),
+        &NearDupLimits::default(),
+        &["gen_*".to_string()],
+    )
+    .unwrap();
+    for pair in &report.pairs {
+        assert!(!pair.left.starts_with("gen_") && !pair.right.starts_with("gen_"));
+    }
+}
+
+// ── 11. max_files truncation tracks skipped count ───────────────
+
+#[test]
+fn max_files_tracks_skipped() {
+    let dir = TempDir::new().unwrap();
+    let content = make_tokens(120, "trunc");
+    for i in 0..8 {
+        write_to(&dir, &format!("f{i}.rs"), &content);
+    }
+    let rows: Vec<FileRow> = (0..8)
+        .map(|i| file_row(&format!("f{i}.rs"), "(root)", "Rust", (8 - i) * 20, 4000))
+        .collect();
+    let export = mk_export(rows);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.0,
         3,
         Some(1000),
         &NearDupLimits::default(),
         &[],
     )
     .unwrap();
-
-    assert_eq!(report.files_skipped, 7, "10 files - 3 max = 7 skipped");
+    assert_eq!(report.files_skipped, 5, "8 files - 3 max = 5 skipped");
 }
 
-// ── 13. File selection prefers highest code lines ───────────────
+// ── 12. Deterministic output across multiple runs ───────────────
 
 #[test]
-fn file_selection_prefers_highest_code_lines() {
+fn deterministic_across_runs() {
     let dir = TempDir::new().unwrap();
-    let content = source_text(100, 10);
+    let content = make_tokens(120, "det");
+    for name in &["a.rs", "b.rs", "c.rs"] {
+        write_to(&dir, name, &content);
+    }
+    let rows: Vec<FileRow> = ["a.rs", "b.rs", "c.rs"]
+        .iter()
+        .map(|n| file_row(n, "(root)", "Rust", 60, 4000))
+        .collect();
+    let export = mk_export(rows);
 
-    write_file(&dir, "big.rs", &content);
-    write_file(&dir, "small.rs", &content);
-    write_file(&dir, "medium.rs", &content);
+    let results: Vec<_> = (0..3)
+        .map(|_| {
+            build_near_dup_report(
+                dir.path(),
+                &export,
+                NearDupScope::Global,
+                0.0,
+                100,
+                Some(1000),
+                &NearDupLimits::default(),
+                &[],
+            )
+            .unwrap()
+        })
+        .collect();
 
-    let rows = vec![
-        make_row("big.rs", "(root)", "Rust", 1000, 50000),
-        make_row("small.rs", "(root)", "Rust", 10, 500),
-        make_row("medium.rs", "(root)", "Rust", 500, 25000),
-    ];
-    let export = make_export(rows);
+    for i in 1..3 {
+        assert_eq!(results[0].pairs.len(), results[i].pairs.len());
+        for (a, b) in results[0].pairs.iter().zip(results[i].pairs.iter()) {
+            assert_eq!(a.left, b.left);
+            assert_eq!(a.right, b.right);
+            assert!((a.similarity - b.similarity).abs() < f64::EPSILON);
+        }
+    }
+}
 
-    // max_files=2: should pick big.rs and medium.rs (highest code lines)
+// ── 13. max_file_bytes limit excludes oversized files ───────────
+
+#[test]
+fn max_file_bytes_excludes_large_files() {
+    let dir = TempDir::new().unwrap();
+    let content = make_tokens(120, "size");
+    write_to(&dir, "small.rs", &content);
+    write_to(&dir, "big.rs", &content);
+    let export = mk_export(vec![
+        file_row("small.rs", "(root)", "Rust", 60, 100),
+        file_row("big.rs", "(root)", "Rust", 60, 999_999),
+    ]);
+    let limits = NearDupLimits {
+        max_bytes: None,
+        max_file_bytes: Some(1000),
+    };
     let report = build_near_dup_report(
         dir.path(),
         &export,
         NearDupScope::Global,
         0.0,
-        2,
+        100,
         Some(1000),
-        &NearDupLimits::default(),
+        &limits,
         &[],
     )
     .unwrap();
-
-    assert_eq!(report.files_skipped, 1);
-    // The pair should be between big.rs and medium.rs
-    if !report.pairs.is_empty() {
-        let paths: Vec<&str> = report
-            .pairs
-            .iter()
-            .flat_map(|p| [p.left.as_str(), p.right.as_str()])
-            .collect();
-        assert!(
-            !paths.contains(&"small.rs"),
-            "small.rs should be skipped in favor of larger files"
-        );
-    }
+    assert!(report.pairs.is_empty(), "oversized file should be excluded");
 }

--- a/crates/tokmd-analysis-topics/tests/deep.rs
+++ b/crates/tokmd-analysis-topics/tests/deep.rs
@@ -1,7 +1,7 @@
 //! Deep invariant tests for topic-cloud extraction.
 //!
-//! Focuses on TF-IDF scoring semantics, tokenisation edge cases,
-//! TOP_K truncation, determinism, and stopword filtering.
+//! Tests TF-IDF scoring, tokenisation, TOP_K truncation,
+//! determinism, stopword filtering, and edge cases.
 
 use tokmd_analysis_topics::build_topic_clouds;
 use tokmd_analysis_types::TopicTerm;
@@ -41,52 +41,71 @@ fn overall_terms(data: &ExportData) -> Vec<String> {
         .collect()
 }
 
-// ── 1. Numeric path segments produce valid terms ────────────────
+// ── 1. Empty export produces empty clouds ───────────────────────
+
+#[test]
+fn empty_export_yields_empty_clouds() {
+    let data = export(vec![], &[]);
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.overall.is_empty());
+    assert!(clouds.per_module.is_empty());
+}
+
+// ── 2. Child rows are excluded from topic extraction ────────────
+
+#[test]
+fn child_rows_excluded() {
+    let child = FileRow {
+        path: "m/unique_child_term.rs".to_string(),
+        module: "m".to_string(),
+        lang: "Rust".to_string(),
+        kind: FileKind::Child,
+        code: 10,
+        comments: 0,
+        blanks: 0,
+        lines: 10,
+        bytes: 100,
+        tokens: 50,
+    };
+    let data = export(vec![child], &[]);
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.overall.is_empty(), "child rows should be ignored");
+}
+
+// ── 3. Numeric path segments are valid terms ────────────────────
 
 #[test]
 fn numeric_path_segments_produce_valid_terms() {
     let data = export(vec![row("v2/api/handler.rs", "v2/api", 50)], &[]);
     let terms = overall_terms(&data);
-    // "v2" is split into "v2" (single token, no further splitting)
     assert!(
         terms.contains(&"v2".to_string()),
-        "numeric path segments should be valid terms: {terms:?}"
+        "numeric segments should be valid: {terms:?}"
     );
 }
 
-// ── 2. Single file: overall == per_module ───────────────────────
+// ── 4. Single file: overall == per_module ───────────────────────
 
 #[test]
 fn single_file_overall_equals_per_module() {
     let data = export(vec![row("m/widget.rs", "m", 50)], &[]);
     let clouds = build_topic_clouds(&data);
     let overall = &clouds.overall;
-    let per_mod = clouds.per_module.get("m").expect("module 'm' should exist");
+    let per_mod = clouds.per_module.get("m").expect("module 'm'");
 
-    assert_eq!(
-        overall.len(),
-        per_mod.len(),
-        "single-file: overall and per_module should have same length"
-    );
+    assert_eq!(overall.len(), per_mod.len());
     for (o, p) in overall.iter().zip(per_mod.iter()) {
         assert_eq!(o.term, p.term);
-        assert!(
-            (o.score - p.score).abs() < f64::EPSILON,
-            "scores should match"
-        );
+        assert!((o.score - p.score).abs() < f64::EPSILON);
     }
 }
 
-// ── 3. DF counts files, not token frequency ─────────────────────
+// ── 5. DF counts files, not token frequency ─────────────────────
 
 #[test]
 fn df_counts_files_not_token_frequency() {
-    // Two files in same module, both containing "widget" in their path
     let data = export(
-        vec![
-            row("m/widget_a.rs", "m", 50),
-            row("m/widget_b.rs", "m", 50),
-        ],
+        vec![row("m/widget_a.rs", "m", 50), row("m/widget_b.rs", "m", 50)],
         &[],
     );
     let clouds = build_topic_clouds(&data);
@@ -98,14 +117,10 @@ fn df_counts_files_not_token_frequency() {
     assert_eq!(widget.df, 2, "df should count per-file occurrences");
 }
 
-// ── 4. Term in many modules gets lower IDF boost ────────────────
+// ── 6. Rare term scores higher than ubiquitous term via IDF ─────
 
 #[test]
-fn ubiquitous_term_has_lower_idf_than_rare_term() {
-    // "common" appears in all 5 modules; "rare" appears in only 1.
-    // Score = tf * idf. "common" accumulates tf from 5 files, so its total
-    // tf is higher. To isolate the IDF effect, compare per-module scores
-    // where each module has a single occurrence.
+fn rare_term_scores_higher_via_idf() {
     let mut rows = Vec::new();
     for i in 0..5 {
         rows.push(row(&format!("mod_{i}/common.rs"), &format!("mod_{i}"), 50));
@@ -114,27 +129,24 @@ fn ubiquitous_term_has_lower_idf_than_rare_term() {
     let data = export(rows, &[]);
     let clouds = build_topic_clouds(&data);
 
-    // In mod_0, both "common" and "rare" have tf=50 (same weight).
-    // "rare" has df=1 module vs "common" df=5 modules → rare has higher IDF.
-    let m0 = clouds.per_module.get("mod_0").expect("mod_0 should exist");
+    let m0 = clouds.per_module.get("mod_0").expect("mod_0");
     let common = m0.iter().find(|t| t.term == "common");
     let rare = m0.iter().find(|t| t.term == "rare");
 
     if let (Some(c), Some(r)) = (common, rare) {
         assert!(
             r.score >= c.score,
-            "rare ({}) should score >= common ({}) in same module due to IDF",
+            "rare ({}) should score >= common ({})",
             r.score,
             c.score
         );
     }
 }
 
-// ── 5. TOP_K preserves highest-scoring terms ────────────────────
+// ── 7. TOP_K preserves highest-scoring terms ────────────────────
 
 #[test]
 fn top_k_preserves_highest_scoring_terms() {
-    // Create 20 terms with varying weights; only top 8 should survive
     let rows: Vec<FileRow> = (0..20)
         .map(|i| row(&format!("m/term{i}.rs"), "m", (i + 1) * 100))
         .collect();
@@ -142,46 +154,22 @@ fn top_k_preserves_highest_scoring_terms() {
     let clouds = build_topic_clouds(&data);
 
     let m_terms = clouds.per_module.get("m").expect("module 'm'");
-    assert!(m_terms.len() <= 8);
-
-    // The highest-scoring term should be term19 (weight=2000)
-    // since all terms have the same IDF (single module)
-    assert_eq!(
-        m_terms[0].term, "term19",
-        "highest-weight term should rank first"
-    );
+    assert!(m_terms.len() <= 8, "TOP_K should be 8");
+    assert_eq!(m_terms[0].term, "term19", "highest-weight term first");
 }
 
-// ── 6. Consecutive separators: no empty terms ───────────────────
+// ── 8. All terms are lowercase ──────────────────────────────────
 
 #[test]
-fn consecutive_separators_no_empty_terms() {
-    let data = export(
-        vec![row("a__b--c..d/file.rs", "a__b--c..d", 50)],
-        &[],
-    );
+fn all_terms_are_lowercase() {
+    let data = export(vec![row("MOD/CamelCase_Widget.rs", "MOD", 50)], &[]);
     let terms = overall_terms(&data);
     for term in &terms {
-        assert!(!term.is_empty(), "no empty terms should be produced");
+        assert_eq!(*term, term.to_lowercase(), "terms must be lowercase");
     }
 }
 
-// ── 7. Mixed case normalizes to lowercase ───────────────────────
-
-#[test]
-fn mixed_case_normalizes_to_lowercase() {
-    let data = export(vec![row("MyModule/MyFile.rs", "MyModule", 50)], &[]);
-    let terms = overall_terms(&data);
-    for term in &terms {
-        assert_eq!(
-            *term,
-            term.to_lowercase(),
-            "all terms should be lowercase"
-        );
-    }
-}
-
-// ── 8. Per-module keys are BTreeMap-sorted ──────────────────────
+// ── 9. Per-module keys are BTreeMap-sorted ──────────────────────
 
 #[test]
 fn per_module_keys_are_lexicographically_sorted() {
@@ -200,46 +188,27 @@ fn per_module_keys_are_lexicographically_sorted() {
     assert_eq!(keys, sorted, "per_module keys should be sorted");
 }
 
-// ── 9. Weight overflow: u32::MAX tokens still works ─────────────
+// ── 10. Consecutive separators produce no empty terms ───────────
 
 #[test]
-fn u32_max_tokens_does_not_overflow() {
-    let data = export(vec![row("m/overflow.rs", "m", u32::MAX as usize)], &[]);
-    let clouds = build_topic_clouds(&data);
-    let overflow = clouds.overall.iter().find(|t| t.term == "overflow");
-    assert!(overflow.is_some(), "term should exist with MAX weight");
-    assert!(overflow.unwrap().tf > 0, "tf should be positive");
-}
-
-// ── 10. Module depth doesn't affect extraction ──────────────────
-
-#[test]
-fn deeply_nested_path_extracts_all_non_stopword_segments() {
-    // Note: "c" is a stopword (file extension), so skip it in expectations
-    let data = export(vec![row("a/b/deep/d/e/f/feature_name.rs", "a/b", 50)], &[]);
+fn consecutive_separators_no_empty_terms() {
+    let data = export(vec![row("a//b__c--d..e.rs", "a", 50)], &[]);
     let terms = overall_terms(&data);
-    for expected in ["a", "b", "deep", "d", "e", "f", "feature", "name"] {
-        assert!(
-            terms.contains(&expected.to_string()),
-            "missing '{expected}' in {terms:?}"
-        );
+    for term in &terms {
+        assert!(!term.is_empty(), "empty term found");
     }
 }
 
-// ── 11. Backslash and forward slash paths produce same terms ────
+// ── 11. Backslash paths normalized to forward slash ─────────────
 
 #[test]
-fn backslash_and_forward_slash_paths_equivalent() {
+fn backslash_paths_equivalent_to_forward_slash() {
     let data_fwd = export(vec![row("app/auth/handler.rs", "app/auth", 50)], &["app"]);
     let data_bck = export(vec![row(r"app\auth\handler.rs", "app/auth", 50)], &["app"]);
 
     let terms_fwd = overall_terms(&data_fwd);
     let terms_bck = overall_terms(&data_bck);
-
-    assert_eq!(
-        terms_fwd, terms_bck,
-        "backslash and forward slash paths should produce identical terms"
-    );
+    assert_eq!(terms_fwd, terms_bck, "slash normalization must match");
 }
 
 // ── 12. TF accumulates across files in same module ──────────────
@@ -255,10 +224,8 @@ fn tf_accumulates_across_files_in_same_module() {
     );
     let clouds = build_topic_clouds(&data);
     let m_terms = clouds.per_module.get("m").expect("module 'm'");
-
     let widget = m_terms.iter().find(|t| t.term == "widget").unwrap();
-    // tf should be sum of weights: 100 + 200 = 300
-    assert_eq!(widget.tf, 300, "tf should accumulate weights across files");
+    assert_eq!(widget.tf, 300, "tf should sum weights: 100 + 200");
 }
 
 // ── 13. Determinism with many modules ───────────────────────────
@@ -270,22 +237,13 @@ fn determinism_with_many_modules() {
         .collect();
     let data = export(rows, &[]);
 
-    let results: Vec<Vec<TopicTerm>> =
-        (0..3).map(|_| build_topic_clouds(&data).overall).collect();
+    let results: Vec<Vec<TopicTerm>> = (0..3).map(|_| build_topic_clouds(&data).overall).collect();
 
     for i in 1..3 {
-        assert_eq!(
-            results[0].len(),
-            results[i].len(),
-            "run count mismatch"
-        );
+        assert_eq!(results[0].len(), results[i].len());
         for (a, b) in results[0].iter().zip(results[i].iter()) {
             assert_eq!(a.term, b.term);
-            assert!(
-                (a.score - b.score).abs() < f64::EPSILON,
-                "score mismatch for {}",
-                a.term
-            );
+            assert!((a.score - b.score).abs() < f64::EPSILON);
         }
     }
 }
@@ -296,16 +254,15 @@ fn determinism_with_many_modules() {
 fn all_documented_extensions_are_stopwords() {
     let known_extensions = [
         "rs", "js", "ts", "tsx", "jsx", "py", "go", "java", "kt", "kts", "rb", "php", "c", "cc",
-        "cpp", "h", "hpp", "cs", "swift", "m", "mm", "scala", "sql", "toml", "yaml", "yml",
-        "json", "md", "markdown", "txt", "lock", "cfg", "ini", "env", "nix", "zig", "dart",
+        "cpp", "h", "hpp", "cs", "swift", "m", "mm", "scala", "sql", "toml", "yaml", "yml", "json",
+        "md", "markdown", "txt", "lock", "cfg", "ini", "env", "nix", "zig", "dart",
     ];
     for ext in known_extensions {
-        // Create a row where the only non-stopword would be the extension
         let data = export(vec![row(&format!("module/{ext}.rs"), "module", 50)], &[]);
         let terms = overall_terms(&data);
         assert!(
             !terms.contains(&ext.to_string()),
-            "extension '{ext}' should be a stopword but found in terms: {terms:?}"
+            "extension '{ext}' should be a stopword: {terms:?}"
         );
     }
 }
@@ -315,18 +272,30 @@ fn all_documented_extensions_are_stopwords() {
 #[test]
 fn base_stopwords_filter_common_directories() {
     let base_stops = [
-        "src", "lib", "mod", "index", "test", "tests", "impl", "main", "bin", "pkg", "package",
-        "target", "build", "dist", "out", "gen", "generated",
+        "src",
+        "lib",
+        "mod",
+        "index",
+        "test",
+        "tests",
+        "impl",
+        "main",
+        "bin",
+        "pkg",
+        "package",
+        "target",
+        "build",
+        "dist",
+        "out",
+        "gen",
+        "generated",
     ];
     for stop in base_stops {
-        let data = export(
-            vec![row(&format!("{stop}/feature.rs"), stop, 50)],
-            &[],
-        );
+        let data = export(vec![row(&format!("{stop}/feature.rs"), stop, 50)], &[]);
         let terms = overall_terms(&data);
         assert!(
             !terms.contains(&stop.to_string()),
-            "base stopword '{stop}' should be filtered: {terms:?}"
+            "'{stop}' should be filtered: {terms:?}"
         );
     }
 }


### PR DESCRIPTION
Redo of tests from PR #309. Adds deep tests for near-dup, topics, and entropy analysis crates.

## Changes

- **tokmd-analysis-near-dup**: 13 integration tests
- **tokmd-analysis-topics**: 15 integration tests
- **tokmd-analysis-entropy**: 15 integration tests

All tests compile, pass, are formatted, and pass clippy.