### PR TITLE
test(w57): depth tests for fun outputs and asset analysis

### DIFF
--- a/crates/tokmd-analysis-assets/tests/assets_depth_w57.rs
+++ b/crates/tokmd-analysis-assets/tests/assets_depth_w57.rs
@@ -1,0 +1,584 @@
+//! W57 depth tests for `tokmd-analysis-assets`.
+//!
+//! Covers asset detection across all six categories, lockfile parsing for
+//! every supported format, classification edge cases, report generation
+//! with mixed types, deterministic ordering, and serde roundtrips.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+use tokmd_analysis_assets::{build_assets_report, build_dependency_report};
+use tokmd_analysis_types::{
+    AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn write_file(dir: &Path, rel: &str, content: &[u8]) -> PathBuf {
+    let full = dir.join(rel);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&full, content).unwrap();
+    PathBuf::from(rel)
+}
+
+// ===========================================================================
+// 1. Image category covers all 9 extensions
+// ===========================================================================
+#[test]
+fn image_all_extensions() {
+    let tmp = TempDir::new().unwrap();
+    let exts = [
+        "png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "tiff", "ico",
+    ];
+    let files: Vec<PathBuf> = exts
+        .iter()
+        .map(|e| write_file(tmp.path(), &format!("img.{e}"), &[0u8; 16]))
+        .collect();
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.categories.len(), 1);
+    assert_eq!(report.categories[0].category, "image");
+    assert_eq!(report.categories[0].files, 9);
+    assert_eq!(report.categories[0].extensions.len(), 9);
+}
+
+// ===========================================================================
+// 2. Video extensions: mpeg and mpg
+// ===========================================================================
+#[test]
+fn video_mpeg_and_mpg() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.mpeg", &[0u8; 10]),
+        write_file(tmp.path(), "b.mpg", &[0u8; 10]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.categories[0].category, "video");
+    assert_eq!(report.categories[0].files, 2);
+}
+
+// ===========================================================================
+// 3. Audio category covers m4a
+// ===========================================================================
+#[test]
+fn audio_m4a_extension() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![write_file(tmp.path(), "track.m4a", &[0u8; 10])];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.categories[0].category, "audio");
+}
+
+// ===========================================================================
+// 4. Archive: xz and 7z
+// ===========================================================================
+#[test]
+fn archive_xz_and_7z() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.xz", &[0u8; 10]),
+        write_file(tmp.path(), "b.7z", &[0u8; 10]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.categories[0].category, "archive");
+    assert_eq!(report.categories[0].files, 2);
+}
+
+// ===========================================================================
+// 5. Binary: jar and class
+// ===========================================================================
+#[test]
+fn binary_jar_and_class() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "app.jar", &[0u8; 10]),
+        write_file(tmp.path(), "Main.class", &[0u8; 10]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.categories[0].category, "binary");
+    assert_eq!(report.categories[0].files, 2);
+}
+
+// ===========================================================================
+// 6. Font: woff and woff2
+// ===========================================================================
+#[test]
+fn font_woff_woff2() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.woff", &[0u8; 10]),
+        write_file(tmp.path(), "b.woff2", &[0u8; 10]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.categories[0].category, "font");
+    assert_eq!(report.categories[0].files, 2);
+}
+
+// ===========================================================================
+// 7. Unrecognised extensions are skipped
+// ===========================================================================
+#[test]
+fn unrecognised_extensions_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.rs", b"fn main() {}"),
+        write_file(tmp.path(), "b.py", b"print()"),
+        write_file(tmp.path(), "c.toml", b"[package]"),
+        write_file(tmp.path(), "d.xml", b"<root/>"),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.total_files, 0);
+    assert_eq!(report.total_bytes, 0);
+}
+
+// ===========================================================================
+// 8. Files without extension are skipped
+// ===========================================================================
+#[test]
+fn no_extension_files_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "Makefile", b"all:"),
+        write_file(tmp.path(), "LICENSE", b"MIT"),
+        write_file(tmp.path(), "Dockerfile", b"FROM rust"),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.total_files, 0);
+}
+
+// ===========================================================================
+// 9. Empty file list → zero everything
+// ===========================================================================
+#[test]
+fn empty_file_list_assets() {
+    let tmp = TempDir::new().unwrap();
+    let report = build_assets_report(tmp.path(), &[]).unwrap();
+    assert_eq!(report.total_files, 0);
+    assert_eq!(report.total_bytes, 0);
+    assert!(report.categories.is_empty());
+    assert!(report.top_files.is_empty());
+}
+
+// ===========================================================================
+// 10. Mixed categories: bytes totals are correct
+// ===========================================================================
+#[test]
+fn mixed_categories_bytes_sum() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.png", &[0u8; 100]),
+        write_file(tmp.path(), "b.mp4", &[0u8; 200]),
+        write_file(tmp.path(), "c.mp3", &[0u8; 50]),
+        write_file(tmp.path(), "d.zip", &[0u8; 150]),
+        write_file(tmp.path(), "e.exe", &[0u8; 75]),
+        write_file(tmp.path(), "f.ttf", &[0u8; 25]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.total_files, 6);
+    assert_eq!(report.total_bytes, 600);
+    let sum: u64 = report.categories.iter().map(|c| c.bytes).sum();
+    assert_eq!(report.total_bytes, sum);
+}
+
+// ===========================================================================
+// 11. Categories sorted by bytes desc, then name asc
+// ===========================================================================
+#[test]
+fn categories_sort_order() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.ttf", &[0u8; 100]), // font
+        write_file(tmp.path(), "b.exe", &[0u8; 100]), // binary
+        write_file(tmp.path(), "c.mp3", &[0u8; 200]), // audio
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.categories[0].category, "audio"); // 200
+    assert_eq!(report.categories[1].category, "binary"); // 100
+    assert_eq!(report.categories[2].category, "font"); // 100
+}
+
+// ===========================================================================
+// 12. Top files capped at 10
+// ===========================================================================
+#[test]
+fn top_files_cap_at_10() {
+    let tmp = TempDir::new().unwrap();
+    let files: Vec<PathBuf> = (0..20)
+        .map(|i| write_file(tmp.path(), &format!("f{i}.png"), &vec![0u8; (i + 1) * 10]))
+        .collect();
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.top_files.len(), 10);
+    // First file has the most bytes
+    assert!(report.top_files[0].bytes >= report.top_files[9].bytes);
+}
+
+// ===========================================================================
+// 13. Top files tiebreak by path ascending
+// ===========================================================================
+#[test]
+fn top_files_tiebreak_path_asc() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "z.png", &[0u8; 50]),
+        write_file(tmp.path(), "a.png", &[0u8; 50]),
+        write_file(tmp.path(), "m.png", &[0u8; 50]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.top_files[0].path, "a.png");
+    assert_eq!(report.top_files[1].path, "m.png");
+    assert_eq!(report.top_files[2].path, "z.png");
+}
+
+// ===========================================================================
+// 14. Paths normalized to forward slashes
+// ===========================================================================
+#[test]
+fn paths_forward_slashes() {
+    let tmp = TempDir::new().unwrap();
+    let rel = write_file(tmp.path(), "deep/nested/dir/logo.svg", &[0u8; 32]);
+    let report = build_assets_report(tmp.path(), &[rel]).unwrap();
+    assert_eq!(report.top_files[0].path, "deep/nested/dir/logo.svg");
+    assert!(!report.top_files[0].path.contains('\\'));
+}
+
+// ===========================================================================
+// 15. Extension stored lowercase
+// ===========================================================================
+#[test]
+fn extension_lowercase() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![write_file(tmp.path(), "IMG.PNG", &[0u8; 10])];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.top_files[0].extension, "png");
+}
+
+// ===========================================================================
+// 16. AssetReport serde roundtrip
+// ===========================================================================
+#[test]
+fn asset_report_serde_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "a.png", &[0u8; 100]),
+        write_file(tmp.path(), "b.mp4", &[0u8; 200]),
+        write_file(tmp.path(), "c.zip", &[0u8; 50]),
+    ];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    let json = serde_json::to_string(&report).unwrap();
+    let rt: AssetReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.total_files, report.total_files);
+    assert_eq!(rt.total_bytes, report.total_bytes);
+    assert_eq!(rt.categories.len(), report.categories.len());
+    assert_eq!(rt.top_files.len(), report.top_files.len());
+}
+
+// ===========================================================================
+// 17. AssetCategoryRow serde roundtrip
+// ===========================================================================
+#[test]
+fn asset_category_row_serde_roundtrip() {
+    let row = AssetCategoryRow {
+        category: "image".to_string(),
+        files: 5,
+        bytes: 1024,
+        extensions: vec!["png".to_string(), "jpg".to_string()],
+    };
+    let json = serde_json::to_string(&row).unwrap();
+    let rt: AssetCategoryRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.category, "image");
+    assert_eq!(rt.files, 5);
+    assert_eq!(rt.bytes, 1024);
+    assert_eq!(rt.extensions, vec!["png", "jpg"]);
+}
+
+// ===========================================================================
+// 18. AssetFileRow serde roundtrip
+// ===========================================================================
+#[test]
+fn asset_file_row_serde_roundtrip() {
+    let row = AssetFileRow {
+        path: "icons/logo.svg".to_string(),
+        bytes: 2048,
+        category: "image".to_string(),
+        extension: "svg".to_string(),
+    };
+    let json = serde_json::to_string(&row).unwrap();
+    let rt: AssetFileRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.path, "icons/logo.svg");
+    assert_eq!(rt.bytes, 2048);
+    assert_eq!(rt.category, "image");
+    assert_eq!(rt.extension, "svg");
+}
+
+// ===========================================================================
+// 19. DependencyReport serde roundtrip
+// ===========================================================================
+#[test]
+fn dependency_report_serde_roundtrip() {
+    let report = DependencyReport {
+        total: 5,
+        lockfiles: vec![
+            LockfileReport {
+                path: "Cargo.lock".to_string(),
+                kind: "cargo".to_string(),
+                dependencies: 3,
+            },
+            LockfileReport {
+                path: "yarn.lock".to_string(),
+                kind: "yarn".to_string(),
+                dependencies: 2,
+            },
+        ],
+    };
+    let json = serde_json::to_string(&report).unwrap();
+    let rt: DependencyReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.total, 5);
+    assert_eq!(rt.lockfiles.len(), 2);
+    assert_eq!(rt.lockfiles[0].kind, "cargo");
+    assert_eq!(rt.lockfiles[1].kind, "yarn");
+}
+
+// ===========================================================================
+// 20. LockfileReport serde roundtrip
+// ===========================================================================
+#[test]
+fn lockfile_report_serde_roundtrip() {
+    let lf = LockfileReport {
+        path: "sub/Cargo.lock".to_string(),
+        kind: "cargo".to_string(),
+        dependencies: 42,
+    };
+    let json = serde_json::to_string(&lf).unwrap();
+    let rt: LockfileReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.path, "sub/Cargo.lock");
+    assert_eq!(rt.kind, "cargo");
+    assert_eq!(rt.dependencies, 42);
+}
+
+// ===========================================================================
+// 21. Cargo.lock counting: text containing "[[package]]" inside values
+// ===========================================================================
+#[test]
+fn cargo_lock_counts_only_package_markers() {
+    let tmp = TempDir::new().unwrap();
+    let content = "[[package]]\nname = \"serde\"\nversion = \"1.0\"\n\n\
+                   [[package]]\nname = \"tokei\"\nversion = \"12.0\"\n\n\
+                   [[package]]\nname = \"clap\"\nversion = \"4.0\"\n";
+    let rel = write_file(tmp.path(), "Cargo.lock", content.as_bytes());
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    assert_eq!(report.lockfiles[0].dependencies, 3);
+    assert_eq!(report.total, 3);
+}
+
+// ===========================================================================
+// 22. package-lock.json: packages field preferred over dependencies
+// ===========================================================================
+#[test]
+fn npm_packages_field_preferred() {
+    let tmp = TempDir::new().unwrap();
+    let content = r#"{
+        "packages": {"": {}, "node_modules/a": {}, "node_modules/b": {}, "node_modules/c": {}},
+        "dependencies": {"x": {}, "y": {}}
+    }"#;
+    let rel = write_file(tmp.path(), "package-lock.json", content.as_bytes());
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    // packages: 4 keys - 1 root = 3 (not 2 from dependencies)
+    assert_eq!(report.lockfiles[0].dependencies, 3);
+}
+
+// ===========================================================================
+// 23. yarn.lock: multiple versions of same package
+// ===========================================================================
+#[test]
+fn yarn_lock_multiple_versions() {
+    let tmp = TempDir::new().unwrap();
+    let content = "# yarn lockfile v1\n\n\
+                   lodash@^4.0.0:\n  version \"4.17.21\"\n\n\
+                   lodash@^3.0.0:\n  version \"3.10.1\"\n\n\
+                   react@^18.0.0:\n  version \"18.2.0\"\n";
+    let rel = write_file(tmp.path(), "yarn.lock", content.as_bytes());
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    assert_eq!(report.lockfiles[0].kind, "yarn");
+    assert_eq!(report.lockfiles[0].dependencies, 3);
+}
+
+// ===========================================================================
+// 24. go.sum: empty file
+// ===========================================================================
+#[test]
+fn go_sum_empty() {
+    let tmp = TempDir::new().unwrap();
+    let rel = write_file(tmp.path(), "go.sum", b"");
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    assert_eq!(report.lockfiles[0].kind, "go");
+    assert_eq!(report.lockfiles[0].dependencies, 0);
+}
+
+// ===========================================================================
+// 25. Gemfile.lock: multiple specs sections
+// ===========================================================================
+#[test]
+fn gemfile_lock_multiple_specs() {
+    let tmp = TempDir::new().unwrap();
+    let content = "GEM\n  remote: https://rubygems.org/\n  specs:\n    rails (7.0.0)\n    rack (2.2.0)\n\nPATH\n  remote: .\n  specs:\n    myapp (1.0.0)\n\nPLATFORMS\n  ruby\n";
+    let rel = write_file(tmp.path(), "Gemfile.lock", content.as_bytes());
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    assert_eq!(report.lockfiles[0].kind, "bundler");
+    // rails + rack in GEM specs, myapp in PATH specs
+    assert!(report.lockfiles[0].dependencies >= 2);
+}
+
+// ===========================================================================
+// 26. Multiple lockfiles: total equals sum
+// ===========================================================================
+#[test]
+fn multiple_lockfiles_total_sum() {
+    let tmp = TempDir::new().unwrap();
+    let cargo = "[[package]]\nname = \"a\"\n\n[[package]]\nname = \"b\"\n";
+    let yarn = "# yarn\npkg@^1:\n  version \"1.0\"\n";
+    let go = "example.com/x v1.0.0 h1:abc=\n";
+    let f1 = write_file(tmp.path(), "Cargo.lock", cargo.as_bytes());
+    let f2 = write_file(tmp.path(), "yarn.lock", yarn.as_bytes());
+    let f3 = write_file(tmp.path(), "go.sum", go.as_bytes());
+    let report = build_dependency_report(tmp.path(), &[f1, f2, f3]).unwrap();
+    let sum: usize = report.lockfiles.iter().map(|l| l.dependencies).sum();
+    assert_eq!(report.total, sum);
+    assert_eq!(report.lockfiles.len(), 3);
+}
+
+// ===========================================================================
+// 27. Non-lockfile names ignored by dependency report
+// ===========================================================================
+#[test]
+fn non_lockfile_names_ignored() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "README.md", b"# Hello"),
+        write_file(tmp.path(), "package.json", b"{}"),
+        write_file(tmp.path(), "Cargo.toml", b"[package]"),
+    ];
+    let report = build_dependency_report(tmp.path(), &files).unwrap();
+    assert!(report.lockfiles.is_empty());
+    assert_eq!(report.total, 0);
+}
+
+// ===========================================================================
+// 28. Empty dependency report
+// ===========================================================================
+#[test]
+fn empty_dependency_report() {
+    let tmp = TempDir::new().unwrap();
+    let report = build_dependency_report(tmp.path(), &[]).unwrap();
+    assert_eq!(report.total, 0);
+    assert!(report.lockfiles.is_empty());
+}
+
+// ===========================================================================
+// 29. Deterministic: same input → same JSON
+// ===========================================================================
+#[test]
+fn asset_report_deterministic_json() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![
+        write_file(tmp.path(), "z.png", &[0u8; 50]),
+        write_file(tmp.path(), "a.mp4", &[0u8; 100]),
+        write_file(tmp.path(), "m.zip", &[0u8; 75]),
+        write_file(tmp.path(), "x.ttf", &[0u8; 25]),
+    ];
+    let j1 = serde_json::to_string(&build_assets_report(tmp.path(), &files).unwrap()).unwrap();
+    let j2 = serde_json::to_string(&build_assets_report(tmp.path(), &files).unwrap()).unwrap();
+    assert_eq!(j1, j2);
+}
+
+// ===========================================================================
+// 30. Deterministic dependency report
+// ===========================================================================
+#[test]
+fn dependency_report_deterministic_json() {
+    let tmp = TempDir::new().unwrap();
+    let cargo = "[[package]]\nname = \"z\"\n\n[[package]]\nname = \"a\"\n";
+    let rel = write_file(tmp.path(), "Cargo.lock", cargo.as_bytes());
+    let j1 = serde_json::to_string(&build_dependency_report(tmp.path(), &[rel.clone()]).unwrap())
+        .unwrap();
+    let j2 = serde_json::to_string(&build_dependency_report(tmp.path(), &[rel]).unwrap()).unwrap();
+    assert_eq!(j1, j2);
+}
+
+// ===========================================================================
+// 31. Zero-byte asset file is still counted
+// ===========================================================================
+#[test]
+fn zero_byte_asset_counted() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![write_file(tmp.path(), "empty.png", &[])];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    assert_eq!(report.total_files, 1);
+    assert_eq!(report.total_bytes, 0);
+    assert_eq!(report.top_files.len(), 1);
+    assert_eq!(report.top_files[0].bytes, 0);
+}
+
+// ===========================================================================
+// 32. Missing lockfile on disk gives zero dependencies
+// ===========================================================================
+#[test]
+fn missing_lockfile_zero_deps() {
+    let tmp = TempDir::new().unwrap();
+    // Don't write the file on disk
+    let rel = PathBuf::from("Cargo.lock");
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    assert_eq!(report.lockfiles[0].dependencies, 0);
+}
+
+// ===========================================================================
+// 33. JSON contains expected keys for asset report
+// ===========================================================================
+#[test]
+fn asset_report_json_keys() {
+    let tmp = TempDir::new().unwrap();
+    let files = vec![write_file(tmp.path(), "a.png", &[0u8; 10])];
+    let report = build_assets_report(tmp.path(), &files).unwrap();
+    let val: serde_json::Value = serde_json::to_value(&report).unwrap();
+    assert!(val.get("total_files").is_some());
+    assert!(val.get("total_bytes").is_some());
+    assert!(val.get("categories").is_some());
+    assert!(val.get("top_files").is_some());
+}
+
+// ===========================================================================
+// 34. JSON contains expected keys for dependency report
+// ===========================================================================
+#[test]
+fn dependency_report_json_keys() {
+    let tmp = TempDir::new().unwrap();
+    let rel = write_file(tmp.path(), "Cargo.lock", b"[[package]]\nname = \"x\"\n");
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    let val: serde_json::Value = serde_json::to_value(&report).unwrap();
+    assert!(val.get("total").is_some());
+    assert!(val.get("lockfiles").is_some());
+    let lf = &val["lockfiles"][0];
+    assert!(lf.get("path").is_some());
+    assert!(lf.get("kind").is_some());
+    assert!(lf.get("dependencies").is_some());
+}
+
+// ===========================================================================
+// 35. pnpm-lock.yaml with many packages
+// ===========================================================================
+#[test]
+fn pnpm_lock_many_packages() {
+    let tmp = TempDir::new().unwrap();
+    let mut content = String::from("lockfileVersion: 5.4\n\npackages:\n");
+    for i in 0..20 {
+        content.push_str(&format!(
+            "  /pkg-{i}/1.0.{i}:\n    resolution: {{integrity: sha512-xxx}}\n"
+        ));
+    }
+    let rel = write_file(tmp.path(), "pnpm-lock.yaml", content.as_bytes());
+    let report = build_dependency_report(tmp.path(), &[rel]).unwrap();
+    assert_eq!(report.lockfiles[0].kind, "pnpm");
+    // Lines starting with "/" and containing ":"
+    assert_eq!(report.lockfiles[0].dependencies, 20);
+}

--- a/crates/tokmd-analysis-fun/tests/fun_depth_w57.rs
+++ b/crates/tokmd-analysis-fun/tests/fun_depth_w57.rs
@@ -1,0 +1,583 @@
+//! W57 depth tests for `tokmd-analysis-fun`.
+//!
+//! Exercises eco-label generation across a wide range of repo sizes and
+//! compositions, serde roundtrips for all report sub-types, deterministic
+//! output ordering, notes formatting edge cases, and property-based
+//! monotonicity/invariant checks.
+
+use tokmd_analysis_fun::build_fun_report;
+use tokmd_analysis_types::{
+    BoilerplateReport, DerivedReport, DerivedTotals, DistributionReport, EcoLabel, FileStatRow,
+    FunReport, IntegrityReport, LangPurityReport, MaxFileReport, NestingReport, PolyglotReport,
+    RateReport, RateRow, RatioReport, RatioRow, ReadingTimeReport, TestDensityReport, TodoReport,
+    TopOffenders,
+};
+
+// ---------------------------------------------------------------------------
+// Helper: build a DerivedReport with configurable bytes and file count
+// ---------------------------------------------------------------------------
+
+fn derived_with(bytes: usize, files: usize, code: usize) -> DerivedReport {
+    let row = FileStatRow {
+        path: "main.rs".to_string(),
+        module: "src".to_string(),
+        lang: "Rust".to_string(),
+        code: 0,
+        comments: 0,
+        blanks: 0,
+        lines: 0,
+        bytes,
+        tokens: 0,
+        doc_pct: Some(0.0),
+        bytes_per_line: Some(0.0),
+        depth: 0,
+    };
+
+    DerivedReport {
+        totals: DerivedTotals {
+            files,
+            code,
+            comments: 0,
+            blanks: 0,
+            lines: code,
+            bytes,
+            tokens: code,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "All".into(),
+                numerator: 0,
+                denominator: 1,
+                ratio: 0.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "All".into(),
+                numerator: 0,
+                denominator: 1,
+                ratio: 0.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "All".into(),
+                numerator: 0,
+                denominator: 1,
+                rate: 0.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: row.clone(),
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 0,
+            avg: 0.0,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 0,
+            prod_lines: 0,
+            test_files: 0,
+            prod_files: 0,
+            ratio: 0.0,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 0,
+            logic_lines: 0,
+            ratio: 0.0,
+            infra_langs: vec![],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 1,
+            entropy: 0.0,
+            dominant_lang: "Rust".to_string(),
+            dominant_lines: code,
+            dominant_pct: 100.0,
+        },
+        distribution: DistributionReport {
+            count: files,
+            min: 1,
+            max: 1,
+            mean: 0.0,
+            median: 0.0,
+            p90: 0.0,
+            p99: 0.0,
+            gini: 0.0,
+        },
+        histogram: Vec::new(),
+        top: TopOffenders {
+            largest_lines: vec![row.clone()],
+            largest_tokens: vec![row.clone()],
+            largest_bytes: vec![row.clone()],
+            least_documented: vec![row.clone()],
+            most_dense: vec![row],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 0.0,
+            lines_per_minute: 0,
+            basis_lines: 0,
+        },
+        context_window: None,
+        cocomo: None,
+        todo: Some(TodoReport {
+            total: 0,
+            density_per_kloc: 0.0,
+            tags: vec![],
+        }),
+        integrity: IntegrityReport {
+            algo: "sha1".to_string(),
+            hash: "placeholder".to_string(),
+            entries: 0,
+        },
+    }
+}
+
+fn derived_bytes(bytes: usize) -> DerivedReport {
+    derived_with(bytes, 1, 1)
+}
+
+// ===========================================================================
+// 1. Empty repo (0 bytes) produces grade A
+// ===========================================================================
+#[test]
+fn empty_repo_gives_grade_a() {
+    let eco = build_fun_report(&derived_bytes(0)).eco_label.unwrap();
+    assert_eq!(eco.label, "A");
+    assert_eq!(eco.score, 95.0);
+    assert_eq!(eco.bytes, 0);
+}
+
+// ===========================================================================
+// 2. Single-file tiny repo
+// ===========================================================================
+#[test]
+fn single_file_tiny_repo() {
+    let eco = build_fun_report(&derived_with(256, 1, 10))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "A");
+    assert_eq!(eco.bytes, 256);
+}
+
+// ===========================================================================
+// 3. Large multi-file repo (50 MB range)
+// ===========================================================================
+#[test]
+fn large_multi_file_repo_grade_c() {
+    let bytes = 30 * 1024 * 1024;
+    let eco = build_fun_report(&derived_with(bytes, 5000, 200_000))
+        .eco_label
+        .unwrap();
+    assert_eq!(eco.label, "C");
+    assert_eq!(eco.score, 65.0);
+}
+
+// ===========================================================================
+// 4. Massive repo (500 MB) produces grade E
+// ===========================================================================
+#[test]
+fn massive_repo_grade_e() {
+    let bytes = 500 * 1024 * 1024;
+    let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+    assert_eq!(eco.label, "E");
+    assert_eq!(eco.score, 30.0);
+}
+
+// ===========================================================================
+// 5. Eco-label always present regardless of bytes
+// ===========================================================================
+#[test]
+fn eco_label_always_some() {
+    for bytes in [0, 1, 100, 1_000_000, 1_000_000_000] {
+        let report = build_fun_report(&derived_bytes(bytes));
+        assert!(
+            report.eco_label.is_some(),
+            "eco_label missing for {bytes} bytes"
+        );
+    }
+}
+
+// ===========================================================================
+// 6. Score monotonically decreases as bytes increase across all bands
+// ===========================================================================
+#[test]
+fn score_monotone_decreasing_across_bands() {
+    let sizes = [
+        0,
+        512 * 1024,
+        2 * 1024 * 1024,
+        15 * 1024 * 1024,
+        100 * 1024 * 1024,
+        300 * 1024 * 1024,
+    ];
+    let scores: Vec<f64> = sizes
+        .iter()
+        .map(|&b| build_fun_report(&derived_bytes(b)).eco_label.unwrap().score)
+        .collect();
+    for w in scores.windows(2) {
+        assert!(w[0] >= w[1], "score not monotone: {} -> {}", w[0], w[1]);
+    }
+}
+
+// ===========================================================================
+// 7. FunReport serde roundtrip preserves all fields
+// ===========================================================================
+#[test]
+fn fun_report_serde_roundtrip_all_fields() {
+    let report = build_fun_report(&derived_bytes(7 * 1024 * 1024));
+    let json = serde_json::to_string(&report).unwrap();
+    let rt: FunReport = serde_json::from_str(&json).unwrap();
+    let orig = report.eco_label.unwrap();
+    let back = rt.eco_label.unwrap();
+    assert_eq!(orig.label, back.label);
+    assert_eq!(orig.score, back.score);
+    assert_eq!(orig.bytes, back.bytes);
+    assert_eq!(orig.notes, back.notes);
+}
+
+// ===========================================================================
+// 8. EcoLabel serde roundtrip standalone
+// ===========================================================================
+#[test]
+fn eco_label_serde_roundtrip_standalone() {
+    let label = EcoLabel {
+        score: 80.0,
+        label: "B".to_string(),
+        bytes: 5_000_000,
+        notes: "Size-based eco label (4.77 MB)".to_string(),
+    };
+    let json = serde_json::to_string(&label).unwrap();
+    let rt: EcoLabel = serde_json::from_str(&json).unwrap();
+    assert_eq!(label.label, rt.label);
+    assert_eq!(label.score, rt.score);
+    assert_eq!(label.bytes, rt.bytes);
+    assert_eq!(label.notes, rt.notes);
+}
+
+// ===========================================================================
+// 9. FunReport with None eco_label round-trips
+// ===========================================================================
+#[test]
+fn fun_report_none_eco_label_roundtrip() {
+    let report = FunReport { eco_label: None };
+    let json = serde_json::to_string(&report).unwrap();
+    let rt: FunReport = serde_json::from_str(&json).unwrap();
+    assert!(rt.eco_label.is_none());
+}
+
+// ===========================================================================
+// 10. JSON pretty-print round-trips identically
+// ===========================================================================
+#[test]
+fn json_pretty_print_roundtrip() {
+    let report = build_fun_report(&derived_bytes(42 * 1024 * 1024));
+    let pretty = serde_json::to_string_pretty(&report).unwrap();
+    let rt: FunReport = serde_json::from_str(&pretty).unwrap();
+    let repretty = serde_json::to_string_pretty(&rt).unwrap();
+    assert_eq!(pretty, repretty);
+}
+
+// ===========================================================================
+// 11. Notes contain MB substring for every band
+// ===========================================================================
+#[test]
+fn notes_always_contain_mb() {
+    let sizes = [0, 500, 1_000_000, 50_000_000, 300_000_000];
+    for &b in &sizes {
+        let eco = build_fun_report(&derived_bytes(b)).eco_label.unwrap();
+        assert!(eco.notes.contains("MB"), "no MB in notes for {b} bytes");
+    }
+}
+
+// ===========================================================================
+// 12. Notes prefix is constant
+// ===========================================================================
+#[test]
+fn notes_prefix_constant() {
+    for &b in &[0usize, 1024, 1_000_000, 999_999_999] {
+        let eco = build_fun_report(&derived_bytes(b)).eco_label.unwrap();
+        assert!(
+            eco.notes.starts_with("Size-based eco label ("),
+            "prefix wrong for {b}: {}",
+            eco.notes
+        );
+    }
+}
+
+// ===========================================================================
+// 13. Notes suffix is constant
+// ===========================================================================
+#[test]
+fn notes_suffix_constant() {
+    for &b in &[0usize, 1024, 1_000_000, 999_999_999] {
+        let eco = build_fun_report(&derived_bytes(b)).eco_label.unwrap();
+        assert!(
+            eco.notes.ends_with(" MB)"),
+            "suffix wrong for {b}: {}",
+            eco.notes
+        );
+    }
+}
+
+// ===========================================================================
+// 14. Bytes field always matches input
+// ===========================================================================
+#[test]
+fn bytes_field_echoes_input() {
+    for &b in &[0usize, 1, 1024, 999_999, 1_000_000_000] {
+        let eco = build_fun_report(&derived_bytes(b)).eco_label.unwrap();
+        assert_eq!(eco.bytes, b as u64);
+    }
+}
+
+// ===========================================================================
+// 15. Deterministic: identical input always yields identical JSON
+// ===========================================================================
+#[test]
+fn deterministic_json_output() {
+    let d = derived_bytes(12_345_678);
+    let j1 = serde_json::to_string(&build_fun_report(&d)).unwrap();
+    let j2 = serde_json::to_string(&build_fun_report(&d)).unwrap();
+    assert_eq!(j1, j2);
+}
+
+// ===========================================================================
+// 16. All five bands produce distinct (label, score) pairs
+// ===========================================================================
+#[test]
+fn five_bands_distinct() {
+    let band_bytes = [
+        0usize,            // A
+        5 * 1024 * 1024,   // B
+        25 * 1024 * 1024,  // C
+        100 * 1024 * 1024, // D
+        500 * 1024 * 1024, // E
+    ];
+    let pairs: Vec<(String, f64)> = band_bytes
+        .iter()
+        .map(|&b| {
+            let e = build_fun_report(&derived_bytes(b)).eco_label.unwrap();
+            (e.label, e.score)
+        })
+        .collect();
+    // All distinct
+    for i in 0..pairs.len() {
+        for j in (i + 1)..pairs.len() {
+            assert_ne!(pairs[i], pairs[j], "bands {i} and {j} collide");
+        }
+    }
+}
+
+// ===========================================================================
+// 17. Grade A score is highest
+// ===========================================================================
+#[test]
+fn grade_a_has_highest_score() {
+    let a_score = build_fun_report(&derived_bytes(0)).eco_label.unwrap().score;
+    for &b in &[5_000_000usize, 25_000_000, 100_000_000, 500_000_000] {
+        let s = build_fun_report(&derived_bytes(b)).eco_label.unwrap().score;
+        assert!(a_score > s, "A score {} not > {}", a_score, s);
+    }
+}
+
+// ===========================================================================
+// 18. Grade E score is lowest
+// ===========================================================================
+#[test]
+fn grade_e_has_lowest_score() {
+    let e_score = build_fun_report(&derived_bytes(500_000_000))
+        .eco_label
+        .unwrap()
+        .score;
+    for &b in &[0usize, 5_000_000, 25_000_000, 100_000_000] {
+        let s = build_fun_report(&derived_bytes(b)).eco_label.unwrap().score;
+        assert!(e_score < s, "E score {} not < {}", e_score, s);
+    }
+}
+
+// ===========================================================================
+// 19. Notes MB value matches computed rounding
+// ===========================================================================
+#[test]
+fn notes_mb_value_matches_computation() {
+    for &bytes in &[0usize, 1, 524_288, 1_048_576, 10_485_760, 104_857_600] {
+        let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+        let mb = bytes as f64 / (1024.0 * 1024.0);
+        let rounded = (mb * 100.0).round() / 100.0;
+        let expected = format!("Size-based eco label ({rounded} MB)");
+        assert_eq!(eco.notes, expected, "notes mismatch for {bytes} bytes");
+    }
+}
+
+// ===========================================================================
+// 20. Changing file count but same bytes produces same eco-label
+// ===========================================================================
+#[test]
+fn file_count_does_not_affect_eco_label() {
+    let bytes = 5 * 1024 * 1024;
+    let e1 = build_fun_report(&derived_with(bytes, 1, 100))
+        .eco_label
+        .unwrap();
+    let e2 = build_fun_report(&derived_with(bytes, 10_000, 500_000))
+        .eco_label
+        .unwrap();
+    assert_eq!(e1.label, e2.label);
+    assert_eq!(e1.score, e2.score);
+    assert_eq!(e1.bytes, e2.bytes);
+}
+
+// ===========================================================================
+// 21. Changing code count but same bytes produces same eco-label
+// ===========================================================================
+#[test]
+fn code_count_does_not_affect_eco_label() {
+    let bytes = 20 * 1024 * 1024;
+    let e1 = build_fun_report(&derived_with(bytes, 100, 10))
+        .eco_label
+        .unwrap();
+    let e2 = build_fun_report(&derived_with(bytes, 100, 1_000_000))
+        .eco_label
+        .unwrap();
+    assert_eq!(e1.label, e2.label);
+    assert_eq!(e1.score, e2.score);
+}
+
+// ===========================================================================
+// 22. JSON contains expected keys
+// ===========================================================================
+#[test]
+fn json_contains_expected_keys() {
+    let report = build_fun_report(&derived_bytes(1024));
+    let val: serde_json::Value = serde_json::to_value(&report).unwrap();
+    assert!(val.get("eco_label").is_some());
+    let eco = val.get("eco_label").unwrap();
+    assert!(eco.get("score").is_some());
+    assert!(eco.get("label").is_some());
+    assert!(eco.get("bytes").is_some());
+    assert!(eco.get("notes").is_some());
+}
+
+// ===========================================================================
+// 23. JSON null eco_label when None
+// ===========================================================================
+#[test]
+fn json_null_eco_label() {
+    let report = FunReport { eco_label: None };
+    let val: serde_json::Value = serde_json::to_value(&report).unwrap();
+    assert!(val.get("eco_label").unwrap().is_null());
+}
+
+// ===========================================================================
+// 24. Boundary: exactly at each MB threshold
+// ===========================================================================
+#[test]
+fn boundary_exact_thresholds() {
+    let cases: Vec<(usize, &str)> = vec![
+        (1_048_576, "A"),   // exactly 1 MB
+        (10_485_760, "B"),  // exactly 10 MB
+        (52_428_800, "C"),  // exactly 50 MB
+        (209_715_200, "D"), // exactly 200 MB
+    ];
+    for (bytes, expected) in cases {
+        let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+        assert_eq!(eco.label, expected, "wrong label at {} bytes", bytes);
+    }
+}
+
+// ===========================================================================
+// 25. Boundary: one byte past each threshold transitions to next band
+// ===========================================================================
+#[test]
+fn boundary_one_past_threshold() {
+    let cases: Vec<(usize, &str)> = vec![
+        (1_048_577, "B"),   // 1 MB + 1
+        (10_485_761, "C"),  // 10 MB + 1
+        (52_428_801, "D"),  // 50 MB + 1
+        (209_715_201, "E"), // 200 MB + 1
+    ];
+    for (bytes, expected) in cases {
+        let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+        assert_eq!(eco.label, expected, "wrong label at {} bytes", bytes);
+    }
+}
+
+// ===========================================================================
+// 26. Score values are exactly the documented constants
+// ===========================================================================
+#[test]
+fn score_exact_values() {
+    let map: Vec<(&str, f64)> = vec![
+        ("A", 95.0),
+        ("B", 80.0),
+        ("C", 65.0),
+        ("D", 45.0),
+        ("E", 30.0),
+    ];
+    let byte_samples = [0, 5_000_000, 25_000_000, 100_000_000, 500_000_000];
+    for (&bytes, (expected_label, expected_score)) in byte_samples.iter().zip(map.iter()) {
+        let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+        assert_eq!(eco.label, *expected_label);
+        assert!((eco.score - expected_score).abs() < f64::EPSILON);
+    }
+}
+
+// ===========================================================================
+// 27. Notes with very large repos show correct MB value
+// ===========================================================================
+#[test]
+fn notes_very_large_repo() {
+    let bytes = 1024 * 1024 * 1024; // 1 GB
+    let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+    assert!(eco.notes.contains("1024 MB"), "got: {}", eco.notes);
+}
+
+// ===========================================================================
+// Property-based tests
+// ===========================================================================
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Every generated report round-trips through JSON.
+        #[test]
+        fn serde_roundtrip_arbitrary(bytes in 0usize..=(1024 * 1024 * 1024)) {
+            let report = build_fun_report(&derived_bytes(bytes));
+            let json = serde_json::to_string(&report).unwrap();
+            let rt: FunReport = serde_json::from_str(&json).unwrap();
+            let o = report.eco_label.unwrap();
+            let r = rt.eco_label.unwrap();
+            prop_assert_eq!(&o.label, &r.label);
+            prop_assert_eq!(o.score, r.score);
+            prop_assert_eq!(o.bytes, r.bytes);
+            prop_assert_eq!(&o.notes, &r.notes);
+        }
+
+        /// Label is always one character long.
+        #[test]
+        fn label_single_char(bytes in 0usize..=(1024 * 1024 * 1024)) {
+            let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+            prop_assert_eq!(eco.label.len(), 1);
+        }
+
+        /// Score is finite and positive.
+        #[test]
+        fn score_finite_positive(bytes in 0usize..=(1024 * 1024 * 1024)) {
+            let eco = build_fun_report(&derived_bytes(bytes)).eco_label.unwrap();
+            prop_assert!(eco.score.is_finite());
+            prop_assert!(eco.score > 0.0);
+        }
+    }
+}


### PR DESCRIPTION
Wave 57 Agent 123: 65 tests across 2 crates.

- tokmd-analysis-fun: 30 tests (eco-label, serde, determinism, boundaries)
- tokmd-analysis-assets: 35 tests (6 asset categories, lockfiles, serde, ordering)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>