### PR TITLE
fix(ci): rustfmt gate.rs and exclude tokmd-python from quality gate

### DIFF
--- a/xtask/src/tasks/gate.rs
+++ b/xtask/src/tasks/gate.rs
@@ -19,7 +19,13 @@ const STEPS: &[Step] = &[
     Step {
         label: "check (warm graph)",
         cmd: "cargo",
-        args: &["check", "--workspace", "--all-features"],
+        args: &[
+            "check",
+            "--workspace",
+            "--all-features",
+            "--exclude",
+            "tokmd-python",
+        ],
         check_args: None,
     },
     Step {
@@ -30,6 +36,8 @@ const STEPS: &[Step] = &[
             "--workspace",
             "--all-targets",
             "--all-features",
+            "--exclude",
+            "tokmd-python",
             "--",
             "-D",
             "warnings",
@@ -39,7 +47,14 @@ const STEPS: &[Step] = &[
     Step {
         label: "test (compile-only)",
         cmd: "cargo",
-        args: &["test", "--workspace", "--all-features", "--no-run"],
+        args: &[
+            "test",
+            "--workspace",
+            "--all-features",
+            "--no-run",
+            "--exclude",
+            "tokmd-python",
+        ],
         check_args: None,
     },
 ];
@@ -76,11 +91,13 @@ pub fn run(args: GateArgs) -> Result<()> {
         for (label, code) in &failures {
             println!("  - {label} (exit code: {code})");
         }
-        
+
         if args.check {
-            println!("\nTip: Run 'cargo xtask gate' (without --check) to auto-fix formatting issues.");
+            println!(
+                "\nTip: Run 'cargo xtask gate' (without --check) to auto-fix formatting issues."
+            );
         }
-        
+
         bail!("quality gate failed with {} failure(s)", failures.len());
     }
 


### PR DESCRIPTION
## Summary

Fixes CI run #1484 (sha 95a5034) which is RED with two failures:

### 1. rustfmt formatting diff in gate.rs
Nightly/1.93 rustfmt expects the long `println!` macro call to be broken across lines and trailing whitespace removed. Fixed by running `cargo fmt`.

### 2. tokmd-python compile error in Quality Gate
The quality gate runs `cargo check/clippy/test --workspace --all-features` which includes `tokmd-python`. Since pyo3 requires Python development headers/libraries that aren't available in the CI runner, this fails.

Fixed by adding `--exclude tokmd-python` to the check, clippy, and test-compile steps in `xtask/src/tasks/gate.rs`. The `fmt` step is unaffected (formatting doesn't require linking).

Note: `tokmd-python` is already excluded from `default-members` in the root `Cargo.toml`, so normal `cargo build/test` (without `--workspace`) already skips it.