### PR TITLE
test: add deep tests for gate and analysis-grid crates

### DIFF
--- a/crates/tokmd-analysis-grid/tests/deep.rs
+++ b/crates/tokmd-analysis-grid/tests/deep.rs
@@ -1,0 +1,970 @@
+//! Deep tests for tokmd-analysis-grid.
+//!
+//! Covers areas not fully exercised by existing tests:
+//! - Preset name completeness against documented names
+//! - Preset flag exclusivity (only specific presets enable specific flags)
+//! - Deep preset superset invariant (including cfg-gated fields)
+//! - Grid row uniqueness (no duplicate enricher configurations)
+//! - PresetPlan needs_files exhaustive verification
+//! - DisabledFeature Debug trait
+//! - PresetKind ordering stability
+//! - Cross-preset flag analysis (which presets share which flags)
+
+use tokmd_analysis_grid::{
+    DisabledFeature, PRESET_GRID, PRESET_KINDS, PresetKind, PresetPlan, preset_plan_for,
+    preset_plan_for_name,
+};
+
+// =========================================================================
+// 1. All presets are defined — preset names match documentation
+// =========================================================================
+
+mod preset_names {
+    use super::*;
+
+    /// Documented preset names from CLAUDE.md / docs.
+    const DOCUMENTED_PRESETS: &[&str] = &[
+        "receipt",
+        "health",
+        "risk",
+        "supply",
+        "architecture",
+        "topics",
+        "security",
+        "identity",
+        "git",
+        "deep",
+        "fun",
+    ];
+
+    #[test]
+    fn all_documented_presets_exist() {
+        for name in DOCUMENTED_PRESETS {
+            assert!(
+                PresetKind::from_str(name).is_some(),
+                "Documented preset '{}' not found in PresetKind::from_str",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn no_undocumented_presets_exist() {
+        let kinds: Vec<&str> = PRESET_KINDS.iter().map(|k| k.as_str()).collect();
+        for name in &kinds {
+            assert!(
+                DOCUMENTED_PRESETS.contains(name),
+                "Preset '{}' exists in code but is not in the documented list",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn preset_count_matches_documentation() {
+        assert_eq!(
+            PRESET_KINDS.len(),
+            DOCUMENTED_PRESETS.len(),
+            "Number of presets in code ({}) doesn't match documentation ({})",
+            PRESET_KINDS.len(),
+            DOCUMENTED_PRESETS.len()
+        );
+    }
+
+    #[test]
+    fn as_str_values_are_all_lowercase_alphabetic() {
+        for kind in PresetKind::all() {
+            let name = kind.as_str();
+            assert!(
+                name.chars().all(|c| c.is_ascii_lowercase()),
+                "Preset name '{}' contains non-lowercase-alpha characters",
+                name
+            );
+            assert!(!name.is_empty(), "Preset name should not be empty");
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_common_invalid_inputs() {
+        let invalid = [
+            "",
+            " ",
+            "RECEIPT",
+            "Receipt",
+            "DEEP",
+            "Deep",
+            "receipt ",
+            " receipt",
+            "receipt\n",
+            "all",
+            "none",
+            "default",
+            "full",
+            "minimal",
+            "custom",
+        ];
+        for input in &invalid {
+            assert!(
+                PresetKind::from_str(input).is_none(),
+                "from_str({:?}) should return None",
+                input
+            );
+        }
+    }
+}
+
+// =========================================================================
+// 2. Feature flags for each preset are consistent
+// =========================================================================
+
+mod preset_flags {
+    use super::*;
+
+    /// Count the number of base flags enabled in a PresetPlan.
+    fn count_base_flags(plan: &PresetPlan) -> usize {
+        let flags: Vec<bool> = vec![
+            plan.assets,
+            plan.deps,
+            plan.todo,
+            plan.dup,
+            plan.imports,
+            plan.git,
+            plan.fun,
+            plan.archetype,
+            plan.topics,
+            plan.entropy,
+            plan.license,
+            plan.complexity,
+            plan.api_surface,
+        ];
+        flags.iter().filter(|&&f| f).count()
+    }
+
+    #[test]
+    fn receipt_has_zero_base_flags() {
+        let plan = preset_plan_for(PresetKind::Receipt);
+        assert_eq!(count_base_flags(&plan), 0);
+    }
+
+    #[test]
+    fn fun_has_exactly_one_base_flag() {
+        let plan = preset_plan_for(PresetKind::Fun);
+        assert_eq!(count_base_flags(&plan), 1);
+        assert!(plan.fun);
+    }
+
+    #[test]
+    fn health_has_exactly_two_base_flags() {
+        let plan = preset_plan_for(PresetKind::Health);
+        assert_eq!(count_base_flags(&plan), 2);
+        assert!(plan.todo);
+        assert!(plan.complexity);
+    }
+
+    #[test]
+    fn risk_has_exactly_two_base_flags() {
+        let plan = preset_plan_for(PresetKind::Risk);
+        assert_eq!(count_base_flags(&plan), 2);
+        assert!(plan.git);
+        assert!(plan.complexity);
+    }
+
+    #[test]
+    fn supply_has_exactly_two_base_flags() {
+        let plan = preset_plan_for(PresetKind::Supply);
+        assert_eq!(count_base_flags(&plan), 2);
+        assert!(plan.assets);
+        assert!(plan.deps);
+    }
+
+    #[test]
+    fn architecture_has_exactly_two_base_flags() {
+        let plan = preset_plan_for(PresetKind::Architecture);
+        assert_eq!(count_base_flags(&plan), 2);
+        assert!(plan.imports);
+        assert!(plan.api_surface);
+    }
+
+    #[test]
+    fn topics_has_exactly_one_base_flag() {
+        let plan = preset_plan_for(PresetKind::Topics);
+        assert_eq!(count_base_flags(&plan), 1);
+        assert!(plan.topics);
+    }
+
+    #[test]
+    fn security_has_exactly_two_base_flags() {
+        let plan = preset_plan_for(PresetKind::Security);
+        assert_eq!(count_base_flags(&plan), 2);
+        assert!(plan.entropy);
+        assert!(plan.license);
+    }
+
+    #[test]
+    fn identity_has_exactly_two_base_flags() {
+        let plan = preset_plan_for(PresetKind::Identity);
+        assert_eq!(count_base_flags(&plan), 2);
+        assert!(plan.git);
+        assert!(plan.archetype);
+    }
+
+    #[test]
+    fn git_has_exactly_one_base_flag() {
+        let plan = preset_plan_for(PresetKind::Git);
+        assert_eq!(count_base_flags(&plan), 1);
+        assert!(plan.git);
+    }
+
+    #[test]
+    fn deep_has_all_base_flags_except_fun() {
+        let plan = preset_plan_for(PresetKind::Deep);
+        // All 12 non-fun flags should be true
+        assert_eq!(count_base_flags(&plan), 12);
+        assert!(!plan.fun);
+    }
+
+    #[test]
+    fn every_non_receipt_preset_has_at_least_one_flag() {
+        for kind in PresetKind::all() {
+            if *kind == PresetKind::Receipt {
+                continue;
+            }
+            let plan = preset_plan_for(*kind);
+            assert!(
+                count_base_flags(&plan) > 0,
+                "Preset {:?} has no flags enabled",
+                kind
+            );
+        }
+    }
+}
+
+// =========================================================================
+// 3. Serialization roundtrip (PresetKind name roundtrip)
+// =========================================================================
+
+mod roundtrips {
+    use super::*;
+
+    #[test]
+    fn from_str_as_str_roundtrip_all_presets() {
+        for kind in PresetKind::all() {
+            let name = kind.as_str();
+            let parsed = PresetKind::from_str(name);
+            assert_eq!(
+                parsed,
+                Some(*kind),
+                "Roundtrip failed for {:?} -> {:?} -> {:?}",
+                kind,
+                name,
+                parsed
+            );
+        }
+    }
+
+    #[test]
+    fn preset_plan_for_name_matches_preset_plan_for_kind() {
+        for kind in PresetKind::all() {
+            let by_kind = preset_plan_for(*kind);
+            let by_name = preset_plan_for_name(kind.as_str()).unwrap();
+            assert_eq!(
+                by_kind, by_name,
+                "Plan mismatch between by-kind and by-name for {:?}",
+                kind
+            );
+        }
+    }
+}
+
+// =========================================================================
+// 4. Grid determines which enrichers to run for a given preset
+// =========================================================================
+
+mod enricher_selection {
+    use super::*;
+
+    #[test]
+    fn preset_grid_row_preset_matches_plan() {
+        for row in &PRESET_GRID {
+            let plan = preset_plan_for(row.preset);
+            assert_eq!(
+                plan, row.plan,
+                "PRESET_GRID row for {:?} doesn't match preset_plan_for",
+                row.preset
+            );
+        }
+    }
+
+    #[test]
+    fn only_supply_and_deep_enable_assets() {
+        let with_assets: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.assets)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_assets.contains(&PresetKind::Supply));
+        assert!(with_assets.contains(&PresetKind::Deep));
+        assert_eq!(
+            with_assets.len(),
+            2,
+            "Only supply and deep should have assets"
+        );
+    }
+
+    #[test]
+    fn only_supply_and_deep_enable_deps() {
+        let with_deps: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.deps)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_deps.contains(&PresetKind::Supply));
+        assert!(with_deps.contains(&PresetKind::Deep));
+        assert_eq!(with_deps.len(), 2);
+    }
+
+    #[test]
+    fn only_health_and_deep_enable_todo() {
+        let with_todo: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.todo)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_todo.contains(&PresetKind::Health));
+        assert!(with_todo.contains(&PresetKind::Deep));
+        assert_eq!(with_todo.len(), 2);
+    }
+
+    #[test]
+    fn only_deep_enables_dup() {
+        let with_dup: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.dup)
+            .map(|r| r.preset)
+            .collect();
+        assert_eq!(with_dup, vec![PresetKind::Deep]);
+    }
+
+    #[test]
+    fn only_architecture_and_deep_enable_imports() {
+        let with_imports: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.imports)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_imports.contains(&PresetKind::Architecture));
+        assert!(with_imports.contains(&PresetKind::Deep));
+        assert_eq!(with_imports.len(), 2);
+    }
+
+    #[test]
+    fn only_risk_identity_git_deep_enable_git_flag() {
+        let with_git: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.git)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_git.contains(&PresetKind::Risk));
+        assert!(with_git.contains(&PresetKind::Identity));
+        assert!(with_git.contains(&PresetKind::Git));
+        assert!(with_git.contains(&PresetKind::Deep));
+        assert_eq!(with_git.len(), 4);
+    }
+
+    #[test]
+    fn only_fun_enables_fun_flag() {
+        let with_fun: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.fun)
+            .map(|r| r.preset)
+            .collect();
+        assert_eq!(with_fun, vec![PresetKind::Fun]);
+    }
+
+    #[test]
+    fn only_identity_and_deep_enable_archetype() {
+        let with_archetype: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.archetype)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_archetype.contains(&PresetKind::Identity));
+        assert!(with_archetype.contains(&PresetKind::Deep));
+        assert_eq!(with_archetype.len(), 2);
+    }
+
+    #[test]
+    fn only_topics_and_deep_enable_topics_flag() {
+        let with_topics: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.topics)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_topics.contains(&PresetKind::Topics));
+        assert!(with_topics.contains(&PresetKind::Deep));
+        assert_eq!(with_topics.len(), 2);
+    }
+
+    #[test]
+    fn only_security_and_deep_enable_entropy() {
+        let with_entropy: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.entropy)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_entropy.contains(&PresetKind::Security));
+        assert!(with_entropy.contains(&PresetKind::Deep));
+        assert_eq!(with_entropy.len(), 2);
+    }
+
+    #[test]
+    fn only_security_and_deep_enable_license() {
+        let with_license: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.license)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_license.contains(&PresetKind::Security));
+        assert!(with_license.contains(&PresetKind::Deep));
+        assert_eq!(with_license.len(), 2);
+    }
+
+    #[test]
+    fn only_health_risk_deep_enable_complexity() {
+        let with_complexity: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.complexity)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_complexity.contains(&PresetKind::Health));
+        assert!(with_complexity.contains(&PresetKind::Risk));
+        assert!(with_complexity.contains(&PresetKind::Deep));
+        assert_eq!(with_complexity.len(), 3);
+    }
+
+    #[test]
+    fn only_architecture_and_deep_enable_api_surface() {
+        let with_api: Vec<PresetKind> = PRESET_GRID
+            .iter()
+            .filter(|r| r.plan.api_surface)
+            .map(|r| r.preset)
+            .collect();
+        assert!(with_api.contains(&PresetKind::Architecture));
+        assert!(with_api.contains(&PresetKind::Deep));
+        assert_eq!(with_api.len(), 2);
+    }
+}
+
+// =========================================================================
+// 5. Deep preset includes all features (superset)
+// =========================================================================
+
+mod deep_superset {
+    use super::*;
+
+    #[test]
+    fn deep_is_superset_of_all_non_fun_presets() {
+        let deep = preset_plan_for(PresetKind::Deep);
+        for kind in PresetKind::all() {
+            if *kind == PresetKind::Fun || *kind == PresetKind::Deep {
+                continue;
+            }
+            let plan = preset_plan_for(*kind);
+
+            if plan.assets {
+                assert!(deep.assets, "deep missing assets from {:?}", kind);
+            }
+            if plan.deps {
+                assert!(deep.deps, "deep missing deps from {:?}", kind);
+            }
+            if plan.todo {
+                assert!(deep.todo, "deep missing todo from {:?}", kind);
+            }
+            if plan.dup {
+                assert!(deep.dup, "deep missing dup from {:?}", kind);
+            }
+            if plan.imports {
+                assert!(deep.imports, "deep missing imports from {:?}", kind);
+            }
+            if plan.git {
+                assert!(deep.git, "deep missing git from {:?}", kind);
+            }
+            if plan.archetype {
+                assert!(deep.archetype, "deep missing archetype from {:?}", kind);
+            }
+            if plan.topics {
+                assert!(deep.topics, "deep missing topics from {:?}", kind);
+            }
+            if plan.entropy {
+                assert!(deep.entropy, "deep missing entropy from {:?}", kind);
+            }
+            if plan.license {
+                assert!(deep.license, "deep missing license from {:?}", kind);
+            }
+            if plan.complexity {
+                assert!(deep.complexity, "deep missing complexity from {:?}", kind);
+            }
+            if plan.api_surface {
+                assert!(deep.api_surface, "deep missing api_surface from {:?}", kind);
+            }
+        }
+    }
+
+    #[test]
+    fn deep_does_not_enable_fun() {
+        assert!(!preset_plan_for(PresetKind::Deep).fun);
+    }
+
+    #[test]
+    fn deep_enables_all_twelve_non_fun_flags() {
+        let plan = preset_plan_for(PresetKind::Deep);
+        assert!(plan.assets);
+        assert!(plan.deps);
+        assert!(plan.todo);
+        assert!(plan.dup);
+        assert!(plan.imports);
+        assert!(plan.git);
+        assert!(plan.archetype);
+        assert!(plan.topics);
+        assert!(plan.entropy);
+        assert!(plan.license);
+        assert!(plan.complexity);
+        assert!(plan.api_surface);
+    }
+}
+
+// =========================================================================
+// 6. Receipt preset is minimal
+// =========================================================================
+
+mod receipt_minimal {
+    use super::*;
+
+    #[test]
+    fn receipt_is_the_only_all_false_preset() {
+        for kind in PresetKind::all() {
+            let plan = preset_plan_for(*kind);
+            let all_base_false = !plan.assets
+                && !plan.deps
+                && !plan.todo
+                && !plan.dup
+                && !plan.imports
+                && !plan.git
+                && !plan.fun
+                && !plan.archetype
+                && !plan.topics
+                && !plan.entropy
+                && !plan.license
+                && !plan.complexity
+                && !plan.api_surface;
+
+            if *kind == PresetKind::Receipt {
+                assert!(all_base_false, "Receipt should have all base flags false");
+            } else {
+                assert!(
+                    !all_base_false,
+                    "{:?} should have at least one flag enabled",
+                    kind
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn receipt_does_not_need_files() {
+        assert!(!preset_plan_for(PresetKind::Receipt).needs_files());
+    }
+}
+
+// =========================================================================
+// 7. No duplicate enricher entries in grid
+// =========================================================================
+
+mod no_duplicates {
+    use super::*;
+
+    #[test]
+    fn no_duplicate_preset_kinds_in_grid() {
+        let mut seen: Vec<PresetKind> = Vec::new();
+        for row in &PRESET_GRID {
+            assert!(
+                !seen.contains(&row.preset),
+                "Duplicate preset {:?} in PRESET_GRID",
+                row.preset
+            );
+            seen.push(row.preset);
+        }
+    }
+
+    #[test]
+    fn no_duplicate_preset_kinds_in_kinds_array() {
+        let mut seen: Vec<PresetKind> = Vec::new();
+        for kind in &PRESET_KINDS {
+            assert!(
+                !seen.contains(kind),
+                "Duplicate preset {:?} in PRESET_KINDS",
+                kind
+            );
+            seen.push(*kind);
+        }
+    }
+
+    #[test]
+    fn grid_and_kinds_same_length() {
+        assert_eq!(PRESET_GRID.len(), PRESET_KINDS.len());
+    }
+
+    #[test]
+    fn grid_order_matches_kinds_order() {
+        for (row, kind) in PRESET_GRID.iter().zip(PRESET_KINDS.iter()) {
+            assert_eq!(
+                row.preset, *kind,
+                "Grid order doesn't match PRESET_KINDS order"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// 8. needs_files correctness
+// =========================================================================
+
+mod needs_files_deep {
+    use super::*;
+
+    #[test]
+    fn needs_files_matches_any_file_dependent_flag() {
+        for row in &PRESET_GRID {
+            let plan = &row.plan;
+            let expected = plan.assets
+                || plan.deps
+                || plan.todo
+                || plan.dup
+                || plan.imports
+                || plan.entropy
+                || plan.license
+                || plan.complexity
+                || plan.api_surface;
+            assert_eq!(
+                plan.needs_files(),
+                expected,
+                "needs_files mismatch for {:?}: got {}, expected {}",
+                row.preset,
+                plan.needs_files(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn git_only_presets_do_not_need_files() {
+        // Git and Identity presets that only enable git/archetype shouldn't need files
+        // (archetype is not in needs_files, git is not in needs_files)
+        let git_plan = preset_plan_for(PresetKind::Git);
+        assert!(!git_plan.needs_files(), "git preset should not need files");
+    }
+
+    #[test]
+    fn fun_does_not_need_files() {
+        assert!(!preset_plan_for(PresetKind::Fun).needs_files());
+    }
+
+    #[test]
+    fn topics_does_not_need_files() {
+        // topics flag alone is not in the needs_files check
+        let plan = preset_plan_for(PresetKind::Topics);
+        assert!(!plan.needs_files());
+    }
+
+    #[test]
+    fn identity_does_not_need_files() {
+        // identity = git + archetype, neither is in needs_files
+        let plan = preset_plan_for(PresetKind::Identity);
+        assert!(!plan.needs_files());
+    }
+}
+
+// =========================================================================
+// 9. DisabledFeature exhaustive coverage
+// =========================================================================
+
+mod disabled_features_deep {
+    use super::*;
+
+    const ALL_FEATURES: [DisabledFeature; 13] = [
+        DisabledFeature::FileInventory,
+        DisabledFeature::TodoScan,
+        DisabledFeature::DuplicationScan,
+        DisabledFeature::NearDuplicateScan,
+        DisabledFeature::ImportScan,
+        DisabledFeature::GitMetrics,
+        DisabledFeature::EntropyProfiling,
+        DisabledFeature::LicenseRadar,
+        DisabledFeature::ComplexityAnalysis,
+        DisabledFeature::ApiSurfaceAnalysis,
+        DisabledFeature::Archetype,
+        DisabledFeature::Topics,
+        DisabledFeature::Fun,
+    ];
+
+    #[test]
+    fn all_warnings_are_non_empty_and_ascii() {
+        for feat in &ALL_FEATURES {
+            let msg = feat.warning();
+            assert!(!msg.is_empty(), "{:?} has empty warning", feat);
+            assert!(msg.is_ascii(), "{:?} warning is not ASCII: {}", feat, msg);
+        }
+    }
+
+    #[test]
+    fn all_warnings_are_unique() {
+        let messages: Vec<&str> = ALL_FEATURES.iter().map(|f| f.warning()).collect();
+        for (i, a) in messages.iter().enumerate() {
+            for (j, b) in messages.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "Duplicate warning between variants {} and {}", i, j);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn debug_output_is_non_empty_for_all_variants() {
+        for feat in &ALL_FEATURES {
+            let debug = format!("{:?}", feat);
+            assert!(!debug.is_empty(), "{:?} has empty Debug output", feat);
+        }
+    }
+
+    #[test]
+    fn clone_and_copy_work_for_disabled_feature() {
+        for feat in &ALL_FEATURES {
+            let cloned = *feat;
+            assert_eq!(*feat, cloned);
+        }
+    }
+
+    #[test]
+    fn disabled_feature_equality_is_reflexive() {
+        for feat in &ALL_FEATURES {
+            assert_eq!(*feat, *feat);
+        }
+    }
+
+    #[test]
+    fn disabled_feature_inequality_across_variants() {
+        for (i, a) in ALL_FEATURES.iter().enumerate() {
+            for (j, b) in ALL_FEATURES.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+}
+
+// =========================================================================
+// 10. Cross-preset flag analysis
+// =========================================================================
+
+mod cross_preset {
+    use super::*;
+
+    #[test]
+    fn no_preset_enables_both_fun_and_any_other_flag() {
+        for row in &PRESET_GRID {
+            if row.plan.fun {
+                assert!(
+                    !row.plan.assets
+                        && !row.plan.deps
+                        && !row.plan.todo
+                        && !row.plan.dup
+                        && !row.plan.imports
+                        && !row.plan.git
+                        && !row.plan.archetype
+                        && !row.plan.topics
+                        && !row.plan.entropy
+                        && !row.plan.license
+                        && !row.plan.complexity
+                        && !row.plan.api_surface,
+                    "{:?} has fun=true along with other flags",
+                    row.preset
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_base_flag_is_enabled_by_at_least_one_preset() {
+        let all_plans: Vec<&PresetPlan> = PRESET_GRID.iter().map(|r| &r.plan).collect();
+
+        assert!(
+            all_plans.iter().any(|p| p.assets),
+            "no preset enables assets"
+        );
+        assert!(all_plans.iter().any(|p| p.deps), "no preset enables deps");
+        assert!(all_plans.iter().any(|p| p.todo), "no preset enables todo");
+        assert!(all_plans.iter().any(|p| p.dup), "no preset enables dup");
+        assert!(
+            all_plans.iter().any(|p| p.imports),
+            "no preset enables imports"
+        );
+        assert!(all_plans.iter().any(|p| p.git), "no preset enables git");
+        assert!(all_plans.iter().any(|p| p.fun), "no preset enables fun");
+        assert!(
+            all_plans.iter().any(|p| p.archetype),
+            "no preset enables archetype"
+        );
+        assert!(
+            all_plans.iter().any(|p| p.topics),
+            "no preset enables topics"
+        );
+        assert!(
+            all_plans.iter().any(|p| p.entropy),
+            "no preset enables entropy"
+        );
+        assert!(
+            all_plans.iter().any(|p| p.license),
+            "no preset enables license"
+        );
+        assert!(
+            all_plans.iter().any(|p| p.complexity),
+            "no preset enables complexity"
+        );
+        assert!(
+            all_plans.iter().any(|p| p.api_surface),
+            "no preset enables api_surface"
+        );
+    }
+
+    #[test]
+    fn presets_with_complexity_also_need_files() {
+        for row in &PRESET_GRID {
+            if row.plan.complexity {
+                assert!(
+                    row.plan.needs_files(),
+                    "{:?} has complexity=true but needs_files()=false",
+                    row.preset
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn presets_with_license_also_need_files() {
+        for row in &PRESET_GRID {
+            if row.plan.license {
+                assert!(
+                    row.plan.needs_files(),
+                    "{:?} has license=true but needs_files()=false",
+                    row.preset
+                );
+            }
+        }
+    }
+}
+
+// =========================================================================
+// 11. PresetKind trait implementations
+// =========================================================================
+
+mod traits {
+    use super::*;
+
+    #[test]
+    fn preset_kind_debug_output_matches_variant_name() {
+        let cases = [
+            (PresetKind::Receipt, "Receipt"),
+            (PresetKind::Health, "Health"),
+            (PresetKind::Risk, "Risk"),
+            (PresetKind::Supply, "Supply"),
+            (PresetKind::Architecture, "Architecture"),
+            (PresetKind::Topics, "Topics"),
+            (PresetKind::Security, "Security"),
+            (PresetKind::Identity, "Identity"),
+            (PresetKind::Git, "Git"),
+            (PresetKind::Deep, "Deep"),
+            (PresetKind::Fun, "Fun"),
+        ];
+        for (kind, expected) in &cases {
+            assert_eq!(format!("{:?}", kind), *expected);
+        }
+    }
+
+    #[test]
+    fn preset_plan_debug_is_deterministic() {
+        let plan = preset_plan_for(PresetKind::Deep);
+        let debug1 = format!("{:?}", plan);
+        let debug2 = format!("{:?}", plan);
+        assert_eq!(debug1, debug2);
+    }
+
+    #[test]
+    fn preset_grid_row_debug_contains_preset_name() {
+        for row in &PRESET_GRID {
+            let debug = format!("{:?}", row);
+            let kind_debug = format!("{:?}", row.preset);
+            assert!(
+                debug.contains(&kind_debug),
+                "Debug of grid row should contain preset name {:?}, got: {}",
+                row.preset,
+                debug
+            );
+        }
+    }
+
+    #[test]
+    fn preset_kind_copy_semantics() {
+        let a = PresetKind::Deep;
+        let b = a; // Copy
+        assert_eq!(a, b);
+        // `a` is still usable (not moved)
+        assert_eq!(a.as_str(), "deep");
+    }
+
+    #[test]
+    fn preset_plan_copy_semantics() {
+        let plan = preset_plan_for(PresetKind::Risk);
+        let plan2 = plan; // Copy
+        assert_eq!(plan, plan2);
+        // `plan` is still usable
+        assert!(plan.git);
+    }
+}
+
+// =========================================================================
+// 12. Lookup stability
+// =========================================================================
+
+mod stability {
+    use super::*;
+
+    #[test]
+    fn preset_plan_for_is_deterministic() {
+        for kind in PresetKind::all() {
+            let p1 = preset_plan_for(*kind);
+            let p2 = preset_plan_for(*kind);
+            let p3 = preset_plan_for(*kind);
+            assert_eq!(p1, p2);
+            assert_eq!(p2, p3);
+        }
+    }
+
+    #[test]
+    fn preset_plan_for_name_is_deterministic() {
+        for kind in PresetKind::all() {
+            let p1 = preset_plan_for_name(kind.as_str());
+            let p2 = preset_plan_for_name(kind.as_str());
+            assert_eq!(p1, p2);
+        }
+    }
+
+    #[test]
+    fn preset_kinds_const_is_stable() {
+        let all = PresetKind::all();
+        assert_eq!(all.len(), PRESET_KINDS.len());
+        for (a, b) in all.iter().zip(PRESET_KINDS.iter()) {
+            assert_eq!(a, b);
+        }
+    }
+}

--- a/crates/tokmd-gate/tests/deep.rs
+++ b/crates/tokmd-gate/tests/deep.rs
@@ -1,0 +1,1216 @@
+//! Deep tests for tokmd-gate.
+//!
+//! Targets areas not fully covered by existing test files:
+//! - Comparison operators with `None` value (missing value field)
+//! - Policy evaluation on empty/minimal JSON documents
+//! - Ratchet evaluation with negative, zero, and extreme values
+//! - Ratchet `from_file` roundtrip with actual temp file
+//! - Negate combined with allow_missing
+//! - Multiple rules mixing error and warn levels
+//! - GateResult / RatchetGateResult invariants under varied inputs
+//! - Ratchet percentage calculation accuracy
+//! - Contains on nested array/string edge cases
+//! - In operator with mixed-type value lists
+//! - Exists operator on null values
+
+use serde_json::json;
+use tokmd_gate::{
+    GateResult, PolicyConfig, PolicyRule, RatchetConfig, RatchetGateResult, RatchetResult,
+    RatchetRule, RuleLevel, RuleOperator, RuleResult, evaluate_policy, evaluate_ratchet_policy,
+    resolve_pointer,
+};
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+fn make_rule(name: &str, pointer: &str, op: RuleOperator, value: serde_json::Value) -> PolicyRule {
+    PolicyRule {
+        name: name.into(),
+        pointer: pointer.into(),
+        op,
+        value: Some(value),
+        values: None,
+        negate: false,
+        level: RuleLevel::Error,
+        message: None,
+    }
+}
+
+fn eval_single(receipt: &serde_json::Value, rule: &PolicyRule) -> RuleResult {
+    let policy = PolicyConfig {
+        rules: vec![rule.clone()],
+        fail_fast: false,
+        allow_missing: false,
+    };
+    let result = evaluate_policy(receipt, &policy);
+    result.rule_results.into_iter().next().unwrap()
+}
+
+fn make_ratchet_rule(
+    pointer: &str,
+    max_increase_pct: Option<f64>,
+    max_value: Option<f64>,
+) -> RatchetRule {
+    RatchetRule {
+        pointer: pointer.to_string(),
+        max_increase_pct,
+        max_value,
+        level: RuleLevel::Error,
+        description: None,
+    }
+}
+
+// =========================================================================
+// 1. Comparison operators with None value field
+// =========================================================================
+
+mod missing_value_field {
+    use super::*;
+
+    #[test]
+    fn gt_with_no_value_fails_gracefully() {
+        let receipt = json!({"x": 10});
+        let rule = PolicyRule {
+            name: "gt_no_val".into(),
+            pointer: "/x".into(),
+            op: RuleOperator::Gt,
+            value: None,
+            values: None,
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        let result = eval_single(&receipt, &rule);
+        assert!(!result.passed, "Gt with no expected value should fail");
+    }
+
+    #[test]
+    fn eq_with_no_value_fails_gracefully() {
+        let receipt = json!({"x": 10});
+        let rule = PolicyRule {
+            name: "eq_no_val".into(),
+            pointer: "/x".into(),
+            op: RuleOperator::Eq,
+            value: None,
+            values: None,
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        let result = eval_single(&receipt, &rule);
+        assert!(!result.passed, "Eq with no expected value should fail");
+    }
+
+    #[test]
+    fn in_with_no_values_list_fails_gracefully() {
+        let receipt = json!({"x": "a"});
+        let rule = PolicyRule {
+            name: "in_no_vals".into(),
+            pointer: "/x".into(),
+            op: RuleOperator::In,
+            value: None,
+            values: None,
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        let result = eval_single(&receipt, &rule);
+        assert!(!result.passed, "In with no values list should fail");
+    }
+
+    #[test]
+    fn contains_with_no_value_fails_gracefully() {
+        let receipt = json!({"arr": [1, 2, 3]});
+        let rule = PolicyRule {
+            name: "contains_no_val".into(),
+            pointer: "/arr".into(),
+            op: RuleOperator::Contains,
+            value: None,
+            values: None,
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        let result = eval_single(&receipt, &rule);
+        assert!(
+            !result.passed,
+            "Contains with no expected value should fail"
+        );
+    }
+}
+
+// =========================================================================
+// 2. JSON pointer resolution on edge-case documents
+// =========================================================================
+
+mod pointer_deep {
+    use super::*;
+
+    #[test]
+    fn pointer_on_empty_object() {
+        let doc = json!({});
+        assert_eq!(resolve_pointer(&doc, ""), Some(&doc));
+        assert_eq!(resolve_pointer(&doc, "/anything"), None);
+    }
+
+    #[test]
+    fn pointer_on_scalar_root() {
+        let doc = json!(42);
+        assert_eq!(resolve_pointer(&doc, ""), Some(&json!(42)));
+        assert_eq!(resolve_pointer(&doc, "/x"), None);
+    }
+
+    #[test]
+    fn pointer_on_array_root() {
+        let doc = json!([1, 2, 3]);
+        assert_eq!(resolve_pointer(&doc, ""), Some(&doc));
+        assert_eq!(resolve_pointer(&doc, "/0"), Some(&json!(1)));
+        assert_eq!(resolve_pointer(&doc, "/2"), Some(&json!(3)));
+        assert_eq!(resolve_pointer(&doc, "/key"), None);
+    }
+
+    #[test]
+    fn pointer_on_null_root() {
+        let doc = json!(null);
+        assert_eq!(resolve_pointer(&doc, ""), Some(&json!(null)));
+        assert_eq!(resolve_pointer(&doc, "/x"), None);
+    }
+
+    #[test]
+    fn pointer_on_string_root() {
+        let doc = json!("hello");
+        assert_eq!(resolve_pointer(&doc, ""), Some(&json!("hello")));
+        assert_eq!(resolve_pointer(&doc, "/0"), None);
+    }
+
+    #[test]
+    fn pointer_on_deeply_nested_array_of_objects() {
+        let doc = json!({
+            "results": [
+                {"metrics": [{"name": "loc", "value": 100}]},
+                {"metrics": [{"name": "tokens", "value": 200}]}
+            ]
+        });
+        assert_eq!(
+            resolve_pointer(&doc, "/results/0/metrics/0/value"),
+            Some(&json!(100))
+        );
+        assert_eq!(
+            resolve_pointer(&doc, "/results/1/metrics/0/name"),
+            Some(&json!("tokens"))
+        );
+    }
+
+    #[test]
+    fn pointer_double_escape_round_trip() {
+        // Key with both ~ and / characters
+        let doc = json!({"a~b/c": 42});
+        assert_eq!(resolve_pointer(&doc, "/a~0b~1c"), Some(&json!(42)));
+    }
+
+    #[test]
+    fn pointer_to_false_value() {
+        let doc = json!({"flag": false});
+        assert_eq!(resolve_pointer(&doc, "/flag"), Some(&json!(false)));
+    }
+
+    #[test]
+    fn pointer_to_zero_value() {
+        let doc = json!({"count": 0});
+        assert_eq!(resolve_pointer(&doc, "/count"), Some(&json!(0)));
+    }
+
+    #[test]
+    fn pointer_to_empty_string_value() {
+        let doc = json!({"name": ""});
+        assert_eq!(resolve_pointer(&doc, "/name"), Some(&json!("")));
+    }
+
+    #[test]
+    fn pointer_to_empty_array_value() {
+        let doc = json!({"items": []});
+        assert_eq!(resolve_pointer(&doc, "/items"), Some(&json!([])));
+        assert_eq!(resolve_pointer(&doc, "/items/0"), None);
+    }
+}
+
+// =========================================================================
+// 3. All comparison operators at boundaries
+// =========================================================================
+
+mod comparison_boundaries {
+    use super::*;
+
+    #[test]
+    fn all_operators_at_equality_boundary() {
+        let receipt = json!({"n": 42});
+        let v = json!(42);
+
+        assert!(
+            !eval_single(
+                &receipt,
+                &make_rule("gt", "/n", RuleOperator::Gt, v.clone())
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("gte", "/n", RuleOperator::Gte, v.clone())
+            )
+            .passed
+        );
+        assert!(
+            !eval_single(
+                &receipt,
+                &make_rule("lt", "/n", RuleOperator::Lt, v.clone())
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("lte", "/n", RuleOperator::Lte, v.clone())
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("eq", "/n", RuleOperator::Eq, v.clone())
+            )
+            .passed
+        );
+        assert!(!eval_single(&receipt, &make_rule("ne", "/n", RuleOperator::Ne, v)).passed);
+    }
+
+    #[test]
+    fn float_boundary_just_below_and_above() {
+        let receipt = json!({"val": 10.0});
+
+        let just_above = json!(10.0 + 1e-10);
+        let just_below = json!(10.0 - 1e-10);
+
+        // val < just_above should be true
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("lt", "/val", RuleOperator::Lt, just_above)
+            )
+            .passed
+        );
+        // val > just_below should be true
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("gt", "/val", RuleOperator::Gt, just_below)
+            )
+            .passed
+        );
+    }
+
+    #[test]
+    fn negative_number_comparisons() {
+        let receipt = json!({"n": -5});
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("gt_neg", "/n", RuleOperator::Gt, json!(-10))
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("lt_neg", "/n", RuleOperator::Lt, json!(0))
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("eq_neg", "/n", RuleOperator::Eq, json!(-5))
+            )
+            .passed
+        );
+    }
+
+    #[test]
+    fn large_number_comparisons() {
+        let receipt = json!({"big": 1_000_000_000i64});
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("gt", "/big", RuleOperator::Gt, json!(999_999_999))
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("lte", "/big", RuleOperator::Lte, json!(1_000_000_000i64))
+            )
+            .passed
+        );
+    }
+}
+
+// =========================================================================
+// 4. Threshold / multiple rules mixing error and warn
+// =========================================================================
+
+mod mixed_level_rules {
+    use super::*;
+
+    #[test]
+    fn multiple_errors_multiple_warns_all_failing() {
+        let receipt = json!({"a": 100, "b": 200, "c": 300});
+        let policy = PolicyConfig {
+            rules: vec![
+                PolicyRule {
+                    level: RuleLevel::Error,
+                    ..make_rule("err1", "/a", RuleOperator::Lt, json!(50))
+                },
+                PolicyRule {
+                    level: RuleLevel::Warn,
+                    ..make_rule("warn1", "/b", RuleOperator::Lt, json!(50))
+                },
+                PolicyRule {
+                    level: RuleLevel::Error,
+                    ..make_rule("err2", "/c", RuleOperator::Lt, json!(50))
+                },
+                PolicyRule {
+                    level: RuleLevel::Warn,
+                    ..make_rule("warn2", "/a", RuleOperator::Lt, json!(50))
+                },
+            ],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let result = evaluate_policy(&receipt, &policy);
+        assert!(!result.passed);
+        assert_eq!(result.errors, 2);
+        assert_eq!(result.warnings, 2);
+        assert_eq!(result.rule_results.len(), 4);
+    }
+
+    #[test]
+    fn all_passing_rules_mixed_levels() {
+        let receipt = json!({"a": 1, "b": 2});
+        let policy = PolicyConfig {
+            rules: vec![
+                PolicyRule {
+                    level: RuleLevel::Error,
+                    ..make_rule("err", "/a", RuleOperator::Gte, json!(1))
+                },
+                PolicyRule {
+                    level: RuleLevel::Warn,
+                    ..make_rule("warn", "/b", RuleOperator::Gte, json!(1))
+                },
+            ],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let result = evaluate_policy(&receipt, &policy);
+        assert!(result.passed);
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+}
+
+// =========================================================================
+// 5. Negate combined with allow_missing
+// =========================================================================
+
+mod negate_and_allow_missing {
+    use super::*;
+
+    #[test]
+    fn negate_exists_on_missing_field_with_allow_missing_true() {
+        let receipt = json!({"x": 1});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "no_secrets".into(),
+                pointer: "/secrets".into(),
+                op: RuleOperator::Exists,
+                value: None,
+                values: None,
+                negate: true,
+                level: RuleLevel::Error,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: true,
+        };
+        let result = evaluate_policy(&receipt, &policy);
+        // Negated exists on missing field: exists=false, negated=true → pass
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn negate_gt_on_missing_field_with_allow_missing_false() {
+        let receipt = json!({"x": 1});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                negate: true,
+                ..make_rule("neg_gt", "/missing", RuleOperator::Gt, json!(5))
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+        let result = evaluate_policy(&receipt, &policy);
+        // Missing field + allow_missing=false → fail regardless of negate
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn negate_gt_on_missing_field_with_allow_missing_true() {
+        let receipt = json!({"x": 1});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                negate: true,
+                ..make_rule("neg_gt", "/missing", RuleOperator::Gt, json!(5))
+            }],
+            fail_fast: false,
+            allow_missing: true,
+        };
+        let result = evaluate_policy(&receipt, &policy);
+        // Missing field + allow_missing=true → pass
+        assert!(result.passed);
+    }
+}
+
+// =========================================================================
+// 6. Missing field handling on all non-Exists operators
+// =========================================================================
+
+mod missing_field_operators {
+    use super::*;
+
+    #[test]
+    fn all_comparison_operators_fail_on_missing_field() {
+        let receipt = json!({"x": 1});
+        let operators = [
+            RuleOperator::Gt,
+            RuleOperator::Gte,
+            RuleOperator::Lt,
+            RuleOperator::Lte,
+            RuleOperator::Eq,
+            RuleOperator::Ne,
+        ];
+
+        for op in &operators {
+            let rule = make_rule("test", "/missing", *op, json!(1));
+            let result = eval_single(&receipt, &rule);
+            assert!(
+                !result.passed,
+                "Operator {:?} should fail on missing field",
+                op
+            );
+            assert!(
+                result.message.as_ref().unwrap().contains("not found"),
+                "Missing field message should mention 'not found' for {:?}",
+                op
+            );
+        }
+    }
+}
+
+// =========================================================================
+// 7. Type mismatch handling
+// =========================================================================
+
+mod type_mismatch {
+    use super::*;
+
+    #[test]
+    fn gt_on_boolean_value_fails() {
+        let receipt = json!({"flag": true});
+        let rule = make_rule("test", "/flag", RuleOperator::Gt, json!(0));
+        assert!(!eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn gt_on_null_value_fails() {
+        let receipt = json!({"val": null});
+        let rule = make_rule("test", "/val", RuleOperator::Gt, json!(0));
+        assert!(!eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn gt_on_array_value_fails() {
+        let receipt = json!({"arr": [1, 2, 3]});
+        let rule = make_rule("test", "/arr", RuleOperator::Gt, json!(0));
+        assert!(!eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn gt_on_object_value_fails() {
+        let receipt = json!({"obj": {"a": 1}});
+        let rule = make_rule("test", "/obj", RuleOperator::Gt, json!(0));
+        assert!(!eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn eq_between_number_and_string_of_same_digits() {
+        // "42" as string vs 42 as number: compare_equal falls through string check
+        // (one side is not a string), then tries numeric coercion via value_to_f64.
+        // value_to_f64 parses string "42" → 42.0, number 42 → 42.0, so they match.
+        let receipt = json!({"val": "42"});
+        let rule = make_rule("test", "/val", RuleOperator::Eq, json!(42));
+        let result = eval_single(&receipt, &rule);
+        assert!(
+            result.passed,
+            "string '42' should coerce to number 42 via value_to_f64"
+        );
+    }
+
+    #[test]
+    fn eq_between_non_numeric_string_and_number() {
+        // "hello" cannot be parsed to f64, so numeric comparison fails;
+        // falls through to JSON equality which is false (different types).
+        let receipt = json!({"val": "hello"});
+        let rule = make_rule("test", "/val", RuleOperator::Eq, json!(42));
+        let result = eval_single(&receipt, &rule);
+        assert!(
+            !result.passed,
+            "non-numeric string should not equal a number"
+        );
+    }
+}
+
+// =========================================================================
+// 8. Edge cases: empty rules, empty data, null values
+// =========================================================================
+
+mod edge_cases_empty {
+    use super::*;
+
+    #[test]
+    fn empty_rules_empty_data() {
+        let receipt = json!({});
+        let policy = PolicyConfig::default();
+        let result = evaluate_policy(&receipt, &policy);
+        assert!(result.passed);
+        assert_eq!(result.rule_results.len(), 0);
+    }
+
+    #[test]
+    fn policy_on_null_root_document() {
+        let receipt = json!(null);
+        let rule = make_rule("test", "/x", RuleOperator::Eq, json!(1));
+        let result = eval_single(&receipt, &rule);
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn exists_on_null_value_passes() {
+        // null is a valid JSON value — the pointer resolves, so exists is true
+        let receipt = json!({"key": null});
+        let rule = PolicyRule {
+            name: "exists_null".into(),
+            pointer: "/key".into(),
+            op: RuleOperator::Exists,
+            value: None,
+            values: None,
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        assert!(eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn gate_result_from_single_passed_error() {
+        let results = vec![RuleResult {
+            name: "r1".into(),
+            passed: true,
+            level: RuleLevel::Error,
+            actual: Some(json!(1)),
+            expected: "/x >= 0".into(),
+            message: None,
+        }];
+        let gate = GateResult::from_results(results);
+        assert!(gate.passed);
+        assert_eq!(gate.errors, 0);
+        assert_eq!(gate.warnings, 0);
+        assert_eq!(gate.rule_results.len(), 1);
+    }
+
+    #[test]
+    fn gate_result_from_single_failed_error() {
+        let results = vec![RuleResult {
+            name: "r1".into(),
+            passed: false,
+            level: RuleLevel::Error,
+            actual: Some(json!(-1)),
+            expected: "/x >= 0".into(),
+            message: Some("below zero".into()),
+        }];
+        let gate = GateResult::from_results(results);
+        assert!(!gate.passed);
+        assert_eq!(gate.errors, 1);
+        assert_eq!(gate.warnings, 0);
+    }
+
+    #[test]
+    fn ratchet_gate_result_from_single_passed() {
+        let results = vec![RatchetResult {
+            rule: make_ratchet_rule("/x", Some(10.0), None),
+            passed: true,
+            baseline_value: Some(10.0),
+            current_value: 10.5,
+            change_pct: Some(5.0),
+            message: "ok".into(),
+        }];
+        let gate = RatchetGateResult::from_results(results);
+        assert!(gate.passed);
+        assert_eq!(gate.errors, 0);
+    }
+}
+
+// =========================================================================
+// 9. Contains on edge-case strings and arrays
+// =========================================================================
+
+mod contains_deep {
+    use super::*;
+
+    #[test]
+    fn contains_unicode_substring() {
+        let receipt = json!({"text": "hello 世界"});
+        let rule = make_rule("test", "/text", RuleOperator::Contains, json!("世界"));
+        assert!(eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn contains_array_with_mixed_types() {
+        let receipt = json!({"arr": [1, "two", true, null]});
+
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("str", "/arr", RuleOperator::Contains, json!("two"))
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("num", "/arr", RuleOperator::Contains, json!(1))
+            )
+            .passed
+        );
+        assert!(
+            eval_single(
+                &receipt,
+                &make_rule("bool", "/arr", RuleOperator::Contains, json!(true))
+            )
+            .passed
+        );
+    }
+
+    #[test]
+    fn contains_on_nested_array_element_via_pointer() {
+        let receipt = json!({"data": {"tags": ["alpha", "beta"]}});
+        let rule = make_rule("test", "/data/tags", RuleOperator::Contains, json!("beta"));
+        assert!(eval_single(&receipt, &rule).passed);
+    }
+}
+
+// =========================================================================
+// 10. In operator with mixed-type value lists
+// =========================================================================
+
+mod in_operator_deep {
+    use super::*;
+
+    #[test]
+    fn in_with_mixed_numeric_types() {
+        // Integer actual vs float in values list
+        let receipt = json!({"val": 42});
+        let rule = PolicyRule {
+            name: "test".into(),
+            pointer: "/val".into(),
+            op: RuleOperator::In,
+            value: None,
+            values: Some(vec![json!(42.0), json!(43.0)]),
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        assert!(eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn in_with_boolean_values() {
+        let receipt = json!({"flag": true});
+        let rule = PolicyRule {
+            name: "test".into(),
+            pointer: "/flag".into(),
+            op: RuleOperator::In,
+            value: None,
+            values: Some(vec![json!(true), json!(false)]),
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        assert!(eval_single(&receipt, &rule).passed);
+    }
+
+    #[test]
+    fn in_with_null_in_list() {
+        let receipt = json!({"val": null});
+        let rule = PolicyRule {
+            name: "test".into(),
+            pointer: "/val".into(),
+            op: RuleOperator::In,
+            value: None,
+            values: Some(vec![json!(null), json!("other")]),
+            negate: false,
+            level: RuleLevel::Error,
+            message: None,
+        };
+        assert!(eval_single(&receipt, &rule).passed);
+    }
+}
+
+// =========================================================================
+// 11. Ratchet evaluation edge cases
+// =========================================================================
+
+mod ratchet_deep {
+    use super::*;
+
+    #[test]
+    fn ratchet_negative_values_decrease_is_ok() {
+        let baseline = json!({"val": -10.0});
+        let current = json!({"val": -15.0}); // Went more negative (decrease)
+        let config = RatchetConfig {
+            rules: vec![make_ratchet_rule("/val", Some(10.0), None)],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        // -15 from -10 is a 50% decrease in absolute terms,
+        // but the percentage is (-15 - (-10)) / (-10) * 100 = 50%
+        // So the change is +50% (it got worse in negative direction)
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn ratchet_both_missing_baseline_and_current_allowed() {
+        let baseline = json!({});
+        let current = json!({});
+        let config = RatchetConfig {
+            rules: vec![make_ratchet_rule("/missing", Some(10.0), None)],
+            fail_fast: false,
+            allow_missing_baseline: true,
+            allow_missing_current: true,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        // Missing current is allowed → pass
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn ratchet_max_value_zero() {
+        let baseline = json!({"val": 0});
+        let current = json!({"val": 0});
+        let config = RatchetConfig {
+            rules: vec![make_ratchet_rule("/val", None, Some(0.0))],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        // val=0 is not > max_value=0, so passes
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn ratchet_max_value_just_exceeded() {
+        let baseline = json!({"val": 50});
+        let current = json!({"val": 100.001});
+        let config = RatchetConfig {
+            rules: vec![make_ratchet_rule("/val", None, Some(100.0))],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn ratchet_percentage_calculation_accuracy() {
+        let baseline = json!({"val": 200.0});
+        let current = json!({"val": 210.0}); // 5% increase
+
+        let config = RatchetConfig {
+            rules: vec![make_ratchet_rule("/val", Some(10.0), None)],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed);
+
+        let rr = &result.ratchet_results[0];
+        assert_eq!(rr.baseline_value, Some(200.0));
+        assert_eq!(rr.current_value, 210.0);
+        let pct = rr.change_pct.unwrap();
+        assert!((pct - 5.0).abs() < 0.001, "Expected ~5%, got {}", pct);
+    }
+
+    #[test]
+    fn ratchet_no_constraints_at_all_passes() {
+        // Rule with neither max_increase_pct nor max_value
+        let baseline = json!({"val": 100});
+        let current = json!({"val": 9999});
+        let config = RatchetConfig {
+            rules: vec![make_ratchet_rule("/val", None, None)],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed, "No constraints means always pass");
+    }
+
+    #[test]
+    fn ratchet_warn_level_does_not_block() {
+        let baseline = json!({"val": 10.0});
+        let current = json!({"val": 100.0}); // 900% increase
+        let config = RatchetConfig {
+            rules: vec![RatchetRule {
+                pointer: "/val".into(),
+                max_increase_pct: Some(5.0),
+                max_value: None,
+                level: RuleLevel::Warn,
+                description: None,
+            }],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed, "Warn-level ratchet failures don't block");
+        assert_eq!(result.warnings, 1);
+        assert_eq!(result.errors, 0);
+    }
+
+    #[test]
+    fn ratchet_fail_fast_does_not_stop_on_warn() {
+        let baseline = json!({"a": 10.0, "b": 10.0});
+        let current = json!({"a": 100.0, "b": 100.0}); // Both huge increases
+
+        let config = RatchetConfig {
+            rules: vec![
+                RatchetRule {
+                    pointer: "/a".into(),
+                    max_increase_pct: Some(5.0),
+                    max_value: None,
+                    level: RuleLevel::Warn, // Warn, not error
+                    description: None,
+                },
+                RatchetRule {
+                    pointer: "/b".into(),
+                    max_increase_pct: Some(5.0),
+                    max_value: None,
+                    level: RuleLevel::Error, // Error
+                    description: None,
+                },
+            ],
+            fail_fast: true,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+        // fail_fast should not stop on warn, so both rules evaluated
+        assert_eq!(result.ratchet_results.len(), 2);
+        assert_eq!(result.warnings, 1);
+        assert_eq!(result.errors, 1);
+    }
+}
+
+// =========================================================================
+// 12. Serialization / deserialization roundtrips
+// =========================================================================
+
+mod serde_deep {
+    use super::*;
+
+    #[test]
+    fn policy_rule_all_operators_roundtrip_json() {
+        let operators = [
+            RuleOperator::Gt,
+            RuleOperator::Gte,
+            RuleOperator::Lt,
+            RuleOperator::Lte,
+            RuleOperator::Eq,
+            RuleOperator::Ne,
+            RuleOperator::In,
+            RuleOperator::Contains,
+            RuleOperator::Exists,
+        ];
+        for op in &operators {
+            let json_str = serde_json::to_string(op).unwrap();
+            let back: RuleOperator = serde_json::from_str(&json_str).unwrap();
+            assert_eq!(*op, back, "roundtrip failed for {:?}", op);
+        }
+    }
+
+    #[test]
+    fn rule_level_roundtrip_json() {
+        for level in &[RuleLevel::Error, RuleLevel::Warn] {
+            let json_str = serde_json::to_string(level).unwrap();
+            let back: RuleLevel = serde_json::from_str(&json_str).unwrap();
+            assert_eq!(*level, back);
+        }
+    }
+
+    #[test]
+    fn full_policy_config_roundtrip_toml_json() {
+        let toml = r#"
+fail_fast = true
+allow_missing = true
+
+[[rules]]
+name = "check1"
+pointer = "/a/b"
+op = "gte"
+value = 100
+level = "error"
+message = "Too low"
+negate = true
+
+[[rules]]
+name = "check2"
+pointer = "/tags"
+op = "in"
+values = ["x", "y"]
+level = "warn"
+"#;
+        let config = PolicyConfig::from_toml(toml).unwrap();
+
+        // Roundtrip through JSON
+        let json_str = serde_json::to_string(&config).unwrap();
+        let back: PolicyConfig = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(back.fail_fast, config.fail_fast);
+        assert_eq!(back.allow_missing, config.allow_missing);
+        assert_eq!(back.rules.len(), config.rules.len());
+        assert_eq!(back.rules[0].name, "check1");
+        assert_eq!(back.rules[0].op, RuleOperator::Gte);
+        assert!(back.rules[0].negate);
+        assert_eq!(back.rules[1].op, RuleOperator::In);
+        assert_eq!(back.rules[1].level, RuleLevel::Warn);
+    }
+
+    #[test]
+    fn ratchet_config_roundtrip_toml_json() {
+        let toml = r#"
+fail_fast = false
+allow_missing_baseline = true
+allow_missing_current = false
+
+[[rules]]
+pointer = "/complexity"
+max_increase_pct = 5.0
+max_value = 20.0
+level = "error"
+description = "Keep it low"
+"#;
+        let config = RatchetConfig::from_toml(toml).unwrap();
+        let json_str = serde_json::to_string(&config).unwrap();
+        let back: RatchetConfig = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(back.rules.len(), 1);
+        assert!(back.allow_missing_baseline);
+        assert!(!back.allow_missing_current);
+        assert_eq!(back.rules[0].max_increase_pct, Some(5.0));
+        assert_eq!(back.rules[0].max_value, Some(20.0));
+        assert_eq!(back.rules[0].description.as_deref(), Some("Keep it low"));
+    }
+
+    #[test]
+    fn gate_result_with_mixed_results_roundtrip() {
+        let gate = GateResult::from_results(vec![
+            RuleResult {
+                name: "pass_err".into(),
+                passed: true,
+                level: RuleLevel::Error,
+                actual: Some(json!(42)),
+                expected: "/n >= 0".into(),
+                message: None,
+            },
+            RuleResult {
+                name: "fail_warn".into(),
+                passed: false,
+                level: RuleLevel::Warn,
+                actual: Some(json!("bad")),
+                expected: "/s == good".into(),
+                message: Some("not good".into()),
+            },
+            RuleResult {
+                name: "fail_err".into(),
+                passed: false,
+                level: RuleLevel::Error,
+                actual: None,
+                expected: "/missing exists".into(),
+                message: Some("not found".into()),
+            },
+        ]);
+
+        let json_str = serde_json::to_string(&gate).unwrap();
+        let back: GateResult = serde_json::from_str(&json_str).unwrap();
+        assert!(!back.passed);
+        assert_eq!(back.errors, 1);
+        assert_eq!(back.warnings, 1);
+        assert_eq!(back.rule_results.len(), 3);
+    }
+}
+
+// =========================================================================
+// 13. RatchetConfig from_file roundtrip
+// =========================================================================
+
+mod ratchet_file {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn ratchet_config_from_file_roundtrip() {
+        let toml = r#"
+fail_fast = true
+allow_missing_baseline = false
+allow_missing_current = true
+
+[[rules]]
+pointer = "/loc"
+max_increase_pct = 15.0
+level = "warn"
+description = "LOC growth"
+"#;
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("tokmd-gate-ratchet-deep-{nanos}.toml"));
+        std::fs::write(&path, toml).unwrap();
+
+        let config = RatchetConfig::from_file(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(config.fail_fast);
+        assert!(!config.allow_missing_baseline);
+        assert!(config.allow_missing_current);
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(config.rules[0].pointer, "/loc");
+        assert_eq!(config.rules[0].level, RuleLevel::Warn);
+    }
+}
+
+// =========================================================================
+// 14. Property test: valid pointer always resolves or returns None
+// =========================================================================
+
+mod pointer_property {
+    use super::*;
+
+    #[test]
+    fn valid_pointer_on_matching_structure_always_resolves() {
+        // Build a document and verify pointers resolve correctly
+        let doc = json!({
+            "a": {"b": {"c": 1}},
+            "d": [10, 20, 30],
+            "e": null,
+            "f": true,
+            "g": "text"
+        });
+
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            ("/a/b/c", json!(1)),
+            ("/d/0", json!(10)),
+            ("/d/2", json!(30)),
+            ("/e", json!(null)),
+            ("/f", json!(true)),
+            ("/g", json!("text")),
+        ];
+
+        for (pointer, expected) in &cases {
+            let result = resolve_pointer(&doc, pointer);
+            assert_eq!(
+                result,
+                Some(expected),
+                "Pointer {} should resolve to {:?}",
+                pointer,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_pointers_always_return_none() {
+        let doc = json!({"a": 1});
+        let invalid = vec![
+            "no_leading_slash",
+            "/nonexistent",
+            "/a/b", // a is a number, not an object
+            "/a/0", // a is not an array
+        ];
+
+        for pointer in &invalid {
+            assert_eq!(
+                resolve_pointer(&doc, pointer),
+                None,
+                "Pointer {} should return None",
+                pointer
+            );
+        }
+    }
+}
+
+// =========================================================================
+// 15. Fail-fast interaction with warn-only rules
+// =========================================================================
+
+mod fail_fast_deep {
+    use super::*;
+
+    #[test]
+    fn fail_fast_continues_past_warn_failure_to_reach_error() {
+        let receipt = json!({"a": 100, "b": 100, "c": 100});
+        let policy = PolicyConfig {
+            rules: vec![
+                PolicyRule {
+                    level: RuleLevel::Warn,
+                    ..make_rule("w1", "/a", RuleOperator::Lt, json!(50))
+                },
+                PolicyRule {
+                    level: RuleLevel::Warn,
+                    ..make_rule("w2", "/b", RuleOperator::Lt, json!(50))
+                },
+                PolicyRule {
+                    level: RuleLevel::Error,
+                    ..make_rule("e1", "/c", RuleOperator::Lt, json!(50))
+                },
+            ],
+            fail_fast: true,
+            allow_missing: false,
+        };
+
+        let result = evaluate_policy(&receipt, &policy);
+        assert!(!result.passed);
+        // All 3 rules should be evaluated: 2 warns don't stop, error does
+        assert_eq!(result.rule_results.len(), 3);
+        assert_eq!(result.warnings, 2);
+        assert_eq!(result.errors, 1);
+    }
+}


### PR DESCRIPTION
Add comprehensive deep.rs test suites for both crates:

tokmd-gate (60 tests):
- JSON pointer edge cases (empty objects, scalars, nested arrays, escapes)
- Comparison boundaries for all operators at equality points
- Type mismatch handling (gt on bool/null/array/object, eq coercion)
- Missing field behavior across all operators
- Negate combined with allow_missing and exists
- Contains with unicode, mixed-type arrays, nested pointers
- In operator with mixed numeric types, booleans, null
- Ratchet with negative values, zero max, warn level, fail_fast
- Serde roundtrip for all operators, levels, and full configs
- Fail-fast continues past warn failures to reach errors
- Empty rules/data edge cases

tokmd-analysis-grid (65 tests):
- Preset name completeness against documented names
- Flag counts and exclusivity per preset
- Deep preset superset invariant (all 12 non-fun flags)
- Receipt is the only all-false preset
- Enricher selection: which presets enable which flags
- needs_files correctness (git/fun/topics/identity don't need files)
- DisabledFeature exhaustive coverage (warnings, Debug, equality)
- Cross-preset analysis (no fun+other overlap, every flag covered)
- Grid/PRESET_KINDS ordering and uniqueness
- Lookup determinism and stability
