### PR TITLE
test(fun): expand fun and eco-label test coverage

### DIFF
--- a/crates/tokmd-analysis-fun/tests/fun_enricher_w54.rs
+++ b/crates/tokmd-analysis-fun/tests/fun_enricher_w54.rs
@@ -1,0 +1,785 @@
+//! Comprehensive tests for tokmd-analysis-fun enricher – wave 54.
+//!
+//! Covers eco-label generation, grade boundaries, notes formatting,
+//! JSON round-trip, determinism, and property-based invariants.
+
+use tokmd_analysis_fun::build_fun_report;
+use tokmd_analysis_types::{
+    BoilerplateReport, DerivedReport, DerivedTotals, DistributionReport, FileStatRow,
+    IntegrityReport, LangPurityReport, MaxFileReport, NestingReport, PolyglotReport, RateReport,
+    RateRow, RatioReport, RatioRow, ReadingTimeReport, TestDensityReport, TodoReport, TopOffenders,
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn derived_with_bytes(bytes: usize) -> DerivedReport {
+    derived_with(bytes, 1, 1, 0, 0)
+}
+
+fn derived_with(
+    bytes: usize,
+    files: usize,
+    code: usize,
+    comments: usize,
+    blanks: usize,
+) -> DerivedReport {
+    let lines = code + comments + blanks;
+    let zero_row = FileStatRow {
+        path: "f.rs".to_string(),
+        module: "src".to_string(),
+        lang: "Rust".to_string(),
+        code: 0,
+        comments: 0,
+        blanks: 0,
+        lines: 0,
+        bytes,
+        tokens: 0,
+        doc_pct: Some(0.0),
+        bytes_per_line: Some(0.0),
+        depth: 0,
+    };
+
+    DerivedReport {
+        totals: DerivedTotals {
+            files,
+            code,
+            comments,
+            blanks,
+            lines,
+            bytes,
+            tokens: code,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "All".into(),
+                numerator: 0,
+                denominator: 1,
+                ratio: 0.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "All".into(),
+                numerator: 0,
+                denominator: 1,
+                ratio: 0.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "All".into(),
+                numerator: 0,
+                denominator: 1,
+                rate: 0.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: zero_row.clone(),
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 0,
+            avg: 0.0,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 0,
+            prod_lines: 0,
+            test_files: 0,
+            prod_files: 0,
+            ratio: 0.0,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 0,
+            logic_lines: 0,
+            ratio: 0.0,
+            infra_langs: vec![],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 0,
+            entropy: 0.0,
+            dominant_lang: "unknown".to_string(),
+            dominant_lines: 0,
+            dominant_pct: 0.0,
+        },
+        distribution: DistributionReport {
+            count: 1,
+            min: 1,
+            max: 1,
+            mean: 0.0,
+            median: 0.0,
+            p90: 0.0,
+            p99: 0.0,
+            gini: 0.0,
+        },
+        histogram: Vec::new(),
+        top: TopOffenders {
+            largest_lines: vec![zero_row.clone()],
+            largest_tokens: vec![zero_row.clone()],
+            largest_bytes: vec![zero_row.clone()],
+            least_documented: vec![zero_row.clone()],
+            most_dense: vec![zero_row],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 0.0,
+            lines_per_minute: 0,
+            basis_lines: 0,
+        },
+        context_window: None,
+        cocomo: None,
+        todo: Some(TodoReport {
+            total: 0,
+            density_per_kloc: 0.0,
+            tags: vec![],
+        }),
+        integrity: IntegrityReport {
+            algo: "sha1".to_string(),
+            hash: "placeholder".to_string(),
+            entries: 0,
+        },
+    }
+}
+
+// ===========================================================================
+// Eco-label is always present
+// ===========================================================================
+
+#[test]
+fn eco_label_present_for_zero_bytes() {
+    let r = build_fun_report(&derived_with_bytes(0));
+    assert!(r.eco_label.is_some());
+}
+
+#[test]
+fn eco_label_present_for_one_byte() {
+    let r = build_fun_report(&derived_with_bytes(1));
+    assert!(r.eco_label.is_some());
+}
+
+#[test]
+fn eco_label_present_for_large_repo() {
+    let r = build_fun_report(&derived_with_bytes(1_000_000_000));
+    assert!(r.eco_label.is_some());
+}
+
+// ===========================================================================
+// Grade A boundary tests (≤ 1 MB)
+// ===========================================================================
+
+#[test]
+fn grade_a_at_zero() {
+    let eco = build_fun_report(&derived_with_bytes(0)).eco_label.unwrap();
+    assert_eq!(eco.label, "A");
+    assert_eq!(eco.score, 95.0);
+    assert_eq!(eco.bytes, 0);
+}
+
+#[test]
+fn grade_a_at_512kb() {
+    let eco = build_fun_report(&derived_with_bytes(512 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "A");
+}
+
+#[test]
+fn grade_a_at_exactly_1mb() {
+    let eco = build_fun_report(&derived_with_bytes(1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "A");
+    assert_eq!(eco.score, 95.0);
+}
+
+// ===========================================================================
+// Grade B boundary tests (> 1 MB, ≤ 10 MB)
+// ===========================================================================
+
+#[test]
+fn grade_b_just_over_1mb() {
+    let eco = build_fun_report(&derived_with_bytes(1024 * 1024 + 1))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "B");
+    assert_eq!(eco.score, 80.0);
+}
+
+#[test]
+fn grade_b_at_5mb() {
+    let eco = build_fun_report(&derived_with_bytes(5 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "B");
+}
+
+#[test]
+fn grade_b_at_exactly_10mb() {
+    let eco = build_fun_report(&derived_with_bytes(10 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "B");
+}
+
+// ===========================================================================
+// Grade C boundary tests (> 10 MB, ≤ 50 MB)
+// ===========================================================================
+
+#[test]
+fn grade_c_just_over_10mb() {
+    let eco = build_fun_report(&derived_with_bytes(10 * 1024 * 1024 + 1))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "C");
+    assert_eq!(eco.score, 65.0);
+}
+
+#[test]
+fn grade_c_at_25mb() {
+    let eco = build_fun_report(&derived_with_bytes(25 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "C");
+}
+
+#[test]
+fn grade_c_at_exactly_50mb() {
+    let eco = build_fun_report(&derived_with_bytes(50 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "C");
+}
+
+// ===========================================================================
+// Grade D boundary tests (> 50 MB, ≤ 200 MB)
+// ===========================================================================
+
+#[test]
+fn grade_d_just_over_50mb() {
+    let eco = build_fun_report(&derived_with_bytes(50 * 1024 * 1024 + 1))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "D");
+    assert_eq!(eco.score, 45.0);
+}
+
+#[test]
+fn grade_d_at_100mb() {
+    let eco = build_fun_report(&derived_with_bytes(100 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "D");
+}
+
+#[test]
+fn grade_d_at_exactly_200mb() {
+    let eco = build_fun_report(&derived_with_bytes(200 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "D");
+}
+
+// ===========================================================================
+// Grade E tests (> 200 MB)
+// ===========================================================================
+
+#[test]
+fn grade_e_just_over_200mb() {
+    let eco = build_fun_report(&derived_with_bytes(200 * 1024 * 1024 + 1))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "E");
+    assert_eq!(eco.score, 30.0);
+}
+
+#[test]
+fn grade_e_at_500mb() {
+    let eco = build_fun_report(&derived_with_bytes(500 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "E");
+}
+
+#[test]
+fn grade_e_at_1gb() {
+    let eco = build_fun_report(&derived_with_bytes(1024 * 1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "E");
+    assert_eq!(eco.score, 30.0);
+}
+
+// ===========================================================================
+// Bytes field always matches input
+// ===========================================================================
+
+#[test]
+fn bytes_field_matches_input_for_all_grades() {
+    let sizes = [
+        0,
+        1,
+        999,
+        1024 * 1024,
+        5 * 1024 * 1024,
+        30 * 1024 * 1024,
+        100 * 1024 * 1024,
+        500 * 1024 * 1024,
+    ];
+    for &bytes in &sizes {
+        let eco = build_fun_report(&derived_with_bytes(bytes))
+            .eco_label
+            .unwrap();
+        assert_eq!(eco.bytes, bytes as u64, "mismatch for {bytes} bytes");
+    }
+}
+
+// ===========================================================================
+// Notes formatting
+// ===========================================================================
+
+#[test]
+fn notes_start_with_prefix() {
+    let eco = build_fun_report(&derived_with_bytes(1000))
+        .eco_label
+        .unwrap();
+    assert!(eco.notes.starts_with("Size-based eco label ("));
+}
+
+#[test]
+fn notes_end_with_mb_suffix() {
+    let eco = build_fun_report(&derived_with_bytes(1000))
+        .eco_label
+        .unwrap();
+    assert!(eco.notes.ends_with(" MB)"));
+}
+
+#[test]
+fn notes_zero_bytes_shows_0_mb() {
+    let eco = build_fun_report(&derived_with_bytes(0)).eco_label.unwrap();
+    assert_eq!(eco.notes, "Size-based eco label (0 MB)");
+}
+
+#[test]
+fn notes_1mb_shows_1_mb() {
+    let eco = build_fun_report(&derived_with_bytes(1024 * 1024))
+        .eco_label
+        .unwrap();
+    assert!(eco.notes.contains("1 MB"), "got: {}", eco.notes);
+}
+
+#[test]
+fn notes_2_5mb_shows_correct_decimal() {
+    // 2.5 MB = 2621440 bytes
+    let eco = build_fun_report(&derived_with_bytes(2_621_440))
+        .eco_label
+        .unwrap();
+    assert!(eco.notes.contains("2.5 MB"), "got: {}", eco.notes);
+}
+
+#[test]
+fn notes_fractional_bytes_round_to_two_decimals() {
+    // 1.23 MB ≈ 1_289_748 bytes (1.23 * 1024 * 1024)
+    let bytes = 1_289_748;
+    let mb = bytes as f64 / (1024.0 * 1024.0);
+    let rounded = (mb * 100.0).round() / 100.0;
+    let eco = build_fun_report(&derived_with_bytes(bytes))
+        .eco_label
+        .unwrap();
+    assert!(
+        eco.notes.contains(&format!("{rounded} MB")),
+        "got: {}",
+        eco.notes
+    );
+}
+
+// ===========================================================================
+// Different DerivedReport configs produce same eco for same bytes
+// ===========================================================================
+
+#[test]
+fn eco_depends_only_on_bytes_not_code_lines() {
+    let bytes = 5_000_000;
+    let r1 = build_fun_report(&derived_with(bytes, 1, 100, 0, 0));
+    let r2 = build_fun_report(&derived_with(bytes, 100, 10000, 5000, 2000));
+    let e1 = r1.eco_label.unwrap();
+    let e2 = r2.eco_label.unwrap();
+    assert_eq!(e1.label, e2.label);
+    assert_eq!(e1.score, e2.score);
+    assert_eq!(e1.bytes, e2.bytes);
+    assert_eq!(e1.notes, e2.notes);
+}
+
+#[test]
+fn eco_depends_only_on_bytes_not_file_count() {
+    let bytes = 30_000_000;
+    let r1 = build_fun_report(&derived_with(bytes, 1, 1, 0, 0));
+    let r2 = build_fun_report(&derived_with(bytes, 10000, 50000, 10000, 5000));
+    assert_eq!(r1.eco_label.unwrap().label, r2.eco_label.unwrap().label,);
+}
+
+// ===========================================================================
+// Determinism
+// ===========================================================================
+
+#[test]
+fn determinism_100_iterations() {
+    let d = derived_with_bytes(7_654_321);
+    let reference = build_fun_report(&d);
+    for _ in 0..100 {
+        let r = build_fun_report(&d);
+        let e_ref = reference.eco_label.as_ref().unwrap();
+        let e = r.eco_label.unwrap();
+        assert_eq!(e.label, e_ref.label);
+        assert_eq!(e.score, e_ref.score);
+        assert_eq!(e.bytes, e_ref.bytes);
+        assert_eq!(e.notes, e_ref.notes);
+    }
+}
+
+// ===========================================================================
+// Score monotonicity
+// ===========================================================================
+
+#[test]
+fn scores_monotonically_decrease_across_all_bands() {
+    let sizes = [
+        0,
+        100,
+        1024 * 1024 - 1,
+        1024 * 1024,
+        1024 * 1024 + 1,
+        5 * 1024 * 1024,
+        10 * 1024 * 1024,
+        10 * 1024 * 1024 + 1,
+        30 * 1024 * 1024,
+        50 * 1024 * 1024,
+        50 * 1024 * 1024 + 1,
+        100 * 1024 * 1024,
+        200 * 1024 * 1024,
+        200 * 1024 * 1024 + 1,
+        500 * 1024 * 1024,
+        1024 * 1024 * 1024,
+    ];
+    let scores: Vec<f64> = sizes
+        .iter()
+        .map(|&b| {
+            build_fun_report(&derived_with_bytes(b))
+                .eco_label
+                .unwrap()
+                .score
+        })
+        .collect();
+    for w in scores.windows(2) {
+        assert!(
+            w[0] >= w[1],
+            "score {} should be >= {}, sizes were monotonically increasing",
+            w[0],
+            w[1]
+        );
+    }
+}
+
+#[test]
+fn labels_never_improve_as_size_grows() {
+    let label_rank = |l: &str| -> u8 {
+        match l {
+            "A" => 5,
+            "B" => 4,
+            "C" => 3,
+            "D" => 2,
+            "E" => 1,
+            _ => 0,
+        }
+    };
+    let sizes = [
+        0,
+        1024 * 1024 + 1,
+        10 * 1024 * 1024 + 1,
+        50 * 1024 * 1024 + 1,
+        200 * 1024 * 1024 + 1,
+    ];
+    let ranks: Vec<u8> = sizes
+        .iter()
+        .map(|&b| {
+            label_rank(
+                &build_fun_report(&derived_with_bytes(b))
+                    .eco_label
+                    .unwrap()
+                    .label,
+            )
+        })
+        .collect();
+    for w in ranks.windows(2) {
+        assert!(w[0] >= w[1], "labels should not improve as size grows");
+    }
+}
+
+// ===========================================================================
+// Score values are from the known set
+// ===========================================================================
+
+#[test]
+fn score_is_one_of_five_known_values() {
+    let known = [95.0, 80.0, 65.0, 45.0, 30.0];
+    for bytes in [
+        0,
+        100,
+        1_000_000,
+        5_000_000,
+        30_000_000,
+        100_000_000,
+        500_000_000,
+    ] {
+        let eco = build_fun_report(&derived_with_bytes(bytes))
+            .eco_label
+            .unwrap();
+        assert!(
+            known.contains(&eco.score),
+            "unknown score {} for {} bytes",
+            eco.score,
+            bytes,
+        );
+    }
+}
+
+// ===========================================================================
+// Label-score bijection
+// ===========================================================================
+
+#[test]
+fn each_label_maps_to_exactly_one_score() {
+    let cases: Vec<(usize, &str, f64)> = vec![
+        (0, "A", 95.0),
+        (2 * 1024 * 1024, "B", 80.0),
+        (20 * 1024 * 1024, "C", 65.0),
+        (100 * 1024 * 1024, "D", 45.0),
+        (300 * 1024 * 1024, "E", 30.0),
+    ];
+    for (bytes, expected_label, expected_score) in cases {
+        let eco = build_fun_report(&derived_with_bytes(bytes))
+            .eco_label
+            .unwrap();
+        assert_eq!(eco.label, expected_label);
+        assert_eq!(eco.score, expected_score);
+    }
+}
+
+// ===========================================================================
+// JSON round-trip
+// ===========================================================================
+
+#[test]
+fn json_round_trip_preserves_all_fields() {
+    let report = build_fun_report(&derived_with_bytes(42_000_000));
+    let json = serde_json::to_string(&report).unwrap();
+    let rt: tokmd_analysis_types::FunReport = serde_json::from_str(&json).unwrap();
+    let orig = report.eco_label.unwrap();
+    let de = rt.eco_label.unwrap();
+    assert_eq!(orig.label, de.label);
+    assert_eq!(orig.score, de.score);
+    assert_eq!(orig.bytes, de.bytes);
+    assert_eq!(orig.notes, de.notes);
+}
+
+#[test]
+fn json_contains_eco_label_key() {
+    let report = build_fun_report(&derived_with_bytes(1000));
+    let json = serde_json::to_string(&report).unwrap();
+    assert!(json.contains("eco_label"));
+}
+
+#[test]
+fn json_contains_all_eco_fields() {
+    let report = build_fun_report(&derived_with_bytes(5_000_000));
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    assert!(json.contains("\"score\""));
+    assert!(json.contains("\"label\""));
+    assert!(json.contains("\"bytes\""));
+    assert!(json.contains("\"notes\""));
+}
+
+#[test]
+fn json_pretty_round_trip_for_every_grade() {
+    for bytes in [
+        0,
+        500_000,
+        5 * 1024 * 1024,
+        25 * 1024 * 1024,
+        100 * 1024 * 1024,
+        300 * 1024 * 1024,
+    ] {
+        let report = build_fun_report(&derived_with_bytes(bytes));
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        let rt: tokmd_analysis_types::FunReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            report.eco_label.unwrap().label,
+            rt.eco_label.unwrap().label,
+            "round-trip failed for {bytes} bytes"
+        );
+    }
+}
+
+// ===========================================================================
+// Edge cases: zero-code repos
+// ===========================================================================
+
+#[test]
+fn zero_code_zero_files_zero_bytes() {
+    let d = derived_with(0, 0, 0, 0, 0);
+    let eco = build_fun_report(&d).eco_label.unwrap();
+    assert_eq!(eco.label, "A");
+    assert_eq!(eco.bytes, 0);
+}
+
+#[test]
+fn many_files_zero_bytes_is_grade_a() {
+    let d = derived_with(0, 1000, 50000, 10000, 5000);
+    let eco = build_fun_report(&d).eco_label.unwrap();
+    assert_eq!(eco.label, "A");
+    assert_eq!(eco.bytes, 0);
+}
+
+#[test]
+fn single_file_one_byte() {
+    let d = derived_with(1, 1, 1, 0, 0);
+    let eco = build_fun_report(&d).eco_label.unwrap();
+    assert_eq!(eco.label, "A");
+    assert_eq!(eco.bytes, 1);
+}
+
+// ===========================================================================
+// Power-of-two byte sizes
+// ===========================================================================
+
+#[test]
+fn power_of_two_byte_sizes_produce_valid_labels() {
+    let known = ["A", "B", "C", "D", "E"];
+    for exp in 0..=30 {
+        let bytes = 1usize << exp;
+        let eco = build_fun_report(&derived_with_bytes(bytes))
+            .eco_label
+            .unwrap();
+        assert!(
+            known.contains(&eco.label.as_str()),
+            "unknown label '{}' for 2^{} = {} bytes",
+            eco.label,
+            exp,
+            bytes,
+        );
+    }
+}
+
+// ===========================================================================
+// Property tests
+// ===========================================================================
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn eco_label_always_some(bytes in 0usize..=(2 * 1024 * 1024 * 1024)) {
+            let r = build_fun_report(&derived_with_bytes(bytes));
+            prop_assert!(r.eco_label.is_some());
+        }
+
+        #[test]
+        fn bytes_field_equals_input(bytes in 0usize..=(2 * 1024 * 1024 * 1024)) {
+            let eco = build_fun_report(&derived_with_bytes(bytes)).eco_label.unwrap();
+            prop_assert_eq!(eco.bytes, bytes as u64);
+        }
+
+        #[test]
+        fn label_in_known_set(bytes in 0usize..=(2 * 1024 * 1024 * 1024)) {
+            let eco = build_fun_report(&derived_with_bytes(bytes)).eco_label.unwrap();
+            prop_assert!(["A", "B", "C", "D", "E"].contains(&eco.label.as_str()));
+        }
+
+        #[test]
+        fn score_in_0_to_100(bytes in 0usize..=(2 * 1024 * 1024 * 1024)) {
+            let eco = build_fun_report(&derived_with_bytes(bytes)).eco_label.unwrap();
+            prop_assert!(eco.score >= 0.0 && eco.score <= 100.0);
+        }
+
+        #[test]
+        fn notes_format_valid(bytes in 0usize..=(2 * 1024 * 1024 * 1024)) {
+            let eco = build_fun_report(&derived_with_bytes(bytes)).eco_label.unwrap();
+            prop_assert!(eco.notes.starts_with("Size-based eco label ("));
+            prop_assert!(eco.notes.ends_with(" MB)"));
+        }
+
+        #[test]
+        fn deterministic(bytes in 0usize..=(2 * 1024 * 1024 * 1024)) {
+            let d = derived_with_bytes(bytes);
+            let e1 = build_fun_report(&d).eco_label.unwrap();
+            let e2 = build_fun_report(&d).eco_label.unwrap();
+            prop_assert_eq!(e1.label, e2.label);
+            prop_assert_eq!(e1.score, e2.score);
+            prop_assert_eq!(e1.bytes, e2.bytes);
+            prop_assert_eq!(e1.notes, e2.notes);
+        }
+
+        #[test]
+        fn monotonic_scores(
+            a in 0usize..=(1024 * 1024 * 1024),
+            b in 0usize..=(1024 * 1024 * 1024),
+        ) {
+            let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+            let s_lo = build_fun_report(&derived_with_bytes(lo)).eco_label.unwrap().score;
+            let s_hi = build_fun_report(&derived_with_bytes(hi)).eco_label.unwrap().score;
+            prop_assert!(s_lo >= s_hi);
+        }
+
+        #[test]
+        fn label_score_consistent(bytes in 0usize..=(2 * 1024 * 1024 * 1024)) {
+            let eco = build_fun_report(&derived_with_bytes(bytes)).eco_label.unwrap();
+            let expected_score = match eco.label.as_str() {
+                "A" => 95.0,
+                "B" => 80.0,
+                "C" => 65.0,
+                "D" => 45.0,
+                "E" => 30.0,
+                other => panic!("unknown label: {other}"),
+            };
+            prop_assert_eq!(eco.score, expected_score);
+        }
+
+        #[test]
+        fn json_round_trip(bytes in 0usize..=(512 * 1024 * 1024)) {
+            let report = build_fun_report(&derived_with_bytes(bytes));
+            let json = serde_json::to_string(&report).unwrap();
+            let rt: tokmd_analysis_types::FunReport = serde_json::from_str(&json).unwrap();
+            let orig = report.eco_label.unwrap();
+            let de = rt.eco_label.unwrap();
+            prop_assert_eq!(orig.label, de.label);
+            prop_assert_eq!(orig.score, de.score);
+            prop_assert_eq!(orig.bytes, de.bytes);
+        }
+
+        #[test]
+        fn different_totals_same_bytes_same_eco(
+            bytes in 0usize..=(512 * 1024 * 1024),
+            files in 1usize..=1000,
+            code in 0usize..=100000,
+        ) {
+            let r1 = build_fun_report(&derived_with(bytes, 1, 1, 0, 0));
+            let r2 = build_fun_report(&derived_with(bytes, files, code, 0, 0));
+            let e1 = r1.eco_label.unwrap();
+            let e2 = r2.eco_label.unwrap();
+            prop_assert_eq!(e1.label, e2.label);
+            prop_assert_eq!(e1.score, e2.score);
+            prop_assert_eq!(e1.bytes, e2.bytes);
+        }
+    }
+}

--- a/crates/tokmd-fun/tests/fun_outputs_w54.rs
+++ b/crates/tokmd-fun/tests/fun_outputs_w54.rs
@@ -1,0 +1,803 @@
+//! Comprehensive tests for tokmd-fun outputs – wave 54.
+//!
+//! Covers OBJ code city rendering and MIDI generation with edge cases,
+//! structural invariants, property tests, and determinism checks.
+
+use tokmd_fun::{MidiNote, ObjBuilding, render_midi, render_obj};
+
+// ===========================================================================
+// OBJ: zero / degenerate dimensions
+// ===========================================================================
+
+#[test]
+fn obj_zero_width_building_produces_flat_geometry() {
+    let b = ObjBuilding {
+        name: "flat_w".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 0.0,
+        d: 1.0,
+        h: 1.0,
+    };
+    let out = render_obj(&[b]);
+    // Still produces 8 vertices and 6 faces (degenerate but valid OBJ)
+    assert_eq!(out.lines().filter(|l| l.starts_with("v ")).count(), 8);
+    assert_eq!(out.lines().filter(|l| l.starts_with("f ")).count(), 6);
+}
+
+#[test]
+fn obj_zero_depth_building_produces_flat_geometry() {
+    let b = ObjBuilding {
+        name: "flat_d".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 0.0,
+        h: 1.0,
+    };
+    let out = render_obj(&[b]);
+    assert_eq!(out.lines().filter(|l| l.starts_with("v ")).count(), 8);
+}
+
+#[test]
+fn obj_zero_height_building_produces_ground_plane() {
+    let b = ObjBuilding {
+        name: "flat_h".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 0.0,
+    };
+    let out = render_obj(&[b]);
+    // All z coords should be 0
+    for line in out.lines().filter(|l| l.starts_with("v ")) {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        let z: f32 = parts[3].parse().unwrap();
+        assert_eq!(z, 0.0, "all z coords should be zero for h=0");
+    }
+}
+
+#[test]
+fn obj_all_zero_dimensions_building_collapses_to_point() {
+    let b = ObjBuilding {
+        name: "point".into(),
+        x: 5.0,
+        y: 3.0,
+        w: 0.0,
+        d: 0.0,
+        h: 0.0,
+    };
+    let out = render_obj(&[b]);
+    // All 8 vertices should be the same point
+    let verts: Vec<&str> = out.lines().filter(|l| l.starts_with("v ")).collect();
+    assert_eq!(verts.len(), 8);
+    for v in &verts {
+        assert_eq!(*v, "v 5 3 0");
+    }
+}
+
+// ===========================================================================
+// OBJ: very large coordinates
+// ===========================================================================
+
+#[test]
+fn obj_large_coordinates_render_without_panic() {
+    let b = ObjBuilding {
+        name: "huge".into(),
+        x: 1e6,
+        y: 1e6,
+        w: 1e6,
+        d: 1e6,
+        h: 1e6,
+    };
+    let out = render_obj(&[b]);
+    assert!(out.contains("o huge"));
+    assert_eq!(out.lines().filter(|l| l.starts_with("v ")).count(), 8);
+}
+
+// ===========================================================================
+// OBJ: unicode and special character names
+// ===========================================================================
+
+#[test]
+fn obj_unicode_name_is_sanitized() {
+    let b = ObjBuilding {
+        name: "日本語テスト".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    };
+    let out = render_obj(&[b]);
+    // All non-ASCII replaced with underscores
+    assert!(out.contains("o ______"));
+    assert!(!out.contains("日本語"));
+}
+
+#[test]
+fn obj_emoji_name_is_sanitized() {
+    let b = ObjBuilding {
+        name: "🚀rocket".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    };
+    let out = render_obj(&[b]);
+    assert!(out.contains("rocket"));
+    // emoji should become underscores
+    assert!(!out.contains("🚀"));
+}
+
+#[test]
+fn obj_empty_name_produces_empty_object_line() {
+    let b = ObjBuilding {
+        name: "".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    };
+    let out = render_obj(&[b]);
+    assert!(out.contains("o \n"));
+}
+
+#[test]
+fn obj_whitespace_name_all_underscores() {
+    let b = ObjBuilding {
+        name: "  \t\n ".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    };
+    let out = render_obj(&[b]);
+    // All whitespace chars should become underscores
+    let obj_line = out.lines().find(|l| l.starts_with("o ")).unwrap();
+    let name_part = &obj_line[2..];
+    assert!(name_part.chars().all(|c| c == '_'));
+}
+
+// ===========================================================================
+// OBJ: structural invariants
+// ===========================================================================
+
+#[test]
+fn obj_header_is_always_first_line() {
+    let out = render_obj(&[ObjBuilding {
+        name: "x".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    }]);
+    assert_eq!(out.lines().next().unwrap(), "# tokmd code city");
+}
+
+#[test]
+fn obj_empty_header_is_only_line() {
+    let out = render_obj(&[]);
+    assert_eq!(out, "# tokmd code city\n");
+    assert_eq!(out.lines().count(), 1);
+}
+
+#[test]
+fn obj_lines_per_building_is_15() {
+    // 1 object + 8 vertex + 6 face = 15 lines per building
+    let out = render_obj(&[ObjBuilding {
+        name: "b".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    }]);
+    // header + 15 building lines
+    assert_eq!(out.lines().count(), 1 + 15);
+}
+
+#[test]
+fn obj_n_buildings_has_correct_line_count() {
+    for n in [1, 2, 5, 10, 50] {
+        let buildings: Vec<ObjBuilding> = (0..n)
+            .map(|i| ObjBuilding {
+                name: format!("b{i}"),
+                x: i as f32 * 2.0,
+                y: 0.0,
+                w: 1.0,
+                d: 1.0,
+                h: 1.0,
+            })
+            .collect();
+        let out = render_obj(&buildings);
+        let expected_lines = 1 + n * 15; // header + 15 per building
+        assert_eq!(
+            out.lines().count(),
+            expected_lines,
+            "n={n}: expected {expected_lines} lines"
+        );
+    }
+}
+
+#[test]
+fn obj_face_indices_reference_valid_vertices() {
+    let buildings: Vec<ObjBuilding> = (0..3)
+        .map(|i| ObjBuilding {
+            name: format!("b{i}"),
+            x: i as f32 * 5.0,
+            y: 0.0,
+            w: 1.0,
+            d: 1.0,
+            h: 1.0,
+        })
+        .collect();
+    let out = render_obj(&buildings);
+    let total_vertices = 3 * 8; // 24
+
+    for line in out.lines().filter(|l| l.starts_with("f ")) {
+        for idx_str in line.split_whitespace().skip(1) {
+            let idx: usize = idx_str.parse().unwrap();
+            assert!(
+                idx >= 1 && idx <= total_vertices,
+                "face index {idx} out of range 1..={total_vertices}"
+            );
+        }
+    }
+}
+
+#[test]
+fn obj_each_face_has_exactly_four_indices() {
+    let out = render_obj(&[ObjBuilding {
+        name: "q".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    }]);
+    for line in out.lines().filter(|l| l.starts_with("f ")) {
+        let indices: Vec<&str> = line.split_whitespace().skip(1).collect();
+        assert_eq!(indices.len(), 4, "face should have 4 indices: {line}");
+    }
+}
+
+// ===========================================================================
+// OBJ: vertex coordinate verification
+// ===========================================================================
+
+#[test]
+fn obj_base_vertex_at_origin() {
+    let b = ObjBuilding {
+        name: "origin".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 1.0,
+    };
+    let out = render_obj(&[b]);
+    // First vertex should be at (x, y, 0) = (0, 0, 0)
+    let verts: Vec<&str> = out.lines().filter(|l| l.starts_with("v ")).collect();
+    assert_eq!(verts[0], "v 0 0 0");
+}
+
+#[test]
+fn obj_top_vertices_have_correct_height() {
+    let b = ObjBuilding {
+        name: "tall".into(),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        d: 1.0,
+        h: 42.0,
+    };
+    let out = render_obj(&[b]);
+    let verts: Vec<&str> = out.lines().filter(|l| l.starts_with("v ")).collect();
+    // Vertices 5-8 (indices 4-7) should have z=42
+    for v in &verts[4..8] {
+        let z: f32 = v.split_whitespace().last().unwrap().parse().unwrap();
+        assert_eq!(z, 42.0);
+    }
+    // Vertices 1-4 (indices 0-3) should have z=0
+    for v in &verts[0..4] {
+        let z: f32 = v.split_whitespace().last().unwrap().parse().unwrap();
+        assert_eq!(z, 0.0);
+    }
+}
+
+// ===========================================================================
+// OBJ: determinism
+// ===========================================================================
+
+#[test]
+fn obj_deterministic_with_many_buildings() {
+    let buildings: Vec<ObjBuilding> = (0..20)
+        .map(|i| ObjBuilding {
+            name: format!("lang_{i}"),
+            x: (i % 5) as f32 * 4.0,
+            y: (i / 5) as f32 * 4.0,
+            w: 2.0,
+            d: 2.0,
+            h: (i as f32 + 1.0) * 3.0,
+        })
+        .collect();
+    let r1 = render_obj(&buildings);
+    let r2 = render_obj(&buildings);
+    assert_eq!(r1, r2);
+}
+
+// ===========================================================================
+// MIDI: zero duration note
+// ===========================================================================
+
+#[test]
+fn midi_zero_duration_note_produces_valid_midi() {
+    let note = MidiNote {
+        key: 60,
+        velocity: 100,
+        start: 0,
+        duration: 0,
+        channel: 0,
+    };
+    let bytes = render_midi(&[note], 120).unwrap();
+    assert_eq!(&bytes[..4], b"MThd");
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    assert_eq!(smf.tracks.len(), 1);
+}
+
+#[test]
+fn midi_zero_duration_has_on_and_off_at_same_tick() {
+    let note = MidiNote {
+        key: 60,
+        velocity: 100,
+        start: 100,
+        duration: 0,
+        channel: 0,
+    };
+    let bytes = render_midi(&[note], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+
+    let mut time = 0u32;
+    let mut on_time = None;
+    let mut off_time = None;
+    for ev in &smf.tracks[0] {
+        time += ev.delta.as_int();
+        match ev.kind {
+            midly::TrackEventKind::Midi {
+                message: midly::MidiMessage::NoteOn { .. },
+                ..
+            } => on_time = Some(time),
+            midly::TrackEventKind::Midi {
+                message: midly::MidiMessage::NoteOff { .. },
+                ..
+            } => off_time = Some(time),
+            _ => {}
+        }
+    }
+    assert_eq!(on_time.unwrap(), off_time.unwrap());
+}
+
+// ===========================================================================
+// MIDI: notes in reverse start order
+// ===========================================================================
+
+#[test]
+fn midi_reverse_order_notes_sorted_by_time() {
+    let notes = vec![
+        MidiNote {
+            key: 60,
+            velocity: 100,
+            start: 960,
+            duration: 480,
+            channel: 0,
+        },
+        MidiNote {
+            key: 64,
+            velocity: 100,
+            start: 480,
+            duration: 480,
+            channel: 0,
+        },
+        MidiNote {
+            key: 67,
+            velocity: 100,
+            start: 0,
+            duration: 480,
+            channel: 0,
+        },
+    ];
+    let bytes = render_midi(&notes, 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+
+    // Verify events are time-sorted by checking deltas are non-negative
+    for ev in &smf.tracks[0] {
+        // delta is always >= 0 by construction (u28)
+        assert!(ev.delta.as_int() < u32::MAX);
+    }
+
+    // Verify the first NoteOn is the one at start=0
+    let mut time = 0u32;
+    for ev in &smf.tracks[0] {
+        time += ev.delta.as_int();
+        if let midly::TrackEventKind::Midi {
+            message: midly::MidiMessage::NoteOn { key, .. },
+            ..
+        } = ev.kind
+        {
+            assert_eq!(time, 0, "first note-on should be at tick 0");
+            assert_eq!(key.as_int(), 67, "first note should be key 67");
+            break;
+        }
+    }
+}
+
+// ===========================================================================
+// MIDI: single tick duration
+// ===========================================================================
+
+#[test]
+fn midi_single_tick_duration_has_correct_off_time() {
+    let note = MidiNote {
+        key: 72,
+        velocity: 90,
+        start: 0,
+        duration: 1,
+        channel: 0,
+    };
+    let bytes = render_midi(&[note], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+
+    let mut time = 0u32;
+    let mut off_time = None;
+    for ev in &smf.tracks[0] {
+        time += ev.delta.as_int();
+        if let midly::TrackEventKind::Midi {
+            message: midly::MidiMessage::NoteOff { .. },
+            ..
+        } = ev.kind
+        {
+            off_time = Some(time);
+        }
+    }
+    assert_eq!(off_time.unwrap(), 1);
+}
+
+// ===========================================================================
+// MIDI: format and timing metadata
+// ===========================================================================
+
+#[test]
+fn midi_format_is_single_track() {
+    let bytes = render_midi(&[], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    assert!(matches!(smf.header.format, midly::Format::SingleTrack));
+}
+
+#[test]
+fn midi_timing_is_480_ticks_per_quarter() {
+    let bytes = render_midi(&[], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    if let midly::Timing::Metrical(tpq) = smf.header.timing {
+        assert_eq!(tpq.as_int(), 480);
+    } else {
+        panic!("expected metrical timing");
+    }
+}
+
+#[test]
+fn midi_end_of_track_is_last_event() {
+    let notes = vec![MidiNote {
+        key: 60,
+        velocity: 100,
+        start: 0,
+        duration: 480,
+        channel: 0,
+    }];
+    let bytes = render_midi(&notes, 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    let last = smf.tracks[0].last().unwrap();
+    assert!(matches!(
+        last.kind,
+        midly::TrackEventKind::Meta(midly::MetaMessage::EndOfTrack)
+    ));
+}
+
+#[test]
+fn midi_tempo_event_is_first() {
+    let bytes = render_midi(&[], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    let first = &smf.tracks[0][0];
+    assert!(
+        matches!(
+            first.kind,
+            midly::TrackEventKind::Meta(midly::MetaMessage::Tempo(_))
+        ),
+        "first event should be tempo"
+    );
+}
+
+// ===========================================================================
+// MIDI: tempo calculation verification
+// ===========================================================================
+
+#[test]
+fn midi_tempo_at_60_bpm_is_1000000_us() {
+    let bytes = render_midi(&[], 60).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    for ev in &smf.tracks[0] {
+        if let midly::TrackEventKind::Meta(midly::MetaMessage::Tempo(t)) = ev.kind {
+            assert_eq!(t.as_int(), 1_000_000);
+            return;
+        }
+    }
+    panic!("no tempo event found");
+}
+
+#[test]
+fn midi_tempo_at_1_bpm_produces_valid_midi() {
+    // 60_000_000 / 1 = 60_000_000 which overflows MIDI's 24-bit tempo field
+    let bytes = render_midi(&[], 1).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    // Just verify a tempo event exists and the file is valid
+    let has_tempo = smf.tracks[0].iter().any(|ev| {
+        matches!(
+            ev.kind,
+            midly::TrackEventKind::Meta(midly::MetaMessage::Tempo(_))
+        )
+    });
+    assert!(has_tempo, "should have a tempo event");
+}
+
+#[test]
+fn midi_tempo_at_0_bpm_clamped_produces_valid_midi() {
+    // 0 BPM clamped to 1, same overflow behavior as 1 BPM
+    let bytes = render_midi(&[], 0).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    let has_tempo = smf.tracks[0].iter().any(|ev| {
+        matches!(
+            ev.kind,
+            midly::TrackEventKind::Meta(midly::MetaMessage::Tempo(_))
+        )
+    });
+    assert!(has_tempo, "should have a tempo event");
+}
+
+// ===========================================================================
+// MIDI: event counts
+// ===========================================================================
+
+#[test]
+fn midi_empty_has_tempo_and_end_of_track() {
+    let bytes = render_midi(&[], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    // 1 tempo + 1 end-of-track = 2 events
+    assert_eq!(smf.tracks[0].len(), 2);
+}
+
+#[test]
+fn midi_single_note_has_4_events() {
+    let note = MidiNote {
+        key: 60,
+        velocity: 100,
+        start: 0,
+        duration: 480,
+        channel: 0,
+    };
+    let bytes = render_midi(&[note], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    // 1 tempo + 1 NoteOn + 1 NoteOff + 1 EndOfTrack = 4
+    assert_eq!(smf.tracks[0].len(), 4);
+}
+
+#[test]
+fn midi_n_notes_has_2n_plus_2_events() {
+    for n in [1, 5, 10, 50] {
+        let notes: Vec<MidiNote> = (0..n)
+            .map(|i| MidiNote {
+                key: 60,
+                velocity: 100,
+                start: i as u32 * 480,
+                duration: 240,
+                channel: 0,
+            })
+            .collect();
+        let bytes = render_midi(&notes, 120).unwrap();
+        let smf = midly::Smf::parse(&bytes).unwrap();
+        let expected = 2 * n + 2; // tempo + n*on + n*off + end
+        assert_eq!(
+            smf.tracks[0].len(),
+            expected,
+            "n={n}: expected {expected} events"
+        );
+    }
+}
+
+// ===========================================================================
+// MIDI: simultaneous notes (chord)
+// ===========================================================================
+
+#[test]
+fn midi_chord_all_notes_start_at_same_time() {
+    let notes: Vec<MidiNote> = [60, 64, 67]
+        .iter()
+        .map(|&k| MidiNote {
+            key: k,
+            velocity: 80,
+            start: 0,
+            duration: 960,
+            channel: 0,
+        })
+        .collect();
+    let bytes = render_midi(&notes, 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+
+    let mut time = 0u32;
+    let mut on_times = vec![];
+    for ev in &smf.tracks[0] {
+        time += ev.delta.as_int();
+        if matches!(
+            ev.kind,
+            midly::TrackEventKind::Midi {
+                message: midly::MidiMessage::NoteOn { .. },
+                ..
+            }
+        ) {
+            on_times.push(time);
+        }
+    }
+    assert_eq!(on_times.len(), 3);
+    assert!(on_times.iter().all(|&t| t == 0), "all notes start at 0");
+}
+
+// ===========================================================================
+// MIDI: channel 15 (highest valid)
+// ===========================================================================
+
+#[test]
+fn midi_channel_15_is_valid() {
+    let note = MidiNote {
+        key: 60,
+        velocity: 100,
+        start: 0,
+        duration: 480,
+        channel: 15,
+    };
+    let bytes = render_midi(&[note], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    let ch = smf.tracks[0].iter().find_map(|ev| match ev.kind {
+        midly::TrackEventKind::Midi { channel, .. } => Some(channel.as_int()),
+        _ => None,
+    });
+    assert_eq!(ch.unwrap(), 15);
+}
+
+#[test]
+fn midi_channel_above_15_clamped() {
+    let note = MidiNote {
+        key: 60,
+        velocity: 100,
+        start: 0,
+        duration: 480,
+        channel: 200,
+    };
+    let bytes = render_midi(&[note], 120).unwrap();
+    let smf = midly::Smf::parse(&bytes).unwrap();
+    let ch = smf.tracks[0].iter().find_map(|ev| match ev.kind {
+        midly::TrackEventKind::Midi { channel, .. } => Some(channel.as_int()),
+        _ => None,
+    });
+    assert_eq!(ch.unwrap(), 15);
+}
+
+// ===========================================================================
+// Property tests
+// ===========================================================================
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn obj_always_starts_with_header(
+            x in -1000.0f32..1000.0,
+            y in -1000.0f32..1000.0,
+            w in 0.0f32..100.0,
+            d in 0.0f32..100.0,
+            h in 0.0f32..100.0,
+        ) {
+            let b = ObjBuilding { name: "p".into(), x, y, w, d, h };
+            let out = render_obj(&[b]);
+            prop_assert!(out.starts_with("# tokmd code city\n"));
+        }
+
+        #[test]
+        fn obj_has_8_vertices_per_building(n in 1usize..=20) {
+            let buildings: Vec<ObjBuilding> = (0..n).map(|i| ObjBuilding {
+                name: format!("b{i}"), x: i as f32, y: 0.0, w: 1.0, d: 1.0, h: 1.0,
+            }).collect();
+            let out = render_obj(&buildings);
+            let vcount = out.lines().filter(|l| l.starts_with("v ")).count();
+            prop_assert_eq!(vcount, n * 8);
+        }
+
+        #[test]
+        fn obj_has_6_faces_per_building(n in 1usize..=20) {
+            let buildings: Vec<ObjBuilding> = (0..n).map(|i| ObjBuilding {
+                name: format!("b{i}"), x: i as f32, y: 0.0, w: 1.0, d: 1.0, h: 1.0,
+            }).collect();
+            let out = render_obj(&buildings);
+            let fcount = out.lines().filter(|l| l.starts_with("f ")).count();
+            prop_assert_eq!(fcount, n * 6);
+        }
+
+        #[test]
+        fn obj_is_deterministic(
+            x in -100.0f32..100.0,
+            y in -100.0f32..100.0,
+            w in 0.0f32..50.0,
+            d in 0.0f32..50.0,
+            h in 0.0f32..50.0,
+        ) {
+            let b = ObjBuilding { name: "det".into(), x, y, w, d, h };
+            prop_assert_eq!(render_obj(&[b.clone()]), render_obj(&[b]));
+        }
+
+        #[test]
+        fn midi_always_valid_header(
+            key in 0u8..=127,
+            vel in 0u8..=127,
+            tempo in 1u16..=300,
+        ) {
+            let note = MidiNote { key, velocity: vel, start: 0, duration: 480, channel: 0 };
+            let bytes = render_midi(&[note], tempo).unwrap();
+            prop_assert_eq!(&bytes[..4], b"MThd");
+        }
+
+        #[test]
+        fn midi_is_deterministic(
+            key in 0u8..=127,
+            vel in 0u8..=127,
+            start in 0u32..10000,
+            dur in 0u32..10000,
+            ch in 0u8..=15,
+            tempo in 1u16..=300,
+        ) {
+            let note = MidiNote { key, velocity: vel, start, duration: dur, channel: ch };
+            let r1 = render_midi(&[note.clone()], tempo).unwrap();
+            let r2 = render_midi(&[note], tempo).unwrap();
+            prop_assert_eq!(r1, r2);
+        }
+
+        #[test]
+        fn midi_event_count_formula(n in 0usize..=50) {
+            let notes: Vec<MidiNote> = (0..n).map(|i| MidiNote {
+                key: 60, velocity: 100, start: i as u32 * 480, duration: 240, channel: 0,
+            }).collect();
+            let bytes = render_midi(&notes, 120).unwrap();
+            let smf = midly::Smf::parse(&bytes).unwrap();
+            // tempo + n*NoteOn + n*NoteOff + EndOfTrack = 2n + 2
+            prop_assert_eq!(smf.tracks[0].len(), 2 * n + 2);
+        }
+
+        #[test]
+        fn midi_end_of_track_always_last(
+            key in 0u8..=127,
+            n in 0usize..=10,
+        ) {
+            let notes: Vec<MidiNote> = (0..n).map(|i| MidiNote {
+                key, velocity: 100, start: i as u32 * 480, duration: 240, channel: 0,
+            }).collect();
+            let bytes = render_midi(&notes, 120).unwrap();
+            let smf = midly::Smf::parse(&bytes).unwrap();
+            let last = smf.tracks[0].last().unwrap();
+            prop_assert!(matches!(last.kind, midly::TrackEventKind::Meta(midly::MetaMessage::EndOfTrack)));
+        }
+    }
+}


### PR DESCRIPTION
Adds 93 tests across tokmd-fun and tokmd-analysis-fun covering eco-label generation, OBJ output, MIDI output, fun enricher integration, grade boundaries, determinism, and property tests.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>