### PR TITLE
fix: remove unused import in context-git tests

### DIFF
--- a/crates/tokmd-context-git/tests/deep_w43.rs
+++ b/crates/tokmd-context-git/tests/deep_w43.rs
@@ -131,7 +131,6 @@ fn hotspot_formula_is_multiplication() {
 
 #[cfg(feature = "git")]
 mod git_feature_tests {
-    use super::*;
     use std::process::Command;
     use tokmd_context_git::compute_git_scores;
     use tokmd_types::{FileKind, FileRow};

--- a/crates/tokmd-format/tests/determinism_w42.rs
+++ b/crates/tokmd-format/tests/determinism_w42.rs
@@ -9,13 +9,13 @@ use std::path::PathBuf;
 
 use tokmd_format::{
     compute_diff_rows, compute_diff_totals, render_diff_md, write_export_csv_to,
-    write_export_jsonl_to, write_lang_report_to, write_module_report_to,
+    write_lang_report_to, write_module_report_to,
 };
 use tokmd_settings::ScanOptions;
 use tokmd_types::{
-    ChildIncludeMode, ChildrenMode, DiffRow, DiffTotals, ExportArgs, ExportData, ExportFormat,
-    FileKind, FileRow, LangArgs, LangReport, LangRow, ModuleArgs, ModuleReport, ModuleRow,
-    RedactMode, TableFormat, Totals,
+    ChildIncludeMode, ChildrenMode, DiffRow, ExportArgs, ExportData, ExportFormat, FileKind,
+    FileRow, LangArgs, LangReport, LangRow, ModuleArgs, ModuleReport, ModuleRow, RedactMode,
+    TableFormat, Totals,
 };
 
 // =========================================================================


### PR DESCRIPTION
Removes unused super::* import that causes Nix clippy failure.