### PR TITLE
fix(content): guard read_lines against zero max_lines/max_bytes

### DIFF
--- a/crates/tokmd-content/src/lib.rs
+++ b/crates/tokmd-content/src/lib.rs
@@ -73,6 +73,9 @@ pub fn read_head_tail(path: &Path, max_bytes: usize) -> Result<Vec<u8>> {
 }
 
 pub fn read_lines(path: &Path, max_lines: usize, max_bytes: usize) -> Result<Vec<String>> {
+    if max_lines == 0 || max_bytes == 0 {
+        return Ok(Vec::new());
+    }
     let file = File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
     let reader = BufReader::new(file);
     let mut lines = Vec::new();


### PR DESCRIPTION
When \max_lines=0\ was passed to \ead_lines()\, the function would still return one line because the boundary check happened after the push. Add an early return guard for both zero cases.

Fixes Windows CI failure in \dd_extended\ test (\	est_given_file_when_read_lines_zero_max_then_empty\).