### PR TITLE
docs: sync ROADMAP.md and NOW.md with current state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ This document outlines the evolution of `tokmd` and the path forward.
 | **v1.7.0** | ✅ Complete | Near-duplicate detection, commit intent, token estimation renames. |
 | **v1.7.1** | ✅ Complete | Focused microcrate extraction (40+ crates), AnalysisFormat to Tier 0. |
 | **v1.7.2** | ✅ Complete | Near-dup enricher extraction, commit intent classification, CI fixes. |
-| **v1.7.x** | ✅ Complete | Deep test expansion: 2,240+ new tests, 36+ PRs, all tiers covered. |
+| **v1.7.x** | ✅ Complete | Deep test expansion: 11,991+ total tests, 55/56 crates with tests/, CI stabilized. |
 | **v1.8.0** | 🔭 Planned  | WASM-ready core: host ports + in-memory scan + WASM CI builds |
 | **v1.9.0** | 🔭 Planned  | WASM distribution + browser runner: zipball ingestion + receipts in-browser |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
@@ -413,14 +413,15 @@ UX work is explicitly **incremental and non-breaking**:
 
 **Goal**: Achieve comprehensive test coverage across all 56 crates with multiple testing strategies at every tier.
 
-### Test Numbers (before → after)
+### Test Numbers
 
-| Metric             | Before  | After    | Delta     |
-| :----------------- | :------ | :------- | :-------- |
-| `#[test]` annotations | ~4,350 | **6,593** | **+2,243** |
-| `proptest!` blocks | 218     | **250**  | **+32**   |
-| Fuzz targets       | 16      | **19**   | **+3**    |
-| Crates with property tests | ~14 | **14+** | Maintained |
+| Metric             | Value       |
+| :----------------- | :---------- |
+| Total tests        | **11,991+** |
+| Crates with `tests/` | **55/56** |
+| `proptest!` blocks | **250+**    |
+| Fuzz targets       | **19**      |
+| Crates with property tests | **14+** |
 
 ### Coverage by Tier
 
@@ -433,10 +434,11 @@ UX work is explicitly **incremental and non-breaking**:
 | 4 | `tokmd-core`, `tokmd-config`, `tokmd-tool-schema`, `tokmd-ffi-envelope` | FFI workflow integration, JSON API round-trip tests |
 | 5 | `tokmd` CLI | E2E tests for all major subcommands |
 
-### What Landed (36+ PRs)
+### What Landed (36+ PRs first wave, 16 PRs second wave)
 
 - [x] Boundary verification tests across core types
 - [x] Determinism regression tests for all receipt-producing paths
+- [x] Byte-stable output regression suite with ordering locks
 - [x] Error handling coverage for edge cases and malformed inputs
 - [x] Snapshot tests (`insta`) for all format renderers (Markdown, TSV, JSON, HTML)
 - [x] Deep analysis crate tests: complexity, halstead, near-dup, topics, entropy, license, archetype, fingerprint, API surface
@@ -445,7 +447,15 @@ UX work is explicitly **incremental and non-breaking**:
 - [x] Property tests expanded across 14+ crates with `proptest`
 - [x] 3 new fuzz targets (import parser, export tree, policy TOML)
 - [x] BDD-style scenario tests (`tests/bdd.rs`) in every `tokmd-analysis-*` crate
+- [x] Doctest coverage expanded across crates
+
+### CI & Performance
+
 - [x] CI green on main with full mutation testing gate passing
+- [x] macOS jobs gated to main-only pushes for CI cost control (#409)
+- [x] Nix CI fixes: resolved `cloned_ref_to_slice_refs` clippy lint for cargo 1.93 (#407)
+- [x] Fix-forward for typo, rustfmt, and content test failures (#390)
+- [x] Reduced allocations in token stream formatting (perf improvement)
 
 ---
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,49 +1,47 @@
 # NOW.md — Current State of tokmd
 
-> Last updated: 2025-07-24
+> Last updated: 2025-07-28
 
 ## Where We Are
 
-v1.7.2 shipped. 56 crates in the workspace. **2,496+ new tests** merged
-across 34 PRs. Deep coverage across all crates. CI green on main.
+v1.7.2 shipped. 56 crates in the workspace. **11,991+ tests** total.
+55/56 crates have `tests/` directories. CI green on main (macOS gated
+to main-only pushes). Two full test-expansion cycles complete.
 
 ---
 
-## NOW — current status
+## NOW — active work
 
-- **2,496+ new tests merged** across 34 PRs.
-- **Deep coverage across all 56 crates.** Every tier covered with unit,
-  integration, snapshot, BDD, and E2E tests.
-- **Full property testing.** `proptest` suites across 10+ crates for
-  invariant verification.
-- **Full BDD test suites.** Every `tokmd-analysis-*` microcrate has
-  dedicated `tests/bdd.rs` scenarios.
-- **Full snapshot testing (insta).** Format renderers, analysis outputs,
-  and CLI commands covered with golden snapshots.
-- **Full CLI E2E testing.** All major subcommands exercised with
-  `assert_cmd` + `predicates`.
-- **CI green on main.** Full gate passing.
+- **Test infrastructure comprehensive.** 11,991+ tests across unit,
+  integration, snapshot, BDD, proptest, and E2E. 16 test-expansion PRs
+  merged in the latest cycle on top of the earlier 36-PR wave.
+- **CI stabilized.** macOS jobs gated to main-only pushes (#409). Nix
+  clippy lint and rustfmt fixes landed (#407, #390). Full gate green.
+- **Perf improvement merged.** Reduced allocations in token stream
+  formatting (top-of-tree commit).
+- **Determinism hardened.** Byte-stable output regression suite and
+  deterministic ordering locks in place.
 
 ---
 
 ## NEXT — immediate priorities
 
-- **Verify CI green after massive test merge wave.** Monitor for flaky
-  tests or regressions introduced by the 34-PR merge.
-- **Monitor for snapshot drift.** Ensure insta snapshots remain stable
-  as codebase evolves.
-- **v1.7.x release preparation.** Changelog, version bumps, publish
-  dry-run.
-- **WASM preparation (v1.8 track).** Host IO abstraction, in-memory
-  scan pipeline, `wasm` feature profile.
+- **v1.8 WASM readiness.** Host IO abstraction, in-memory scan
+  pipeline, `wasm` feature profile, WASM CI builds.
+- **Bindings parity.** Ensure Python and Node.js bindings cover the
+  full workflow surface (analyze, diff, sensor).
+- **Schema hardening.** Lock remaining schema versions with contract
+  tests; publish updated `docs/schema.json`.
+- **Mutation testing expansion.** Broaden `cargo-mutants` coverage
+  across more crates for test quality verification.
 
 ---
 
 ## LATER — roadmap horizon
 
-- **v1.9 "Browser runner."** WASM API crate (`tokmd-wasm`), zipball
-  ingestion, in-browser receipt generation without server-side compute.
-- **EffortlessMetrics/adze integration track.** AST seams for
-  tree-sitter/Adze-based complexity and function extraction.
-- **Full mutation testing coverage.** Expand `cargo-mutants` across all
-  crates for comprehensive test quality verification.
+- **v1.9 browser runner.** `tokmd-wasm` crate, zipball ingestion,
+  in-browser receipt generation without server-side compute.
+- **v2.0 MCP server.** `tokmd serve` for native Claude/MCP-client
+  integration, streaming analysis, plugin system.
+- **Adze AST integration.** Tree-sitter/Adze-based complexity and
+  function extraction (v4.0 long-term track).


### PR DESCRIPTION
Updates ROADMAP.md and docs/NOW.md to reflect the current state of the project including massive test expansion (11,991+ tests across 55/56 crates), CI stabilization (macOS gated, Nix fixes), and perf improvements.

### Changes
- **ROADMAP.md**: Updated v1.7.x test numbers to 11,991+ total, added CI & Performance subsection documenting macOS gating, Nix fixes, and allocation reduction
- **docs/NOW.md**: Refreshed all three sections — NOW (test + CI + perf status), NEXT (WASM readiness, bindings parity, schema hardening), LATER (browser runner, MCP server, Adze)