### PR TITLE
test(core): deep FFI and envelope tests

### DIFF
--- a/crates/tokmd-core/tests/ffi_w43.rs
+++ b/crates/tokmd-core/tests/ffi_w43.rs
@@ -1,0 +1,535 @@
+//! Wave 43: Deep FFI entrypoint tests for `run_json`.
+//!
+//! Focuses on:
+//! - Response envelope contract (ok/data/error fields)
+//! - All modes: version, lang, module, export, diff
+//! - Error handling: invalid JSON, unknown mode, bad settings
+//! - Schema version propagation
+//! - JSON validity invariant (every call returns parseable JSON)
+//! - Idempotency of error envelopes
+//! - Nested settings parsing through FFI boundary
+//! - Mode-specific receipt field validation
+//! - Edge-case inputs: empty strings, unicode, null fields
+
+use serde_json::Value;
+use tokmd_core::ffi::run_json;
+
+// ═══════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════
+
+fn parse(result: &str) -> Value {
+    serde_json::from_str(result)
+        .unwrap_or_else(|e| panic!("run_json must return valid JSON: {e}\nraw: {result}"))
+}
+
+fn ok(result: &str) -> Value {
+    let v = parse(result);
+    assert_eq!(v["ok"], true, "expected ok=true: {result}");
+    assert!(v.get("data").is_some(), "ok envelope must have 'data'");
+    assert!(
+        v.get("error").is_none(),
+        "ok envelope must not have 'error'"
+    );
+    v
+}
+
+fn err(result: &str) -> Value {
+    let v = parse(result);
+    assert_eq!(v["ok"], false, "expected ok=false: {result}");
+    assert!(v.get("error").is_some(), "error envelope must have 'error'");
+    assert!(
+        v.get("data").is_none(),
+        "error envelope must not have 'data'"
+    );
+    v
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. Version mode
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_version_returns_ok() {
+    ok(&run_json("version", "{}"));
+}
+
+#[test]
+fn w43_version_has_version_string() {
+    let v = ok(&run_json("version", "{}"));
+    let ver = v["data"]["version"].as_str().expect("version is string");
+    assert!(!ver.is_empty());
+    assert!(ver.contains('.'), "should be semver: {ver}");
+}
+
+#[test]
+fn w43_version_has_schema_version() {
+    let v = ok(&run_json("version", "{}"));
+    let sv = v["data"]["schema_version"]
+        .as_u64()
+        .expect("schema_version");
+    assert_eq!(sv, u64::from(tokmd_types::SCHEMA_VERSION));
+}
+
+#[test]
+fn w43_version_ignores_extra_fields() {
+    let v = ok(&run_json("version", r#"{"extra": "stuff", "foo": 42}"#));
+    assert!(v["data"]["version"].is_string());
+}
+
+#[test]
+fn w43_version_idempotent() {
+    let r1 = run_json("version", "{}");
+    let r2 = run_json("version", "{}");
+    assert_eq!(r1, r2, "version should be byte-identical across calls");
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. Lang mode
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_lang_default_args_returns_ok() {
+    ok(&run_json("lang", "{}"));
+}
+
+#[test]
+fn w43_lang_receipt_has_mode_field() {
+    let v = ok(&run_json("lang", "{}"));
+    assert_eq!(v["data"]["mode"].as_str(), Some("lang"));
+}
+
+#[test]
+fn w43_lang_receipt_has_schema_version() {
+    let v = ok(&run_json("lang", "{}"));
+    let sv = v["data"]["schema_version"].as_u64().unwrap();
+    assert_eq!(sv, u64::from(tokmd_types::SCHEMA_VERSION));
+}
+
+#[test]
+fn w43_lang_receipt_has_generated_at_ms() {
+    let v = ok(&run_json("lang", "{}"));
+    let ts = v["data"]["generated_at_ms"].as_u64().unwrap();
+    // Should be after 2020-01-01
+    assert!(ts > 1_577_836_800_000);
+}
+
+#[test]
+fn w43_lang_receipt_has_tool_info() {
+    let v = ok(&run_json("lang", "{}"));
+    assert!(v["data"]["tool"]["name"].is_string());
+    assert!(v["data"]["tool"]["version"].is_string());
+}
+
+#[test]
+fn w43_lang_receipt_has_rows_array() {
+    let v = ok(&run_json("lang", "{}"));
+    assert!(v["data"]["rows"].is_array());
+}
+
+#[test]
+fn w43_lang_receipt_has_scan_metadata() {
+    let v = ok(&run_json("lang", "{}"));
+    assert!(v["data"]["scan"].is_object());
+}
+
+#[test]
+fn w43_lang_receipt_has_args_metadata() {
+    let v = ok(&run_json("lang", "{}"));
+    assert!(v["data"]["args"].is_object());
+}
+
+#[test]
+fn w43_lang_with_top_parameter() {
+    let v = ok(&run_json("lang", r#"{"top": 1}"#));
+    let rows = v["data"]["rows"].as_array().unwrap();
+    // top=1 means at most 1 language row + optional "Other"
+    assert!(rows.len() <= 2);
+}
+
+#[test]
+fn w43_lang_with_files_parameter() {
+    let v = ok(&run_json("lang", r#"{"files": true}"#));
+    assert_eq!(v["data"]["args"]["with_files"], true);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. Module mode
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_module_default_args_returns_ok() {
+    ok(&run_json("module", "{}"));
+}
+
+#[test]
+fn w43_module_receipt_has_mode() {
+    let v = ok(&run_json("module", "{}"));
+    assert_eq!(v["data"]["mode"].as_str(), Some("module"));
+}
+
+#[test]
+fn w43_module_receipt_has_schema_version() {
+    let v = ok(&run_json("module", "{}"));
+    let sv = v["data"]["schema_version"].as_u64().unwrap();
+    assert_eq!(sv, u64::from(tokmd_types::SCHEMA_VERSION));
+}
+
+#[test]
+fn w43_module_receipt_has_rows() {
+    let v = ok(&run_json("module", "{}"));
+    assert!(v["data"]["rows"].is_array());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 4. Export mode
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_export_default_args_returns_ok() {
+    ok(&run_json("export", "{}"));
+}
+
+#[test]
+fn w43_export_receipt_has_mode() {
+    let v = ok(&run_json("export", "{}"));
+    assert_eq!(v["data"]["mode"].as_str(), Some("export"));
+}
+
+#[test]
+fn w43_export_receipt_has_schema_version() {
+    let v = ok(&run_json("export", "{}"));
+    let sv = v["data"]["schema_version"].as_u64().unwrap();
+    assert_eq!(sv, u64::from(tokmd_types::SCHEMA_VERSION));
+}
+
+#[test]
+fn w43_export_receipt_has_rows() {
+    let v = ok(&run_json("export", "{}"));
+    assert!(v["data"]["rows"].is_array());
+    let rows = v["data"]["rows"].as_array().unwrap();
+    assert!(!rows.is_empty(), "should find files in cwd");
+}
+
+#[test]
+fn w43_export_rows_have_path_and_lang() {
+    let v = ok(&run_json("export", "{}"));
+    let rows = v["data"]["rows"].as_array().unwrap();
+    for row in rows.iter().take(5) {
+        assert!(row["path"].is_string(), "row must have path: {row}");
+        assert!(row["lang"].is_string(), "row must have lang: {row}");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 5. Invalid mode
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_invalid_mode_returns_error_envelope() {
+    let v = err(&run_json("invalid_mode", "{}"));
+    assert_eq!(v["error"]["code"].as_str(), Some("unknown_mode"));
+}
+
+#[test]
+fn w43_invalid_mode_message_includes_mode_name() {
+    let v = err(&run_json("foobar", "{}"));
+    let msg = v["error"]["message"].as_str().unwrap();
+    assert!(
+        msg.contains("foobar"),
+        "error should mention the mode: {msg}"
+    );
+}
+
+#[test]
+fn w43_empty_mode_is_unknown() {
+    let v = err(&run_json("", "{}"));
+    assert_eq!(v["error"]["code"].as_str(), Some("unknown_mode"));
+}
+
+#[test]
+fn w43_case_sensitive_mode() {
+    // "Lang" is not "lang"
+    let v = err(&run_json("Lang", "{}"));
+    assert_eq!(v["error"]["code"].as_str(), Some("unknown_mode"));
+}
+
+#[test]
+fn w43_mode_with_spaces() {
+    let v = err(&run_json(" lang ", "{}"));
+    assert_eq!(v["error"]["code"].as_str(), Some("unknown_mode"));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 6. Invalid JSON input
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_invalid_json_returns_error_envelope() {
+    let v = err(&run_json("lang", "invalid json"));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_json"));
+}
+
+#[test]
+fn w43_empty_string_input_returns_error() {
+    let v = err(&run_json("lang", ""));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_json"));
+}
+
+#[test]
+fn w43_truncated_json_returns_error() {
+    let v = err(&run_json("lang", r#"{"paths": ["sr"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_json"));
+}
+
+#[test]
+fn w43_json_array_is_parseable_but_may_succeed_or_fail() {
+    // A JSON array parses fine but field extraction uses defaults
+    let result = run_json("lang", "[]");
+    let v = parse(&result);
+    assert!(v["ok"].is_boolean());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 7. Envelope contract invariants
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_every_response_has_ok_boolean() {
+    let cases = [
+        ("version", "{}"),
+        ("lang", "{}"),
+        ("module", "{}"),
+        ("export", "{}"),
+        ("bogus", "{}"),
+        ("lang", "bad"),
+        ("diff", "{}"),
+    ];
+    for (mode, args) in &cases {
+        let result = run_json(mode, args);
+        let v = parse(&result);
+        assert!(
+            v["ok"].is_boolean(),
+            "ok must be bool for mode={mode} args={args}"
+        );
+    }
+}
+
+#[test]
+fn w43_success_envelope_has_data_not_error() {
+    let v = ok(&run_json("version", "{}"));
+    assert!(v.get("data").is_some());
+    assert!(v.get("error").is_none());
+}
+
+#[test]
+fn w43_error_envelope_has_error_not_data() {
+    let v = err(&run_json("bogus", "{}"));
+    assert!(v.get("error").is_some());
+    assert!(v.get("data").is_none());
+}
+
+#[test]
+fn w43_error_envelope_has_code_and_message() {
+    let v = err(&run_json("bogus", "{}"));
+    let e = &v["error"];
+    assert!(e["code"].is_string(), "error.code must be string");
+    assert!(e["message"].is_string(), "error.message must be string");
+}
+
+#[test]
+fn w43_all_responses_are_valid_json() {
+    let cases = [
+        ("", ""),
+        ("lang", ""),
+        ("lang", "null"),
+        ("lang", "42"),
+        ("\0", "{}"),
+        ("lang", r#"{"top": -1}"#),
+        ("export", r#"{"format": "yaml"}"#),
+        ("module", r#"{"module_depth": "deep"}"#),
+        ("diff", r#"{"from":"a"}"#),
+    ];
+    for (mode, args) in &cases {
+        let result = run_json(mode, args);
+        let parsed: Result<Value, _> = serde_json::from_str(&result);
+        assert!(
+            parsed.is_ok(),
+            "Invalid JSON for mode={mode:?} args={args:?}: {result}"
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 8. Strict settings validation through FFI
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_lang_invalid_top_type_returns_error() {
+    let v = err(&run_json("lang", r#"{"top": "ten"}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("top"));
+}
+
+#[test]
+fn w43_lang_invalid_files_type_returns_error() {
+    let v = err(&run_json("lang", r#"{"files": "yes"}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("files"));
+}
+
+#[test]
+fn w43_lang_invalid_children_returns_error() {
+    let v = err(&run_json("lang", r#"{"children": "merge"}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("children"));
+}
+
+#[test]
+fn w43_export_invalid_format_returns_error() {
+    let v = err(&run_json("export", r#"{"format": "xml"}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("format"));
+}
+
+#[test]
+fn w43_export_invalid_redact_returns_error() {
+    let v = err(&run_json("export", r#"{"redact": "partial"}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("redact"));
+}
+
+#[test]
+fn w43_scan_invalid_hidden_type_returns_error() {
+    let v = err(&run_json("lang", r#"{"hidden": 1}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+}
+
+#[test]
+fn w43_scan_invalid_paths_type_returns_error() {
+    let v = err(&run_json("lang", r#"{"paths": "not-array"}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+}
+
+#[test]
+fn w43_scan_invalid_config_returns_error() {
+    let v = err(&run_json("lang", r#"{"config": "invalid"}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 9. Nested scan object settings through FFI
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_nested_scan_object_works() {
+    let v = ok(&run_json("lang", r#"{"scan": {"paths": ["."]}}"#));
+    assert_eq!(v["data"]["mode"].as_str(), Some("lang"));
+}
+
+#[test]
+fn w43_nested_scan_invalid_field_returns_error() {
+    let v = err(&run_json("lang", r#"{"scan": {"hidden": "nope"}}"#));
+    assert_eq!(v["error"]["code"].as_str(), Some("invalid_settings"));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 10. Diff mode errors
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_diff_missing_from_returns_error() {
+    let v = err(&run_json("diff", r#"{"to": "."}"#));
+    assert!(v["error"]["message"].as_str().unwrap().contains("from"));
+}
+
+#[test]
+fn w43_diff_missing_to_returns_error() {
+    let v = err(&run_json("diff", r#"{"from": "."}"#));
+    assert!(v["error"]["message"].as_str().unwrap().contains("to"));
+}
+
+#[test]
+fn w43_diff_missing_both_returns_error() {
+    err(&run_json("diff", "{}"));
+}
+
+#[test]
+fn w43_diff_self_returns_zero_deltas() {
+    let v = ok(&run_json("diff", r#"{"from": ".", "to": "."}"#));
+    if let Some(rows) = v["data"]["diff_rows"].as_array() {
+        for row in rows {
+            assert_eq!(row["delta_code"].as_i64(), Some(0));
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 11. Unicode and special characters
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_unicode_in_mode_returns_error() {
+    let v = err(&run_json("日本語", "{}"));
+    assert_eq!(v["error"]["code"].as_str(), Some("unknown_mode"));
+}
+
+#[test]
+fn w43_null_args_json_produces_valid_json() {
+    let result = run_json("lang", "null");
+    let v = parse(&result);
+    assert!(v["ok"].is_boolean());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 12. Feature-gated modes
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+#[cfg(not(feature = "analysis"))]
+fn w43_analyze_without_feature_returns_not_implemented() {
+    let v = err(&run_json("analyze", "{}"));
+    assert_eq!(v["error"]["code"].as_str(), Some("not_implemented"));
+}
+
+#[test]
+#[cfg(not(feature = "cockpit"))]
+fn w43_cockpit_without_feature_returns_not_implemented() {
+    let v = err(&run_json("cockpit", "{}"));
+    assert_eq!(v["error"]["code"].as_str(), Some("not_implemented"));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 13. Error code consistency
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_error_codes_are_snake_case() {
+    let cases = [
+        ("bogus", "{}"),
+        ("lang", "bad json"),
+        ("lang", r#"{"top": "x"}"#),
+        ("export", r#"{"format": "yaml"}"#),
+    ];
+    for (mode, args) in &cases {
+        let v = err(&run_json(mode, args));
+        let code = v["error"]["code"].as_str().unwrap();
+        assert!(
+            code.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+            "error code must be snake_case: {code} for mode={mode}"
+        );
+    }
+}
+
+#[test]
+fn w43_error_messages_are_non_empty() {
+    let cases = [("bogus", "{}"), ("lang", ""), ("diff", "{}")];
+    for (mode, args) in &cases {
+        let v = err(&run_json(mode, args));
+        let msg = v["error"]["message"].as_str().unwrap();
+        assert!(
+            !msg.is_empty(),
+            "error message must not be empty for mode={mode}"
+        );
+    }
+}

--- a/crates/tokmd-ffi-envelope/tests/deep_w43.rs
+++ b/crates/tokmd-ffi-envelope/tests/deep_w43.rs
@@ -1,0 +1,328 @@
+//! Wave 43: Deep tests for `tokmd-ffi-envelope`.
+//!
+//! Focuses on:
+//! - Envelope wrapping: ok responses and error responses
+//! - Serde roundtrip through `extract_data_json`
+//! - Schema version presence in live envelopes
+//! - Error variant equality, display, and clone
+//! - Edge cases: nested data, large payloads, type coercion
+//! - Integration with live `run_json` envelopes
+
+use serde_json::{Value, json};
+use tokmd_ffi_envelope::{
+    EnvelopeExtractError, extract_data, extract_data_from_json, extract_data_json,
+    format_error_message, parse_envelope,
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. Ok envelope wrapping
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_ok_envelope_extracts_data_object() {
+    let env = json!({"ok": true, "data": {"mode": "lang", "schema_version": 2}});
+    let data = extract_data(env).unwrap();
+    assert_eq!(data["mode"], "lang");
+    assert_eq!(data["schema_version"], 2);
+}
+
+#[test]
+fn w43_ok_envelope_extracts_nested_data() {
+    let env = json!({"ok": true, "data": {"a": {"b": {"c": 42}}}});
+    let data = extract_data(env).unwrap();
+    assert_eq!(data["a"]["b"]["c"], 42);
+}
+
+#[test]
+fn w43_ok_envelope_with_null_data_returns_null() {
+    let env = json!({"ok": true, "data": null});
+    let data = extract_data(env).unwrap();
+    assert!(data.is_null());
+}
+
+#[test]
+fn w43_ok_envelope_without_data_returns_full_envelope() {
+    let env = json!({"ok": true, "extra": "field"});
+    let data = extract_data(env.clone()).unwrap();
+    assert_eq!(data, env);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. Error envelope wrapping
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_error_envelope_returns_upstream_error() {
+    let env = json!({"ok": false, "error": {"code": "scan_error", "message": "Scan failed"}});
+    let err = extract_data(env).unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::Upstream(_)));
+    assert!(err.to_string().contains("scan_error"));
+    assert!(err.to_string().contains("Scan failed"));
+}
+
+#[test]
+fn w43_error_envelope_without_error_obj() {
+    let env = json!({"ok": false});
+    let err = extract_data(env).unwrap_err();
+    assert_eq!(
+        err,
+        EnvelopeExtractError::Upstream("Unknown error".to_string())
+    );
+}
+
+#[test]
+fn w43_error_envelope_with_null_error() {
+    let env = json!({"ok": false, "error": null});
+    let err = extract_data(env).unwrap_err();
+    assert_eq!(
+        err,
+        EnvelopeExtractError::Upstream("Unknown error".to_string())
+    );
+}
+
+#[test]
+fn w43_error_envelope_ignores_data_when_not_ok() {
+    let env =
+        json!({"ok": false, "data": {"ignored": true}, "error": {"code": "e", "message": "m"}});
+    let err = extract_data(env).unwrap_err();
+    assert_eq!(err, EnvelopeExtractError::Upstream("[e] m".to_string()));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. Serde roundtrip
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_roundtrip_object_through_extract_data_json() {
+    let input = r#"{"ok":true,"data":{"mode":"lang","rows":[{"lang":"Rust","code":100}]}}"#;
+    let output = extract_data_json(input).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["mode"], "lang");
+    assert_eq!(parsed["rows"][0]["lang"], "Rust");
+    assert_eq!(parsed["rows"][0]["code"], 100);
+}
+
+#[test]
+fn w43_roundtrip_array_through_extract_data_json() {
+    let input = r#"{"ok":true,"data":[1,2,3,4,5]}"#;
+    let output = extract_data_json(input).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed.as_array().unwrap().len(), 5);
+}
+
+#[test]
+fn w43_roundtrip_string_through_extract_data_json() {
+    let input = r#"{"ok":true,"data":"hello world"}"#;
+    let output = extract_data_json(input).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed, "hello world");
+}
+
+#[test]
+fn w43_roundtrip_preserves_numeric_precision() {
+    let input = r#"{"ok":true,"data":{"big":9007199254740992,"neg":-42,"float":3.14159}}"#;
+    let output = extract_data_json(input).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["big"], 9007199254740992_u64);
+    assert_eq!(parsed["neg"], -42);
+    assert!((parsed["float"].as_f64().unwrap() - 3.14159).abs() < 1e-10);
+}
+
+#[test]
+fn w43_roundtrip_preserves_unicode() {
+    let input = r#"{"ok":true,"data":{"emoji":"🦀","jp":"日本語"}}"#;
+    let output = extract_data_json(input).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["emoji"], "🦀");
+    assert_eq!(parsed["jp"], "日本語");
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 4. Schema version in live envelopes
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_live_version_envelope_has_schema_version() {
+    let result = tokmd_core::ffi::run_json("version", "{}");
+    let data = extract_data_from_json(&result).unwrap();
+    let sv = data["schema_version"].as_u64().expect("schema_version");
+    assert!(sv > 0, "schema_version should be positive");
+}
+
+#[test]
+fn w43_live_lang_envelope_has_schema_version() {
+    let result = tokmd_core::ffi::run_json("lang", "{}");
+    let data = extract_data_from_json(&result).unwrap();
+    let sv = data["schema_version"].as_u64().expect("schema_version");
+    assert!(sv > 0, "schema_version should be positive");
+}
+
+#[test]
+fn w43_live_error_envelope_propagates_through_extract() {
+    let result = tokmd_core::ffi::run_json("bogus", "{}");
+    let err = extract_data_from_json(&result).unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::Upstream(_)));
+    assert!(err.to_string().contains("unknown_mode"));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 5. parse_envelope edge cases
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_parse_envelope_accepts_bare_number() {
+    let v = parse_envelope("12345").unwrap();
+    assert_eq!(v, json!(12345));
+}
+
+#[test]
+fn w43_parse_envelope_accepts_bare_bool() {
+    let v = parse_envelope("false").unwrap();
+    assert_eq!(v, json!(false));
+}
+
+#[test]
+fn w43_parse_envelope_rejects_empty() {
+    let err = parse_envelope("").unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::JsonParse(_)));
+}
+
+#[test]
+fn w43_parse_envelope_rejects_partial() {
+    let err = parse_envelope(r#"{"ok": "#).unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::JsonParse(_)));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 6. format_error_message edge cases
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_format_error_with_numeric_code() {
+    let obj = json!({"code": 404, "message": "Not found"});
+    // numeric code falls back to "unknown"
+    assert_eq!(format_error_message(Some(&obj)), "[unknown] Not found");
+}
+
+#[test]
+fn w43_format_error_with_empty_strings() {
+    let obj = json!({"code": "", "message": ""});
+    assert_eq!(format_error_message(Some(&obj)), "[] ");
+}
+
+#[test]
+fn w43_format_error_with_boolean_values() {
+    let obj = json!({"code": true, "message": false});
+    // both fall back to defaults
+    assert_eq!(format_error_message(Some(&obj)), "[unknown] Unknown error");
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 7. Error type traits
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_error_variants_implement_display() {
+    let cases: Vec<EnvelopeExtractError> = vec![
+        EnvelopeExtractError::JsonParse("eof".to_string()),
+        EnvelopeExtractError::JsonSerialize("fail".to_string()),
+        EnvelopeExtractError::InvalidResponseFormat,
+        EnvelopeExtractError::Upstream("upstream msg".to_string()),
+    ];
+    for err in &cases {
+        let display = err.to_string();
+        assert!(!display.is_empty(), "Display must produce non-empty string");
+    }
+}
+
+#[test]
+fn w43_error_clone_produces_equal_value() {
+    let err = EnvelopeExtractError::Upstream("test".to_string());
+    let cloned = err.clone();
+    assert_eq!(err, cloned);
+}
+
+#[test]
+fn w43_error_debug_includes_variant() {
+    let err = EnvelopeExtractError::JsonParse("eof".to_string());
+    let dbg = format!("{err:?}");
+    assert!(dbg.contains("JsonParse"));
+}
+
+#[test]
+fn w43_different_error_variants_are_not_equal() {
+    let a = EnvelopeExtractError::JsonParse("x".to_string());
+    let b = EnvelopeExtractError::Upstream("x".to_string());
+    assert_ne!(a, b);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 8. Type coercion in ok field
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_ok_as_string_true_treated_as_error() {
+    let env = json!({"ok": "true", "data": {"x": 1}});
+    assert!(extract_data(env).is_err());
+}
+
+#[test]
+fn w43_ok_as_integer_1_treated_as_error() {
+    let env = json!({"ok": 1, "data": {"x": 1}});
+    assert!(extract_data(env).is_err());
+}
+
+#[test]
+fn w43_missing_ok_field_treated_as_error() {
+    let env = json!({"data": {"x": 1}});
+    assert!(extract_data(env).is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 9. extract_data_from_json error paths
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_from_json_invalid_input() {
+    let err = extract_data_from_json("not json").unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::JsonParse(_)));
+}
+
+#[test]
+fn w43_from_json_non_object() {
+    let err = extract_data_from_json("42").unwrap_err();
+    assert_eq!(err, EnvelopeExtractError::InvalidResponseFormat);
+}
+
+#[test]
+fn w43_from_json_error_envelope() {
+    let input = r#"{"ok":false,"error":{"code":"e","message":"m"}}"#;
+    let err = extract_data_from_json(input).unwrap_err();
+    assert!(err.to_string().contains("[e] m"));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 10. Consistency between parse+extract and extract_from_json
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn w43_two_step_matches_one_step() {
+    let input = r#"{"ok":true,"data":{"val":99}}"#;
+    let via_two = {
+        let parsed = parse_envelope(input).unwrap();
+        extract_data(parsed).unwrap()
+    };
+    let via_one = extract_data_from_json(input).unwrap();
+    assert_eq!(via_two, via_one);
+}
+
+#[test]
+fn w43_two_step_error_matches_one_step() {
+    let input = r#"{"ok":false,"error":{"code":"c","message":"m"}}"#;
+    let via_two = {
+        let parsed = parse_envelope(input).unwrap();
+        extract_data(parsed).unwrap_err()
+    };
+    let via_one = extract_data_from_json(input).unwrap_err();
+    assert_eq!(via_two, via_one);
+}


### PR DESCRIPTION
Wave 43: 93 tests for tokmd-core FFI entrypoint (58 tests) and tokmd-ffi-envelope (35 tests).

**tokmd-core/tests/ffi_w43.rs** (58 tests):
- Version mode: ok response, schema_version, idempotency
- Lang mode: receipt structure, mode field, rows, tool info, scan/args metadata, top/files params
- Module mode: receipt structure, schema_version, rows
- Export mode: receipt structure, rows with path/lang fields
- Invalid mode: error envelope, case sensitivity, spaces, unicode
- Invalid JSON: garbage, empty, truncated, bare array
- Envelope contract: ok is always boolean, success has data not error, error has code+message
- Strict settings validation: invalid types for top/files/children/format/redact/hidden/paths/config
- Nested scan object parsing
- Diff mode: missing from/to, self-diff zero deltas
- Feature-gated: analyze/cockpit not_implemented without features
- Error code snake_case invariant, non-empty messages

**tokmd-ffi-envelope/tests/deep_w43.rs** (35 tests):
- Ok envelope extraction: object, nested, null, missing data
- Error envelope: upstream error, missing error obj, null error, data ignored
- Serde roundtrip: object, array, string, numeric precision, unicode
- Live integration: schema_version in version/lang envelopes, error propagation
- parse_envelope edge cases: bare number/bool, empty, partial
- format_error_message: numeric code, empty strings, boolean values
- Error traits: Display, Clone, Debug, PartialEq/Ne
- Type coercion: ok as string/integer/missing treated as error
- Consistency: two-step vs one-step extraction