### PR TITLE
fix(tests): correct serde(flatten) JSON paths in FFI contract and pipeline tests

### DIFF
--- a/crates/tokmd-core/tests/ffi_contract.rs
+++ b/crates/tokmd-core/tests/ffi_contract.rs
@@ -66,7 +66,8 @@ fn lang_mode_returns_ok_with_receipt() {
     let result = run_json("lang", r#"{"paths": ["src"]}"#);
     let v = assert_ok(&result);
     assert_eq!(v["data"]["mode"], "lang");
-    assert!(v["data"]["report"]["rows"].is_array());
+    // LangReport is #[serde(flatten)]'d into LangReceipt, so rows is at top level
+    assert!(v["data"]["rows"].is_array());
 }
 
 #[test]
@@ -90,7 +91,8 @@ fn module_mode_returns_ok_with_receipt() {
     let result = run_json("module", r#"{"paths": ["src"]}"#);
     let v = assert_ok(&result);
     assert_eq!(v["data"]["mode"], "module");
-    assert!(v["data"]["report"]["rows"].is_array());
+    // ModuleReport is #[serde(flatten)]'d into ModuleReceipt, so rows is at top level
+    assert!(v["data"]["rows"].is_array());
 }
 
 // ============================================================================
@@ -102,7 +104,8 @@ fn export_mode_returns_ok_with_receipt() {
     let result = run_json("export", r#"{"paths": ["src"]}"#);
     let v = assert_ok(&result);
     assert_eq!(v["data"]["mode"], "export");
-    assert!(v["data"]["data"]["rows"].is_array());
+    // ExportData is #[serde(flatten)]'d into ExportReceipt, so rows is at top level
+    assert!(v["data"]["rows"].is_array());
 }
 
 // ============================================================================

--- a/crates/tokmd-core/tests/pipeline_integration.rs
+++ b/crates/tokmd-core/tests/pipeline_integration.rs
@@ -119,7 +119,8 @@ fn export_workflow_json_round_trips() {
         parsed["schema_version"].as_u64().unwrap() as u32,
         SCHEMA_VERSION
     );
-    assert!(parsed["data"]["rows"].is_array());
+    // ExportData is #[serde(flatten)]'d into ExportReceipt, so rows is at top level
+    assert!(parsed["rows"].is_array());
 }
 
 #[test]


### PR DESCRIPTION
## What changed

Fixed 4 test assertions in \	okmd-core\ that used incorrect JSON paths for receipts with \#[serde(flatten)]\.

### Root cause

\LangReceipt\, \ModuleReceipt\, and \ExportReceipt\ all use \#[serde(flatten)]\ on their inner report/data structs, which flattens the fields directly into the parent JSON object. The tests incorrectly accessed \["data"]["report"]["rows"]\ instead of \["data"]["rows"]\.

### Fixes

| Test file | Test name | Wrong path | Correct path |
|---|---|---|---|
| \fi_contract.rs\ | \lang_mode_returns_ok_with_receipt\ | \data.report.rows\ | \data.rows\ |
| \fi_contract.rs\ | \module_mode_returns_ok_with_receipt\ | \data.report.rows\ | \data.rows\ |
| \fi_contract.rs\ | \xport_mode_returns_ok_with_receipt\ | \data.data.rows\ | \data.rows\ |
| \pipeline_integration.rs\ | \xport_workflow_json_round_trips\ | \parsed.data.rows\ | \parsed.rows\ |

### Testing

- \cargo test -p tokmd-core --test ffi_contract\: 14/14 passed
- \cargo test -p tokmd-core --test pipeline_integration\: 15/15 passed
- \cargo test --workspace\: 12,754 tests, 0 failures

**Disposition: A (MERGE NOW)** — surgical fix for broken tests