### PR TITLE
feat: devex lint-fix and quality gate workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,13 +2,25 @@
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-if ! git diff --cached --name-only --diff-filter=ACMR | grep -E '\.rs$|(^|/)Cargo\.toml$|^Cargo\.lock$' >/dev/null; then
+# Fast exit if no Rust-relevant files staged
+if ! git diff --cached --name-only --diff-filter=ACMR \
+  | grep -qE '\.rs$|(^|/)Cargo\.toml$|^Cargo\.lock$'; then
   exit 0
 fi
 
-echo "pre-commit: cargo fmt --check"
-cargo fmt --all -- --check
+# Capture staged file list for selective restage
+staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"
 
+# Auto-fix: fmt + clippy --fix + clippy verify
+echo "pre-commit: cargo xtask lint-fix"
+cargo xtask lint-fix
+
+# Restage only originally-staged files (safe selective restage)
+echo "$staged_files" | while IFS= read -r f; do
+  [ -f "$f" ] && git add "$f"
+done
+
+# Typos check (optional)
 if command -v typos &>/dev/null; then
   echo "pre-commit: typos --diff"
   typos --diff

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+echo "pre-push: cargo xtask gate --check"
+cargo xtask gate --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --all-features --verbose
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose
       env:
         CI: true
 
@@ -55,10 +55,10 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --all-features --verbose
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose
       env:
         CI: true
 
@@ -82,27 +82,16 @@ jobs:
       - name: Guard analysis microcrate boundaries
         run: cargo xtask boundaries-check
 
-  fmt:
-    name: Rustfmt
+  gate:
+    name: Quality Gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
-      - name: Check formatting
-        run: cargo fmt -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - name: Lint
-        run: cargo clippy -- -D warnings
+          components: clippy, rustfmt
+      - name: Run quality gate
+        run: cargo xtask gate --check
 
   deny:
     name: Cargo Deny
@@ -284,8 +273,7 @@ jobs:
       - msrv
       - build
       - build-macos
-      - fmt
-      - clippy
+      - gate
       - deny
       - typos
       - proptest-smoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,28 @@ cargo clippy -- -D warnings          # Lint with strict warnings
 cargo install --path crates/tokmd    # Local install
 ```
 
+## Developer Workflow
+
+| Command | Purpose |
+|---------|---------|
+| `cargo xtask lint-fix` | Auto-fix fmt + clippy, then verify |
+| `cargo xtask lint-fix --no-clippy` | Fast fmt-only fix |
+| `cargo xtask gate --check` | Full quality gate (read-only) |
+| `cargo xtask gate` | Quality gate with auto-fix fmt step |
+
+### Git Hooks Setup
+
+```bash
+git config core.hooksPath .githooks
+```
+
+- **pre-commit**: `cargo xtask lint-fix` + restage + typos
+- **pre-push**: `cargo xtask gate --check`
+
+### Agent Rule
+
+Always run `cargo xtask lint-fix` before considering a code-editing task complete. This ensures fmt and clippy issues are resolved before the user sees the result.
+
 ## Architecture
 
 The codebase follows a tiered microcrate architecture: **types → scan → model → format → analysis → CLI**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,18 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 ### Local Hooks
 
-Enable the project's pre-commit hook to catch formatting and typo issues before they reach CI:
+Enable the project's git hooks for automated lint-fix and quality gating:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-This is a one-time setup. The hook runs `cargo fmt --check` and `typos --diff` (if installed) on every commit. You can bypass it with `git commit --no-verify` in emergencies.
+This is a one-time setup. Two hooks are provided:
+
+- **pre-commit** — Runs `cargo xtask lint-fix` (fmt + clippy --fix + clippy verify), restages fixed files, and runs `typos --diff` (if installed). Only triggers when `.rs`, `Cargo.toml`, or `Cargo.lock` files are staged.
+- **pre-push** — Runs `cargo xtask gate --check` (fmt check + cargo check + clippy + test compile-only) to catch issues before they reach CI.
+
+You can bypass hooks with `git commit --no-verify` or `git push --no-verify` in emergencies.
 
 ## Project Structure
 
@@ -270,8 +275,9 @@ exclude_re = ["impl.*Display", "fn main\\("]
 
 ## Code Style
 
--   Run `cargo fmt` before committing.
--   Run `cargo clippy -- -D warnings` to catch common issues.
+-   Run `cargo xtask lint-fix` to auto-fix formatting and clippy issues.
+-   Run `cargo xtask lint-fix --no-clippy` for a fast fmt-only fix.
+-   Run `cargo xtask gate --check` to verify the full quality gate locally.
 
 ## Contribution Areas
 

--- a/Justfile
+++ b/Justfile
@@ -55,3 +55,23 @@ fmt-check:
 
 # Run all checks (fmt, lint, test)
 check: fmt-check lint test
+
+# Configure git to use project hooks
+setup:
+    git config core.hooksPath .githooks
+
+# Run pre-merge quality gate
+gate:
+    cargo xtask gate
+
+# Run gate in check-only mode (no file modifications)
+gate-check:
+    cargo xtask gate --check
+
+# Auto-fix lint issues (fmt + clippy --fix) then verify
+lint-fix:
+    cargo xtask lint-fix
+
+# Verify lint without modifying files
+lint-check:
+    cargo xtask lint-fix --check

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -20,6 +20,10 @@ pub enum Commands {
     Docs(DocsArgs),
     /// Verify dependency boundaries for analysis microcrates
     BoundariesCheck(BoundariesCheckArgs),
+    /// Run pre-merge quality gate (fmt, check, clippy, test-compile)
+    Gate(GateArgs),
+    /// Auto-fix lint issues (fmt + clippy --fix) then verify
+    LintFix(LintFixArgs),
 }
 
 #[derive(Args, Debug, Clone, Default)]
@@ -139,6 +143,24 @@ pub struct BumpArgs {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct BoundariesCheckArgs {}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct GateArgs {
+    /// Run in check-only mode (no file modifications)
+    #[arg(long)]
+    pub check: bool,
+}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct LintFixArgs {
+    /// Verify lint without modifying files
+    #[arg(long)]
+    pub check: bool,
+
+    /// Skip clippy --fix step
+    #[arg(long)]
+    pub no_clippy: bool,
+}
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct CockpitArgs {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,8 @@ fn main() -> Result<()> {
         Some(cli::Commands::Cockpit(args)) => tasks::cockpit::run(args),
         Some(cli::Commands::Docs(args)) => tasks::docs::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
+        Some(cli::Commands::Gate(args)) => tasks::gate::run(args),
+        Some(cli::Commands::LintFix(args)) => tasks::lint_fix::run(args),
         None => tasks::publish::run(PublishArgs::default()),
     }
 }

--- a/xtask/src/tasks/gate.rs
+++ b/xtask/src/tasks/gate.rs
@@ -1,0 +1,75 @@
+use crate::cli::GateArgs;
+use anyhow::{bail, Result};
+use std::process::Command;
+
+struct Step {
+    label: &'static str,
+    cmd: &'static str,
+    args: &'static [&'static str],
+    check_args: Option<&'static [&'static str]>,
+}
+
+const STEPS: &[Step] = &[
+    Step {
+        label: "fmt",
+        cmd: "cargo",
+        args: &["fmt", "--all"],
+        check_args: Some(&["fmt", "--all", "--", "--check"]),
+    },
+    Step {
+        label: "check (warm graph)",
+        cmd: "cargo",
+        args: &["check", "--workspace", "--all-features"],
+        check_args: None,
+    },
+    Step {
+        label: "clippy",
+        cmd: "cargo",
+        args: &[
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ],
+        check_args: None,
+    },
+    Step {
+        label: "test (compile-only)",
+        cmd: "cargo",
+        args: &["test", "--workspace", "--all-features", "--no-run"],
+        check_args: None,
+    },
+];
+
+pub fn run(args: GateArgs) -> Result<()> {
+    let total = STEPS.len();
+    let mut passed = 0usize;
+
+    for (i, step) in STEPS.iter().enumerate() {
+        let idx = i + 1;
+        let effective_args = if args.check {
+            step.check_args.unwrap_or(step.args)
+        } else {
+            step.args
+        };
+
+        println!("[{idx}/{total}] {}", step.label);
+
+        let status = Command::new(step.cmd).args(effective_args).status()?;
+
+        if !status.success() {
+            bail!(
+                "Step {idx}/{total} ({}) failed with exit code {}",
+                step.label,
+                status.code().unwrap_or(-1)
+            );
+        }
+        passed += 1;
+    }
+
+    println!("gate: {passed}/{total} steps passed");
+    Ok(())
+}

--- a/xtask/src/tasks/lint_fix.rs
+++ b/xtask/src/tasks/lint_fix.rs
@@ -1,0 +1,69 @@
+use crate::cli::LintFixArgs;
+use anyhow::{bail, Result};
+use std::process::Command;
+
+pub fn run(args: LintFixArgs) -> Result<()> {
+    // Step 1: fmt
+    if args.check {
+        println!("[1/2] cargo fmt --all -- --check");
+        let status = Command::new("cargo")
+            .args(["fmt", "--all", "--", "--check"])
+            .status()?;
+        if !status.success() {
+            bail!("fmt check failed");
+        }
+    } else {
+        println!("[1/{}] cargo fmt --all", if args.no_clippy { 1 } else { 3 });
+        let status = Command::new("cargo").args(["fmt", "--all"]).status()?;
+        if !status.success() {
+            bail!("fmt failed");
+        }
+    }
+
+    if args.no_clippy {
+        println!("lint-fix: clippy skipped (--no-clippy)");
+        println!("lint-fix: all steps passed");
+        return Ok(());
+    }
+
+    // Step 2 (non-check): clippy --fix (best-effort)
+    if !args.check {
+        println!("[2/3] cargo clippy --fix (best-effort)");
+        let status = Command::new("cargo")
+            .args([
+                "clippy",
+                "--fix",
+                "--workspace",
+                "--all-targets",
+                "--all-features",
+                "--allow-dirty",
+                "--allow-staged",
+            ])
+            .status()?;
+        if !status.success() {
+            eprintln!("warning: clippy --fix returned non-zero (continuing to verify)");
+        }
+    }
+
+    // Step 3 (or 2 in check mode): strict clippy verify
+    let verify_step = if args.check { 2 } else { 3 };
+    let total = verify_step;
+    println!("[{verify_step}/{total}] cargo clippy (verify)");
+    let status = Command::new("cargo")
+        .args([
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ])
+        .status()?;
+    if !status.success() {
+        bail!("clippy verify failed");
+    }
+
+    println!("lint-fix: all steps passed");
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -2,4 +2,6 @@ pub mod boundaries_check;
 pub mod bump;
 pub mod cockpit;
 pub mod docs;
+pub mod gate;
+pub mod lint_fix;
 pub mod publish;


### PR DESCRIPTION
## Summary

- Add `cargo xtask lint-fix` (fmt + clippy --fix + verify) and `cargo xtask gate` (fmt → check → clippy → test-compile) commands with `--check` and `--no-clippy` flags
- Replace `cargo build` step with `cargo check` in gate (warm graph, no codegen) and reorder before clippy so it reuses warmed artifacts
- Fix `--no-clippy` bug: previously still ran clippy verify, now returns early after fmt
- Rewrite `.githooks/pre-commit` to run lint-fix with selective restage of originally-staged files
- Add `.githooks/pre-push` running `gate --check` before push
- Consolidate CI `fmt` + `clippy` jobs into single `gate` job
- Update CONTRIBUTING.md (hooks + code style) and CLAUDE.md (developer workflow + agent rule)

## Test plan

- [x] `cargo build -p xtask` compiles
- [ ] `cargo xtask gate --check` — full gate passes
- [ ] `cargo xtask lint-fix --no-clippy` — runs fmt only, no clippy
- [ ] `cargo xtask lint-fix` — runs fmt + clippy fix + clippy verify
- [ ] CI `gate` job passes (replaces fmt+clippy)
- [ ] Review `.githooks/pre-commit` and `.githooks/pre-push` for correctness