### PR TITLE
test: deep tests for envelope and substrate contracts

### DIFF
--- a/crates/tokmd-analysis-entropy/tests/deep.rs
+++ b/crates/tokmd-analysis-entropy/tests/deep.rs
@@ -468,11 +468,7 @@ fn entropy_values_within_theoretical_bounds() {
     write_repeated(&dir.path().join("zeros.bin"), 0x00, 1024);
     write_repeated(&dir.path().join("ones.bin"), 0xFF, 1024);
     write_pseudorandom(&dir.path().join("random.bin"), 0x1234, 4096);
-    fs::write(
-        dir.path().join("text.txt"),
-        "hello world ".repeat(100),
-    )
-    .unwrap();
+    fs::write(dir.path().join("text.txt"), "hello world ".repeat(100)).unwrap();
 
     let export = export_for_paths(&names);
     let files: Vec<PathBuf> = names.iter().map(PathBuf::from).collect();

--- a/crates/tokmd-analysis-near-dup/tests/deep.rs
+++ b/crates/tokmd-analysis-near-dup/tests/deep.rs
@@ -121,14 +121,8 @@ fn similarity_degrades_with_increasing_divergence() {
         .map(|p| p.similarity);
 
     if let (Some(ab), Some(ac), Some(ad)) = (sim_ab, sim_ac, sim_ad) {
-        assert!(
-            ab >= ac,
-            "a-b similarity ({ab}) should be >= a-c ({ac})"
-        );
-        assert!(
-            ac >= ad,
-            "a-c similarity ({ac}) should be >= a-d ({ad})"
-        );
+        assert!(ab >= ac, "a-b similarity ({ab}) should be >= a-c ({ac})");
+        assert!(ac >= ad, "a-c similarity ({ac}) should be >= a-d ({ad})");
     }
 }
 
@@ -525,7 +519,15 @@ fn ten_files_max_three_yields_seven_skipped() {
         write_file(&dir, &name, &content);
     }
     let rows: Vec<FileRow> = (0..10)
-        .map(|i| make_row(&format!("f{i:02}.rs"), "(root)", "Rust", (10 - i) * 10, 5000))
+        .map(|i| {
+            make_row(
+                &format!("f{i:02}.rs"),
+                "(root)",
+                "Rust",
+                (10 - i) * 10,
+                5000,
+            )
+        })
         .collect();
     let export = make_export(rows);
 

--- a/crates/tokmd-analysis-topics/tests/deep.rs
+++ b/crates/tokmd-analysis-topics/tests/deep.rs
@@ -83,10 +83,7 @@ fn single_file_overall_equals_per_module() {
 fn df_counts_files_not_token_frequency() {
     // Two files in same module, both containing "widget" in their path
     let data = export(
-        vec![
-            row("m/widget_a.rs", "m", 50),
-            row("m/widget_b.rs", "m", 50),
-        ],
+        vec![row("m/widget_a.rs", "m", 50), row("m/widget_b.rs", "m", 50)],
         &[],
     );
     let clouds = build_topic_clouds(&data);
@@ -156,10 +153,7 @@ fn top_k_preserves_highest_scoring_terms() {
 
 #[test]
 fn consecutive_separators_no_empty_terms() {
-    let data = export(
-        vec![row("a__b--c..d/file.rs", "a__b--c..d", 50)],
-        &[],
-    );
+    let data = export(vec![row("a__b--c..d/file.rs", "a__b--c..d", 50)], &[]);
     let terms = overall_terms(&data);
     for term in &terms {
         assert!(!term.is_empty(), "no empty terms should be produced");
@@ -173,11 +167,7 @@ fn mixed_case_normalizes_to_lowercase() {
     let data = export(vec![row("MyModule/MyFile.rs", "MyModule", 50)], &[]);
     let terms = overall_terms(&data);
     for term in &terms {
-        assert_eq!(
-            *term,
-            term.to_lowercase(),
-            "all terms should be lowercase"
-        );
+        assert_eq!(*term, term.to_lowercase(), "all terms should be lowercase");
     }
 }
 
@@ -270,15 +260,10 @@ fn determinism_with_many_modules() {
         .collect();
     let data = export(rows, &[]);
 
-    let results: Vec<Vec<TopicTerm>> =
-        (0..3).map(|_| build_topic_clouds(&data).overall).collect();
+    let results: Vec<Vec<TopicTerm>> = (0..3).map(|_| build_topic_clouds(&data).overall).collect();
 
     for i in 1..3 {
-        assert_eq!(
-            results[0].len(),
-            results[i].len(),
-            "run count mismatch"
-        );
+        assert_eq!(results[0].len(), results[i].len(), "run count mismatch");
         for (a, b) in results[0].iter().zip(results[i].iter()) {
             assert_eq!(a.term, b.term);
             assert!(
@@ -296,8 +281,8 @@ fn determinism_with_many_modules() {
 fn all_documented_extensions_are_stopwords() {
     let known_extensions = [
         "rs", "js", "ts", "tsx", "jsx", "py", "go", "java", "kt", "kts", "rb", "php", "c", "cc",
-        "cpp", "h", "hpp", "cs", "swift", "m", "mm", "scala", "sql", "toml", "yaml", "yml",
-        "json", "md", "markdown", "txt", "lock", "cfg", "ini", "env", "nix", "zig", "dart",
+        "cpp", "h", "hpp", "cs", "swift", "m", "mm", "scala", "sql", "toml", "yaml", "yml", "json",
+        "md", "markdown", "txt", "lock", "cfg", "ini", "env", "nix", "zig", "dart",
     ];
     for ext in known_extensions {
         // Create a row where the only non-stopword would be the extension
@@ -315,14 +300,26 @@ fn all_documented_extensions_are_stopwords() {
 #[test]
 fn base_stopwords_filter_common_directories() {
     let base_stops = [
-        "src", "lib", "mod", "index", "test", "tests", "impl", "main", "bin", "pkg", "package",
-        "target", "build", "dist", "out", "gen", "generated",
+        "src",
+        "lib",
+        "mod",
+        "index",
+        "test",
+        "tests",
+        "impl",
+        "main",
+        "bin",
+        "pkg",
+        "package",
+        "target",
+        "build",
+        "dist",
+        "out",
+        "gen",
+        "generated",
     ];
     for stop in base_stops {
-        let data = export(
-            vec![row(&format!("{stop}/feature.rs"), stop, 50)],
-            &[],
-        );
+        let data = export(vec![row(&format!("{stop}/feature.rs"), stop, 50)], &[]);
         let terms = overall_terms(&data);
         assert!(
             !terms.contains(&stop.to_string()),

--- a/crates/tokmd-envelope/tests/deep.rs
+++ b/crates/tokmd-envelope/tests/deep.rs
@@ -1,0 +1,709 @@
+//! Deep contract tests for `tokmd-envelope`.
+//!
+//! Covers error handling for malformed input, forward-compatibility
+//! (extra JSON fields), deterministic serialization, double-roundtrip
+//! stability, JSON structure invariants, and edge-case fingerprinting.
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use tokmd_envelope::{
+    Artifact, CapabilityState, CapabilityStatus, Finding, FindingLocation, FindingSeverity,
+    GateItem, GateResults, SENSOR_REPORT_SCHEMA, SensorReport, ToolMeta, Verdict,
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn minimal_report() -> SensorReport {
+    SensorReport::new(
+        ToolMeta::tokmd("1.0.0", "test"),
+        "2025-01-01T00:00:00Z".into(),
+        Verdict::Pass,
+        "ok".into(),
+    )
+}
+
+fn full_report() -> SensorReport {
+    let mut caps = BTreeMap::new();
+    caps.insert("mutation".into(), CapabilityStatus::available());
+    caps.insert(
+        "coverage".into(),
+        CapabilityStatus::unavailable("no artifact"),
+    );
+
+    let mut report = SensorReport::new(
+        ToolMeta::tokmd("2.0.0", "cockpit"),
+        "2025-06-15T12:00:00Z".into(),
+        Verdict::Warn,
+        "2 findings".into(),
+    );
+    report.add_finding(
+        Finding::new(
+            "risk",
+            "hotspot",
+            FindingSeverity::Warn,
+            "Hot",
+            "Churn high",
+        )
+        .with_location(FindingLocation::path_line("src/lib.rs", 42))
+        .with_evidence(serde_json::json!({"churn": 99}))
+        .with_docs_url("https://example.com/hotspot")
+        .with_fingerprint("tokmd"),
+    );
+    report.add_finding(Finding::new(
+        "contract",
+        "schema_changed",
+        FindingSeverity::Info,
+        "Schema",
+        "v1->v2",
+    ));
+    report = report
+        .with_artifacts(vec![
+            Artifact::comment("out/comment.md")
+                .with_id("c1")
+                .with_mime("text/markdown"),
+            Artifact::badge("out/badge.svg"),
+        ])
+        .with_capabilities(caps)
+        .with_data(serde_json::json!({"custom": [1, 2, 3]}));
+    report
+}
+
+// =============================================================================
+// 1. Deterministic serialization: same input always produces identical JSON
+// =============================================================================
+
+#[test]
+fn deterministic_serialization_minimal() {
+    let r = minimal_report();
+    let j1 = serde_json::to_string(&r).unwrap();
+    let j2 = serde_json::to_string(&r).unwrap();
+    assert_eq!(j1, j2);
+}
+
+#[test]
+fn deterministic_serialization_full() {
+    let r = full_report();
+    let j1 = serde_json::to_string_pretty(&r).unwrap();
+    let j2 = serde_json::to_string_pretty(&r).unwrap();
+    assert_eq!(j1, j2);
+}
+
+// =============================================================================
+// 2. Double-roundtrip stability (serialize → deser → serialize = same bytes)
+// =============================================================================
+
+#[test]
+fn double_roundtrip_minimal() {
+    let json1 = serde_json::to_string(&minimal_report()).unwrap();
+    let mid: SensorReport = serde_json::from_str(&json1).unwrap();
+    let json2 = serde_json::to_string(&mid).unwrap();
+    assert_eq!(json1, json2);
+}
+
+#[test]
+fn double_roundtrip_full() {
+    let json1 = serde_json::to_string(&full_report()).unwrap();
+    let mid: SensorReport = serde_json::from_str(&json1).unwrap();
+    let json2 = serde_json::to_string(&mid).unwrap();
+    assert_eq!(json1, json2);
+}
+
+// =============================================================================
+// 3. Error handling: malformed JSON input
+// =============================================================================
+
+#[test]
+fn reject_empty_string() {
+    let result = serde_json::from_str::<SensorReport>("");
+    assert!(result.is_err());
+}
+
+#[test]
+fn reject_invalid_json() {
+    let result = serde_json::from_str::<SensorReport>("{not json}");
+    assert!(result.is_err());
+}
+
+#[test]
+fn reject_missing_required_field_schema() {
+    let json = r#"{
+        "tool": {"name": "t", "version": "1", "mode": "m"},
+        "generated_at": "2025-01-01T00:00:00Z",
+        "verdict": "pass",
+        "summary": "ok",
+        "findings": []
+    }"#;
+    let result = serde_json::from_str::<SensorReport>(json);
+    assert!(result.is_err(), "missing 'schema' field should fail");
+}
+
+#[test]
+fn reject_missing_required_field_tool() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "generated_at": "2025-01-01T00:00:00Z",
+        "verdict": "pass",
+        "summary": "ok",
+        "findings": []
+    }"#;
+    let result = serde_json::from_str::<SensorReport>(json);
+    assert!(result.is_err(), "missing 'tool' field should fail");
+}
+
+#[test]
+fn reject_missing_required_field_verdict() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "tool": {"name": "t", "version": "1", "mode": "m"},
+        "generated_at": "2025-01-01T00:00:00Z",
+        "summary": "ok",
+        "findings": []
+    }"#;
+    let result = serde_json::from_str::<SensorReport>(json);
+    assert!(result.is_err(), "missing 'verdict' field should fail");
+}
+
+#[test]
+fn reject_missing_required_field_findings() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "tool": {"name": "t", "version": "1", "mode": "m"},
+        "generated_at": "2025-01-01T00:00:00Z",
+        "verdict": "pass",
+        "summary": "ok"
+    }"#;
+    let result = serde_json::from_str::<SensorReport>(json);
+    assert!(result.is_err(), "missing 'findings' field should fail");
+}
+
+#[test]
+fn reject_invalid_verdict_value() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "tool": {"name": "t", "version": "1", "mode": "m"},
+        "generated_at": "2025-01-01T00:00:00Z",
+        "verdict": "INVALID",
+        "summary": "ok",
+        "findings": []
+    }"#;
+    let result = serde_json::from_str::<SensorReport>(json);
+    assert!(result.is_err(), "invalid verdict value should fail");
+}
+
+#[test]
+fn reject_invalid_severity_value() {
+    let json = r#"{
+        "check_id": "risk",
+        "code": "hotspot",
+        "severity": "CRITICAL",
+        "title": "T",
+        "message": "M"
+    }"#;
+    let result = serde_json::from_str::<Finding>(json);
+    assert!(result.is_err(), "invalid severity value should fail");
+}
+
+#[test]
+fn reject_invalid_capability_state() {
+    let json = r#"{"status": "unknown_state"}"#;
+    let result = serde_json::from_str::<CapabilityStatus>(json);
+    assert!(result.is_err(), "invalid capability state should fail");
+}
+
+#[test]
+fn reject_findings_not_array() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "tool": {"name": "t", "version": "1", "mode": "m"},
+        "generated_at": "2025-01-01T00:00:00Z",
+        "verdict": "pass",
+        "summary": "ok",
+        "findings": "not-an-array"
+    }"#;
+    let result = serde_json::from_str::<SensorReport>(json);
+    assert!(result.is_err(), "findings as string should fail");
+}
+
+#[test]
+fn reject_verdict_as_integer() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "tool": {"name": "t", "version": "1", "mode": "m"},
+        "generated_at": "2025-01-01T00:00:00Z",
+        "verdict": 42,
+        "summary": "ok",
+        "findings": []
+    }"#;
+    let result = serde_json::from_str::<SensorReport>(json);
+    assert!(result.is_err(), "verdict as integer should fail");
+}
+
+// =============================================================================
+// 4. Forward compatibility: extra/unknown fields are silently ignored
+// =============================================================================
+
+#[test]
+fn forward_compat_extra_top_level_fields_ignored() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "tool": {"name": "tokmd", "version": "1.0.0", "mode": "test"},
+        "generated_at": "2025-01-01T00:00:00Z",
+        "verdict": "pass",
+        "summary": "ok",
+        "findings": [],
+        "future_field": "some value",
+        "another_future": 42
+    }"#;
+    // serde default behavior: unknown fields are ignored for structs
+    // without deny_unknown_fields.
+    let report: SensorReport = serde_json::from_str(json).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+#[test]
+fn forward_compat_extra_finding_fields_ignored() {
+    let json = r#"{
+        "check_id": "risk",
+        "code": "hotspot",
+        "severity": "warn",
+        "title": "Hot",
+        "message": "Churn",
+        "future_score": 99.9,
+        "future_tags": ["a", "b"]
+    }"#;
+    let finding: Finding = serde_json::from_str(json).unwrap();
+    assert_eq!(finding.check_id, "risk");
+    assert_eq!(finding.code, "hotspot");
+}
+
+#[test]
+fn forward_compat_extra_tool_meta_fields_ignored() {
+    let json = r#"{"name": "tokmd", "version": "1.0", "mode": "scan", "extra": true}"#;
+    let meta: ToolMeta = serde_json::from_str(json).unwrap();
+    assert_eq!(meta.name, "tokmd");
+}
+
+#[test]
+fn forward_compat_extra_artifact_fields_ignored() {
+    let json = r#"{"type": "badge", "path": "out/b.svg", "future_size": 1024}"#;
+    let a: Artifact = serde_json::from_str(json).unwrap();
+    assert_eq!(a.artifact_type, "badge");
+}
+
+#[test]
+fn forward_compat_extra_gate_item_fields_ignored() {
+    let json = r#"{"id": "mutation", "status": "pass", "future_metric": "x"}"#;
+    let g: GateItem = serde_json::from_str(json).unwrap();
+    assert_eq!(g.id, "mutation");
+    assert_eq!(g.status, Verdict::Pass);
+}
+
+#[test]
+fn forward_compat_extra_location_fields_ignored() {
+    let json = r#"{"path": "src/lib.rs", "line": 10, "column": 5, "end_line": 20}"#;
+    let loc: FindingLocation = serde_json::from_str(json).unwrap();
+    assert_eq!(loc.path, "src/lib.rs");
+    assert_eq!(loc.line, Some(10));
+    assert_eq!(loc.column, Some(5));
+}
+
+// =============================================================================
+// 5. JSON structure invariants
+// =============================================================================
+
+#[test]
+fn json_required_keys_all_present_in_full_report() {
+    let value = serde_json::to_value(&full_report()).unwrap();
+    let obj = value.as_object().unwrap();
+
+    // Required top-level keys
+    for key in [
+        "schema",
+        "tool",
+        "generated_at",
+        "verdict",
+        "summary",
+        "findings",
+    ] {
+        assert!(obj.contains_key(key), "missing required key: {key}");
+    }
+    // Optional keys present since full_report populates them
+    for key in ["artifacts", "capabilities", "data"] {
+        assert!(obj.contains_key(key), "missing optional key: {key}");
+    }
+}
+
+#[test]
+fn json_tool_nested_keys() {
+    let value = serde_json::to_value(&full_report()).unwrap();
+    let tool = value["tool"].as_object().unwrap();
+    for key in ["name", "version", "mode"] {
+        assert!(tool.contains_key(key), "tool missing key: {key}");
+    }
+}
+
+#[test]
+fn json_finding_nested_keys() {
+    let value = serde_json::to_value(&full_report()).unwrap();
+    let finding = value["findings"][0].as_object().unwrap();
+    for key in ["check_id", "code", "severity", "title", "message"] {
+        assert!(finding.contains_key(key), "finding missing key: {key}");
+    }
+    // Optional keys present on first finding (which has them)
+    for key in ["location", "evidence", "docs_url", "fingerprint"] {
+        assert!(
+            finding.contains_key(key),
+            "finding missing optional key: {key}"
+        );
+    }
+    // Second finding has no optional fields
+    let finding2 = value["findings"][1].as_object().unwrap();
+    for key in ["location", "evidence", "docs_url", "fingerprint"] {
+        assert!(
+            !finding2.contains_key(key),
+            "finding2 should not have key: {key}"
+        );
+    }
+}
+
+#[test]
+fn json_artifact_type_rename() {
+    let value = serde_json::to_value(&full_report()).unwrap();
+    let art = value["artifacts"][0].as_object().unwrap();
+    // Serde renames `artifact_type` → `type`
+    assert!(art.contains_key("type"));
+    assert!(!art.contains_key("artifact_type"));
+}
+
+#[test]
+fn json_capabilities_btreemap_sorted() {
+    let value = serde_json::to_value(&full_report()).unwrap();
+    let caps = value["capabilities"].as_object().unwrap();
+    let keys: Vec<&String> = caps.keys().collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(
+        keys, sorted,
+        "capabilities keys should be sorted (BTreeMap)"
+    );
+}
+
+// =============================================================================
+// 6. Fingerprint invariants
+// =============================================================================
+
+#[test]
+fn fingerprint_clone_stability() {
+    let f = Finding::new("risk", "hotspot", FindingSeverity::Warn, "T", "M")
+        .with_location(FindingLocation::path("src/x.rs"))
+        .with_fingerprint("tokmd");
+    let cloned = f.clone();
+    assert_eq!(f.fingerprint, cloned.fingerprint);
+    assert_eq!(
+        f.compute_fingerprint("tokmd"),
+        cloned.compute_fingerprint("tokmd")
+    );
+}
+
+#[test]
+fn fingerprint_ignores_severity_and_title() {
+    let f1 = Finding::new("check", "code", FindingSeverity::Error, "Title A", "Msg A")
+        .with_location(FindingLocation::path("same.rs"));
+    let f2 = Finding::new("check", "code", FindingSeverity::Info, "Title B", "Msg B")
+        .with_location(FindingLocation::path("same.rs"));
+    assert_eq!(
+        f1.compute_fingerprint("tool"),
+        f2.compute_fingerprint("tool"),
+        "fingerprint should only depend on (tool, check_id, code, path)"
+    );
+}
+
+#[test]
+fn fingerprint_hex_chars_only() {
+    let f = Finding::new("a", "b", FindingSeverity::Info, "T", "M")
+        .with_location(FindingLocation::path("unicode/日本語.rs"));
+    let fp = f.compute_fingerprint("tool");
+    assert_eq!(fp.len(), 32);
+    assert!(
+        fp.chars().all(|c| c.is_ascii_hexdigit()),
+        "fingerprint must be hex: {fp}"
+    );
+}
+
+#[test]
+fn fingerprint_null_byte_separator_prevents_collision() {
+    // Ensure the \0 separator prevents collisions between
+    // e.g., (tool="ab", check_id="c") and (tool="a", check_id="bc")
+    let f1 = Finding::new("bc", "d", FindingSeverity::Info, "T", "M");
+    let f2 = Finding::new("c", "d", FindingSeverity::Info, "T", "M");
+    // Different check_id => different fingerprint (even with tool prefix)
+    assert_ne!(
+        f1.compute_fingerprint("a"),
+        f2.compute_fingerprint("ab"),
+        "null separators should prevent cross-field collisions"
+    );
+}
+
+// =============================================================================
+// 7. Verdict and severity edge cases
+// =============================================================================
+
+#[test]
+fn verdict_copy_semantics() {
+    let v = Verdict::Fail;
+    let v2 = v; // Copy
+    assert_eq!(v, v2);
+    assert_eq!(v, Verdict::Fail); // original still usable
+}
+
+#[test]
+fn severity_copy_semantics() {
+    let s = FindingSeverity::Error;
+    let s2 = s; // Copy
+    assert_eq!(s, s2);
+    assert_eq!(s, FindingSeverity::Error);
+}
+
+#[test]
+fn verdict_eq_all_pairs() {
+    let all = [
+        Verdict::Pass,
+        Verdict::Fail,
+        Verdict::Warn,
+        Verdict::Skip,
+        Verdict::Pending,
+    ];
+    for (i, a) in all.iter().enumerate() {
+        for (j, b) in all.iter().enumerate() {
+            if i == j {
+                assert_eq!(a, b);
+            } else {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}
+
+#[test]
+fn severity_eq_all_pairs() {
+    let all = [
+        FindingSeverity::Error,
+        FindingSeverity::Warn,
+        FindingSeverity::Info,
+    ];
+    for (i, a) in all.iter().enumerate() {
+        for (j, b) in all.iter().enumerate() {
+            if i == j {
+                assert_eq!(a, b);
+            } else {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}
+
+// =============================================================================
+// 8. CapabilityStatus constructors produce correct state
+// =============================================================================
+
+#[test]
+fn capability_constructors_exhaustive() {
+    let avail = CapabilityStatus::available();
+    assert_eq!(avail.status, CapabilityState::Available);
+    assert!(avail.reason.is_none());
+
+    let unavail = CapabilityStatus::unavailable("reason");
+    assert_eq!(unavail.status, CapabilityState::Unavailable);
+    assert_eq!(unavail.reason.as_deref(), Some("reason"));
+
+    let skip = CapabilityStatus::skipped("reason");
+    assert_eq!(skip.status, CapabilityState::Skipped);
+    assert_eq!(skip.reason.as_deref(), Some("reason"));
+
+    let with_reason = CapabilityStatus::new(CapabilityState::Available).with_reason("extra");
+    assert_eq!(with_reason.status, CapabilityState::Available);
+    assert_eq!(with_reason.reason.as_deref(), Some("extra"));
+}
+
+// =============================================================================
+// 9. GateResults empty items
+// =============================================================================
+
+#[test]
+fn gate_results_empty_items_roundtrip() {
+    let gates = GateResults::new(Verdict::Pass, vec![]);
+    let json = serde_json::to_string(&gates).unwrap();
+    let back: GateResults = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.status, Verdict::Pass);
+    assert!(back.items.is_empty());
+}
+
+// =============================================================================
+// 10. SensorReport schema field cannot be overridden by constructor
+// =============================================================================
+
+#[test]
+fn constructor_always_sets_schema() {
+    let report = SensorReport::new(
+        ToolMeta::new("x", "0", "y"),
+        String::new(),
+        Verdict::Skip,
+        String::new(),
+    );
+    assert_eq!(report.schema, SENSOR_REPORT_SCHEMA);
+}
+
+// =============================================================================
+// 11. Large data payload roundtrip
+// =============================================================================
+
+#[test]
+fn large_data_payload_roundtrip() {
+    let big_array: Vec<serde_json::Value> = (0..1000).map(|i| serde_json::json!(i)).collect();
+    let report = minimal_report().with_data(serde_json::json!({"big": big_array}));
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    let data = back.data.unwrap();
+    let arr = data["big"].as_array().unwrap();
+    assert_eq!(arr.len(), 1000);
+}
+
+// =============================================================================
+// 12. Deserialize from known-good fixture with all verdict/severity combos
+// =============================================================================
+
+#[test]
+fn deserialize_all_verdict_values() {
+    for v in ["pass", "fail", "warn", "skip", "pending"] {
+        let json = format!(
+            r#"{{
+                "schema": "sensor.report.v1",
+                "tool": {{"name": "t", "version": "1", "mode": "m"}},
+                "generated_at": "2025-01-01T00:00:00Z",
+                "verdict": "{v}",
+                "summary": "ok",
+                "findings": []
+            }}"#
+        );
+        let report: SensorReport =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("verdict '{v}' failed: {e}"));
+        assert_eq!(report.verdict.to_string(), v);
+    }
+}
+
+#[test]
+fn deserialize_all_severity_values() {
+    for s in ["error", "warn", "info"] {
+        let json = format!(
+            r#"{{
+                "check_id": "c",
+                "code": "x",
+                "severity": "{s}",
+                "title": "T",
+                "message": "M"
+            }}"#
+        );
+        let finding: Finding =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("severity '{s}' failed: {e}"));
+        assert_eq!(finding.severity.to_string(), s);
+    }
+}
+
+#[test]
+fn deserialize_all_capability_states() {
+    for state in ["available", "unavailable", "skipped"] {
+        let json = format!(r#"{{"status": "{state}"}}"#);
+        let cs: CapabilityStatus = serde_json::from_str(&json)
+            .unwrap_or_else(|e| panic!("capability state '{state}' failed: {e}"));
+        let back_json = serde_json::to_value(&cs.status).unwrap();
+        assert_eq!(back_json.as_str().unwrap(), state);
+    }
+}
+
+// =============================================================================
+// Property tests
+// =============================================================================
+
+proptest! {
+    /// Double roundtrip is always stable for arbitrary reports.
+    #[test]
+    fn prop_double_roundtrip_stable(
+        verdict_idx in 0usize..5,
+        n_findings in 0usize..8,
+        has_data in any::<bool>(),
+    ) {
+        let verdicts = [Verdict::Pass, Verdict::Fail, Verdict::Warn, Verdict::Skip, Verdict::Pending];
+        let severities = [FindingSeverity::Error, FindingSeverity::Warn, FindingSeverity::Info];
+
+        let mut report = SensorReport::new(
+            ToolMeta::tokmd("1.0.0", "deep"),
+            "2025-01-01T00:00:00Z".into(),
+            verdicts[verdict_idx],
+            format!("{n_findings} findings"),
+        );
+        for i in 0..n_findings {
+            report.add_finding(Finding::new(
+                format!("chk{i}"), format!("code{i}"),
+                severities[i % 3], format!("T{i}"), format!("M{i}"),
+            ));
+        }
+        if has_data {
+            report = report.with_data(serde_json::json!({"k": "v"}));
+        }
+
+        let json1 = serde_json::to_string(&report).unwrap();
+        let mid: SensorReport = serde_json::from_str(&json1).unwrap();
+        let json2 = serde_json::to_string(&mid).unwrap();
+        prop_assert_eq!(json1, json2);
+    }
+
+    /// Fingerprint is always 32 hex chars for any tool/check/code/path combo.
+    #[test]
+    fn prop_fingerprint_format(
+        tool in ".{0,50}",
+        check_id in ".{0,30}",
+        code in ".{0,30}",
+        path in ".{0,100}",
+    ) {
+        let f = Finding::new(&check_id, &code, FindingSeverity::Info, "T", "M")
+            .with_location(FindingLocation::path(&path));
+        let fp = f.compute_fingerprint(&tool);
+        prop_assert_eq!(fp.len(), 32);
+        prop_assert!(fp.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    /// Optional fields that are None do not appear in serialized JSON.
+    #[test]
+    fn prop_none_fields_omitted(
+        has_artifacts in any::<bool>(),
+        has_caps in any::<bool>(),
+        has_data in any::<bool>(),
+    ) {
+        let mut report = minimal_report();
+        if has_artifacts {
+            report = report.with_artifacts(vec![Artifact::badge("b.svg")]);
+        }
+        if has_caps {
+            let mut caps = BTreeMap::new();
+            caps.insert("x".into(), CapabilityStatus::available());
+            report = report.with_capabilities(caps);
+        }
+        if has_data {
+            report = report.with_data(serde_json::json!({"k": 1}));
+        }
+
+        let json = serde_json::to_string(&report).unwrap();
+        if !has_artifacts {
+            prop_assert!(!json.contains("\"artifacts\""));
+        }
+        if !has_caps {
+            prop_assert!(!json.contains("\"capabilities\""));
+        }
+        if !has_data {
+            prop_assert!(!json.contains("\"data\""));
+        }
+    }
+}

--- a/crates/tokmd-substrate/tests/deep.rs
+++ b/crates/tokmd-substrate/tests/deep.rs
@@ -1,0 +1,807 @@
+//! Deep contract tests for `tokmd-substrate`.
+//!
+//! Covers error handling for malformed input, forward-compatibility
+//! (extra JSON fields), deterministic serialization, double-roundtrip
+//! stability, JSON structure invariants, extreme values, and
+//! deserialization from external fixtures.
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_file(path: &str, lang: &str, code: usize, in_diff: bool) -> SubstrateFile {
+    SubstrateFile {
+        path: path.to_string(),
+        lang: lang.to_string(),
+        code,
+        lines: code + 20,
+        bytes: code * 30,
+        tokens: code * 7,
+        module: path
+            .rsplit_once('/')
+            .map(|(m, _)| m)
+            .unwrap_or("")
+            .to_string(),
+        in_diff,
+    }
+}
+
+fn empty_substrate() -> RepoSubstrate {
+    RepoSubstrate {
+        repo_root: "/repo".to_string(),
+        files: vec![],
+        lang_summary: BTreeMap::new(),
+        diff_range: None,
+        total_tokens: 0,
+        total_bytes: 0,
+        total_code_lines: 0,
+    }
+}
+
+fn populated_substrate() -> RepoSubstrate {
+    let files = vec![
+        make_file("src/lib.rs", "Rust", 200, true),
+        make_file("src/main.rs", "Rust", 100, false),
+        make_file("src/util.py", "Python", 80, true),
+        make_file("README.md", "Markdown", 30, false),
+    ];
+    let mut lang_summary = BTreeMap::new();
+    lang_summary.insert(
+        "Rust".to_string(),
+        LangSummary {
+            files: 2,
+            code: 300,
+            lines: 340,
+            bytes: 9000,
+            tokens: 2100,
+        },
+    );
+    lang_summary.insert(
+        "Python".to_string(),
+        LangSummary {
+            files: 1,
+            code: 80,
+            lines: 100,
+            bytes: 2400,
+            tokens: 560,
+        },
+    );
+    lang_summary.insert(
+        "Markdown".to_string(),
+        LangSummary {
+            files: 1,
+            code: 30,
+            lines: 50,
+            bytes: 900,
+            tokens: 210,
+        },
+    );
+
+    RepoSubstrate {
+        repo_root: "/home/user/project".to_string(),
+        files,
+        lang_summary,
+        diff_range: Some(DiffRange {
+            base: "v1.0.0".to_string(),
+            head: "HEAD".to_string(),
+            changed_files: vec!["src/lib.rs".to_string(), "src/util.py".to_string()],
+            commit_count: 7,
+            insertions: 50,
+            deletions: 20,
+        }),
+        total_tokens: 2870,
+        total_bytes: 12300,
+        total_code_lines: 410,
+    }
+}
+
+// =============================================================================
+// 1. Deterministic serialization
+// =============================================================================
+
+#[test]
+fn deterministic_serialization_empty() {
+    let s = empty_substrate();
+    let j1 = serde_json::to_string(&s).unwrap();
+    let j2 = serde_json::to_string(&s).unwrap();
+    assert_eq!(j1, j2);
+}
+
+#[test]
+fn deterministic_serialization_populated() {
+    let s = populated_substrate();
+    let j1 = serde_json::to_string_pretty(&s).unwrap();
+    let j2 = serde_json::to_string_pretty(&s).unwrap();
+    assert_eq!(j1, j2);
+}
+
+// =============================================================================
+// 2. Double-roundtrip stability
+// =============================================================================
+
+#[test]
+fn double_roundtrip_empty() {
+    let json1 = serde_json::to_string(&empty_substrate()).unwrap();
+    let mid: RepoSubstrate = serde_json::from_str(&json1).unwrap();
+    let json2 = serde_json::to_string(&mid).unwrap();
+    assert_eq!(json1, json2);
+}
+
+#[test]
+fn double_roundtrip_populated() {
+    let json1 = serde_json::to_string(&populated_substrate()).unwrap();
+    let mid: RepoSubstrate = serde_json::from_str(&json1).unwrap();
+    let json2 = serde_json::to_string(&mid).unwrap();
+    assert_eq!(json1, json2);
+}
+
+// =============================================================================
+// 3. Error handling: malformed JSON input
+// =============================================================================
+
+#[test]
+fn reject_empty_string() {
+    let result = serde_json::from_str::<RepoSubstrate>("");
+    assert!(result.is_err());
+}
+
+#[test]
+fn reject_invalid_json() {
+    let result = serde_json::from_str::<RepoSubstrate>("{broken}");
+    assert!(result.is_err());
+}
+
+#[test]
+fn reject_missing_required_field_repo_root() {
+    let json = r#"{
+        "files": [],
+        "lang_summary": {},
+        "total_tokens": 0,
+        "total_bytes": 0,
+        "total_code_lines": 0
+    }"#;
+    let result = serde_json::from_str::<RepoSubstrate>(json);
+    assert!(result.is_err(), "missing 'repo_root' should fail");
+}
+
+#[test]
+fn reject_missing_required_field_files() {
+    let json = r#"{
+        "repo_root": "/repo",
+        "lang_summary": {},
+        "total_tokens": 0,
+        "total_bytes": 0,
+        "total_code_lines": 0
+    }"#;
+    let result = serde_json::from_str::<RepoSubstrate>(json);
+    assert!(result.is_err(), "missing 'files' should fail");
+}
+
+#[test]
+fn reject_missing_required_field_total_tokens() {
+    let json = r#"{
+        "repo_root": "/repo",
+        "files": [],
+        "lang_summary": {},
+        "total_bytes": 0,
+        "total_code_lines": 0
+    }"#;
+    let result = serde_json::from_str::<RepoSubstrate>(json);
+    assert!(result.is_err(), "missing 'total_tokens' should fail");
+}
+
+#[test]
+fn reject_files_not_array() {
+    let json = r#"{
+        "repo_root": "/repo",
+        "files": "not-an-array",
+        "lang_summary": {},
+        "total_tokens": 0,
+        "total_bytes": 0,
+        "total_code_lines": 0
+    }"#;
+    let result = serde_json::from_str::<RepoSubstrate>(json);
+    assert!(result.is_err(), "'files' as string should fail");
+}
+
+#[test]
+fn reject_total_code_lines_as_string() {
+    let json = r#"{
+        "repo_root": "/repo",
+        "files": [],
+        "lang_summary": {},
+        "total_tokens": 0,
+        "total_bytes": 0,
+        "total_code_lines": "not a number"
+    }"#;
+    let result = serde_json::from_str::<RepoSubstrate>(json);
+    assert!(result.is_err(), "string for usize field should fail");
+}
+
+#[test]
+fn reject_negative_numeric_field() {
+    let json = r#"{
+        "repo_root": "/repo",
+        "files": [],
+        "lang_summary": {},
+        "total_tokens": -1,
+        "total_bytes": 0,
+        "total_code_lines": 0
+    }"#;
+    let result = serde_json::from_str::<RepoSubstrate>(json);
+    assert!(result.is_err(), "negative value for usize should fail");
+}
+
+#[test]
+fn reject_substrate_file_missing_path() {
+    let json = r#"{
+        "lang": "Rust",
+        "code": 10,
+        "lines": 20,
+        "bytes": 300,
+        "tokens": 70,
+        "module": "src",
+        "in_diff": false
+    }"#;
+    let result = serde_json::from_str::<SubstrateFile>(json);
+    assert!(result.is_err(), "missing 'path' should fail");
+}
+
+#[test]
+fn reject_substrate_file_missing_in_diff() {
+    let json = r#"{
+        "path": "src/lib.rs",
+        "lang": "Rust",
+        "code": 10,
+        "lines": 20,
+        "bytes": 300,
+        "tokens": 70,
+        "module": "src"
+    }"#;
+    let result = serde_json::from_str::<SubstrateFile>(json);
+    assert!(result.is_err(), "missing 'in_diff' should fail");
+}
+
+#[test]
+fn reject_lang_summary_code_as_string() {
+    let json = r#"{
+        "files": 1,
+        "code": "not-a-number",
+        "lines": 20,
+        "bytes": 300,
+        "tokens": 70
+    }"#;
+    let result = serde_json::from_str::<LangSummary>(json);
+    assert!(result.is_err(), "string for usize should fail");
+}
+
+// =============================================================================
+// 4. Forward compatibility: extra/unknown fields ignored
+// =============================================================================
+
+#[test]
+fn forward_compat_extra_substrate_fields_ignored() {
+    let json = r#"{
+        "repo_root": "/repo",
+        "files": [],
+        "lang_summary": {},
+        "total_tokens": 0,
+        "total_bytes": 0,
+        "total_code_lines": 0,
+        "future_field": "value",
+        "future_number": 42
+    }"#;
+    let sub: RepoSubstrate = serde_json::from_str(json).unwrap();
+    assert_eq!(sub.repo_root, "/repo");
+}
+
+#[test]
+fn forward_compat_extra_file_fields_ignored() {
+    let json = r#"{
+        "path": "src/lib.rs",
+        "lang": "Rust",
+        "code": 100,
+        "lines": 120,
+        "bytes": 3000,
+        "tokens": 700,
+        "module": "src",
+        "in_diff": true,
+        "future_complexity": 42,
+        "future_tags": ["a"]
+    }"#;
+    let file: SubstrateFile = serde_json::from_str(json).unwrap();
+    assert_eq!(file.path, "src/lib.rs");
+    assert_eq!(file.code, 100);
+    assert!(file.in_diff);
+}
+
+#[test]
+fn forward_compat_extra_diff_range_fields_ignored() {
+    let json = r#"{
+        "base": "main",
+        "head": "dev",
+        "changed_files": [],
+        "commit_count": 0,
+        "insertions": 0,
+        "deletions": 0,
+        "future_merge_base": "abc123"
+    }"#;
+    let dr: DiffRange = serde_json::from_str(json).unwrap();
+    assert_eq!(dr.base, "main");
+}
+
+#[test]
+fn forward_compat_extra_lang_summary_fields_ignored() {
+    let json = r#"{
+        "files": 5,
+        "code": 200,
+        "lines": 250,
+        "bytes": 6000,
+        "tokens": 1400,
+        "future_avg_complexity": 3.5
+    }"#;
+    let ls: LangSummary = serde_json::from_str(json).unwrap();
+    assert_eq!(ls.files, 5);
+    assert_eq!(ls.code, 200);
+}
+
+// =============================================================================
+// 5. JSON structure invariants
+// =============================================================================
+
+#[test]
+fn json_required_keys_present_in_populated_substrate() {
+    let value = serde_json::to_value(&populated_substrate()).unwrap();
+    let obj = value.as_object().unwrap();
+    for key in [
+        "repo_root",
+        "files",
+        "lang_summary",
+        "total_tokens",
+        "total_bytes",
+        "total_code_lines",
+    ] {
+        assert!(obj.contains_key(key), "missing required key: {key}");
+    }
+    // diff_range is optional but present here
+    assert!(obj.contains_key("diff_range"));
+}
+
+#[test]
+fn json_file_has_all_required_keys() {
+    let value = serde_json::to_value(&populated_substrate()).unwrap();
+    let file = value["files"][0].as_object().unwrap();
+    for key in [
+        "path", "lang", "code", "lines", "bytes", "tokens", "module", "in_diff",
+    ] {
+        assert!(file.contains_key(key), "file missing key: {key}");
+    }
+}
+
+#[test]
+fn json_lang_summary_has_all_required_keys() {
+    let value = serde_json::to_value(&populated_substrate()).unwrap();
+    let rust = value["lang_summary"]["Rust"].as_object().unwrap();
+    for key in ["files", "code", "lines", "bytes", "tokens"] {
+        assert!(rust.contains_key(key), "lang_summary missing key: {key}");
+    }
+}
+
+#[test]
+fn json_diff_range_has_all_required_keys() {
+    let value = serde_json::to_value(&populated_substrate()).unwrap();
+    let dr = value["diff_range"].as_object().unwrap();
+    for key in [
+        "base",
+        "head",
+        "changed_files",
+        "commit_count",
+        "insertions",
+        "deletions",
+    ] {
+        assert!(dr.contains_key(key), "diff_range missing key: {key}");
+    }
+}
+
+#[test]
+fn json_lang_summary_keys_sorted() {
+    let value = serde_json::to_value(&populated_substrate()).unwrap();
+    let summary = value["lang_summary"].as_object().unwrap();
+    let keys: Vec<&String> = summary.keys().collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "lang_summary keys should be sorted");
+}
+
+// =============================================================================
+// 6. Extreme values
+// =============================================================================
+
+#[test]
+fn extreme_usize_values_roundtrip() {
+    let file = SubstrateFile {
+        path: "extreme.rs".to_string(),
+        lang: "Rust".to_string(),
+        code: usize::MAX,
+        lines: usize::MAX,
+        bytes: usize::MAX,
+        tokens: usize::MAX,
+        module: "".to_string(),
+        in_diff: true,
+    };
+    let json = serde_json::to_string(&file).unwrap();
+    let back: SubstrateFile = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.code, usize::MAX);
+    assert_eq!(back.lines, usize::MAX);
+    assert_eq!(back.bytes, usize::MAX);
+    assert_eq!(back.tokens, usize::MAX);
+}
+
+#[test]
+fn zero_values_file_roundtrip() {
+    let file = SubstrateFile {
+        path: "empty.rs".to_string(),
+        lang: "Rust".to_string(),
+        code: 0,
+        lines: 0,
+        bytes: 0,
+        tokens: 0,
+        module: "".to_string(),
+        in_diff: false,
+    };
+    let json = serde_json::to_string(&file).unwrap();
+    let back: SubstrateFile = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.code, 0);
+    assert_eq!(back.lines, 0);
+    assert_eq!(back.bytes, 0);
+    assert_eq!(back.tokens, 0);
+}
+
+#[test]
+fn extreme_diff_range_roundtrip() {
+    let dr = DiffRange {
+        base: "a".repeat(500),
+        head: "b".repeat(500),
+        changed_files: (0..500).map(|i| format!("file_{i}.rs")).collect(),
+        commit_count: usize::MAX,
+        insertions: usize::MAX,
+        deletions: usize::MAX,
+    };
+    let json = serde_json::to_string(&dr).unwrap();
+    let back: DiffRange = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.changed_files.len(), 500);
+    assert_eq!(back.commit_count, usize::MAX);
+}
+
+// =============================================================================
+// 7. Empty string edge cases
+// =============================================================================
+
+#[test]
+fn empty_strings_roundtrip() {
+    let sub = RepoSubstrate {
+        repo_root: String::new(),
+        files: vec![SubstrateFile {
+            path: String::new(),
+            lang: String::new(),
+            code: 0,
+            lines: 0,
+            bytes: 0,
+            tokens: 0,
+            module: String::new(),
+            in_diff: false,
+        }],
+        lang_summary: {
+            let mut m = BTreeMap::new();
+            m.insert(
+                String::new(),
+                LangSummary {
+                    files: 1,
+                    code: 0,
+                    lines: 0,
+                    bytes: 0,
+                    tokens: 0,
+                },
+            );
+            m
+        },
+        diff_range: Some(DiffRange {
+            base: String::new(),
+            head: String::new(),
+            changed_files: vec![String::new()],
+            commit_count: 0,
+            insertions: 0,
+            deletions: 0,
+        }),
+        total_tokens: 0,
+        total_bytes: 0,
+        total_code_lines: 0,
+    };
+    let json = serde_json::to_string(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.repo_root, "");
+    assert_eq!(back.files[0].path, "");
+    assert_eq!(back.files[0].lang, "");
+    assert!(back.lang_summary.contains_key(""));
+    let dr = back.diff_range.unwrap();
+    assert_eq!(dr.base, "");
+    assert_eq!(dr.changed_files, vec![""]);
+}
+
+// =============================================================================
+// 8. Clone deep equality
+// =============================================================================
+
+#[test]
+fn clone_produces_identical_json() {
+    let original = populated_substrate();
+    let cloned = original.clone();
+    let j1 = serde_json::to_string(&original).unwrap();
+    let j2 = serde_json::to_string(&cloned).unwrap();
+    assert_eq!(j1, j2);
+}
+
+// =============================================================================
+// 9. diff_files and files_for_lang interaction
+// =============================================================================
+
+#[test]
+fn diff_files_subset_of_files_for_lang() {
+    let sub = populated_substrate();
+    let diff_rust: Vec<_> = sub.diff_files().filter(|f| f.lang == "Rust").collect();
+    let all_rust: Vec<_> = sub.files_for_lang("Rust").collect();
+    // Every diff Rust file should also be in all_rust
+    for df in &diff_rust {
+        assert!(
+            all_rust.iter().any(|f| f.path == df.path),
+            "diff file {} not found in files_for_lang",
+            df.path
+        );
+    }
+    assert!(diff_rust.len() <= all_rust.len());
+}
+
+#[test]
+fn diff_files_count_consistent_with_in_diff_flag() {
+    let sub = populated_substrate();
+    let expected = sub.files.iter().filter(|f| f.in_diff).count();
+    assert_eq!(sub.diff_files().count(), expected);
+}
+
+// =============================================================================
+// 10. Deserialization from external JSON fixture
+// =============================================================================
+
+#[test]
+fn deserialize_minimal_external_json() {
+    let json = r#"{
+        "repo_root": "/external/repo",
+        "files": [],
+        "lang_summary": {},
+        "total_tokens": 0,
+        "total_bytes": 0,
+        "total_code_lines": 0
+    }"#;
+    let sub: RepoSubstrate = serde_json::from_str(json).unwrap();
+    assert_eq!(sub.repo_root, "/external/repo");
+    assert!(sub.files.is_empty());
+    assert!(sub.diff_range.is_none());
+}
+
+#[test]
+fn deserialize_complete_external_json() {
+    let json = r#"{
+        "repo_root": "/ext",
+        "files": [
+            {
+                "path": "src/main.go",
+                "lang": "Go",
+                "code": 500,
+                "lines": 600,
+                "bytes": 15000,
+                "tokens": 3500,
+                "module": "src",
+                "in_diff": true
+            },
+            {
+                "path": "go.mod",
+                "lang": "Go Module",
+                "code": 10,
+                "lines": 15,
+                "bytes": 300,
+                "tokens": 70,
+                "module": "",
+                "in_diff": false
+            }
+        ],
+        "lang_summary": {
+            "Go": {"files": 1, "code": 500, "lines": 600, "bytes": 15000, "tokens": 3500},
+            "Go Module": {"files": 1, "code": 10, "lines": 15, "bytes": 300, "tokens": 70}
+        },
+        "diff_range": {
+            "base": "main",
+            "head": "feature/api",
+            "changed_files": ["src/main.go"],
+            "commit_count": 3,
+            "insertions": 25,
+            "deletions": 10
+        },
+        "total_tokens": 3570,
+        "total_bytes": 15300,
+        "total_code_lines": 510
+    }"#;
+    let sub: RepoSubstrate = serde_json::from_str(json).unwrap();
+    assert_eq!(sub.files.len(), 2);
+    assert_eq!(sub.lang_summary.len(), 2);
+    assert_eq!(sub.files[0].lang, "Go");
+    assert!(sub.files[0].in_diff);
+    assert!(!sub.files[1].in_diff);
+    let dr = sub.diff_range.unwrap();
+    assert_eq!(dr.base, "main");
+    assert_eq!(dr.changed_files, vec!["src/main.go"]);
+    assert_eq!(sub.total_code_lines, 510);
+}
+
+// =============================================================================
+// Property tests
+// =============================================================================
+
+fn arb_lang_summary() -> impl Strategy<Value = LangSummary> {
+    (
+        0..100usize,
+        0..10_000usize,
+        0..20_000usize,
+        0..1_000_000usize,
+        0..100_000usize,
+    )
+        .prop_map(|(files, code, lines, bytes, tokens)| LangSummary {
+            files,
+            code,
+            lines,
+            bytes,
+            tokens,
+        })
+}
+
+fn arb_substrate_file() -> impl Strategy<Value = SubstrateFile> {
+    (
+        "[a-z/]{1,40}",
+        "[A-Za-z]{1,15}",
+        0..10_000usize,
+        0..10_000usize,
+        0..1_000_000usize,
+        0..100_000usize,
+        "[a-z/]{0,20}",
+        any::<bool>(),
+    )
+        .prop_map(
+            |(path, lang, code, lines, bytes, tokens, module, in_diff)| SubstrateFile {
+                path,
+                lang,
+                code,
+                lines,
+                bytes,
+                tokens,
+                module,
+                in_diff,
+            },
+        )
+}
+
+fn arb_diff_range() -> impl Strategy<Value = DiffRange> {
+    (
+        "[a-z0-9./-]{1,20}",
+        "[a-z0-9./-]{1,20}",
+        prop::collection::vec("[a-z/.]{1,30}", 0..10),
+        0..500usize,
+        0..10_000usize,
+        0..10_000usize,
+    )
+        .prop_map(
+            |(base, head, changed_files, commit_count, insertions, deletions)| DiffRange {
+                base,
+                head,
+                changed_files,
+                commit_count,
+                insertions,
+                deletions,
+            },
+        )
+}
+
+proptest! {
+    /// Serialization is deterministic for arbitrary substrates.
+    #[test]
+    fn prop_serialization_deterministic(
+        root in "[a-z/]{1,30}",
+        files in prop::collection::vec(arb_substrate_file(), 0..5),
+        langs in prop::collection::btree_map("[A-Za-z]{1,10}", arb_lang_summary(), 0..3),
+        diff_range in prop::option::of(arb_diff_range()),
+        total_tokens in 0usize..100_000,
+        total_bytes in 0usize..1_000_000,
+        total_code_lines in 0usize..100_000,
+    ) {
+        let sub = RepoSubstrate {
+            repo_root: root,
+            files,
+            lang_summary: langs,
+            diff_range,
+            total_tokens,
+            total_bytes,
+            total_code_lines,
+        };
+        let j1 = serde_json::to_string(&sub).unwrap();
+        let j2 = serde_json::to_string(&sub).unwrap();
+        prop_assert_eq!(&j1, &j2);
+    }
+
+    /// Double roundtrip is always stable.
+    #[test]
+    fn prop_double_roundtrip_stable(
+        root in "[a-z/]{1,30}",
+        files in prop::collection::vec(arb_substrate_file(), 0..5),
+        total in 0usize..100_000,
+    ) {
+        let sub = RepoSubstrate {
+            repo_root: root,
+            files,
+            lang_summary: BTreeMap::new(),
+            diff_range: None,
+            total_tokens: total,
+            total_bytes: total,
+            total_code_lines: total,
+        };
+        let json1 = serde_json::to_string(&sub).unwrap();
+        let mid: RepoSubstrate = serde_json::from_str(&json1).unwrap();
+        let json2 = serde_json::to_string(&mid).unwrap();
+        prop_assert_eq!(json1, json2);
+    }
+
+    /// diff_files() always returns a subset of files.
+    #[test]
+    fn prop_diff_files_is_subset(
+        files in prop::collection::vec(arb_substrate_file(), 0..20),
+    ) {
+        let sub = RepoSubstrate {
+            repo_root: "/r".to_string(),
+            files,
+            lang_summary: BTreeMap::new(),
+            diff_range: None,
+            total_tokens: 0,
+            total_bytes: 0,
+            total_code_lines: 0,
+        };
+        let diff_count = sub.diff_files().count();
+        let expected = sub.files.iter().filter(|f| f.in_diff).count();
+        prop_assert_eq!(diff_count, expected);
+        prop_assert!(diff_count <= sub.files.len());
+    }
+
+    /// files_for_lang returns only matching files.
+    #[test]
+    fn prop_files_for_lang_correct(
+        files in prop::collection::vec(arb_substrate_file(), 0..20),
+        lang in "[A-Za-z]{1,10}",
+    ) {
+        let sub = RepoSubstrate {
+            repo_root: "/r".to_string(),
+            files,
+            lang_summary: BTreeMap::new(),
+            diff_range: None,
+            total_tokens: 0,
+            total_bytes: 0,
+            total_code_lines: 0,
+        };
+        for f in sub.files_for_lang(&lang) {
+            prop_assert_eq!(&f.lang, &lang);
+        }
+        let count = sub.files_for_lang(&lang).count();
+        let expected = sub.files.iter().filter(|f| f.lang == lang).count();
+        prop_assert_eq!(count, expected);
+    }
+}

--- a/crates/tokmd-types/tests/proptest_deep.rs
+++ b/crates/tokmd-types/tests/proptest_deep.rs
@@ -6,10 +6,10 @@
 
 use proptest::prelude::*;
 use tokmd_types::{
-    cockpit::COCKPIT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode, CommitIntentKind, ConfigMode,
-    DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind, InclusionPolicy, RedactMode,
-    TableFormat, TokenEstimationMeta, Totals, CONTEXT_BUNDLE_SCHEMA_VERSION,
-    CONTEXT_SCHEMA_VERSION, HANDOFF_SCHEMA_VERSION, SCHEMA_VERSION,
+    CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode,
+    CommitIntentKind, ConfigMode, DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind,
+    HANDOFF_SCHEMA_VERSION, InclusionPolicy, RedactMode, SCHEMA_VERSION, TableFormat,
+    TokenEstimationMeta, Totals, cockpit::COCKPIT_SCHEMA_VERSION,
 };
 
 // =========================================================================


### PR DESCRIPTION
Adds comprehensive deep test suites for the `tokmd-envelope` and `tokmd-substrate` Tier 0 contract crates.

## Coverage added

**tokmd-envelope** (`tests/deep.rs`):
- Deterministic serialization (minimal + full payloads)
- Double-roundtrip stability
- 10 malformed input rejection tests
- 6 forward compatibility tests (extra JSON fields)
- JSON structure invariant assertions
- Fingerprint edge cases (clone stability, hex format, collision prevention)
- Verdict/Severity Copy semantics and exhaustive equality
- CapabilityStatus constructor coverage
- Large data payload roundtrip
- Known fixture deserialization
- Property tests (roundtrip, fingerprint format, None-field omission)

**tokmd-substrate** (`tests/deep.rs`):
- Deterministic serialization
- Double-roundtrip stability
- 10 malformed input rejection tests
- 4 forward compatibility tests
- JSON structure invariant assertions
- Extreme values (usize::MAX, zeros)
- Empty string edge cases
- Clone deep equality
- diff_files/files_for_lang interaction tests
- External JSON fixture deserialization
- Property tests (determinism, roundtrip, diff_files subset, files_for_lang correctness)
