### PR TITLE
test(proptest): property test expansion across 5 crates

### DIFF
--- a/crates/tokmd-analysis-complexity/tests/proptest_w40.rs
+++ b/crates/tokmd-analysis-complexity/tests/proptest_w40.rs
@@ -1,0 +1,184 @@
+//! Property-based tests for tokmd-analysis-complexity.
+//!
+//! Covers: histogram invariants, aggregate max bounds,
+//! risk classification ordering, and determinism.
+
+use proptest::prelude::*;
+use tokmd_analysis_complexity::generate_complexity_histogram;
+use tokmd_analysis_types::{ComplexityRisk, FileComplexity};
+
+fn make_file_complexity(path: &str, cyclomatic: usize, functions: usize) -> FileComplexity {
+    FileComplexity {
+        path: path.to_string(),
+        module: "src".to_string(),
+        function_count: functions,
+        max_function_length: functions * 5,
+        cyclomatic_complexity: cyclomatic,
+        cognitive_complexity: None,
+        max_nesting: None,
+        risk_level: ComplexityRisk::Low,
+        functions: None,
+    }
+}
+
+// =========================================================================
+// Histogram: bucket counts sum to total
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn histogram_counts_sum_to_total(
+        complexities in prop::collection::vec(0usize..100, 0..50),
+    ) {
+        let files: Vec<FileComplexity> = complexities.iter().enumerate()
+            .map(|(i, &c)| make_file_complexity(&format!("src/f{}.rs", i), c, 1))
+            .collect();
+
+        let histogram = generate_complexity_histogram(&files, 5);
+        let count_sum: u32 = histogram.counts.iter().sum();
+        prop_assert_eq!(count_sum, histogram.total,
+            "Bucket counts sum {} != total {}", count_sum, histogram.total);
+    }
+
+    #[test]
+    fn histogram_total_equals_file_count(
+        complexities in prop::collection::vec(0usize..100, 0..50),
+    ) {
+        let files: Vec<FileComplexity> = complexities.iter().enumerate()
+            .map(|(i, &c)| make_file_complexity(&format!("src/f{}.rs", i), c, 1))
+            .collect();
+
+        let histogram = generate_complexity_histogram(&files, 5);
+        prop_assert_eq!(histogram.total, files.len() as u32,
+            "Histogram total {} != file count {}", histogram.total, files.len());
+    }
+}
+
+// =========================================================================
+// Histogram: always has 7 buckets
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn histogram_always_seven_buckets(
+        complexities in prop::collection::vec(0usize..200, 0..30),
+    ) {
+        let files: Vec<FileComplexity> = complexities.iter().enumerate()
+            .map(|(i, &c)| make_file_complexity(&format!("src/f{}.rs", i), c, 1))
+            .collect();
+
+        let histogram = generate_complexity_histogram(&files, 5);
+        prop_assert_eq!(histogram.buckets.len(), 7, "Must always have 7 buckets");
+        prop_assert_eq!(histogram.counts.len(), 7, "Must always have 7 count entries");
+    }
+}
+
+// =========================================================================
+// Histogram: bucket boundaries are evenly spaced
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(30))]
+
+    #[test]
+    fn histogram_bucket_boundaries_sequential(
+        bucket_size in 1u32..20,
+        complexities in prop::collection::vec(0usize..100, 1..20),
+    ) {
+        let files: Vec<FileComplexity> = complexities.iter().enumerate()
+            .map(|(i, &c)| make_file_complexity(&format!("src/f{}.rs", i), c, 1))
+            .collect();
+
+        let histogram = generate_complexity_histogram(&files, bucket_size);
+        for (i, &boundary) in histogram.buckets.iter().enumerate() {
+            prop_assert_eq!(boundary, (i as u32) * bucket_size,
+                "Bucket {} boundary {} != expected {}", i, boundary, (i as u32) * bucket_size);
+        }
+    }
+}
+
+// =========================================================================
+// Aggregate max: max >= any individual complexity
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn max_cyclomatic_geq_any_individual(
+        complexities in prop::collection::vec(0usize..200, 1..30),
+    ) {
+        let files: Vec<FileComplexity> = complexities.iter().enumerate()
+            .map(|(i, &c)| make_file_complexity(&format!("src/f{}.rs", i), c, 1))
+            .collect();
+
+        let max_cyclomatic = files.iter().map(|f| f.cyclomatic_complexity).max().unwrap_or(0);
+        for file in &files {
+            prop_assert!(max_cyclomatic >= file.cyclomatic_complexity,
+                "Aggregate max {} < individual {}", max_cyclomatic, file.cyclomatic_complexity);
+        }
+    }
+
+    #[test]
+    fn max_function_length_geq_any_individual(
+        lengths in prop::collection::vec(0usize..500, 1..30),
+    ) {
+        let files: Vec<FileComplexity> = lengths.iter().enumerate()
+            .map(|(i, &l)| {
+                let mut fc = make_file_complexity(&format!("src/f{}.rs", i), 1, 1);
+                fc.max_function_length = l;
+                fc
+            })
+            .collect();
+
+        let aggregate_max = files.iter().map(|f| f.max_function_length).max().unwrap_or(0);
+        for file in &files {
+            prop_assert!(aggregate_max >= file.max_function_length,
+                "Aggregate max_fn_len {} < individual {}", aggregate_max, file.max_function_length);
+        }
+    }
+}
+
+// =========================================================================
+// Histogram: determinism
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn histogram_is_deterministic(
+        complexities in prop::collection::vec(0usize..100, 0..30),
+    ) {
+        let files: Vec<FileComplexity> = complexities.iter().enumerate()
+            .map(|(i, &c)| make_file_complexity(&format!("src/f{}.rs", i), c, 1))
+            .collect();
+
+        let a = generate_complexity_histogram(&files, 5);
+        let b = generate_complexity_histogram(&files, 5);
+        prop_assert_eq!(a.counts, b.counts, "Histogram must be deterministic");
+        prop_assert_eq!(a.total, b.total);
+    }
+}
+
+// =========================================================================
+// Empty input: histogram gracefully handles empty
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn histogram_empty_input_zero_total(
+        bucket_size in 1u32..20,
+    ) {
+        let histogram = generate_complexity_histogram(&[], bucket_size);
+        prop_assert_eq!(histogram.total, 0, "Empty input should have total 0");
+        let sum: u32 = histogram.counts.iter().sum();
+        prop_assert_eq!(sum, 0, "Empty input should have all-zero counts");
+    }
+}

--- a/crates/tokmd-analysis-derived/tests/proptest_w40.rs
+++ b/crates/tokmd-analysis-derived/tests/proptest_w40.rs
@@ -1,0 +1,262 @@
+//! Property-based tests for tokmd-analysis-derived.
+//!
+//! Covers: density bounds, COCOMO monotonicity, distribution invariants,
+//! comment ratio bounds, histogram exhaustiveness, and determinism.
+
+use proptest::prelude::*;
+use tokmd_analysis_derived::derive_report;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+fn make_row(code: usize, comments: usize, blanks: usize) -> FileRow {
+    let lines = code + comments + blanks;
+    FileRow {
+        path: format!("src/file_{}.rs", code ^ comments),
+        module: "src".to_string(),
+        lang: "Rust".to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments,
+        blanks,
+        lines,
+        bytes: lines * 40,
+        tokens: lines * 4,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+// =========================================================================
+// Density: doc_density ratio is always in [0.0, 1.0]
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn doc_density_between_zero_and_one(
+        code in 0usize..5000,
+        comments in 0usize..5000,
+        blanks in 0usize..1000,
+    ) {
+        let export = make_export(vec![make_row(code, comments, blanks)]);
+        let report = derive_report(&export, None);
+        let ratio = report.doc_density.total.ratio;
+        prop_assert!(ratio >= 0.0 && ratio <= 1.0,
+            "doc_density ratio {} out of [0,1] for code={} comments={}", ratio, code, comments);
+    }
+}
+
+// =========================================================================
+// Whitespace ratio: always non-negative, matches blanks/(code+comments)
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn whitespace_ratio_non_negative(
+        code in 0usize..5000,
+        comments in 0usize..5000,
+        blanks in 0usize..5000,
+    ) {
+        let export = make_export(vec![make_row(code, comments, blanks)]);
+        let report = derive_report(&export, None);
+        let ratio = report.whitespace.total.ratio;
+        prop_assert!(ratio >= 0.0,
+            "whitespace ratio {} must be non-negative", ratio);
+        let denom = code + comments;
+        if denom == 0 {
+            prop_assert_eq!(ratio, 0.0, "ratio should be 0 when denom is 0");
+        }
+    }
+}
+
+// =========================================================================
+// COCOMO: effort is monotonically increasing with code lines
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn cocomo_effort_monotonic(
+        small_code in 100usize..1000,
+        extra in 500usize..5000,
+    ) {
+        let large_code = small_code + extra;
+        let small_export = make_export(vec![make_row(small_code, 10, 5)]);
+        let large_export = make_export(vec![make_row(large_code, 10, 5)]);
+        let small_report = derive_report(&small_export, None);
+        let large_report = derive_report(&large_export, None);
+
+        let small_effort = small_report.cocomo.as_ref().unwrap().effort_pm;
+        let large_effort = large_report.cocomo.as_ref().unwrap().effort_pm;
+        prop_assert!(large_effort >= small_effort,
+            "COCOMO effort should be monotonic: {} (code={}) vs {} (code={})",
+            small_effort, small_code, large_effort, large_code);
+    }
+
+    #[test]
+    fn cocomo_zero_code_returns_none(
+        comments in 0usize..500,
+        blanks in 0usize..200,
+    ) {
+        let export = make_export(vec![make_row(0, comments, blanks)]);
+        let report = derive_report(&export, None);
+        prop_assert!(report.cocomo.is_none(),
+            "COCOMO should be None for zero code lines");
+    }
+}
+
+// =========================================================================
+// Distribution: histogram bucket percentages sum to ~1.0
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(60))]
+
+    #[test]
+    fn histogram_pct_sum_to_one(
+        sizes in prop::collection::vec(1usize..2000, 1..20),
+    ) {
+        let rows: Vec<FileRow> = sizes.iter().enumerate().map(|(i, &s)| {
+            FileRow {
+                path: format!("src/file_{}.rs", i),
+                module: "src".to_string(),
+                lang: "Rust".to_string(),
+                kind: FileKind::Parent,
+                code: s / 2,
+                comments: s / 4,
+                blanks: s - s / 2 - s / 4,
+                lines: s,
+                bytes: s * 40,
+                tokens: s * 4,
+            }
+        }).collect();
+
+        let export = make_export(rows);
+        let report = derive_report(&export, None);
+        let pct_sum: f64 = report.histogram.iter().map(|b| b.pct).sum();
+        prop_assert!((pct_sum - 1.0).abs() < 0.01,
+            "Histogram percentages sum {} should be ~1.0", pct_sum);
+    }
+
+    #[test]
+    fn histogram_files_sum_to_count(
+        sizes in prop::collection::vec(1usize..2000, 1..20),
+    ) {
+        let rows: Vec<FileRow> = sizes.iter().enumerate().map(|(i, &s)| {
+            FileRow {
+                path: format!("src/file_{}.rs", i),
+                module: "src".to_string(),
+                lang: "Rust".to_string(),
+                kind: FileKind::Parent,
+                code: s / 2,
+                comments: s / 4,
+                blanks: s - s / 2 - s / 4,
+                lines: s,
+                bytes: s * 40,
+                tokens: s * 4,
+            }
+        }).collect();
+
+        let n = rows.len();
+        let export = make_export(rows);
+        let report = derive_report(&export, None);
+        let file_sum: usize = report.histogram.iter().map(|b| b.files).sum();
+        prop_assert_eq!(file_sum, n,
+            "Histogram file counts should sum to total file count");
+    }
+}
+
+// =========================================================================
+// Distribution statistics: min <= median <= max, gini in [0, 1]
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(60))]
+
+    #[test]
+    fn distribution_min_leq_median_leq_max(
+        sizes in prop::collection::vec(1usize..5000, 1..30),
+    ) {
+        let rows: Vec<FileRow> = sizes.iter().enumerate().map(|(i, &s)| {
+            FileRow {
+                path: format!("src/file_{}.rs", i),
+                module: "src".to_string(),
+                lang: "Rust".to_string(),
+                kind: FileKind::Parent,
+                code: s,
+                comments: 0,
+                blanks: 0,
+                lines: s,
+                bytes: s * 30,
+                tokens: s * 3,
+            }
+        }).collect();
+
+        let export = make_export(rows);
+        let report = derive_report(&export, None);
+        let dist = &report.distribution;
+        prop_assert!(dist.min as f64 <= dist.median,
+            "min {} > median {}", dist.min, dist.median);
+        prop_assert!(dist.median <= dist.max as f64,
+            "median {} > max {}", dist.median, dist.max);
+    }
+
+    #[test]
+    fn distribution_gini_in_unit_range(
+        sizes in prop::collection::vec(1usize..5000, 2..30),
+    ) {
+        let rows: Vec<FileRow> = sizes.iter().enumerate().map(|(i, &s)| {
+            FileRow {
+                path: format!("src/file_{}.rs", i),
+                module: "src".to_string(),
+                lang: "Rust".to_string(),
+                kind: FileKind::Parent,
+                code: s,
+                comments: 0,
+                blanks: 0,
+                lines: s,
+                bytes: s * 30,
+                tokens: s * 3,
+            }
+        }).collect();
+
+        let export = make_export(rows);
+        let report = derive_report(&export, None);
+        let gini = report.distribution.gini;
+        prop_assert!(gini >= 0.0 && gini <= 1.0,
+            "Gini {} out of [0,1]", gini);
+    }
+}
+
+// =========================================================================
+// Determinism: same input always produces same output
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(30))]
+
+    #[test]
+    fn derive_report_is_deterministic(
+        code in 10usize..2000,
+        comments in 0usize..500,
+        blanks in 0usize..200,
+    ) {
+        let export = make_export(vec![make_row(code, comments, blanks)]);
+        let a = derive_report(&export, Some(128_000));
+        let b = derive_report(&export, Some(128_000));
+
+        let json_a = serde_json::to_string(&a).unwrap();
+        let json_b = serde_json::to_string(&b).unwrap();
+        prop_assert_eq!(json_a, json_b, "derive_report must be deterministic");
+    }
+}

--- a/crates/tokmd-badge/tests/proptest_w40.rs
+++ b/crates/tokmd-badge/tests/proptest_w40.rs
@@ -1,0 +1,151 @@
+//! Additional property-based tests for tokmd-badge SVG rendering (wave 40).
+//!
+//! Covers: badge text containment, positive width, non-empty output,
+//! empty-string handling, and Unicode width safety.
+
+use proptest::prelude::*;
+use tokmd_badge::badge_svg;
+
+// =========================================================================
+// Badge text contains the formatted value (after XML escaping)
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn badge_contains_label_text(
+        label in "[a-zA-Z0-9]{1,20}",
+        value in "[a-zA-Z0-9]{1,15}",
+    ) {
+        let svg = badge_svg(&label, &value);
+        prop_assert!(svg.contains(&label),
+            "Badge SVG should contain label '{}'", label);
+    }
+
+    #[test]
+    fn badge_contains_value_text(
+        label in "[a-zA-Z0-9]{1,20}",
+        value in "[a-zA-Z0-9]{1,15}",
+    ) {
+        let svg = badge_svg(&label, &value);
+        prop_assert!(svg.contains(&value),
+            "Badge SVG should contain value '{}'", value);
+    }
+}
+
+// =========================================================================
+// Badge width is always positive
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn badge_width_always_positive(
+        label in ".*",
+        value in ".*",
+    ) {
+        let svg = badge_svg(&label, &value);
+        let width = extract_svg_width(&svg);
+        prop_assert!(width > 0, "Badge width must be positive, got {}", width);
+    }
+}
+
+// =========================================================================
+// Badge output is never empty
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn badge_output_never_empty(
+        label in ".{0,50}",
+        value in ".{0,30}",
+    ) {
+        let svg = badge_svg(&label, &value);
+        prop_assert!(!svg.is_empty(), "Badge SVG must not be empty");
+        prop_assert!(svg.len() > 100, "Badge SVG should be a substantial string");
+    }
+}
+
+// =========================================================================
+// Empty inputs produce valid SVG
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(30))]
+
+    #[test]
+    fn empty_label_produces_valid_svg(
+        value in "[a-zA-Z0-9]{0,20}",
+    ) {
+        let svg = badge_svg("", &value);
+        prop_assert!(svg.starts_with("<svg "), "Must start with <svg");
+        prop_assert!(svg.ends_with("</svg>"), "Must end with </svg>");
+    }
+
+    #[test]
+    fn empty_value_produces_valid_svg(
+        label in "[a-zA-Z0-9]{0,20}",
+    ) {
+        let svg = badge_svg(&label, "");
+        prop_assert!(svg.starts_with("<svg "), "Must start with <svg");
+        prop_assert!(svg.ends_with("</svg>"), "Must end with </svg>");
+    }
+}
+
+// =========================================================================
+// Numeric value formatting: digits appear in badge
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn badge_contains_formatted_number(
+        n in 0u64..1_000_000,
+    ) {
+        let formatted = n.to_string();
+        let svg = badge_svg("lines", &formatted);
+        prop_assert!(svg.contains(&formatted),
+            "Badge should contain formatted number '{}'", formatted);
+    }
+}
+
+// =========================================================================
+// Width formula consistency: label+value width = total
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn width_is_sum_of_segments(
+        label in "[a-zA-Z0-9]{0,25}",
+        value in "[a-zA-Z0-9]{0,20}",
+    ) {
+        let label_chars = label.chars().count() as i32;
+        let value_chars = value.chars().count() as i32;
+        let expected_label_w = (label_chars * 7 + 20).max(60);
+        let expected_value_w = (value_chars * 7 + 20).max(60);
+        let expected_total = expected_label_w + expected_value_w;
+
+        let svg = badge_svg(&label, &value);
+        let actual = extract_svg_width(&svg);
+        prop_assert_eq!(actual, expected_total,
+            "Width {} != expected {} for label='{}' value='{}'",
+            actual, expected_total, label, value);
+    }
+}
+
+// =========================================================================
+// Helper
+// =========================================================================
+
+fn extract_svg_width(svg: &str) -> i32 {
+    let start = svg.find("width=\"").expect("width attr") + 7;
+    let end = svg[start..].find('"').expect("width close") + start;
+    svg[start..end].parse().expect("numeric width")
+}

--- a/crates/tokmd-envelope/tests/proptest_w40.rs
+++ b/crates/tokmd-envelope/tests/proptest_w40.rs
@@ -1,0 +1,222 @@
+//! Property-based tests for tokmd-envelope.
+//!
+//! Covers: SensorReport serde roundtrip, finding_id non-empty,
+//! fingerprint format, verdict exhaustiveness, and capability roundtrip.
+
+use proptest::prelude::*;
+use tokmd_envelope::{
+    findings, Artifact, CapabilityStatus, Finding, FindingLocation, FindingSeverity, SensorReport,
+    ToolMeta, Verdict, SENSOR_REPORT_SCHEMA,
+};
+
+fn arb_verdict() -> impl Strategy<Value = Verdict> {
+    prop_oneof![
+        Just(Verdict::Pass),
+        Just(Verdict::Fail),
+        Just(Verdict::Warn),
+        Just(Verdict::Skip),
+        Just(Verdict::Pending),
+    ]
+}
+
+fn arb_severity() -> impl Strategy<Value = FindingSeverity> {
+    prop_oneof![
+        Just(FindingSeverity::Error),
+        Just(FindingSeverity::Warn),
+        Just(FindingSeverity::Info),
+    ]
+}
+
+// =========================================================================
+// SensorReport roundtrips through serde
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn sensor_report_serde_roundtrip(
+        tool_name in "[a-z]{3,12}",
+        version in "[0-9]{1,2}\\.[0-9]{1,2}\\.[0-9]{1,2}",
+        mode in "[a-z]{3,10}",
+        verdict in arb_verdict(),
+        summary in "[a-zA-Z0-9 ]{5,50}",
+    ) {
+        let report = SensorReport::new(
+            ToolMeta::new(&tool_name, &version, &mode),
+            "2024-06-15T12:00:00Z".to_string(),
+            verdict,
+            summary.clone(),
+        );
+
+        let json = serde_json::to_string(&report).unwrap();
+        let back: SensorReport = serde_json::from_str(&json).unwrap();
+
+        prop_assert_eq!(&back.schema, SENSOR_REPORT_SCHEMA);
+        prop_assert_eq!(&back.tool.name, &tool_name);
+        prop_assert_eq!(&back.tool.version, &version);
+        prop_assert_eq!(&back.tool.mode, &mode);
+        prop_assert_eq!(back.verdict, verdict);
+        prop_assert_eq!(&back.summary, &summary);
+    }
+}
+
+// =========================================================================
+// SensorReport with findings roundtrips
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(60))]
+
+    #[test]
+    fn report_with_findings_roundtrip(
+        check_id in "[a-z]{3,10}",
+        code in "[a-z_]{3,15}",
+        severity in arb_severity(),
+        title in "[a-zA-Z0-9 ]{5,30}",
+        message in "[a-zA-Z0-9 ]{10,60}",
+        path in "[a-z/]{3,20}\\.rs",
+    ) {
+        let mut report = SensorReport::new(
+            ToolMeta::tokmd("1.0.0", "test"),
+            "2024-01-01T00:00:00Z".to_string(),
+            Verdict::Warn,
+            "Test report".to_string(),
+        );
+        report.add_finding(
+            Finding::new(&check_id, &code, severity, &title, &message)
+                .with_location(FindingLocation::path(&path)),
+        );
+
+        let json = serde_json::to_string(&report).unwrap();
+        let back: SensorReport = serde_json::from_str(&json).unwrap();
+
+        prop_assert_eq!(back.findings.len(), 1);
+        prop_assert_eq!(&back.findings[0].check_id, &check_id);
+        prop_assert_eq!(&back.findings[0].code, &code);
+        prop_assert_eq!(&back.findings[0].title, &title);
+        let loc = back.findings[0].location.as_ref().unwrap();
+        prop_assert_eq!(&loc.path, &path);
+    }
+}
+
+// =========================================================================
+// finding_id is always non-empty
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn finding_id_always_non_empty(
+        tool in "[a-z]{2,10}",
+        check_id in "[a-z]{2,10}",
+        code in "[a-z_]{2,15}",
+    ) {
+        let fid = findings::finding_id(&tool, &check_id, &code);
+        prop_assert!(!fid.is_empty(), "finding_id must not be empty");
+        prop_assert!(fid.contains('.'), "finding_id should contain dots: {}", fid);
+        let parts: Vec<&str> = fid.split('.').collect();
+        prop_assert_eq!(parts.len(), 3, "finding_id should have 3 parts: {}", fid);
+        prop_assert_eq!(parts[0], tool.as_str());
+        prop_assert_eq!(parts[1], check_id.as_str());
+        prop_assert_eq!(parts[2], code.as_str());
+    }
+}
+
+// =========================================================================
+// Fingerprint: always 32 hex characters
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn fingerprint_is_32_hex_chars(
+        check_id in "[a-z]{3,10}",
+        code in "[a-z_]{3,15}",
+        path in "[a-z/]{3,20}\\.rs",
+    ) {
+        let finding = Finding::new(&check_id, &code, FindingSeverity::Info, "title", "message")
+            .with_location(FindingLocation::path(&path));
+        let fp = finding.compute_fingerprint("tokmd");
+
+        prop_assert_eq!(fp.len(), 32,
+            "Fingerprint should be 32 chars, got {} ('{}')", fp.len(), fp);
+        prop_assert!(fp.chars().all(|c| c.is_ascii_hexdigit()),
+            "Fingerprint should be all hex: '{}'", fp);
+    }
+
+    #[test]
+    fn fingerprint_deterministic(
+        check_id in "[a-z]{3,10}",
+        code in "[a-z_]{3,15}",
+    ) {
+        let finding = Finding::new(&check_id, &code, FindingSeverity::Warn, "t", "m");
+        let fp1 = finding.compute_fingerprint("tokmd");
+        let fp2 = finding.compute_fingerprint("tokmd");
+        prop_assert_eq!(fp1, fp2, "Fingerprint must be deterministic");
+    }
+}
+
+// =========================================================================
+// Verdict: Display and serde agree
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+
+    #[test]
+    fn verdict_display_matches_serde(
+        verdict in arb_verdict(),
+    ) {
+        let display = verdict.to_string();
+        let json = serde_json::to_value(verdict).unwrap();
+        prop_assert_eq!(json.as_str().unwrap(), display.as_str(),
+            "Display '{}' != serde '{}'", display, json);
+    }
+}
+
+// =========================================================================
+// Capability roundtrip
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn capability_status_roundtrip(
+        reason in "[a-zA-Z0-9 ]{5,30}",
+        state_idx in 0usize..3,
+    ) {
+        let status = match state_idx {
+            0 => CapabilityStatus::available().with_reason(&reason),
+            1 => CapabilityStatus::unavailable(&reason),
+            _ => CapabilityStatus::skipped(&reason),
+        };
+
+        let json = serde_json::to_string(&status).unwrap();
+        let back: CapabilityStatus = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(back.reason.as_deref(), Some(reason.as_str()));
+    }
+}
+
+// =========================================================================
+// Artifact serde roundtrip
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn artifact_roundtrip(
+        artifact_type in "[a-z]{3,10}",
+        path in "[a-z/]{3,25}",
+    ) {
+        let artifact = Artifact::new(&artifact_type, &path);
+        let json = serde_json::to_string(&artifact).unwrap();
+        let back: Artifact = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(&back.artifact_type, &artifact_type);
+        prop_assert_eq!(&back.path, &path);
+    }
+}

--- a/crates/tokmd-scan-args/tests/proptest_w40.rs
+++ b/crates/tokmd-scan-args/tests/proptest_w40.rs
@@ -1,0 +1,181 @@
+//! Additional property-based tests for tokmd-scan-args (wave 40).
+//!
+//! Covers: normalize idempotency, path count preservation,
+//! redaction flag consistency, and config mode propagation.
+
+use std::path::{Path, PathBuf};
+
+use proptest::prelude::*;
+use tokmd_scan_args::{normalize_scan_input, scan_args};
+use tokmd_settings::ScanOptions;
+use tokmd_types::RedactMode;
+
+// =========================================================================
+// Normalize is idempotent: normalize(normalize(x)) == normalize(x)
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn normalize_is_idempotent(
+        parts in prop::collection::vec("[a-z]{2,8}", 1..5),
+    ) {
+        let path = parts.join("/");
+        let once = normalize_scan_input(Path::new(&path));
+        let twice = normalize_scan_input(Path::new(&once));
+        prop_assert_eq!(once, twice, "normalize must be idempotent");
+    }
+}
+
+// =========================================================================
+// Normalize output is never empty
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn normalize_output_never_empty(
+        path in ".{0,40}",
+    ) {
+        let normalized = normalize_scan_input(Path::new(&path));
+        prop_assert!(!normalized.is_empty(),
+            "Normalized output must never be empty for input '{}'", path);
+    }
+}
+
+// =========================================================================
+// Path count preservation: output paths count matches input
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn scan_args_path_count_matches_input(
+        path_values in prop::collection::vec("[a-z]{2,10}", 1..8),
+    ) {
+        let paths: Vec<PathBuf> = path_values.iter().map(PathBuf::from).collect();
+        let scan_options = ScanOptions::default();
+        let args = scan_args(&paths, &scan_options, None);
+        prop_assert_eq!(args.paths.len(), paths.len(),
+            "Output path count {} != input count {}", args.paths.len(), paths.len());
+    }
+
+    #[test]
+    fn scan_args_path_count_preserved_under_redaction(
+        path_values in prop::collection::vec("[a-z]{2,10}\\.[a-z]{1,3}", 1..8),
+    ) {
+        let paths: Vec<PathBuf> = path_values.iter().map(PathBuf::from).collect();
+        let scan_options = ScanOptions::default();
+        let args = scan_args(&paths, &scan_options, Some(RedactMode::Paths));
+        prop_assert_eq!(args.paths.len(), paths.len(),
+            "Redacted path count {} != input count {}", args.paths.len(), paths.len());
+    }
+}
+
+// =========================================================================
+// Excluded count preservation
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(60))]
+
+    #[test]
+    fn excluded_count_preserved(
+        excluded in prop::collection::vec("[a-z]{3,10}", 0..5),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let scan_options = ScanOptions {
+            excluded: excluded.clone(),
+            ..Default::default()
+        };
+        let args_none = scan_args(&paths, &scan_options, None);
+        let args_redact = scan_args(&paths, &scan_options, Some(RedactMode::Paths));
+        prop_assert_eq!(args_none.excluded.len(), excluded.len(),
+            "Non-redacted excluded count mismatch");
+        prop_assert_eq!(args_redact.excluded.len(), excluded.len(),
+            "Redacted excluded count mismatch");
+    }
+}
+
+// =========================================================================
+// excluded_redacted flag matches redaction mode
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn excluded_redacted_flag_correct(
+        excluded in prop::collection::vec("[a-z]{3,10}", 1..5),
+        redact_idx in 0usize..4,
+    ) {
+        let redact = [None, Some(RedactMode::None), Some(RedactMode::Paths), Some(RedactMode::All)][redact_idx];
+        let paths = vec![PathBuf::from(".")];
+        let scan_options = ScanOptions {
+            excluded: excluded.clone(),
+            ..Default::default()
+        };
+        let args = scan_args(&paths, &scan_options, redact);
+
+        let should_be_redacted = matches!(redact, Some(RedactMode::Paths | RedactMode::All));
+        prop_assert_eq!(args.excluded_redacted, should_be_redacted,
+            "excluded_redacted flag should be {} for redact mode {:?}", should_be_redacted, redact);
+    }
+}
+
+// =========================================================================
+// Boolean flags propagation
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn hidden_flag_propagated(
+        hidden in any::<bool>(),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let scan_options = ScanOptions {
+            hidden,
+            ..Default::default()
+        };
+        let args = scan_args(&paths, &scan_options, None);
+        prop_assert_eq!(args.hidden, hidden, "hidden flag must propagate");
+    }
+
+    #[test]
+    fn treat_doc_strings_flag_propagated(
+        treat_doc in any::<bool>(),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let scan_options = ScanOptions {
+            treat_doc_strings_as_comments: treat_doc,
+            ..Default::default()
+        };
+        let args = scan_args(&paths, &scan_options, None);
+        prop_assert_eq!(args.treat_doc_strings_as_comments, treat_doc,
+            "treat_doc_strings_as_comments must propagate");
+    }
+}
+
+// =========================================================================
+// Normalize never contains backslash
+// =========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(80))]
+
+    #[test]
+    fn normalize_forward_slashes_only(
+        parts in prop::collection::vec("[a-z]{2,6}", 1..6),
+    ) {
+        // Mix of forward and backslash separators
+        let mixed = parts.join("\\");
+        let normalized = normalize_scan_input(Path::new(&mixed));
+        prop_assert!(!normalized.contains('\\'),
+            "Normalized '{}' must not contain backslash", normalized);
+    }
+}


### PR DESCRIPTION
Adds property-based tests verifying mathematical invariants and roundtrip guarantees