### PR TITLE
test(analysis): deep enricher tests

### DIFF
--- a/crates/tokmd-analysis-archetype/tests/deep_w42.rs
+++ b/crates/tokmd-analysis-archetype/tests/deep_w42.rs
@@ -1,0 +1,212 @@
+//! Wave-42 deep tests for archetype inference.
+//!
+//! Tests archetype detection for various repo shapes, scoring correctness,
+//! priority ordering, serde roundtrips, and edge cases.
+
+use tokmd_analysis_archetype::detect_archetype;
+use tokmd_analysis_types::Archetype;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn parent_row(path: &str) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: "(root)".to_string(),
+        lang: "Unknown".to_string(),
+        kind: FileKind::Parent,
+        code: 1,
+        comments: 0,
+        blanks: 0,
+        lines: 1,
+        bytes: 10,
+        tokens: 2,
+    }
+}
+
+fn export_with_paths(paths: &[&str]) -> ExportData {
+    ExportData {
+        rows: paths.iter().map(|p| parent_row(p)).collect(),
+        module_roots: vec![],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ── 1. Rust workspace library (no CLI) ──────────────────────────
+
+#[test]
+fn rust_workspace_library_no_main() {
+    let export = export_with_paths(&[
+        "Cargo.toml",
+        "crates/core/src/lib.rs",
+        "crates/utils/src/lib.rs",
+    ]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Rust workspace");
+    assert!(!arch.kind.contains("CLI"));
+}
+
+// ── 2. Rust workspace CLI detected via bin dir ──────────────────
+
+#[test]
+fn rust_workspace_cli_via_bin() {
+    let export = export_with_paths(&[
+        "Cargo.toml",
+        "crates/app/src/lib.rs",
+        "crates/app/src/bin/main.rs",
+    ]);
+    let arch = detect_archetype(&export).unwrap();
+    assert!(arch.kind.contains("CLI"), "expected CLI: {}", arch.kind);
+}
+
+// ── 3. Next.js app with .mjs config ────────────────────────────
+
+#[test]
+fn nextjs_mjs_config() {
+    let export = export_with_paths(&["package.json", "next.config.mjs", "app/page.tsx"]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Next.js app");
+    assert!(arch.evidence.iter().any(|e| e.contains("next.config.mjs")));
+}
+
+// ── 4. Containerized service with kubernetes/ directory ──────────
+
+#[test]
+fn containerized_service_kubernetes_dir() {
+    let export = export_with_paths(&["Dockerfile", "kubernetes/deployment.yaml", "src/main.go"]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Containerized service");
+    assert!(arch.evidence.contains(&"Dockerfile".to_string()));
+}
+
+// ── 5. Infrastructure-as-code via .tf files ─────────────────────
+
+#[test]
+fn iac_detected_from_tf_extension() {
+    let export = export_with_paths(&["main.tf", "variables.tf", "outputs.tf"]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Infrastructure as code");
+}
+
+// ── 6. Python package via pyproject.toml ────────────────────────
+
+#[test]
+fn python_package_pyproject() {
+    let export = export_with_paths(&["pyproject.toml", "src/mylib/__init__.py"]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Python package");
+    assert!(arch.evidence.contains(&"pyproject.toml".to_string()));
+}
+
+// ── 7. Node package fallback ────────────────────────────────────
+
+#[test]
+fn node_package_fallback_when_no_nextjs() {
+    let export = export_with_paths(&["package.json", "src/index.ts"]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Node package");
+}
+
+// ── 8. Priority: Rust workspace > Node package ──────────────────
+
+#[test]
+fn priority_rust_over_node() {
+    let export = export_with_paths(&[
+        "Cargo.toml",
+        "crates/wasm/src/lib.rs",
+        "package.json",
+        "src/index.js",
+    ]);
+    let arch = detect_archetype(&export).unwrap();
+    assert!(
+        arch.kind.contains("Rust workspace"),
+        "Rust workspace should take priority over Node package: {}",
+        arch.kind
+    );
+}
+
+// ── 9. Serde roundtrip for Archetype ────────────────────────────
+
+#[test]
+fn archetype_serde_roundtrip() {
+    let arch = Archetype {
+        kind: "Rust workspace (CLI)".to_string(),
+        evidence: vec![
+            "Cargo.toml".to_string(),
+            "crates/foo/src/lib.rs".to_string(),
+        ],
+    };
+    let json = serde_json::to_string(&arch).unwrap();
+    let deser: Archetype = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.kind, arch.kind);
+    assert_eq!(deser.evidence, arch.evidence);
+}
+
+// ── 10. No archetype for unrecognised repo ──────────────────────
+
+#[test]
+fn no_archetype_for_unrecognised_repo() {
+    let export = export_with_paths(&["README.md", "docs/guide.md", "Makefile"]);
+    assert!(detect_archetype(&export).is_none());
+}
+
+// ── 11. Backslash paths are normalised ──────────────────────────
+
+#[test]
+fn backslash_paths_normalised_to_forward_slash() {
+    let export = export_with_paths(&[
+        "Cargo.toml",
+        "crates\\cli\\src\\main.rs",
+        "crates\\cli\\src\\lib.rs",
+    ]);
+    let arch = detect_archetype(&export).unwrap();
+    assert!(
+        arch.kind.contains("Rust workspace"),
+        "backslash paths should be normalised: {}",
+        arch.kind
+    );
+}
+
+// ── 12. Evidence always contains at least one entry ─────────────
+
+#[test]
+fn evidence_always_non_empty() {
+    let shapes: Vec<Vec<&str>> = vec![
+        vec!["Cargo.toml", "crates/x/src/lib.rs"],
+        vec!["package.json", "next.config.js"],
+        vec!["Dockerfile", "k8s/deploy.yaml"],
+        vec!["main.tf"],
+        vec!["pyproject.toml"],
+        vec!["package.json"],
+    ];
+    for paths in &shapes {
+        let export = export_with_paths(paths);
+        if let Some(arch) = detect_archetype(&export) {
+            assert!(
+                !arch.evidence.is_empty(),
+                "evidence should not be empty for {:?} → {}",
+                paths,
+                arch.kind
+            );
+        }
+    }
+}
+
+// ── 13. IaC inside terraform/ subdir detected ───────────────────
+
+#[test]
+fn iac_terraform_subdir() {
+    let export = export_with_paths(&["terraform/modules/vpc/main.tf"]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Infrastructure as code");
+}
+
+// ── 14. Next.js with .ts config ─────────────────────────────────
+
+#[test]
+fn nextjs_ts_config() {
+    let export = export_with_paths(&["package.json", "next.config.ts"]);
+    let arch = detect_archetype(&export).unwrap();
+    assert_eq!(arch.kind, "Next.js app");
+}

--- a/crates/tokmd-analysis-near-dup/tests/deep_w42.rs
+++ b/crates/tokmd-analysis-near-dup/tests/deep_w42.rs
@@ -1,0 +1,572 @@
+//! Wave-42 deep tests for near-duplicate detection.
+//!
+//! Tests various similarity thresholds, exact duplicates, unique codebases,
+//! edge cases (empty files, one-line files), scope isolation, and serde.
+
+use std::io::Write;
+use tempfile::TempDir;
+use tokmd_analysis_near_dup::{NearDupLimits, build_near_dup_report};
+use tokmd_analysis_types::NearDupScope;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn make_row(path: &str, module: &str, lang: &str, code: usize, bytes: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments: 0,
+        blanks: 0,
+        lines: code,
+        bytes,
+        tokens: code * 5,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn write_file(dir: &TempDir, rel: &str, content: &str) {
+    let path = dir.path().join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+fn long_source(n: usize, seed: usize) -> String {
+    (0..n)
+        .map(|i| format!("token_{seed}_{i}"))
+        .collect::<Vec<_>>()
+        .join(" + ")
+}
+
+fn limits() -> NearDupLimits {
+    NearDupLimits {
+        max_bytes: None,
+        max_file_bytes: Some(1_000_000),
+    }
+}
+
+// ── 1. Exact duplicate files produce similarity ~1.0 ────────────
+
+#[test]
+fn exact_duplicates_similarity_near_one() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(150, 0);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+
+    let rows = vec![
+        make_row("a.rs", "mod", "Rust", 150, content.len()),
+        make_row("b.rs", "mod", "Rust", 150, content.len()),
+    ];
+    let export = make_export(rows);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert_eq!(report.pairs.len(), 1);
+    assert!(
+        report.pairs[0].similarity >= 0.99,
+        "exact dups should be ~1.0, got {}",
+        report.pairs[0].similarity
+    );
+}
+
+// ── 2. Completely unique files produce no pairs ─────────────────
+
+#[test]
+fn unique_files_no_pairs() {
+    let dir = TempDir::new().unwrap();
+    write_file(&dir, "a.rs", &long_source(100, 1));
+    write_file(&dir, "b.rs", &long_source(100, 2));
+    write_file(&dir, "c.rs", &long_source(100, 3));
+
+    let rows = vec![
+        make_row("a.rs", "mod", "Rust", 100, 500),
+        make_row("b.rs", "mod", "Rust", 100, 500),
+        make_row("c.rs", "mod", "Rust", 100, 500),
+    ];
+    let export = make_export(rows);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert!(
+        report.pairs.is_empty(),
+        "unique files should produce no pairs, got {}",
+        report.pairs.len()
+    );
+}
+
+// ── 3. Empty files produce no fingerprints (no pairs) ───────────
+
+#[test]
+fn empty_files_no_pairs() {
+    let dir = TempDir::new().unwrap();
+    write_file(&dir, "empty1.rs", "");
+    write_file(&dir, "empty2.rs", "");
+
+    let rows = vec![
+        make_row("empty1.rs", "mod", "Rust", 0, 0),
+        make_row("empty2.rs", "mod", "Rust", 0, 0),
+    ];
+    let export = make_export(rows);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.1,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert!(
+        report.pairs.is_empty(),
+        "empty files should produce no pairs"
+    );
+}
+
+// ── 4. One-line files too short for k-gram ──────────────────────
+
+#[test]
+fn one_line_files_too_short_for_fingerprinting() {
+    let dir = TempDir::new().unwrap();
+    write_file(&dir, "short1.rs", "fn main() {}");
+    write_file(&dir, "short2.rs", "fn main() {}");
+
+    let rows = vec![
+        make_row("short1.rs", "mod", "Rust", 1, 13),
+        make_row("short2.rs", "mod", "Rust", 1, 13),
+    ];
+    let export = make_export(rows);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.1,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    // Files with fewer than K=25 tokens produce no fingerprints
+    assert!(
+        report.pairs.is_empty(),
+        "short files should produce no pairs"
+    );
+}
+
+// ── 5. High threshold filters out moderate duplicates ───────────
+
+#[test]
+fn high_threshold_filters_moderate_duplicates() {
+    let dir = TempDir::new().unwrap();
+    // Shared prefix with divergent suffixes
+    let shared: String = (0..80)
+        .map(|i| format!("shared_{i}"))
+        .collect::<Vec<_>>()
+        .join(" + ");
+    let a = format!("{} + {}", shared, long_source(40, 10));
+    let b = format!("{} + {}", shared, long_source(40, 20));
+    write_file(&dir, "a.rs", &a);
+    write_file(&dir, "b.rs", &b);
+
+    let rows = vec![
+        make_row("a.rs", "mod", "Rust", 120, a.len()),
+        make_row("b.rs", "mod", "Rust", 120, b.len()),
+    ];
+    let export = make_export(rows);
+
+    // With threshold 0.99 the partially-similar pair should be filtered
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.99,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert!(
+        report.pairs.is_empty(),
+        "threshold 0.99 should filter moderate dups"
+    );
+}
+
+// ── 6. Low threshold catches moderate duplicates ────────────────
+
+#[test]
+fn low_threshold_catches_moderate_duplicates() {
+    let dir = TempDir::new().unwrap();
+    let shared: String = (0..80)
+        .map(|i| format!("common_{i}"))
+        .collect::<Vec<_>>()
+        .join(" + ");
+    let a = format!("{} + {}", shared, long_source(30, 10));
+    let b = format!("{} + {}", shared, long_source(30, 20));
+    write_file(&dir, "a.rs", &a);
+    write_file(&dir, "b.rs", &b);
+
+    let rows = vec![
+        make_row("a.rs", "mod", "Rust", 110, a.len()),
+        make_row("b.rs", "mod", "Rust", 110, b.len()),
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.3,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert!(
+        !report.pairs.is_empty(),
+        "low threshold should detect moderate dups"
+    );
+}
+
+// ── 7. Module scope isolates comparisons ────────────────────────
+
+#[test]
+fn module_scope_isolates_comparisons() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(100, 0);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+
+    // Same content, different modules
+    let rows = vec![
+        make_row("a.rs", "mod_a", "Rust", 100, content.len()),
+        make_row("b.rs", "mod_b", "Rust", 100, content.len()),
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Module,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    // Files in different modules should not be compared under Module scope
+    assert!(
+        report.pairs.is_empty(),
+        "module scope should isolate comparisons"
+    );
+}
+
+// ── 8. Lang scope groups by language ────────────────────────────
+
+#[test]
+fn lang_scope_groups_by_language() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(100, 0);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.py", &content);
+
+    let rows = vec![
+        make_row("a.rs", "mod", "Rust", 100, content.len()),
+        make_row("b.py", "mod", "Python", 100, content.len()),
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Lang,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    // Different languages under Lang scope should not pair
+    assert!(
+        report.pairs.is_empty(),
+        "lang scope should separate Rust and Python"
+    );
+}
+
+// ── 9. max_pairs truncates output ───────────────────────────────
+
+#[test]
+fn max_pairs_truncates_output() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(100, 0);
+    // Create 4 identical files → 6 pairs
+    for i in 0..4 {
+        write_file(&dir, &format!("f{i}.rs"), &content);
+    }
+
+    let rows: Vec<FileRow> = (0..4)
+        .map(|i| make_row(&format!("f{i}.rs"), "mod", "Rust", 100, content.len()))
+        .collect();
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        Some(2),
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert!(report.pairs.len() <= 2, "max_pairs should truncate");
+    assert!(report.truncated, "truncated flag should be set");
+}
+
+// ── 10. Child rows are excluded from analysis ───────────────────
+
+#[test]
+fn child_rows_excluded() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(100, 0);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+
+    let rows = vec![
+        FileRow {
+            path: "a.rs".to_string(),
+            module: "mod".to_string(),
+            lang: "Rust".to_string(),
+            kind: FileKind::Child,
+            code: 100,
+            comments: 0,
+            blanks: 0,
+            lines: 100,
+            bytes: content.len(),
+            tokens: 500,
+        },
+        FileRow {
+            path: "b.rs".to_string(),
+            module: "mod".to_string(),
+            lang: "Rust".to_string(),
+            kind: FileKind::Child,
+            code: 100,
+            comments: 0,
+            blanks: 0,
+            lines: 100,
+            bytes: content.len(),
+            tokens: 500,
+        },
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert_eq!(report.files_analyzed, 0, "child rows should be excluded");
+}
+
+// ── 11. Serde roundtrip for NearDuplicateReport ─────────────────
+
+#[test]
+fn near_dup_report_serde_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(100, 0);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+
+    let rows = vec![
+        make_row("a.rs", "mod", "Rust", 100, content.len()),
+        make_row("b.rs", "mod", "Rust", 100, content.len()),
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let deser: tokmd_analysis_types::NearDuplicateReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.files_analyzed, report.files_analyzed);
+    assert_eq!(deser.pairs.len(), report.pairs.len());
+}
+
+// ── 12. Pairs sorted by similarity descending ───────────────────
+
+#[test]
+fn pairs_sorted_by_similarity_desc() {
+    let dir = TempDir::new().unwrap();
+    let base: String = (0..100)
+        .map(|i| format!("base_{i}"))
+        .collect::<Vec<_>>()
+        .join(" + ");
+
+    // Create files with varying similarity to base
+    write_file(&dir, "base.rs", &base);
+    let near = format!("{} + {}", base, long_source(5, 1));
+    write_file(&dir, "near.rs", &near);
+    let far = format!(
+        "{} + {}",
+        (0..50)
+            .map(|i| format!("base_{i}"))
+            .collect::<Vec<_>>()
+            .join(" + "),
+        long_source(60, 2)
+    );
+    write_file(&dir, "far.rs", &far);
+
+    let rows = vec![
+        make_row("base.rs", "mod", "Rust", 100, base.len()),
+        make_row("near.rs", "mod", "Rust", 105, near.len()),
+        make_row("far.rs", "mod", "Rust", 110, far.len()),
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.1,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    for window in report.pairs.windows(2) {
+        assert!(
+            window[0].similarity >= window[1].similarity,
+            "pairs should be sorted by similarity desc"
+        );
+    }
+}
+
+// ── 13. Exclude patterns filter files ───────────────────────────
+
+#[test]
+fn exclude_patterns_filter_files() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(100, 0);
+    write_file(&dir, "src/a.rs", &content);
+    write_file(&dir, "src/b.rs", &content);
+    write_file(&dir, "vendor/c.rs", &content);
+
+    let rows = vec![
+        make_row("src/a.rs", "src", "Rust", 100, content.len()),
+        make_row("src/b.rs", "src", "Rust", 100, content.len()),
+        make_row("vendor/c.rs", "vendor", "Rust", 100, content.len()),
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &["vendor/**".to_string()],
+    )
+    .unwrap();
+
+    assert_eq!(report.excluded_by_pattern, Some(1));
+    // Only src files compared
+    assert_eq!(report.files_analyzed, 2);
+}
+
+// ── 14. Global scope finds cross-module duplicates ──────────────
+
+#[test]
+fn global_scope_finds_cross_module_dups() {
+    let dir = TempDir::new().unwrap();
+    let content = long_source(100, 0);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+
+    let rows = vec![
+        make_row("a.rs", "mod_a", "Rust", 100, content.len()),
+        make_row("b.rs", "mod_b", "Python", 100, content.len()),
+    ];
+    let export = make_export(rows);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits(),
+        &[],
+    )
+    .unwrap();
+
+    assert!(
+        !report.pairs.is_empty(),
+        "global scope should find cross-module dups"
+    );
+}

--- a/crates/tokmd-analysis-topics/tests/deep_w42.rs
+++ b/crates/tokmd-analysis-topics/tests/deep_w42.rs
@@ -1,0 +1,221 @@
+//! Wave-42 deep tests for topic-cloud extraction.
+//!
+//! Tests topic extraction from paths, stopword filtering, TF-IDF scoring,
+//! determinism, serde roundtrip, and edge cases.
+
+use tokmd_analysis_topics::build_topic_clouds;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn row(path: &str, module: &str, tokens: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: "Rust".to_string(),
+        kind: FileKind::Parent,
+        code: 10,
+        comments: 0,
+        blanks: 0,
+        lines: 10,
+        bytes: 100,
+        tokens,
+    }
+}
+
+fn export(rows: Vec<FileRow>, roots: &[&str]) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: roots.iter().map(|r| r.to_string()).collect(),
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn overall_terms(data: &ExportData) -> Vec<String> {
+    build_topic_clouds(data)
+        .overall
+        .iter()
+        .map(|e| e.term.clone())
+        .collect()
+}
+
+// ── 1. Stopwords are filtered out ───────────────────────────────
+
+#[test]
+fn stopwords_filtered_from_topics() {
+    let data = export(vec![row("src/lib/auth/handler.rs", "auth", 50)], &[]);
+    let terms = overall_terms(&data);
+    // "src", "lib", "rs" are all stopwords
+    assert!(
+        !terms.contains(&"src".to_string()),
+        "src should be a stopword"
+    );
+    assert!(
+        !terms.contains(&"lib".to_string()),
+        "lib should be a stopword"
+    );
+    assert!(
+        !terms.contains(&"rs".to_string()),
+        "rs should be a stopword"
+    );
+    assert!(terms.contains(&"auth".to_string()));
+    assert!(terms.contains(&"handler".to_string()));
+}
+
+// ── 2. Module roots are stopwords ───────────────────────────────
+
+#[test]
+fn module_roots_are_stopwords() {
+    let data = export(
+        vec![row("crates/auth/login.rs", "crates/auth", 50)],
+        &["crates"],
+    );
+    let terms = overall_terms(&data);
+    assert!(
+        !terms.contains(&"crates".to_string()),
+        "module root 'crates' should be a stopword"
+    );
+    assert!(terms.contains(&"auth".to_string()));
+}
+
+// ── 3. Deterministic output across repeated calls ───────────────
+
+#[test]
+fn topic_clouds_deterministic() {
+    let data = export(
+        vec![
+            row("api/auth/login.rs", "api/auth", 50),
+            row("api/auth/token.rs", "api/auth", 50),
+            row("api/payments/stripe.rs", "api/payments", 50),
+        ],
+        &[],
+    );
+    let clouds1 = build_topic_clouds(&data);
+    let clouds2 = build_topic_clouds(&data);
+    assert_eq!(clouds1.overall.len(), clouds2.overall.len());
+    for (a, b) in clouds1.overall.iter().zip(clouds2.overall.iter()) {
+        assert_eq!(a.term, b.term);
+        assert_eq!(a.tf, b.tf);
+    }
+}
+
+// ── 4. Empty export produces empty topics ───────────────────────
+
+#[test]
+fn empty_export_produces_empty_topics() {
+    let data = export(vec![], &[]);
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.overall.is_empty());
+    assert!(clouds.per_module.is_empty());
+}
+
+// ── 5. Child rows are excluded ──────────────────────────────────
+
+#[test]
+fn child_rows_excluded_from_topics() {
+    let mut r = row("api/handler.rs", "api", 50);
+    r.kind = FileKind::Child;
+    let data = export(vec![r], &[]);
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.overall.is_empty());
+}
+
+// ── 6. Per-module clouds are separate ───────────────────────────
+
+#[test]
+fn per_module_clouds_separate() {
+    let data = export(
+        vec![
+            row("auth/login.rs", "auth", 50),
+            row("auth/signup.rs", "auth", 50),
+            row("billing/invoice.rs", "billing", 50),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.per_module.contains_key("auth"));
+    assert!(clouds.per_module.contains_key("billing"));
+    let auth_terms: Vec<_> = clouds.per_module["auth"].iter().map(|t| &t.term).collect();
+    let billing_terms: Vec<_> = clouds.per_module["billing"]
+        .iter()
+        .map(|t| &t.term)
+        .collect();
+    assert!(auth_terms.contains(&&"login".to_string()));
+    assert!(billing_terms.contains(&&"invoice".to_string()));
+}
+
+// ── 7. Serde roundtrip for TopicClouds ──────────────────────────
+
+#[test]
+fn topic_clouds_serde_roundtrip() {
+    let data = export(
+        vec![
+            row("api/handler.rs", "api", 50),
+            row("api/router.rs", "api", 40),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    let json = serde_json::to_string(&clouds).unwrap();
+    let deser: tokmd_analysis_types::TopicClouds = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.overall.len(), clouds.overall.len());
+    for (a, b) in deser.overall.iter().zip(clouds.overall.iter()) {
+        assert_eq!(a.term, b.term);
+    }
+}
+
+// ── 8. Overall limited to TOP_K=8 entries ───────────────────────
+
+#[test]
+fn overall_capped_at_top_k() {
+    // Create many distinct terms
+    let rows: Vec<FileRow> = (0..20)
+        .map(|i| row(&format!("unique_term_{i}/file.rs"), "mod", 50))
+        .collect();
+    let data = export(rows, &[]);
+    let clouds = build_topic_clouds(&data);
+    assert!(
+        clouds.overall.len() <= 8,
+        "overall should be capped at TOP_K=8, got {}",
+        clouds.overall.len()
+    );
+}
+
+// ── 9. Scores are positive ──────────────────────────────────────
+
+#[test]
+fn all_scores_positive() {
+    let data = export(
+        vec![
+            row("api/handler.rs", "api", 50),
+            row("core/engine.rs", "core", 100),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    for term in &clouds.overall {
+        assert!(term.score > 0.0, "score should be positive: {:?}", term);
+    }
+}
+
+// ── 10. Underscore and hyphen splitting ─────────────────────────
+
+#[test]
+fn underscore_and_hyphen_splitting() {
+    let data = export(vec![row("api/my_cool-handler.rs", "api", 50)], &[]);
+    let terms = overall_terms(&data);
+    assert!(terms.contains(&"my".to_string()));
+    assert!(terms.contains(&"cool".to_string()));
+    assert!(terms.contains(&"handler".to_string()));
+}
+
+// ── 11. Backslash paths normalised ──────────────────────────────
+
+#[test]
+fn backslash_paths_normalised() {
+    let data = export(vec![row("api\\handler\\auth.rs", "api", 50)], &[]);
+    let terms = overall_terms(&data);
+    assert!(terms.contains(&"handler".to_string()));
+    assert!(terms.contains(&"auth".to_string()));
+}

--- a/crates/tokmd-analysis-util/tests/deep_w42.rs
+++ b/crates/tokmd-analysis-util/tests/deep_w42.rs
@@ -1,0 +1,167 @@
+//! Wave-42 deep tests for analysis utility helpers.
+//!
+//! Tests path normalization, depth counting, test-path detection,
+//! infra-lang classification, and empty_file_row construction.
+
+use std::path::PathBuf;
+
+use tokmd_analysis_util::{
+    empty_file_row, is_infra_lang, is_test_path, normalize_path, path_depth,
+};
+
+// ── 1. path_depth with nested paths ─────────────────────────────
+
+#[test]
+fn path_depth_counts_nested_segments() {
+    assert_eq!(path_depth("a/b/c/d.rs"), 4);
+    assert_eq!(path_depth("a.rs"), 1);
+    assert_eq!(path_depth("a/b.rs"), 2);
+}
+
+// ── 2. path_depth minimum is 1 ─────────────────────────────────
+
+#[test]
+fn path_depth_minimum_one_for_empty() {
+    assert_eq!(path_depth(""), 1);
+}
+
+// ── 3. path_depth ignores trailing slash ────────────────────────
+
+#[test]
+fn path_depth_trailing_slash() {
+    assert_eq!(path_depth("a/b/"), 2);
+    assert_eq!(path_depth("a/b/c/"), 3);
+}
+
+// ── 4. is_test_path detects test directory variants ─────────────
+
+#[test]
+fn is_test_path_directory_variants() {
+    assert!(is_test_path("src/test/foo.rs"));
+    assert!(is_test_path("src/tests/foo.rs"));
+    assert!(is_test_path("src/__tests__/foo.rs"));
+    assert!(is_test_path("src/spec/foo.rs"));
+    assert!(is_test_path("src/specs/foo.rs"));
+}
+
+// ── 5. is_test_path detects file name patterns ──────────────────
+
+#[test]
+fn is_test_path_file_patterns() {
+    assert!(is_test_path("src/foo_test.rs"));
+    assert!(is_test_path("src/test_foo.rs"));
+    assert!(is_test_path("src/foo.test.js"));
+    assert!(is_test_path("src/foo.spec.ts"));
+}
+
+// ── 6. is_test_path rejects non-test paths ──────────────────────
+
+#[test]
+fn is_test_path_rejects_non_test() {
+    assert!(!is_test_path("src/main.rs"));
+    assert!(!is_test_path("src/lib.rs"));
+    assert!(!is_test_path("src/contest/foo.rs")); // "contest" contains "test" but not as dir segment
+}
+
+// ── 7. is_infra_lang comprehensive ──────────────────────────────
+
+#[test]
+fn is_infra_lang_all_known() {
+    let infra = [
+        "json",
+        "yaml",
+        "toml",
+        "markdown",
+        "xml",
+        "html",
+        "css",
+        "scss",
+        "less",
+        "makefile",
+        "dockerfile",
+        "hcl",
+        "terraform",
+        "nix",
+        "cmake",
+        "ini",
+        "properties",
+        "gitignore",
+        "gitconfig",
+        "editorconfig",
+        "csv",
+        "tsv",
+        "svg",
+    ];
+    for lang in &infra {
+        assert!(is_infra_lang(lang), "{} should be infra", lang);
+    }
+}
+
+// ── 8. is_infra_lang rejects code languages ─────────────────────
+
+#[test]
+fn is_infra_lang_rejects_code() {
+    let code = [
+        "rust",
+        "python",
+        "javascript",
+        "typescript",
+        "go",
+        "java",
+        "c",
+        "cpp",
+    ];
+    for lang in &code {
+        assert!(!is_infra_lang(lang), "{} should not be infra", lang);
+    }
+}
+
+// ── 9. normalize_path strips root prefix ────────────────────────
+
+#[test]
+fn normalize_path_strips_root() {
+    let root = PathBuf::from("project");
+    assert_eq!(normalize_path("project/src/main.rs", &root), "src/main.rs");
+}
+
+// ── 10. normalize_path handles backslashes ──────────────────────
+
+#[test]
+fn normalize_path_backslashes() {
+    let root = PathBuf::from("project");
+    assert_eq!(normalize_path(r"project\src\lib.rs", &root), "src/lib.rs");
+}
+
+// ── 11. empty_file_row has all zeros ────────────────────────────
+
+#[test]
+fn empty_file_row_zeroed() {
+    let row = empty_file_row();
+    assert_eq!(row.code, 0);
+    assert_eq!(row.comments, 0);
+    assert_eq!(row.blanks, 0);
+    assert_eq!(row.lines, 0);
+    assert_eq!(row.bytes, 0);
+    assert_eq!(row.tokens, 0);
+    assert_eq!(row.depth, 0);
+    assert!(row.path.is_empty());
+    assert!(row.module.is_empty());
+    assert!(row.lang.is_empty());
+}
+
+// ── 12. is_infra_lang is case-insensitive ───────────────────────
+
+#[test]
+fn is_infra_lang_case_insensitive() {
+    assert!(is_infra_lang("JSON"));
+    assert!(is_infra_lang("Yaml"));
+    assert!(is_infra_lang("TOML"));
+    assert!(is_infra_lang("Html"));
+}
+
+// ── 13. path_depth with double slashes ──────────────────────────
+
+#[test]
+fn path_depth_double_slashes_ignored() {
+    assert_eq!(path_depth("a//b//c"), 3);
+}


### PR DESCRIPTION
Wave 42: 35+ enricher tests for archetype, near-dup, topics, util

## Summary
- **archetype** (14 tests): repo shape detection (library, CLI, Next.js, containerized, IaC, Python, Node), priority ordering, serde roundtrip, backslash normalization, evidence validation
- **near-dup** (14 tests): exact duplicates, unique files, empty/short files, threshold filtering, scope isolation (module/lang/global), max_pairs truncation, child exclusion, serde roundtrip, exclude patterns, sort order
- **topics** (11 tests): stopword filtering, module root stopwords, determinism, empty export, child exclusion, per-module separation, serde roundtrip, TOP_K cap, score positivity, token splitting, backslash normalization
- **util** (13 tests): path_depth variants, is_test_path patterns, is_infra_lang comprehensive, normalize_path edge cases, empty_file_row, case insensitivity

Total: 52 new tests