### PR TITLE
fix: resolve rustfmt, type-mismatch and typos CI failures on main

### DIFF
--- a/crates/tokmd-analysis-entropy/tests/deep.rs
+++ b/crates/tokmd-analysis-entropy/tests/deep.rs
@@ -468,11 +468,7 @@ fn entropy_values_within_theoretical_bounds() {
     write_repeated(&dir.path().join("zeros.bin"), 0x00, 1024);
     write_repeated(&dir.path().join("ones.bin"), 0xFF, 1024);
     write_pseudorandom(&dir.path().join("random.bin"), 0x1234, 4096);
-    fs::write(
-        dir.path().join("text.txt"),
-        "hello world ".repeat(100),
-    )
-    .unwrap();
+    fs::write(dir.path().join("text.txt"), "hello world ".repeat(100)).unwrap();
 
     let export = export_for_paths(&names);
     let files: Vec<PathBuf> = names.iter().map(PathBuf::from).collect();

--- a/crates/tokmd-analysis-near-dup/tests/deep.rs
+++ b/crates/tokmd-analysis-near-dup/tests/deep.rs
@@ -121,14 +121,8 @@ fn similarity_degrades_with_increasing_divergence() {
         .map(|p| p.similarity);
 
     if let (Some(ab), Some(ac), Some(ad)) = (sim_ab, sim_ac, sim_ad) {
-        assert!(
-            ab >= ac,
-            "a-b similarity ({ab}) should be >= a-c ({ac})"
-        );
-        assert!(
-            ac >= ad,
-            "a-c similarity ({ac}) should be >= a-d ({ad})"
-        );
+        assert!(ab >= ac, "a-b similarity ({ab}) should be >= a-c ({ac})");
+        assert!(ac >= ad, "a-c similarity ({ac}) should be >= a-d ({ad})");
     }
 }
 
@@ -525,7 +519,15 @@ fn ten_files_max_three_yields_seven_skipped() {
         write_file(&dir, &name, &content);
     }
     let rows: Vec<FileRow> = (0..10)
-        .map(|i| make_row(&format!("f{i:02}.rs"), "(root)", "Rust", (10 - i) * 10, 5000))
+        .map(|i| {
+            make_row(
+                &format!("f{i:02}.rs"),
+                "(root)",
+                "Rust",
+                (10 - i) * 10,
+                5000,
+            )
+        })
         .collect();
     let export = make_export(rows);
 

--- a/crates/tokmd-analysis-topics/tests/deep.rs
+++ b/crates/tokmd-analysis-topics/tests/deep.rs
@@ -83,10 +83,7 @@ fn single_file_overall_equals_per_module() {
 fn df_counts_files_not_token_frequency() {
     // Two files in same module, both containing "widget" in their path
     let data = export(
-        vec![
-            row("m/widget_a.rs", "m", 50),
-            row("m/widget_b.rs", "m", 50),
-        ],
+        vec![row("m/widget_a.rs", "m", 50), row("m/widget_b.rs", "m", 50)],
         &[],
     );
     let clouds = build_topic_clouds(&data);
@@ -156,10 +153,7 @@ fn top_k_preserves_highest_scoring_terms() {
 
 #[test]
 fn consecutive_separators_no_empty_terms() {
-    let data = export(
-        vec![row("a__b--c..d/file.rs", "a__b--c..d", 50)],
-        &[],
-    );
+    let data = export(vec![row("a__b--c..d/file.rs", "a__b--c..d", 50)], &[]);
     let terms = overall_terms(&data);
     for term in &terms {
         assert!(!term.is_empty(), "no empty terms should be produced");
@@ -173,11 +167,7 @@ fn mixed_case_normalizes_to_lowercase() {
     let data = export(vec![row("MyModule/MyFile.rs", "MyModule", 50)], &[]);
     let terms = overall_terms(&data);
     for term in &terms {
-        assert_eq!(
-            *term,
-            term.to_lowercase(),
-            "all terms should be lowercase"
-        );
+        assert_eq!(*term, term.to_lowercase(), "all terms should be lowercase");
     }
 }
 
@@ -231,13 +221,13 @@ fn deeply_nested_path_extracts_all_non_stopword_segments() {
 #[test]
 fn backslash_and_forward_slash_paths_equivalent() {
     let data_fwd = export(vec![row("app/auth/handler.rs", "app/auth", 50)], &["app"]);
-    let data_bck = export(vec![row(r"app\auth\handler.rs", "app/auth", 50)], &["app"]);
+    let data_back = export(vec![row(r"app\auth\handler.rs", "app/auth", 50)], &["app"]);
 
     let terms_fwd = overall_terms(&data_fwd);
-    let terms_bck = overall_terms(&data_bck);
+    let terms_back = overall_terms(&data_back);
 
     assert_eq!(
-        terms_fwd, terms_bck,
+        terms_fwd, terms_back,
         "backslash and forward slash paths should produce identical terms"
     );
 }
@@ -270,15 +260,10 @@ fn determinism_with_many_modules() {
         .collect();
     let data = export(rows, &[]);
 
-    let results: Vec<Vec<TopicTerm>> =
-        (0..3).map(|_| build_topic_clouds(&data).overall).collect();
+    let results: Vec<Vec<TopicTerm>> = (0..3).map(|_| build_topic_clouds(&data).overall).collect();
 
     for i in 1..3 {
-        assert_eq!(
-            results[0].len(),
-            results[i].len(),
-            "run count mismatch"
-        );
+        assert_eq!(results[0].len(), results[i].len(), "run count mismatch");
         for (a, b) in results[0].iter().zip(results[i].iter()) {
             assert_eq!(a.term, b.term);
             assert!(
@@ -296,8 +281,8 @@ fn determinism_with_many_modules() {
 fn all_documented_extensions_are_stopwords() {
     let known_extensions = [
         "rs", "js", "ts", "tsx", "jsx", "py", "go", "java", "kt", "kts", "rb", "php", "c", "cc",
-        "cpp", "h", "hpp", "cs", "swift", "m", "mm", "scala", "sql", "toml", "yaml", "yml",
-        "json", "md", "markdown", "txt", "lock", "cfg", "ini", "env", "nix", "zig", "dart",
+        "cpp", "h", "hpp", "cs", "swift", "m", "mm", "scala", "sql", "toml", "yaml", "yml", "json",
+        "md", "markdown", "txt", "lock", "cfg", "ini", "env", "nix", "zig", "dart",
     ];
     for ext in known_extensions {
         // Create a row where the only non-stopword would be the extension
@@ -315,14 +300,26 @@ fn all_documented_extensions_are_stopwords() {
 #[test]
 fn base_stopwords_filter_common_directories() {
     let base_stops = [
-        "src", "lib", "mod", "index", "test", "tests", "impl", "main", "bin", "pkg", "package",
-        "target", "build", "dist", "out", "gen", "generated",
+        "src",
+        "lib",
+        "mod",
+        "index",
+        "test",
+        "tests",
+        "impl",
+        "main",
+        "bin",
+        "pkg",
+        "package",
+        "target",
+        "build",
+        "dist",
+        "out",
+        "gen",
+        "generated",
     ];
     for stop in base_stops {
-        let data = export(
-            vec![row(&format!("{stop}/feature.rs"), stop, 50)],
-            &[],
-        );
+        let data = export(vec![row(&format!("{stop}/feature.rs"), stop, 50)], &[]);
         let terms = overall_terms(&data);
         assert!(
             !terms.contains(&stop.to_string()),

--- a/crates/tokmd-types/tests/proptest_deep.rs
+++ b/crates/tokmd-types/tests/proptest_deep.rs
@@ -6,10 +6,10 @@
 
 use proptest::prelude::*;
 use tokmd_types::{
-    cockpit::COCKPIT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode, CommitIntentKind, ConfigMode,
-    DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind, InclusionPolicy, RedactMode,
-    TableFormat, TokenEstimationMeta, Totals, CONTEXT_BUNDLE_SCHEMA_VERSION,
-    CONTEXT_SCHEMA_VERSION, HANDOFF_SCHEMA_VERSION, SCHEMA_VERSION,
+    CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode,
+    CommitIntentKind, ConfigMode, DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind,
+    HANDOFF_SCHEMA_VERSION, InclusionPolicy, RedactMode, SCHEMA_VERSION, TableFormat,
+    TokenEstimationMeta, Totals, cockpit::COCKPIT_SCHEMA_VERSION,
 };
 
 // =========================================================================
@@ -49,7 +49,7 @@ proptest! {
             ExportFormat::Csv,
             ExportFormat::Jsonl,
             ExportFormat::Json,
-            ExportFormat::CycloneDx,
+            ExportFormat::Cyclonedx,
         ][idx];
         let json = serde_json::to_string(&fmt).unwrap();
         let parsed: ExportFormat = serde_json::from_str(&json).unwrap();
@@ -66,26 +66,27 @@ proptest! {
 
     #[test]
     fn redact_mode_roundtrip(idx in 0usize..3) {
-        let mode = [RedactMode::None, RedactMode::Hash, RedactMode::Short][idx];
+        let mode = [RedactMode::None, RedactMode::Paths, RedactMode::All][idx];
         let json = serde_json::to_string(&mode).unwrap();
         let parsed: RedactMode = serde_json::from_str(&json).unwrap();
         prop_assert_eq!(mode, parsed);
     }
 
     #[test]
-    fn config_mode_roundtrip(idx in 0usize..3) {
-        let mode = [ConfigMode::Auto, ConfigMode::Off, ConfigMode::Path][idx];
+    fn config_mode_roundtrip(idx in 0usize..2) {
+        let mode = [ConfigMode::Auto, ConfigMode::None][idx];
         let json = serde_json::to_string(&mode).unwrap();
         let parsed: ConfigMode = serde_json::from_str(&json).unwrap();
         prop_assert_eq!(mode, parsed);
     }
 
     #[test]
-    fn inclusion_policy_roundtrip(idx in 0usize..3) {
+    fn inclusion_policy_roundtrip(idx in 0usize..4) {
         let policy = [
-            InclusionPolicy::All,
-            InclusionPolicy::Smart,
-            InclusionPolicy::Minimal,
+            InclusionPolicy::Full,
+            InclusionPolicy::HeadTail,
+            InclusionPolicy::Summary,
+            InclusionPolicy::Skip,
         ][idx];
         let json = serde_json::to_string(&policy).unwrap();
         let parsed: InclusionPolicy = serde_json::from_str(&json).unwrap();
@@ -93,13 +94,15 @@ proptest! {
     }
 
     #[test]
-    fn file_classification_roundtrip(idx in 0usize..5) {
+    fn file_classification_roundtrip(idx in 0usize..7) {
         let cls = [
-            FileClassification::Source,
-            FileClassification::Config,
-            FileClassification::Documentation,
-            FileClassification::Data,
             FileClassification::Generated,
+            FileClassification::Fixture,
+            FileClassification::Vendored,
+            FileClassification::Lockfile,
+            FileClassification::Minified,
+            FileClassification::DataBlob,
+            FileClassification::Sourcemap,
         ][idx];
         let json = serde_json::to_string(&cls).unwrap();
         let parsed: FileClassification = serde_json::from_str(&json).unwrap();
@@ -107,13 +110,20 @@ proptest! {
     }
 
     #[test]
-    fn commit_intent_roundtrip(idx in 0usize..5) {
+    fn commit_intent_roundtrip(idx in 0usize..12) {
         let intent = [
-            CommitIntentKind::Feature,
+            CommitIntentKind::Feat,
             CommitIntentKind::Fix,
             CommitIntentKind::Refactor,
             CommitIntentKind::Docs,
+            CommitIntentKind::Test,
             CommitIntentKind::Chore,
+            CommitIntentKind::Ci,
+            CommitIntentKind::Build,
+            CommitIntentKind::Perf,
+            CommitIntentKind::Style,
+            CommitIntentKind::Revert,
+            CommitIntentKind::Other,
         ][idx];
         let json = serde_json::to_string(&intent).unwrap();
         let parsed: CommitIntentKind = serde_json::from_str(&json).unwrap();
@@ -177,9 +187,21 @@ proptest! {
             lang: "Rust".into(),
             old_code: old,
             new_code: new,
-            delta: new as i64 - old as i64,
+            delta_code: new as i64 - old as i64,
+            old_lines: 0,
+            new_lines: 0,
+            delta_lines: 0,
+            old_files: 0,
+            new_files: 0,
+            delta_files: 0,
+            old_bytes: 0,
+            new_bytes: 0,
+            delta_bytes: 0,
+            old_tokens: 0,
+            new_tokens: 0,
+            delta_tokens: 0,
         };
-        prop_assert_eq!(row.delta, row.new_code as i64 - row.old_code as i64);
+        prop_assert_eq!(row.delta_code, row.new_code as i64 - row.old_code as i64);
     }
 
     #[test]
@@ -191,7 +213,19 @@ proptest! {
             lang: "Go".into(),
             old_code: old,
             new_code: new,
-            delta: new as i64 - old as i64,
+            delta_code: new as i64 - old as i64,
+            old_lines: 0,
+            new_lines: 0,
+            delta_lines: 0,
+            old_files: 0,
+            new_files: 0,
+            delta_files: 0,
+            old_bytes: 0,
+            new_bytes: 0,
+            delta_bytes: 0,
+            old_tokens: 0,
+            new_tokens: 0,
+            delta_tokens: 0,
         };
         let json = serde_json::to_string(&row).unwrap();
         let parsed: DiffRow = serde_json::from_str(&json).unwrap();
@@ -211,7 +245,7 @@ proptest! {
         let t = DiffTotals::default();
         prop_assert_eq!(t.old_code, 0);
         prop_assert_eq!(t.new_code, 0);
-        prop_assert_eq!(t.delta, 0);
+        prop_assert_eq!(t.delta_code, 0);
     }
 }
 
@@ -226,7 +260,7 @@ proptest! {
     fn token_estimation_ordering_invariant(
         source_bytes in 1usize..10_000_000,
     ) {
-        let meta = TokenEstimationMeta::from_source_bytes(source_bytes);
+        let meta = TokenEstimationMeta::from_bytes(source_bytes, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert!(
             meta.tokens_min <= meta.tokens_est,
             "min ({}) must be <= est ({})",
@@ -243,13 +277,13 @@ proptest! {
     fn token_estimation_source_bytes_preserved(
         source_bytes in 0usize..10_000_000,
     ) {
-        let meta = TokenEstimationMeta::from_source_bytes(source_bytes);
+        let meta = TokenEstimationMeta::from_bytes(source_bytes, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert_eq!(meta.source_bytes, source_bytes);
     }
 
     #[test]
     fn token_estimation_zero_bytes_zero_tokens(_dummy in 0..1u8) {
-        let meta = TokenEstimationMeta::from_source_bytes(0);
+        let meta = TokenEstimationMeta::from_bytes(0, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert_eq!(meta.tokens_min, 0);
         prop_assert_eq!(meta.tokens_est, 0);
         prop_assert_eq!(meta.tokens_max, 0);
@@ -259,8 +293,7 @@ proptest! {
     fn token_estimation_custom_bounds_ordering(
         source_bytes in 1usize..10_000_000,
     ) {
-        // Default bounds should always produce ordered results
-        let meta = TokenEstimationMeta::from_source_bytes(source_bytes);
+        let meta = TokenEstimationMeta::from_bytes(source_bytes, TokenEstimationMeta::DEFAULT_BPT_EST);
         prop_assert!(meta.tokens_min <= meta.tokens_max);
     }
 }
@@ -285,7 +318,7 @@ proptest! {
 
     #[test]
     fn file_classification_serialization_is_snake_case(_dummy in 0..1u8) {
-        let json = serde_json::to_string(&FileClassification::Source).unwrap();
+        let json = serde_json::to_string(&FileClassification::Generated).unwrap();
         let s = json.trim_matches('"');
         prop_assert!(
             !s.chars().any(|c| c.is_uppercase()),
@@ -295,7 +328,7 @@ proptest! {
 
     #[test]
     fn commit_intent_serialization_is_snake_case(_dummy in 0..1u8) {
-        let json = serde_json::to_string(&CommitIntentKind::Feature).unwrap();
+        let json = serde_json::to_string(&CommitIntentKind::Feat).unwrap();
         let s = json.trim_matches('"');
         prop_assert!(
             !s.chars().any(|c| c.is_uppercase()),


### PR DESCRIPTION
P0 fix-forward: resolves all CI failures on main branch.

## Changes
- **rustfmt**: Fix import ordering in proptest_deep.rs + formatting in analysis-entropy and analysis-near-dup tests
- **Type mismatches**: Fix 23 compilation errors in proptest_deep.rs where test referenced wrong enum variant names, missing struct fields, and renamed methods
- **typos**: Rename \ck\ → \ack\ in analysis-topics tests to satisfy typos checker

## Verified
- \cargo fmt -- --check\ ✅
- \cargo test -p tokmd-types --test proptest_deep\ ✅ (22 tests pass)
- \cargo test -p tokmd-analysis-topics --test deep\ ✅ (15 tests pass)