### PR TITLE
test(scan): deep tests for scan-args and exclude

### DIFF
--- a/crates/tokmd-exclude/tests/deep_w43.rs
+++ b/crates/tokmd-exclude/tests/deep_w43.rs
@@ -1,0 +1,193 @@
+//! Wave 43 – deep tests for `tokmd-exclude`.
+
+use std::path::Path;
+
+use tokmd_exclude::{add_exclude_pattern, has_exclude_pattern, normalize_exclude_pattern};
+
+/// Helper: build an absolute root from the temp dir.
+fn abs_root(suffix: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("tokmd-excl-w43-{suffix}"))
+}
+
+// ── normalize_exclude_pattern ──────────────────────────────────────
+
+#[test]
+fn normalize_strips_root_prefix_from_absolute_path() {
+    let root = abs_root("a");
+    let path = root.join("src").join("main.rs");
+    assert_eq!(normalize_exclude_pattern(&root, &path), "src/main.rs");
+}
+
+#[test]
+fn normalize_strips_root_with_trailing_dirs() {
+    let root = abs_root("b");
+    let path = root.join("out").join("bundle.js");
+    assert_eq!(normalize_exclude_pattern(&root, &path), "out/bundle.js");
+}
+
+#[test]
+fn normalize_keeps_relative_path_as_is() {
+    let root = abs_root("c");
+    let path = Path::new("vendor/dep.rs");
+    assert_eq!(normalize_exclude_pattern(&root, path), "vendor/dep.rs");
+}
+
+#[test]
+fn normalize_strips_leading_dot_slash() {
+    let root = abs_root("d");
+    let path = Path::new("./out/bundle.js");
+    assert_eq!(normalize_exclude_pattern(&root, path), "out/bundle.js");
+}
+
+#[test]
+fn normalize_handles_outside_absolute_path() {
+    let root = abs_root("e");
+    let outside = abs_root("e-outside").join("file.txt");
+    let result = normalize_exclude_pattern(&root, &outside);
+    // Cannot strip root → keeps full path (normalized)
+    assert!(result.contains("file.txt"));
+}
+
+#[test]
+fn normalize_handles_dotfiles() {
+    let root = abs_root("f");
+    let path = root.join(".gitignore");
+    assert_eq!(normalize_exclude_pattern(&root, &path), ".gitignore");
+}
+
+#[test]
+fn normalize_handles_deeply_nested() {
+    let root = abs_root("g");
+    let path = root.join("b").join("c").join("d").join("e.txt");
+    assert_eq!(normalize_exclude_pattern(&root, &path), "b/c/d/e.txt");
+}
+
+#[test]
+fn normalize_root_equals_path_gives_empty() {
+    let root = abs_root("h");
+    let result = normalize_exclude_pattern(&root, &root);
+    // When path == root, strip_prefix yields "" → normalized to ""
+    assert!(result.is_empty());
+}
+
+// ── has_exclude_pattern ────────────────────────────────────────────
+
+#[test]
+fn has_pattern_finds_exact_match() {
+    let existing = vec!["out/bundle".to_string()];
+    assert!(has_exclude_pattern(&existing, "out/bundle"));
+}
+
+#[test]
+fn has_pattern_matches_with_leading_dot_slash() {
+    let existing = vec!["out/bundle".to_string()];
+    assert!(has_exclude_pattern(&existing, "./out/bundle"));
+}
+
+#[test]
+fn has_pattern_no_false_positive() {
+    let existing = vec!["src/lib.rs".to_string()];
+    assert!(!has_exclude_pattern(&existing, "src/main.rs"));
+}
+
+#[test]
+fn has_pattern_empty_existing_returns_false() {
+    let existing: Vec<String> = vec![];
+    assert!(!has_exclude_pattern(&existing, "anything"));
+}
+
+#[test]
+fn has_pattern_normalizes_backslashes() {
+    let existing = vec!["out/bundle".to_string()];
+    assert!(has_exclude_pattern(&existing, "out\\bundle"));
+}
+
+#[test]
+fn has_pattern_normalizes_both_sides() {
+    let existing = vec!["./out\\bundle".to_string()];
+    assert!(has_exclude_pattern(&existing, "out/bundle"));
+}
+
+// ── add_exclude_pattern ────────────────────────────────────────────
+
+#[test]
+fn add_pattern_inserts_new() {
+    let mut patterns = vec![];
+    assert!(add_exclude_pattern(&mut patterns, "dist".to_string()));
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0], "dist");
+}
+
+#[test]
+fn add_pattern_rejects_empty() {
+    let mut patterns = vec![];
+    assert!(!add_exclude_pattern(&mut patterns, String::new()));
+    assert!(patterns.is_empty());
+}
+
+#[test]
+fn add_pattern_rejects_duplicate_exact() {
+    let mut patterns = vec!["dist".to_string()];
+    assert!(!add_exclude_pattern(&mut patterns, "dist".to_string()));
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn add_pattern_rejects_duplicate_after_normalization() {
+    let mut patterns = vec!["out/bundle".to_string()];
+    assert!(!add_exclude_pattern(
+        &mut patterns,
+        "./out/bundle".to_string()
+    ));
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn add_pattern_rejects_backslash_duplicate() {
+    let mut patterns = vec!["out/bundle".to_string()];
+    assert!(!add_exclude_pattern(
+        &mut patterns,
+        "out\\bundle".to_string()
+    ));
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn add_pattern_multiple_unique_patterns() {
+    let mut patterns = vec![];
+    assert!(add_exclude_pattern(&mut patterns, "a".to_string()));
+    assert!(add_exclude_pattern(&mut patterns, "b".to_string()));
+    assert!(add_exclude_pattern(&mut patterns, "c".to_string()));
+    assert_eq!(patterns.len(), 3);
+}
+
+#[test]
+fn add_pattern_preserves_original_form() {
+    let mut patterns = vec![];
+    add_exclude_pattern(&mut patterns, "out/bundle".to_string());
+    assert_eq!(patterns[0], "out/bundle");
+}
+
+// ── combined / edge cases ──────────────────────────────────────────
+
+#[test]
+fn roundtrip_add_then_has() {
+    let mut patterns = vec![];
+    add_exclude_pattern(&mut patterns, "target".to_string());
+    add_exclude_pattern(&mut patterns, "node_modules".to_string());
+    assert!(has_exclude_pattern(&patterns, "target"));
+    assert!(has_exclude_pattern(&patterns, "node_modules"));
+    assert!(!has_exclude_pattern(&patterns, "vendor"));
+}
+
+#[test]
+fn add_rejects_normalized_variant_of_existing() {
+    let mut patterns = vec![];
+    add_exclude_pattern(&mut patterns, "./vendor/lib".to_string());
+    // Try adding the same thing without dot-slash
+    assert!(!add_exclude_pattern(
+        &mut patterns,
+        "vendor/lib".to_string()
+    ));
+    assert_eq!(patterns.len(), 1);
+}

--- a/crates/tokmd-scan-args/tests/deep_w43.rs
+++ b/crates/tokmd-scan-args/tests/deep_w43.rs
@@ -1,0 +1,268 @@
+//! Wave 43 – deep tests for `tokmd-scan-args`.
+
+use std::path::{Path, PathBuf};
+
+use tokmd_scan_args::{normalize_scan_input, scan_args};
+use tokmd_settings::ScanOptions;
+use tokmd_types::RedactMode;
+
+// ── normalize_scan_input ───────────────────────────────────────────
+
+#[test]
+fn normalize_single_dot_slash() {
+    assert_eq!(normalize_scan_input(Path::new("./src")), "src");
+}
+
+#[test]
+fn normalize_triple_dot_slash() {
+    assert_eq!(normalize_scan_input(Path::new("./././lib")), "lib");
+}
+
+#[test]
+fn normalize_bare_dot() {
+    assert_eq!(normalize_scan_input(Path::new(".")), ".");
+}
+
+#[test]
+fn normalize_empty_after_strip_becomes_dot() {
+    // "./" stripped to "" should become "."
+    assert_eq!(normalize_scan_input(Path::new("./")), ".");
+}
+
+#[test]
+fn normalize_preserves_absolute_path() {
+    let abs = if cfg!(windows) {
+        "C:/project"
+    } else {
+        "/project"
+    };
+    let result = normalize_scan_input(Path::new(abs));
+    assert!(result.contains("project"));
+}
+
+#[test]
+fn normalize_backslashes_become_forward() {
+    // On Windows the path "src\\main.rs" should normalise to "src/main.rs"
+    let result = normalize_scan_input(Path::new("src/main.rs"));
+    assert_eq!(result, "src/main.rs");
+}
+
+// ── scan_args – defaults ───────────────────────────────────────────
+
+#[test]
+fn default_scan_options_produce_default_flags() {
+    let args = scan_args(&[PathBuf::from(".")], &ScanOptions::default(), None);
+    assert!(!args.hidden);
+    assert!(!args.no_ignore);
+    assert!(!args.no_ignore_parent);
+    assert!(!args.no_ignore_dot);
+    assert!(!args.no_ignore_vcs);
+    assert!(!args.treat_doc_strings_as_comments);
+    assert!(args.excluded.is_empty());
+    assert!(!args.excluded_redacted);
+}
+
+#[test]
+fn paths_forwarded_without_redaction_when_none() {
+    let paths = vec![PathBuf::from("src"), PathBuf::from("lib")];
+    let args = scan_args(&paths, &ScanOptions::default(), None);
+    assert_eq!(args.paths, vec!["src", "lib"]);
+}
+
+// ── scan_args – no_ignore cascade ──────────────────────────────────
+
+#[test]
+fn no_ignore_cascades_to_all_sub_flags() {
+    let opts = ScanOptions {
+        no_ignore: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.no_ignore_parent);
+    assert!(args.no_ignore_dot);
+    assert!(args.no_ignore_vcs);
+}
+
+#[test]
+fn individual_sub_flags_do_not_cross_pollinate() {
+    let opts = ScanOptions {
+        no_ignore_parent: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.no_ignore_parent);
+    assert!(!args.no_ignore_dot);
+    assert!(!args.no_ignore_vcs);
+}
+
+#[test]
+fn no_ignore_dot_alone_sets_only_dot() {
+    let opts = ScanOptions {
+        no_ignore_dot: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.no_ignore_dot);
+    assert!(!args.no_ignore_parent);
+    assert!(!args.no_ignore_vcs);
+}
+
+// ── scan_args – redaction ──────────────────────────────────────────
+
+#[test]
+fn redact_paths_mode_hashes_paths() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let args = scan_args(&paths, &ScanOptions::default(), Some(RedactMode::Paths));
+    // Redacted path should NOT equal the original
+    assert_ne!(args.paths[0], "src/lib.rs");
+    // Redacted path retains extension
+    assert!(args.paths[0].ends_with(".rs"), "expected .rs extension");
+}
+
+#[test]
+fn redact_all_mode_hashes_paths() {
+    let paths = vec![PathBuf::from("src/main.rs")];
+    let args = scan_args(&paths, &ScanOptions::default(), Some(RedactMode::All));
+    assert_ne!(args.paths[0], "src/main.rs");
+    assert!(args.paths[0].ends_with(".rs"));
+}
+
+#[test]
+fn redact_none_does_not_hash() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let args = scan_args(&paths, &ScanOptions::default(), Some(RedactMode::None));
+    assert_eq!(args.paths[0], "src/lib.rs");
+}
+
+#[test]
+fn redaction_is_deterministic() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions::default();
+    let a = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    let b = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_eq!(a.paths, b.paths);
+}
+
+#[test]
+fn excluded_patterns_redacted_when_paths_mode() {
+    let opts = ScanOptions {
+        excluded: vec!["target".to_string(), "node_modules".to_string()],
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, Some(RedactMode::Paths));
+    assert!(args.excluded_redacted);
+    assert_eq!(args.excluded.len(), 2);
+    assert_ne!(args.excluded[0], "target");
+    assert_ne!(args.excluded[1], "node_modules");
+}
+
+#[test]
+fn excluded_not_redacted_without_redact_mode() {
+    let opts = ScanOptions {
+        excluded: vec!["target".to_string()],
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(!args.excluded_redacted);
+    assert_eq!(args.excluded[0], "target");
+}
+
+#[test]
+fn excluded_redacted_false_when_excluded_list_empty() {
+    let args = scan_args(
+        &[PathBuf::from(".")],
+        &ScanOptions::default(),
+        Some(RedactMode::Paths),
+    );
+    // No patterns → nothing to redact
+    assert!(!args.excluded_redacted);
+}
+
+// ── scan_args – boolean flag passthrough ───────────────────────────
+
+#[test]
+fn hidden_flag_passthrough() {
+    let opts = ScanOptions {
+        hidden: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.hidden);
+}
+
+#[test]
+fn treat_doc_strings_as_comments_passthrough() {
+    let opts = ScanOptions {
+        treat_doc_strings_as_comments: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.treat_doc_strings_as_comments);
+}
+
+// ── serde roundtrip ────────────────────────────────────────────────
+
+#[test]
+fn scan_args_serde_roundtrip() {
+    let opts = ScanOptions {
+        excluded: vec!["build".to_string()],
+        hidden: true,
+        no_ignore: true,
+        treat_doc_strings_as_comments: true,
+        ..Default::default()
+    };
+    let original = scan_args(&[PathBuf::from("src")], &opts, None);
+    let json = serde_json::to_string(&original).expect("serialize");
+    let restored: tokmd_types::ScanArgs = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(original.paths, restored.paths);
+    assert_eq!(original.excluded, restored.excluded);
+    assert_eq!(original.hidden, restored.hidden);
+    assert_eq!(original.no_ignore, restored.no_ignore);
+    assert_eq!(original.no_ignore_parent, restored.no_ignore_parent);
+    assert_eq!(original.no_ignore_dot, restored.no_ignore_dot);
+    assert_eq!(original.no_ignore_vcs, restored.no_ignore_vcs);
+    assert_eq!(
+        original.treat_doc_strings_as_comments,
+        restored.treat_doc_strings_as_comments
+    );
+    assert_eq!(original.excluded_redacted, restored.excluded_redacted);
+}
+
+#[test]
+fn redacted_scan_args_serde_roundtrip_preserves_hashes() {
+    let opts = ScanOptions {
+        excluded: vec!["vendor".to_string()],
+        ..Default::default()
+    };
+    let original = scan_args(&[PathBuf::from("src/lib.rs")], &opts, Some(RedactMode::All));
+    let json = serde_json::to_string(&original).expect("serialize");
+    let restored: tokmd_types::ScanArgs = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(original.paths, restored.paths);
+    assert_eq!(original.excluded, restored.excluded);
+    assert!(restored.excluded_redacted);
+}
+
+// ── scan_args – multiple paths ─────────────────────────────────────
+
+#[test]
+fn multiple_paths_all_normalized() {
+    let paths = vec![
+        PathBuf::from("./src"),
+        PathBuf::from("././lib"),
+        PathBuf::from("tests"),
+    ];
+    let args = scan_args(&paths, &ScanOptions::default(), None);
+    assert_eq!(args.paths, vec!["src", "lib", "tests"]);
+}
+
+#[test]
+fn multiple_paths_all_redacted() {
+    let paths = vec![PathBuf::from("src/a.rs"), PathBuf::from("src/b.rs")];
+    let args = scan_args(&paths, &ScanOptions::default(), Some(RedactMode::Paths));
+    assert_ne!(
+        args.paths[0], args.paths[1],
+        "different files → different hashes"
+    );
+    assert!(args.paths[0].ends_with(".rs"));
+    assert!(args.paths[1].ends_with(".rs"));
+}


### PR DESCRIPTION
Wave 43b: 47 tests (24 scan-args + 23 exclude)

### scan-args (24 tests)
- normalize_scan_input: dot-slash stripping, empty, absolute, backslash
- scan_args construction: defaults, flag passthrough, no_ignore cascade
- Redaction: Paths/All/None modes, determinism, excluded hashing
- Serde roundtrip: plain and redacted

### exclude (23 tests)
- normalize_exclude_pattern: root stripping, relative, dot-slash, dotfiles, deeply nested, outside paths
- has_exclude_pattern: exact, normalized, backslash, empty
- add_exclude_pattern: insert, reject empty/duplicate, normalization dedup, multi-insert
- Combined: roundtrip add→has, normalized variant rejection