### PR TITLE
test(proptest): property tests for scan, model, redact

### DIFF
--- a/crates/tokmd-model/tests/proptest_w42.rs
+++ b/crates/tokmd-model/tests/proptest_w42.rs
@@ -1,0 +1,293 @@
+//! Wave 42 property-based tests for tokmd-model.
+//!
+//! Covers LangRow/ModuleRow aggregation invariants, sorting stability,
+//! avg() corner cases, normalize_path properties, and module_key computation.
+
+use proptest::prelude::*;
+use std::path::Path;
+use tokmd_model::{avg, module_key, normalize_path};
+use tokmd_types::{LangRow, ModuleRow};
+
+// ============================================================================
+// Strategies
+// ============================================================================
+
+fn arb_lang_row() -> impl Strategy<Value = LangRow> {
+    (
+        "[A-Z][a-z]{2,10}",
+        0usize..50_000,    // code
+        0usize..50_000,    // comments (used to derive lines)
+        0usize..50_000,    // blanks   (used to derive lines)
+        0usize..500,       // files
+        0usize..5_000_000, // bytes
+        0usize..500_000,   // tokens
+    )
+        .prop_map(|(lang, code, comments, blanks, files, bytes, tokens)| {
+            let lines = code + comments + blanks;
+            let avg_lines = avg(lines, files);
+            LangRow {
+                lang,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            }
+        })
+}
+
+fn arb_module_row() -> impl Strategy<Value = ModuleRow> {
+    (
+        "[a-z][a-z0-9_/]{1,15}",
+        0usize..50_000,
+        0usize..50_000,
+        0usize..50_000,
+        0usize..500,
+        0usize..5_000_000,
+        0usize..500_000,
+    )
+        .prop_map(|(module, code, comments, blanks, files, bytes, tokens)| {
+            let lines = code + comments + blanks;
+            let avg_lines = avg(lines, files);
+            ModuleRow {
+                module,
+                code,
+                lines,
+                files,
+                bytes,
+                tokens,
+                avg_lines,
+            }
+        })
+}
+
+// ============================================================================
+// avg() properties
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    #[test]
+    fn avg_zero_files_returns_zero(lines in 0usize..100_000) {
+        prop_assert_eq!(avg(lines, 0), 0);
+    }
+
+    #[test]
+    fn avg_zero_lines_returns_zero(files in 1usize..10_000) {
+        prop_assert_eq!(avg(0, files), 0);
+    }
+
+    #[test]
+    fn avg_result_bounded(lines in 0usize..100_000, files in 1usize..10_000) {
+        let r = avg(lines, files);
+        let lo = lines / files;
+        let hi = if lines % files == 0 { lo } else { lo + 1 };
+        prop_assert!(r >= lo && r <= hi,
+            "avg({},{})={} not in [{},{}]", lines, files, r, lo, hi);
+    }
+
+    #[test]
+    fn avg_exact_division(q in 1usize..5_000, files in 1usize..5_000) {
+        prop_assert_eq!(avg(q * files, files), q);
+    }
+}
+
+// ============================================================================
+// LangRow aggregation invariants
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// lines >= code always holds for well-formed rows.
+    #[test]
+    fn lang_row_lines_ge_code(row in arb_lang_row()) {
+        prop_assert!(row.lines >= row.code,
+            "lines ({}) must be >= code ({})", row.lines, row.code);
+    }
+
+    /// Summing a collection of LangRows preserves total code.
+    #[test]
+    fn lang_row_sum_is_additive(rows in prop::collection::vec(arb_lang_row(), 0..20)) {
+        let sum_code: usize = rows.iter().map(|r| r.code).sum();
+        let sum_lines: usize = rows.iter().map(|r| r.lines).sum();
+        let sum_files: usize = rows.iter().map(|r| r.files).sum();
+        let sum_bytes: usize = rows.iter().map(|r| r.bytes).sum();
+        let sum_tokens: usize = rows.iter().map(|r| r.tokens).sum();
+
+        // Re-summing must yield the same result (addition is associative)
+        prop_assert_eq!(sum_code, rows.iter().map(|r| r.code).sum::<usize>());
+        prop_assert_eq!(sum_lines, rows.iter().map(|r| r.lines).sum::<usize>());
+        prop_assert_eq!(sum_files, rows.iter().map(|r| r.files).sum::<usize>());
+        prop_assert_eq!(sum_bytes, rows.iter().map(|r| r.bytes).sum::<usize>());
+        prop_assert_eq!(sum_tokens, rows.iter().map(|r| r.tokens).sum::<usize>());
+    }
+
+    /// Sorting LangRows by (code desc, lang asc) is stable and idempotent.
+    #[test]
+    fn lang_row_sort_idempotent(rows in prop::collection::vec(arb_lang_row(), 0..30)) {
+        let sort_fn = |v: &mut Vec<LangRow>| {
+            v.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+        };
+        let mut once = rows.clone();
+        sort_fn(&mut once);
+        let mut twice = once.clone();
+        sort_fn(&mut twice);
+        prop_assert_eq!(once, twice);
+    }
+
+    /// Sorting preserves the number of rows.
+    #[test]
+    fn lang_row_sort_preserves_count(rows in prop::collection::vec(arb_lang_row(), 0..30)) {
+        let mut sorted = rows.clone();
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+        prop_assert_eq!(sorted.len(), rows.len());
+    }
+
+    /// Sorted LangRows are in descending code order.
+    #[test]
+    fn lang_row_sorted_descending(rows in prop::collection::vec(arb_lang_row(), 2..20)) {
+        let mut sorted = rows;
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+        for w in sorted.windows(2) {
+            prop_assert!(
+                w[0].code > w[1].code || (w[0].code == w[1].code && w[0].lang <= w[1].lang),
+                "Sort order violated: {:?} before {:?}", w[0], w[1]
+            );
+        }
+    }
+}
+
+// ============================================================================
+// ModuleRow aggregation invariants
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// lines >= code for well-formed ModuleRows.
+    #[test]
+    fn module_row_lines_ge_code(row in arb_module_row()) {
+        prop_assert!(row.lines >= row.code,
+            "lines ({}) must be >= code ({})", row.lines, row.code);
+    }
+
+    /// Sorting ModuleRows by (code desc, module asc) is idempotent.
+    #[test]
+    fn module_row_sort_idempotent(rows in prop::collection::vec(arb_module_row(), 0..30)) {
+        let sort_fn = |v: &mut Vec<ModuleRow>| {
+            v.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+        };
+        let mut once = rows.clone();
+        sort_fn(&mut once);
+        let mut twice = once.clone();
+        sort_fn(&mut twice);
+        prop_assert_eq!(once, twice);
+    }
+
+    /// Sorted ModuleRows are in descending code order.
+    #[test]
+    fn module_row_sorted_descending(rows in prop::collection::vec(arb_module_row(), 2..20)) {
+        let mut sorted = rows;
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+        for w in sorted.windows(2) {
+            prop_assert!(
+                w[0].code > w[1].code || (w[0].code == w[1].code && w[0].module <= w[1].module),
+                "Sort order violated: {:?} before {:?}", w[0], w[1]
+            );
+        }
+    }
+
+    /// Sorting preserves sum of code across all rows.
+    #[test]
+    fn module_row_sort_preserves_code_sum(rows in prop::collection::vec(arb_module_row(), 0..30)) {
+        let sum_before: usize = rows.iter().map(|r| r.code).sum();
+        let mut sorted = rows;
+        sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+        let sum_after: usize = sorted.iter().map(|r| r.code).sum();
+        prop_assert_eq!(sum_before, sum_after);
+    }
+}
+
+// ============================================================================
+// normalize_path properties
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Normalized paths never contain backslashes.
+    #[test]
+    fn normalize_no_backslash(s in "[a-zA-Z0-9_./\\\\]{1,40}") {
+        let p = Path::new(&s);
+        let norm = normalize_path(p, None);
+        prop_assert!(!norm.contains('\\'), "Backslash in: {}", norm);
+    }
+
+    /// Normalized paths never start with "./".
+    #[test]
+    fn normalize_no_leading_dot_slash(s in "[a-zA-Z0-9_./]{1,30}") {
+        let p = Path::new(&s);
+        let norm = normalize_path(p, None);
+        prop_assert!(!norm.starts_with("./"), "Leading ./ in: {}", norm);
+    }
+
+    /// Normalization is idempotent.
+    #[test]
+    fn normalize_idempotent(s in "[a-zA-Z0-9_/]{1,30}") {
+        let p = Path::new(&s);
+        let n1 = normalize_path(p, None);
+        let n2 = normalize_path(Path::new(&n1), None);
+        prop_assert_eq!(n1, n2);
+    }
+}
+
+// ============================================================================
+// module_key properties
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// module_key never panics on arbitrary input.
+    #[test]
+    fn module_key_never_panics(
+        path in "[a-zA-Z0-9_/.]{1,40}",
+        roots in prop::collection::vec("[a-zA-Z0-9_]+", 0..4),
+        depth in 0usize..8
+    ) {
+        let _ = module_key(&path, &roots, depth);
+    }
+
+    /// module_key is deterministic.
+    #[test]
+    fn module_key_deterministic(
+        path in "[a-zA-Z0-9_/]+\\.[a-z]+",
+        roots in prop::collection::vec("[a-zA-Z0-9_]+", 0..3),
+        depth in 1usize..5
+    ) {
+        let k1 = module_key(&path, &roots, depth);
+        let k2 = module_key(&path, &roots, depth);
+        prop_assert_eq!(k1, k2);
+    }
+
+    /// Root-level files always map to "(root)".
+    #[test]
+    fn module_key_root_file(filename in "[a-zA-Z0-9_]+\\.[a-z]+") {
+        let k = module_key(&filename, &[], 2);
+        prop_assert_eq!(k.clone(), "(root)", "Single file '{}' should be (root), got '{}'", filename, k);
+    }
+
+    /// module_key output never contains backslashes.
+    #[test]
+    fn module_key_no_backslash(
+        path in "[a-zA-Z0-9_/\\\\]+\\.[a-z]+",
+        roots in prop::collection::vec("[a-zA-Z0-9_]+", 0..3),
+        depth in 1usize..5
+    ) {
+        let k = module_key(&path, &roots, depth);
+        prop_assert!(!k.contains('\\'), "Module key contains backslash: {}", k);
+    }
+}

--- a/crates/tokmd-redact/tests/proptest_w42.rs
+++ b/crates/tokmd-redact/tests/proptest_w42.rs
@@ -1,0 +1,195 @@
+//! Wave 42 property-based tests for tokmd-redact.
+//!
+//! Covers: non-emptiness, determinism, collision resistance, extension
+//! preservation, cross-platform normalization, and idempotency.
+
+use proptest::prelude::*;
+use tokmd_redact::{redact_path, short_hash};
+
+// ============================================================================
+// Strategies
+// ============================================================================
+
+fn arb_path() -> impl Strategy<Value = String> {
+    prop::collection::vec("[a-zA-Z0-9_.-]+", 1..=6).prop_map(|parts| parts.join("/"))
+}
+
+fn arb_extension() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("rs".to_string()),
+        Just("py".to_string()),
+        Just("go".to_string()),
+        Just("js".to_string()),
+        Just("ts".to_string()),
+        Just("json".to_string()),
+        Just("toml".to_string()),
+        Just("md".to_string()),
+    ]
+}
+
+fn arb_path_with_ext() -> impl Strategy<Value = String> {
+    (arb_path(), arb_extension()).prop_map(|(p, ext)| format!("{}.{}", p, ext))
+}
+
+fn arb_extensionless_path() -> impl Strategy<Value = String> {
+    prop::collection::vec("[a-zA-Z0-9_-]+", 1..=5)
+        .prop_filter("no dots", |parts| parts.iter().all(|p| !p.contains('.')))
+        .prop_map(|parts| parts.join("/"))
+}
+
+// ============================================================================
+// short_hash: non-emptiness and format
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Redacted paths are never empty.
+    #[test]
+    fn redact_path_never_empty(path in arb_path_with_ext()) {
+        let r = redact_path(&path);
+        prop_assert!(!r.is_empty(), "Redacted path must not be empty");
+    }
+
+    /// short_hash always returns exactly 16 lowercase hex chars.
+    #[test]
+    fn short_hash_always_16_hex(input in ".*") {
+        let h = short_hash(&input);
+        prop_assert_eq!(h.len(), 16);
+        prop_assert!(h.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "Not lowercase hex: {}", h);
+    }
+
+    /// short_hash output is never empty.
+    #[test]
+    fn short_hash_never_empty(input in ".*") {
+        prop_assert!(!short_hash(&input).is_empty());
+    }
+}
+
+// ============================================================================
+// Determinism: same input → same output
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// short_hash is deterministic.
+    #[test]
+    fn short_hash_deterministic(input in ".*") {
+        prop_assert_eq!(short_hash(&input), short_hash(&input));
+    }
+
+    /// redact_path is deterministic.
+    #[test]
+    fn redact_path_deterministic(path in arb_path_with_ext()) {
+        prop_assert_eq!(redact_path(&path), redact_path(&path));
+    }
+
+    /// Triple invocation returns same result.
+    #[test]
+    fn short_hash_triple_stable(input in "\\PC{0,50}") {
+        let h1 = short_hash(&input);
+        let h2 = short_hash(&input);
+        let h3 = short_hash(&input);
+        prop_assert_eq!(&h1, &h2);
+        prop_assert_eq!(&h2, &h3);
+    }
+}
+
+// ============================================================================
+// Collision resistance: different inputs → different outputs
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Different short strings produce different hashes.
+    #[test]
+    fn different_inputs_different_hashes(a in "[a-z]{1,20}", b in "[a-z]{1,20}") {
+        prop_assume!(a != b);
+        prop_assert_ne!(short_hash(&a), short_hash(&b),
+            "Collision: '{}' and '{}' hash the same", a, b);
+    }
+
+    /// Different paths produce different redacted outputs.
+    #[test]
+    fn different_paths_different_redactions(
+        a in "[a-z]{2,10}/[a-z]{2,10}\\.[a-z]{1,4}",
+        b in "[a-z]{2,10}/[a-z]{2,10}\\.[a-z]{1,4}"
+    ) {
+        prop_assume!(a != b);
+        // The redacted outputs may still collide if only the extension differs
+        // and the base path is the same, but for truly different paths this holds.
+        let ra = redact_path(&a);
+        let rb = redact_path(&b);
+        // At minimum, the hash portion should differ
+        prop_assert_ne!(&ra[..16], &rb[..16],
+            "Hash collision for '{}' and '{}'", a, b);
+    }
+}
+
+// ============================================================================
+// Extension preservation
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// redact_path preserves the final file extension.
+    #[test]
+    fn redact_preserves_extension(path in arb_path_with_ext()) {
+        let ext = path.rsplit('.').next().unwrap();
+        let r = redact_path(&path);
+        prop_assert!(r.ends_with(&format!(".{}", ext)),
+            "'{}' should end with '.{}', got '{}'", path, ext, r);
+    }
+
+    /// Extensionless paths redact to exactly 16 chars with no dot.
+    #[test]
+    fn redact_extensionless_no_dot(path in arb_extensionless_path()) {
+        let r = redact_path(&path);
+        prop_assert_eq!(r.len(), 16);
+        prop_assert!(!r.contains('.'), "Extensionless '{}' → '{}' contains dot", path, r);
+    }
+
+    /// Redacted path length = 16 + 1 + ext.len() for paths with extensions.
+    #[test]
+    fn redact_length_matches(path in arb_path_with_ext()) {
+        let ext = path.rsplit('.').next().unwrap();
+        let r = redact_path(&path);
+        prop_assert_eq!(r.len(), 16 + 1 + ext.len(),
+            "Length mismatch for '{}': got {}", path, r.len());
+    }
+}
+
+// ============================================================================
+// Cross-platform normalization
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Unix and Windows paths produce identical hashes.
+    #[test]
+    fn hash_cross_platform(path in arb_path()) {
+        let unix = path.replace('\\', "/");
+        let win = path.replace('/', "\\");
+        prop_assert_eq!(short_hash(&unix), short_hash(&win),
+            "Cross-platform mismatch: {} vs {}", unix, win);
+    }
+
+    /// Unix and Windows paths produce identical redacted output.
+    #[test]
+    fn redact_cross_platform(path in arb_path_with_ext()) {
+        let unix = path.replace('\\', "/");
+        let win = path.replace('/', "\\");
+        prop_assert_eq!(redact_path(&unix), redact_path(&win));
+    }
+
+    /// Leading "./" is transparent to hashing.
+    #[test]
+    fn hash_leading_dot_slash_transparent(path in arb_path()) {
+        prop_assert_eq!(short_hash(&path), short_hash(&format!("./{}", path)));
+    }
+}

--- a/crates/tokmd-scan/tests/proptest_w42.rs
+++ b/crates/tokmd-scan/tests/proptest_w42.rs
@@ -1,0 +1,280 @@
+//! Wave 42 property-based tests for tokmd-scan.
+//!
+//! Covers ScanOptions construction, config mapping robustness,
+//! flag interaction properties, and exclude-pattern handling.
+
+use proptest::prelude::*;
+use proptest::string::string_regex;
+use tokmd_settings::ScanOptions;
+use tokmd_types::ConfigMode;
+
+// ============================================================================
+// Strategies
+// ============================================================================
+
+fn arb_exclude_pattern() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("target".to_string()),
+        Just("node_modules".to_string()),
+        Just(".git".to_string()),
+        Just("*.min.js".to_string()),
+        Just("**/*.bak".to_string()),
+        string_regex("[a-zA-Z0-9_-]{1,20}").unwrap(),
+        string_regex("[a-zA-Z0-9_-]{1,10}/\\*\\*").unwrap(),
+    ]
+}
+
+fn arb_scan_options() -> impl Strategy<Value = ScanOptions> {
+    (
+        prop::collection::vec(arb_exclude_pattern(), 0..=5),
+        prop_oneof![Just(ConfigMode::Auto), Just(ConfigMode::None)],
+        any::<bool>(),
+        any::<bool>(),
+        any::<bool>(),
+        any::<bool>(),
+        any::<bool>(),
+        any::<bool>(),
+    )
+        .prop_map(
+            |(
+                excluded,
+                config,
+                hidden,
+                no_ignore,
+                no_ignore_parent,
+                no_ignore_dot,
+                no_ignore_vcs,
+                treat_doc_strings_as_comments,
+            )| {
+                ScanOptions {
+                    excluded,
+                    config,
+                    hidden,
+                    no_ignore,
+                    no_ignore_parent,
+                    no_ignore_dot,
+                    no_ignore_vcs,
+                    treat_doc_strings_as_comments,
+                }
+            },
+        )
+}
+
+fn build_config(args: &ScanOptions) -> tokei::Config {
+    let mut cfg = match args.config {
+        ConfigMode::Auto => tokei::Config::from_config_files(),
+        ConfigMode::None => tokei::Config::default(),
+    };
+    if args.hidden {
+        cfg.hidden = Some(true);
+    }
+    if args.no_ignore {
+        cfg.no_ignore = Some(true);
+        cfg.no_ignore_dot = Some(true);
+        cfg.no_ignore_parent = Some(true);
+        cfg.no_ignore_vcs = Some(true);
+    }
+    if args.no_ignore_dot {
+        cfg.no_ignore_dot = Some(true);
+    }
+    if args.no_ignore_parent {
+        cfg.no_ignore_parent = Some(true);
+    }
+    if args.no_ignore_vcs {
+        cfg.no_ignore_vcs = Some(true);
+    }
+    if args.treat_doc_strings_as_comments {
+        cfg.treat_doc_strings_as_comments = Some(true);
+    }
+    cfg
+}
+
+// ============================================================================
+// Config mapping: arbitrary ScanOptions never panics
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// Arbitrary ScanOptions always produces a valid tokei Config.
+    #[test]
+    fn arbitrary_scan_options_produces_valid_config(args in arb_scan_options()) {
+        let cfg = build_config(&args);
+        // Just accessing fields proves it didn't panic
+        let _ = (cfg.hidden, cfg.no_ignore, cfg.treat_doc_strings_as_comments);
+    }
+
+    /// Excluded patterns can always be collected into &str slices.
+    #[test]
+    fn excluded_patterns_always_convertible(args in arb_scan_options()) {
+        let ignores: Vec<&str> = args.excluded.iter().map(|s| s.as_str()).collect();
+        prop_assert_eq!(ignores.len(), args.excluded.len());
+    }
+
+    /// Config mapping is deterministic: same input yields same output.
+    #[test]
+    fn config_mapping_deterministic(args in arb_scan_options()) {
+        let c1 = build_config(&args);
+        let c2 = build_config(&args);
+        prop_assert_eq!(c1.hidden, c2.hidden);
+        prop_assert_eq!(c1.no_ignore, c2.no_ignore);
+        prop_assert_eq!(c1.no_ignore_dot, c2.no_ignore_dot);
+        prop_assert_eq!(c1.no_ignore_parent, c2.no_ignore_parent);
+        prop_assert_eq!(c1.no_ignore_vcs, c2.no_ignore_vcs);
+        prop_assert_eq!(c1.treat_doc_strings_as_comments, c2.treat_doc_strings_as_comments);
+    }
+}
+
+// ============================================================================
+// Flag implication: no_ignore ⊃ all sub-flags
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// When no_ignore=true, all sub-ignore flags are forced true.
+    #[test]
+    fn no_ignore_forces_all_sub_flags(args in arb_scan_options()) {
+        prop_assume!(args.no_ignore);
+        let cfg = build_config(&args);
+        prop_assert_eq!(cfg.no_ignore, Some(true));
+        prop_assert_eq!(cfg.no_ignore_dot, Some(true));
+        prop_assert_eq!(cfg.no_ignore_parent, Some(true));
+        prop_assert_eq!(cfg.no_ignore_vcs, Some(true));
+    }
+
+    /// When no_ignore=false, sub-flags reflect their individual values.
+    #[test]
+    fn sub_flags_independent_when_no_ignore_false(args in arb_scan_options()) {
+        prop_assume!(!args.no_ignore);
+        let mut cfg = tokei::Config::default();
+        if args.no_ignore_dot { cfg.no_ignore_dot = Some(true); }
+        if args.no_ignore_parent { cfg.no_ignore_parent = Some(true); }
+        if args.no_ignore_vcs { cfg.no_ignore_vcs = Some(true); }
+
+        prop_assert_eq!(cfg.no_ignore_dot.unwrap_or(false), args.no_ignore_dot);
+        prop_assert_eq!(cfg.no_ignore_parent.unwrap_or(false), args.no_ignore_parent);
+        prop_assert_eq!(cfg.no_ignore_vcs.unwrap_or(false), args.no_ignore_vcs);
+    }
+
+    /// hidden flag is orthogonal to ignore flags.
+    #[test]
+    fn hidden_orthogonal_to_ignore(
+        hidden in any::<bool>(),
+        no_ignore in any::<bool>(),
+        no_ignore_dot in any::<bool>(),
+    ) {
+        let args = ScanOptions {
+            excluded: vec![],
+            config: ConfigMode::None,
+            hidden,
+            no_ignore,
+            no_ignore_parent: false,
+            no_ignore_dot,
+            no_ignore_vcs: false,
+            treat_doc_strings_as_comments: false,
+        };
+        let cfg = build_config(&args);
+        prop_assert_eq!(cfg.hidden.unwrap_or(false), hidden);
+    }
+
+    /// treat_doc_strings_as_comments is orthogonal to all ignore flags.
+    #[test]
+    fn doc_strings_orthogonal(
+        treat_doc in any::<bool>(),
+        no_ignore in any::<bool>(),
+    ) {
+        let args = ScanOptions {
+            excluded: vec![],
+            config: ConfigMode::None,
+            hidden: false,
+            no_ignore,
+            no_ignore_parent: false,
+            no_ignore_dot: false,
+            no_ignore_vcs: false,
+            treat_doc_strings_as_comments: treat_doc,
+        };
+        let cfg = build_config(&args);
+        prop_assert_eq!(cfg.treat_doc_strings_as_comments.unwrap_or(false), treat_doc);
+    }
+}
+
+// ============================================================================
+// Exclude pattern properties
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// Duplicating exclude patterns doesn't cause panics.
+    #[test]
+    fn duplicate_excludes_harmless(p in arb_exclude_pattern(), n in 1usize..5) {
+        let args = ScanOptions {
+            excluded: vec![p; n],
+            config: ConfigMode::None,
+            hidden: false,
+            no_ignore: false,
+            no_ignore_parent: false,
+            no_ignore_dot: false,
+            no_ignore_vcs: false,
+            treat_doc_strings_as_comments: false,
+        };
+        let ignores: Vec<&str> = args.excluded.iter().map(|s| s.as_str()).collect();
+        prop_assert_eq!(ignores.len(), n);
+    }
+
+    /// Empty exclude list always works.
+    #[test]
+    fn empty_excludes_always_valid(args in arb_scan_options()) {
+        let mut a = args;
+        a.excluded = vec![];
+        let ignores: Vec<&str> = a.excluded.iter().map(|s| s.as_str()).collect();
+        prop_assert!(ignores.is_empty());
+        let _ = build_config(&a);
+    }
+}
+
+// ============================================================================
+// Scan result properties (using real filesystem)
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(5))]
+
+    /// Scanning the crate's own src/ with any valid ScanOptions never panics
+    /// and produces non-negative counts.
+    #[test]
+    fn scan_own_src_never_panics_and_counts_nonneg(args in arb_scan_options()) {
+        let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+        let result = tokmd_scan::scan(&[src], &args);
+        prop_assert!(result.is_ok(), "scan failed: {:?}", result.err());
+        let langs = result.unwrap();
+        for (_lt, lang) in langs.iter() {
+            prop_assert!(lang.code <= lang.lines(),
+                "code ({}) should not exceed total lines ({})", lang.code, lang.lines());
+        }
+    }
+
+    /// Scanning always finds Rust files in this crate's src/.
+    #[test]
+    fn scan_finds_rust_in_own_src(_dummy in 0u8..5) {
+        let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+        let args = ScanOptions::default();
+        let langs = tokmd_scan::scan(&[src], &args).unwrap();
+        prop_assert!(
+            langs.get(&tokei::LanguageType::Rust).is_some(),
+            "Should find Rust in scan crate src"
+        );
+    }
+
+    /// Language names from scan results are never empty strings.
+    #[test]
+    fn language_names_non_empty(_dummy in 0u8..3) {
+        let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+        let args = ScanOptions::default();
+        let langs = tokmd_scan::scan(&[src], &args).unwrap();
+        for (lt, _lang) in langs.iter() {
+            prop_assert!(!lt.name().is_empty(), "Language name should not be empty");
+        }
+    }
+}


### PR DESCRIPTION
Wave 42b: 46 property-based tests across three crates.

### crates/tokmd-scan/tests/proptest_w42.rs (12 tests)
- Arbitrary ScanOptions config mapping robustness
- Flag implication (no_ignore ⊃ sub-flags)
- Exclude pattern handling
- Real filesystem scan properties

### crates/tokmd-model/tests/proptest_w42.rs (20 tests)
- avg() corner cases and bounds
- LangRow aggregation invariants and sorting
- ModuleRow sorting stability and code-sum preservation
- normalize_path properties (no backslash, idempotent)
- module_key computation (determinism, root files, no backslash)

### crates/tokmd-redact/tests/proptest_w42.rs (14 tests)
- short_hash format (16 lowercase hex)
- Determinism (same input → same output)
- Collision resistance (different inputs → different hashes)
- Extension preservation
- Cross-platform normalization