### PR TITLE
feat(wasm): add tokmd-io-port crate with ReadFs trait and MemFs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,6 +3524,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokmd-io-port"
+version = "1.7.2"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "tokmd-math"
 version = "1.7.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "crates/tokmd-types",
     "crates/tokmd-cockpit",
     "crates/tokmd-walk",
+    "crates/tokmd-io-port",
     "fuzz",
     "xtask",
 ]
@@ -184,6 +185,7 @@ tokmd-tokeignore = { path = "crates/tokmd-tokeignore", version = "1.7.2" }
 tokmd-tool-schema = { path = "crates/tokmd-tool-schema", version = "1.7.2" }
 tokmd-types = { path = "crates/tokmd-types", version = "1.7.2" }
 tokmd-walk = { path = "crates/tokmd-walk", version = "1.7.2" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.7.2" }
 tokmd-gate = { path = "crates/tokmd-gate", version = "1.7.2" }
 tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.7.2" }
 

--- a/crates/tokmd-io-port/Cargo.toml
+++ b/crates/tokmd-io-port/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tokmd-io-port"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "I/O port traits for host-abstracted file access, enabling WASM targets."
+readme = "README.md"
+keywords = ["io", "wasm", "abstraction", "filesystem", "microcrate"]
+categories = ["development-tools"]
+documentation = "https://docs.rs/tokmd-io-port"
+
+[dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tokmd-io-port/README.md
+++ b/crates/tokmd-io-port/README.md
@@ -1,0 +1,18 @@
+# tokmd-io-port
+
+I/O port traits for host-abstracted file access.
+
+Provides `ReadFs` – a trait that abstracts read-only filesystem operations so
+that `tokmd-scan` (and other crates) can work against in-memory data when
+compiled for WASM targets.
+
+## Implementations
+
+| Struct   | Purpose                            |
+|----------|------------------------------------|
+| `HostFs` | Delegates to `std::fs` (default)   |
+| `MemFs`  | In-memory store for tests and WASM |
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/tokmd-io-port/src/lib.rs
+++ b/crates/tokmd-io-port/src/lib.rs
@@ -1,0 +1,291 @@
+//! # tokmd-io-port
+//!
+//! **Tier 0 (Contract)**
+//!
+//! I/O port traits for host-abstracted file access.
+//! Enables WASM targets by replacing real fs with in-memory backends.
+//!
+//! ## What belongs here
+//! * The `ReadFs` trait and its implementations
+//! * `HostFs` – delegates to `std::fs`
+//! * `MemFs` – in-memory store for tests and WASM
+//!
+//! ## What does NOT belong here
+//! * Directory traversal / walking (use tokmd-walk)
+//! * Content scanning (use tokmd-scan)
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// Read-only filesystem port.
+pub trait ReadFs {
+    type Error: std::error::Error;
+
+    fn read_to_string(&self, path: &Path) -> Result<String, Self::Error>;
+    fn read_bytes(&self, path: &Path) -> Result<Vec<u8>, Self::Error>;
+    fn exists(&self, path: &Path) -> bool;
+    fn is_dir(&self, path: &Path) -> bool;
+    fn is_file(&self, path: &Path) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// HostFs – default std::fs implementation
+// ---------------------------------------------------------------------------
+
+/// Default host filesystem implementation.
+#[derive(Debug, Clone, Copy)]
+pub struct HostFs;
+
+impl ReadFs for HostFs {
+    type Error = std::io::Error;
+
+    fn read_to_string(&self, path: &Path) -> Result<String, Self::Error> {
+        std::fs::read_to_string(path)
+    }
+
+    fn read_bytes(&self, path: &Path) -> Result<Vec<u8>, Self::Error> {
+        std::fs::read(path)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        path.is_file()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MemFs – in-memory filesystem for testing and WASM
+// ---------------------------------------------------------------------------
+
+/// In-memory filesystem for testing and WASM.
+///
+/// Files are stored as byte vectors keyed by path. Directories are inferred
+/// from the set of stored file paths – any path that is a proper prefix of a
+/// stored file is considered a directory.
+#[derive(Debug, Clone, Default)]
+pub struct MemFs {
+    files: BTreeMap<PathBuf, Vec<u8>>,
+}
+
+/// Error type returned by [`MemFs`] operations.
+#[derive(Debug)]
+pub struct MemFsError {
+    kind: MemFsErrorKind,
+    path: PathBuf,
+}
+
+#[derive(Debug)]
+enum MemFsErrorKind {
+    NotFound,
+    InvalidUtf8,
+}
+
+impl std::fmt::Display for MemFsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            MemFsErrorKind::NotFound => write!(f, "not found: {}", self.path.display()),
+            MemFsErrorKind::InvalidUtf8 => {
+                write!(f, "invalid UTF-8 in: {}", self.path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for MemFsError {}
+
+impl MemFs {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a UTF-8 file.
+    pub fn add_file(&mut self, path: impl Into<PathBuf>, contents: impl Into<String>) {
+        self.files.insert(path.into(), contents.into().into_bytes());
+    }
+
+    /// Insert a binary file.
+    pub fn add_bytes(&mut self, path: impl Into<PathBuf>, bytes: impl Into<Vec<u8>>) {
+        self.files.insert(path.into(), bytes.into());
+    }
+
+    fn not_found(&self, path: &Path) -> MemFsError {
+        MemFsError {
+            kind: MemFsErrorKind::NotFound,
+            path: path.to_path_buf(),
+        }
+    }
+}
+
+impl ReadFs for MemFs {
+    type Error = MemFsError;
+
+    fn read_to_string(&self, path: &Path) -> Result<String, Self::Error> {
+        let bytes = self.files.get(path).ok_or_else(|| self.not_found(path))?;
+        String::from_utf8(bytes.clone()).map_err(|_| MemFsError {
+            kind: MemFsErrorKind::InvalidUtf8,
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn read_bytes(&self, path: &Path) -> Result<Vec<u8>, Self::Error> {
+        self.files
+            .get(path)
+            .cloned()
+            .ok_or_else(|| self.not_found(path))
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.is_file(path) || self.is_dir(path)
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        // A path is a directory if any stored file has it as a proper prefix.
+        self.files.keys().any(|k| k.starts_with(path) && k != path)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.files.contains_key(path)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- HostFs tests ----
+
+    #[test]
+    fn host_fs_read_to_string() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("hello.txt");
+        std::fs::write(&file, "hello world").unwrap();
+
+        let fs = HostFs;
+        assert_eq!(fs.read_to_string(&file).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn host_fs_read_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("data.bin");
+        std::fs::write(&file, b"\x00\x01\x02").unwrap();
+
+        let fs = HostFs;
+        assert_eq!(fs.read_bytes(&file).unwrap(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn host_fs_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("exists.txt");
+        std::fs::write(&file, "").unwrap();
+
+        let fs = HostFs;
+        assert!(fs.exists(&file));
+        assert!(!fs.exists(&dir.path().join("nope.txt")));
+    }
+
+    #[test]
+    fn host_fs_is_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = HostFs;
+        assert!(fs.is_dir(dir.path()));
+        assert!(!fs.is_dir(&dir.path().join("nope")));
+    }
+
+    #[test]
+    fn host_fs_is_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("f.txt");
+        std::fs::write(&file, "x").unwrap();
+
+        let fs = HostFs;
+        assert!(fs.is_file(&file));
+        assert!(!fs.is_file(dir.path()));
+    }
+
+    #[test]
+    fn host_fs_read_missing_file_errors() {
+        let fs = HostFs;
+        let result = fs.read_to_string(Path::new("/definitely/not/here.txt"));
+        assert!(result.is_err());
+    }
+
+    // ---- MemFs tests ----
+
+    #[test]
+    fn mem_fs_read_to_string() {
+        let mut fs = MemFs::new();
+        fs.add_file(PathBuf::from("a.txt"), "contents");
+        assert_eq!(fs.read_to_string(Path::new("a.txt")).unwrap(), "contents");
+    }
+
+    #[test]
+    fn mem_fs_read_bytes() {
+        let mut fs = MemFs::new();
+        fs.add_bytes(PathBuf::from("b.bin"), vec![0xDE, 0xAD]);
+        assert_eq!(fs.read_bytes(Path::new("b.bin")).unwrap(), vec![0xDE, 0xAD]);
+    }
+
+    #[test]
+    fn mem_fs_not_found() {
+        let fs = MemFs::new();
+        let err = fs.read_to_string(Path::new("missing.txt")).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn mem_fs_invalid_utf8() {
+        let mut fs = MemFs::new();
+        fs.add_bytes(PathBuf::from("bad.txt"), vec![0xFF, 0xFE]);
+        let err = fs.read_to_string(Path::new("bad.txt")).unwrap_err();
+        assert!(err.to_string().contains("invalid UTF-8"));
+    }
+
+    #[test]
+    fn mem_fs_exists() {
+        let mut fs = MemFs::new();
+        fs.add_file(PathBuf::from("src/lib.rs"), "fn main() {}");
+        assert!(fs.exists(Path::new("src/lib.rs")));
+        assert!(fs.exists(Path::new("src"))); // directory
+        assert!(!fs.exists(Path::new("nope")));
+    }
+
+    #[test]
+    fn mem_fs_is_dir() {
+        let mut fs = MemFs::new();
+        fs.add_file(PathBuf::from("src/lib.rs"), "");
+        assert!(fs.is_dir(Path::new("src")));
+        assert!(!fs.is_dir(Path::new("src/lib.rs"))); // file, not dir
+        assert!(!fs.is_dir(Path::new("other")));
+    }
+
+    #[test]
+    fn mem_fs_is_file() {
+        let mut fs = MemFs::new();
+        fs.add_file(PathBuf::from("src/lib.rs"), "");
+        assert!(fs.is_file(Path::new("src/lib.rs")));
+        assert!(!fs.is_file(Path::new("src")));
+    }
+
+    #[test]
+    fn mem_fs_default_is_empty() {
+        let fs = MemFs::default();
+        assert!(!fs.exists(Path::new("anything")));
+    }
+}


### PR DESCRIPTION
## Summary

Introduces 	okmd-io-port, a new microcrate with trait-based I/O ports that abstract filesystem access. This is a prerequisite for WASM support — it allows 	okmd-scan and other crates to operate against in-memory data instead of requiring a real filesystem.

## What's included

| Type | Name | Purpose |
|------|------|---------|
| Trait | \ReadFs\ | Read-only filesystem port (\ead_to_string\, \ead_bytes\, \xists\, \is_dir\, \is_file\) |
| Struct | \HostFs\ | Default implementation delegating to \std::fs\ |
| Struct | \MemFs\ | \BTreeMap\-backed in-memory filesystem for tests and WASM |

## Test coverage

14 unit tests covering both implementations (HostFs and MemFs), including error paths (not found, invalid UTF-8).

## What's NOT included

This is a **new crate with no consumers yet**. Wiring \ReadFs\ into \	okmd-scan\ and \	okmd-walk\ will follow in a separate PR.

## Checklist

- [x] New crate added to workspace \members\ and \workspace.dependencies\
- [x] \cargo fmt\ clean
- [x] \cargo test -p tokmd-io-port\ — 14/14 passing
- [x] No existing crates modified (additive only)