### PR TITLE
fix: resolve clippy let_and_return in envelope proptest

### DIFF
--- a/crates/tokmd-envelope/tests/proptest_w53.rs
+++ b/crates/tokmd-envelope/tests/proptest_w53.rs
@@ -89,8 +89,7 @@ fn full_report(
     for f in findings {
         report.add_finding(f);
     }
-    let report = report.with_artifacts(artifacts).with_capabilities(caps);
-    report
+    report.with_artifacts(artifacts).with_capabilities(caps)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Single line fix for Nix Build clippy failure.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>