### PR TITLE
ci: gate macOS jobs to main-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Build
+      run: cargo build --verbose
+
+    - name: Run tests
+      run: cargo test --verbose
+      env:
+        CI: true
+
+  build-macos:
+    name: Build & Test (macOS)
+    if: github.event_name == 'push'
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v6
@@ -143,10 +162,26 @@ jobs:
 
   nix:
     name: Nix Build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Check flake
+        run: nix flake check
+
+      - name: Build package
+        run: nix build
+
+  nix-macos:
+    name: Nix Build (macOS)
+    if: github.event_name == 'push'
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -248,6 +283,7 @@ jobs:
     needs:
       - msrv
       - build
+      - build-macos
       - fmt
       - clippy
       - deny
@@ -256,6 +292,7 @@ jobs:
       - publish-plan
       - docs-check
       - nix
+      - nix-macos
       - mutation
       - feature-boundaries
     steps:


### PR DESCRIPTION
## Summary
- Remove `macos-latest` from `build` and `nix` job matrices so PRs only run on Linux + Windows
- Add dedicated `build-macos` and `nix-macos` jobs gated with `if: github.event_name == 'push'` (main only)
- Add both new jobs to `ci-required` needs list — the existing status check treats `skipped` as passing

## Motivation
macOS runners are scarce and slow. tokmd is pure Rust with no Apple-specific behavior, so Linux validates correctness and Windows catches platform path issues. macOS on main provides confidence sampling without blocking PR queues.

## Test plan
- [ ] On this PR, `build-macos` and `nix-macos` should show as skipped
- [ ] `ci-required` gate should still pass with those jobs skipped
- [ ] After merge, a push to main should run all jobs including macOS