### PR TITLE
test(w59): depth tests for sensor trait and substrate sharing

### DIFF
--- a/crates/tokmd-sensor/tests/proptest_w59.rs
+++ b/crates/tokmd-sensor/tests/proptest_w59.rs
@@ -1,0 +1,162 @@
+//! Property-based tests for sensor trait invariants.
+//!
+//! Verifies that sensors produce valid reports regardless of substrate content.
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use tokmd_envelope::{SensorReport, ToolMeta, Verdict, SENSOR_REPORT_SCHEMA};
+use tokmd_sensor::EffortlessSensor;
+use tokmd_substrate::{LangSummary, RepoSubstrate, SubstrateFile};
+
+// ── Strategies ───────────────────────────────────────────────────
+
+fn arb_substrate_file() -> impl Strategy<Value = SubstrateFile> {
+    (
+        "[a-z]+(/[a-z]+){0,3}\\.[a-z]{1,4}",
+        prop::sample::select(vec![
+            "Rust", "Python", "TypeScript", "Go", "Java", "C", "Shell",
+        ]),
+        0usize..5_000,
+        0usize..10_000,
+        0usize..500_000,
+        0usize..125_000,
+        "[a-z]+(/[a-z]+){0,2}",
+        any::<bool>(),
+    )
+        .prop_map(
+            |(path, lang, code, lines, bytes, tokens, module, in_diff)| SubstrateFile {
+                path,
+                lang: lang.to_string(),
+                code,
+                lines,
+                bytes,
+                tokens,
+                module,
+                in_diff,
+            },
+        )
+}
+
+fn arb_substrate() -> impl Strategy<Value = RepoSubstrate> {
+    proptest::collection::vec(arb_substrate_file(), 0..20).prop_map(|files| {
+        let mut lang_summary: BTreeMap<String, LangSummary> = BTreeMap::new();
+        for f in &files {
+            let e = lang_summary.entry(f.lang.clone()).or_insert(LangSummary {
+                files: 0,
+                code: 0,
+                lines: 0,
+                bytes: 0,
+                tokens: 0,
+            });
+            e.files += 1;
+            e.code += f.code;
+            e.lines += f.lines;
+            e.bytes += f.bytes;
+            e.tokens += f.tokens;
+        }
+        let total_tokens = files.iter().map(|f| f.tokens).sum();
+        let total_bytes = files.iter().map(|f| f.bytes).sum();
+        let total_code_lines = files.iter().map(|f| f.code).sum();
+        RepoSubstrate {
+            repo_root: "/repo".to_string(),
+            files,
+            lang_summary,
+            diff_range: None,
+            total_tokens,
+            total_bytes,
+            total_code_lines,
+        }
+    })
+}
+
+/// A generic sensor for property testing.
+struct PropSensor;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PropSettings;
+
+impl EffortlessSensor for PropSensor {
+    type Settings = PropSettings;
+    fn name(&self) -> &str {
+        "prop-sensor"
+    }
+    fn version(&self) -> &str {
+        "0.0.1"
+    }
+    fn run(&self, _settings: &PropSettings, sub: &RepoSubstrate) -> anyhow::Result<SensorReport> {
+        let verdict = if sub.files.is_empty() {
+            Verdict::Skip
+        } else {
+            Verdict::Pass
+        };
+        Ok(SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "check"),
+            "2024-01-01T00:00:00Z".to_string(),
+            verdict,
+            format!("{} files scanned", sub.files.len()),
+        ))
+    }
+}
+
+// ── Properties ───────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn report_always_has_valid_schema(sub in arb_substrate()) {
+        let report = PropSensor.run(&PropSettings, &sub).unwrap();
+        prop_assert_eq!(report.schema.as_str(), SENSOR_REPORT_SCHEMA);
+    }
+
+    #[test]
+    fn report_tool_meta_always_matches(sub in arb_substrate()) {
+        let report = PropSensor.run(&PropSettings, &sub).unwrap();
+        prop_assert_eq!(report.tool.name.as_str(), "prop-sensor");
+        prop_assert_eq!(report.tool.version.as_str(), "0.0.1");
+    }
+
+    #[test]
+    fn empty_substrate_always_skips(sub in arb_substrate()) {
+        let report = PropSensor.run(&PropSettings, &sub).unwrap();
+        if sub.files.is_empty() {
+            prop_assert_eq!(report.verdict, Verdict::Skip);
+        } else {
+            prop_assert_eq!(report.verdict, Verdict::Pass);
+        }
+    }
+
+    #[test]
+    fn report_json_roundtrips(sub in arb_substrate()) {
+        let report = PropSensor.run(&PropSettings, &sub).unwrap();
+        let json = serde_json::to_string(&report).unwrap();
+        let back: SensorReport = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(back.verdict, report.verdict);
+        prop_assert_eq!(back.schema, report.schema);
+        prop_assert_eq!(back.tool.name, report.tool.name);
+    }
+
+    #[test]
+    fn report_is_deterministic(sub in arb_substrate()) {
+        let r1 = PropSensor.run(&PropSettings, &sub).unwrap();
+        let r2 = PropSensor.run(&PropSettings, &sub).unwrap();
+        let j1 = serde_json::to_string(&r1).unwrap();
+        let j2 = serde_json::to_string(&r2).unwrap();
+        prop_assert_eq!(j1, j2);
+    }
+
+    #[test]
+    fn substrate_totals_consistent(sub in arb_substrate()) {
+        let computed_code: usize = sub.files.iter().map(|f| f.code).sum();
+        let computed_tokens: usize = sub.files.iter().map(|f| f.tokens).sum();
+        let computed_bytes: usize = sub.files.iter().map(|f| f.bytes).sum();
+        prop_assert_eq!(sub.total_code_lines, computed_code);
+        prop_assert_eq!(sub.total_tokens, computed_tokens);
+        prop_assert_eq!(sub.total_bytes, computed_bytes);
+    }
+
+    #[test]
+    fn lang_summary_files_count_matches(sub in arb_substrate()) {
+        let total_from_summary: usize = sub.lang_summary.values().map(|l| l.files).sum();
+        prop_assert_eq!(total_from_summary, sub.files.len());
+    }
+}

--- a/crates/tokmd-sensor/tests/trait_depth_w59.rs
+++ b/crates/tokmd-sensor/tests/trait_depth_w59.rs
@@ -1,0 +1,517 @@
+//! Depth tests for the `EffortlessSensor` trait contract.
+//!
+//! Covers: trait implementation patterns, verdict logic, settings serde,
+//! report construction, edge cases, and determinism.
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokmd_envelope::{
+    Artifact, CapabilityStatus, Finding, FindingSeverity, SensorReport, ToolMeta, Verdict,
+    SENSOR_REPORT_SCHEMA,
+};
+use tokmd_sensor::EffortlessSensor;
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+fn make_file(path: &str, lang: &str, code: usize) -> SubstrateFile {
+    SubstrateFile {
+        path: path.to_string(),
+        lang: lang.to_string(),
+        code,
+        lines: code + 20,
+        bytes: code * 30,
+        tokens: code * 8,
+        module: path
+            .rsplit_once('/')
+            .map(|(m, _)| m)
+            .unwrap_or("")
+            .to_string(),
+        in_diff: false,
+    }
+}
+
+fn make_file_in_diff(path: &str, lang: &str, code: usize) -> SubstrateFile {
+    let mut f = make_file(path, lang, code);
+    f.in_diff = true;
+    f
+}
+
+fn substrate_from_files(files: Vec<SubstrateFile>) -> RepoSubstrate {
+    let mut lang_summary: BTreeMap<String, LangSummary> = BTreeMap::new();
+    for f in &files {
+        let e = lang_summary.entry(f.lang.clone()).or_insert(LangSummary {
+            files: 0,
+            code: 0,
+            lines: 0,
+            bytes: 0,
+            tokens: 0,
+        });
+        e.files += 1;
+        e.code += f.code;
+        e.lines += f.lines;
+        e.bytes += f.bytes;
+        e.tokens += f.tokens;
+    }
+    let total_tokens = files.iter().map(|f| f.tokens).sum();
+    let total_bytes = files.iter().map(|f| f.bytes).sum();
+    let total_code_lines = files.iter().map(|f| f.code).sum();
+    RepoSubstrate {
+        repo_root: "/repo".to_string(),
+        files,
+        lang_summary,
+        diff_range: None,
+        total_tokens,
+        total_bytes,
+        total_code_lines,
+    }
+}
+
+fn empty_substrate() -> RepoSubstrate {
+    substrate_from_files(vec![])
+}
+
+fn single_file_substrate() -> RepoSubstrate {
+    substrate_from_files(vec![make_file("src/lib.rs", "Rust", 100)])
+}
+
+fn multi_lang_substrate() -> RepoSubstrate {
+    substrate_from_files(vec![
+        make_file("src/lib.rs", "Rust", 200),
+        make_file("src/main.py", "Python", 150),
+        make_file("src/app.ts", "TypeScript", 300),
+        make_file_in_diff("src/new.rs", "Rust", 50),
+    ])
+}
+
+// ── Test sensors ─────────────────────────────────────────────────
+
+/// Threshold-based sensor that warns when code exceeds a limit.
+struct ThresholdSensor;
+
+#[derive(Serialize, Deserialize)]
+struct ThresholdSettings {
+    max_code_lines: usize,
+}
+
+impl EffortlessSensor for ThresholdSensor {
+    type Settings = ThresholdSettings;
+    fn name(&self) -> &str {
+        "threshold"
+    }
+    fn version(&self) -> &str {
+        "1.0.0"
+    }
+    fn run(&self, settings: &ThresholdSettings, sub: &RepoSubstrate) -> Result<SensorReport> {
+        let verdict = if sub.total_code_lines > settings.max_code_lines {
+            Verdict::Fail
+        } else {
+            Verdict::Pass
+        };
+        Ok(SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "check"),
+            "2024-06-01T00:00:00Z".to_string(),
+            verdict,
+            format!("{} lines", sub.total_code_lines),
+        ))
+    }
+}
+
+/// Language-counting sensor that produces findings per language.
+struct LangCountSensor;
+
+#[derive(Serialize, Deserialize)]
+struct LangCountSettings {
+    min_languages: usize,
+}
+
+impl EffortlessSensor for LangCountSensor {
+    type Settings = LangCountSettings;
+    fn name(&self) -> &str {
+        "lang-count"
+    }
+    fn version(&self) -> &str {
+        "0.2.0"
+    }
+    fn run(&self, settings: &LangCountSettings, sub: &RepoSubstrate) -> Result<SensorReport> {
+        let count = sub.lang_summary.len();
+        let verdict = if count >= settings.min_languages {
+            Verdict::Pass
+        } else {
+            Verdict::Warn
+        };
+        let mut report = SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "analyze"),
+            "2024-06-01T00:00:00Z".to_string(),
+            verdict,
+            format!("{count} languages found"),
+        );
+        for lang in sub.lang_summary.keys() {
+            report.add_finding(Finding::new(
+                "inventory",
+                "language",
+                FindingSeverity::Info,
+                lang,
+                format!("Language {lang} detected"),
+            ));
+        }
+        Ok(report)
+    }
+}
+
+/// Diff-aware sensor that only cares about changed files.
+struct DiffSensor;
+
+#[derive(Serialize, Deserialize)]
+struct DiffSettings;
+
+impl EffortlessSensor for DiffSensor {
+    type Settings = DiffSettings;
+    fn name(&self) -> &str {
+        "diff-sensor"
+    }
+    fn version(&self) -> &str {
+        "0.1.0"
+    }
+    fn run(&self, _settings: &DiffSettings, sub: &RepoSubstrate) -> Result<SensorReport> {
+        let diff_count = sub.diff_files().count();
+        let verdict = if diff_count == 0 {
+            Verdict::Skip
+        } else {
+            Verdict::Pass
+        };
+        Ok(SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "diff"),
+            "2024-06-01T00:00:00Z".to_string(),
+            verdict,
+            format!("{diff_count} files in diff"),
+        ))
+    }
+}
+
+/// Sensor that always fails for error path testing.
+struct FailingSensor;
+
+#[derive(Serialize, Deserialize)]
+struct FailSettings {
+    should_fail: bool,
+}
+
+impl EffortlessSensor for FailingSensor {
+    type Settings = FailSettings;
+    fn name(&self) -> &str {
+        "failing"
+    }
+    fn version(&self) -> &str {
+        "0.0.1"
+    }
+    fn run(&self, settings: &FailSettings, _sub: &RepoSubstrate) -> Result<SensorReport> {
+        if settings.should_fail {
+            anyhow::bail!("intentional failure");
+        }
+        Ok(SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "check"),
+            "2024-06-01T00:00:00Z".to_string(),
+            Verdict::Pass,
+            "ok".to_string(),
+        ))
+    }
+}
+
+// ── Trait contract tests ─────────────────────────────────────────
+
+#[test]
+fn sensor_name_is_stable() {
+    let s = ThresholdSensor;
+    assert_eq!(s.name(), s.name(), "name() must be pure");
+}
+
+#[test]
+fn sensor_version_is_stable() {
+    let s = ThresholdSensor;
+    assert_eq!(s.version(), s.version(), "version() must be pure");
+}
+
+#[test]
+fn threshold_pass_below_limit() {
+    let sub = single_file_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 500,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+#[test]
+fn threshold_fail_above_limit() {
+    let sub = multi_lang_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 100,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Fail);
+}
+
+#[test]
+fn threshold_pass_at_exact_boundary() {
+    let sub = single_file_substrate(); // 100 lines
+    let settings = ThresholdSettings {
+        max_code_lines: 100,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass, "equal should pass (not >)");
+}
+
+#[test]
+fn threshold_on_empty_substrate() {
+    let sub = empty_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 0,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+// ── Lang-count sensor tests ─────────────────────────────────────
+
+#[test]
+fn lang_count_pass_when_enough() {
+    let sub = multi_lang_substrate();
+    let settings = LangCountSettings { min_languages: 2 };
+    let report = LangCountSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+    assert_eq!(report.findings.len(), 3); // Rust, Python, TypeScript
+}
+
+#[test]
+fn lang_count_warn_when_too_few() {
+    let sub = single_file_substrate();
+    let settings = LangCountSettings { min_languages: 5 };
+    let report = LangCountSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Warn);
+}
+
+#[test]
+fn lang_count_empty_substrate() {
+    let sub = empty_substrate();
+    let settings = LangCountSettings { min_languages: 1 };
+    let report = LangCountSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Warn);
+    assert!(report.findings.is_empty());
+}
+
+#[test]
+fn lang_count_findings_match_languages() {
+    let sub = multi_lang_substrate();
+    let settings = LangCountSettings { min_languages: 1 };
+    let report = LangCountSensor.run(&settings, &sub).unwrap();
+    let finding_titles: Vec<&str> = report.findings.iter().map(|f| f.title.as_str()).collect();
+    // BTreeMap ensures alphabetical order
+    assert_eq!(finding_titles, vec!["Python", "Rust", "TypeScript"]);
+}
+
+// ── Diff-aware sensor tests ─────────────────────────────────────
+
+#[test]
+fn diff_sensor_skip_when_no_diff_files() {
+    let sub = single_file_substrate(); // no in_diff files
+    let report = DiffSensor.run(&DiffSettings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Skip);
+}
+
+#[test]
+fn diff_sensor_pass_when_diff_files_exist() {
+    let sub = multi_lang_substrate(); // has one in_diff file
+    let report = DiffSensor.run(&DiffSettings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+    assert!(report.summary.contains("1 files in diff"));
+}
+
+// ── Error path tests ─────────────────────────────────────────────
+
+#[test]
+fn failing_sensor_returns_error() {
+    let sub = empty_substrate();
+    let settings = FailSettings { should_fail: true };
+    let result = FailingSensor.run(&settings, &sub);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("intentional failure"));
+}
+
+#[test]
+fn failing_sensor_succeeds_when_not_failing() {
+    let sub = empty_substrate();
+    let settings = FailSettings { should_fail: false };
+    let report = FailingSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+// ── Report envelope correctness ──────────────────────────────────
+
+#[test]
+fn report_has_correct_schema() {
+    let sub = single_file_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 1000,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.schema, SENSOR_REPORT_SCHEMA);
+}
+
+#[test]
+fn report_tool_meta_matches_sensor() {
+    let sub = single_file_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 1000,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.tool.name, "threshold");
+    assert_eq!(report.tool.version, "1.0.0");
+    assert_eq!(report.tool.mode, "check");
+}
+
+#[test]
+fn report_findings_empty_by_default() {
+    let sub = single_file_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 1000,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    assert!(report.findings.is_empty());
+}
+
+#[test]
+fn report_serde_roundtrip() {
+    let sub = multi_lang_substrate();
+    let settings = LangCountSettings { min_languages: 1 };
+    let report = LangCountSensor.run(&settings, &sub).unwrap();
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.verdict, report.verdict);
+    assert_eq!(back.findings.len(), report.findings.len());
+    assert_eq!(back.schema, SENSOR_REPORT_SCHEMA);
+}
+
+#[test]
+fn report_with_artifacts() {
+    let sub = single_file_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 1000,
+    };
+    let mut report = ThresholdSensor.run(&settings, &sub).unwrap();
+    let report = report;
+    let report = report.with_artifacts(vec![Artifact::receipt("out/receipt.json")]);
+    assert!(report.artifacts.is_some());
+    assert_eq!(report.artifacts.as_ref().unwrap().len(), 1);
+}
+
+#[test]
+fn report_with_capabilities() {
+    let sub = single_file_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 1000,
+    };
+    let mut report = ThresholdSensor.run(&settings, &sub).unwrap();
+    report.add_capability("git", CapabilityStatus::available());
+    report.add_capability("content", CapabilityStatus::unavailable("not compiled"));
+    let caps = report.capabilities.as_ref().unwrap();
+    assert_eq!(caps.len(), 2);
+    assert!(caps.contains_key("git"));
+    assert!(caps.contains_key("content"));
+}
+
+#[test]
+fn report_with_data_payload() {
+    let sub = single_file_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 1000,
+    };
+    let report = ThresholdSensor.run(&settings, &sub).unwrap();
+    let report = report.with_data(serde_json::json!({"extra": true}));
+    assert!(report.data.is_some());
+}
+
+// ── Determinism tests ────────────────────────────────────────────
+
+#[test]
+fn same_inputs_produce_identical_reports() {
+    let sub = multi_lang_substrate();
+    let settings = LangCountSettings { min_languages: 1 };
+    let r1 = LangCountSensor.run(&settings, &sub).unwrap();
+    let r2 = LangCountSensor.run(&settings, &sub).unwrap();
+    let j1 = serde_json::to_string(&r1).unwrap();
+    let j2 = serde_json::to_string(&r2).unwrap();
+    assert_eq!(j1, j2, "deterministic: same inputs → same JSON");
+}
+
+#[test]
+fn finding_order_is_deterministic() {
+    let sub = multi_lang_substrate();
+    let settings = LangCountSettings { min_languages: 1 };
+    let r1 = LangCountSensor.run(&settings, &sub).unwrap();
+    let r2 = LangCountSensor.run(&settings, &sub).unwrap();
+    let titles1: Vec<&str> = r1.findings.iter().map(|f| f.title.as_str()).collect();
+    let titles2: Vec<&str> = r2.findings.iter().map(|f| f.title.as_str()).collect();
+    assert_eq!(titles1, titles2);
+}
+
+// ── Settings serde tests ─────────────────────────────────────────
+
+#[test]
+fn threshold_settings_roundtrip() {
+    let s = ThresholdSettings {
+        max_code_lines: 42,
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let back: ThresholdSettings = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.max_code_lines, 42);
+}
+
+#[test]
+fn diff_settings_unit_struct_roundtrip() {
+    let s = DiffSettings;
+    let json = serde_json::to_string(&s).unwrap();
+    assert_eq!(json, "null");
+    let _back: DiffSettings = serde_json::from_str(&json).unwrap();
+}
+
+// ── Multiple sensors on same substrate ───────────────────────────
+
+#[test]
+fn multiple_sensors_share_substrate() {
+    let sub = multi_lang_substrate();
+    let r1 = ThresholdSensor
+        .run(&ThresholdSettings { max_code_lines: 1000 }, &sub)
+        .unwrap();
+    let r2 = LangCountSensor
+        .run(&LangCountSettings { min_languages: 1 }, &sub)
+        .unwrap();
+    let r3 = DiffSensor.run(&DiffSettings, &sub).unwrap();
+
+    // All sensors ran on the same substrate without issues
+    assert_eq!(r1.verdict, Verdict::Pass);
+    assert_eq!(r2.verdict, Verdict::Pass);
+    assert_eq!(r3.verdict, Verdict::Pass);
+
+    // Substrate is unchanged (immutable borrow)
+    assert_eq!(sub.total_code_lines, 700);
+    assert_eq!(sub.lang_summary.len(), 3);
+}
+
+#[test]
+fn substrate_with_diff_range_propagates_to_sensors() {
+    let mut sub = multi_lang_substrate();
+    sub.diff_range = Some(DiffRange {
+        base: "main".to_string(),
+        head: "feature".to_string(),
+        changed_files: vec!["src/new.rs".to_string()],
+        commit_count: 2,
+        insertions: 10,
+        deletions: 3,
+    });
+    let report = DiffSensor.run(&DiffSettings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}

--- a/crates/tokmd-substrate/tests/proptest_w59.rs
+++ b/crates/tokmd-substrate/tests/proptest_w59.rs
@@ -1,0 +1,232 @@
+//! Property-based tests for `tokmd-substrate` invariants.
+//!
+//! Verifies serde roundtrips, totals consistency, and structural
+//! invariants for arbitrary substrate inputs.
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// ── Strategies ───────────────────────────────────────────────────
+
+fn arb_lang_summary() -> impl Strategy<Value = LangSummary> {
+    (
+        0..100usize,
+        0..10_000usize,
+        0..10_000usize,
+        0..1_000_000usize,
+        0..100_000usize,
+    )
+        .prop_map(|(files, code, lines, bytes, tokens)| LangSummary {
+            files,
+            code,
+            lines,
+            bytes,
+            tokens,
+        })
+}
+
+fn arb_substrate_file() -> impl Strategy<Value = SubstrateFile> {
+    (
+        "[a-z]+(/[a-z]+){0,3}\\.[a-z]{1,4}",
+        "[A-Z][a-z]+",
+        0usize..5_000,
+        0usize..10_000,
+        0usize..500_000,
+        0usize..125_000,
+        "[a-z]+(/[a-z]+){0,2}",
+        any::<bool>(),
+    )
+        .prop_map(
+            |(path, lang, code, lines, bytes, tokens, module, in_diff)| SubstrateFile {
+                path,
+                lang,
+                code,
+                lines,
+                bytes,
+                tokens,
+                module,
+                in_diff,
+            },
+        )
+}
+
+fn arb_diff_range() -> impl Strategy<Value = DiffRange> {
+    (
+        "[a-z]+",
+        "[a-z]+",
+        proptest::collection::vec("[a-z/]+\\.[a-z]{1,4}", 0..10),
+        0usize..100,
+        0usize..1000,
+        0usize..1000,
+    )
+        .prop_map(
+            |(base, head, changed_files, commit_count, insertions, deletions)| DiffRange {
+                base,
+                head,
+                changed_files,
+                commit_count,
+                insertions,
+                deletions,
+            },
+        )
+}
+
+fn arb_substrate_consistent() -> impl Strategy<Value = RepoSubstrate> {
+    proptest::collection::vec(arb_substrate_file(), 0..15).prop_map(|files| {
+        let mut lang_summary: BTreeMap<String, LangSummary> = BTreeMap::new();
+        for f in &files {
+            let e = lang_summary.entry(f.lang.clone()).or_insert(LangSummary {
+                files: 0,
+                code: 0,
+                lines: 0,
+                bytes: 0,
+                tokens: 0,
+            });
+            e.files += 1;
+            e.code += f.code;
+            e.lines += f.lines;
+            e.bytes += f.bytes;
+            e.tokens += f.tokens;
+        }
+        let total_tokens = files.iter().map(|f| f.tokens).sum();
+        let total_bytes = files.iter().map(|f| f.bytes).sum();
+        let total_code_lines = files.iter().map(|f| f.code).sum();
+        RepoSubstrate {
+            repo_root: "/repo".to_string(),
+            files,
+            lang_summary,
+            diff_range: None,
+            total_tokens,
+            total_bytes,
+            total_code_lines,
+        }
+    })
+}
+
+// ── Property tests ───────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn substrate_file_serde_roundtrip(file in arb_substrate_file()) {
+        let json = serde_json::to_string(&file).unwrap();
+        let back: SubstrateFile = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(back.path, file.path);
+        prop_assert_eq!(back.lang, file.lang);
+        prop_assert_eq!(back.code, file.code);
+        prop_assert_eq!(back.lines, file.lines);
+        prop_assert_eq!(back.bytes, file.bytes);
+        prop_assert_eq!(back.tokens, file.tokens);
+        prop_assert_eq!(back.module, file.module);
+        prop_assert_eq!(back.in_diff, file.in_diff);
+    }
+
+    #[test]
+    fn lang_summary_serde_roundtrip(ls in arb_lang_summary()) {
+        let json = serde_json::to_string(&ls).unwrap();
+        let back: LangSummary = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(back.files, ls.files);
+        prop_assert_eq!(back.code, ls.code);
+        prop_assert_eq!(back.lines, ls.lines);
+        prop_assert_eq!(back.bytes, ls.bytes);
+        prop_assert_eq!(back.tokens, ls.tokens);
+    }
+
+    #[test]
+    fn diff_range_serde_roundtrip(dr in arb_diff_range()) {
+        let json = serde_json::to_string(&dr).unwrap();
+        let back: DiffRange = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(back.base, dr.base);
+        prop_assert_eq!(back.head, dr.head);
+        prop_assert_eq!(back.changed_files.len(), dr.changed_files.len());
+        prop_assert_eq!(back.commit_count, dr.commit_count);
+        prop_assert_eq!(back.insertions, dr.insertions);
+        prop_assert_eq!(back.deletions, dr.deletions);
+    }
+
+    #[test]
+    fn substrate_serde_roundtrip(sub in arb_substrate_consistent()) {
+        let json = serde_json::to_string(&sub).unwrap();
+        let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(back.files.len(), sub.files.len());
+        prop_assert_eq!(back.lang_summary.len(), sub.lang_summary.len());
+        prop_assert_eq!(back.total_code_lines, sub.total_code_lines);
+        prop_assert_eq!(back.total_tokens, sub.total_tokens);
+        prop_assert_eq!(back.total_bytes, sub.total_bytes);
+    }
+
+    #[test]
+    fn totals_equal_file_sums(sub in arb_substrate_consistent()) {
+        let sum_code: usize = sub.files.iter().map(|f| f.code).sum();
+        let sum_tokens: usize = sub.files.iter().map(|f| f.tokens).sum();
+        let sum_bytes: usize = sub.files.iter().map(|f| f.bytes).sum();
+        prop_assert_eq!(sub.total_code_lines, sum_code);
+        prop_assert_eq!(sub.total_tokens, sum_tokens);
+        prop_assert_eq!(sub.total_bytes, sum_bytes);
+    }
+
+    #[test]
+    fn lang_summary_file_count_equals_file_vec_len(sub in arb_substrate_consistent()) {
+        let summary_total: usize = sub.lang_summary.values().map(|l| l.files).sum();
+        prop_assert_eq!(summary_total, sub.files.len());
+    }
+
+    #[test]
+    fn lang_summary_code_equals_total(sub in arb_substrate_consistent()) {
+        let summary_code: usize = sub.lang_summary.values().map(|l| l.code).sum();
+        prop_assert_eq!(summary_code, sub.total_code_lines);
+    }
+
+    #[test]
+    fn diff_files_subset_of_files(sub in arb_substrate_consistent()) {
+        let diff_count = sub.diff_files().count();
+        let in_diff_count = sub.files.iter().filter(|f| f.in_diff).count();
+        prop_assert_eq!(diff_count, in_diff_count);
+    }
+
+    #[test]
+    fn files_for_lang_partition(sub in arb_substrate_consistent()) {
+        // files_for_lang for each known language should cover all files
+        let mut total = 0usize;
+        for lang in sub.lang_summary.keys() {
+            total += sub.files_for_lang(lang).count();
+        }
+        prop_assert_eq!(total, sub.files.len());
+    }
+
+    #[test]
+    fn clone_preserves_all_fields(sub in arb_substrate_consistent()) {
+        let cloned = sub.clone();
+        let j1 = serde_json::to_string(&sub).unwrap();
+        let j2 = serde_json::to_string(&cloned).unwrap();
+        prop_assert_eq!(j1, j2);
+    }
+
+    #[test]
+    fn lang_summary_keys_sorted(sub in arb_substrate_consistent()) {
+        let keys: Vec<&String> = sub.lang_summary.keys().collect();
+        for w in keys.windows(2) {
+            prop_assert!(w[0] <= w[1], "BTreeMap keys must be sorted");
+        }
+    }
+
+    #[test]
+    fn empty_files_means_zero_totals(
+        root in "[a-z/]+",
+    ) {
+        let sub = RepoSubstrate {
+            repo_root: root,
+            files: vec![],
+            lang_summary: BTreeMap::new(),
+            diff_range: None,
+            total_tokens: 0,
+            total_bytes: 0,
+            total_code_lines: 0,
+        };
+        prop_assert_eq!(sub.total_code_lines, 0);
+        prop_assert_eq!(sub.total_tokens, 0);
+        prop_assert_eq!(sub.total_bytes, 0);
+        prop_assert!(sub.diff_files().next().is_none());
+    }
+}

--- a/crates/tokmd-substrate/tests/substrate_depth_w59.rs
+++ b/crates/tokmd-substrate/tests/substrate_depth_w59.rs
@@ -1,0 +1,473 @@
+//! Depth tests for `RepoSubstrate` construction, field access, serde,
+//! sharing, and edge cases.
+
+use std::collections::BTreeMap;
+
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+fn make_file(path: &str, lang: &str, code: usize) -> SubstrateFile {
+    SubstrateFile {
+        path: path.to_string(),
+        lang: lang.to_string(),
+        code,
+        lines: code + 20,
+        bytes: code * 30,
+        tokens: code * 8,
+        module: path
+            .rsplit_once('/')
+            .map(|(m, _)| m)
+            .unwrap_or("")
+            .to_string(),
+        in_diff: false,
+    }
+}
+
+fn make_file_in_diff(path: &str, lang: &str, code: usize) -> SubstrateFile {
+    let mut f = make_file(path, lang, code);
+    f.in_diff = true;
+    f
+}
+
+fn substrate_from_files(files: Vec<SubstrateFile>) -> RepoSubstrate {
+    let mut lang_summary: BTreeMap<String, LangSummary> = BTreeMap::new();
+    for f in &files {
+        let e = lang_summary.entry(f.lang.clone()).or_insert(LangSummary {
+            files: 0,
+            code: 0,
+            lines: 0,
+            bytes: 0,
+            tokens: 0,
+        });
+        e.files += 1;
+        e.code += f.code;
+        e.lines += f.lines;
+        e.bytes += f.bytes;
+        e.tokens += f.tokens;
+    }
+    let total_tokens = files.iter().map(|f| f.tokens).sum();
+    let total_bytes = files.iter().map(|f| f.bytes).sum();
+    let total_code_lines = files.iter().map(|f| f.code).sum();
+    RepoSubstrate {
+        repo_root: "/repo".to_string(),
+        files,
+        lang_summary,
+        diff_range: None,
+        total_tokens,
+        total_bytes,
+        total_code_lines,
+    }
+}
+
+fn empty_substrate() -> RepoSubstrate {
+    substrate_from_files(vec![])
+}
+
+fn multi_lang_substrate() -> RepoSubstrate {
+    substrate_from_files(vec![
+        make_file("src/lib.rs", "Rust", 200),
+        make_file("src/main.py", "Python", 150),
+        make_file("tests/test.py", "Python", 80),
+        make_file_in_diff("src/app.ts", "TypeScript", 300),
+        make_file_in_diff("src/new.rs", "Rust", 50),
+    ])
+}
+
+fn sample_diff_range() -> DiffRange {
+    DiffRange {
+        base: "main".to_string(),
+        head: "feature/w59".to_string(),
+        changed_files: vec!["src/app.ts".to_string(), "src/new.rs".to_string()],
+        commit_count: 5,
+        insertions: 42,
+        deletions: 10,
+    }
+}
+
+// ── Construction tests ───────────────────────────────────────────
+
+#[test]
+fn empty_substrate_has_zero_totals() {
+    let sub = empty_substrate();
+    assert_eq!(sub.total_code_lines, 0);
+    assert_eq!(sub.total_tokens, 0);
+    assert_eq!(sub.total_bytes, 0);
+    assert!(sub.files.is_empty());
+    assert!(sub.lang_summary.is_empty());
+}
+
+#[test]
+fn single_file_substrate_totals() {
+    let f = make_file("src/lib.rs", "Rust", 100);
+    let sub = substrate_from_files(vec![f]);
+    assert_eq!(sub.total_code_lines, 100);
+    assert_eq!(sub.total_tokens, 800);
+    assert_eq!(sub.total_bytes, 3000);
+    assert_eq!(sub.files.len(), 1);
+    assert_eq!(sub.lang_summary.len(), 1);
+}
+
+#[test]
+fn multi_file_totals_are_sum_of_parts() {
+    let sub = multi_lang_substrate();
+    let expected_code = 200 + 150 + 80 + 300 + 50;
+    assert_eq!(sub.total_code_lines, expected_code);
+    let expected_tokens: usize = sub.files.iter().map(|f| f.tokens).sum();
+    assert_eq!(sub.total_tokens, expected_tokens);
+}
+
+#[test]
+fn lang_summary_aggregates_correctly() {
+    let sub = multi_lang_substrate();
+    assert_eq!(sub.lang_summary.len(), 3);
+
+    let rust = sub.lang_summary.get("Rust").unwrap();
+    assert_eq!(rust.files, 2);
+    assert_eq!(rust.code, 250); // 200 + 50
+
+    let python = sub.lang_summary.get("Python").unwrap();
+    assert_eq!(python.files, 2);
+    assert_eq!(python.code, 230); // 150 + 80
+
+    let ts = sub.lang_summary.get("TypeScript").unwrap();
+    assert_eq!(ts.files, 1);
+    assert_eq!(ts.code, 300);
+}
+
+#[test]
+fn lang_summary_keys_are_sorted() {
+    let sub = multi_lang_substrate();
+    let keys: Vec<&String> = sub.lang_summary.keys().collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "BTreeMap guarantees sorted keys");
+}
+
+// ── Field access tests ───────────────────────────────────────────
+
+#[test]
+fn repo_root_is_preserved() {
+    let sub = empty_substrate();
+    assert_eq!(sub.repo_root, "/repo");
+}
+
+#[test]
+fn diff_range_none_by_default() {
+    let sub = empty_substrate();
+    assert!(sub.diff_range.is_none());
+}
+
+#[test]
+fn diff_range_when_set() {
+    let mut sub = multi_lang_substrate();
+    sub.diff_range = Some(sample_diff_range());
+    let dr = sub.diff_range.as_ref().unwrap();
+    assert_eq!(dr.base, "main");
+    assert_eq!(dr.head, "feature/w59");
+    assert_eq!(dr.changed_files.len(), 2);
+    assert_eq!(dr.commit_count, 5);
+    assert_eq!(dr.insertions, 42);
+    assert_eq!(dr.deletions, 10);
+}
+
+// ── diff_files() method tests ────────────────────────────────────
+
+#[test]
+fn diff_files_returns_only_in_diff() {
+    let sub = multi_lang_substrate();
+    let diff: Vec<&SubstrateFile> = sub.diff_files().collect();
+    assert_eq!(diff.len(), 2);
+    for f in &diff {
+        assert!(f.in_diff);
+    }
+}
+
+#[test]
+fn diff_files_empty_when_none_in_diff() {
+    let sub = substrate_from_files(vec![
+        make_file("a.rs", "Rust", 10),
+        make_file("b.rs", "Rust", 20),
+    ]);
+    let diff: Vec<&SubstrateFile> = sub.diff_files().collect();
+    assert!(diff.is_empty());
+}
+
+#[test]
+fn diff_files_all_when_all_in_diff() {
+    let sub = substrate_from_files(vec![
+        make_file_in_diff("a.rs", "Rust", 10),
+        make_file_in_diff("b.rs", "Rust", 20),
+    ]);
+    let diff: Vec<&SubstrateFile> = sub.diff_files().collect();
+    assert_eq!(diff.len(), 2);
+}
+
+// ── files_for_lang() method tests ────────────────────────────────
+
+#[test]
+fn files_for_lang_filters_correctly() {
+    let sub = multi_lang_substrate();
+    let rust_files: Vec<&SubstrateFile> = sub.files_for_lang("Rust").collect();
+    assert_eq!(rust_files.len(), 2);
+    for f in &rust_files {
+        assert_eq!(f.lang, "Rust");
+    }
+}
+
+#[test]
+fn files_for_lang_returns_empty_for_missing() {
+    let sub = multi_lang_substrate();
+    let go_files: Vec<&SubstrateFile> = sub.files_for_lang("Go").collect();
+    assert!(go_files.is_empty());
+}
+
+#[test]
+fn files_for_lang_case_sensitive() {
+    let sub = multi_lang_substrate();
+    let lower: Vec<&SubstrateFile> = sub.files_for_lang("rust").collect();
+    assert!(lower.is_empty(), "language match should be case-sensitive");
+}
+
+#[test]
+fn files_for_lang_on_empty_substrate() {
+    let sub = empty_substrate();
+    let files: Vec<&SubstrateFile> = sub.files_for_lang("Rust").collect();
+    assert!(files.is_empty());
+}
+
+// ── SubstrateFile field tests ────────────────────────────────────
+
+#[test]
+fn substrate_file_module_from_path() {
+    let f = make_file("src/utils/helpers.rs", "Rust", 50);
+    assert_eq!(f.module, "src/utils");
+}
+
+#[test]
+fn substrate_file_module_root_file() {
+    let f = make_file("lib.rs", "Rust", 50);
+    assert_eq!(f.module, "");
+}
+
+// ── Serde roundtrip tests ────────────────────────────────────────
+
+#[test]
+fn substrate_full_roundtrip() {
+    let mut sub = multi_lang_substrate();
+    sub.diff_range = Some(sample_diff_range());
+    let json = serde_json::to_string_pretty(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.repo_root, sub.repo_root);
+    assert_eq!(back.files.len(), sub.files.len());
+    assert_eq!(back.lang_summary.len(), sub.lang_summary.len());
+    assert_eq!(back.total_code_lines, sub.total_code_lines);
+    assert_eq!(back.total_tokens, sub.total_tokens);
+    assert_eq!(back.total_bytes, sub.total_bytes);
+    assert!(back.diff_range.is_some());
+}
+
+#[test]
+fn substrate_empty_roundtrip() {
+    let sub = empty_substrate();
+    let json = serde_json::to_string(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert!(back.files.is_empty());
+    assert!(back.lang_summary.is_empty());
+    assert_eq!(back.total_code_lines, 0);
+}
+
+#[test]
+fn substrate_without_diff_omits_field() {
+    let sub = empty_substrate();
+    let json = serde_json::to_string(&sub).unwrap();
+    assert!(
+        !json.contains("diff_range"),
+        "None diff_range should be omitted via skip_serializing_if"
+    );
+}
+
+#[test]
+fn substrate_with_diff_includes_field() {
+    let mut sub = empty_substrate();
+    sub.diff_range = Some(sample_diff_range());
+    let json = serde_json::to_string(&sub).unwrap();
+    assert!(json.contains("diff_range"));
+    assert!(json.contains("feature/w59"));
+}
+
+#[test]
+fn diff_range_roundtrip() {
+    let dr = sample_diff_range();
+    let json = serde_json::to_string(&dr).unwrap();
+    let back: DiffRange = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.base, "main");
+    assert_eq!(back.head, "feature/w59");
+    assert_eq!(back.changed_files.len(), 2);
+    assert_eq!(back.commit_count, 5);
+    assert_eq!(back.insertions, 42);
+    assert_eq!(back.deletions, 10);
+}
+
+#[test]
+fn lang_summary_roundtrip() {
+    let ls = LangSummary {
+        files: 10,
+        code: 500,
+        lines: 600,
+        bytes: 15000,
+        tokens: 3750,
+    };
+    let json = serde_json::to_string(&ls).unwrap();
+    let back: LangSummary = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.files, 10);
+    assert_eq!(back.code, 500);
+    assert_eq!(back.lines, 600);
+    assert_eq!(back.bytes, 15000);
+    assert_eq!(back.tokens, 3750);
+}
+
+#[test]
+fn substrate_file_roundtrip() {
+    let f = make_file_in_diff("src/lib.rs", "Rust", 100);
+    let json = serde_json::to_string(&f).unwrap();
+    let back: SubstrateFile = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.path, "src/lib.rs");
+    assert_eq!(back.lang, "Rust");
+    assert_eq!(back.code, 100);
+    assert!(back.in_diff);
+}
+
+// ── Clone tests ──────────────────────────────────────────────────
+
+#[test]
+fn substrate_clone_is_independent() {
+    let sub = multi_lang_substrate();
+    let mut cloned = sub.clone();
+    cloned.repo_root = "/other".to_string();
+    assert_eq!(sub.repo_root, "/repo");
+    assert_eq!(cloned.repo_root, "/other");
+}
+
+#[test]
+fn substrate_file_clone_is_independent() {
+    let f = make_file("a.rs", "Rust", 50);
+    let mut cloned = f.clone();
+    cloned.code = 999;
+    assert_eq!(f.code, 50);
+    assert_eq!(cloned.code, 999);
+}
+
+// ── Sharing (immutable borrow) tests ─────────────────────────────
+
+#[test]
+fn substrate_shared_across_consumers() {
+    let sub = multi_lang_substrate();
+
+    // Simulate multiple consumers reading from the same substrate
+    let consumer1_langs: Vec<&str> = sub.lang_summary.keys().map(|k| k.as_str()).collect();
+    let consumer2_code = sub.total_code_lines;
+    let consumer3_diff: Vec<&str> = sub.diff_files().map(|f| f.path.as_str()).collect();
+
+    assert_eq!(consumer1_langs.len(), 3);
+    assert_eq!(consumer2_code, 780);
+    assert_eq!(consumer3_diff.len(), 2);
+}
+
+#[test]
+fn substrate_ref_multiple_iterators() {
+    let sub = multi_lang_substrate();
+
+    // Multiple iterators on same substrate
+    let rust_count = sub.files_for_lang("Rust").count();
+    let python_count = sub.files_for_lang("Python").count();
+    let diff_count = sub.diff_files().count();
+
+    assert_eq!(rust_count, 2);
+    assert_eq!(python_count, 2);
+    assert_eq!(diff_count, 2);
+}
+
+// ── Edge cases ───────────────────────────────────────────────────
+
+#[test]
+fn substrate_single_zero_code_file() {
+    let f = SubstrateFile {
+        path: "empty.txt".to_string(),
+        lang: "Text".to_string(),
+        code: 0,
+        lines: 0,
+        bytes: 0,
+        tokens: 0,
+        module: "".to_string(),
+        in_diff: false,
+    };
+    let sub = substrate_from_files(vec![f]);
+    assert_eq!(sub.total_code_lines, 0);
+    assert_eq!(sub.files.len(), 1);
+    assert_eq!(sub.lang_summary.get("Text").unwrap().code, 0);
+}
+
+#[test]
+fn substrate_many_languages() {
+    let langs = [
+        "Rust", "Python", "Go", "Java", "C", "C++", "JavaScript", "TypeScript", "Ruby", "Shell",
+    ];
+    let files: Vec<SubstrateFile> = langs
+        .iter()
+        .enumerate()
+        .map(|(i, lang)| make_file(&format!("src/file{i}.x"), lang, (i + 1) * 10))
+        .collect();
+    let sub = substrate_from_files(files);
+    assert_eq!(sub.lang_summary.len(), 10);
+    assert_eq!(sub.files.len(), 10);
+}
+
+#[test]
+fn diff_range_empty_changed_files() {
+    let dr = DiffRange {
+        base: "v1.0".to_string(),
+        head: "v2.0".to_string(),
+        changed_files: vec![],
+        commit_count: 0,
+        insertions: 0,
+        deletions: 0,
+    };
+    let json = serde_json::to_string(&dr).unwrap();
+    let back: DiffRange = serde_json::from_str(&json).unwrap();
+    assert!(back.changed_files.is_empty());
+    assert_eq!(back.commit_count, 0);
+}
+
+#[test]
+fn substrate_large_values() {
+    let f = SubstrateFile {
+        path: "huge.rs".to_string(),
+        lang: "Rust".to_string(),
+        code: 1_000_000,
+        lines: 1_200_000,
+        bytes: 50_000_000,
+        tokens: 12_000_000,
+        module: "".to_string(),
+        in_diff: false,
+    };
+    let sub = substrate_from_files(vec![f]);
+    assert_eq!(sub.total_code_lines, 1_000_000);
+    assert_eq!(sub.total_bytes, 50_000_000);
+}
+
+#[test]
+fn substrate_debug_impl() {
+    let sub = empty_substrate();
+    let dbg = format!("{:?}", sub);
+    assert!(dbg.contains("RepoSubstrate"));
+    assert!(dbg.contains("repo_root"));
+}
+
+#[test]
+fn substrate_file_debug_impl() {
+    let f = make_file("a.rs", "Rust", 10);
+    let dbg = format!("{:?}", f);
+    assert!(dbg.contains("SubstrateFile"));
+    assert!(dbg.contains("a.rs"));
+}


### PR DESCRIPTION
## Wave 59 — sensor + substrate depth tests

80 new tests across 4 files:
- trait_depth_w59.rs: sensor contract, verdict logic, report construction
- proptest_w59.rs (sensor): schema validity, JSON roundtrip, determinism
- substrate_depth_w59.rs: construction, field access, serde roundtrips
- proptest_w59.rs (substrate): serde roundtrips, totals invariants

All tests pass locally.