### PR TITLE
test(w59): depth tests for math statistics and path normalization

### DIFF
--- a/crates/tokmd-math/tests/property_w59.rs
+++ b/crates/tokmd-math/tests/property_w59.rs
@@ -1,0 +1,146 @@
+//! Wave-59 property-based tests for tokmd-math — statistical bounds,
+//! sorting invariants, and algebraic properties.
+
+use proptest::prelude::*;
+use tokmd_math::{gini_coefficient, percentile, round_f64, safe_ratio};
+
+// ── round_f64 properties ─────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    #[test]
+    fn round_idempotent(val in -1e6f64..1e6, dec in 0u32..10) {
+        let once = round_f64(val, dec);
+        let twice = round_f64(once, dec);
+        prop_assert!(
+            (once - twice).abs() < f64::EPSILON,
+            "round_f64 must be idempotent: once={once}, twice={twice}"
+        );
+    }
+
+    #[test]
+    fn round_preserves_finiteness(val in -1e15f64..1e15, dec in 0u32..10) {
+        let r = round_f64(val, dec);
+        prop_assert!(r.is_finite(), "round_f64 of finite input should be finite");
+    }
+
+    #[test]
+    fn round_zero_decimals_is_integer(val in -1e6f64..1e6) {
+        let r = round_f64(val, 0);
+        prop_assert_eq!(r, r.round(), "zero-decimal rounding should be integer");
+    }
+
+    // ── safe_ratio properties ────────────────────────────────────────────
+
+    #[test]
+    fn safe_ratio_non_negative(n in 0usize..1_000_000, d in 0usize..1_000_000) {
+        let r = safe_ratio(n, d);
+        prop_assert!(r >= 0.0, "safe_ratio must be non-negative, got {r}");
+    }
+
+    #[test]
+    fn safe_ratio_finite(n in 0usize..=usize::MAX, d in 0usize..=usize::MAX) {
+        let r = safe_ratio(n, d);
+        prop_assert!(r.is_finite(), "safe_ratio must always be finite");
+    }
+
+    #[test]
+    fn safe_ratio_zero_denom_always_zero(n in 0usize..1_000_000) {
+        prop_assert_eq!(safe_ratio(n, 0), 0.0);
+    }
+
+    // ── percentile properties ────────────────────────────────────────────
+
+    #[test]
+    fn percentile_bounded_by_min_max(
+        mut data in prop::collection::vec(0usize..10_000, 1..100),
+        pct in 0.0f64..=1.0,
+    ) {
+        data.sort();
+        let p = percentile(&data, pct);
+        let min = *data.first().unwrap() as f64;
+        let max = *data.last().unwrap() as f64;
+        prop_assert!(p >= min, "percentile {p} < min {min}");
+        prop_assert!(p <= max, "percentile {p} > max {max}");
+    }
+
+    #[test]
+    fn percentile_zero_is_minimum(
+        mut data in prop::collection::vec(0usize..10_000, 1..50),
+    ) {
+        data.sort();
+        let p = percentile(&data, 0.0);
+        prop_assert_eq!(p, *data.first().unwrap() as f64);
+    }
+
+    #[test]
+    fn percentile_one_is_maximum(
+        mut data in prop::collection::vec(0usize..10_000, 1..50),
+    ) {
+        data.sort();
+        let p = percentile(&data, 1.0);
+        prop_assert_eq!(p, *data.last().unwrap() as f64);
+    }
+
+    #[test]
+    fn percentile_monotonic(
+        mut data in prop::collection::vec(0usize..10_000, 2..50),
+    ) {
+        data.sort();
+        let mut prev = percentile(&data, 0.0);
+        for i in 1..=10 {
+            let pct = i as f64 / 10.0;
+            let cur = percentile(&data, pct);
+            prop_assert!(cur >= prev, "percentile not monotonic: p({})={} < p({})={}", pct, cur, (i-1) as f64 / 10.0, prev);
+            prev = cur;
+        }
+    }
+
+    // ── gini_coefficient properties ──────────────────────────────────────
+
+    #[test]
+    fn gini_bounded(
+        mut data in prop::collection::vec(0usize..10_000, 1..100),
+    ) {
+        data.sort();
+        let g = gini_coefficient(&data);
+        prop_assert!(g >= 0.0, "gini must be >= 0, got {g}");
+        prop_assert!(g <= 1.0, "gini must be <= 1, got {g}");
+    }
+
+    #[test]
+    fn gini_uniform_is_zero(val in 1usize..10_000, len in 2usize..50) {
+        let data = vec![val; len];
+        let g = gini_coefficient(&data);
+        prop_assert!(
+            g.abs() < 1e-10,
+            "uniform distribution should have gini ≈ 0, got {g}"
+        );
+    }
+
+    #[test]
+    fn gini_scale_invariant(
+        mut data in prop::collection::vec(1usize..1_000, 2..30),
+        factor in 1usize..100,
+    ) {
+        data.sort();
+        let g1 = gini_coefficient(&data);
+        let scaled: Vec<usize> = data.iter().map(|v| v * factor).collect();
+        let g2 = gini_coefficient(&scaled);
+        prop_assert!(
+            (g1 - g2).abs() < 1e-10,
+            "gini should be scale-invariant: g1={g1}, g2={g2}"
+        );
+    }
+
+    #[test]
+    fn gini_deterministic(
+        mut data in prop::collection::vec(0usize..5_000, 1..50),
+    ) {
+        data.sort();
+        let g1 = gini_coefficient(&data);
+        let g2 = gini_coefficient(&data);
+        prop_assert_eq!(g1.to_bits(), g2.to_bits(), "gini must be deterministic");
+    }
+}

--- a/crates/tokmd-math/tests/stats_edge_w59.rs
+++ b/crates/tokmd-math/tests/stats_edge_w59.rs
@@ -1,0 +1,261 @@
+//! Wave-59 depth tests for statistical functions — edge cases, known values,
+//! overflow behaviour, and COCOMO-style estimation inputs.
+
+use tokmd_math::{gini_coefficient, percentile, round_f64, safe_ratio};
+
+// ── round_f64 ────────────────────────────────────────────────────────────
+
+#[test]
+fn round_zero_decimals_truncates_fraction() {
+    assert_eq!(round_f64(2.4, 0), 2.0);
+    assert_eq!(round_f64(2.5, 0), 3.0); // banker's rounding not used
+    assert_eq!(round_f64(2.6, 0), 3.0);
+}
+
+#[test]
+fn round_high_precision_preserves_digits() {
+    assert_eq!(round_f64(1.123_456_789, 6), 1.123_457);
+    assert_eq!(round_f64(1.123_456_789, 8), 1.123_456_79);
+}
+
+#[test]
+fn round_negative_values() {
+    assert_eq!(round_f64(-3.456, 2), -3.46);
+    assert_eq!(round_f64(-0.005, 2), -0.01);
+    assert_eq!(round_f64(-100.999, 1), -101.0);
+}
+
+#[test]
+fn round_nan_returns_nan() {
+    assert!(round_f64(f64::NAN, 2).is_nan());
+}
+
+#[test]
+fn round_infinity_returns_infinity() {
+    assert_eq!(round_f64(f64::INFINITY, 3), f64::INFINITY);
+    assert_eq!(round_f64(f64::NEG_INFINITY, 3), f64::NEG_INFINITY);
+}
+
+#[test]
+fn round_very_large_value() {
+    let big = 1e15;
+    let result = round_f64(big, 2);
+    assert_eq!(result, big);
+}
+
+#[test]
+fn round_zero_is_zero() {
+    assert_eq!(round_f64(0.0, 5), 0.0);
+    assert_eq!(round_f64(-0.0, 3), 0.0);
+}
+
+// ── safe_ratio ───────────────────────────────────────────────────────────
+
+#[test]
+fn safe_ratio_zero_numerator() {
+    assert_eq!(safe_ratio(0, 100), 0.0);
+}
+
+#[test]
+fn safe_ratio_equal_values_gives_one() {
+    assert_eq!(safe_ratio(42, 42), 1.0);
+}
+
+#[test]
+fn safe_ratio_both_zero() {
+    assert_eq!(safe_ratio(0, 0), 0.0);
+}
+
+#[test]
+fn safe_ratio_large_values() {
+    let r = safe_ratio(usize::MAX, usize::MAX);
+    assert_eq!(r, 1.0);
+}
+
+#[test]
+fn safe_ratio_one_over_three() {
+    assert_eq!(safe_ratio(1, 3), 0.3333);
+}
+
+#[test]
+fn safe_ratio_two_over_three() {
+    assert_eq!(safe_ratio(2, 3), 0.6667);
+}
+
+#[test]
+fn safe_ratio_numerator_greater_than_denominator() {
+    let r = safe_ratio(10, 3);
+    assert_eq!(r, 3.3333);
+}
+
+// ── percentile ───────────────────────────────────────────────────────────
+
+#[test]
+fn percentile_empty_slice_returns_zero() {
+    assert_eq!(percentile(&[], 0.5), 0.0);
+}
+
+#[test]
+fn percentile_single_element() {
+    assert_eq!(percentile(std::slice::from_ref(&42usize), 0.0), 42.0);
+    assert_eq!(percentile(std::slice::from_ref(&42usize), 0.5), 42.0);
+    assert_eq!(percentile(std::slice::from_ref(&42usize), 1.0), 42.0);
+}
+
+#[test]
+fn percentile_two_elements() {
+    let data = [10, 20];
+    assert_eq!(percentile(&data, 0.0), 10.0);
+    assert_eq!(percentile(&data, 1.0), 20.0);
+}
+
+#[test]
+fn percentile_median_of_odd_count() {
+    let data = [1, 2, 3, 4, 5];
+    assert_eq!(percentile(&data, 0.5), 3.0);
+}
+
+#[test]
+fn percentile_median_of_even_count() {
+    let data = [10, 20, 30, 40];
+    // ceil-based indexing: idx = ceil(0.5 * 3) = 2 → 30
+    assert_eq!(percentile(&data, 0.5), 30.0);
+}
+
+#[test]
+fn percentile_all_same() {
+    let data = [7, 7, 7, 7, 7];
+    assert_eq!(percentile(&data, 0.0), 7.0);
+    assert_eq!(percentile(&data, 0.5), 7.0);
+    assert_eq!(percentile(&data, 1.0), 7.0);
+}
+
+#[test]
+fn percentile_all_zeros() {
+    let data = [0, 0, 0, 0];
+    assert_eq!(percentile(&data, 0.5), 0.0);
+}
+
+#[test]
+fn percentile_known_quartiles() {
+    let data: Vec<usize> = (1..=100).collect();
+    assert_eq!(percentile(&data, 0.0), 1.0);
+    assert_eq!(percentile(&data, 1.0), 100.0);
+    // p25: ceil(0.25 * 99) = 25 → data[25] = 26
+    assert_eq!(percentile(&data, 0.25), 26.0);
+}
+
+#[test]
+fn percentile_monotonic_across_range() {
+    let data: Vec<usize> = (0..50).collect();
+    let mut prev = percentile(&data, 0.0);
+    for i in 1..=20 {
+        let pct = i as f64 / 20.0;
+        let cur = percentile(&data, pct);
+        assert!(cur >= prev, "percentile should be monotonically non-decreasing");
+        prev = cur;
+    }
+}
+
+// ── gini_coefficient ─────────────────────────────────────────────────────
+
+#[test]
+fn gini_empty_returns_zero() {
+    assert_eq!(gini_coefficient(&[]), 0.0);
+}
+
+#[test]
+fn gini_single_element_returns_zero() {
+    assert_eq!(gini_coefficient(std::slice::from_ref(&1000usize)), 0.0);
+}
+
+#[test]
+fn gini_all_zeros_returns_zero() {
+    assert_eq!(gini_coefficient(&[0, 0, 0, 0, 0]), 0.0);
+}
+
+#[test]
+fn gini_uniform_distribution_is_zero() {
+    assert!((gini_coefficient(&[10, 10, 10, 10]) - 0.0).abs() < 1e-10);
+}
+
+#[test]
+fn gini_maximum_inequality() {
+    // [0, 0, 0, N] should approach 0.75 for 4 elements
+    let g = gini_coefficient(&[0, 0, 0, 1000]);
+    assert!(g > 0.7, "near-maximum inequality should produce gini > 0.7, got {g}");
+    assert!(g <= 1.0, "gini should never exceed 1.0");
+}
+
+#[test]
+fn gini_known_value_three_elements() {
+    // [1, 2, 3]: Gini = (2*1+2*2*2+2*3*3 - (3+1)*(1+2+3)) / (3*6)
+    // Manual: accum = (2*1-4)*1 + (2*2-4)*2 + (2*3-4)*3 = -2+0+6 = 4
+    // gini = 4 / (3*6) = 4/18 ≈ 0.2222
+    let g = gini_coefficient(&[1, 2, 3]);
+    assert!((g - 2.0 / 9.0).abs() < 1e-10, "expected 2/9 ≈ 0.2222, got {g}");
+}
+
+#[test]
+fn gini_bounded_zero_to_one() {
+    let cases: &[&[usize]] = &[
+        &[1, 1, 1],
+        &[0, 0, 100],
+        &[1, 2, 3, 4, 5],
+        &[1, 100],
+        &[1, 1, 1, 1, 1, 1, 1000],
+    ];
+    for data in cases {
+        let g = gini_coefficient(data);
+        assert!(g >= 0.0, "gini should be >= 0.0 for {data:?}, got {g}");
+        assert!(g <= 1.0, "gini should be <= 1.0 for {data:?}, got {g}");
+    }
+}
+
+#[test]
+fn gini_scale_invariant() {
+    let base = [1usize, 2, 5, 10];
+    let scaled: Vec<usize> = base.iter().map(|v| v * 1000).collect();
+    let g1 = gini_coefficient(&base);
+    let g2 = gini_coefficient(&scaled);
+    assert!((g1 - g2).abs() < 1e-10, "gini should be scale-invariant");
+}
+
+#[test]
+fn gini_two_elements_asymmetric() {
+    // [1, 99]: accum = (2*1-3)*1 + (2*2-3)*99 = -1+99 = 98
+    // gini = 98 / (2*100) = 0.49
+    let g = gini_coefficient(&[1, 99]);
+    assert!((g - 0.49).abs() < 1e-10, "expected 0.49, got {g}");
+}
+
+// ── COCOMO-style composition ─────────────────────────────────────────────
+
+#[test]
+fn cocomo_effort_round_trip() {
+    // COCOMO basic: effort = a * (KLOC)^b
+    // Verify round_f64 + safe_ratio compose for typical metric pipelines
+    let total_lines: usize = 15_000;
+    let code_lines: usize = 10_500;
+    let ratio = safe_ratio(code_lines, total_lines);
+    assert_eq!(ratio, 0.7);
+
+    let kloc = code_lines as f64 / 1000.0;
+    let effort = round_f64(2.4 * kloc.powf(1.05), 2);
+    assert!(effort > 0.0);
+    assert!(effort.is_finite());
+}
+
+// ── Determinism ──────────────────────────────────────────────────────────
+
+#[test]
+fn all_functions_deterministic_over_100_iterations() {
+    let data = [1usize, 5, 10, 20, 50];
+    for _ in 0..100 {
+        assert_eq!(round_f64(1.23456, 3), 1.235);
+        assert_eq!(safe_ratio(7, 13), 0.5385);
+        assert_eq!(percentile(&data, 0.5), 10.0);
+        let g = gini_coefficient(&data);
+        assert!((g - gini_coefficient(&data)).abs() < f64::EPSILON);
+    }
+}

--- a/crates/tokmd-path/tests/normalize_w59.rs
+++ b/crates/tokmd-path/tests/normalize_w59.rs
@@ -1,0 +1,261 @@
+//! Wave-59 depth tests for path normalization — edge cases, Windows paths,
+//! UNC paths, dots, unicode, and deeply-nested inputs.
+
+use tokmd_path::{normalize_rel_path, normalize_slashes};
+
+// ── normalize_slashes: basic ─────────────────────────────────────────────
+
+#[test]
+fn slashes_empty_string() {
+    assert_eq!(normalize_slashes(""), "");
+}
+
+#[test]
+fn slashes_single_backslash() {
+    assert_eq!(normalize_slashes("\\"), "/");
+}
+
+#[test]
+fn slashes_single_forward_slash() {
+    assert_eq!(normalize_slashes("/"), "/");
+}
+
+#[test]
+fn slashes_only_forward_slashes_unchanged() {
+    let p = "a/b/c/d/e";
+    assert_eq!(normalize_slashes(p), p);
+}
+
+#[test]
+fn slashes_all_backslashes() {
+    assert_eq!(normalize_slashes("a\\b\\c\\d"), "a/b/c/d");
+}
+
+#[test]
+fn slashes_mixed_separators() {
+    assert_eq!(normalize_slashes("a\\b/c\\d/e"), "a/b/c/d/e");
+}
+
+// ── normalize_slashes: Windows paths ─────────────────────────────────────
+
+#[test]
+fn slashes_windows_drive_letter() {
+    assert_eq!(normalize_slashes("C:\\Users\\dev\\src"), "C:/Users/dev/src");
+}
+
+#[test]
+fn slashes_unc_path() {
+    assert_eq!(
+        normalize_slashes("\\\\server\\share\\dir"),
+        "//server/share/dir"
+    );
+}
+
+#[test]
+fn slashes_windows_long_path_prefix() {
+    assert_eq!(
+        normalize_slashes("\\\\?\\C:\\long\\path"),
+        "//?/C:/long/path"
+    );
+}
+
+// ── normalize_slashes: special characters ────────────────────────────────
+
+#[test]
+fn slashes_preserves_dots() {
+    assert_eq!(normalize_slashes("..\\..\\src"), "../../src");
+    assert_eq!(normalize_slashes(".\\local"), "./local");
+}
+
+#[test]
+fn slashes_preserves_spaces() {
+    assert_eq!(
+        normalize_slashes("my dir\\sub dir\\file.rs"),
+        "my dir/sub dir/file.rs"
+    );
+}
+
+#[test]
+fn slashes_consecutive_backslashes() {
+    assert_eq!(normalize_slashes("a\\\\b\\\\\\c"), "a//b///c");
+}
+
+#[test]
+fn slashes_trailing_backslash() {
+    assert_eq!(normalize_slashes("dir\\"), "dir/");
+}
+
+// ── normalize_slashes: unicode ───────────────────────────────────────────
+
+#[test]
+fn slashes_cjk_path() {
+    assert_eq!(normalize_slashes("项目\\源码\\主.rs"), "项目/源码/主.rs");
+}
+
+#[test]
+fn slashes_emoji_path() {
+    assert_eq!(normalize_slashes("📁\\📄"), "📁/📄");
+}
+
+#[test]
+fn slashes_arabic_path() {
+    assert_eq!(normalize_slashes("مجلد\\ملف"), "مجلد/ملف");
+}
+
+// ── normalize_slashes: length preservation ───────────────────────────────
+
+#[test]
+fn slashes_length_preserved() {
+    let inputs = [
+        "",
+        "abc",
+        "a\\b\\c",
+        "\\\\unc\\share",
+        "no/change",
+        "a\\b/c\\d",
+    ];
+    for input in &inputs {
+        assert_eq!(
+            normalize_slashes(input).len(),
+            input.len(),
+            "length should be preserved for '{input}'"
+        );
+    }
+}
+
+// ── normalize_rel_path: basic ────────────────────────────────────────────
+
+#[test]
+fn rel_empty_string() {
+    assert_eq!(normalize_rel_path(""), "");
+}
+
+#[test]
+fn rel_dot_only() {
+    // "./" stripped → ""
+    // but "." alone has no "/" so no strip
+    assert_eq!(normalize_rel_path("."), ".");
+}
+
+#[test]
+fn rel_dot_slash_only() {
+    assert_eq!(normalize_rel_path("./"), "");
+}
+
+#[test]
+fn rel_dot_backslash_only() {
+    assert_eq!(normalize_rel_path(".\\"), "");
+}
+
+#[test]
+fn rel_strips_leading_dot_slash() {
+    assert_eq!(normalize_rel_path("./src/main.rs"), "src/main.rs");
+}
+
+#[test]
+fn rel_strips_leading_dot_backslash() {
+    assert_eq!(normalize_rel_path(".\\src\\main.rs"), "src/main.rs");
+}
+
+#[test]
+fn rel_strips_multiple_dot_slash() {
+    assert_eq!(normalize_rel_path("././././src/lib.rs"), "src/lib.rs");
+}
+
+#[test]
+fn rel_preserves_double_dot() {
+    assert_eq!(normalize_rel_path("../lib.rs"), "../lib.rs");
+    assert_eq!(normalize_rel_path("..\\lib.rs"), "../lib.rs");
+}
+
+#[test]
+fn rel_preserves_mid_path_dot() {
+    assert_eq!(normalize_rel_path("src/./lib.rs"), "src/./lib.rs");
+}
+
+#[test]
+fn rel_absolute_path_unchanged() {
+    assert_eq!(normalize_rel_path("/usr/bin"), "/usr/bin");
+}
+
+#[test]
+fn rel_windows_absolute_normalizes_slashes() {
+    assert_eq!(normalize_rel_path("C:\\src\\lib.rs"), "C:/src/lib.rs");
+}
+
+// ── normalize_rel_path: deeply nested ────────────────────────────────────
+
+#[test]
+fn rel_deeply_nested_path() {
+    let deep = "a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z";
+    assert_eq!(normalize_rel_path(&format!("./{deep}")), deep);
+}
+
+#[test]
+fn rel_long_path_over_260_chars() {
+    let segment = "abcdefghij/";
+    let long: String = segment.repeat(30);
+    let input = format!("./{long}file.rs");
+    let expected = format!("{long}file.rs");
+    assert_eq!(normalize_rel_path(&input), expected);
+}
+
+// ── normalize_rel_path: unicode ──────────────────────────────────────────
+
+#[test]
+fn rel_unicode_path_normalization() {
+    assert_eq!(
+        normalize_rel_path(".\\项目\\源码\\主.rs"),
+        "项目/源码/主.rs"
+    );
+}
+
+#[test]
+fn rel_emoji_with_dot_prefix() {
+    assert_eq!(normalize_rel_path("./📁/📄.txt"), "📁/📄.txt");
+}
+
+// ── idempotency ──────────────────────────────────────────────────────────
+
+#[test]
+fn slashes_idempotent_batch() {
+    let inputs = [
+        "",
+        "a\\b",
+        "C:\\Users\\dev",
+        "already/forward",
+        "\\\\unc\\share",
+    ];
+    for input in &inputs {
+        let once = normalize_slashes(input);
+        let twice = normalize_slashes(&once);
+        assert_eq!(once, twice, "normalize_slashes not idempotent for '{input}'");
+    }
+}
+
+#[test]
+fn rel_idempotent_batch() {
+    let inputs = [
+        "",
+        "./src/main.rs",
+        ".\\src\\main.rs",
+        "src/main.rs",
+        "././a/b",
+        "../up",
+    ];
+    for input in &inputs {
+        let once = normalize_rel_path(input);
+        let twice = normalize_rel_path(&once);
+        assert_eq!(once, twice, "normalize_rel_path not idempotent for '{input}'");
+    }
+}
+
+// ── determinism ──────────────────────────────────────────────────────────
+
+#[test]
+fn both_functions_deterministic_100_iterations() {
+    for _ in 0..100 {
+        assert_eq!(normalize_slashes("a\\b\\c"), "a/b/c");
+        assert_eq!(normalize_rel_path("./src\\lib.rs"), "src/lib.rs");
+    }
+}

--- a/crates/tokmd-path/tests/property_w59.rs
+++ b/crates/tokmd-path/tests/property_w59.rs
@@ -1,0 +1,124 @@
+//! Wave-59 property-based tests for tokmd-path — idempotency, invariants,
+//! and algebraic relationships between normalize functions.
+
+use proptest::prelude::*;
+use tokmd_path::{normalize_rel_path, normalize_slashes};
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    // ── normalize_slashes properties ─────────────────────────────────────
+
+    #[test]
+    fn slashes_no_backslashes_in_output(path in "\\PC{0,200}") {
+        let result = normalize_slashes(&path);
+        prop_assert!(
+            !result.contains('\\'),
+            "output must not contain backslashes: {result:?}"
+        );
+    }
+
+    #[test]
+    fn slashes_idempotent(path in "\\PC{0,200}") {
+        let once = normalize_slashes(&path);
+        let twice = normalize_slashes(&once);
+        prop_assert_eq!(&once, &twice);
+    }
+
+    #[test]
+    fn slashes_preserves_length(path in "\\PC{0,200}") {
+        let result = normalize_slashes(&path);
+        prop_assert_eq!(
+            result.len(), path.len(),
+            "length must be preserved: input={}, output={}", path.len(), result.len()
+        );
+    }
+
+    #[test]
+    fn slashes_preserves_non_backslash_chars(path in "[a-zA-Z0-9/. _-]{0,100}") {
+        // Paths without backslashes should pass through unchanged
+        let result = normalize_slashes(&path);
+        prop_assert_eq!(&result, &path);
+    }
+
+    #[test]
+    fn slashes_forward_slash_count_gte_input(path in "\\PC{0,100}") {
+        let input_fwd = path.chars().filter(|c| *c == '/').count();
+        let input_back = path.chars().filter(|c| *c == '\\').count();
+        let output_fwd = normalize_slashes(&path).chars().filter(|c| *c == '/').count();
+        prop_assert_eq!(
+            output_fwd, input_fwd + input_back,
+            "output forward slashes should equal input forward + back slashes"
+        );
+    }
+
+    // ── normalize_rel_path properties ────────────────────────────────────
+
+    #[test]
+    fn rel_no_backslashes_in_output(path in "\\PC{0,200}") {
+        let result = normalize_rel_path(&path);
+        prop_assert!(
+            !result.contains('\\'),
+            "output must not contain backslashes: {result:?}"
+        );
+    }
+
+    #[test]
+    fn rel_idempotent(path in "\\PC{0,200}") {
+        let once = normalize_rel_path(&path);
+        let twice = normalize_rel_path(&once);
+        prop_assert_eq!(&once, &twice);
+    }
+
+    #[test]
+    fn rel_no_leading_dot_slash(path in "\\PC{0,200}") {
+        let result = normalize_rel_path(&path);
+        prop_assert!(
+            !result.starts_with("./"),
+            "output must not start with './': {result:?}"
+        );
+    }
+
+    #[test]
+    fn rel_result_is_suffix_of_slashes(path in "\\PC{0,200}") {
+        let slashed = normalize_slashes(&path);
+        let rel = normalize_rel_path(&path);
+        prop_assert!(
+            slashed.ends_with(&rel),
+            "normalize_rel_path result '{}' should be a suffix of normalize_slashes result '{}'",
+            rel, slashed
+        );
+    }
+
+    #[test]
+    fn rel_length_lte_slashes(path in "\\PC{0,200}") {
+        let slashed = normalize_slashes(&path);
+        let rel = normalize_rel_path(&path);
+        prop_assert!(
+            rel.len() <= slashed.len(),
+            "rel_path length {} should be <= slashes length {}",
+            rel.len(), slashed.len()
+        );
+    }
+
+    // ── cross-function properties ────────────────────────────────────────
+
+    #[test]
+    fn rel_path_then_slashes_is_identity_on_result(path in "\\PC{0,200}") {
+        let rel = normalize_rel_path(&path);
+        let slashed_of_rel = normalize_slashes(&rel);
+        // normalize_slashes on already-normalized rel should be no-op
+        prop_assert_eq!(&rel, &slashed_of_rel);
+    }
+
+    #[test]
+    fn slashes_then_rel_equals_rel(path in "\\PC{0,200}") {
+        let slashed = normalize_slashes(&path);
+        let rel_of_slashed = normalize_rel_path(&slashed);
+        let rel_direct = normalize_rel_path(&path);
+        prop_assert_eq!(
+            &rel_of_slashed, &rel_direct,
+            "normalize_rel_path should commute with normalize_slashes"
+        );
+    }
+}


### PR DESCRIPTION
## Wave 59 — math + path depth tests

94 new tests across 4 files:
- stats_edge_w59.rs: round_f64, safe_ratio, percentile, COCOMO
- property_w59.rs (math): idempotency, finiteness, bounds, determinism
- normalize_w59.rs: Windows paths, UNC, unicode, dots, deeply nested
- property_w59.rs (path): no-backslash invariant, idempotency

All tests pass locally.