### PR TITLE
docs: expand doctests across public API items

### DIFF
--- a/crates/tokmd-ffi-envelope/src/lib.rs
+++ b/crates/tokmd-ffi-envelope/src/lib.rs
@@ -26,6 +26,19 @@ pub enum EnvelopeExtractError {
 }
 
 /// Parse a JSON envelope.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_ffi_envelope::parse_envelope;
+///
+/// let val = parse_envelope(r#"{"ok": true, "data": 42}"#).unwrap();
+/// assert_eq!(val["ok"], true);
+/// assert_eq!(val["data"], 42);
+///
+/// // Invalid JSON returns an error
+/// assert!(parse_envelope("{not json").is_err());
+/// ```
 pub fn parse_envelope(result_json: &str) -> Result<Value, EnvelopeExtractError> {
     serde_json::from_str(result_json)
         .map_err(|err| EnvelopeExtractError::JsonParse(err.to_string()))
@@ -35,6 +48,19 @@ pub fn parse_envelope(result_json: &str) -> Result<Value, EnvelopeExtractError> 
 ///
 /// Expected shape: `{"code": "...", "message": "..."}`.
 /// Falls back to `"Unknown error"` when missing or invalid.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_ffi_envelope::format_error_message;
+/// use serde_json::json;
+///
+/// let err = json!({"code": "scan_failed", "message": "Path not found"});
+/// assert_eq!(format_error_message(Some(&err)), "[scan_failed] Path not found");
+///
+/// // Missing fields fall back to defaults
+/// assert_eq!(format_error_message(None), "Unknown error");
+/// ```
 pub fn format_error_message(error_obj: Option<&Value>) -> String {
     let Some(error_obj) = error_obj else {
         return "Unknown error".to_string();
@@ -60,6 +86,21 @@ pub fn format_error_message(error_obj: Option<&Value>) -> String {
 /// - If `ok` is true and `data` exists, return `data`.
 /// - If `ok` is true and `data` is missing, return the full envelope unchanged.
 /// - Otherwise return an `Upstream` error with a normalized message.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_ffi_envelope::extract_data;
+/// use serde_json::json;
+///
+/// let envelope = json!({"ok": true, "data": {"count": 5}});
+/// let data = extract_data(envelope).unwrap();
+/// assert_eq!(data["count"], 5);
+///
+/// // An error envelope returns Err
+/// let fail = json!({"ok": false, "error": {"code": "e", "message": "boom"}});
+/// assert!(extract_data(fail).is_err());
+/// ```
 pub fn extract_data(envelope: Value) -> Result<Value, EnvelopeExtractError> {
     let Some(obj) = envelope.as_object() else {
         return Err(EnvelopeExtractError::InvalidResponseFormat);
@@ -79,12 +120,33 @@ pub fn extract_data(envelope: Value) -> Result<Value, EnvelopeExtractError> {
 }
 
 /// Parse and extract from a JSON envelope string.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_ffi_envelope::extract_data_from_json;
+///
+/// let json_str = r#"{"ok": true, "data": {"mode": "lang"}}"#;
+/// let data = extract_data_from_json(json_str).unwrap();
+/// assert_eq!(data["mode"], "lang");
+/// ```
 pub fn extract_data_from_json(result_json: &str) -> Result<Value, EnvelopeExtractError> {
     let envelope = parse_envelope(result_json)?;
     extract_data(envelope)
 }
 
 /// Parse and extract, returning a JSON-encoded data payload.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_ffi_envelope::extract_data_json;
+///
+/// let input = r#"{"ok": true, "data": {"v": 1}}"#;
+/// let json_out = extract_data_json(input).unwrap();
+/// let parsed: serde_json::Value = serde_json::from_str(&json_out).unwrap();
+/// assert_eq!(parsed["v"], 1);
+/// ```
 pub fn extract_data_json(result_json: &str) -> Result<String, EnvelopeExtractError> {
     let data = extract_data_from_json(result_json)?;
     serde_json::to_string(&data).map_err(|err| EnvelopeExtractError::JsonSerialize(err.to_string()))

--- a/crates/tokmd-math/src/lib.rs
+++ b/crates/tokmd-math/src/lib.rs
@@ -13,6 +13,15 @@
 /// assert_eq!(round_f64(12.34567, 4), 12.3457);
 /// assert_eq!(round_f64(1.5, 0), 2.0);
 /// ```
+///
+/// Rounding at zero decimal places:
+///
+/// ```
+/// use tokmd_math::round_f64;
+///
+/// assert_eq!(round_f64(2.4, 0), 2.0);
+/// assert_eq!(round_f64(2.6, 0), 3.0);
+/// ```
 #[must_use]
 pub fn round_f64(value: f64, decimals: u32) -> f64 {
     let factor = 10f64.powi(decimals as i32);
@@ -28,6 +37,15 @@ pub fn round_f64(value: f64, decimals: u32) -> f64 {
 ///
 /// assert_eq!(safe_ratio(1, 4), 0.25);
 /// assert_eq!(safe_ratio(5, 0), 0.0); // division by zero returns 0
+/// ```
+///
+/// Fractional ratios are rounded to four decimal places:
+///
+/// ```
+/// use tokmd_math::safe_ratio;
+///
+/// assert_eq!(safe_ratio(1, 3), 0.3333);
+/// assert_eq!(safe_ratio(2, 3), 0.6667);
 /// ```
 #[must_use]
 pub fn safe_ratio(numer: usize, denom: usize) -> f64 {
@@ -49,6 +67,15 @@ pub fn safe_ratio(numer: usize, denom: usize) -> f64 {
 /// assert_eq!(percentile(&values, 0.0), 10.0);
 /// assert_eq!(percentile(&values, 0.9), 50.0);
 /// assert_eq!(percentile(&[], 0.5), 0.0); // empty slice returns 0
+/// ```
+///
+/// Computing the median:
+///
+/// ```
+/// use tokmd_math::percentile;
+///
+/// let data = [1, 2, 3, 4, 5];
+/// assert_eq!(percentile(&data, 0.5), 3.0);
 /// ```
 #[must_use]
 pub fn percentile(sorted: &[usize], pct: f64) -> f64 {
@@ -74,6 +101,18 @@ pub fn percentile(sorted: &[usize], pct: f64) -> f64 {
 ///
 /// // Unequal distribution produces a positive Gini
 /// assert!(gini_coefficient(&[1, 1, 1, 100]) > 0.0);
+/// ```
+///
+/// Single-element and all-zero slices:
+///
+/// ```
+/// use tokmd_math::gini_coefficient;
+///
+/// // A single element has zero inequality
+/// assert_eq!(gini_coefficient(&[42]), 0.0);
+///
+/// // All zeros also return 0 (no division by zero)
+/// assert_eq!(gini_coefficient(&[0, 0, 0]), 0.0);
 /// ```
 #[must_use]
 pub fn gini_coefficient(sorted: &[usize]) -> f64 {

--- a/crates/tokmd-module-key/src/lib.rs
+++ b/crates/tokmd-module-key/src/lib.rs
@@ -23,6 +23,20 @@
 /// // Non-root directories use only the first segment
 /// assert_eq!(module_key("src/lib.rs", &roots, 2), "src");
 /// ```
+///
+/// Windows-style paths and empty roots:
+///
+/// ```
+/// use tokmd_module_key::module_key;
+///
+/// let roots = vec!["crates".into()];
+///
+/// // Backslash paths are normalized before key computation
+/// assert_eq!(module_key("crates\\foo\\src\\lib.rs", &roots, 2), "crates/foo");
+///
+/// // With no module roots every path uses the first directory segment
+/// assert_eq!(module_key("crates/foo/src/lib.rs", &[], 2), "crates");
+/// ```
 #[must_use]
 pub fn module_key(path: &str, module_roots: &[String], module_depth: usize) -> String {
     let mut p = path.replace('\\', "/");
@@ -56,6 +70,23 @@ pub fn module_key(path: &str, module_roots: &[String], module_depth: usize) -> S
 /// assert_eq!(
 ///     module_key_from_normalized("README.md", &roots, 2),
 ///     "(root)"
+/// );
+/// ```
+///
+/// Depth overflow and non-root directories:
+///
+/// ```
+/// use tokmd_module_key::module_key_from_normalized;
+///
+/// let roots = vec!["crates".into()];
+///
+/// // Non-root directories always map to the first segment
+/// assert_eq!(module_key_from_normalized("src/main.rs", &roots, 2), "src");
+///
+/// // A depth larger than available segments uses all of them
+/// assert_eq!(
+///     module_key_from_normalized("crates/foo/bar/baz.rs", &roots, 10),
+///     "crates/foo/bar"
 /// );
 /// ```
 #[must_use]

--- a/crates/tokmd-path/src/lib.rs
+++ b/crates/tokmd-path/src/lib.rs
@@ -10,6 +10,16 @@
 /// assert_eq!(normalize_slashes("src\\lib.rs"), "src/lib.rs");
 /// assert_eq!(normalize_slashes("already/forward"), "already/forward");
 /// ```
+///
+/// Mixed separators are all converted:
+///
+/// ```
+/// use tokmd_path::normalize_slashes;
+///
+/// assert_eq!(normalize_slashes("a\\b/c\\d"), "a/b/c/d");
+/// // Already-normalized paths pass through unchanged
+/// assert_eq!(normalize_slashes("no/change"), "no/change");
+/// ```
 #[must_use]
 pub fn normalize_slashes(path: &str) -> String {
     if path.contains('\\') {
@@ -32,6 +42,17 @@ pub fn normalize_slashes(path: &str) -> String {
 /// assert_eq!(normalize_rel_path(".\\src\\main.rs"), "src/main.rs");
 /// assert_eq!(normalize_rel_path("../lib.rs"), "../lib.rs");
 /// assert_eq!(normalize_rel_path("././src/lib.rs"), "src/lib.rs");
+/// ```
+///
+/// Idempotency — normalizing twice gives the same result:
+///
+/// ```
+/// use tokmd_path::normalize_rel_path;
+///
+/// let once = normalize_rel_path(".\\src\\lib.rs");
+/// let twice = normalize_rel_path(&once);
+/// assert_eq!(once, twice);
+/// assert_eq!(once, "src/lib.rs");
 /// ```
 #[must_use]
 pub fn normalize_rel_path(path: &str) -> String {

--- a/crates/tokmd-redact/src/lib.rs
+++ b/crates/tokmd-redact/src/lib.rs
@@ -58,6 +58,21 @@ fn clean_path(s: &str) -> String {
 /// // Cross-platform consistency: same hash regardless of separator
 /// assert_eq!(short_hash("src\\lib"), short_hash("src/lib"));
 /// ```
+///
+/// Dot-prefix and interior-dot normalization:
+///
+/// ```
+/// use tokmd_redact::short_hash;
+///
+/// // Leading "./" is stripped before hashing
+/// assert_eq!(short_hash("./src/lib"), short_hash("src/lib"));
+///
+/// // Interior "/." segments are resolved
+/// assert_eq!(short_hash("crates/./foo"), short_hash("crates/foo"));
+///
+/// // Different inputs always produce different hashes
+/// assert_ne!(short_hash("alpha"), short_hash("beta"));
+/// ```
 pub fn short_hash(s: &str) -> String {
     let cleaned = clean_path(s);
     let mut hex = blake3::hash(cleaned.as_bytes()).to_hex().to_string();
@@ -84,6 +99,20 @@ pub fn short_hash(s: &str) -> String {
 ///
 /// // Cross-platform consistency: same hash regardless of separator
 /// assert_eq!(redact_path("src\\main.rs"), redact_path("src/main.rs"));
+/// ```
+///
+/// Files without an extension produce a bare 16-character hash:
+///
+/// ```
+/// use tokmd_redact::redact_path;
+///
+/// let bare = redact_path("Makefile");
+/// assert_eq!(bare.len(), 16);
+/// assert!(!bare.contains('.'));
+///
+/// // Double extensions: only the final extension is preserved
+/// let gz = redact_path("archive.tar.gz");
+/// assert!(gz.ends_with(".gz"));
 /// ```
 pub fn redact_path(path: &str) -> String {
     let cleaned = clean_path(path);


### PR DESCRIPTION
Wave 42b: 15+ new doctests across utility crates

## Changes

Added 15 new doctest blocks across 5 crates:

- **tokmd-redact** (2 new): dot-prefix normalization, no-extension/double-extension paths
- **tokmd-path** (2 new): mixed separators, idempotency demonstration
- **tokmd-module-key** (2 new): Windows paths/empty roots, depth overflow/non-root dirs
- **tokmd-math** (4 new): zero-decimal rounding, fractional ratio precision, median, single-element/all-zero Gini
- **tokmd-ffi-envelope** (5 new): parse_envelope, format_error_message, extract_data, extract_data_from_json, extract_data_json

All 25 doctests pass (10 existing + 15 new).