### PR TITLE
test(w59): depth tests for module-key derivation and scan-args metadata

### DIFF
--- a/crates/tokmd-module-key/tests/derivation_w59.rs
+++ b/crates/tokmd-module-key/tests/derivation_w59.rs
@@ -1,0 +1,358 @@
+//! W59 — module key derivation: depth, edge cases, dot segments, sorting.
+
+use tokmd_module_key::{module_key, module_key_from_normalized};
+
+// ═══════════════════════════════════════════════════════════════════
+// Basic derivation from various paths
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn derive_root_level_various_extensions() {
+    for name in ["Cargo.toml", "README.md", ".gitignore", "Makefile.bak"] {
+        assert_eq!(module_key(name, &[], 2), "(root)", "failed for {name}");
+    }
+}
+
+#[test]
+fn derive_single_dir_no_roots() {
+    assert_eq!(module_key("src/main.rs", &[], 2), "src");
+}
+
+#[test]
+fn derive_single_dir_matching_root() {
+    let roots = vec!["src".into()];
+    assert_eq!(module_key("src/main.rs", &roots, 2), "src");
+}
+
+#[test]
+fn derive_two_dirs_matching_root_depth_2() {
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("crates/foo/lib.rs", &roots, 2), "crates/foo");
+}
+
+#[test]
+fn derive_three_dirs_matching_root_depth_2() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key("crates/foo/src/lib.rs", &roots, 2),
+        "crates/foo"
+    );
+}
+
+#[test]
+fn derive_three_dirs_matching_root_depth_3() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key("crates/foo/src/lib.rs", &roots, 3),
+        "crates/foo/src"
+    );
+}
+
+#[test]
+fn derive_non_matching_root_ignores_depth() {
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("docs/guide/intro.md", &roots, 5), "docs");
+}
+
+#[test]
+fn derive_backslash_normalized() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key(r"crates\tokmd\src\lib.rs", &roots, 2),
+        "crates/tokmd"
+    );
+}
+
+#[test]
+fn derive_mixed_separators() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key(r"crates/tokmd\src/lib.rs", &roots, 2),
+        "crates/tokmd"
+    );
+}
+
+#[test]
+fn derive_leading_dot_slash_stripped() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key("./crates/foo/lib.rs", &roots, 2),
+        "crates/foo"
+    );
+}
+
+#[test]
+fn derive_leading_slash_stripped() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key("/crates/foo/lib.rs", &roots, 2),
+        "crates/foo"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Depth-based module grouping
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn depth_zero_clamps_to_one_segment() {
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("crates/a/b/c.rs", &roots, 0), "crates");
+}
+
+#[test]
+fn depth_one_returns_root_only() {
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("crates/a/b/c.rs", &roots, 1), "crates");
+}
+
+#[test]
+fn depth_two_returns_root_plus_one() {
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("crates/a/b/c.rs", &roots, 2), "crates/a");
+}
+
+#[test]
+fn depth_three_returns_root_plus_two() {
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("crates/a/b/c.rs", &roots, 3), "crates/a/b");
+}
+
+#[test]
+fn depth_exceeds_available_dirs() {
+    let roots = vec!["crates".into()];
+    // path has 2 dir segments: crates/foo — depth 100 caps at available
+    assert_eq!(module_key("crates/foo/lib.rs", &roots, 100), "crates/foo");
+}
+
+#[test]
+fn depth_progression_adds_segments() {
+    let roots = vec!["crates".into()];
+    let path = "crates/a/b/c/d/file.rs";
+    let expected = [
+        (1, "crates"),
+        (2, "crates/a"),
+        (3, "crates/a/b"),
+        (4, "crates/a/b/c"),
+        (5, "crates/a/b/c/d"),
+    ];
+    for (depth, want) in expected {
+        assert_eq!(
+            module_key(path, &roots, depth),
+            want,
+            "depth {depth}"
+        );
+    }
+}
+
+#[test]
+fn depth_monotonically_grows_segment_count() {
+    let roots = vec!["pkg".into()];
+    let path = "pkg/a/b/c/d/e/f.rs";
+    let mut prev = 0;
+    for d in 0..=8 {
+        let count = module_key(path, &roots, d).split('/').count();
+        assert!(count >= prev, "depth {d}: {count} < {prev}");
+        prev = count;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Edge cases: empty path, single component, deeply nested
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn edge_empty_path() {
+    assert_eq!(module_key("", &[], 2), "(root)");
+}
+
+#[test]
+fn edge_single_slash() {
+    assert_eq!(module_key("/", &[], 2), "(root)");
+}
+
+#[test]
+fn edge_dot_only() {
+    assert_eq!(module_key(".", &[], 2), "(root)");
+}
+
+#[test]
+fn edge_dot_slash_only() {
+    assert_eq!(module_key("./", &[], 2), "(root)");
+}
+
+#[test]
+fn edge_filename_no_directory() {
+    assert_eq!(module_key("lib.rs", &["crates".into()], 2), "(root)");
+}
+
+#[test]
+fn edge_deeply_nested_20_levels() {
+    let roots = vec!["a".into()];
+    let dirs: Vec<&str> = (0..20).map(|_| "x").collect();
+    let path = format!("a/{}/file.rs", dirs.join("/"));
+    let key = module_key(&path, &roots, 5);
+    assert_eq!(key.split('/').count(), 5);
+}
+
+#[test]
+fn edge_single_char_segments() {
+    let roots = vec!["a".into()];
+    assert_eq!(module_key("a/b/c/d.rs", &roots, 3), "a/b/c");
+}
+
+#[test]
+fn edge_hyphenated_segments() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key("crates/tokmd-scan/src/lib.rs", &roots, 2),
+        "crates/tokmd-scan"
+    );
+}
+
+#[test]
+fn edge_underscored_segments() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key("crates/my_crate/src/lib.rs", &roots, 2),
+        "crates/my_crate"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Dot segment filtering (`.` segments should be filtered out)
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn dot_segment_in_middle_skipped() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key_from_normalized("crates/./foo/lib.rs", &roots, 2),
+        "crates/foo"
+    );
+}
+
+#[test]
+fn multiple_dot_segments_all_skipped() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key_from_normalized("crates/./././bar/lib.rs", &roots, 2),
+        "crates/bar"
+    );
+}
+
+#[test]
+fn dot_segment_with_depth_3() {
+    let roots = vec!["crates".into()];
+    // crates/./foo/src/lib.rs → dirs: crates, foo, src (dot filtered)
+    assert_eq!(
+        module_key_from_normalized("crates/./foo/src/lib.rs", &roots, 3),
+        "crates/foo/src"
+    );
+}
+
+#[test]
+fn empty_segments_filtered() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key_from_normalized("crates///foo/lib.rs", &roots, 2),
+        "crates/foo"
+    );
+}
+
+#[test]
+fn dot_only_dir_becomes_root() {
+    assert_eq!(
+        module_key_from_normalized("./lib.rs", &[], 2),
+        "(root)"
+    );
+}
+
+#[test]
+fn dot_only_dir_with_root_config() {
+    let roots = vec!["crates".into()];
+    assert_eq!(
+        module_key_from_normalized("./lib.rs", &roots, 2),
+        "(root)"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Sorting behavior of module keys
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn sort_root_before_alpha() {
+    let roots = vec!["crates".into()];
+    let mut keys = vec![
+        module_key("crates/z/lib.rs", &roots, 2),
+        module_key("README.md", &roots, 2),
+        module_key("crates/a/lib.rs", &roots, 2),
+    ];
+    keys.sort();
+    assert_eq!(keys[0], "(root)");
+}
+
+#[test]
+fn sort_alphabetical_within_module_root() {
+    let roots = vec!["crates".into()];
+    let mut keys: Vec<String> = ["crates/zzz/lib.rs", "crates/aaa/lib.rs", "crates/mmm/lib.rs"]
+        .iter()
+        .map(|p| module_key(p, &roots, 2))
+        .collect();
+    keys.sort();
+    assert_eq!(keys, ["crates/aaa", "crates/mmm", "crates/zzz"]);
+}
+
+#[test]
+fn sort_deterministic_repeated_calls() {
+    let roots = vec!["crates".into()];
+    let path = "crates/tokmd-format/src/lib.rs";
+    let results: Vec<String> = (0..20).map(|_| module_key(path, &roots, 2)).collect();
+    assert!(results.windows(2).all(|w| w[0] == w[1]));
+}
+
+#[test]
+fn sort_all_variant_forms_produce_same_key() {
+    let roots = vec!["crates".into()];
+    let variants = [
+        "crates/foo/lib.rs",
+        r"crates\foo\lib.rs",
+        "./crates/foo/lib.rs",
+        r".\crates\foo\lib.rs",
+        "/crates/foo/lib.rs",
+    ];
+    let keys: Vec<String> = variants.iter().map(|p| module_key(p, &roots, 2)).collect();
+    assert!(keys.windows(2).all(|w| w[0] == w[1]));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Multiple roots
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn multiple_roots_each_matches_independently() {
+    let roots = vec!["crates".into(), "packages".into(), "libs".into()];
+    assert_eq!(module_key("crates/a/lib.rs", &roots, 2), "crates/a");
+    assert_eq!(module_key("packages/b/lib.rs", &roots, 2), "packages/b");
+    assert_eq!(module_key("libs/c/lib.rs", &roots, 2), "libs/c");
+}
+
+#[test]
+fn non_matching_root_returns_first_dir_regardless_of_depth() {
+    let roots = vec!["crates".into()];
+    for depth in [1, 2, 5, 10] {
+        assert_eq!(
+            module_key("vendor/lib/deep/file.rs", &roots, depth),
+            "vendor",
+            "depth {depth}"
+        );
+    }
+}
+
+#[test]
+fn root_prefix_no_false_match() {
+    // "crates-extra" should NOT match the root "crates"
+    let roots = vec!["crates".into()];
+    assert_eq!(module_key("crates-extra/foo/lib.rs", &roots, 2), "crates-extra");
+}

--- a/crates/tokmd-module-key/tests/properties_w59.rs
+++ b/crates/tokmd-module-key/tests/properties_w59.rs
@@ -1,0 +1,172 @@
+//! W59 — property-based tests for module-key determinism and invariants.
+
+use proptest::prelude::*;
+use tokmd_module_key::{module_key, module_key_from_normalized};
+
+proptest! {
+    // ── Determinism ──────────────────────────────────────────────────
+
+    #[test]
+    fn deterministic_same_input_same_output(
+        dirs in prop::collection::vec("[a-z]{1,6}", 1..6),
+        filename in "[a-z]{1,6}\\.[a-z]{1,3}",
+        depth in 0usize..8,
+    ) {
+        let path = format!("{}/{}", dirs.join("/"), filename);
+        let roots = vec![dirs[0].clone()];
+        let k1 = module_key(&path, &roots, depth);
+        let k2 = module_key(&path, &roots, depth);
+        prop_assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn deterministic_from_normalized(
+        dirs in prop::collection::vec("[a-z]{1,6}", 1..5),
+        filename in "[a-z]{1,6}\\.[a-z]{1,3}",
+        depth in 1usize..6,
+    ) {
+        let path = format!("{}/{}", dirs.join("/"), filename);
+        let roots: Vec<String> = vec![];
+        let k1 = module_key_from_normalized(&path, &roots, depth);
+        let k2 = module_key_from_normalized(&path, &roots, depth);
+        prop_assert_eq!(k1, k2);
+    }
+
+    // ── Output never contains backslashes ────────────────────────────
+
+    #[test]
+    fn output_no_backslash(
+        path in "[a-zA-Z0-9_./\\\\]{1,60}",
+        depth in 0usize..8,
+    ) {
+        let roots = vec!["crates".into(), "src".into()];
+        let key = module_key(&path, &roots, depth);
+        prop_assert!(!key.contains('\\'), "backslash in key: {key:?}");
+    }
+
+    // ── Output never empty ───────────────────────────────────────────
+
+    #[test]
+    fn output_never_empty(
+        path in "[a-zA-Z0-9_./\\\\]{0,60}",
+        depth in 0usize..8,
+    ) {
+        let key = module_key(&path, &[], depth);
+        prop_assert!(!key.is_empty());
+    }
+
+    // ── Output never ends with slash ─────────────────────────────────
+
+    #[test]
+    fn output_no_trailing_slash(
+        dirs in prop::collection::vec("[a-z]{1,5}", 1..6),
+        filename in "[a-z]{1,5}\\.[a-z]{1,3}",
+        depth in 1usize..8,
+    ) {
+        let path = format!("{}/{}", dirs.join("/"), filename);
+        let key = module_key(&path, &[], depth);
+        prop_assert!(!key.ends_with('/'), "trailing slash: {key:?}");
+    }
+
+    // ── Output never starts with slash ───────────────────────────────
+
+    #[test]
+    fn output_no_leading_slash(
+        path in "[a-zA-Z0-9_./\\\\]{1,60}\\.[a-z]{1,3}",
+        depth in 0usize..6,
+    ) {
+        let key = module_key(&path, &[], depth);
+        prop_assert!(!key.starts_with('/'), "leading slash: {key:?}");
+    }
+
+    // ── Depth monotonicity ───────────────────────────────────────────
+
+    #[test]
+    fn depth_monotonic_segment_count(
+        root in "[a-z]{1,4}",
+        subdirs in prop::collection::vec("[a-z]{1,4}", 3..7),
+        filename in "[a-z]{1,4}\\.[a-z]{1,3}",
+    ) {
+        let path = format!("{}/{}/{}", root, subdirs.join("/"), filename);
+        let roots = vec![root.clone()];
+        let mut prev = 0;
+        for d in 0..=7 {
+            let segs = module_key(&path, &roots, d).split('/').count();
+            prop_assert!(segs >= prev, "depth {d}: {segs} < {prev}");
+            prev = segs;
+        }
+    }
+
+    // ── Key segments are subset of path dirs ─────────────────────────
+
+    #[test]
+    fn key_segments_from_path(
+        dirs in prop::collection::vec("[a-z]{2,6}", 2..5),
+        filename in "[a-z]{2,6}\\.[a-z]{1,3}",
+        depth in 1usize..5,
+    ) {
+        let path = format!("{}/{}", dirs.join("/"), filename);
+        let roots = vec![dirs[0].clone()];
+        let key = module_key(&path, &roots, depth);
+        for seg in key.split('/') {
+            prop_assert!(
+                dirs.contains(&seg.to_string()),
+                "key segment {seg:?} not in dirs {dirs:?}"
+            );
+        }
+    }
+
+    // ── Separator normalization ──────────────────────────────────────
+
+    #[test]
+    fn backslash_and_forward_slash_equivalent(
+        parts in prop::collection::vec("[a-z]{1,5}", 2..5),
+        filename in "[a-z]{1,5}\\.[a-z]{1,3}",
+        depth in 1usize..5,
+    ) {
+        let fwd = format!("{}/{}", parts.join("/"), filename);
+        let bck = format!("{}\\{}", parts.join("\\"), filename);
+        let roots: Vec<String> = vec![];
+        prop_assert_eq!(module_key(&fwd, &roots, depth), module_key(&bck, &roots, depth));
+    }
+
+    // ── Dot-slash prefix idempotence ─────────────────────────────────
+
+    #[test]
+    fn dot_slash_prefix_stripped(
+        dirs in prop::collection::vec("[a-z]{1,5}", 1..4),
+        filename in "[a-z]{1,5}\\.[a-z]{1,3}",
+        depth in 1usize..4,
+    ) {
+        let plain = format!("{}/{}", dirs.join("/"), filename);
+        let dotted = format!("./{}/{}", dirs.join("/"), filename);
+        let roots: Vec<String> = vec![];
+        prop_assert_eq!(module_key(&plain, &roots, depth), module_key(&dotted, &roots, depth));
+    }
+
+    // ── Root file detection ──────────────────────────────────────────
+
+    #[test]
+    fn root_files_always_root(
+        filename in "[a-zA-Z][a-zA-Z0-9_]{0,10}\\.[a-z]{1,4}",
+    ) {
+        let key = module_key(&filename, &[], 2);
+        prop_assert_eq!(key, "(root)");
+    }
+
+    // ── Depth 0 equals depth 1 ───────────────────────────────────────
+
+    #[test]
+    fn depth_zero_equals_one(
+        root in "[a-z]{1,4}",
+        subdirs in prop::collection::vec("[a-z]{1,4}", 1..4),
+        filename in "[a-z]{1,4}\\.[a-z]{1,3}",
+    ) {
+        let path = format!("{}/{}/{}", root, subdirs.join("/"), filename);
+        let roots = vec![root.clone()];
+        prop_assert_eq!(
+            module_key(&path, &roots, 0),
+            module_key(&path, &roots, 1)
+        );
+    }
+}

--- a/crates/tokmd-scan-args/tests/construction_w59.rs
+++ b/crates/tokmd-scan-args/tests/construction_w59.rs
@@ -1,0 +1,417 @@
+//! W59 — scan-args construction, redaction wiring, edge cases.
+
+use std::path::{Path, PathBuf};
+
+use tokmd_scan_args::{normalize_scan_input, scan_args};
+use tokmd_settings::ScanOptions;
+use tokmd_types::RedactMode;
+
+// ═══════════════════════════════════════════════════════════════════
+// normalize_scan_input
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn normalize_plain_relative_path() {
+    assert_eq!(normalize_scan_input(Path::new("src/lib.rs")), "src/lib.rs");
+}
+
+#[test]
+fn normalize_strips_single_dot_slash() {
+    assert_eq!(normalize_scan_input(Path::new("./src/lib.rs")), "src/lib.rs");
+}
+
+#[test]
+fn normalize_strips_repeated_dot_slash() {
+    assert_eq!(normalize_scan_input(Path::new("././src/lib.rs")), "src/lib.rs");
+}
+
+#[test]
+fn normalize_empty_relative_becomes_dot() {
+    assert_eq!(normalize_scan_input(Path::new("./")), ".");
+}
+
+#[test]
+fn normalize_bare_dot_stays_dot() {
+    assert_eq!(normalize_scan_input(Path::new(".")), ".");
+}
+
+#[test]
+fn normalize_backslashes_to_forward() {
+    let result = normalize_scan_input(Path::new("src\\main.rs"));
+    assert!(!result.contains('\\'), "backslash found: {result}");
+}
+
+#[test]
+fn normalize_preserves_non_dot_path() {
+    assert_eq!(normalize_scan_input(Path::new("crates/foo/src")), "crates/foo/src");
+}
+
+#[test]
+fn normalize_deep_nested_path() {
+    assert_eq!(
+        normalize_scan_input(Path::new("a/b/c/d/e/f/g.rs")),
+        "a/b/c/d/e/f/g.rs"
+    );
+}
+
+#[test]
+fn normalize_idempotent() {
+    let once = normalize_scan_input(Path::new("./src/lib.rs"));
+    let twice = normalize_scan_input(Path::new(&once));
+    assert_eq!(once, twice);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// ScanArgs construction — no redaction
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn scan_args_no_redaction_preserves_paths() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.paths, vec!["src/lib.rs"]);
+}
+
+#[test]
+fn scan_args_redact_none_preserves_paths() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, Some(RedactMode::None));
+    assert_eq!(args.paths, vec!["src/lib.rs"]);
+}
+
+#[test]
+fn scan_args_no_redaction_preserves_exclusions() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into(), "node_modules".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.excluded, vec!["target", "node_modules"]);
+    assert!(!args.excluded_redacted);
+}
+
+#[test]
+fn scan_args_multiple_paths_preserved() {
+    let paths = vec![
+        PathBuf::from("src"),
+        PathBuf::from("tests"),
+        PathBuf::from("benches"),
+    ];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.paths.len(), 3);
+    assert_eq!(args.paths[0], "src");
+    assert_eq!(args.paths[1], "tests");
+    assert_eq!(args.paths[2], "benches");
+}
+
+#[test]
+fn scan_args_empty_paths_vec() {
+    let paths: Vec<PathBuf> = vec![];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert!(args.paths.is_empty());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Redaction wiring
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn scan_args_redact_paths_mode_redacts() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_ne!(args.paths[0], "src/lib.rs", "path should be redacted");
+    assert_ne!(args.excluded[0], "target", "exclusion should be redacted");
+    assert!(args.excluded_redacted);
+}
+
+#[test]
+fn scan_args_redact_all_mode_redacts() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, Some(RedactMode::All));
+    assert_ne!(args.paths[0], "src/lib.rs");
+    assert_ne!(args.excluded[0], "target");
+    assert!(args.excluded_redacted);
+}
+
+#[test]
+fn scan_args_redact_paths_and_all_produce_same_paths() {
+    let paths = vec![PathBuf::from("crates/foo/src/lib.rs")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        ..Default::default()
+    };
+    let a = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    let b = scan_args(&paths, &opts, Some(RedactMode::All));
+    assert_eq!(a.paths, b.paths);
+    assert_eq!(a.excluded, b.excluded);
+}
+
+#[test]
+fn scan_args_excluded_redacted_false_when_empty_exclusions() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    // No exclusions → excluded_redacted should be false even with redaction
+    assert!(!args.excluded_redacted);
+}
+
+#[test]
+fn scan_args_excluded_redacted_false_when_no_redact() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, None);
+    assert!(!args.excluded_redacted);
+}
+
+#[test]
+fn scan_args_path_count_preserved_under_redaction() {
+    let paths: Vec<PathBuf> = (0..5).map(|i| PathBuf::from(format!("dir{i}/file.rs"))).collect();
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_eq!(args.paths.len(), 5);
+}
+
+#[test]
+fn scan_args_exclusion_count_preserved_under_redaction() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        excluded: vec!["a".into(), "b".into(), "c".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_eq!(args.excluded.len(), 3);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Deterministic hash generation
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn scan_args_deterministic_paths() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions::default();
+    let a = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    let b = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_eq!(a.paths, b.paths);
+}
+
+#[test]
+fn scan_args_deterministic_exclusions() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into(), "dist".into()],
+        ..Default::default()
+    };
+    let a = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    let b = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_eq!(a.excluded, b.excluded);
+}
+
+#[test]
+fn scan_args_deterministic_all_fields() {
+    let paths = vec![PathBuf::from("crates/a"), PathBuf::from("crates/b")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        hidden: true,
+        no_ignore: true,
+        treat_doc_strings_as_comments: true,
+        ..Default::default()
+    };
+    let a = scan_args(&paths, &opts, Some(RedactMode::All));
+    let b = scan_args(&paths, &opts, Some(RedactMode::All));
+    assert_eq!(a.paths, b.paths);
+    assert_eq!(a.excluded, b.excluded);
+    assert_eq!(a.excluded_redacted, b.excluded_redacted);
+    assert_eq!(a.hidden, b.hidden);
+    assert_eq!(a.no_ignore, b.no_ignore);
+    assert_eq!(a.no_ignore_parent, b.no_ignore_parent);
+    assert_eq!(a.no_ignore_dot, b.no_ignore_dot);
+    assert_eq!(a.no_ignore_vcs, b.no_ignore_vcs);
+    assert_eq!(a.treat_doc_strings_as_comments, b.treat_doc_strings_as_comments);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Boolean flag wiring
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn scan_args_no_ignore_enables_all_sub_flags() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        no_ignore: true,
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, None);
+    assert!(args.no_ignore_parent);
+    assert!(args.no_ignore_dot);
+    assert!(args.no_ignore_vcs);
+}
+
+#[test]
+fn scan_args_sub_flags_independent_when_no_ignore_false() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        no_ignore: false,
+        no_ignore_parent: true,
+        no_ignore_dot: false,
+        no_ignore_vcs: true,
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, None);
+    assert!(args.no_ignore_parent);
+    assert!(!args.no_ignore_dot);
+    assert!(args.no_ignore_vcs);
+}
+
+#[test]
+fn scan_args_hidden_flag_passed_through() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        hidden: true,
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, None);
+    assert!(args.hidden);
+}
+
+#[test]
+fn scan_args_treat_doc_strings_flag_passed_through() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        treat_doc_strings_as_comments: true,
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, None);
+    assert!(args.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn scan_args_boolean_flags_independent_of_redaction() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        hidden: true,
+        no_ignore: true,
+        treat_doc_strings_as_comments: true,
+        ..Default::default()
+    };
+    let without = scan_args(&paths, &opts, None);
+    let with_paths = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    let with_all = scan_args(&paths, &opts, Some(RedactMode::All));
+
+    assert_eq!(without.hidden, with_paths.hidden);
+    assert_eq!(without.hidden, with_all.hidden);
+    assert_eq!(without.no_ignore, with_paths.no_ignore);
+    assert_eq!(without.treat_doc_strings_as_comments, with_all.treat_doc_strings_as_comments);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Edge cases: empty paths, special characters
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn scan_args_dot_path_normalizes() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.paths, vec!["."]);
+}
+
+#[test]
+fn scan_args_dot_slash_path_normalizes() {
+    let paths = vec![PathBuf::from("./")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.paths, vec!["."]);
+}
+
+#[test]
+fn scan_args_repeated_dot_slash_normalizes() {
+    let paths = vec![PathBuf::from("././src")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.paths, vec!["src"]);
+}
+
+#[test]
+fn scan_args_paths_with_spaces() {
+    let paths = vec![PathBuf::from("my project/src/lib.rs")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.paths[0], "my project/src/lib.rs");
+}
+
+#[test]
+fn scan_args_paths_with_unicode() {
+    let paths = vec![PathBuf::from("données/résumé.rs")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert!(args.paths[0].contains("données"));
+}
+
+#[test]
+fn scan_args_redaction_hides_original_long_segments() {
+    let paths = vec![PathBuf::from("secret_project/internal/api.rs")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    let redacted = &args.paths[0];
+    assert!(
+        !redacted.contains("secret_project"),
+        "original segment leaked: {redacted}"
+    );
+    assert!(
+        !redacted.contains("internal"),
+        "original segment leaked: {redacted}"
+    );
+}
+
+#[test]
+fn scan_args_redaction_hides_exclusion_values() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        excluded: vec!["my_secret_dir".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert!(
+        !args.excluded[0].contains("my_secret_dir"),
+        "exclusion leaked: {}",
+        args.excluded[0]
+    );
+}
+
+#[test]
+fn scan_args_no_backslashes_in_output_paths() {
+    let paths = vec![
+        PathBuf::from("src\\lib.rs"),
+        PathBuf::from("tests\\test.rs"),
+    ];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    for p in &args.paths {
+        assert!(!p.contains('\\'), "backslash in output: {p}");
+    }
+}
+
+#[test]
+fn scan_args_single_path_via_slice_from_ref() {
+    let p = PathBuf::from("src/lib.rs");
+    let opts = ScanOptions::default();
+    let args = scan_args(std::slice::from_ref(&p), &opts, None);
+    assert_eq!(args.paths, vec!["src/lib.rs"]);
+}

--- a/crates/tokmd-scan-args/tests/properties_w59.rs
+++ b/crates/tokmd-scan-args/tests/properties_w59.rs
@@ -1,0 +1,234 @@
+//! W59 — property tests for scan-args determinism and redaction invariants.
+
+use std::path::{Path, PathBuf};
+
+use proptest::prelude::*;
+use tokmd_scan_args::{normalize_scan_input, scan_args};
+use tokmd_settings::ScanOptions;
+use tokmd_types::RedactMode;
+
+fn pathish() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop::sample::select(
+            "abcdefghijklmnopqrstuvwxyz0123456789_/.\\"
+                .chars()
+                .collect::<Vec<_>>(),
+        ),
+        0..40,
+    )
+    .prop_map(|chars| chars.into_iter().collect())
+}
+
+fn redact_mode() -> impl Strategy<Value = Option<RedactMode>> {
+    prop_oneof![
+        Just(None),
+        Just(Some(RedactMode::None)),
+        Just(Some(RedactMode::Paths)),
+        Just(Some(RedactMode::All)),
+    ]
+}
+
+proptest! {
+    // ── Normalization ────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_never_contains_backslash(input in pathish()) {
+        let result = normalize_scan_input(Path::new(&input));
+        prop_assert!(!result.contains('\\'));
+    }
+
+    #[test]
+    fn normalize_never_empty(input in pathish()) {
+        let result = normalize_scan_input(Path::new(&input));
+        prop_assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn normalize_never_starts_with_dot_slash(input in pathish()) {
+        let result = normalize_scan_input(Path::new(&input));
+        prop_assert!(!result.starts_with("./"));
+    }
+
+    #[test]
+    fn normalize_idempotent(input in pathish()) {
+        let once = normalize_scan_input(Path::new(&input));
+        let twice = normalize_scan_input(Path::new(&once));
+        prop_assert_eq!(once, twice);
+    }
+
+    // ── Determinism ──────────────────────────────────────────────────
+
+    #[test]
+    fn scan_args_deterministic(
+        path in pathish(),
+        mode in redact_mode(),
+    ) {
+        let paths = vec![PathBuf::from(&path)];
+        let opts = ScanOptions::default();
+        let a = scan_args(&paths, &opts, mode);
+        let b = scan_args(&paths, &opts, mode);
+        prop_assert_eq!(a.paths, b.paths);
+        prop_assert_eq!(a.excluded, b.excluded);
+        prop_assert_eq!(a.excluded_redacted, b.excluded_redacted);
+    }
+
+    // ── Path count preservation ──────────────────────────────────────
+
+    #[test]
+    fn scan_args_preserves_path_count(
+        raw in prop::collection::vec(pathish(), 0..10),
+        mode in redact_mode(),
+    ) {
+        let paths: Vec<PathBuf> = raw.iter().map(PathBuf::from).collect();
+        let opts = ScanOptions::default();
+        let args = scan_args(&paths, &opts, mode);
+        prop_assert_eq!(args.paths.len(), paths.len());
+    }
+
+    // ── Exclusion count preservation ─────────────────────────────────
+
+    #[test]
+    fn scan_args_preserves_exclusion_count(
+        excluded in prop::collection::vec(pathish(), 0..10),
+        mode in redact_mode(),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let opts = ScanOptions {
+            excluded: excluded.clone(),
+            ..Default::default()
+        };
+        let args = scan_args(&paths, &opts, mode);
+        prop_assert_eq!(args.excluded.len(), excluded.len());
+    }
+
+    // ── No backslashes in output ─────────────────────────────────────
+
+    #[test]
+    fn scan_args_no_backslash_in_paths(
+        raw in prop::collection::vec(pathish(), 1..5),
+        mode in redact_mode(),
+    ) {
+        let paths: Vec<PathBuf> = raw.iter().map(PathBuf::from).collect();
+        let opts = ScanOptions::default();
+        let args = scan_args(&paths, &opts, mode);
+        for p in &args.paths {
+            prop_assert!(!p.contains('\\'), "backslash: {p}");
+        }
+    }
+
+    // ── excluded_redacted consistency ────────────────────────────────
+
+    #[test]
+    fn excluded_redacted_correct(
+        excluded in prop::collection::vec(pathish(), 0..5),
+        mode in redact_mode(),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let opts = ScanOptions {
+            excluded: excluded.clone(),
+            ..Default::default()
+        };
+        let args = scan_args(&paths, &opts, mode);
+        let should_redact = matches!(mode, Some(RedactMode::Paths | RedactMode::All));
+        let expected = should_redact && !excluded.is_empty();
+        prop_assert_eq!(args.excluded_redacted, expected);
+    }
+
+    // ── no_ignore implies all sub-flags ──────────────────────────────
+
+    #[test]
+    fn no_ignore_implies_sub_flags(
+        no_ignore_parent in any::<bool>(),
+        no_ignore_dot in any::<bool>(),
+        no_ignore_vcs in any::<bool>(),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let opts = ScanOptions {
+            no_ignore: true,
+            no_ignore_parent,
+            no_ignore_dot,
+            no_ignore_vcs,
+            ..Default::default()
+        };
+        let args = scan_args(&paths, &opts, None);
+        prop_assert!(args.no_ignore_parent);
+        prop_assert!(args.no_ignore_dot);
+        prop_assert!(args.no_ignore_vcs);
+    }
+
+    // ── Boolean flags independent of redaction ───────────────────────
+
+    #[test]
+    fn boolean_flags_survive_redaction(
+        hidden in any::<bool>(),
+        no_ignore in any::<bool>(),
+        docstrings in any::<bool>(),
+        mode in redact_mode(),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let opts = ScanOptions {
+            hidden,
+            no_ignore,
+            treat_doc_strings_as_comments: docstrings,
+            ..Default::default()
+        };
+        let args = scan_args(&paths, &opts, mode);
+        prop_assert_eq!(args.hidden, hidden);
+        prop_assert_eq!(args.no_ignore, no_ignore);
+        prop_assert_eq!(args.treat_doc_strings_as_comments, docstrings);
+    }
+
+    // ── Non-redact modes preserve exclusions verbatim ────────────────
+
+    #[test]
+    fn non_redact_preserves_exclusions(
+        excluded in prop::collection::vec("[a-z]{1,10}", 0..5),
+    ) {
+        let paths = vec![PathBuf::from(".")];
+        let opts = ScanOptions {
+            excluded: excluded.clone(),
+            ..Default::default()
+        };
+        let args_none = scan_args(&paths, &opts, None);
+        let args_mode_none = scan_args(&paths, &opts, Some(RedactMode::None));
+        prop_assert_eq!(&args_none.excluded, &excluded);
+        prop_assert_eq!(&args_mode_none.excluded, &excluded);
+    }
+
+    // ── Redact Paths == Redact All for path/exclusion output ─────────
+
+    #[test]
+    fn redact_paths_equals_all_for_paths(
+        raw in prop::collection::vec("[a-z]{2,8}", 1..4),
+        excluded in prop::collection::vec("[a-z]{2,8}", 0..3),
+    ) {
+        let paths: Vec<PathBuf> = raw.iter().map(PathBuf::from).collect();
+        let opts = ScanOptions {
+            excluded,
+            ..Default::default()
+        };
+        let a = scan_args(&paths, &opts, Some(RedactMode::Paths));
+        let b = scan_args(&paths, &opts, Some(RedactMode::All));
+        prop_assert_eq!(a.paths, b.paths);
+        prop_assert_eq!(a.excluded, b.excluded);
+    }
+
+    // ── Redacted paths don't leak long original segments ─────────────
+
+    #[test]
+    fn redacted_paths_hide_originals(
+        segments in prop::collection::vec("[a-z]{5,10}", 1..4),
+    ) {
+        let path_str = segments.join("/") + ".rs";
+        let paths = vec![PathBuf::from(&path_str)];
+        let opts = ScanOptions::default();
+        let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+        let redacted = &args.paths[0];
+        for seg in &segments {
+            prop_assert!(
+                !redacted.contains(seg.as_str()),
+                "segment {seg:?} leaked in {redacted:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Wave 59 — module-key + scan-args depth tests

110+ tests across 4 files:
- derivation_w59.rs: path derivation, depth grouping, dot-segment filtering
- properties_w59.rs (module-key): determinism, output invariants
- construction_w59.rs: normalization, redaction wiring, hashing
- properties_w59.rs (scan-args): normalization invariants, determinism

All tests pass locally.