### PR TITLE
test(foundations): expand math, module-key, and path edge case tests

### DIFF
--- a/crates/tokmd-math/tests/numerical_stability.rs
+++ b/crates/tokmd-math/tests/numerical_stability.rs
@@ -1,0 +1,189 @@
+//! Numerical stability and precision tests for tokmd-math.
+
+use proptest::prelude::*;
+use tokmd_math::{gini_coefficient, percentile, round_f64, safe_ratio};
+
+// ── Very large numbers ──────────────────────────────────────────────
+
+#[test]
+fn safe_ratio_large_values_no_panic() {
+    let large = usize::MAX / 2;
+    let ratio = safe_ratio(large, large);
+    assert_eq!(ratio, 1.0);
+}
+
+#[test]
+fn safe_ratio_near_max_usize() {
+    let ratio = safe_ratio(usize::MAX, 1);
+    assert!(ratio.is_finite());
+    assert!(ratio > 0.0);
+}
+
+#[test]
+fn safe_ratio_max_over_max_is_one() {
+    assert_eq!(safe_ratio(usize::MAX, usize::MAX), 1.0);
+}
+
+#[test]
+fn percentile_with_large_values() {
+    let values = [usize::MAX - 2, usize::MAX - 1, usize::MAX];
+    let p = percentile(&values, 0.5);
+    assert!(p.is_finite());
+    assert!(p > 0.0);
+}
+
+#[test]
+fn gini_with_large_values_no_panic() {
+    let values = [1usize, usize::MAX / 1000, usize::MAX / 100];
+    let g = gini_coefficient(&values);
+    assert!(g.is_finite());
+    assert!(g >= 0.0);
+}
+
+// ── Floating point edge cases ───────────────────────────────────────
+
+#[test]
+fn round_f64_nan_stays_nan() {
+    assert!(round_f64(f64::NAN, 2).is_nan());
+}
+
+#[test]
+fn round_f64_infinity_stays_infinity() {
+    assert_eq!(round_f64(f64::INFINITY, 3), f64::INFINITY);
+    assert_eq!(round_f64(f64::NEG_INFINITY, 3), f64::NEG_INFINITY);
+}
+
+#[test]
+fn round_f64_negative_zero() {
+    let val = round_f64(-0.0, 5);
+    assert_eq!(val, 0.0);
+}
+
+#[test]
+fn round_f64_very_small_positive() {
+    let val = round_f64(f64::MIN_POSITIVE, 10);
+    assert!(val.is_finite());
+}
+
+#[test]
+fn round_f64_subnormal() {
+    let subnormal = 5e-324_f64;
+    let val = round_f64(subnormal, 5);
+    assert!(val.is_finite());
+}
+
+#[test]
+fn round_f64_large_magnitude() {
+    let val = round_f64(1e15, 2);
+    assert!(val.is_finite());
+    assert_eq!(val, 1e15);
+}
+
+#[test]
+fn round_f64_max_decimals_does_not_overflow() {
+    // u32::MAX as i32 is negative, but powi should still return finite
+    let val = round_f64(1.5, 15);
+    assert!(val.is_finite());
+}
+
+// ── Accumulator overflow prevention ─────────────────────────────────
+
+#[test]
+fn gini_many_large_values_no_overflow() {
+    let values = vec![usize::MAX / 10000; 100];
+    let g = gini_coefficient(&values);
+    assert!(g.is_finite());
+    // Uniform distribution — should be near zero
+    assert!(g.abs() < 1e-5);
+}
+
+#[test]
+fn gini_increasing_large_values_is_finite() {
+    let values: Vec<usize> = (1..=100).map(|i| i * (usize::MAX / 100_000)).collect();
+    let g = gini_coefficient(&values);
+    assert!(g.is_finite());
+    assert!(g >= 0.0);
+}
+
+#[test]
+fn percentile_thousand_elements_no_issue() {
+    let values: Vec<usize> = (0..1000).collect();
+    let p50 = percentile(&values, 0.5);
+    assert!(p50.is_finite());
+    assert!(p50 >= 0.0 && p50 <= 999.0);
+}
+
+// ── safe_ratio precision ────────────────────────────────────────────
+
+#[test]
+fn safe_ratio_precision_thirds() {
+    assert_eq!(safe_ratio(1, 3), 0.3333);
+    assert_eq!(safe_ratio(2, 3), 0.6667);
+}
+
+#[test]
+fn safe_ratio_precision_sevenths() {
+    let ratio = safe_ratio(1, 7);
+    // 1/7 ≈ 0.142857... → rounds to 0.1429
+    assert_eq!(ratio, 0.1429);
+}
+
+// ── Property tests: no panics on valid input ────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    #[test]
+    fn round_f64_never_panics(value in prop::num::f64::ANY, decimals in 0u32..20) {
+        let _ = round_f64(value, decimals);
+    }
+
+    #[test]
+    fn safe_ratio_never_panics(numer in 0usize..=usize::MAX, denom in 0usize..=usize::MAX) {
+        let r = safe_ratio(numer, denom);
+        if denom == 0 {
+            prop_assert_eq!(r, 0.0);
+        } else {
+            prop_assert!(r.is_finite());
+        }
+    }
+
+    #[test]
+    fn percentile_never_panics(
+        mut values in prop::collection::vec(0usize..=1_000_000_000, 0..200),
+        pct in 0.0f64..=1.0
+    ) {
+        values.sort();
+        let p = percentile(&values, pct);
+        prop_assert!(p.is_finite() || values.is_empty());
+    }
+
+    #[test]
+    fn gini_never_panics(
+        values in prop::collection::vec(0usize..=1_000_000, 0..200)
+    ) {
+        let mut sorted = values;
+        sorted.sort();
+        let g = gini_coefficient(&sorted);
+        prop_assert!(g.is_finite());
+    }
+
+    #[test]
+    fn round_f64_finite_input_finite_output(
+        value in -1e12f64..1e12,
+        decimals in 0u32..10
+    ) {
+        let result = round_f64(value, decimals);
+        prop_assert!(result.is_finite(), "finite input should yield finite output");
+    }
+
+    #[test]
+    fn safe_ratio_result_is_always_finite_or_zero(
+        numer in 0usize..10_000_000,
+        denom in 0usize..10_000_000
+    ) {
+        let r = safe_ratio(numer, denom);
+        prop_assert!(r.is_finite());
+        prop_assert!(r >= 0.0);
+    }
+}

--- a/crates/tokmd-math/tests/statistical_edge_cases.rs
+++ b/crates/tokmd-math/tests/statistical_edge_cases.rs
@@ -1,0 +1,186 @@
+//! Edge-case tests for statistical helpers in tokmd-math.
+
+use proptest::prelude::*;
+use tokmd_math::{gini_coefficient, percentile, round_f64, safe_ratio};
+
+// ── Median with all identical values ────────────────────────────────
+
+#[test]
+fn median_of_identical_values_returns_that_value() {
+    let values = [5usize; 100];
+    assert_eq!(percentile(&values, 0.5), 5.0);
+}
+
+#[test]
+fn median_of_identical_zeros_returns_zero() {
+    let values = [0usize; 50];
+    assert_eq!(percentile(&values, 0.5), 0.0);
+}
+
+#[test]
+fn median_of_identical_large_value() {
+    let values = [999_999usize; 10];
+    assert_eq!(percentile(&values, 0.5), 999_999.0);
+}
+
+// ── Percentile with 1 element ───────────────────────────────────────
+
+#[test]
+fn percentile_single_element_at_every_quantile() {
+    for pct in [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0] {
+        assert_eq!(percentile(&[42], pct), 42.0, "pct={pct}");
+    }
+}
+
+#[test]
+fn percentile_single_zero_element() {
+    assert_eq!(percentile(&[0], 0.5), 0.0);
+}
+
+// ── Standard deviation / variance proxy (Gini with 0 variance) ─────
+
+#[test]
+fn gini_zero_variance_uniform_small() {
+    let values = [10usize, 10, 10];
+    assert!(gini_coefficient(&values).abs() < 1e-10);
+}
+
+#[test]
+fn gini_zero_variance_uniform_large() {
+    let values = vec![42usize; 1000];
+    assert!(gini_coefficient(&values).abs() < 1e-10);
+}
+
+// ── COCOMO-like extreme inputs (ratio at 0 LOC and very large LOC) ──
+
+#[test]
+fn safe_ratio_zero_loc_numerator() {
+    assert_eq!(safe_ratio(0, 1_000_000), 0.0);
+}
+
+#[test]
+fn safe_ratio_very_large_numerator() {
+    let ratio = safe_ratio(10_000_000, 1);
+    assert_eq!(ratio, 10_000_000.0);
+}
+
+#[test]
+fn safe_ratio_very_large_both() {
+    let ratio = safe_ratio(1_000_000, 1_000_000);
+    assert_eq!(ratio, 1.0);
+}
+
+#[test]
+fn safe_ratio_large_numerator_small_denominator() {
+    let ratio = safe_ratio(999_999, 3);
+    assert!(ratio > 100_000.0);
+    assert!(ratio.is_finite());
+}
+
+// ── Ratio calculations with zero denominators ───────────────────────
+
+#[test]
+fn safe_ratio_zero_zero() {
+    assert_eq!(safe_ratio(0, 0), 0.0);
+}
+
+#[test]
+fn safe_ratio_nonzero_zero() {
+    assert_eq!(safe_ratio(42, 0), 0.0);
+}
+
+#[test]
+fn safe_ratio_max_usize_zero() {
+    assert_eq!(safe_ratio(usize::MAX, 0), 0.0);
+}
+
+// ── round_f64 edge cases ────────────────────────────────────────────
+
+#[test]
+fn round_f64_exact_half_rounds_away_from_zero() {
+    // Rust's f64::round uses "round half away from zero"
+    assert_eq!(round_f64(0.5, 0), 1.0);
+    assert_eq!(round_f64(-0.5, 0), -1.0);
+    assert_eq!(round_f64(2.5, 0), 3.0);
+}
+
+#[test]
+fn round_f64_high_precision() {
+    let val = round_f64(1.0 / 3.0, 10);
+    assert!((val - 0.3333333333).abs() < 1e-10);
+}
+
+// ── Gini with extreme inequality ────────────────────────────────────
+
+#[test]
+fn gini_extreme_inequality() {
+    let mut values = vec![0usize; 99];
+    values.push(1_000_000);
+    values.sort();
+    let g = gini_coefficient(&values);
+    assert!(g > 0.9, "extreme inequality should yield high Gini: {g}");
+}
+
+#[test]
+fn gini_two_element_max_inequality() {
+    let g = gini_coefficient(&[0, 100]);
+    assert!((g - 0.5).abs() < 1e-10);
+}
+
+// ── Percentile boundary behavior ────────────────────────────────────
+
+#[test]
+fn percentile_two_elements_boundary() {
+    let values = [1usize, 100];
+    assert_eq!(percentile(&values, 0.0), 1.0);
+    assert_eq!(percentile(&values, 1.0), 100.0);
+}
+
+#[test]
+fn percentile_large_sorted_slice() {
+    let values: Vec<usize> = (1..=1000).collect();
+    assert_eq!(percentile(&values, 0.0), 1.0);
+    assert_eq!(percentile(&values, 1.0), 1000.0);
+    let median = percentile(&values, 0.5);
+    assert!(median >= 1.0 && median <= 1000.0);
+}
+
+// ── Property test: mean proxy is between min and max ────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    #[test]
+    fn mean_is_between_min_and_max(
+        values in prop::collection::vec(1usize..10000, 2..100)
+    ) {
+        let sum: f64 = values.iter().map(|v| *v as f64).sum();
+        let mean = sum / values.len() as f64;
+        let min_val = *values.iter().min().unwrap() as f64;
+        let max_val = *values.iter().max().unwrap() as f64;
+        prop_assert!(mean >= min_val, "mean {mean} < min {min_val}");
+        prop_assert!(mean <= max_val, "mean {mean} > max {max_val}");
+    }
+
+    #[test]
+    fn safe_ratio_zero_denom_always_zero(numer in 0usize..1_000_000) {
+        prop_assert_eq!(safe_ratio(numer, 0), 0.0);
+    }
+
+    #[test]
+    fn gini_uniform_always_zero(value in 1usize..10000, len in 2usize..50) {
+        let values = vec![value; len];
+        let g = gini_coefficient(&values);
+        prop_assert!(g.abs() < 1e-10, "uniform Gini should be ~0, got {g}");
+    }
+
+    #[test]
+    fn percentile_identical_values_always_returns_value(
+        value in 0usize..10000,
+        len in 1usize..100,
+        pct in 0.0f64..=1.0
+    ) {
+        let values = vec![value; len];
+        prop_assert_eq!(percentile(&values, pct), value as f64);
+    }
+}

--- a/crates/tokmd-module-key/tests/deep_edge_cases.rs
+++ b/crates/tokmd-module-key/tests/deep_edge_cases.rs
@@ -1,0 +1,223 @@
+//! Deep edge-case tests for module key derivation.
+
+use proptest::prelude::*;
+use tokmd_module_key::{module_key, module_key_from_normalized};
+
+// ── Paths with dots (./src, ../lib) ─────────────────────────────────
+
+#[test]
+fn dot_slash_src_is_stripped() {
+    let roots = vec!["src".into()];
+    assert_eq!(module_key("./src/lib.rs", &roots, 2), "src");
+}
+
+#[test]
+fn double_dot_slash_is_not_stripped() {
+    let roots = vec!["src".into()];
+    // "../lib" — the ".." is the first dir segment, not a module root
+    assert_eq!(module_key("../lib/foo.rs", &roots, 2), "..");
+}
+
+#[test]
+fn dot_slash_dot_slash_fully_stripped() {
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("././crates/foo/lib.rs", &roots, 2), "crates/foo");
+}
+
+#[test]
+fn dot_in_directory_name_not_confused_with_dot_segment() {
+    let roots = vec![".config".into()];
+    assert_eq!(
+        module_key(".config/settings/app.toml", &roots, 2),
+        ".config/settings"
+    );
+}
+
+#[test]
+fn dotdot_as_module_root() {
+    // ".." as a module root should still work via matching
+    let roots = vec!["..".into()];
+    assert_eq!(module_key("../lib/foo.rs", &roots, 2), "../lib");
+}
+
+// ── Deeply nested paths (10+ levels) ────────────────────────────────
+
+#[test]
+fn ten_level_nesting_with_root() {
+    let roots = vec!["a".into()];
+    let path = "a/b/c/d/e/f/g/h/i/j/file.rs";
+    assert_eq!(module_key(path, &roots, 5), "a/b/c/d/e");
+}
+
+#[test]
+fn ten_level_nesting_depth_exceeds_dirs() {
+    let roots = vec!["a".into()];
+    let path = "a/b/c/d/e/f/g/h/i/j/file.rs";
+    // 10 dir segments, depth 20 should use all 10
+    assert_eq!(module_key(path, &roots, 20), "a/b/c/d/e/f/g/h/i/j");
+}
+
+#[test]
+fn deep_nesting_without_root_returns_first_dir() {
+    let roots: Vec<String> = vec![];
+    let path = "x/y/z/a/b/c/d/e/f/g/h/i.rs";
+    assert_eq!(module_key(path, &roots, 5), "x");
+}
+
+#[test]
+fn fifteen_level_nesting_depth_3() {
+    let roots = vec!["root".into()];
+    let segments: Vec<&str> = (0..14).map(|_| "sub").collect();
+    let path = format!("root/{}/file.rs", segments.join("/"));
+    let key = module_key(&path, &roots, 3);
+    assert_eq!(key.split('/').count(), 3);
+}
+
+// ── Windows-style paths (backslashes) ───────────────────────────────
+
+#[test]
+fn pure_backslash_path() {
+    let roots = vec!["src".into()];
+    assert_eq!(module_key(r"src\main.rs", &roots, 2), "src");
+}
+
+#[test]
+fn backslash_with_root_and_depth() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key(r"crates\tokmd\src\lib.rs", &roots, 3),
+        "crates/tokmd/src"
+    );
+}
+
+#[test]
+fn mixed_slash_backslash() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key(r"crates/foo\bar/baz\qux.rs", &roots, 4),
+        "crates/foo/bar/baz"
+    );
+}
+
+#[test]
+fn dot_backslash_prefix() {
+    let roots = vec!["lib".into()];
+    assert_eq!(module_key(r".\lib\mod.rs", &roots, 2), "lib");
+}
+
+// ── Empty path segments ─────────────────────────────────────────────
+
+#[test]
+fn consecutive_slashes_skipped_in_normalized() {
+    let roots = vec!["a".into()];
+    assert_eq!(
+        module_key_from_normalized("a///b///c/file.rs", &roots, 3),
+        "a/b/c"
+    );
+}
+
+#[test]
+fn trailing_slash_before_filename_in_normalized() {
+    let roots = vec!["src".into()];
+    // "src//lib.rs" — empty segment between slashes
+    assert_eq!(module_key_from_normalized("src//lib.rs", &roots, 2), "src");
+}
+
+#[test]
+fn only_slashes_yields_root() {
+    assert_eq!(module_key("///", &[], 2), "(root)");
+}
+
+// ── Unicode path components ─────────────────────────────────────────
+
+#[test]
+fn unicode_dir_chinese() {
+    let roots = vec!["项目".into()];
+    assert_eq!(module_key("项目/源码/main.rs", &roots, 2), "项目/源码");
+}
+
+#[test]
+fn unicode_dir_emoji() {
+    let roots = vec!["📁".into()];
+    assert_eq!(module_key("📁/data/file.txt", &roots, 2), "📁/data");
+}
+
+#[test]
+fn unicode_dir_japanese() {
+    let roots = vec!["ソース".into()];
+    assert_eq!(module_key("ソース/コア/lib.rs", &roots, 2), "ソース/コア");
+}
+
+#[test]
+fn unicode_mixed_with_ascii() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key("crates/données/src/lib.rs", &roots, 2),
+        "crates/données"
+    );
+}
+
+#[test]
+fn unicode_non_root_returns_first_segment() {
+    let roots: Vec<String> = vec![];
+    assert_eq!(module_key("über/cool/file.rs", &roots, 3), "über");
+}
+
+// ── Property test: deterministic for same input ─────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    #[test]
+    fn module_key_is_deterministic(
+        dirs in prop::collection::vec("[a-zA-Z0-9_]+", 1..8),
+        filename in "[a-zA-Z0-9_]+\\.[a-z]+",
+        ref roots in prop::collection::vec("[a-zA-Z0-9_]+".prop_map(String::from), 0..4),
+        depth in 0usize..10
+    ) {
+        let path = format!("{}/{}", dirs.join("/"), filename);
+        let k1 = module_key(&path, roots, depth);
+        let k2 = module_key(&path, roots, depth);
+        prop_assert_eq!(&k1, &k2);
+    }
+
+    #[test]
+    fn module_key_from_normalized_is_deterministic(
+        dirs in prop::collection::vec("[a-zA-Z0-9_]+", 1..8),
+        filename in "[a-zA-Z0-9_]+\\.[a-z]+",
+        ref roots in prop::collection::vec("[a-zA-Z0-9_]+".prop_map(String::from), 0..4),
+        depth in 0usize..10
+    ) {
+        let path = format!("{}/{}", dirs.join("/"), filename);
+        let k1 = module_key_from_normalized(&path, roots, depth);
+        let k2 = module_key_from_normalized(&path, roots, depth);
+        prop_assert_eq!(&k1, &k2);
+    }
+
+    #[test]
+    fn deep_nesting_never_panics(
+        depth_count in 1usize..20,
+        depth in 0usize..25,
+        ref roots in prop::collection::vec("[a-zA-Z0-9_]+".prop_map(String::from), 0..3)
+    ) {
+        let segments: Vec<String> = (0..depth_count).map(|i| format!("d{i}")).collect();
+        let path = format!("{}/file.rs", segments.join("/"));
+        let key = module_key(&path, roots, depth);
+        prop_assert!(!key.is_empty());
+        prop_assert!(!key.contains('\\'));
+    }
+
+    #[test]
+    fn backslash_and_forward_slash_equivalent(
+        dirs in prop::collection::vec("[a-zA-Z0-9_]+", 2..6),
+        filename in "[a-zA-Z0-9_]+\\.[a-z]+",
+        ref roots in prop::collection::vec("[a-zA-Z0-9_]+".prop_map(String::from), 0..3),
+        depth in 1usize..5
+    ) {
+        let forward = format!("{}/{}", dirs.join("/"), filename);
+        let backward = format!("{}\\{}", dirs.join("\\"), filename);
+        let k_fwd = module_key(&forward, roots, depth);
+        let k_bwd = module_key(&backward, roots, depth);
+        prop_assert_eq!(&k_fwd, &k_bwd);
+    }
+}

--- a/crates/tokmd-path/tests/normalization_hardening.rs
+++ b/crates/tokmd-path/tests/normalization_hardening.rs
@@ -1,0 +1,270 @@
+//! Hardening tests for path normalization edge cases.
+
+use proptest::prelude::*;
+use tokmd_path::{normalize_rel_path, normalize_slashes};
+
+// ── Mixed separators (forward + back slashes) ───────────────────────
+
+#[test]
+fn mixed_separators_all_become_forward() {
+    assert_eq!(normalize_slashes(r"a\b/c\d/e"), "a/b/c/d/e");
+}
+
+#[test]
+fn mixed_separators_complex() {
+    assert_eq!(
+        normalize_slashes(r"foo\bar/baz\qux/quux"),
+        "foo/bar/baz/qux/quux"
+    );
+}
+
+#[test]
+fn mixed_rel_path() {
+    assert_eq!(normalize_rel_path(r".\src/lib\mod.rs"), "src/lib/mod.rs");
+}
+
+#[test]
+fn alternating_separators() {
+    assert_eq!(normalize_slashes(r"a/b\c/d\e/f\g"), "a/b/c/d/e/f/g");
+}
+
+// ── UNC paths (\\server\share) ──────────────────────────────────────
+
+#[test]
+fn unc_path_backslashes_converted() {
+    assert_eq!(
+        normalize_slashes(r"\\server\share\dir\file.txt"),
+        "//server/share/dir/file.txt"
+    );
+}
+
+#[test]
+fn unc_path_rel_normalization() {
+    let result = normalize_rel_path(r"\\server\share\file.txt");
+    assert!(!result.contains('\\'));
+    assert_eq!(result, "//server/share/file.txt");
+}
+
+#[test]
+fn unc_path_with_deep_nesting() {
+    assert_eq!(
+        normalize_slashes(r"\\host\share\a\b\c\d.rs"),
+        "//host/share/a/b/c/d.rs"
+    );
+}
+
+// ── Drive letter paths (C:\foo) ─────────────────────────────────────
+
+#[test]
+fn drive_letter_path_normalized() {
+    assert_eq!(
+        normalize_slashes(r"C:\Users\me\code\file.rs"),
+        "C:/Users/me/code/file.rs"
+    );
+}
+
+#[test]
+fn drive_letter_with_forward_slashes_unchanged() {
+    assert_eq!(
+        normalize_slashes("D:/Projects/rust/main.rs"),
+        "D:/Projects/rust/main.rs"
+    );
+}
+
+#[test]
+fn drive_letter_rel_path() {
+    let result = normalize_rel_path(r"C:\code\src\lib.rs");
+    assert_eq!(result, "C:/code/src/lib.rs");
+    assert!(!result.contains('\\'));
+}
+
+// ── Relative paths (../foo/bar) ─────────────────────────────────────
+
+#[test]
+fn dotdot_preserved_by_normalize_slashes() {
+    assert_eq!(normalize_slashes("../foo/bar"), "../foo/bar");
+}
+
+#[test]
+fn dotdot_preserved_by_normalize_rel_path() {
+    assert_eq!(normalize_rel_path("../foo/bar"), "../foo/bar");
+}
+
+#[test]
+fn dotdot_with_backslash() {
+    assert_eq!(normalize_rel_path(r"..\foo\bar"), "../foo/bar");
+}
+
+#[test]
+fn dotdot_nested() {
+    assert_eq!(
+        normalize_rel_path("../../deep/path/file.rs"),
+        "../../deep/path/file.rs"
+    );
+}
+
+#[test]
+fn dot_slash_then_dotdot() {
+    assert_eq!(normalize_rel_path("./../foo/bar.rs"), "../foo/bar.rs");
+}
+
+// ── Path components with spaces ─────────────────────────────────────
+
+#[test]
+fn spaces_in_directory_names() {
+    assert_eq!(
+        normalize_slashes(r"My Documents\Projects\file.txt"),
+        "My Documents/Projects/file.txt"
+    );
+}
+
+#[test]
+fn spaces_in_filename() {
+    assert_eq!(normalize_slashes(r"src\my file.rs"), "src/my file.rs");
+}
+
+#[test]
+fn spaces_rel_path() {
+    assert_eq!(
+        normalize_rel_path(r".\My Code\src\lib.rs"),
+        "My Code/src/lib.rs"
+    );
+}
+
+#[test]
+fn leading_and_trailing_spaces_in_segments() {
+    // Spaces are part of the path content, not stripped
+    let result = normalize_slashes(r" src \ lib.rs ");
+    assert_eq!(result, " src / lib.rs ");
+}
+
+// ── Very long paths (260+ chars) ────────────────────────────────────
+
+#[test]
+fn long_path_270_chars() {
+    let segment = "abcdefghij"; // 10 chars
+    let segments: Vec<&str> = (0..26).map(|_| segment).collect();
+    let long_path = segments.join("/") + "/file.rs";
+    assert!(long_path.len() > 260);
+    let result = normalize_slashes(&long_path);
+    assert!(!result.contains('\\'));
+    assert_eq!(result, long_path);
+}
+
+#[test]
+fn long_path_with_backslashes() {
+    let segment = "abcdefghij";
+    let segments: Vec<&str> = (0..26).map(|_| segment).collect();
+    let long_path = segments.join("\\") + "\\file.rs";
+    assert!(long_path.len() > 260);
+    let result = normalize_slashes(&long_path);
+    assert!(!result.contains('\\'));
+}
+
+#[test]
+fn long_path_rel_normalization() {
+    let segment = "longdir_xyz";
+    let segments: Vec<&str> = (0..25).map(|_| segment).collect();
+    let long_path = format!("./{}/file.rs", segments.join("/"));
+    assert!(long_path.len() > 260);
+    let result = normalize_rel_path(&long_path);
+    assert!(!result.starts_with("./"));
+    assert!(!result.contains('\\'));
+}
+
+// ── Empty and minimal inputs ────────────────────────────────────────
+
+#[test]
+fn empty_string() {
+    assert_eq!(normalize_slashes(""), "");
+    assert_eq!(normalize_rel_path(""), "");
+}
+
+#[test]
+fn single_dot() {
+    assert_eq!(normalize_slashes("."), ".");
+    assert_eq!(normalize_rel_path("."), ".");
+}
+
+#[test]
+fn single_slash() {
+    assert_eq!(normalize_slashes("/"), "/");
+    assert_eq!(normalize_rel_path("/"), "/");
+}
+
+#[test]
+fn single_backslash() {
+    assert_eq!(normalize_slashes("\\"), "/");
+    assert_eq!(normalize_rel_path("\\"), "/");
+}
+
+#[test]
+fn dot_slash_only() {
+    assert_eq!(normalize_rel_path("./"), "");
+}
+
+#[test]
+fn multiple_dot_slashes() {
+    assert_eq!(normalize_rel_path("./././"), "");
+}
+
+// ── Property test: normalize is idempotent ──────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    #[test]
+    fn normalize_slashes_idempotent(path in "\\PC{0,200}") {
+        let once = normalize_slashes(&path);
+        let twice = normalize_slashes(&once);
+        prop_assert_eq!(&once, &twice);
+    }
+
+    #[test]
+    fn normalize_rel_path_idempotent(path in "\\PC{0,200}") {
+        let once = normalize_rel_path(&path);
+        let twice = normalize_rel_path(&once);
+        prop_assert_eq!(&once, &twice);
+    }
+
+    #[test]
+    fn normalize_slashes_never_contains_backslash(path in "\\PC{0,200}") {
+        let result = normalize_slashes(&path);
+        prop_assert!(!result.contains('\\'));
+    }
+
+    #[test]
+    fn normalize_rel_path_never_contains_backslash(path in "\\PC{0,200}") {
+        let result = normalize_rel_path(&path);
+        prop_assert!(!result.contains('\\'));
+    }
+
+    #[test]
+    fn long_path_idempotent(
+        segments in prop::collection::vec("[a-zA-Z0-9_]{5,15}", 20..40),
+    ) {
+        let path = format!("{}/file.rs", segments.join("/"));
+        let once = normalize_rel_path(&path);
+        let twice = normalize_rel_path(&once);
+        prop_assert_eq!(&once, &twice);
+    }
+
+    #[test]
+    fn mixed_separator_path_idempotent(
+        segments in prop::collection::vec("[a-zA-Z0-9_]+", 2..8),
+    ) {
+        // Build a path with alternating / and \
+        let mut path = String::new();
+        for (i, seg) in segments.iter().enumerate() {
+            if i > 0 {
+                if i % 2 == 0 { path.push('/'); } else { path.push('\\'); }
+            }
+            path.push_str(seg);
+        }
+        path.push_str(".rs");
+        let once = normalize_slashes(&path);
+        let twice = normalize_slashes(&once);
+        prop_assert_eq!(&once, &twice);
+        prop_assert!(!once.contains('\\'));
+    }
+}


### PR DESCRIPTION
Wave 46: Adds 106 tests for foundation crates. Covers statistical edge cases, numerical stability, module key derivation with Unicode/deep paths, and path normalization hardening with property tests for idempotency and determinism.