### PR TITLE
test(determinism): add hardening tests for output stability

### DIFF
--- a/crates/tokmd-types/tests/determinism_proptest.rs
+++ b/crates/tokmd-types/tests/determinism_proptest.rs
@@ -54,8 +54,8 @@ fn arb_lang_rows_with_ties() -> impl Strategy<Value = Vec<LangRow>> {
                 0usize..500_000,
                 0usize..500,
             )
-                .prop_map(
-                    |(lang, code, lines, files, bytes, tokens, avg_lines)| LangRow {
+                .prop_map(|(lang, code, lines, files, bytes, tokens, avg_lines)| {
+                    LangRow {
                         lang,
                         code,
                         lines,
@@ -63,8 +63,8 @@ fn arb_lang_rows_with_ties() -> impl Strategy<Value = Vec<LangRow>> {
                         bytes,
                         tokens,
                         avg_lines,
-                    },
-                ),
+                    }
+                }),
             3..30,
         )
     })

--- a/crates/tokmd/tests/determinism_hardening.rs
+++ b/crates/tokmd/tests/determinism_hardening.rs
@@ -326,10 +326,7 @@ fn hardening_module_json_no_backslash_in_modules() {
 
     for row in rows {
         let module = row["module"].as_str().unwrap();
-        assert!(
-            !module.contains('\\'),
-            "backslash in module name: {module}"
-        );
+        assert!(!module.contains('\\'), "backslash in module name: {module}");
     }
 }
 


### PR DESCRIPTION
Adds determinism hardening tests that verify byte-identical output, stable sorting, path normalization, and redaction consistency.

## New Tests

### \crates/tokmd/tests/determinism_hardening.rs\ (16 integration tests)
- **5-run byte stability**: \lang\, \module\, \xport\ JSON verified identical across 5 consecutive runs
- **Cross-format row-count consistency**: JSON vs JSONL vs CSV row counts must agree
- **Recursive JSON key ordering**: All nested keys verified alphabetically sorted (BTreeMap invariant)
- **No silent truncation**: Row counts stable across repeated runs
- **Sort ordering**: Lang (desc code, asc name), module (desc code, asc name), export (desc code, asc path)
- **Path normalization**: No backslashes in JSON, TSV, or CSV output
- **Redaction determinism**: \--redact paths\ produces byte-identical output across runs

### \crates/tokmd-types/tests/determinism_proptest.rs\ (12 property tests)
- **Sorting with ties**: Many rows sharing same code count, tie-breaking by name verified
- **Sort-serialize roundtrip**: sort → JSON → deserialize → sort → JSON = identical
- **Path normalization composition**: \
ormalize_slashes\ then \
ormalize_rel_path\ is idempotent
- **BTreeMap merge determinism**: Key order independent of merge direction
- **Redaction stability**: 5-call hash stability, extension preservation, cross-platform equivalence

All 28 tests pass. No clippy warnings.