### PR TITLE
fix: Nix Build compatibility for Rust 1.93

### DIFF
--- a/crates/tokmd-analysis-assets/tests/assets_depth_w57.rs
+++ b/crates/tokmd-analysis-assets/tests/assets_depth_w57.rs
@@ -500,8 +500,10 @@ fn dependency_report_deterministic_json() {
     let tmp = TempDir::new().unwrap();
     let cargo = "[[package]]\nname = \"z\"\n\n[[package]]\nname = \"a\"\n";
     let rel = write_file(tmp.path(), "Cargo.lock", cargo.as_bytes());
-    let j1 = serde_json::to_string(&build_dependency_report(tmp.path(), &[rel.clone()]).unwrap())
-        .unwrap();
+    let j1 = serde_json::to_string(
+        &build_dependency_report(tmp.path(), std::slice::from_ref(&rel)).unwrap(),
+    )
+    .unwrap();
     let j2 = serde_json::to_string(&build_dependency_report(tmp.path(), &[rel]).unwrap()).unwrap();
     assert_eq!(j1, j2);
 }

--- a/crates/tokmd-context-git/tests/context_git_depth_w55.rs
+++ b/crates/tokmd-context-git/tests/context_git_depth_w55.rs
@@ -257,12 +257,13 @@ fn hotspot_equals_lines_times_commits_manually() {
 #[test]
 fn all_hotspots_non_negative() {
     let mut h = BTreeMap::new();
-    h.insert("a.rs".to_string(), 0);
+    h.insert("a.rs".to_string(), 0_usize);
     h.insert("b.rs".to_string(), 100);
     h.insert("c.rs".to_string(), usize::MAX);
+    // usize is inherently non-negative; verify all values are present
+    assert_eq!(h.len(), 3);
     for val in h.values() {
-        // usize is always non-negative
-        assert!(*val <= usize::MAX);
+        assert_eq!(*val, *val);
     }
 }
 

--- a/crates/tokmd-fun/tests/fun_outputs_w54.rs
+++ b/crates/tokmd-fun/tests/fun_outputs_w54.rs
@@ -746,7 +746,7 @@ mod properties {
             h in 0.0f32..50.0,
         ) {
             let b = ObjBuilding { name: "det".into(), x, y, w, d, h };
-            prop_assert_eq!(render_obj(&[b.clone()]), render_obj(&[b]));
+            prop_assert_eq!(render_obj(std::slice::from_ref(&b)), render_obj(&[b]));
         }
 
         #[test]
@@ -770,7 +770,7 @@ mod properties {
             tempo in 1u16..=300,
         ) {
             let note = MidiNote { key, velocity: vel, start, duration: dur, channel: ch };
-            let r1 = render_midi(&[note.clone()], tempo).unwrap();
+            let r1 = render_midi(std::slice::from_ref(&note), tempo).unwrap();
             let r2 = render_midi(&[note], tempo).unwrap();
             prop_assert_eq!(r1, r2);
         }

--- a/xtask/src/tasks/gate.rs
+++ b/xtask/src/tasks/gate.rs
@@ -1,5 +1,5 @@
 use crate::cli::GateArgs;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::process::Command;
 
 struct Step {
@@ -76,11 +76,13 @@ pub fn run(args: GateArgs) -> Result<()> {
         for (label, code) in &failures {
             println!("  - {label} (exit code: {code})");
         }
-        
+
         if args.check {
-            println!("\nTip: Run 'cargo xtask gate' (without --check) to auto-fix formatting issues.");
+            println!(
+                "\nTip: Run 'cargo xtask gate' (without --check) to auto-fix formatting issues."
+            );
         }
-        
+
         bail!("quality gate failed with {} failure(s)", failures.len());
     }
 

--- a/xtask/src/tasks/lint_fix.rs
+++ b/xtask/src/tasks/lint_fix.rs
@@ -1,5 +1,5 @@
 use crate::cli::LintFixArgs;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::process::Command;
 
 pub fn run(args: LintFixArgs) -> Result<()> {


### PR DESCRIPTION
## What changed
- Fix trailing whitespace and long println! in xtask gate.rs (Rust 1.93 rustfmt)
- Replace \&[x.clone()]\ with \std::slice::from_ref(&x)\ (clippy::cloned_ref_to_slice_refs)
- Remove always-true \ssert!(*val <= usize::MAX)\ (clippy::absurd_extreme_comparisons)

## Why
Rust 1.93 (used by Nix Build) has stricter clippy and rustfmt. These fixes address all known Nix Build failures including formatting issues introduced by #506.

## Files changed
- xtask/src/tasks/gate.rs (trailing whitespace + long line)
- crates/tokmd-fun/tests/fun_outputs_w54.rs (cloned_ref_to_slice_refs)
- crates/tokmd-analysis-assets/tests/assets_depth_w57.rs (cloned_ref_to_slice_refs)
- crates/tokmd-context-git/tests/context_git_depth_w55.rs (absurd_extreme_comparisons)

Supersedes #512 and #505.

## Disposition: MERGE NOW (A)