### PR TITLE
test(api-surface,content): add deep integration tests

### DIFF
--- a/crates/tokmd-analysis-api-surface/tests/deep.rs
+++ b/crates/tokmd-analysis-api-surface/tests/deep.rs
@@ -1,0 +1,657 @@
+//! Deep integration tests for `tokmd-analysis-api-surface`.
+//!
+//! Covers: public function/struct/enum detection across languages, empty files,
+//! non-Rust files, API surface item counting, serialization roundtrip, and
+//! deterministic output.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tokmd_analysis_api_surface::build_api_surface_report;
+use tokmd_analysis_types::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
+use tokmd_analysis_util::AnalysisLimits;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_row(path: &str, module: &str, lang: &str) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code: 10,
+        comments: 2,
+        blanks: 1,
+        lines: 13,
+        bytes: 100,
+        tokens: 30,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn default_limits() -> AnalysisLimits {
+    AnalysisLimits::default()
+}
+
+fn write_temp_files(files: &[(&str, &str)]) -> (tempfile::TempDir, Vec<PathBuf>) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let mut paths = Vec::new();
+    for (rel, content) in files {
+        let full = dir.path().join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&full, content).unwrap();
+        paths.push(PathBuf::from(rel));
+    }
+    (dir, paths)
+}
+
+// ---------------------------------------------------------------------------
+// 1. Detect public functions in Rust code
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rust_pub_fn_detected_in_report() {
+    let code = "pub fn alpha() {}\npub fn beta() {}\nfn gamma() {}\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 2);
+    assert_eq!(report.internal_items, 1);
+    assert_eq!(report.total_items, 3);
+}
+
+#[test]
+fn rust_pub_async_fn_detected() {
+    let code = "pub async fn serve() {}\nasync fn helper() {}\n";
+    let (dir, paths) = write_temp_files(&[("server.rs", code)]);
+    let export = make_export(vec![make_row("server.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+    assert_eq!(report.internal_items, 1);
+}
+
+#[test]
+fn rust_pub_unsafe_fn_detected() {
+    let code = "pub unsafe fn dangerous() {}\nunsafe fn secret() {}\n";
+    let (dir, paths) = write_temp_files(&[("ffi.rs", code)]);
+    let export = make_export(vec![make_row("ffi.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+    assert_eq!(report.internal_items, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Detect public structs/enums
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rust_pub_struct_detected() {
+    let code = "pub struct Config {\n    pub name: String,\n}\nstruct Internal {}\n";
+    let (dir, paths) = write_temp_files(&[("types.rs", code)]);
+    let export = make_export(vec![make_row("types.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+    assert_eq!(report.internal_items, 1);
+}
+
+#[test]
+fn rust_pub_enum_detected() {
+    let code = "pub enum Color {\n    Red,\n    Green,\n    Blue,\n}\nenum Secret {}\n";
+    let (dir, paths) = write_temp_files(&[("colors.rs", code)]);
+    let export = make_export(vec![make_row("colors.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+    assert_eq!(report.internal_items, 1);
+}
+
+#[test]
+fn rust_pub_trait_detected() {
+    let code = "pub trait Handler {\n    fn handle(&self);\n}\ntrait Internal {}\n";
+    let (dir, paths) = write_temp_files(&[("traits.rs", code)]);
+    let export = make_export(vec![make_row("traits.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 1);
+    // `fn handle(&self);` inside the trait is also counted as an internal item
+    // because the heuristic matches trimmed lines starting with `fn `.
+    assert_eq!(report.internal_items, 2);
+}
+
+#[test]
+fn rust_pub_type_const_static_mod_detected() {
+    let code = concat!(
+        "pub type Result<T> = std::result::Result<T, Error>;\n",
+        "pub const MAX: usize = 100;\n",
+        "pub static GLOBAL: &str = \"hello\";\n",
+        "pub mod utils;\n",
+        "pub unsafe trait Marker {}\n",
+    );
+    let (dir, paths) = write_temp_files(&[("defs.rs", code)]);
+    let export = make_export(vec![make_row("defs.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 5);
+}
+
+#[test]
+fn rust_pub_crate_items_detected_as_public() {
+    let code = concat!(
+        "pub(crate) fn internal_api() {}\n",
+        "pub(super) struct ParentVisible {}\n",
+        "pub(in crate::module) enum Scoped {}\n",
+    );
+    let (dir, paths) = write_temp_files(&[("scoped.rs", code)]);
+    let export = make_export(vec![make_row("scoped.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    // pub(crate), pub(super), pub(in ...) are all treated as public
+    assert_eq!(report.public_items, 3);
+    assert_eq!(report.internal_items, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Handle empty files
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_file_yields_zero_items() {
+    let (dir, paths) = write_temp_files(&[("empty.rs", "")]);
+    let export = make_export(vec![make_row("empty.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.total_items, 0);
+    assert_eq!(report.public_items, 0);
+    assert_eq!(report.internal_items, 0);
+    assert_eq!(report.public_ratio, 0.0);
+    assert_eq!(report.documented_ratio, 0.0);
+}
+
+#[test]
+fn empty_file_list_yields_zero_items() {
+    let dir = tempfile::tempdir().unwrap();
+    let export = make_export(vec![]);
+    let report = build_api_surface_report(dir.path(), &[], &export, &default_limits()).unwrap();
+
+    assert_eq!(report.total_items, 0);
+    assert!(report.by_language.is_empty());
+    assert!(report.by_module.is_empty());
+    assert!(report.top_exporters.is_empty());
+}
+
+#[test]
+fn comment_only_file_yields_zero_items() {
+    let code = "// Just a comment\n// Another comment\n/* block comment */\n";
+    let (dir, paths) = write_temp_files(&[("comments.rs", code)]);
+    let export = make_export(vec![make_row("comments.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.total_items, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Handle non-Rust files (unsupported languages)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unsupported_language_files_skipped() {
+    let (dir, paths) = write_temp_files(&[
+        ("style.css", ".class { color: red; }\n"),
+        ("data.json", "{\"key\": \"value\"}\n"),
+        ("readme.md", "# Title\n\nSome text.\n"),
+    ]);
+    let export = make_export(vec![
+        make_row("style.css", ".", "CSS"),
+        make_row("data.json", ".", "JSON"),
+        make_row("readme.md", ".", "Markdown"),
+    ]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.total_items, 0);
+    assert!(report.by_language.is_empty());
+}
+
+#[test]
+fn binary_file_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("binary.rs"), b"\x00\x01\x02\x03\xff\xfe").unwrap();
+    let paths = vec![PathBuf::from("binary.rs")];
+    let export = make_export(vec![make_row("binary.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.total_items, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Count API surface items (multi-language)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multi_language_item_counts_are_consistent() {
+    let rust = "pub fn r_pub() {}\nfn r_priv() {}\n";
+    let js = "export function j_pub() {}\nfunction j_priv() {}\n";
+    let ts = "export class TsPub {}\nclass TsPriv {}\nexport interface ITsFace {}\n";
+    let py = "def py_pub():\n    pass\ndef _py_priv():\n    pass\nclass PyClass:\n    pass\n";
+    let go = "func GoPub() {}\nfunc goPriv() {}\ntype GoType struct {}\n";
+    let java = "public class JPub {}\nclass JPriv {}\npublic interface IJFace {}\n";
+
+    let (dir, paths) = write_temp_files(&[
+        ("lib.rs", rust),
+        ("index.js", js),
+        ("types.ts", ts),
+        ("main.py", py),
+        ("main.go", go),
+        ("App.java", java),
+    ]);
+    let export = make_export(vec![
+        make_row("lib.rs", "rust", "Rust"),
+        make_row("index.js", "js", "JavaScript"),
+        make_row("types.ts", "ts", "TypeScript"),
+        make_row("main.py", "py", "Python"),
+        make_row("main.go", "go", "Go"),
+        make_row("App.java", "java", "Java"),
+    ]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    // Verify totals = sum of per-language
+    let lang_total: usize = report.by_language.values().map(|l| l.total_items).sum();
+    let lang_pub: usize = report.by_language.values().map(|l| l.public_items).sum();
+    let lang_int: usize = report.by_language.values().map(|l| l.internal_items).sum();
+    assert_eq!(report.total_items, lang_total);
+    assert_eq!(report.public_items, lang_pub);
+    assert_eq!(report.internal_items, lang_int);
+    assert_eq!(
+        report.total_items,
+        report.public_items + report.internal_items
+    );
+    assert_eq!(report.by_language.len(), 6);
+}
+
+#[test]
+fn public_ratio_computed_correctly() {
+    let code = "pub fn a() {}\npub fn b() {}\nfn c() {}\nfn d() {}\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.total_items, 4);
+    assert_eq!(report.public_items, 2);
+    assert_eq!(report.public_ratio, 0.5);
+}
+
+#[test]
+fn documented_ratio_computed_correctly() {
+    let code = concat!(
+        "/// Documented public\n",
+        "pub fn documented() {}\n",
+        "pub fn undocumented() {}\n",
+    );
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 2);
+    assert_eq!(report.documented_ratio, 0.5);
+}
+
+#[test]
+fn top_exporters_contain_correct_counts() {
+    let code_a = "pub fn one() {}\npub fn two() {}\npub fn three() {}\n";
+    let code_b = "pub fn only_one() {}\nfn priv_b() {}\n";
+    let (dir, paths) = write_temp_files(&[("big.rs", code_a), ("small.rs", code_b)]);
+    let export = make_export(vec![
+        make_row("big.rs", "src", "Rust"),
+        make_row("small.rs", "src", "Rust"),
+    ]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.top_exporters.len(), 2);
+    // Sorted by public_items descending
+    assert_eq!(report.top_exporters[0].public_items, 3);
+    assert_eq!(report.top_exporters[1].public_items, 1);
+}
+
+#[test]
+fn by_module_aggregates_across_files_in_same_module() {
+    let code_a = "pub fn a1() {}\nfn a2() {}\n";
+    let code_b = "pub fn b1() {}\npub fn b2() {}\n";
+    let (dir, paths) = write_temp_files(&[("src/a.rs", code_a), ("src/b.rs", code_b)]);
+    let export = make_export(vec![
+        make_row("src/a.rs", "src", "Rust"),
+        make_row("src/b.rs", "src", "Rust"),
+    ]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.by_module.len(), 1);
+    assert_eq!(report.by_module[0].module, "src");
+    assert_eq!(report.by_module[0].total_items, 4);
+    assert_eq!(report.by_module[0].public_items, 3);
+}
+
+#[test]
+fn by_language_shows_per_lang_breakdown() {
+    let rust = "pub fn r() {}\nfn r2() {}\n";
+    let py = "def py_pub():\n    pass\n";
+    let (dir, paths) = write_temp_files(&[("lib.rs", rust), ("main.py", py)]);
+    let export = make_export(vec![
+        make_row("lib.rs", "src", "Rust"),
+        make_row("main.py", "py", "Python"),
+    ]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.by_language.len(), 2);
+    let rust_surface = &report.by_language["Rust"];
+    assert_eq!(rust_surface.total_items, 2);
+    assert_eq!(rust_surface.public_items, 1);
+    assert_eq!(rust_surface.internal_items, 1);
+    assert_eq!(rust_surface.public_ratio, 0.5);
+
+    let py_surface = &report.by_language["Python"];
+    assert_eq!(py_surface.total_items, 1);
+    assert_eq!(py_surface.public_items, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Serialization roundtrip of results
+// ---------------------------------------------------------------------------
+
+#[test]
+fn report_json_roundtrip_preserves_all_fields() {
+    let code = concat!(
+        "/// Documented\n",
+        "pub fn documented() {}\n",
+        "pub struct Config {}\n",
+        "fn private_fn() {}\n",
+        "enum InternalEnum {}\n",
+    );
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", "src", "Rust")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let deserialized: ApiSurfaceReport = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.total_items, report.total_items);
+    assert_eq!(deserialized.public_items, report.public_items);
+    assert_eq!(deserialized.internal_items, report.internal_items);
+    assert_eq!(deserialized.public_ratio, report.public_ratio);
+    assert_eq!(deserialized.documented_ratio, report.documented_ratio);
+    assert_eq!(deserialized.by_language.len(), report.by_language.len());
+    assert_eq!(deserialized.by_module.len(), report.by_module.len());
+    assert_eq!(deserialized.top_exporters.len(), report.top_exporters.len());
+    for (key, orig) in &report.by_language {
+        let deser = &deserialized.by_language[key];
+        assert_eq!(deser.total_items, orig.total_items);
+        assert_eq!(deser.public_items, orig.public_items);
+        assert_eq!(deser.internal_items, orig.internal_items);
+        assert_eq!(deser.public_ratio, orig.public_ratio);
+    }
+}
+
+#[test]
+fn empty_report_serializes_and_deserializes() {
+    let dir = tempfile::tempdir().unwrap();
+    let export = make_export(vec![]);
+    let report = build_api_surface_report(dir.path(), &[], &export, &default_limits()).unwrap();
+
+    let json = serde_json::to_string(&report).unwrap();
+    let deserialized: ApiSurfaceReport = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.total_items, 0);
+    assert!(deserialized.by_language.is_empty());
+    assert!(deserialized.by_module.is_empty());
+    assert!(deserialized.top_exporters.is_empty());
+}
+
+#[test]
+fn lang_api_surface_json_roundtrip() {
+    let surface = LangApiSurface {
+        total_items: 10,
+        public_items: 7,
+        internal_items: 3,
+        public_ratio: 0.7,
+    };
+    let json = serde_json::to_string(&surface).unwrap();
+    let deser: LangApiSurface = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.total_items, 10);
+    assert_eq!(deser.public_items, 7);
+    assert_eq!(deser.internal_items, 3);
+    assert_eq!(deser.public_ratio, 0.7);
+}
+
+#[test]
+fn module_api_row_json_roundtrip() {
+    let row = ModuleApiRow {
+        module: "core".to_string(),
+        total_items: 20,
+        public_items: 15,
+        public_ratio: 0.75,
+    };
+    let json = serde_json::to_string(&row).unwrap();
+    let deser: ModuleApiRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.module, "core");
+    assert_eq!(deser.total_items, 20);
+}
+
+#[test]
+fn api_export_item_json_roundtrip() {
+    let item = ApiExportItem {
+        path: "src/lib.rs".to_string(),
+        lang: "Rust".to_string(),
+        public_items: 5,
+        total_items: 8,
+    };
+    let json = serde_json::to_string(&item).unwrap();
+    let deser: ApiExportItem = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.path, "src/lib.rs");
+    assert_eq!(deser.public_items, 5);
+}
+
+// ---------------------------------------------------------------------------
+// 7. Deterministic results
+// ---------------------------------------------------------------------------
+
+#[test]
+fn report_is_deterministic_across_multiple_runs() {
+    let code = concat!(
+        "pub fn alpha() {}\n",
+        "pub struct Beta {}\n",
+        "fn gamma() {}\n",
+        "pub enum Delta {}\n",
+        "/// Doc\npub trait Epsilon {}\n",
+    );
+    let (dir, paths) = write_temp_files(&[("lib.rs", code)]);
+    let export = make_export(vec![make_row("lib.rs", "src", "Rust")]);
+
+    let report1 = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+    let report2 = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    let json1 = serde_json::to_string(&report1).unwrap();
+    let json2 = serde_json::to_string(&report2).unwrap();
+    assert_eq!(json1, json2, "Reports should be byte-identical");
+}
+
+#[test]
+fn multi_file_report_is_deterministic() {
+    let code_a = "pub fn a() {}\nfn a_priv() {}\n";
+    let code_b = "pub struct B {}\nenum BPriv {}\n";
+    let code_c = "export function cPub() {}\nfunction cPriv() {}\n";
+
+    let (dir, paths) = write_temp_files(&[("a.rs", code_a), ("b.rs", code_b), ("c.js", code_c)]);
+    let export = make_export(vec![
+        make_row("a.rs", "src", "Rust"),
+        make_row("b.rs", "src", "Rust"),
+        make_row("c.js", "web", "JavaScript"),
+    ]);
+
+    let report1 = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+    let report2 = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    let json1 = serde_json::to_string(&report1).unwrap();
+    let json2 = serde_json::to_string(&report2).unwrap();
+    assert_eq!(json1, json2);
+}
+
+#[test]
+fn by_language_uses_btreemap_for_stable_ordering() {
+    let rust = "pub fn r() {}\n";
+    let js = "export function j() {}\n";
+    let py = "def p():\n    pass\n";
+
+    let (dir, paths) = write_temp_files(&[("lib.rs", rust), ("index.js", js), ("main.py", py)]);
+    let export = make_export(vec![
+        make_row("lib.rs", "src", "Rust"),
+        make_row("index.js", "web", "JavaScript"),
+        make_row("main.py", "py", "Python"),
+    ]);
+
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+    let keys: Vec<&String> = report.by_language.keys().collect();
+    let mut sorted_keys = keys.clone();
+    sorted_keys.sort();
+    assert_eq!(
+        keys, sorted_keys,
+        "by_language keys should be sorted (BTreeMap)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Additional edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn max_bytes_limit_stops_processing_early() {
+    let code = "pub fn found() {}\n";
+    let (dir, paths) = write_temp_files(&[("a.rs", code), ("b.rs", code)]);
+    let export = make_export(vec![
+        make_row("a.rs", "src", "Rust"),
+        make_row("b.rs", "src", "Rust"),
+    ]);
+
+    let limits = AnalysisLimits {
+        max_bytes: Some(5),
+        ..Default::default()
+    };
+    let report = build_api_surface_report(dir.path(), &paths, &export, &limits).unwrap();
+    // With a tiny budget, at most one file is processed
+    assert!(report.public_items <= 1);
+}
+
+#[test]
+fn js_ts_all_export_forms_detected() {
+    let code = concat!(
+        "export function fn1() {}\n",
+        "export async function fn2() {}\n",
+        "export class Cls1 {}\n",
+        "export const CONST1 = 1;\n",
+        "export let let1 = 2;\n",
+        "export default function main() {}\n",
+        "export interface IFace {}\n",
+        "export type MyType = string;\n",
+        "export enum MyEnum {}\n",
+        "export abstract class AbsCls {}\n",
+    );
+    let (dir, paths) = write_temp_files(&[("all.ts", code)]);
+    let export = make_export(vec![make_row("all.ts", "src", "TypeScript")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 10);
+}
+
+#[test]
+fn go_method_receiver_public_and_private() {
+    let code = concat!(
+        "func (s *Server) Start() {}\n",
+        "func (s *Server) stop() {}\n",
+        "type Config struct {}\n",
+        "type config struct {}\n",
+    );
+    let (dir, paths) = write_temp_files(&[("server.go", code)]);
+    let export = make_export(vec![make_row("server.go", "pkg", "Go")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 2); // Start, Config
+    assert_eq!(report.internal_items, 2); // stop, config
+}
+
+#[test]
+fn java_public_method_with_return_type_detected() {
+    let code = concat!(
+        "public String getName() { return name; }\n",
+        "public void setName(String name) { this.name = name; }\n",
+        "private int count() { return 0; }\n",
+    );
+    let (dir, paths) = write_temp_files(&[("Bean.java", code)]);
+    let export = make_export(vec![make_row("Bean.java", "com", "Java")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 2);
+    assert_eq!(report.internal_items, 1);
+}
+
+#[test]
+fn python_docstring_detection_across_forms() {
+    let code = concat!(
+        "def documented():\n",
+        "    \"\"\"Has docstring.\"\"\"\n",
+        "    pass\n",
+        "\n",
+        "def also_documented():\n",
+        "    '''Single-quote docstring.'''\n",
+        "    pass\n",
+        "\n",
+        "def undocumented():\n",
+        "    pass\n",
+    );
+    let (dir, paths) = write_temp_files(&[("mod.py", code)]);
+    let export = make_export(vec![make_row("mod.py", "pkg", "Python")]);
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    assert_eq!(report.public_items, 3);
+    // documented + also_documented have docstrings
+    assert!(report.documented_ratio > 0.0);
+}
+
+#[test]
+fn child_file_rows_are_ignored() {
+    let code = "pub fn visible() {}\n";
+    let (dir, paths) = write_temp_files(&[("child.rs", code)]);
+    let export = ExportData {
+        rows: vec![FileRow {
+            path: "child.rs".to_string(),
+            module: "src".to_string(),
+            lang: "Rust".to_string(),
+            kind: FileKind::Child,
+            code: 10,
+            comments: 0,
+            blanks: 0,
+            lines: 10,
+            bytes: 50,
+            tokens: 20,
+        }],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+    let report = build_api_surface_report(dir.path(), &paths, &export, &default_limits()).unwrap();
+
+    // Child rows are filtered out of the row_map
+    assert_eq!(report.total_items, 0);
+}

--- a/crates/tokmd-analysis-content/Cargo.toml
+++ b/crates/tokmd-analysis-content/Cargo.toml
@@ -23,4 +23,5 @@ blake3.workspace = true
 
 [dev-dependencies]
 proptest = "1.10.0"
+serde_json = "1"
 tempfile = "3.23.0"

--- a/crates/tokmd-analysis-content/tests/deep.rs
+++ b/crates/tokmd-analysis-content/tests/deep.rs
@@ -1,0 +1,941 @@
+//! Deep integration tests for `tokmd-analysis-content`.
+//!
+//! Covers: TODO detection in various comment styles, import/dependency
+//! extraction, duplicate detection, empty file handling, large file handling,
+//! and serialization of results.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use tokmd_analysis_content::{
+    ContentLimits, ImportGranularity, build_duplicate_report, build_import_report,
+    build_todo_report,
+};
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn file_row(path: &str, module: &str, lang: &str, bytes: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code: 10,
+        comments: 2,
+        blanks: 1,
+        lines: 13,
+        bytes,
+        tokens: 80,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. TODO detection in various comment styles
+// ---------------------------------------------------------------------------
+
+#[test]
+fn todo_in_c_style_line_comment() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("main.rs"),
+        "// TODO: implement this\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("main.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 1);
+    let tags: BTreeMap<String, usize> = report
+        .tags
+        .iter()
+        .map(|t| (t.tag.clone(), t.count))
+        .collect();
+    assert_eq!(tags.get("TODO"), Some(&1));
+}
+
+#[test]
+fn fixme_in_block_comment() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("code.c"),
+        "/* FIXME: memory leak */\nint x = 0;\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("code.c")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 500).unwrap();
+
+    assert_eq!(report.total, 1);
+    let tags: BTreeMap<String, usize> = report
+        .tags
+        .iter()
+        .map(|t| (t.tag.clone(), t.count))
+        .collect();
+    assert_eq!(tags.get("FIXME"), Some(&1));
+}
+
+#[test]
+fn hack_in_python_comment() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("script.py"),
+        "# HACK: workaround for bug\ndef main():\n    pass\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("script.py")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 500).unwrap();
+
+    assert_eq!(report.total, 1);
+    let tags: BTreeMap<String, usize> = report
+        .tags
+        .iter()
+        .map(|t| (t.tag.clone(), t.count))
+        .collect();
+    assert_eq!(tags.get("HACK"), Some(&1));
+}
+
+#[test]
+fn xxx_tag_detected() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("code.rs"), "// XXX: needs review\nfn foo() {}\n").unwrap();
+
+    let files = vec![PathBuf::from("code.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 500).unwrap();
+
+    assert_eq!(report.total, 1);
+    let tags: BTreeMap<String, usize> = report
+        .tags
+        .iter()
+        .map(|t| (t.tag.clone(), t.count))
+        .collect();
+    assert_eq!(tags.get("XXX"), Some(&1));
+}
+
+#[test]
+fn all_four_tags_in_one_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let content = concat!(
+        "// TODO: first\n",
+        "// FIXME: second\n",
+        "// HACK: third\n",
+        "// XXX: fourth\n",
+        "fn main() {}\n",
+    );
+    std::fs::write(root.join("mixed.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("mixed.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 4);
+    let tags: BTreeMap<String, usize> = report
+        .tags
+        .iter()
+        .map(|t| (t.tag.clone(), t.count))
+        .collect();
+    assert_eq!(tags.get("TODO"), Some(&1));
+    assert_eq!(tags.get("FIXME"), Some(&1));
+    assert_eq!(tags.get("HACK"), Some(&1));
+    assert_eq!(tags.get("XXX"), Some(&1));
+}
+
+#[test]
+fn multiple_todos_on_same_line() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("double.rs"),
+        "// TODO: first TODO: second on same line\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("double.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 2);
+}
+
+#[test]
+fn case_insensitive_todo_detection() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("case.rs"),
+        "// todo: lowercase\n// Todo: mixed\n// TODO: upper\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("case.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    // count_tags does case-insensitive matching
+    assert_eq!(report.total, 3);
+}
+
+#[test]
+fn todos_across_multiple_files() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("a.rs"), "// TODO: in file a\n").unwrap();
+    std::fs::write(root.join("b.rs"), "// TODO: in file b\n// FIXME: also b\n").unwrap();
+
+    let files = vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 3);
+}
+
+#[test]
+fn todo_density_calculation() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("code.rs"),
+        "// TODO: a\n// TODO: b\n// TODO: c\n// TODO: d\n// TODO: e\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("code.rs")];
+    // 5 TODOs in 2000 lines of code = 2.5 per kLOC
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 2000).unwrap();
+
+    assert_eq!(report.total, 5);
+    assert_eq!(report.density_per_kloc, 2.5);
+}
+
+#[test]
+fn zero_code_lines_density_is_zero() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("code.rs"), "// TODO: something\n").unwrap();
+
+    let files = vec![PathBuf::from("code.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 0).unwrap();
+
+    assert_eq!(report.total, 1);
+    assert_eq!(report.density_per_kloc, 0.0);
+}
+
+#[test]
+fn binary_file_skipped_for_todo_scan() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("binary.bin"), b"\x00\x01\x02TODO\x00\xff").unwrap();
+
+    let files = vec![PathBuf::from("binary.bin")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 0);
+}
+
+#[test]
+fn no_tags_file_returns_zero_total() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("clean.rs"),
+        "fn main() {\n    println!(\"hello\");\n}\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("clean.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 500).unwrap();
+
+    assert_eq!(report.total, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Import/dependency extraction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rust_use_statements_extracted() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("lib.rs"),
+        "use std::io;\nuse serde::Serialize;\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("lib.rs")];
+    let export = make_export(vec![file_row("lib.rs", "src", "Rust", 60)]);
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::Module,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert!(report.edges.len() >= 2);
+    assert_eq!(report.granularity, "module");
+}
+
+#[test]
+fn python_imports_extracted() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("app.py"),
+        "import os\nimport sys\nfrom pathlib import Path\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("app.py")];
+    let export = make_export(vec![file_row("app.py", "src", "Python", 50)]);
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::Module,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert!(report.edges.len() >= 2);
+    assert!(report.edges.iter().all(|e| e.from == "src"));
+}
+
+#[test]
+fn typescript_imports_extracted() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("index.ts"),
+        "import React from \"react\";\nimport { useState } from \"react\";\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("index.ts")];
+    let export = make_export(vec![file_row("index.ts", "web", "TypeScript", 70)]);
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::Module,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert!(!report.edges.is_empty());
+    assert!(report.edges.iter().all(|e| e.from == "web"));
+}
+
+#[test]
+fn file_granularity_uses_file_path_as_from() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("main.py"), "import requests\n").unwrap();
+
+    let files = vec![PathBuf::from("main.py")];
+    let export = make_export(vec![file_row("main.py", "pkg", "Python", 20)]);
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::File,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert_eq!(report.granularity, "file");
+    assert_eq!(report.edges.len(), 1);
+    assert_eq!(report.edges[0].from, "main.py");
+}
+
+#[test]
+fn unsupported_language_skipped_for_imports() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("data.json"), "{\"import\": \"not real\"}\n").unwrap();
+
+    let files = vec![PathBuf::from("data.json")];
+    let export = make_export(vec![file_row("data.json", "root", "JSON", 30)]);
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::Module,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert!(report.edges.is_empty());
+}
+
+#[test]
+fn import_edges_sorted_by_count_descending() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    // Multiple use of serde, single use of tokio
+    std::fs::write(
+        root.join("lib.rs"),
+        "use serde::Serialize;\nuse serde::Deserialize;\nuse tokio::spawn;\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("lib.rs")];
+    let export = make_export(vec![file_row("lib.rs", "src", "Rust", 80)]);
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::Module,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    for w in report.edges.windows(2) {
+        assert!(
+            w[0].count >= w[1].count,
+            "edges not sorted by count desc: {} < {}",
+            w[0].count,
+            w[1].count
+        );
+    }
+}
+
+#[test]
+fn import_max_bytes_budget_respected() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("a.py"), "import os\n").unwrap();
+    std::fs::write(root.join("b.py"), "import sys\n").unwrap();
+
+    let files = vec![PathBuf::from("a.py"), PathBuf::from("b.py")];
+    let export = make_export(vec![
+        file_row("a.py", "root", "Python", 10),
+        file_row("b.py", "root", "Python", 10),
+    ]);
+
+    let limits = ContentLimits {
+        max_bytes: Some(5),
+        max_file_bytes: None,
+    };
+    let report =
+        build_import_report(root, &files, &export, ImportGranularity::Module, &limits).unwrap();
+
+    assert!(report.edges.len() <= 1);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Duplicate detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_identical_files_form_one_group() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let content = "fn duplicate() { println!(\"hello\"); }\n";
+    std::fs::write(root.join("a.rs"), content).unwrap();
+    std::fs::write(root.join("b.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")];
+    let export = make_export(vec![
+        file_row("a.rs", "root", "Rust", content.len()),
+        file_row("b.rs", "root", "Rust", content.len()),
+    ]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    assert_eq!(report.groups.len(), 1);
+    assert_eq!(report.groups[0].files.len(), 2);
+    assert_eq!(report.wasted_bytes, content.len() as u64);
+    assert_eq!(report.strategy, "exact-blake3");
+}
+
+#[test]
+fn three_identical_files_waste_2x_size() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let content = "identical content for triplication\n";
+    std::fs::write(root.join("a.txt"), content).unwrap();
+    std::fs::write(root.join("b.txt"), content).unwrap();
+    std::fs::write(root.join("c.txt"), content).unwrap();
+
+    let files = vec![
+        PathBuf::from("a.txt"),
+        PathBuf::from("b.txt"),
+        PathBuf::from("c.txt"),
+    ];
+    let export = make_export(vec![
+        file_row("a.txt", "root", "Text", content.len()),
+        file_row("b.txt", "root", "Text", content.len()),
+        file_row("c.txt", "root", "Text", content.len()),
+    ]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    assert_eq!(report.groups.len(), 1);
+    assert_eq!(report.wasted_bytes, 2 * content.len() as u64);
+}
+
+#[test]
+fn no_duplicates_yields_empty_groups() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("x.rs"), "fn unique_x() {}\n").unwrap();
+    std::fs::write(root.join("y.rs"), "fn unique_y() {}\n").unwrap();
+
+    let files = vec![PathBuf::from("x.rs"), PathBuf::from("y.rs")];
+    let export = make_export(vec![
+        file_row("x.rs", "root", "Rust", 18),
+        file_row("y.rs", "root", "Rust", 18),
+    ]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    assert!(report.groups.is_empty());
+    assert_eq!(report.wasted_bytes, 0);
+}
+
+#[test]
+fn duplicate_groups_sorted_by_size_descending() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let small = "sm\n";
+    let large = "x".repeat(200) + "\n";
+    std::fs::write(root.join("s1.txt"), small).unwrap();
+    std::fs::write(root.join("s2.txt"), small).unwrap();
+    std::fs::write(root.join("l1.txt"), &large).unwrap();
+    std::fs::write(root.join("l2.txt"), &large).unwrap();
+
+    let files = vec![
+        PathBuf::from("s1.txt"),
+        PathBuf::from("s2.txt"),
+        PathBuf::from("l1.txt"),
+        PathBuf::from("l2.txt"),
+    ];
+    let export = make_export(vec![]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    assert_eq!(report.groups.len(), 2);
+    assert!(report.groups[0].bytes >= report.groups[1].bytes);
+}
+
+#[test]
+fn duplicate_files_within_group_sorted_alphabetically() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let content = "same content for sort test\n";
+    std::fs::write(root.join("z.txt"), content).unwrap();
+    std::fs::write(root.join("a.txt"), content).unwrap();
+    std::fs::write(root.join("m.txt"), content).unwrap();
+
+    let files = vec![
+        PathBuf::from("z.txt"),
+        PathBuf::from("a.txt"),
+        PathBuf::from("m.txt"),
+    ];
+    let export = make_export(vec![]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    assert_eq!(report.groups.len(), 1);
+    let group_files = &report.groups[0].files;
+    let mut sorted = group_files.clone();
+    sorted.sort();
+    assert_eq!(group_files, &sorted, "files within group should be sorted");
+}
+
+#[test]
+fn density_report_has_correct_metrics() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let content = "exactly same content for density test\n";
+    std::fs::write(root.join("d1.rs"), content).unwrap();
+    std::fs::write(root.join("d2.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("d1.rs"), PathBuf::from("d2.rs")];
+    let export = make_export(vec![
+        file_row("d1.rs", "src", "Rust", content.len()),
+        file_row("d2.rs", "src", "Rust", content.len()),
+    ]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    let density = report.density.as_ref().expect("density present");
+    assert_eq!(density.duplicate_groups, 1);
+    assert_eq!(density.duplicate_files, 2);
+    assert_eq!(density.wasted_bytes, content.len() as u64);
+    assert!(density.wasted_pct_of_codebase > 0.0);
+}
+
+#[test]
+fn density_by_module_tracks_per_module_metrics() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::create_dir_all(root.join("mod_a")).unwrap();
+    std::fs::create_dir_all(root.join("mod_b")).unwrap();
+
+    let content = "cross-module duplicate content\n";
+    std::fs::write(root.join("mod_a/dup.rs"), content).unwrap();
+    std::fs::write(root.join("mod_b/dup.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("mod_a/dup.rs"), PathBuf::from("mod_b/dup.rs")];
+    let export = make_export(vec![
+        file_row("mod_a/dup.rs", "mod_a", "Rust", content.len()),
+        file_row("mod_b/dup.rs", "mod_b", "Rust", content.len()),
+    ]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    let density = report.density.as_ref().expect("density present");
+    assert!(density.by_module.len() >= 2);
+}
+
+#[test]
+fn max_file_bytes_skips_large_files_for_duplicates() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let big = "x".repeat(1000);
+    std::fs::write(root.join("big1.txt"), &big).unwrap();
+    std::fs::write(root.join("big2.txt"), &big).unwrap();
+
+    let files = vec![PathBuf::from("big1.txt"), PathBuf::from("big2.txt")];
+    let limits = ContentLimits {
+        max_bytes: None,
+        max_file_bytes: Some(100),
+    };
+    let report = build_duplicate_report(root, &files, &make_export(vec![]), &limits).unwrap();
+
+    assert!(report.groups.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 4. Empty file handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_file_list_todo_report() {
+    let temp = tempfile::tempdir().unwrap();
+    let report = build_todo_report(temp.path(), &[], &ContentLimits::default(), 1000).unwrap();
+
+    assert_eq!(report.total, 0);
+    assert_eq!(report.density_per_kloc, 0.0);
+}
+
+#[test]
+fn empty_file_list_duplicate_report() {
+    let temp = tempfile::tempdir().unwrap();
+    let report = build_duplicate_report(
+        temp.path(),
+        &[],
+        &make_export(vec![]),
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert!(report.groups.is_empty());
+    assert_eq!(report.wasted_bytes, 0);
+}
+
+#[test]
+fn empty_file_list_import_report() {
+    let temp = tempfile::tempdir().unwrap();
+    let report = build_import_report(
+        temp.path(),
+        &[],
+        &make_export(vec![]),
+        ImportGranularity::Module,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert!(report.edges.is_empty());
+    assert_eq!(report.granularity, "module");
+}
+
+#[test]
+fn zero_byte_files_not_treated_as_duplicates() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("empty1.txt"), "").unwrap();
+    std::fs::write(root.join("empty2.txt"), "").unwrap();
+
+    let files = vec![PathBuf::from("empty1.txt"), PathBuf::from("empty2.txt")];
+    let report = build_duplicate_report(
+        root,
+        &files,
+        &make_export(vec![]),
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert!(report.groups.is_empty());
+}
+
+#[test]
+fn empty_text_file_for_todo_yields_zero() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("blank.rs"), "").unwrap();
+
+    let files = vec![PathBuf::from("blank.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 500).unwrap();
+
+    assert_eq!(report.total, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Large file handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn large_file_todo_scan_with_max_file_bytes() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    // Create a file with TODO at the end, beyond the byte limit
+    let mut content = String::new();
+    for _ in 0..500 {
+        content.push_str("// normal line of code\n");
+    }
+    content.push_str("// TODO: hidden at end\n");
+    std::fs::write(root.join("large.rs"), &content).unwrap();
+
+    let files = vec![PathBuf::from("large.rs")];
+    let limits = ContentLimits {
+        max_bytes: None,
+        max_file_bytes: Some(200),
+    };
+    let report = build_todo_report(root, &files, &limits, 1000).unwrap();
+
+    // With 200 byte limit, the TODO at the end should not be found
+    assert_eq!(report.total, 0);
+}
+
+#[test]
+fn large_file_todo_scan_within_limits_finds_tags() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    // TODO at the start, within limits
+    let mut content = String::from("// TODO: found at start\n");
+    for _ in 0..500 {
+        content.push_str("// normal line\n");
+    }
+    std::fs::write(root.join("large.rs"), &content).unwrap();
+
+    let files = vec![PathBuf::from("large.rs")];
+    let limits = ContentLimits {
+        max_bytes: None,
+        max_file_bytes: Some(200),
+    };
+    let report = build_todo_report(root, &files, &limits, 1000).unwrap();
+
+    assert_eq!(report.total, 1);
+}
+
+#[test]
+fn max_bytes_budget_limits_total_processing() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    std::fs::write(root.join("f1.rs"), "// TODO: in file 1\n").unwrap();
+    std::fs::write(root.join("f2.rs"), "// TODO: in file 2\n").unwrap();
+    std::fs::write(root.join("f3.rs"), "// TODO: in file 3\n").unwrap();
+
+    let files = vec![
+        PathBuf::from("f1.rs"),
+        PathBuf::from("f2.rs"),
+        PathBuf::from("f3.rs"),
+    ];
+    let limits = ContentLimits {
+        max_bytes: Some(15),
+        max_file_bytes: None,
+    };
+    let report = build_todo_report(root, &files, &limits, 1000).unwrap();
+
+    // With a tiny budget, not all files are scanned
+    assert!(report.total < 3);
+}
+
+#[test]
+fn many_duplicate_files_produces_correct_wasted_bytes() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let content = "common content for many-file test\n";
+    let mut files = Vec::new();
+    for i in 0..10 {
+        let name = format!("file{}.txt", i);
+        std::fs::write(root.join(&name), content).unwrap();
+        files.push(PathBuf::from(name));
+    }
+
+    let report = build_duplicate_report(
+        root,
+        &files,
+        &make_export(vec![]),
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    assert_eq!(report.groups.len(), 1);
+    assert_eq!(report.groups[0].files.len(), 10);
+    // 9 copies are "wasted"
+    assert_eq!(report.wasted_bytes, 9 * content.len() as u64);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Serialization of results
+// ---------------------------------------------------------------------------
+
+#[test]
+fn todo_report_serializes_to_json() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("code.rs"),
+        "// TODO: first\n// FIXME: second\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("code.rs")];
+    let report = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    let json = serde_json::to_string(&report).unwrap();
+    assert!(json.contains("\"total\""));
+    assert!(json.contains("\"density_per_kloc\""));
+    assert!(json.contains("\"tags\""));
+
+    let deser: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser["total"], 2);
+}
+
+#[test]
+fn duplicate_report_serializes_to_json() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let content = "duplicate content for serialization test\n";
+    std::fs::write(root.join("a.rs"), content).unwrap();
+    std::fs::write(root.join("b.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")];
+    let export = make_export(vec![
+        file_row("a.rs", "root", "Rust", content.len()),
+        file_row("b.rs", "root", "Rust", content.len()),
+    ]);
+    let report = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    let json = serde_json::to_string(&report).unwrap();
+    assert!(json.contains("\"groups\""));
+    assert!(json.contains("\"wasted_bytes\""));
+    assert!(json.contains("\"strategy\""));
+    assert!(json.contains("exact-blake3"));
+
+    let deser: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser["groups"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn import_report_serializes_to_json() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("lib.rs"), "use serde::Serialize;\n").unwrap();
+
+    let files = vec![PathBuf::from("lib.rs")];
+    let export = make_export(vec![file_row("lib.rs", "src", "Rust", 30)]);
+    let report = build_import_report(
+        root,
+        &files,
+        &export,
+        ImportGranularity::Module,
+        &ContentLimits::default(),
+    )
+    .unwrap();
+
+    let json = serde_json::to_string(&report).unwrap();
+    assert!(json.contains("\"granularity\""));
+    assert!(json.contains("\"edges\""));
+    assert!(json.contains("module"));
+}
+
+#[test]
+fn todo_report_is_deterministic() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("code.rs"),
+        "// TODO: a\n// FIXME: b\n// HACK: c\n// XXX: d\n",
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("code.rs")];
+    let r1 = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+    let r2 = build_todo_report(root, &files, &ContentLimits::default(), 1000).unwrap();
+
+    let j1 = serde_json::to_string(&r1).unwrap();
+    let j2 = serde_json::to_string(&r2).unwrap();
+    assert_eq!(j1, j2, "TODO reports should be deterministic");
+}
+
+#[test]
+fn duplicate_report_is_deterministic() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let content = "deterministic duplicate test content\n";
+    std::fs::write(root.join("a.rs"), content).unwrap();
+    std::fs::write(root.join("b.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")];
+    let export = make_export(vec![
+        file_row("a.rs", "root", "Rust", content.len()),
+        file_row("b.rs", "root", "Rust", content.len()),
+    ]);
+
+    let r1 = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+    let r2 = build_duplicate_report(root, &files, &export, &ContentLimits::default()).unwrap();
+
+    let j1 = serde_json::to_string(&r1).unwrap();
+    let j2 = serde_json::to_string(&r2).unwrap();
+    assert_eq!(j1, j2, "Duplicate reports should be deterministic");
+}
+
+// ---------------------------------------------------------------------------
+// Additional: ContentLimits edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn content_limits_default_has_no_limits() {
+    let limits = ContentLimits::default();
+    assert!(limits.max_bytes.is_none());
+    assert!(limits.max_file_bytes.is_none());
+}
+
+#[test]
+fn content_limits_is_debug_clone_copy() {
+    let limits = ContentLimits {
+        max_bytes: Some(1024),
+        max_file_bytes: Some(512),
+    };
+    let debug = format!("{:?}", limits);
+    assert!(debug.contains("ContentLimits"));
+    let cloned = limits;
+    assert_eq!(cloned.max_bytes, Some(1024));
+    assert_eq!(cloned.max_file_bytes, Some(512));
+}
+
+#[test]
+fn import_granularity_is_debug_clone_copy() {
+    let g = ImportGranularity::Module;
+    let debug = format!("{:?}", g);
+    assert!(debug.contains("Module"));
+    let _copy = g;
+}


### PR DESCRIPTION
Add comprehensive test suites for `tokmd-analysis-api-surface` (33 tests) and `tokmd-analysis-content` (44 tests).

## API Surface Tests (33 tests)
- Public function/struct/enum/trait/type detection for Rust
- JavaScript/TypeScript export form detection  
- Python docstring detection across forms
- Go public/private method receiver detection
- Java public method detection
- Empty file, comment-only file, and binary file handling
- Child file row filtering
- Multi-language item count consistency
- by_module aggregation and by_language breakdown
- max_bytes limit processing
- JSON serialization roundtrip for all report types
- Deterministic output across multiple runs

## Content Tests (44 tests)
- TODO/FIXME/HACK/XXX tag detection (case-insensitive)
- Block comment and multi-line detection
- Density calculation and per-module breakdown
- Rust use, Python import, TypeScript import extraction
- Module vs File granularity for imports
- Exact BLAKE3 duplicate detection
- Zero-byte file exclusion from duplicates
- Wasted bytes and group sorting
- max_bytes and max_file_bytes budget limits
- JSON serialization roundtrip for all report types
- Deterministic output across multiple runs