### PR TITLE
test(analysis): deepen explain and HTML rendering coverage

### DIFF
--- a/crates/tokmd-analysis-explain/tests/explain_depth_w55.rs
+++ b/crates/tokmd-analysis-explain/tests/explain_depth_w55.rs
@@ -1,0 +1,413 @@
+//! W55 depth tests for tokmd-analysis-explain: lookup semantics,
+//! catalog invariants, normalization boundary, and determinism.
+
+use tokmd_analysis_explain::{catalog, lookup};
+
+// ── lookup: semantic content per metric category ────────────────────
+
+#[test]
+fn lookup_whitespace_ratio_mentions_blank() {
+    let text = lookup("whitespace_ratio").unwrap();
+    assert!(
+        text.to_lowercase().contains("blank"),
+        "whitespace_ratio summary should mention blank lines"
+    );
+}
+
+#[test]
+fn lookup_test_density_mentions_test_files() {
+    let text = lookup("test_density").unwrap();
+    assert!(
+        text.to_lowercase().contains("test"),
+        "test_density should mention tests"
+    );
+}
+
+#[test]
+fn lookup_todo_density_mentions_markers() {
+    let text = lookup("todo_density").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("todo") || lower.contains("fixme") || lower.contains("marker"),
+        "todo_density should mention markers"
+    );
+}
+
+#[test]
+fn lookup_polyglot_entropy_mentions_language() {
+    let text = lookup("polyglot_entropy").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("language") || lower.contains("distribution"),
+        "polyglot_entropy should mention language distribution"
+    );
+}
+
+#[test]
+fn lookup_bus_factor_mentions_author() {
+    let text = lookup("bus_factor").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("author") || lower.contains("ownership"),
+        "bus_factor should mention authorship"
+    );
+}
+
+#[test]
+fn lookup_freshness_mentions_recency_or_stale() {
+    let text = lookup("freshness").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("recen") || lower.contains("stale") || lower.contains("change"),
+        "freshness should mention recency or staleness"
+    );
+}
+
+#[test]
+fn lookup_coupling_mentions_modules_or_commits() {
+    let text = lookup("coupling").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("module") || lower.contains("commit") || lower.contains("changed"),
+        "coupling should mention modules or commits"
+    );
+}
+
+#[test]
+fn lookup_predictive_churn_mentions_velocity() {
+    let text = lookup("predictive_churn").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("velocity") || lower.contains("trend") || lower.contains("churn"),
+        "predictive_churn should mention velocity or trend"
+    );
+}
+
+#[test]
+fn lookup_duplicate_waste_mentions_redundant() {
+    let text = lookup("duplicate_waste").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("redundant") || lower.contains("duplicate"),
+        "duplicate_waste should mention redundancy"
+    );
+}
+
+#[test]
+fn lookup_imports_mentions_dependency() {
+    let text = lookup("imports").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("dependency") || lower.contains("import"),
+        "imports should mention dependency or import"
+    );
+}
+
+#[test]
+fn lookup_entropy_suspects_mentions_entropy() {
+    let text = lookup("entropy_suspects").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("entropy") || lower.contains("packed") || lower.contains("binary"),
+        "entropy_suspects should mention entropy or packed"
+    );
+}
+
+#[test]
+fn lookup_license_radar_mentions_spdx_or_license() {
+    let text = lookup("license_radar").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("spdx") || lower.contains("license"),
+        "license_radar should mention SPDX or license"
+    );
+}
+
+#[test]
+fn lookup_archetype_mentions_repository_type() {
+    let text = lookup("archetype").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("repository") || lower.contains("type") || lower.contains("inference"),
+        "archetype should mention repository type"
+    );
+}
+
+#[test]
+fn lookup_context_window_fit_mentions_token() {
+    let text = lookup("context_window_fit").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("token") || lower.contains("context") || lower.contains("window"),
+        "context_window_fit should mention token or context"
+    );
+}
+
+#[test]
+fn lookup_maintainability_index_mentions_maintainability() {
+    let text = lookup("maintainability_index").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("maintainability") || lower.contains("sei"),
+        "maintainability_index should mention maintainability"
+    );
+}
+
+#[test]
+fn lookup_technical_debt_ratio_mentions_debt() {
+    let text = lookup("technical_debt_ratio").unwrap();
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("debt") || lower.contains("complexity"),
+        "technical_debt_ratio should mention debt"
+    );
+}
+
+// ── lookup: separator and normalization edge cases ──────────────────
+
+#[test]
+fn lookup_dot_hyphen_space_all_normalize_identically() {
+    let via_underscore = lookup("doc_density").unwrap();
+    let via_dot = lookup("doc.density").unwrap();
+    let via_hyphen = lookup("doc-density").unwrap();
+    let via_space = lookup("doc density").unwrap();
+    assert_eq!(via_underscore, via_dot);
+    assert_eq!(via_underscore, via_hyphen);
+    assert_eq!(via_underscore, via_space);
+}
+
+#[test]
+fn lookup_mixed_separator_chains_resolve() {
+    // e.g. "avg-cyclomatic" with hyphen
+    assert!(lookup("avg-cyclomatic").is_some());
+    assert!(lookup("avg.cyclomatic").is_some());
+    assert!(lookup("avg cyclomatic").is_some());
+}
+
+#[test]
+fn lookup_triple_word_keys_normalize_across_separators() {
+    let canonical = lookup("code_age_distribution").unwrap();
+    assert_eq!(lookup("code-age-distribution").unwrap(), canonical);
+    assert_eq!(lookup("code.age.distribution").unwrap(), canonical);
+    assert_eq!(lookup("code age distribution").unwrap(), canonical);
+}
+
+#[test]
+fn lookup_case_insensitive_for_all_canonical_keys() {
+    let keys = [
+        "doc_density",
+        "gini",
+        "halstead",
+        "archetype",
+        "imports",
+        "freshness",
+    ];
+    for key in keys {
+        let lower = lookup(key).unwrap();
+        let upper = lookup(&key.to_uppercase()).unwrap();
+        assert_eq!(lower, upper, "case mismatch for {key}");
+    }
+}
+
+#[test]
+fn lookup_with_leading_and_trailing_spaces_resolves() {
+    assert_eq!(
+        lookup("  gini  ").unwrap(),
+        lookup("gini").unwrap(),
+        "trimming should normalize padded key"
+    );
+}
+
+#[test]
+fn lookup_with_interior_tab_does_not_resolve() {
+    // Tab is not a separator replacement
+    assert!(lookup("doc\tdensity").is_none());
+}
+
+// ── lookup: output format invariants ────────────────────────────────
+
+#[test]
+fn lookup_output_starts_with_canonical_key_for_all_entries() {
+    let all = [
+        "doc_density",
+        "whitespace_ratio",
+        "verbosity",
+        "test_density",
+        "todo_density",
+        "polyglot_entropy",
+        "gini",
+        "avg_cyclomatic",
+        "max_cyclomatic",
+        "avg_cognitive",
+        "max_nesting_depth",
+        "maintainability_index",
+        "technical_debt_ratio",
+        "halstead",
+        "complexity_histogram",
+        "hotspots",
+        "bus_factor",
+        "freshness",
+        "code_age_distribution",
+        "coupling",
+        "predictive_churn",
+        "duplicate_waste",
+        "duplication_density",
+        "imports",
+        "entropy_suspects",
+        "license_radar",
+        "archetype",
+        "context_window_fit",
+    ];
+    for key in all {
+        let text = lookup(key).unwrap();
+        assert!(
+            text.starts_with(&format!("{key}:")),
+            "lookup({key}) should start with '{key}:', got: {text}"
+        );
+    }
+}
+
+#[test]
+fn lookup_summary_length_is_reasonable_for_every_key() {
+    let all = [
+        "doc_density",
+        "whitespace_ratio",
+        "verbosity",
+        "gini",
+        "hotspots",
+        "bus_factor",
+        "coupling",
+        "imports",
+        "archetype",
+    ];
+    for key in all {
+        let text = lookup(key).unwrap();
+        let summary = text.split_once(": ").unwrap().1;
+        assert!(
+            summary.len() >= 10,
+            "summary for '{key}' is too short: {summary}"
+        );
+        assert!(
+            summary.len() <= 200,
+            "summary for '{key}' is too long ({} chars)",
+            summary.len()
+        );
+    }
+}
+
+#[test]
+fn lookup_output_is_ascii_for_all_canonical_keys() {
+    let all = ["doc_density", "gini", "halstead", "archetype", "imports"];
+    for key in all {
+        let text = lookup(key).unwrap();
+        assert!(
+            text.is_ascii(),
+            "lookup({key}) output should be ASCII: {text}"
+        );
+    }
+}
+
+// ── catalog: determinism and stability ──────────────────────────────
+
+#[test]
+fn catalog_is_deterministic_across_100_calls() {
+    let baseline = catalog();
+    for i in 0..100 {
+        assert_eq!(catalog(), baseline, "catalog() diverged on call {i}");
+    }
+}
+
+#[test]
+fn catalog_keys_are_strictly_alphabetical() {
+    let text = catalog();
+    let keys: Vec<&str> = text
+        .lines()
+        .skip(1)
+        .filter_map(|l| l.strip_prefix("- "))
+        .collect();
+    for window in keys.windows(2) {
+        assert!(
+            window[0] < window[1],
+            "catalog order violation: '{}' should come before '{}'",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+#[test]
+fn catalog_does_not_contain_duplicates() {
+    let text = catalog();
+    let keys: Vec<&str> = text
+        .lines()
+        .skip(1)
+        .filter_map(|l| l.strip_prefix("- "))
+        .collect();
+    let set: std::collections::BTreeSet<&str> = keys.iter().copied().collect();
+    assert_eq!(keys.len(), set.len(), "catalog has duplicate entries");
+}
+
+#[test]
+fn catalog_every_line_after_header_starts_with_dash_space() {
+    let text = catalog();
+    for (i, line) in text.lines().enumerate().skip(1) {
+        assert!(
+            line.starts_with("- "),
+            "catalog line {i} should start with '- ', got: {line}"
+        );
+    }
+}
+
+#[test]
+fn catalog_contains_no_blank_lines() {
+    for (i, line) in catalog().lines().enumerate() {
+        assert!(
+            !line.is_empty(),
+            "catalog should not have blank line at index {i}"
+        );
+    }
+}
+
+#[test]
+fn catalog_ends_with_trailing_newline() {
+    assert!(catalog().ends_with('\n'));
+}
+
+// ── Cross-cutting: alias ↔ canonical round-trip ─────────────────────
+
+#[test]
+fn alias_lookup_always_returns_canonical_key_prefix() {
+    let pairs = [
+        ("docs", "doc_density"),
+        ("mi", "maintainability_index"),
+        ("churn", "predictive_churn"),
+        ("dup", "duplicate_waste"),
+        ("entropy", "entropy_suspects"),
+        ("license", "license_radar"),
+        ("staleness", "freshness"),
+        ("ownership", "bus_factor"),
+    ];
+    for (alias, canonical) in pairs {
+        let text = lookup(alias).unwrap();
+        assert!(
+            text.starts_with(&format!("{canonical}:")),
+            "alias '{alias}' should resolve to canonical '{canonical}', got: {text}"
+        );
+    }
+}
+
+#[test]
+fn all_catalog_keys_round_trip_through_lookup() {
+    let text = catalog();
+    for line in text.lines().skip(1) {
+        if let Some(key) = line.strip_prefix("- ") {
+            let result = lookup(key);
+            assert!(result.is_some(), "catalog key '{key}' must be lookupable");
+            let explanation = result.unwrap();
+            assert!(
+                explanation.starts_with(&format!("{key}:")),
+                "lookup of catalog key '{key}' should start with '{key}:'"
+            );
+        }
+    }
+}

--- a/crates/tokmd-analysis-html/tests/html_rendering_w55.rs
+++ b/crates/tokmd-analysis-html/tests/html_rendering_w55.rs
@@ -1,0 +1,658 @@
+//! W55 depth tests for tokmd-analysis-html: rendering structure,
+//! escaping safety, numeric formatting, data attributes, and determinism.
+
+use tokmd_analysis_html::render;
+use tokmd_analysis_types::*;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: 2,
+        generated_at_ms: 0,
+        tool: tokmd_types::ToolInfo {
+            name: "tokmd".into(),
+            version: "0.0.0".into(),
+        },
+        mode: "analysis".into(),
+        status: tokmd_types::ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec!["test".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "html".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            max_file_bytes: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn make_file_row(path: &str, module: &str, lang: &str, code: usize) -> FileStatRow {
+    FileStatRow {
+        path: path.into(),
+        module: module.into(),
+        lang: lang.into(),
+        code,
+        comments: code / 5,
+        blanks: code / 10,
+        lines: code + code / 5 + code / 10,
+        bytes: code * 50,
+        tokens: code * 3,
+        doc_pct: Some(0.15),
+        bytes_per_line: Some(40.0),
+        depth: path.matches('/').count(),
+    }
+}
+
+fn derived_with_files(files: Vec<FileStatRow>) -> DerivedReport {
+    let total_code: usize = files.iter().map(|f| f.code).sum();
+    let total_lines: usize = files.iter().map(|f| f.lines).sum();
+    let total_tokens: usize = files.iter().map(|f| f.tokens).sum();
+    let total_bytes: usize = files.iter().map(|f| f.bytes).sum();
+
+    DerivedReport {
+        totals: DerivedTotals {
+            files: files.len(),
+            code: total_code,
+            comments: total_code / 5,
+            blanks: total_code / 10,
+            lines: total_lines,
+            bytes: total_bytes,
+            tokens: total_tokens,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: total_code / 5,
+                denominator: total_code.max(1),
+                ratio: 0.2,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: total_code / 10,
+                denominator: total_lines.max(1),
+                ratio: 0.07,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: total_bytes,
+                denominator: total_lines.max(1),
+                rate: 40.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: files
+                .first()
+                .cloned()
+                .unwrap_or_else(|| make_file_row("empty", ".", "Text", 0)),
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 3,
+            avg: 1.5,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 0,
+            prod_lines: total_code,
+            test_files: 0,
+            prod_files: files.len(),
+            ratio: 0.0,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 0,
+            logic_lines: total_code,
+            ratio: 0.0,
+            infra_langs: vec![],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 1,
+            entropy: 0.0,
+            dominant_lang: "Rust".into(),
+            dominant_lines: total_code,
+            dominant_pct: 1.0,
+        },
+        distribution: DistributionReport {
+            count: files.len(),
+            min: files.iter().map(|f| f.lines).min().unwrap_or(0),
+            max: files.iter().map(|f| f.lines).max().unwrap_or(0),
+            mean: if files.is_empty() {
+                0.0
+            } else {
+                total_lines as f64 / files.len() as f64
+            },
+            median: 0.0,
+            p90: 0.0,
+            p99: 0.0,
+            gini: 0.3,
+        },
+        histogram: vec![],
+        top: TopOffenders {
+            largest_lines: files.clone(),
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: total_lines as f64 / 20.0,
+            lines_per_minute: 20,
+            basis_lines: total_lines,
+        },
+        context_window: None,
+        cocomo: None,
+        todo: None,
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "test".into(),
+            entries: files.len(),
+        },
+    }
+}
+
+// ── HTML structure: document skeleton ────────────────────────────────
+
+#[test]
+fn render_minimal_contains_title_element() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<title>"), "should contain <title>");
+    assert!(html.contains("</title>"), "should close </title>");
+}
+
+#[test]
+fn render_minimal_contains_style_block() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<style>"), "should embed CSS");
+    assert!(html.contains("</style>"), "should close style block");
+}
+
+#[test]
+fn render_minimal_contains_viewport_meta() {
+    let html = render(&minimal_receipt());
+    assert!(
+        html.contains("viewport"),
+        "should include viewport meta tag for responsive layout"
+    );
+}
+
+#[test]
+fn render_contains_lang_attribute_on_html_tag() {
+    let html = render(&minimal_receipt());
+    assert!(
+        html.contains(r#"<html lang="en">"#),
+        "html tag should have lang attribute"
+    );
+}
+
+// ── HTML structure: metric cards ────────────────────────────────────
+
+#[test]
+fn render_no_metric_cards_without_derived() {
+    let html = render(&minimal_receipt());
+    assert_eq!(
+        html.matches(r#"class="metric-card""#).count(),
+        0,
+        "no metric cards when derived is None"
+    );
+}
+
+#[test]
+fn render_metric_cards_show_files_label() {
+    let mut r = minimal_receipt();
+    r.derived = Some(derived_with_files(vec![make_file_row(
+        "a.rs", ".", "Rust", 50,
+    )]));
+    let html = render(&r);
+    assert!(html.contains(">Files<"), "Files label should appear");
+}
+
+#[test]
+fn render_metric_cards_show_lines_label() {
+    let mut r = minimal_receipt();
+    r.derived = Some(derived_with_files(vec![make_file_row(
+        "a.rs", ".", "Rust", 50,
+    )]));
+    let html = render(&r);
+    assert!(html.contains(">Lines<"), "Lines label should appear");
+}
+
+#[test]
+fn render_metric_cards_show_doc_pct_label() {
+    let mut r = minimal_receipt();
+    r.derived = Some(derived_with_files(vec![make_file_row(
+        "a.rs", ".", "Rust", 50,
+    )]));
+    let html = render(&r);
+    assert!(html.contains(">Doc%<"), "Doc% label should appear");
+}
+
+// ── HTML escaping: comprehensive XSS vectors ────────────────────────
+
+#[test]
+fn render_escapes_svg_onload_in_path() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("<svg onload=alert(1)>", ".", "SVG", 10)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(!html.contains("<svg onload=alert(1)>"));
+    assert!(html.contains("&lt;svg onload=alert(1)&gt;"));
+}
+
+#[test]
+fn render_escapes_ampersand_sequences_in_path() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("src/a&amp;b.rs", "src", "Rust", 10)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    // The literal & in &amp; should be double-escaped
+    assert!(html.contains("a&amp;amp;b.rs"));
+}
+
+#[test]
+fn render_escapes_all_five_html_special_chars() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("a<b>c&d\"e'f", "mod<x>", "L&\"ang'", 10)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    // path
+    assert!(html.contains("a&lt;b&gt;c&amp;d&quot;e&#x27;f"));
+    // module
+    assert!(html.contains("mod&lt;x&gt;"));
+    // lang
+    assert!(html.contains("L&amp;&quot;ang&#x27;"));
+}
+
+#[test]
+fn render_json_section_never_contains_raw_angle_brackets() {
+    let mut r = minimal_receipt();
+    let files = vec![
+        make_file_row("<script>evil</script>", ".", "JS", 10),
+        make_file_row("a>b<c", ".", "Text", 5),
+    ];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+
+    if let Some(start) = html.find("const REPORT_DATA =") {
+        let json_start = start + "const REPORT_DATA =".len();
+        if let Some(end) = html[json_start..].find(';') {
+            let json_section = &html[json_start..json_start + end];
+            assert!(!json_section.contains('<'), "JSON must not contain raw <");
+            assert!(!json_section.contains('>'), "JSON must not contain raw >");
+        }
+    }
+}
+
+#[test]
+fn render_json_uses_unicode_escapes_for_angle_brackets() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("<test>", ".", "JS", 10)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(
+        html.contains("\\u003c") && html.contains("\\u003e"),
+        "JSON should use \\u003c and \\u003e"
+    );
+}
+
+// ── Numeric formatting ──────────────────────────────────────────────
+
+#[test]
+fn render_small_numbers_have_no_suffix() {
+    let mut r = minimal_receipt();
+    let mut d = derived_with_files(vec![make_file_row("a.rs", ".", "Rust", 1)]);
+    d.totals.code = 42;
+    r.derived = Some(d);
+    let html = render(&r);
+    assert!(
+        html.contains(r#"<span class="value">42</span>"#),
+        "42 should appear without suffix"
+    );
+}
+
+#[test]
+fn render_exactly_999_has_no_k_suffix() {
+    let mut r = minimal_receipt();
+    let mut d = derived_with_files(vec![make_file_row("a.rs", ".", "Rust", 1)]);
+    d.totals.lines = 999;
+    r.derived = Some(d);
+    let html = render(&r);
+    assert!(html.contains(">999<"), "999 lines should not have K suffix");
+}
+
+#[test]
+fn render_1500_uses_k_suffix() {
+    let mut r = minimal_receipt();
+    let mut d = derived_with_files(vec![make_file_row("a.rs", ".", "Rust", 1)]);
+    d.totals.tokens = 1500;
+    r.derived = Some(d);
+    let html = render(&r);
+    assert!(html.contains("1.5K"), "1500 should render as 1.5K");
+}
+
+#[test]
+fn render_millions_use_m_suffix() {
+    let mut r = minimal_receipt();
+    let mut d = derived_with_files(vec![make_file_row("a.rs", ".", "Rust", 1)]);
+    d.totals.code = 3_700_000;
+    r.derived = Some(d);
+    let html = render(&r);
+    assert!(html.contains("3.7M"), "3700000 should render as 3.7M");
+}
+
+#[test]
+fn render_zero_renders_as_plain_zero() {
+    let mut r = minimal_receipt();
+    let mut d = derived_with_files(vec![make_file_row("a.rs", ".", "Rust", 1)]);
+    d.totals.tokens = 0;
+    r.derived = Some(d);
+    let html = render(&r);
+    // "0" as a value span
+    assert!(html.contains(r#"<span class="value">0</span><span class="label">Tokens</span>"#));
+}
+
+// ── Table rows: structure and data attributes ───────────────────────
+
+#[test]
+fn render_table_row_contains_all_seven_data_attributes() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("src/app.rs", "src", "Rust", 300)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+
+    for attr in &[
+        "data-path=",
+        "data-module=",
+        "data-lang=",
+        "data-lines=",
+        "data-code=",
+        "data-tokens=",
+        "data-bytes=",
+    ] {
+        assert!(html.contains(attr), "missing attribute {attr}");
+    }
+}
+
+#[test]
+fn render_data_code_holds_raw_numeric_value() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("x.rs", ".", "Rust", 4200)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(
+        html.contains("data-code=\"4200\""),
+        "data-code should hold raw 4200"
+    );
+}
+
+#[test]
+fn render_data_tokens_holds_raw_numeric_value() {
+    let mut r = minimal_receipt();
+    // code=1000 → tokens=1000*3=3000
+    let files = vec![make_file_row("x.rs", ".", "Rust", 1000)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(
+        html.contains("data-tokens=\"3000\""),
+        "data-tokens should hold raw 3000"
+    );
+}
+
+#[test]
+fn render_lang_badge_class_present_in_rows() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("a.py", ".", "Python", 50)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(
+        html.contains("lang-badge"),
+        "table rows should include lang-badge class"
+    );
+}
+
+// ── Table rows: file cap at 100 ─────────────────────────────────────
+
+#[test]
+fn render_exactly_100_files_renders_100_rows() {
+    let mut r = minimal_receipt();
+    let files: Vec<FileStatRow> = (0..100)
+        .map(|i| make_file_row(&format!("f{i}.rs"), ".", "Rust", 10))
+        .collect();
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert_eq!(html.matches("<tr><td").count(), 100);
+}
+
+#[test]
+fn render_101_files_renders_only_100_rows() {
+    let mut r = minimal_receipt();
+    let files: Vec<FileStatRow> = (0..101)
+        .map(|i| make_file_row(&format!("f{i}.rs"), ".", "Rust", 10))
+        .collect();
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert_eq!(html.matches("<tr><td").count(), 100);
+}
+
+#[test]
+fn render_zero_files_with_derived_renders_no_rows() {
+    let mut r = minimal_receipt();
+    r.derived = Some(derived_with_files(vec![]));
+    let html = render(&r);
+    assert_eq!(html.matches("<tr><td").count(), 0);
+}
+
+// ── Context window card ─────────────────────────────────────────────
+
+#[test]
+fn render_context_fit_card_shows_percentage() {
+    let mut r = minimal_receipt();
+    let mut d = derived_with_files(vec![make_file_row("a.rs", ".", "Rust", 100)]);
+    d.context_window = Some(ContextWindowReport {
+        window_tokens: 100_000,
+        total_tokens: 5000,
+        pct: 0.05,
+        fits: true,
+    });
+    r.derived = Some(d);
+    let html = render(&r);
+    assert!(
+        html.contains("5.0%"),
+        "context fit card should display 5.0%"
+    );
+}
+
+#[test]
+fn render_no_context_fit_card_when_absent() {
+    let mut r = minimal_receipt();
+    let mut d = derived_with_files(vec![make_file_row("a.rs", ".", "Rust", 100)]);
+    d.context_window = None;
+    r.derived = Some(d);
+    let html = render(&r);
+    assert!(
+        !html.contains("Context Fit"),
+        "no Context Fit card without context_window"
+    );
+}
+
+// ── Special characters in paths ─────────────────────────────────────
+
+#[test]
+fn render_handles_path_with_dots_and_hyphens() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row(
+        "my-project/src/lib.v2.rs",
+        "my-project/src",
+        "Rust",
+        50,
+    )];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(html.contains("my-project/src/lib.v2.rs"));
+}
+
+#[test]
+fn render_handles_deeply_nested_path() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row(
+        "a/b/c/d/e/f/g/h/i/j.rs",
+        "a/b/c/d/e/f/g/h/i",
+        "Rust",
+        10,
+    )];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(html.contains("a/b/c/d/e/f/g/h/i/j.rs"));
+}
+
+#[test]
+fn render_handles_unicode_in_module_name() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("src/café.rs", "src/café", "Rust", 10)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+    assert!(html.contains("café"), "Unicode module name should appear");
+}
+
+// ── REPORT_DATA JSON structure ──────────────────────────────────────
+
+#[test]
+fn render_report_json_contains_files_key() {
+    let mut r = minimal_receipt();
+    r.derived = Some(derived_with_files(vec![make_file_row(
+        "a.rs", ".", "Rust", 10,
+    )]));
+    let html = render(&r);
+    assert!(html.contains("\"files\""), "JSON should contain files key");
+}
+
+#[test]
+fn render_report_json_empty_when_no_derived() {
+    let html = render(&minimal_receipt());
+    assert!(
+        html.contains("{\"files\":[]}"),
+        "JSON should be empty files array when no derived"
+    );
+}
+
+#[test]
+fn render_report_json_contains_file_fields() {
+    let mut r = minimal_receipt();
+    let files = vec![make_file_row("src/lib.rs", "src", "Rust", 100)];
+    r.derived = Some(derived_with_files(files));
+    let html = render(&r);
+
+    // Extract JSON section
+    let start = html.find("const REPORT_DATA =").unwrap() + "const REPORT_DATA =".len();
+    let end = html[start..].find(';').unwrap();
+    let json_str = html[start..start + end].trim();
+    let parsed: serde_json::Value = serde_json::from_str(json_str).unwrap();
+
+    let file = &parsed["files"][0];
+    assert_eq!(file["path"], "src/lib.rs");
+    assert_eq!(file["module"], "src");
+    assert_eq!(file["lang"], "Rust");
+    assert_eq!(file["code"], 100);
+}
+
+// ── Determinism ─────────────────────────────────────────────────────
+
+#[test]
+fn render_deterministic_excluding_timestamp() {
+    let mut r = minimal_receipt();
+    r.derived = Some(derived_with_files(vec![
+        make_file_row("a.rs", "src", "Rust", 100),
+        make_file_row("b.py", "lib", "Python", 50),
+    ]));
+
+    let html1 = render(&r);
+    let html2 = render(&r);
+
+    // Strip timestamps for comparison
+    let strip_ts = |s: &str| -> String {
+        if let Some(start) = s.find("20") {
+            if let Some(end) = s.find(" UTC") {
+                return format!("{}{}", &s[..start], &s[end + 4..]);
+            }
+        }
+        s.to_string()
+    };
+    assert_eq!(strip_ts(&html1), strip_ts(&html2));
+}
+
+#[test]
+fn render_same_input_produces_same_row_count() {
+    let mut r = minimal_receipt();
+    let files: Vec<FileStatRow> = (0..25)
+        .map(|i| make_file_row(&format!("f{i}.rs"), ".", "Rust", 10 + i))
+        .collect();
+    r.derived = Some(derived_with_files(files));
+
+    let count1 = render(&r).matches("<tr><td").count();
+    let count2 = render(&r).matches("<tr><td").count();
+    assert_eq!(count1, count2);
+    assert_eq!(count1, 25);
+}
+
+// ── CSS classes present in template ─────────────────────────────────
+
+#[test]
+fn render_template_contains_container_class() {
+    let html = render(&minimal_receipt());
+    assert!(
+        html.contains("container"),
+        "template should use container class"
+    );
+}
+
+#[test]
+fn render_template_contains_css_variables() {
+    let html = render(&minimal_receipt());
+    assert!(
+        html.contains("--bg-primary"),
+        "template should define CSS custom properties"
+    );
+}


### PR DESCRIPTION
Adds 70 tests for analysis explanation and HTML output rendering including XSS escaping, metric cards, and determinism.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>