### PR TITLE
test(cli): expand e2e coverage for badge, init, tools, completions commands

### DIFF
--- a/crates/tokmd/tests/cli_badge_e2e.rs
+++ b/crates/tokmd/tests/cli_badge_e2e.rs
@@ -1,0 +1,126 @@
+//! End-to-end tests for `tokmd badge` — metric variants, SVG structure,
+//! and file-output behaviour.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ---------------------------------------------------------------------------
+// Metric variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn badge_doc_metric_produces_svg_with_label() {
+    tokmd_cmd()
+        .args(["badge", "--metric", "doc"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<svg"))
+        .stdout(predicate::str::contains("</svg>"))
+        .stdout(predicate::str::contains("doc"));
+}
+
+#[test]
+fn badge_blank_metric_produces_svg_with_label() {
+    tokmd_cmd()
+        .args(["badge", "--metric", "blank"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<svg"))
+        .stdout(predicate::str::contains("</svg>"))
+        .stdout(predicate::str::contains("blank"));
+}
+
+#[test]
+fn badge_lines_svg_contains_xmlns_attribute() {
+    tokmd_cmd()
+        .args(["badge", "--metric", "lines"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("xmlns"));
+}
+
+#[test]
+fn badge_tokens_svg_is_well_formed() {
+    let output = tokmd_cmd()
+        .args(["badge", "--metric", "tokens"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let svg = String::from_utf8(output.stdout).expect("valid UTF-8");
+    assert!(svg.starts_with("<svg"), "SVG should start with <svg tag");
+    assert!(svg.contains("</svg>"), "SVG should have closing tag");
+    assert!(svg.contains("tokens"), "SVG should contain metric label");
+}
+
+// ---------------------------------------------------------------------------
+// File output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn badge_out_flag_writes_valid_svg_file() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let out_file = dir.path().join("out.svg");
+
+    tokmd_cmd()
+        .args(["badge", "--metric", "doc", "--out"])
+        .arg(&out_file)
+        .assert()
+        .success()
+        .stdout("");
+
+    let content = std::fs::read_to_string(&out_file)?;
+    assert!(content.contains("<svg"), "file should contain SVG");
+    assert!(content.contains("doc"), "file should contain metric label");
+    Ok(())
+}
+
+#[test]
+fn badge_out_to_nested_dir_creates_file() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let nested = dir.path().join("sub").join("dir");
+    std::fs::create_dir_all(&nested)?;
+    let out_file = nested.join("badge.svg");
+
+    tokmd_cmd()
+        .args(["badge", "--metric", "bytes", "--out"])
+        .arg(&out_file)
+        .assert()
+        .success();
+
+    assert!(out_file.exists(), "badge file should exist");
+    let content = std::fs::read_to_string(&out_file)?;
+    assert!(content.contains("<svg"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn badge_missing_metric_flag_fails() {
+    tokmd_cmd()
+        .arg("badge")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--metric"));
+}
+
+#[test]
+fn badge_invalid_metric_fails() {
+    tokmd_cmd()
+        .args(["badge", "--metric", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}

--- a/crates/tokmd/tests/cli_completions_e2e.rs
+++ b/crates/tokmd/tests/cli_completions_e2e.rs
@@ -1,0 +1,136 @@
+//! End-to-end tests for `tokmd completions` — shell-specific output
+//! validation for bash, zsh, fish, powershell, and elvish.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ---------------------------------------------------------------------------
+// Bash
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completions_bash_contains_tokmd_reference() {
+    tokmd_cmd()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd"));
+}
+
+#[test]
+fn completions_bash_contains_complete_keyword() {
+    tokmd_cmd()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete"));
+}
+
+// ---------------------------------------------------------------------------
+// Zsh
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completions_zsh_contains_tokmd_reference() {
+    tokmd_cmd()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd"));
+}
+
+#[test]
+fn completions_zsh_contains_compdef_or_arguments() {
+    tokmd_cmd()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#compdef").or(predicate::str::contains("_arguments")));
+}
+
+// ---------------------------------------------------------------------------
+// Fish
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completions_fish_contains_complete_command() {
+    tokmd_cmd()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete"));
+}
+
+#[test]
+fn completions_fish_references_tokmd() {
+    tokmd_cmd()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd"));
+}
+
+// ---------------------------------------------------------------------------
+// PowerShell
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completions_powershell_contains_register() {
+    tokmd_cmd()
+        .args(["completions", "powershell"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Register-ArgumentCompleter"));
+}
+
+#[test]
+fn completions_powershell_references_tokmd() {
+    tokmd_cmd()
+        .args(["completions", "powershell"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd"));
+}
+
+// ---------------------------------------------------------------------------
+// Elvish
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completions_elvish_produces_non_empty_output() {
+    tokmd_cmd()
+        .args(["completions", "elvish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn completions_elvish_references_tokmd() {
+    tokmd_cmd()
+        .args(["completions", "elvish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd"));
+}
+
+// ---------------------------------------------------------------------------
+// Error case
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completions_invalid_shell_fails() {
+    tokmd_cmd()
+        .args(["completions", "tcsh"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}

--- a/crates/tokmd/tests/cli_init_e2e.rs
+++ b/crates/tokmd/tests/cli_init_e2e.rs
@@ -1,0 +1,164 @@
+//! End-to-end tests for `tokmd init` — file creation, templates, overwrite
+//! protection, and `--dir` flag.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ---------------------------------------------------------------------------
+// File creation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_creates_tokeignore_in_temp_dir() {
+    let dir = tempdir().unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .args(["init", "--non-interactive"])
+        .assert()
+        .success();
+
+    assert!(
+        dir.path().join(".tokeignore").exists(),
+        ".tokeignore should be created"
+    );
+    let content = std::fs::read_to_string(dir.path().join(".tokeignore")).unwrap();
+    assert!(!content.is_empty(), ".tokeignore should not be empty");
+}
+
+#[test]
+fn init_with_dir_flag_creates_tokeignore_in_target() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("project");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.args(["init", "--non-interactive", "--dir"])
+        .arg(&target)
+        .assert()
+        .success();
+
+    assert!(
+        target.join(".tokeignore").exists(),
+        ".tokeignore should be created in --dir target"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Overwrite protection and --force
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_does_not_overwrite_existing_tokeignore() {
+    let dir = tempdir().unwrap();
+    let existing = dir.path().join(".tokeignore");
+    std::fs::write(&existing, "# my custom rules\n").unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .args(["init", "--non-interactive"])
+        .assert()
+        .failure();
+
+    let content = std::fs::read_to_string(&existing).unwrap();
+    assert_eq!(content, "# my custom rules\n", "file should be untouched");
+}
+
+#[test]
+fn init_force_overwrites_existing_tokeignore() {
+    let dir = tempdir().unwrap();
+    let existing = dir.path().join(".tokeignore");
+    std::fs::write(&existing, "# old rules\n").unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .args(["init", "--non-interactive", "--force"])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&existing).unwrap();
+    assert_ne!(content, "# old rules\n", "file should be overwritten");
+    assert!(!content.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// --print flag (stdout, no file created)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_print_outputs_template_to_stdout() {
+    tokmd_cmd()
+        .args(["init", "--print", "--non-interactive"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn init_print_does_not_create_file() {
+    let dir = tempdir().unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .args(["init", "--print", "--non-interactive"])
+        .assert()
+        .success();
+
+    assert!(
+        !dir.path().join(".tokeignore").exists(),
+        "--print should not create .tokeignore"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Template profiles
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_print_python_template_contains_venv() {
+    tokmd_cmd()
+        .args([
+            "init",
+            "--print",
+            "--template",
+            "python",
+            "--non-interactive",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("venv").or(predicate::str::contains("__pycache__")));
+}
+
+#[test]
+fn init_print_go_template_contains_vendor() {
+    tokmd_cmd()
+        .args(["init", "--print", "--template", "go", "--non-interactive"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("vendor"));
+}
+
+#[test]
+fn init_print_cpp_template_produces_output() {
+    tokmd_cmd()
+        .args(["init", "--print", "--template", "cpp", "--non-interactive"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn init_print_mono_template_produces_output() {
+    tokmd_cmd()
+        .args(["init", "--print", "--template", "mono", "--non-interactive"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}

--- a/crates/tokmd/tests/cli_output_formats.rs
+++ b/crates/tokmd/tests/cli_output_formats.rs
@@ -1,0 +1,297 @@
+//! Cross-command output-format tests validating structural invariants of
+//! JSON, TSV, CSV, and JSONL outputs.
+
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ===========================================================================
+// lang --format json
+// ===========================================================================
+
+#[test]
+fn lang_json_has_schema_version_field() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        json["schema_version"].is_number(),
+        "JSON output must include schema_version"
+    );
+}
+
+#[test]
+fn lang_json_rows_sorted_descending_by_code() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows is array");
+
+    // Filter out "Other" bucket which may break sort expectation
+    let code_vals: Vec<u64> = rows
+        .iter()
+        .filter(|r| r["lang"].as_str() != Some("Other"))
+        .filter_map(|r| r["code"].as_u64())
+        .collect();
+
+    for window in code_vals.windows(2) {
+        assert!(
+            window[0] >= window[1],
+            "rows should be sorted descending by code: {} < {}",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+#[test]
+fn lang_json_has_args_metadata() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        json["args"].is_object(),
+        "JSON should contain args metadata"
+    );
+}
+
+// ===========================================================================
+// lang --format tsv
+// ===========================================================================
+
+#[test]
+fn lang_tsv_header_contains_expected_columns() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "tsv"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let header = stdout.lines().next().expect("should have header line");
+    assert!(header.contains('\t'), "header should be tab-separated");
+    assert!(
+        header.contains("Code") || header.contains("code"),
+        "header should contain Code column"
+    );
+}
+
+#[test]
+fn lang_tsv_data_rows_have_same_column_count_as_header() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "tsv"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.len() >= 2, "need header + data");
+
+    let header_cols = lines[0].split('\t').count();
+    for (i, line) in lines[1..].iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cols = line.split('\t').count();
+        assert_eq!(
+            cols,
+            header_cols,
+            "row {} has {} cols, header has {}",
+            i + 1,
+            cols,
+            header_cols
+        );
+    }
+}
+
+// ===========================================================================
+// module --format json
+// ===========================================================================
+
+#[test]
+fn module_json_rows_have_module_field() {
+    let output = tokmd_cmd()
+        .args(["module", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows is array");
+
+    for row in rows {
+        assert!(
+            row["module"].is_string(),
+            "each row should have module field"
+        );
+        assert!(row["code"].is_number(), "each row should have code field");
+    }
+}
+
+#[test]
+fn module_json_has_mode_field() {
+    let output = tokmd_cmd()
+        .args(["module", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["mode"], "module");
+}
+
+// ===========================================================================
+// export --format csv
+// ===========================================================================
+
+#[test]
+fn export_csv_header_contains_path_and_language() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "csv"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let header = stdout.lines().next().expect("should have header");
+    assert!(
+        header.contains("path") || header.contains("file"),
+        "CSV header should have path/file column"
+    );
+    assert!(
+        header.contains("language") || header.contains("lang"),
+        "CSV header should have language column"
+    );
+}
+
+#[test]
+fn export_csv_rows_have_consistent_column_count() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "csv"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.len() >= 2, "need header + data");
+
+    let header_cols = lines[0].split(',').count();
+    for (i, line) in lines[1..].iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cols = line.split(',').count();
+        assert_eq!(
+            cols,
+            header_cols,
+            "CSV row {} has {} cols, header has {}",
+            i + 1,
+            cols,
+            header_cols
+        );
+    }
+}
+
+// ===========================================================================
+// export --format jsonl
+// ===========================================================================
+
+#[test]
+fn export_jsonl_meta_line_has_schema_version() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "jsonl"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let first = stdout.lines().next().expect("should have first line");
+    let meta: Value = serde_json::from_str(first).expect("first line is JSON");
+    assert!(
+        meta["schema_version"].is_number(),
+        "meta line should have schema_version"
+    );
+}
+
+#[test]
+fn export_jsonl_data_rows_have_path_field() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "jsonl"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(lines.len() >= 2, "need meta + at least one data row");
+
+    // Skip first line (meta), check data rows
+    for (i, line) in lines[1..].iter().enumerate() {
+        let row: Value =
+            serde_json::from_str(line).unwrap_or_else(|e| panic!("line {} invalid: {}", i + 2, e));
+        assert!(
+            row["path"].is_string() || row["file"].is_string(),
+            "data row {} should have path or file field",
+            i + 2
+        );
+    }
+}
+
+// ===========================================================================
+// export --format json
+// ===========================================================================
+
+#[test]
+fn export_json_envelope_has_mode_export() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["mode"], "export");
+    assert!(json["schema_version"].is_number());
+    assert!(json["rows"].is_array());
+}
+
+#[test]
+fn export_json_rows_have_code_and_language() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows array");
+
+    for row in rows {
+        assert!(row["code"].is_number(), "each row should have code");
+        assert!(
+            row["language"].is_string() || row["lang"].is_string(),
+            "each row should have language"
+        );
+    }
+}

--- a/crates/tokmd/tests/cli_tools_e2e.rs
+++ b/crates/tokmd/tests/cli_tools_e2e.rs
@@ -1,0 +1,183 @@
+//! End-to-end tests for `tokmd tools` — format variants, tool name
+//! enumeration, and structural validation.
+
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tools_openai_each_function_has_name_and_description() {
+    let output = tokmd_cmd()
+        .args(["tools", "--format", "openai"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let funcs = json["functions"].as_array().expect("functions array");
+
+    for func in funcs {
+        assert!(func["name"].is_string(), "each function needs a name");
+        assert!(
+            func["description"].is_string(),
+            "each function needs a description"
+        );
+    }
+}
+
+#[test]
+fn tools_openai_contains_lang_and_export() {
+    let output = tokmd_cmd()
+        .args(["tools", "--format", "openai"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let names: Vec<&str> = json["functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|f| f["name"].as_str())
+        .collect();
+
+    assert!(names.contains(&"lang"), "should contain lang");
+    assert!(names.contains(&"export"), "should contain export");
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tools_anthropic_each_tool_has_name_and_input_schema() {
+    let output = tokmd_cmd()
+        .args(["tools", "--format", "anthropic"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let tools = json["tools"].as_array().expect("tools array");
+
+    for tool in tools {
+        assert!(tool["name"].is_string(), "each tool needs a name");
+        assert!(
+            tool["input_schema"].is_object(),
+            "each tool needs input_schema"
+        );
+    }
+}
+
+#[test]
+fn tools_anthropic_contains_module_and_analyze() {
+    let output = tokmd_cmd()
+        .args(["tools", "--format", "anthropic"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let names: Vec<&str> = json["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+
+    assert!(names.contains(&"module"), "should contain module");
+    assert!(names.contains(&"analyze"), "should contain analyze");
+}
+
+// ---------------------------------------------------------------------------
+// JSON Schema format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tools_jsonschema_has_name_and_tools_array() {
+    let output = tokmd_cmd()
+        .args(["tools", "--format", "jsonschema"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["name"].is_string(), "envelope should have name");
+    assert!(
+        json["schema_version"].is_number(),
+        "envelope should have schema_version"
+    );
+
+    let tools = json["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty());
+
+    for tool in tools {
+        assert!(tool["name"].is_string());
+        assert!(tool["parameters"].is_object());
+    }
+}
+
+#[test]
+fn tools_jsonschema_contains_context_and_gate() {
+    let output = tokmd_cmd()
+        .args(["tools", "--format", "jsonschema"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let names: Vec<&str> = json["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+
+    assert!(names.contains(&"context"), "should contain context");
+    assert!(names.contains(&"gate"), "should contain gate");
+}
+
+// ---------------------------------------------------------------------------
+// Clap format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tools_clap_format_has_tools_with_parameters() {
+    let output = tokmd_cmd()
+        .args(["tools", "--format", "clap"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["schema_version"].is_number());
+
+    let tools = json["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty());
+    for tool in tools {
+        assert!(tool["name"].is_string());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error case
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tools_invalid_format_fails() {
+    tokmd_cmd()
+        .args(["tools", "--format", "yaml"])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
Wave 46: Adds 51 end-to-end CLI tests covering badge SVG generation, init tokeignore creation, tools schema output in all formats, shell completion generation, and cross-command output format validation.