### PR TITLE
test: deep proptest properties across core crates

### DIFF
--- a/crates/tokmd-gate/tests/proptest_deep.rs
+++ b/crates/tokmd-gate/tests/proptest_deep.rs
@@ -1,0 +1,245 @@
+//! Deep property-based tests for tokmd-gate.
+//!
+//! Covers deterministic policy evaluation, invalid pointer safety,
+//! operator serde round-trips, and GateResult invariants.
+
+use proptest::prelude::*;
+use serde_json::json;
+use tokmd_gate::{
+    GateResult, PolicyConfig, PolicyRule, RuleLevel, RuleOperator, RuleResult, evaluate_policy,
+    resolve_pointer,
+};
+
+// =========================================================================
+// Strategies
+// =========================================================================
+
+fn arb_operator() -> impl Strategy<Value = RuleOperator> {
+    prop_oneof![
+        Just(RuleOperator::Gt),
+        Just(RuleOperator::Gte),
+        Just(RuleOperator::Lt),
+        Just(RuleOperator::Lte),
+        Just(RuleOperator::Eq),
+        Just(RuleOperator::Ne),
+        Just(RuleOperator::In),
+        Just(RuleOperator::Contains),
+        Just(RuleOperator::Exists),
+    ]
+}
+
+fn arb_level() -> impl Strategy<Value = RuleLevel> {
+    prop_oneof![Just(RuleLevel::Error), Just(RuleLevel::Warn)]
+}
+
+// =========================================================================
+// Gate evaluation is deterministic: same inputs → same result
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn evaluate_policy_is_deterministic(
+        val in -500i64..500,
+        threshold in -500i64..500,
+        op in arb_operator(),
+        level in arb_level(),
+    ) {
+        let receipt = json!({"metric": val});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "det_test".into(),
+                pointer: "/metric".into(),
+                op,
+                value: Some(json!(threshold)),
+                values: None,
+                negate: false,
+                level,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+
+        let r1 = evaluate_policy(&receipt, &policy);
+        let r2 = evaluate_policy(&receipt, &policy);
+
+        prop_assert_eq!(r1.passed, r2.passed, "Determinism: passed must be same");
+        prop_assert_eq!(r1.errors, r2.errors, "Determinism: errors must be same");
+        prop_assert_eq!(r1.warnings, r2.warnings, "Determinism: warnings must be same");
+        prop_assert_eq!(
+            r1.rule_results.len(),
+            r2.rule_results.len(),
+            "Determinism: rule_results count must be same"
+        );
+    }
+}
+
+// =========================================================================
+// Invalid JSON pointers never panic
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    #[test]
+    fn resolve_pointer_never_panics(
+        pointer in "\\PC{0,50}",
+    ) {
+        let doc = json!({"a": {"b": [1, 2, 3]}, "c": "hello"});
+        // Must not panic regardless of input
+        let _ = resolve_pointer(&doc, &pointer);
+    }
+
+    #[test]
+    fn resolve_pointer_no_leading_slash_is_none(
+        key in "[a-zA-Z_][a-zA-Z0-9_]{0,15}",
+    ) {
+        let doc = json!({&key: 42});
+        let result = resolve_pointer(&doc, &key);
+        prop_assert!(result.is_none(), "Pointer without / must return None");
+    }
+
+    #[test]
+    fn resolve_pointer_empty_is_root(
+        val in -1000i64..1000,
+    ) {
+        let doc = json!({"x": val});
+        let result = resolve_pointer(&doc, "");
+        prop_assert_eq!(result, Some(&doc));
+    }
+}
+
+// =========================================================================
+// evaluate_policy never panics on arbitrary JSON
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn evaluate_policy_never_panics_missing_pointer(
+        pointer in "/[a-zA-Z_]{1,10}(/[a-zA-Z_]{1,10}){0,3}",
+        op in arb_operator(),
+        level in arb_level(),
+        allow_missing in any::<bool>(),
+    ) {
+        // Receipt that likely doesn't match the generated pointer
+        let receipt = json!({"unrelated": 42});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "fuzz_rule".into(),
+                pointer,
+                op,
+                value: Some(json!(100)),
+                values: None,
+                negate: false,
+                level,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing,
+        };
+        // Must not panic
+        let _ = evaluate_policy(&receipt, &policy);
+    }
+}
+
+// =========================================================================
+// GateResult invariants: errors == 0 ↔ passed
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn gate_result_passed_iff_no_errors(
+        n_pass in 0usize..5,
+        n_warn in 0usize..5,
+        n_error in 0usize..5,
+    ) {
+        let mut results = Vec::new();
+        for i in 0..n_pass {
+            results.push(RuleResult {
+                name: format!("pass_{}", i),
+                passed: true,
+                level: RuleLevel::Error,
+                actual: None,
+                expected: "x".into(),
+                message: None,
+            });
+        }
+        for i in 0..n_warn {
+            results.push(RuleResult {
+                name: format!("warn_{}", i),
+                passed: false,
+                level: RuleLevel::Warn,
+                actual: None,
+                expected: "x".into(),
+                message: Some("warning".into()),
+            });
+        }
+        for i in 0..n_error {
+            results.push(RuleResult {
+                name: format!("error_{}", i),
+                passed: false,
+                level: RuleLevel::Error,
+                actual: None,
+                expected: "x".into(),
+                message: Some("error".into()),
+            });
+        }
+
+        let gate = GateResult::from_results(results);
+
+        prop_assert_eq!(gate.errors, n_error);
+        prop_assert_eq!(gate.warnings, n_warn);
+        if n_error == 0 {
+            prop_assert!(gate.passed, "Should pass when no errors");
+        } else {
+            prop_assert!(!gate.passed, "Should fail when errors > 0");
+        }
+    }
+}
+
+// =========================================================================
+// RuleOperator serde round-trip
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn rule_operator_serde_roundtrip(op in arb_operator()) {
+        let json = serde_json::to_string(&op).unwrap();
+        let parsed: RuleOperator = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(op, parsed);
+    }
+
+    #[test]
+    fn rule_level_serde_roundtrip(level in arb_level()) {
+        let json = serde_json::to_string(&level).unwrap();
+        let parsed: RuleLevel = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(level, parsed);
+    }
+}
+
+// =========================================================================
+// Empty policy always passes
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn empty_policy_always_passes(val in -10000i64..10000) {
+        let receipt = json!({"anything": val});
+        let policy = PolicyConfig::default();
+        let result = evaluate_policy(&receipt, &policy);
+        prop_assert!(result.passed, "Empty policy must always pass");
+        prop_assert_eq!(result.errors, 0);
+        prop_assert_eq!(result.warnings, 0);
+        prop_assert!(result.rule_results.is_empty());
+    }
+}

--- a/crates/tokmd-model/tests/proptest_deep.rs
+++ b/crates/tokmd-model/tests/proptest_deep.rs
@@ -1,0 +1,269 @@
+//! Deep property-based tests for tokmd-model.
+//!
+//! Covers sorting stability, aggregation invariants,
+//! normalize_path idempotency, and module_key determinism.
+
+use proptest::prelude::*;
+use std::path::Path;
+use tokmd_model::{avg, module_key, normalize_path};
+use tokmd_types::{LangRow, ModuleRow};
+
+// =========================================================================
+// Strategies
+// =========================================================================
+
+fn arb_lang_row() -> impl Strategy<Value = LangRow> {
+    (
+        "[A-Z][a-zA-Z0-9 #+]{0,15}",
+        0usize..500_000,
+        0usize..1_000_000,
+        0usize..5_000,
+        0usize..50_000_000,
+        0usize..5_000_000,
+        0usize..2_000,
+    )
+        .prop_map(
+            |(lang, code, lines, files, bytes, tokens, avg_lines)| LangRow {
+                lang,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            },
+        )
+}
+
+fn arb_module_row() -> impl Strategy<Value = ModuleRow> {
+    (
+        "[a-z][a-zA-Z0-9_/]{0,20}",
+        0usize..500_000,
+        0usize..1_000_000,
+        0usize..5_000,
+        0usize..50_000_000,
+        0usize..5_000_000,
+        0usize..2_000,
+    )
+        .prop_map(
+            |(module, code, lines, files, bytes, tokens, avg_lines)| ModuleRow {
+                module,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            },
+        )
+}
+
+// =========================================================================
+// Sorting stability: desc by code, then asc by name
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn lang_rows_sort_is_stable(rows in prop::collection::vec(arb_lang_row(), 0..20)) {
+        let mut sorted1 = rows.clone();
+        sorted1.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+
+        let mut sorted2 = rows;
+        sorted2.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+
+        prop_assert_eq!(&sorted1, &sorted2, "Sorting must be deterministic");
+    }
+
+    #[test]
+    fn lang_rows_sorted_descending_by_code(rows in prop::collection::vec(arb_lang_row(), 2..15)) {
+        let mut sorted = rows;
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+
+        for window in sorted.windows(2) {
+            prop_assert!(
+                window[0].code >= window[1].code,
+                "Rows must be sorted descending by code: {} >= {}",
+                window[0].code, window[1].code
+            );
+            if window[0].code == window[1].code {
+                prop_assert!(
+                    window[0].lang <= window[1].lang,
+                    "Equal-code rows must be sorted ascending by name: {} <= {}",
+                    window[0].lang, window[1].lang
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn module_rows_sort_is_stable(rows in prop::collection::vec(arb_module_row(), 0..20)) {
+        let mut sorted1 = rows.clone();
+        sorted1.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+
+        let mut sorted2 = rows;
+        sorted2.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+
+        prop_assert_eq!(&sorted1, &sorted2, "Module sorting must be deterministic");
+    }
+
+    #[test]
+    fn module_rows_sorted_descending_by_code(rows in prop::collection::vec(arb_module_row(), 2..15)) {
+        let mut sorted = rows;
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+
+        for window in sorted.windows(2) {
+            prop_assert!(
+                window[0].code >= window[1].code,
+                "Module rows must be sorted descending by code"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// Aggregation invariant: code values are always non-negative (usize)
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn lang_row_code_always_non_negative(row in arb_lang_row()) {
+        // usize is always >= 0, but verify after serde roundtrip
+        let json = serde_json::to_string(&row).unwrap();
+        let parsed: LangRow = serde_json::from_str(&json).unwrap();
+        // code is usize, so it's always >= 0 by type; verify roundtrip preserves
+        prop_assert_eq!(row.code, parsed.code);
+        prop_assert_eq!(row.lines, parsed.lines);
+        prop_assert_eq!(row.files, parsed.files);
+    }
+
+    #[test]
+    fn module_row_code_always_non_negative(row in arb_module_row()) {
+        let json = serde_json::to_string(&row).unwrap();
+        let parsed: ModuleRow = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(row.code, parsed.code);
+        prop_assert_eq!(row.lines, parsed.lines);
+        prop_assert_eq!(row.files, parsed.files);
+    }
+}
+
+// =========================================================================
+// normalize_path: idempotent, forward-slash only, no leading ./
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn normalize_path_idempotent_deep(
+        parts in prop::collection::vec("[a-zA-Z0-9_]{1,10}", 1..=6),
+        ext in prop::sample::select(vec!["rs", "py", "go", "js", "toml", "md"]),
+    ) {
+        let raw = format!("{}.{}", parts.join("/"), ext);
+        let p = Path::new(&raw);
+        let once = normalize_path(p, None);
+        let twice = normalize_path(Path::new(&once), None);
+        prop_assert_eq!(&once, &twice, "normalize_path must be idempotent");
+    }
+
+    #[test]
+    fn normalize_path_backslash_becomes_forward(
+        parts in prop::collection::vec("[a-zA-Z0-9_]{1,8}", 2..=5),
+    ) {
+        let win_path = parts.join("\\");
+        let p = Path::new(&win_path);
+        let normalized = normalize_path(p, None);
+        prop_assert!(
+            !normalized.contains('\\'),
+            "normalize_path must not contain backslash: {}", normalized
+        );
+    }
+
+    #[test]
+    fn normalize_path_no_leading_dot_slash_deep(
+        parts in prop::collection::vec("[a-zA-Z0-9_]{1,8}", 1..=4),
+        ext in prop::sample::select(vec!["rs", "py", "go"]),
+    ) {
+        let raw = format!("./{}.{}", parts.join("/"), ext);
+        let p = Path::new(&raw);
+        let normalized = normalize_path(p, None);
+        prop_assert!(
+            !normalized.starts_with("./"),
+            "normalize_path must strip leading ./: {}", normalized
+        );
+    }
+}
+
+// =========================================================================
+// module_key: deterministic on same input
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn module_key_is_deterministic(
+        dir in "[a-zA-Z0-9_]{1,10}",
+        subdirs in prop::collection::vec("[a-zA-Z0-9_]{1,10}", 1..=3),
+        filename in "[a-zA-Z0-9_]{1,10}\\.[a-z]{1,4}",
+        depth in 1usize..5,
+    ) {
+        let path_parts: Vec<&str> = std::iter::once(dir.as_str())
+            .chain(subdirs.iter().map(|s| s.as_str()))
+            .chain(std::iter::once(filename.as_str()))
+            .collect();
+        let path = path_parts.join("/");
+        let roots = vec![dir.clone()];
+
+        let k1 = module_key(&path, &roots, depth);
+        let k2 = module_key(&path, &roots, depth);
+        prop_assert_eq!(&k1, &k2, "module_key must be deterministic");
+    }
+
+    #[test]
+    fn module_key_root_files_always_root(
+        filename in "[a-zA-Z0-9_]{1,15}\\.[a-z]{1,4}",
+        depth in 1usize..5,
+    ) {
+        let key = module_key(&filename, &[], depth);
+        prop_assert_eq!(key, "(root)", "Root-level files must map to (root)");
+    }
+}
+
+// =========================================================================
+// avg: invariants
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn avg_never_exceeds_lines(lines in 0usize..100_000, files in 1usize..1_000) {
+        let result = avg(lines, files);
+        prop_assert!(
+            result <= lines,
+            "avg({}, {}) = {} must not exceed lines", lines, files, result
+        );
+    }
+
+    #[test]
+    fn avg_zero_files_is_zero(lines in 0usize..100_000) {
+        prop_assert_eq!(avg(lines, 0), 0);
+    }
+
+    #[test]
+    fn avg_monotonic_in_lines(
+        lines_a in 0usize..50_000,
+        extra in 0usize..50_000,
+        files in 1usize..1_000,
+    ) {
+        let lines_b = lines_a + extra;
+        prop_assert!(
+            avg(lines_b, files) >= avg(lines_a, files),
+            "avg must be monotonically non-decreasing in lines"
+        );
+    }
+}

--- a/crates/tokmd-redact/tests/proptest_deep.proptest-regressions
+++ b/crates/tokmd-redact/tests/proptest_deep.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 96c05f71a91ca6a63cec6d7997b4e68ad801203b71e069500b9431f15feb731d # shrinks to segments = ["ELd", "0", "Bcn0C_u-_"], ext = "py"

--- a/crates/tokmd-redact/tests/proptest_deep.rs
+++ b/crates/tokmd-redact/tests/proptest_deep.rs
@@ -26,7 +26,7 @@ fn arb_path_with_ext() -> impl Strategy<Value = String> {
 }
 
 fn arb_directory_segment() -> impl Strategy<Value = String> {
-    "[a-zA-Z0-9_-]{1,20}"
+    "[a-zA-Z][a-zA-Z0-9_-]{2,19}"
 }
 
 // =========================================================================
@@ -203,5 +203,72 @@ proptest! {
 
         prop_assert_eq!(&r_unix, &r_win, "Unix and Windows paths should redact identically");
         prop_assert_eq!(&r_unix, &r_mixed, "Mixed separators should redact identically");
+    }
+}
+
+// =========================================================================
+// Idempotency: redacting the same input always gives the same output
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn redact_path_idempotent_across_calls(path in arb_path_with_ext()) {
+        let first = redact_path(&path);
+        let second = redact_path(&path);
+        let third = redact_path(&path);
+        prop_assert_eq!(&first, &second);
+        prop_assert_eq!(&second, &third);
+    }
+
+    #[test]
+    fn short_hash_always_hex(input in ".{1,200}") {
+        let hash = short_hash(&input);
+        prop_assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "short_hash must produce only hex chars, got: {}", hash
+        );
+    }
+
+    #[test]
+    fn short_hash_length_is_16(input in ".{0,500}") {
+        let hash = short_hash(&input);
+        prop_assert_eq!(hash.len(), 16, "short_hash must be 16 chars, got {}", hash.len());
+    }
+}
+
+// =========================================================================
+// Dot-prefix normalization: ./path and path produce same redaction
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn dot_prefix_normalizes_for_redact(
+        parts in prop::collection::vec("[a-zA-Z0-9_]{1,8}", 1..=4),
+        ext in prop::sample::select(vec!["rs", "py", "go", "js"]),
+    ) {
+        let plain = format!("{}.{}", parts.join("/"), ext);
+        let dotted = format!("./{}.{}", parts.join("/"), ext);
+        prop_assert_eq!(
+            redact_path(&plain),
+            redact_path(&dotted),
+            "Dot-prefix should be normalized away"
+        );
+    }
+
+    #[test]
+    fn dot_prefix_normalizes_for_short_hash(
+        parts in prop::collection::vec("[a-zA-Z0-9_]{1,8}", 1..=4),
+    ) {
+        let plain = parts.join("/");
+        let dotted = format!("./{}", plain);
+        prop_assert_eq!(
+            short_hash(&plain),
+            short_hash(&dotted),
+            "Dot-prefix should be normalized for short_hash"
+        );
     }
 }

--- a/crates/tokmd-types/tests/proptest_deep.rs
+++ b/crates/tokmd-types/tests/proptest_deep.rs
@@ -1,15 +1,16 @@
 //! Deep property-based tests for tokmd-types.
 //!
 //! Covers enum serde round-trips, schema version invariants,
-//! TokenEstimationMeta ordering, DiffRow delta invariants, and
+//! TokenEstimationMeta ordering, DiffRow delta invariants,
+//! LangRow/ModuleRow roundtrips, path normalization, and
 //! serialization casing conventions.
 
 use proptest::prelude::*;
 use tokmd_types::{
-    cockpit::COCKPIT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode, CommitIntentKind, ConfigMode,
-    DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind, InclusionPolicy, RedactMode,
-    TableFormat, TokenEstimationMeta, Totals, CONTEXT_BUNDLE_SCHEMA_VERSION,
-    CONTEXT_SCHEMA_VERSION, HANDOFF_SCHEMA_VERSION, SCHEMA_VERSION,
+    CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode,
+    CommitIntentKind, ConfigMode, DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind,
+    HANDOFF_SCHEMA_VERSION, InclusionPolicy, RedactMode, SCHEMA_VERSION, TableFormat,
+    TokenEstimationMeta, Totals, cockpit::COCKPIT_SCHEMA_VERSION,
 };
 
 // =========================================================================
@@ -36,8 +37,8 @@ proptest! {
     }
 
     #[test]
-    fn table_format_roundtrip(idx in 0usize..2) {
-        let fmt = [TableFormat::Md, TableFormat::Tsv][idx];
+    fn table_format_roundtrip(idx in 0usize..3) {
+        let fmt = [TableFormat::Md, TableFormat::Tsv, TableFormat::Json][idx];
         let json = serde_json::to_string(&fmt).unwrap();
         let parsed: TableFormat = serde_json::from_str(&json).unwrap();
         prop_assert_eq!(fmt, parsed);
@@ -49,7 +50,7 @@ proptest! {
             ExportFormat::Csv,
             ExportFormat::Jsonl,
             ExportFormat::Json,
-            ExportFormat::CycloneDx,
+            ExportFormat::Cyclonedx,
         ][idx];
         let json = serde_json::to_string(&fmt).unwrap();
         let parsed: ExportFormat = serde_json::from_str(&json).unwrap();
@@ -66,26 +67,27 @@ proptest! {
 
     #[test]
     fn redact_mode_roundtrip(idx in 0usize..3) {
-        let mode = [RedactMode::None, RedactMode::Hash, RedactMode::Short][idx];
+        let mode = [RedactMode::None, RedactMode::Paths, RedactMode::All][idx];
         let json = serde_json::to_string(&mode).unwrap();
         let parsed: RedactMode = serde_json::from_str(&json).unwrap();
         prop_assert_eq!(mode, parsed);
     }
 
     #[test]
-    fn config_mode_roundtrip(idx in 0usize..3) {
-        let mode = [ConfigMode::Auto, ConfigMode::Off, ConfigMode::Path][idx];
+    fn config_mode_roundtrip(idx in 0usize..2) {
+        let mode = [ConfigMode::Auto, ConfigMode::None][idx];
         let json = serde_json::to_string(&mode).unwrap();
         let parsed: ConfigMode = serde_json::from_str(&json).unwrap();
         prop_assert_eq!(mode, parsed);
     }
 
     #[test]
-    fn inclusion_policy_roundtrip(idx in 0usize..3) {
+    fn inclusion_policy_roundtrip(idx in 0usize..4) {
         let policy = [
-            InclusionPolicy::All,
-            InclusionPolicy::Smart,
-            InclusionPolicy::Minimal,
+            InclusionPolicy::Full,
+            InclusionPolicy::HeadTail,
+            InclusionPolicy::Summary,
+            InclusionPolicy::Skip,
         ][idx];
         let json = serde_json::to_string(&policy).unwrap();
         let parsed: InclusionPolicy = serde_json::from_str(&json).unwrap();
@@ -95,11 +97,11 @@ proptest! {
     #[test]
     fn file_classification_roundtrip(idx in 0usize..5) {
         let cls = [
-            FileClassification::Source,
-            FileClassification::Config,
-            FileClassification::Documentation,
-            FileClassification::Data,
             FileClassification::Generated,
+            FileClassification::Fixture,
+            FileClassification::Vendored,
+            FileClassification::Lockfile,
+            FileClassification::Minified,
         ][idx];
         let json = serde_json::to_string(&cls).unwrap();
         let parsed: FileClassification = serde_json::from_str(&json).unwrap();
@@ -107,12 +109,13 @@ proptest! {
     }
 
     #[test]
-    fn commit_intent_roundtrip(idx in 0usize..5) {
+    fn commit_intent_roundtrip(idx in 0usize..6) {
         let intent = [
-            CommitIntentKind::Feature,
+            CommitIntentKind::Feat,
             CommitIntentKind::Fix,
             CommitIntentKind::Refactor,
             CommitIntentKind::Docs,
+            CommitIntentKind::Test,
             CommitIntentKind::Chore,
         ][idx];
         let json = serde_json::to_string(&intent).unwrap();
@@ -162,7 +165,7 @@ proptest! {
 }
 
 // =========================================================================
-// DiffRow: delta always equals new - old (as i64)
+// DiffRow: delta_code always equals new_code - old_code (as i64)
 // =========================================================================
 
 proptest! {
@@ -170,28 +173,37 @@ proptest! {
 
     #[test]
     fn diff_row_delta_equals_new_minus_old(
-        old in 0usize..100_000,
-        new in 0usize..100_000,
+        old_code in 0usize..100_000,
+        new_code in 0usize..100_000,
     ) {
+        let delta_code = new_code as i64 - old_code as i64;
         let row = DiffRow {
             lang: "Rust".into(),
-            old_code: old,
-            new_code: new,
-            delta: new as i64 - old as i64,
+            old_code,
+            new_code,
+            delta_code,
+            old_lines: 0, new_lines: 0, delta_lines: 0,
+            old_files: 0, new_files: 0, delta_files: 0,
+            old_bytes: 0, new_bytes: 0, delta_bytes: 0,
+            old_tokens: 0, new_tokens: 0, delta_tokens: 0,
         };
-        prop_assert_eq!(row.delta, row.new_code as i64 - row.old_code as i64);
+        prop_assert_eq!(row.delta_code, row.new_code as i64 - row.old_code as i64);
     }
 
     #[test]
     fn diff_row_roundtrip(
-        old in 0usize..100_000,
-        new in 0usize..100_000,
+        old_code in 0usize..100_000,
+        new_code in 0usize..100_000,
     ) {
         let row = DiffRow {
             lang: "Go".into(),
-            old_code: old,
-            new_code: new,
-            delta: new as i64 - old as i64,
+            old_code,
+            new_code,
+            delta_code: new_code as i64 - old_code as i64,
+            old_lines: 0, new_lines: 0, delta_lines: 0,
+            old_files: 0, new_files: 0, delta_files: 0,
+            old_bytes: 0, new_bytes: 0, delta_bytes: 0,
+            old_tokens: 0, new_tokens: 0, delta_tokens: 0,
         };
         let json = serde_json::to_string(&row).unwrap();
         let parsed: DiffRow = serde_json::from_str(&json).unwrap();
@@ -211,7 +223,7 @@ proptest! {
         let t = DiffTotals::default();
         prop_assert_eq!(t.old_code, 0);
         prop_assert_eq!(t.new_code, 0);
-        prop_assert_eq!(t.delta, 0);
+        prop_assert_eq!(t.delta_code, 0);
     }
 }
 
@@ -226,7 +238,7 @@ proptest! {
     fn token_estimation_ordering_invariant(
         source_bytes in 1usize..10_000_000,
     ) {
-        let meta = TokenEstimationMeta::from_source_bytes(source_bytes);
+        let meta = TokenEstimationMeta::from_bytes(source_bytes, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert!(
             meta.tokens_min <= meta.tokens_est,
             "min ({}) must be <= est ({})",
@@ -243,13 +255,13 @@ proptest! {
     fn token_estimation_source_bytes_preserved(
         source_bytes in 0usize..10_000_000,
     ) {
-        let meta = TokenEstimationMeta::from_source_bytes(source_bytes);
+        let meta = TokenEstimationMeta::from_bytes(source_bytes, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert_eq!(meta.source_bytes, source_bytes);
     }
 
     #[test]
     fn token_estimation_zero_bytes_zero_tokens(_dummy in 0..1u8) {
-        let meta = TokenEstimationMeta::from_source_bytes(0);
+        let meta = TokenEstimationMeta::from_bytes(0, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert_eq!(meta.tokens_min, 0);
         prop_assert_eq!(meta.tokens_est, 0);
         prop_assert_eq!(meta.tokens_max, 0);
@@ -259,8 +271,7 @@ proptest! {
     fn token_estimation_custom_bounds_ordering(
         source_bytes in 1usize..10_000_000,
     ) {
-        // Default bounds should always produce ordered results
-        let meta = TokenEstimationMeta::from_source_bytes(source_bytes);
+        let meta = TokenEstimationMeta::from_bytes(source_bytes, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert!(meta.tokens_min <= meta.tokens_max);
     }
 }
@@ -274,7 +285,6 @@ proptest! {
 
     #[test]
     fn enum_serialization_is_lowercase(_dummy in 0..1u8) {
-        // spot-check that serde(rename_all) is applied
         let json = serde_json::to_string(&ChildrenMode::Collapse).unwrap();
         prop_assert_eq!(json, "\"collapse\"");
         let json = serde_json::to_string(&TableFormat::Md).unwrap();
@@ -285,7 +295,7 @@ proptest! {
 
     #[test]
     fn file_classification_serialization_is_snake_case(_dummy in 0..1u8) {
-        let json = serde_json::to_string(&FileClassification::Source).unwrap();
+        let json = serde_json::to_string(&FileClassification::Generated).unwrap();
         let s = json.trim_matches('"');
         prop_assert!(
             !s.chars().any(|c| c.is_uppercase()),
@@ -295,11 +305,126 @@ proptest! {
 
     #[test]
     fn commit_intent_serialization_is_snake_case(_dummy in 0..1u8) {
-        let json = serde_json::to_string(&CommitIntentKind::Feature).unwrap();
+        let json = serde_json::to_string(&CommitIntentKind::Feat).unwrap();
         let s = json.trim_matches('"');
         prop_assert!(
             !s.chars().any(|c| c.is_uppercase()),
             "CommitIntentKind should be lowercase: {}", s
         );
+    }
+}
+
+// =========================================================================
+// LangRow serde round-trip with arbitrary values
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn lang_row_deep_roundtrip(
+        lang in "[A-Z][a-zA-Z0-9 #+]{0,20}",
+        code in 0usize..1_000_000,
+        lines in 0usize..2_000_000,
+        files in 0usize..10_000,
+        bytes in 0usize..100_000_000,
+        tokens in 0usize..10_000_000,
+        avg_lines in 0usize..5000,
+    ) {
+        let row = tokmd_types::LangRow { lang, code, lines, files, bytes, tokens, avg_lines };
+        let json = serde_json::to_string(&row).unwrap();
+        let parsed: tokmd_types::LangRow = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(row, parsed);
+    }
+
+    #[test]
+    fn module_row_deep_roundtrip(
+        module in "[a-z][a-zA-Z0-9_/]{0,30}",
+        code in 0usize..1_000_000,
+        lines in 0usize..2_000_000,
+        files in 0usize..10_000,
+        bytes in 0usize..100_000_000,
+        tokens in 0usize..10_000_000,
+        avg_lines in 0usize..5000,
+    ) {
+        let row = tokmd_types::ModuleRow { module, code, lines, files, bytes, tokens, avg_lines };
+        let json = serde_json::to_string(&row).unwrap();
+        let parsed: tokmd_types::ModuleRow = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(row, parsed);
+    }
+}
+
+// =========================================================================
+// Path normalization via tokmd-path: idempotent and forward-slash only
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn path_normalize_idempotent(
+        parts in proptest::collection::vec("[a-zA-Z0-9_]{1,10}", 1..=5),
+        ext in proptest::sample::select(vec!["rs", "py", "go", "js", "toml"]),
+    ) {
+        let raw = format!("{}.{}", parts.join("/"), ext);
+        let once = tokmd_path::normalize_rel_path(&raw);
+        let twice = tokmd_path::normalize_rel_path(&once);
+        prop_assert_eq!(&once, &twice, "normalize must be idempotent");
+    }
+
+    #[test]
+    fn path_normalize_no_backslash(
+        parts in proptest::collection::vec("[a-zA-Z0-9_]{1,8}", 1..=4),
+    ) {
+        let raw = parts.join("\\");
+        let normalized = tokmd_path::normalize_slashes(&raw);
+        prop_assert!(
+            !normalized.contains('\\'),
+            "Normalized path must not contain backslash: {}", normalized
+        );
+    }
+
+    #[test]
+    fn path_normalize_backslash_forward_slash_equivalent(
+        parts in proptest::collection::vec("[a-zA-Z0-9_]{1,8}", 2..=5),
+    ) {
+        let unix_path = parts.join("/");
+        let win_path = parts.join("\\");
+        prop_assert_eq!(
+            tokmd_path::normalize_slashes(&unix_path),
+            tokmd_path::normalize_slashes(&win_path),
+            "Forward and backslash paths must normalize identically"
+        );
+    }
+}
+
+// =========================================================================
+// DiffRow: serde roundtrip with extreme values
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn diff_row_extreme_values(
+        old_code in 0usize..1_000_000,
+        new_code in 0usize..1_000_000,
+    ) {
+        let delta_code = new_code as i64 - old_code as i64;
+        let row = DiffRow {
+            lang: "Test".into(),
+            old_code,
+            new_code,
+            delta_code,
+            old_lines: 0, new_lines: 0, delta_lines: 0,
+            old_files: 0, new_files: 0, delta_files: 0,
+            old_bytes: 0, new_bytes: 0, delta_bytes: 0,
+            old_tokens: 0, new_tokens: 0, delta_tokens: 0,
+        };
+        let json = serde_json::to_string(&row).unwrap();
+        let parsed: DiffRow = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(row.delta_code, parsed.delta_code);
+        prop_assert_eq!(row.old_code, parsed.old_code);
+        prop_assert_eq!(row.new_code, parsed.new_code);
     }
 }


### PR DESCRIPTION
Add property-based tests for types, redact, gate, and model crates.

## Changes

### tokmd-types (enhanced proptest_deep.rs)
- LangRow/ModuleRow serde roundtrips with arbitrary values
- Path normalization idempotency and forward-slash invariants via tokmd-path
- DiffRow roundtrip with extreme values
- Fixed stale enum variants to match current API (RedactMode, ConfigMode, etc.)

### tokmd-redact (enhanced proptest_deep.rs)
- Idempotency: multiple calls produce identical output
- short_hash always produces hex-only output of length 16
- Dot-prefix normalization equivalence
- Fixed flaky segment-leak test (short segments like '0' matched hex output)

### tokmd-gate (new proptest_deep.rs)
- Policy evaluation is deterministic on same inputs
- Invalid/arbitrary JSON pointers never panic
- GateResult invariant: passed iff errors == 0
- RuleOperator and RuleLevel serde roundtrips
- Empty policy always passes

### tokmd-model (new proptest_deep.rs)
- Sorting is stable and consistent (desc by code, asc by name)
- Aggregation preserves non-negative invariants via serde roundtrip
- normalize_path idempotency, no backslashes, no leading ./
- module_key determinism and root-file invariant
- avg monotonicity and bounds