### PR TITLE
fix: repair mismatched braces in proptest_deep.rs files

### DIFF
--- a/crates/tokmd-format/tests/proptest_deep.rs
+++ b/crates/tokmd-format/tests/proptest_deep.rs
@@ -17,18 +17,6 @@ use tokmd_types::{
     ModuleArgs, ModuleReport, ModuleRow, RedactMode, TableFormat, Totals,
 };
 
-// ---------------------------------------------------------------------------
-// Strategies (copied from existing properties.rs to ensure consistency)
-// ---------------------------------------------------------------------------
-//! Covers: diff row symmetry, diff totals idempotency,
-//! output determinism across formats, and structural invariants.
-
-use proptest::prelude::*;
-
-use tokmd_format::{compute_diff_rows, compute_diff_totals};
-use tokmd_settings::ChildrenMode;
-use tokmd_types::{LangReport, LangRow, Totals};
-
 // =========================================================================
 // Strategies
 // =========================================================================
@@ -36,7 +24,14 @@ use tokmd_types::{LangReport, LangRow, Totals};
 fn arb_lang_row() -> impl Strategy<Value = LangRow> {
     (
         prop::sample::select(vec![
-            "Rust", "Python", "Go", "Java", "C", "TOML", "YAML", "JSON",
+            "Rust",
+            "Python",
+            "Go",
+            "Java",
+            "C",
+            "TOML",
+            "YAML",
+            "JSON",
             "Rust",
             "Python",
             "Go",
@@ -62,7 +57,6 @@ fn arb_lang_row() -> impl Strategy<Value = LangRow> {
 }
 
 fn arb_lang_report() -> impl Strategy<Value = LangReport> {
-    prop::collection::vec(arb_lang_row(), 1..6).prop_map(|rows| {
     prop::collection::vec(arb_lang_row(), 1..8).prop_map(|rows| {
         let mut seen = std::collections::HashSet::new();
         let rows: Vec<LangRow> = rows
@@ -343,8 +337,13 @@ proptest! {
 }
 
 // ---------------------------------------------------------------------------
-// CSV: consistent column count
+// Diff: self-diff produces zero deltas
 // ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
     fn self_diff_produces_zero_deltas(report in arb_lang_report()) {
         let rows = compute_diff_rows(&report, &report);
         for row in &rows {
@@ -461,8 +460,13 @@ proptest! {
 }
 
 // ---------------------------------------------------------------------------
-// JSONL: each line is valid JSON
+// Diff: rows are deterministic
 // ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
     fn diff_rows_are_deterministic(
         from in arb_lang_report(),
         to in arb_lang_report(),
@@ -522,8 +526,13 @@ proptest! {
 }
 
 // ---------------------------------------------------------------------------
-// Diff: row sums equal totals (deep)
+// Diff: row count covers union of languages
 // ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
     fn diff_row_count_is_union_of_languages(
         from in arb_lang_report(),
         to in arb_lang_report(),
@@ -569,6 +578,9 @@ proptest! {
 
         prop_assert_eq!(totals.old_code, totals.new_code);
         prop_assert_eq!(totals.delta_code, 0);
+    }
+
+    #[test]
     fn diff_each_row_delta_consistent(
         from in arb_lang_report(),
         to in arb_lang_report(),

--- a/crates/tokmd-gate/tests/proptest_deep.rs
+++ b/crates/tokmd-gate/tests/proptest_deep.rs
@@ -176,6 +176,12 @@ proptest! {
 
 // =========================================================================
 // Gt/Lt complementary: for a != b, exactly one of (a > b) or (a < b) is true
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
     fn gt_lte_are_complements(a in -500i64..500, b in -500i64..500) {
         let receipt = json!({"n": a});
         let gt_rule = make_test_rule("/n", RuleOperator::Gt, json!(b));
@@ -423,6 +429,8 @@ proptest! {
         let result = evaluate_single_rule(&receipt, &rule);
         prop_assert!(result.passed, "Value equal to threshold should pass gte");
     }
+
+    #[test]
     fn gate_result_counts_consistent(
         n_pass in 0usize..5,
         n_fail_error in 0usize..5,

--- a/crates/tokmd-model/tests/proptest_deep.rs
+++ b/crates/tokmd-model/tests/proptest_deep.rs
@@ -30,7 +30,15 @@ fn arb_lang_row() -> impl Strategy<Value = LangRow> {
     )
         .prop_map(|(lang, code, lines, files, bytes, tokens)| {
             let avg_lines = if files > 0 { lines / files } else { 0 };
-            LangRow { lang, code, lines, files, bytes, tokens, avg_lines }
+            LangRow {
+                lang,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            }
         })
 }
 
@@ -43,15 +51,23 @@ fn arb_module_row() -> impl Strategy<Value = ModuleRow> {
             "benches".to_string(),
             "examples".to_string(),
         ]),
-        1usize..50_000,     // code
-        1usize..100_000,    // lines
-        1usize..500,        // files
-        1usize..5_000_000,  // bytes
-        1usize..500_000,    // tokens
+        1usize..50_000,    // code
+        1usize..100_000,   // lines
+        1usize..500,       // files
+        1usize..5_000_000, // bytes
+        1usize..500_000,   // tokens
     )
         .prop_map(|(module, code, lines, files, bytes, tokens)| {
             let avg_lines = if files > 0 { lines / files } else { 0 };
-            ModuleRow { module, code, lines, files, bytes, tokens, avg_lines }
+            ModuleRow {
+                module,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            }
         })
 }
 
@@ -64,8 +80,13 @@ fn arb_totals() -> impl Strategy<Value = Totals> {
         0usize..10_000_000,
         0usize..5000,
     )
-        .prop_map(|(code, lines, files, bytes, tokens, avg_lines)| {
-            Totals { code, lines, files, bytes, tokens, avg_lines }
+        .prop_map(|(code, lines, files, bytes, tokens, avg_lines)| Totals {
+            code,
+            lines,
+            files,
+            bytes,
+            tokens,
+            avg_lines,
         })
 }
 
@@ -124,10 +145,8 @@ proptest! {
 
 // =========================================================================
 // Totals: serde round-trip
-//! Covers: avg monotonicity, module_key depth constraints,
-//! normalize_path cross-platform equivalence, and aggregation idempotency.
+// =========================================================================
 
-use proptest::prelude::*;
 use std::path::Path;
 use tokmd_model::{avg, module_key, normalize_path};
 
@@ -265,7 +284,13 @@ proptest! {
 }
 
 // =========================================================================
-// LangRow: JSON round-trip preserves all fields
+// module_key: depth constraints
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
     fn module_key_depth_1_max_one_segment(
         parts in prop::collection::vec("[a-z]{2,6}", 2..6),
         filename in "[a-z]{2,6}\\.[a-z]{1,3}",
@@ -349,6 +374,17 @@ proptest! {
         prop_assert_eq!(t.bytes, 0);
         prop_assert_eq!(t.tokens, 0);
         prop_assert_eq!(t.avg_lines, 0);
+    }
+}
+
+// =========================================================================
+// normalize_path: cross-platform equivalence
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
     fn normalize_path_forward_backslash_equivalent(
         parts in prop::collection::vec("[a-z]{2,6}", 2..5),
         filename in "[a-z]{2,6}\\.[a-z]{1,3}",

--- a/crates/tokmd-types/tests/proptest_deep.rs
+++ b/crates/tokmd-types/tests/proptest_deep.rs
@@ -6,10 +6,10 @@
 
 use proptest::prelude::*;
 use tokmd_types::{
-    cockpit::COCKPIT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode, CommitIntentKind, ConfigMode,
-    DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind, InclusionPolicy, RedactMode,
-    TableFormat, TokenEstimationMeta, Totals, CONTEXT_BUNDLE_SCHEMA_VERSION,
-    CONTEXT_SCHEMA_VERSION, HANDOFF_SCHEMA_VERSION, SCHEMA_VERSION,
+    CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode,
+    CommitIntentKind, ConfigMode, DiffRow, DiffTotals, ExportFormat, FileClassification, FileKind,
+    HANDOFF_SCHEMA_VERSION, InclusionPolicy, RedactMode, SCHEMA_VERSION, TableFormat,
+    TokenEstimationMeta, Totals, cockpit::COCKPIT_SCHEMA_VERSION,
 };
 
 // =========================================================================


### PR DESCRIPTION
Fix-forward for main CI: repair syntax errors in proptest_deep.rs test files (mismatched braces in proptest! macro blocks) and fix rustfmt import ordering.

## Changes
- **tokmd-format**: remove duplicate prop_map line in arb_lang_report(), wrap floating diff test functions in proptest! blocks, add missing closing brace and #[test] attributes, remove duplicate imports
- **tokmd-gate**: wrap floating complement tests in proptest! block, add missing #[test] for gate_result_counts_consistent
- **tokmd-model**: wrap floating module_key tests in proptest! block, close totals_zero_construction body, split into separate proptest! block for normalize_path tests, remove duplicate import
- **tokmd-types**: fix rustfmt import ordering

All four crates verified to compile with `cargo test -p <crate> --no-run` and `cargo fmt --check` passes.