### PR TITLE
test(contracts): add schema versioning and backward compatibility tests

### DIFF
--- a/crates/tokmd-analysis-types/tests/schema_contract.rs
+++ b/crates/tokmd-analysis-types/tests/schema_contract.rs
@@ -1,0 +1,286 @@
+//! Schema versioning and contract tests for tokmd-analysis-types.
+
+use serde_json::Value;
+use tokmd_analysis_types::{
+    ANALYSIS_SCHEMA_VERSION, AnalysisArgsMeta, AnalysisReceipt, AnalysisSource, Archetype,
+    BASELINE_VERSION, EntropyReport, FunReport, ImportReport,
+};
+use tokmd_types::{ScanStatus, ToolInfo};
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn sample_analysis_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo {
+            name: "tokmd".into(),
+            version: "1.0.0".into(),
+        },
+        mode: "analyze".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec![".".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "json".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            max_file_bytes: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+// ── Schema version constants ─────────────────────────────────────────────
+
+#[test]
+fn analysis_schema_version_is_positive() {
+    assert!(
+        ANALYSIS_SCHEMA_VERSION > 0,
+        "ANALYSIS_SCHEMA_VERSION must be a positive integer"
+    );
+}
+
+#[test]
+fn analysis_schema_version_pinned() {
+    assert_eq!(ANALYSIS_SCHEMA_VERSION, 8);
+}
+
+#[test]
+fn baseline_version_pinned() {
+    assert_eq!(BASELINE_VERSION, 1);
+}
+
+// ── JSON round-trip ──────────────────────────────────────────────────────
+
+#[test]
+fn analysis_receipt_json_roundtrip() {
+    let receipt = sample_analysis_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let back: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, ANALYSIS_SCHEMA_VERSION);
+    assert_eq!(back.mode, "analyze");
+    assert!(back.derived.is_none());
+    assert!(back.git.is_none());
+}
+
+#[test]
+fn schema_version_field_in_json() {
+    let receipt = sample_analysis_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema_version"], ANALYSIS_SCHEMA_VERSION);
+}
+
+// ── Enricher output types are serializable ───────────────────────────────
+
+#[test]
+fn archetype_serializable() {
+    let a = Archetype {
+        kind: "monorepo".into(),
+        evidence: vec!["multiple crates".into()],
+    };
+    let json = serde_json::to_string(&a).unwrap();
+    let back: Archetype = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.kind, "monorepo");
+}
+
+#[test]
+fn entropy_report_serializable() {
+    let r = EntropyReport { suspects: vec![] };
+    let json = serde_json::to_string(&r).unwrap();
+    let back: EntropyReport = serde_json::from_str(&json).unwrap();
+    assert!(back.suspects.is_empty());
+}
+
+#[test]
+fn import_report_serializable() {
+    let r = ImportReport {
+        granularity: "module".into(),
+        edges: vec![],
+    };
+    let json = serde_json::to_string(&r).unwrap();
+    let back: ImportReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.granularity, "module");
+}
+
+#[test]
+fn fun_report_serializable() {
+    let r = FunReport { eco_label: None };
+    let json = serde_json::to_string(&r).unwrap();
+    let back: FunReport = serde_json::from_str(&json).unwrap();
+    assert!(back.eco_label.is_none());
+}
+
+// ── Derived report defaults are valid ────────────────────────────────────
+
+#[test]
+fn analysis_receipt_with_all_none_enrichers_roundtrips() {
+    let receipt = sample_analysis_receipt();
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+
+    // All optional enrichers serialize as null
+    assert!(v["archetype"].is_null());
+    assert!(v["topics"].is_null());
+    assert!(v["entropy"].is_null());
+    assert!(v["git"].is_null());
+    assert!(v["complexity"].is_null());
+    assert!(v["fun"].is_null());
+
+    // Can still deserialize back
+    let back: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, ANALYSIS_SCHEMA_VERSION);
+}
+
+// ── Preset names are stable strings ──────────────────────────────────────
+
+#[test]
+fn preset_names_stable() {
+    let known_presets = [
+        "receipt",
+        "health",
+        "risk",
+        "supply",
+        "architecture",
+        "topics",
+        "security",
+        "identity",
+        "git",
+        "deep",
+        "fun",
+    ];
+
+    // Verify the default preset is "receipt"
+    let receipt = sample_analysis_receipt();
+    assert_eq!(receipt.args.preset, "receipt");
+
+    // Verify all known presets are strings (contract: presets are plain strings, not enums)
+    for preset in &known_presets {
+        let mut r = sample_analysis_receipt();
+        r.args.preset = preset.to_string();
+        let json = serde_json::to_string(&r).unwrap();
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["args"]["preset"].as_str().unwrap(), *preset);
+    }
+}
+
+// ── Backward compatibility: extra fields are ignored ─────────────────────
+
+#[test]
+fn unknown_fields_in_json_are_tolerated() {
+    let mut receipt = sample_analysis_receipt();
+    receipt.args.preset = "receipt".into();
+    let json = serde_json::to_string(&receipt).unwrap();
+
+    // Add an unknown top-level field
+    let mut v: Value = serde_json::from_str(&json).unwrap();
+    v["future_field"] = Value::String("hello".into());
+    let extended_json = serde_json::to_string(&v).unwrap();
+
+    // Deserialization should succeed (serde default is to ignore unknown fields)
+    let back: AnalysisReceipt = serde_json::from_str(&extended_json).unwrap();
+    assert_eq!(back.schema_version, ANALYSIS_SCHEMA_VERSION);
+}
+
+// ── Property tests ───────────────────────────────────────────────────────
+
+mod properties {
+    use proptest::prelude::*;
+    use tokmd_analysis_types::{
+        ANALYSIS_SCHEMA_VERSION, AnalysisArgsMeta, AnalysisReceipt, AnalysisSource,
+    };
+    use tokmd_types::{ScanStatus, ToolInfo};
+
+    fn arb_analysis_receipt() -> impl Strategy<Value = AnalysisReceipt> {
+        (any::<u128>(), "[a-z]{3,8}").prop_map(|(ts, preset)| AnalysisReceipt {
+            schema_version: ANALYSIS_SCHEMA_VERSION,
+            generated_at_ms: ts,
+            tool: ToolInfo {
+                name: "tokmd".into(),
+                version: "1.0.0".into(),
+            },
+            mode: "analyze".into(),
+            status: ScanStatus::Complete,
+            warnings: vec![],
+            source: AnalysisSource {
+                inputs: vec![".".into()],
+                export_path: None,
+                base_receipt_path: None,
+                export_schema_version: None,
+                export_generated_at_ms: None,
+                base_signature: None,
+                module_roots: vec![],
+                module_depth: 2,
+                children: "collapse".into(),
+            },
+            args: AnalysisArgsMeta {
+                preset,
+                format: "json".into(),
+                window_tokens: None,
+                git: None,
+                max_files: None,
+                max_bytes: None,
+                max_commits: None,
+                max_commit_files: None,
+                max_file_bytes: None,
+                import_granularity: "module".into(),
+            },
+            archetype: None,
+            topics: None,
+            entropy: None,
+            predictive_churn: None,
+            corporate_fingerprint: None,
+            license: None,
+            derived: None,
+            assets: None,
+            deps: None,
+            git: None,
+            imports: None,
+            dup: None,
+            complexity: None,
+            api_surface: None,
+            fun: None,
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn analysis_receipt_roundtrip(receipt in arb_analysis_receipt()) {
+            let json = serde_json::to_string(&receipt).unwrap();
+            let back: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(back.schema_version, ANALYSIS_SCHEMA_VERSION);
+            prop_assert_eq!(&back.args.preset, &receipt.args.preset);
+        }
+    }
+}

--- a/crates/tokmd-envelope/tests/contract_hardening.rs
+++ b/crates/tokmd-envelope/tests/contract_hardening.rs
@@ -1,0 +1,245 @@
+//! Contract hardening tests for tokmd-envelope SensorReport.
+
+use serde_json::Value;
+use tokmd_envelope::{
+    Artifact, Finding, FindingLocation, FindingSeverity, SENSOR_REPORT_SCHEMA, SensorReport,
+    ToolMeta, Verdict,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn sample_tool_meta() -> ToolMeta {
+    ToolMeta::tokmd("1.0.0", "cockpit")
+}
+
+fn sample_report() -> SensorReport {
+    SensorReport::new(
+        sample_tool_meta(),
+        "2024-01-15T12:00:00Z".into(),
+        Verdict::Pass,
+        "All checks passed".into(),
+    )
+}
+
+fn sample_finding() -> Finding {
+    Finding::new(
+        "risk",
+        "hotspot",
+        FindingSeverity::Warn,
+        "Hot file detected",
+        "src/lib.rs has high churn",
+    )
+    .with_location(FindingLocation::path_line("src/lib.rs", 42))
+    .with_fingerprint("tokmd")
+}
+
+// ── SensorReport serialization/deserialization ───────────────────────────
+
+#[test]
+fn sensor_report_json_roundtrip() {
+    let report = sample_report();
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema, SENSOR_REPORT_SCHEMA);
+    assert_eq!(back.verdict, Verdict::Pass);
+    assert_eq!(back.summary, "All checks passed");
+}
+
+#[test]
+fn sensor_report_with_findings_roundtrip() {
+    let mut report = sample_report();
+    report.add_finding(sample_finding());
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.findings.len(), 1);
+    assert_eq!(back.findings[0].check_id, "risk");
+    assert_eq!(back.findings[0].code, "hotspot");
+}
+
+#[test]
+fn sensor_report_with_artifacts_roundtrip() {
+    let report = sample_report().with_artifacts(vec![Artifact::new("receipt", "output.json")]);
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    let artifacts = back.artifacts.unwrap();
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].artifact_type, "receipt");
+}
+
+#[test]
+fn sensor_report_with_data_roundtrip() {
+    let data = serde_json::json!({"key": "value", "count": 42});
+    let report = sample_report().with_data(data.clone());
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.data.unwrap(), data);
+}
+
+// ── Envelope fields ──────────────────────────────────────────────────────
+
+#[test]
+fn envelope_has_schema_field() {
+    let report = sample_report();
+    let json = serde_json::to_string(&report).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema"].as_str().unwrap(), "sensor.report.v1");
+}
+
+#[test]
+fn envelope_has_timestamp() {
+    let report = sample_report();
+    let json = serde_json::to_string(&report).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert!(v["generated_at"].is_string());
+    assert!(!v["generated_at"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn envelope_has_tool_fields() {
+    let report = sample_report();
+    let json = serde_json::to_string(&report).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["tool"]["name"].as_str().unwrap(), "tokmd");
+    assert_eq!(v["tool"]["version"].as_str().unwrap(), "1.0.0");
+    assert_eq!(v["tool"]["mode"].as_str().unwrap(), "cockpit");
+}
+
+#[test]
+fn envelope_has_verdict() {
+    let report = sample_report();
+    let json = serde_json::to_string(&report).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["verdict"].as_str().unwrap(), "pass");
+}
+
+// ── Verdict serde stability ──────────────────────────────────────────────
+
+#[test]
+fn verdict_serde_values() {
+    assert_eq!(serde_json::to_string(&Verdict::Pass).unwrap(), "\"pass\"");
+    assert_eq!(serde_json::to_string(&Verdict::Fail).unwrap(), "\"fail\"");
+    assert_eq!(serde_json::to_string(&Verdict::Warn).unwrap(), "\"warn\"");
+    assert_eq!(serde_json::to_string(&Verdict::Skip).unwrap(), "\"skip\"");
+    assert_eq!(
+        serde_json::to_string(&Verdict::Pending).unwrap(),
+        "\"pending\""
+    );
+}
+
+#[test]
+fn verdict_default_is_pass() {
+    assert_eq!(Verdict::default(), Verdict::Pass);
+}
+
+// ── Finding ID stability ─────────────────────────────────────────────────
+
+#[test]
+fn finding_ids_are_stable() {
+    use tokmd_envelope::findings;
+
+    assert_eq!(findings::risk::CHECK_ID, "risk");
+    assert_eq!(findings::risk::HOTSPOT, "hotspot");
+    assert_eq!(findings::risk::COUPLING, "coupling");
+    assert_eq!(findings::risk::BUS_FACTOR, "bus_factor");
+
+    assert_eq!(findings::contract::CHECK_ID, "contract");
+    assert_eq!(findings::contract::SCHEMA_CHANGED, "schema_changed");
+    assert_eq!(findings::contract::API_CHANGED, "api_changed");
+
+    assert_eq!(findings::supply::CHECK_ID, "supply");
+    assert_eq!(findings::supply::LOCKFILE_CHANGED, "lockfile_changed");
+
+    assert_eq!(findings::gate::CHECK_ID, "gate");
+    assert_eq!(findings::gate::MUTATION_FAILED, "mutation_failed");
+}
+
+// ── Fingerprint stability ────────────────────────────────────────────────
+
+#[test]
+fn fingerprint_is_deterministic() {
+    let f = sample_finding();
+    let fp1 = f.compute_fingerprint("tokmd");
+    let fp2 = f.compute_fingerprint("tokmd");
+    assert_eq!(fp1, fp2);
+    assert_eq!(fp1.len(), 32, "fingerprint should be 32 hex chars");
+}
+
+#[test]
+fn fingerprint_changes_with_tool_name() {
+    let f = sample_finding();
+    let fp1 = f.compute_fingerprint("tokmd");
+    let fp2 = f.compute_fingerprint("other-tool");
+    assert_ne!(fp1, fp2);
+}
+
+// ── Empty receipts are valid envelopes ───────────────────────────────────
+
+#[test]
+fn empty_report_is_valid() {
+    let report = SensorReport::new(
+        ToolMeta::new("test", "0.0.1", "check"),
+        "2024-01-01T00:00:00Z".into(),
+        Verdict::Skip,
+        "No checks ran".into(),
+    );
+    let json = serde_json::to_string(&report).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema"].as_str().unwrap(), SENSOR_REPORT_SCHEMA);
+    assert!(v["findings"].as_array().unwrap().is_empty());
+    // Optional fields should not appear when None
+    assert!(v.get("artifacts").is_none() || v["artifacts"].is_null());
+    assert!(v.get("data").is_none() || v["data"].is_null());
+}
+
+// ── Schema string constant ───────────────────────────────────────────────
+
+#[test]
+fn sensor_report_schema_constant() {
+    assert_eq!(SENSOR_REPORT_SCHEMA, "sensor.report.v1");
+}
+
+// ── Property tests ───────────────────────────────────────────────────────
+
+mod properties {
+    use proptest::prelude::*;
+    use tokmd_envelope::{SENSOR_REPORT_SCHEMA, SensorReport, ToolMeta, Verdict};
+
+    fn arb_verdict() -> impl Strategy<Value = Verdict> {
+        prop_oneof![
+            Just(Verdict::Pass),
+            Just(Verdict::Fail),
+            Just(Verdict::Warn),
+            Just(Verdict::Skip),
+            Just(Verdict::Pending),
+        ]
+    }
+
+    fn arb_sensor_report() -> impl Strategy<Value = SensorReport> {
+        (
+            "[a-z]{3,8}",
+            "[0-9]+\\.[0-9]+\\.[0-9]+",
+            "[a-z]{3,8}",
+            arb_verdict(),
+            ".{1,50}",
+        )
+            .prop_map(|(name, version, mode, verdict, summary)| {
+                SensorReport::new(
+                    ToolMeta::new(&name, &version, &mode),
+                    "2024-01-01T00:00:00Z".into(),
+                    verdict,
+                    summary,
+                )
+            })
+    }
+
+    proptest! {
+        #[test]
+        fn envelope_json_roundtrip(report in arb_sensor_report()) {
+            let json = serde_json::to_string(&report).unwrap();
+            let back: SensorReport = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(&back.schema, SENSOR_REPORT_SCHEMA);
+            prop_assert_eq!(back.verdict, report.verdict);
+            prop_assert_eq!(&back.tool.name, &report.tool.name);
+        }
+    }
+}

--- a/crates/tokmd-settings/tests/settings_compat.rs
+++ b/crates/tokmd-settings/tests/settings_compat.rs
@@ -1,0 +1,263 @@
+//! Backward compatibility tests for tokmd-settings.
+
+use tokmd_settings::{
+    AnalyzeSettings, CockpitSettings, ExportSettings, LangSettings, ModuleSettings, ScanOptions,
+    ScanSettings, TomlConfig,
+};
+use tokmd_types::{ChildIncludeMode, ChildrenMode, ConfigMode, ExportFormat, RedactMode};
+
+// ── ScanOptions defaults ─────────────────────────────────────────────────
+
+#[test]
+fn scan_options_defaults() {
+    let opts = ScanOptions::default();
+    assert!(opts.excluded.is_empty());
+    assert_eq!(opts.config, ConfigMode::Auto);
+    assert!(!opts.hidden);
+    assert!(!opts.no_ignore);
+    assert!(!opts.no_ignore_parent);
+    assert!(!opts.no_ignore_dot);
+    assert!(!opts.no_ignore_vcs);
+    assert!(!opts.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn scan_settings_defaults() {
+    let s = ScanSettings::default();
+    assert!(s.paths.is_empty());
+    assert!(s.options.excluded.is_empty());
+}
+
+#[test]
+fn lang_settings_defaults() {
+    let l = LangSettings::default();
+    assert_eq!(l.top, 0);
+    assert!(!l.files);
+    assert_eq!(l.children, ChildrenMode::Collapse);
+    assert!(l.redact.is_none());
+}
+
+#[test]
+fn module_settings_defaults() {
+    let m = ModuleSettings::default();
+    assert_eq!(m.top, 0);
+    assert_eq!(m.module_depth, 2);
+    assert_eq!(m.children, ChildIncludeMode::Separate);
+    assert!(m.module_roots.contains(&"crates".to_string()));
+    assert!(m.module_roots.contains(&"packages".to_string()));
+}
+
+#[test]
+fn export_settings_defaults() {
+    let e = ExportSettings::default();
+    assert_eq!(e.format, ExportFormat::Jsonl);
+    assert_eq!(e.module_depth, 2);
+    assert_eq!(e.min_code, 0);
+    assert_eq!(e.max_rows, 0);
+    assert_eq!(e.redact, RedactMode::None);
+    assert!(e.meta);
+    assert!(e.strip_prefix.is_none());
+}
+
+#[test]
+fn analyze_settings_defaults() {
+    let a = AnalyzeSettings::default();
+    assert_eq!(a.preset, "receipt");
+    assert_eq!(a.granularity, "module");
+    assert!(a.window.is_none());
+    assert!(a.git.is_none());
+    assert!(a.max_files.is_none());
+}
+
+#[test]
+fn cockpit_settings_defaults() {
+    let c = CockpitSettings::default();
+    assert_eq!(c.base, "main");
+    assert_eq!(c.head, "HEAD");
+    assert_eq!(c.range_mode, "two-dot");
+    assert!(c.baseline.is_none());
+}
+
+// ── JSON serialization round-trips ───────────────────────────────────────
+
+#[test]
+fn scan_options_json_roundtrip() {
+    let opts = ScanOptions {
+        excluded: vec!["target".into(), "node_modules".into()],
+        config: ConfigMode::None,
+        hidden: true,
+        no_ignore: false,
+        no_ignore_parent: true,
+        no_ignore_dot: false,
+        no_ignore_vcs: true,
+        treat_doc_strings_as_comments: true,
+    };
+    let json = serde_json::to_string(&opts).unwrap();
+    let back: ScanOptions = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.excluded, opts.excluded);
+    assert!(back.hidden);
+    assert!(back.no_ignore_parent);
+    assert!(back.no_ignore_vcs);
+    assert!(back.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn analyze_settings_json_roundtrip() {
+    let s = AnalyzeSettings {
+        preset: "deep".into(),
+        window: Some(128_000),
+        git: Some(true),
+        max_files: Some(500),
+        max_bytes: Some(10_000_000),
+        max_file_bytes: Some(1_000_000),
+        max_commits: Some(100),
+        max_commit_files: Some(50),
+        granularity: "file".into(),
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let back: AnalyzeSettings = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.preset, "deep");
+    assert_eq!(back.window, Some(128_000));
+    assert_eq!(back.git, Some(true));
+}
+
+// ── TOML serialization ──────────────────────────────────────────────────
+
+#[test]
+fn toml_config_roundtrip() {
+    let config = TomlConfig::default();
+    let toml_str = toml::to_string(&config).unwrap();
+    let back: TomlConfig = toml::from_str(&toml_str).unwrap();
+    // Defaults should survive serialization
+    assert!(back.scan.paths.is_none());
+    assert!(back.analyze.preset.is_none());
+}
+
+#[test]
+fn toml_config_parse_minimal() {
+    let toml_str = r#"
+[scan]
+hidden = true
+
+[analyze]
+preset = "health"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.scan.hidden, Some(true));
+    assert_eq!(config.analyze.preset, Some("health".into()));
+}
+
+// ── Removing optional fields doesn't break deserialization ───────────────
+
+#[test]
+fn missing_optional_fields_use_defaults() {
+    // A minimal JSON with only required defaults
+    let json = r#"{"excluded":[],"config":"auto","hidden":false,"no_ignore":false,"no_ignore_parent":false,"no_ignore_dot":false,"no_ignore_vcs":false,"treat_doc_strings_as_comments":false}"#;
+    let opts: ScanOptions = serde_json::from_str(json).unwrap();
+    assert!(!opts.hidden);
+    assert_eq!(opts.config, ConfigMode::Auto);
+}
+
+#[test]
+fn empty_json_deserializes_to_defaults_for_scan_options() {
+    // ScanOptions has #[serde(default)] on all fields
+    let opts: ScanOptions = serde_json::from_str("{}").unwrap();
+    assert!(opts.excluded.is_empty());
+    assert!(!opts.hidden);
+    assert_eq!(opts.config, ConfigMode::Auto);
+}
+
+#[test]
+fn empty_json_deserializes_to_defaults_for_toml_config() {
+    let config: TomlConfig = toml::from_str("").unwrap();
+    assert!(config.scan.paths.is_none());
+    assert!(config.analyze.preset.is_none());
+    assert!(config.module.roots.is_none());
+}
+
+#[test]
+fn partial_analyze_settings_deserializes() {
+    let json = r#"{"preset":"risk"}"#;
+    let s: AnalyzeSettings = serde_json::from_str(json).unwrap();
+    assert_eq!(s.preset, "risk");
+    // Other fields should get defaults
+    assert!(s.window.is_none());
+    assert!(s.git.is_none());
+    assert_eq!(s.granularity, "module");
+}
+
+// ── Serde aliases work correctly ─────────────────────────────────────────
+
+#[test]
+fn config_mode_serde_variants() {
+    let auto: ConfigMode = serde_json::from_str("\"auto\"").unwrap();
+    assert_eq!(auto, ConfigMode::Auto);
+    let none: ConfigMode = serde_json::from_str("\"none\"").unwrap();
+    assert_eq!(none, ConfigMode::None);
+}
+
+#[test]
+fn children_mode_serde_variants() {
+    let collapse: ChildrenMode = serde_json::from_str("\"collapse\"").unwrap();
+    assert_eq!(collapse, ChildrenMode::Collapse);
+    let separate: ChildrenMode = serde_json::from_str("\"separate\"").unwrap();
+    assert_eq!(separate, ChildrenMode::Separate);
+}
+
+#[test]
+fn child_include_mode_serde_variants() {
+    let sep: ChildIncludeMode = serde_json::from_str("\"separate\"").unwrap();
+    assert_eq!(sep, ChildIncludeMode::Separate);
+    let po: ChildIncludeMode = serde_json::from_str("\"parents-only\"").unwrap();
+    assert_eq!(po, ChildIncludeMode::ParentsOnly);
+}
+
+#[test]
+fn export_format_serde_variants() {
+    for (s, expected) in [
+        ("\"jsonl\"", ExportFormat::Jsonl),
+        ("\"csv\"", ExportFormat::Csv),
+        ("\"json\"", ExportFormat::Json),
+        ("\"cyclonedx\"", ExportFormat::Cyclonedx),
+    ] {
+        let v: ExportFormat = serde_json::from_str(s).unwrap();
+        assert_eq!(v, expected);
+    }
+}
+
+#[test]
+fn redact_mode_serde_variants() {
+    for (s, expected) in [
+        ("\"none\"", RedactMode::None),
+        ("\"paths\"", RedactMode::Paths),
+        ("\"all\"", RedactMode::All),
+    ] {
+        let v: RedactMode = serde_json::from_str(s).unwrap();
+        assert_eq!(v, expected);
+    }
+}
+
+// ── Property tests ───────────────────────────────────────────────────────
+
+mod properties {
+    use proptest::prelude::*;
+    use tokmd_settings::ScanOptions;
+
+    proptest! {
+        #[test]
+        fn scan_options_roundtrip(
+            hidden in any::<bool>(),
+            no_ignore in any::<bool>(),
+        ) {
+            let opts = ScanOptions {
+                hidden,
+                no_ignore,
+                ..Default::default()
+            };
+            let json = serde_json::to_string(&opts).unwrap();
+            let back: ScanOptions = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(back.hidden, hidden);
+            prop_assert_eq!(back.no_ignore, no_ignore);
+        }
+    }
+}

--- a/crates/tokmd-types/tests/schema_contract.rs
+++ b/crates/tokmd-types/tests/schema_contract.rs
@@ -1,0 +1,414 @@
+//! Schema versioning and backward compatibility contract tests for tokmd-types.
+
+use serde_json::Value;
+use tokmd_types::{
+    CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION, ChildIncludeMode, ChildrenMode,
+    ConfigMode, DiffReceipt, DiffTotals, ExportArgsMeta, ExportData, ExportFormat, ExportReceipt,
+    FileKind, FileRow, HANDOFF_SCHEMA_VERSION, LangArgsMeta, LangReceipt, LangReport, LangRow,
+    ModuleArgsMeta, ModuleReceipt, ModuleReport, ModuleRow, RedactMode, SCHEMA_VERSION, ScanArgs,
+    ScanStatus, ToolInfo, Totals,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn sample_tool_info() -> ToolInfo {
+    ToolInfo {
+        name: "tokmd".into(),
+        version: "1.0.0".into(),
+    }
+}
+
+fn sample_scan_args() -> ScanArgs {
+    ScanArgs {
+        paths: vec![".".into()],
+        excluded: vec![],
+        excluded_redacted: false,
+        config: ConfigMode::Auto,
+        hidden: false,
+        no_ignore: false,
+        no_ignore_parent: false,
+        no_ignore_dot: false,
+        no_ignore_vcs: false,
+        treat_doc_strings_as_comments: false,
+    }
+}
+
+fn sample_totals() -> Totals {
+    Totals {
+        code: 100,
+        lines: 150,
+        files: 5,
+        bytes: 4000,
+        tokens: 1000,
+        avg_lines: 30,
+    }
+}
+
+fn sample_lang_receipt() -> LangReceipt {
+    LangReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: sample_tool_info(),
+        mode: "lang".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        scan: sample_scan_args(),
+        args: LangArgsMeta {
+            format: "json".into(),
+            top: 0,
+            with_files: false,
+            children: ChildrenMode::Collapse,
+        },
+        report: LangReport {
+            rows: vec![LangRow {
+                lang: "Rust".into(),
+                code: 100,
+                lines: 150,
+                files: 5,
+                bytes: 4000,
+                tokens: 1000,
+                avg_lines: 30,
+            }],
+            total: sample_totals(),
+            with_files: false,
+            children: ChildrenMode::Collapse,
+            top: 0,
+        },
+    }
+}
+
+fn sample_module_receipt() -> ModuleReceipt {
+    ModuleReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: sample_tool_info(),
+        mode: "module".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        scan: sample_scan_args(),
+        args: ModuleArgsMeta {
+            format: "json".into(),
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+            top: 0,
+        },
+        report: ModuleReport {
+            rows: vec![ModuleRow {
+                module: "crates/tokmd-types".into(),
+                code: 100,
+                lines: 150,
+                files: 5,
+                bytes: 4000,
+                tokens: 1000,
+                avg_lines: 30,
+            }],
+            total: sample_totals(),
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+            top: 0,
+        },
+    }
+}
+
+fn sample_export_receipt() -> ExportReceipt {
+    ExportReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: sample_tool_info(),
+        mode: "export".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        scan: sample_scan_args(),
+        args: ExportArgsMeta {
+            format: ExportFormat::Jsonl,
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+            min_code: 0,
+            max_rows: 0,
+            redact: RedactMode::None,
+            strip_prefix: None,
+            strip_prefix_redacted: false,
+        },
+        data: ExportData {
+            rows: vec![FileRow {
+                path: "src/lib.rs".into(),
+                module: "crates/tokmd-types".into(),
+                lang: "Rust".into(),
+                kind: FileKind::Parent,
+                code: 100,
+                comments: 20,
+                blanks: 30,
+                lines: 150,
+                bytes: 4000,
+                tokens: 1000,
+            }],
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+        },
+    }
+}
+
+// ── Schema version constants ─────────────────────────────────────────────
+
+#[test]
+fn schema_version_is_positive() {
+    assert!(
+        SCHEMA_VERSION > 0,
+        "SCHEMA_VERSION must be a positive integer"
+    );
+}
+
+#[test]
+fn schema_version_pinned() {
+    assert_eq!(SCHEMA_VERSION, 2);
+}
+
+#[test]
+fn all_schema_versions_are_positive() {
+    assert!(HANDOFF_SCHEMA_VERSION > 0);
+    assert!(CONTEXT_BUNDLE_SCHEMA_VERSION > 0);
+    assert!(CONTEXT_SCHEMA_VERSION > 0);
+}
+
+// ── Default values ───────────────────────────────────────────────────────
+
+#[test]
+fn config_mode_default_is_auto() {
+    assert_eq!(ConfigMode::default(), ConfigMode::Auto);
+}
+
+#[test]
+fn tool_info_default_has_empty_fields() {
+    let ti = ToolInfo::default();
+    assert!(ti.name.is_empty());
+    assert!(ti.version.is_empty());
+}
+
+#[test]
+fn diff_totals_default_all_zero() {
+    let dt = DiffTotals::default();
+    assert_eq!(dt.old_code, 0);
+    assert_eq!(dt.new_code, 0);
+    assert_eq!(dt.delta_code, 0);
+    assert_eq!(dt.old_files, 0);
+    assert_eq!(dt.new_files, 0);
+    assert_eq!(dt.delta_files, 0);
+    assert_eq!(dt.old_tokens, 0);
+    assert_eq!(dt.new_tokens, 0);
+    assert_eq!(dt.delta_tokens, 0);
+}
+
+// ── JSON serialization round-trips ───────────────────────────────────────
+
+#[test]
+fn lang_receipt_json_roundtrip() {
+    let receipt = sample_lang_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let back: LangReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.mode, "lang");
+    assert_eq!(back.report.rows.len(), 1);
+    assert_eq!(back.report.rows[0].lang, "Rust");
+}
+
+#[test]
+fn module_receipt_json_roundtrip() {
+    let receipt = sample_module_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let back: ModuleReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.mode, "module");
+    assert_eq!(back.report.rows.len(), 1);
+}
+
+#[test]
+fn export_receipt_json_roundtrip() {
+    let receipt = sample_export_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let back: ExportReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.mode, "export");
+    assert_eq!(back.data.rows.len(), 1);
+    assert_eq!(back.data.rows[0].path, "src/lib.rs");
+}
+
+#[test]
+fn diff_receipt_json_roundtrip() {
+    let receipt = DiffReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: sample_tool_info(),
+        mode: "diff".into(),
+        from_source: "v1.0".into(),
+        to_source: "v2.0".into(),
+        diff_rows: vec![],
+        totals: DiffTotals::default(),
+    };
+    let json = serde_json::to_string(&receipt).unwrap();
+    let back: DiffReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.from_source, "v1.0");
+    assert_eq!(back.to_source, "v2.0");
+}
+
+// ── schema_version field appears in serialized output ────────────────────
+
+#[test]
+fn schema_version_field_in_lang_json() {
+    let receipt = sample_lang_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema_version"], SCHEMA_VERSION);
+}
+
+#[test]
+fn schema_version_field_in_module_json() {
+    let receipt = sample_module_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema_version"], SCHEMA_VERSION);
+}
+
+#[test]
+fn schema_version_field_in_export_json() {
+    let receipt = sample_export_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema_version"], SCHEMA_VERSION);
+}
+
+// ── Enum serde stability ─────────────────────────────────────────────────
+
+#[test]
+fn children_mode_serde_values() {
+    assert_eq!(
+        serde_json::to_string(&ChildrenMode::Collapse).unwrap(),
+        "\"collapse\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ChildrenMode::Separate).unwrap(),
+        "\"separate\""
+    );
+}
+
+#[test]
+fn export_format_serde_values() {
+    assert_eq!(
+        serde_json::to_string(&ExportFormat::Jsonl).unwrap(),
+        "\"jsonl\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ExportFormat::Csv).unwrap(),
+        "\"csv\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ExportFormat::Json).unwrap(),
+        "\"json\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ExportFormat::Cyclonedx).unwrap(),
+        "\"cyclonedx\""
+    );
+}
+
+#[test]
+fn redact_mode_serde_values() {
+    assert_eq!(
+        serde_json::to_string(&RedactMode::None).unwrap(),
+        "\"none\""
+    );
+    assert_eq!(
+        serde_json::to_string(&RedactMode::Paths).unwrap(),
+        "\"paths\""
+    );
+    assert_eq!(serde_json::to_string(&RedactMode::All).unwrap(), "\"all\"");
+}
+
+// ── Property tests ───────────────────────────────────────────────────────
+
+mod properties {
+    use proptest::prelude::*;
+    use tokmd_types::{
+        ChildrenMode, LangArgsMeta, LangReceipt, LangReport, LangRow, SCHEMA_VERSION, ScanArgs,
+        ScanStatus, ToolInfo, Totals,
+    };
+
+    fn arb_lang_receipt() -> impl Strategy<Value = LangReceipt> {
+        (
+            any::<u128>(),
+            proptest::collection::vec("[a-zA-Z]{2,10}", 0..5),
+        )
+            .prop_map(|(ts, langs)| {
+                let rows: Vec<LangRow> = langs
+                    .iter()
+                    .map(|l| LangRow {
+                        lang: l.clone(),
+                        code: 10,
+                        lines: 15,
+                        files: 1,
+                        bytes: 400,
+                        tokens: 100,
+                        avg_lines: 15,
+                    })
+                    .collect();
+                let total = Totals {
+                    code: rows.iter().map(|r| r.code).sum(),
+                    lines: rows.iter().map(|r| r.lines).sum(),
+                    files: rows.iter().map(|r| r.files).sum(),
+                    bytes: rows.iter().map(|r| r.bytes).sum(),
+                    tokens: rows.iter().map(|r| r.tokens).sum(),
+                    avg_lines: 15,
+                };
+                LangReceipt {
+                    schema_version: SCHEMA_VERSION,
+                    generated_at_ms: ts,
+                    tool: ToolInfo {
+                        name: "tokmd".into(),
+                        version: "1.0.0".into(),
+                    },
+                    mode: "lang".into(),
+                    status: ScanStatus::Complete,
+                    warnings: vec![],
+                    scan: ScanArgs {
+                        paths: vec![".".into()],
+                        excluded: vec![],
+                        excluded_redacted: false,
+                        config: tokmd_types::ConfigMode::Auto,
+                        hidden: false,
+                        no_ignore: false,
+                        no_ignore_parent: false,
+                        no_ignore_dot: false,
+                        no_ignore_vcs: false,
+                        treat_doc_strings_as_comments: false,
+                    },
+                    args: LangArgsMeta {
+                        format: "json".into(),
+                        top: 0,
+                        with_files: false,
+                        children: ChildrenMode::Collapse,
+                    },
+                    report: LangReport {
+                        rows,
+                        total,
+                        with_files: false,
+                        children: ChildrenMode::Collapse,
+                        top: 0,
+                    },
+                }
+            })
+    }
+
+    proptest! {
+        #[test]
+        fn receipt_json_roundtrip(receipt in arb_lang_receipt()) {
+            let json = serde_json::to_string(&receipt).unwrap();
+            let back: LangReceipt = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(back.schema_version, SCHEMA_VERSION);
+            prop_assert_eq!(back.report.rows.len(), receipt.report.rows.len());
+        }
+    }
+}


### PR DESCRIPTION
Wave 46: Adds 67 schema contract tests across tokmd-types, tokmd-analysis-types, tokmd-envelope, and tokmd-settings. Verifies schema version constants, JSON/TOML round-trips, backward compatibility, enum serde stability, and property-based testing.