### PR TITLE
test(w59): depth tests for exclude patterns and export tree construction

### DIFF
--- a/crates/tokmd-exclude/tests/pattern_matching_w59.rs
+++ b/crates/tokmd-exclude/tests/pattern_matching_w59.rs
@@ -1,0 +1,246 @@
+//! W59 – Exclude pattern matching: normalization, dedup, edge cases.
+
+use std::path::{Path, PathBuf};
+use tokmd_exclude::{add_exclude_pattern, has_exclude_pattern, normalize_exclude_pattern};
+
+// ── normalize_exclude_pattern ────────────────────────────────────────
+
+#[test]
+fn normalize_strips_single_dot_slash_prefix() {
+    let root = Path::new("repo");
+    let got = normalize_exclude_pattern(root, Path::new("./src/main.rs"));
+    assert_eq!(got, "src/main.rs");
+}
+
+#[test]
+fn normalize_strips_repeated_dot_slash_prefixes() {
+    let root = Path::new("repo");
+    let got = normalize_exclude_pattern(root, Path::new("././././a.rs"));
+    assert_eq!(got, "a.rs");
+}
+
+#[test]
+fn normalize_converts_backslashes_to_forward_slashes() {
+    let root = Path::new("repo");
+    let got = normalize_exclude_pattern(root, Path::new(r"src\lib\util.rs"));
+    assert_eq!(got, "src/lib/util.rs");
+}
+
+#[test]
+fn normalize_absolute_under_root_strips_root() {
+    let root = std::env::temp_dir().join("w59-root");
+    let abs = root.join("src").join("main.rs");
+    let got = normalize_exclude_pattern(&root, &abs);
+    assert_eq!(got, "src/main.rs");
+}
+
+#[test]
+fn normalize_absolute_outside_root_keeps_full() {
+    let root = std::env::temp_dir().join("w59-root");
+    let outside = std::env::temp_dir().join("w59-other").join("file.txt");
+    let got = normalize_exclude_pattern(&root, &outside);
+    let expected = tokmd_path::normalize_rel_path(&outside.to_string_lossy());
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn normalize_preserves_dotfiles() {
+    let root = Path::new("project");
+    let got = normalize_exclude_pattern(root, Path::new(".gitignore"));
+    assert_eq!(got, ".gitignore");
+}
+
+#[test]
+fn normalize_preserves_hidden_directories() {
+    let root = Path::new("project");
+    let got = normalize_exclude_pattern(root, Path::new(".config/settings.json"));
+    assert_eq!(got, ".config/settings.json");
+}
+
+#[test]
+fn normalize_empty_relative_path() {
+    let root = Path::new("project");
+    let got = normalize_exclude_pattern(root, Path::new(""));
+    assert_eq!(got, "");
+}
+
+#[test]
+fn normalize_single_segment_file() {
+    let root = Path::new("project");
+    let got = normalize_exclude_pattern(root, Path::new("Makefile"));
+    assert_eq!(got, "Makefile");
+}
+
+#[test]
+fn normalize_deeply_nested_path() {
+    let root = Path::new("repo");
+    let got = normalize_exclude_pattern(root, Path::new("a/b/c/d/e/f.rs"));
+    assert_eq!(got, "a/b/c/d/e/f.rs");
+}
+
+#[test]
+fn normalize_preserves_double_dot_parent_refs() {
+    let root = Path::new("repo");
+    let got = normalize_exclude_pattern(root, Path::new("../sibling/file.txt"));
+    assert_eq!(got, "../sibling/file.txt");
+}
+
+// ── has_exclude_pattern ──────────────────────────────────────────────
+
+#[test]
+fn has_exclude_finds_exact_match() {
+    let existing = vec!["src/main.rs".to_string()];
+    assert!(has_exclude_pattern(&existing, "src/main.rs"));
+}
+
+#[test]
+fn has_exclude_finds_backslash_variant() {
+    let existing = vec!["src/main.rs".to_string()];
+    assert!(has_exclude_pattern(&existing, r"src\main.rs"));
+}
+
+#[test]
+fn has_exclude_finds_dot_slash_variant() {
+    let existing = vec!["src/main.rs".to_string()];
+    assert!(has_exclude_pattern(&existing, "./src/main.rs"));
+}
+
+#[test]
+fn has_exclude_returns_false_for_absent_pattern() {
+    let existing = vec!["src/main.rs".to_string()];
+    assert!(!has_exclude_pattern(&existing, "src/lib.rs"));
+}
+
+#[test]
+fn has_exclude_empty_existing_list() {
+    let existing: Vec<String> = vec![];
+    assert!(!has_exclude_pattern(&existing, "any/path"));
+}
+
+#[test]
+fn has_exclude_empty_pattern_against_nonempty_list() {
+    let existing = vec!["src/main.rs".to_string()];
+    assert!(!has_exclude_pattern(&existing, ""));
+}
+
+#[test]
+fn has_exclude_multiple_patterns_finds_second() {
+    let existing = vec!["a/b.rs".to_string(), "c/d.rs".to_string()];
+    assert!(has_exclude_pattern(&existing, "c/d.rs"));
+}
+
+#[test]
+fn has_exclude_case_sensitive() {
+    let existing = vec!["SRC/Main.rs".to_string()];
+    assert!(!has_exclude_pattern(&existing, "src/main.rs"));
+    assert!(has_exclude_pattern(&existing, "SRC/Main.rs"));
+}
+
+// ── add_exclude_pattern ──────────────────────────────────────────────
+
+#[test]
+fn add_returns_true_for_new_pattern() {
+    let mut patterns = vec![];
+    assert!(add_exclude_pattern(&mut patterns, "src/a.rs".to_string()));
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn add_returns_false_for_exact_duplicate() {
+    let mut patterns = vec!["src/a.rs".to_string()];
+    assert!(!add_exclude_pattern(
+        &mut patterns,
+        "src/a.rs".to_string()
+    ));
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn add_returns_false_for_backslash_duplicate() {
+    let mut patterns = vec!["src/a.rs".to_string()];
+    assert!(!add_exclude_pattern(
+        &mut patterns,
+        r"src\a.rs".to_string()
+    ));
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn add_returns_false_for_dot_slash_duplicate() {
+    let mut patterns = vec!["src/a.rs".to_string()];
+    assert!(!add_exclude_pattern(
+        &mut patterns,
+        "./src/a.rs".to_string()
+    ));
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn add_rejects_empty_string() {
+    let mut patterns = vec![];
+    assert!(!add_exclude_pattern(&mut patterns, String::new()));
+    assert!(patterns.is_empty());
+}
+
+#[test]
+fn add_accumulates_distinct_patterns() {
+    let mut patterns = vec![];
+    assert!(add_exclude_pattern(
+        &mut patterns,
+        "a/b.rs".to_string()
+    ));
+    assert!(add_exclude_pattern(
+        &mut patterns,
+        "c/d.rs".to_string()
+    ));
+    assert!(add_exclude_pattern(
+        &mut patterns,
+        "e/f.rs".to_string()
+    ));
+    assert_eq!(patterns.len(), 3);
+}
+
+// ── Combined workflows ───────────────────────────────────────────────
+
+#[test]
+fn normalize_then_add_dedupes_cross_platform_paths() {
+    let root = PathBuf::from("project");
+    let mut patterns = vec![];
+    let p1 = normalize_exclude_pattern(&root, Path::new(r".\out\result.json"));
+    let p2 = normalize_exclude_pattern(&root, Path::new("./out/result.json"));
+    assert!(add_exclude_pattern(&mut patterns, p1));
+    assert!(!add_exclude_pattern(&mut patterns, p2));
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0], "out/result.json");
+}
+
+#[test]
+fn add_then_has_roundtrip() {
+    let mut patterns = vec![];
+    add_exclude_pattern(&mut patterns, "dist/bundle.js".to_string());
+    assert!(has_exclude_pattern(&patterns, "dist/bundle.js"));
+    assert!(has_exclude_pattern(&patterns, r"dist\bundle.js"));
+    assert!(has_exclude_pattern(&patterns, "./dist/bundle.js"));
+}
+
+#[test]
+fn batch_insert_with_mixed_styles_dedupes() {
+    let mut patterns = vec![];
+    let inputs = [
+        "out/lang.json",
+        r"out\lang.json",
+        "./out/lang.json",
+        r".\out\lang.json",
+    ];
+    for input in &inputs {
+        add_exclude_pattern(&mut patterns, (*input).to_string());
+    }
+    assert_eq!(patterns.len(), 1);
+}
+
+#[test]
+fn root_equal_to_path_yields_empty() {
+    let root = std::env::temp_dir().join("w59-same");
+    let got = normalize_exclude_pattern(&root, &root);
+    assert_eq!(got, "");
+}

--- a/crates/tokmd-exclude/tests/properties_w59.rs
+++ b/crates/tokmd-exclude/tests/properties_w59.rs
@@ -1,0 +1,105 @@
+//! W59 – Property-based tests for tokmd-exclude.
+
+use std::path::PathBuf;
+
+use proptest::prelude::*;
+use tokmd_exclude::{add_exclude_pattern, has_exclude_pattern, normalize_exclude_pattern};
+
+fn segment() -> impl Strategy<Value = String> {
+    "[a-zA-Z0-9_-]{1,8}".prop_map(String::from)
+}
+
+fn rel_path() -> impl Strategy<Value = String> {
+    prop::collection::vec(segment(), 1..6).prop_map(|parts| parts.join("/"))
+}
+
+proptest! {
+    /// Once a pattern is added then re-evaluated through `has_exclude_pattern`,
+    /// the result remains `true` regardless of the slash style used.
+    #[test]
+    fn excluded_stays_excluded_after_re_evaluation(path in rel_path()) {
+        let mut patterns = Vec::new();
+        add_exclude_pattern(&mut patterns, path.clone());
+
+        // Re-evaluate with forward slashes.
+        prop_assert!(has_exclude_pattern(&patterns, &path));
+
+        // Re-evaluate with backslash variant.
+        let bs = path.replace('/', "\\");
+        prop_assert!(has_exclude_pattern(&patterns, &bs));
+
+        // Re-evaluate with ./ prefix.
+        let prefixed = format!("./{path}");
+        prop_assert!(has_exclude_pattern(&patterns, &prefixed));
+    }
+
+    /// `normalize_exclude_pattern` never produces a string with backslashes.
+    #[test]
+    fn normalize_never_produces_backslashes(path in rel_path()) {
+        let root = PathBuf::from("root");
+        let got = normalize_exclude_pattern(&root, PathBuf::from(&path).as_path());
+        prop_assert!(!got.contains('\\'), "backslash found in: {got}");
+    }
+
+    /// `normalize_exclude_pattern` is idempotent on relative paths.
+    #[test]
+    fn normalize_idempotent(path in rel_path()) {
+        let root = PathBuf::from("root");
+        let first = normalize_exclude_pattern(&root, PathBuf::from(&path).as_path());
+        let second = normalize_exclude_pattern(&root, PathBuf::from(&first).as_path());
+        prop_assert_eq!(first, second);
+    }
+
+    /// Adding a path then its `./-` prefixed form never grows the vec beyond 1.
+    #[test]
+    fn add_dot_slash_prefix_never_duplicates(path in rel_path()) {
+        let mut patterns = Vec::new();
+        add_exclude_pattern(&mut patterns, path.clone());
+        let dot_prefixed = format!("./{path}");
+        let inserted = add_exclude_pattern(&mut patterns, dot_prefixed);
+        prop_assert!(!inserted);
+        prop_assert_eq!(patterns.len(), 1);
+    }
+
+    /// Adding a path then its backslash form never grows the vec beyond 1.
+    #[test]
+    fn add_backslash_variant_never_duplicates(path in rel_path()) {
+        let mut patterns = Vec::new();
+        add_exclude_pattern(&mut patterns, path.clone());
+        let bs = path.replace('/', "\\");
+        let inserted = add_exclude_pattern(&mut patterns, bs);
+        prop_assert!(!inserted);
+        prop_assert_eq!(patterns.len(), 1);
+    }
+
+    /// Two distinct paths yield two entries.
+    #[test]
+    fn two_distinct_paths_yield_two_entries(
+        a in rel_path(),
+        b in rel_path(),
+    ) {
+        prop_assume!(a != b);
+        let mut patterns = Vec::new();
+        add_exclude_pattern(&mut patterns, a);
+        add_exclude_pattern(&mut patterns, b);
+        prop_assert_eq!(patterns.len(), 2);
+    }
+
+    /// The result of `normalize_exclude_pattern` never starts with `./`.
+    #[test]
+    fn result_never_starts_with_dot_slash(path in rel_path()) {
+        let root = PathBuf::from("repo");
+        let got = normalize_exclude_pattern(&root, PathBuf::from(&path).as_path());
+        prop_assert!(!got.starts_with("./"), "starts with ./: {got}");
+    }
+
+    /// Normalization preserves segment count for relative paths.
+    #[test]
+    fn segment_count_preserved(segments in prop::collection::vec(segment(), 1..6)) {
+        let root = PathBuf::from("repo");
+        let path_str = segments.join("/");
+        let got = normalize_exclude_pattern(&root, PathBuf::from(&path_str).as_path());
+        let got_segs: Vec<&str> = got.split('/').collect();
+        prop_assert_eq!(got_segs.len(), segments.len());
+    }
+}

--- a/crates/tokmd-export-tree/tests/properties_w59.rs
+++ b/crates/tokmd-export-tree/tests/properties_w59.rs
@@ -1,0 +1,210 @@
+//! W59 – Property-based tests for tokmd-export-tree.
+
+use proptest::prelude::*;
+use tokmd_export_tree::{render_analysis_tree, render_handoff_tree};
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+fn path_segment() -> impl Strategy<Value = String> {
+    "[a-z]{1,8}".prop_map(String::from)
+}
+
+fn filename() -> impl Strategy<Value = String> {
+    "[a-z]{1,6}\\.rs".prop_map(String::from)
+}
+
+fn path_strategy() -> impl Strategy<Value = String> {
+    (prop::collection::vec(path_segment(), 0..4), filename()).prop_map(|(dirs, file)| {
+        if dirs.is_empty() {
+            file
+        } else {
+            format!("{}/{}", dirs.join("/"), file)
+        }
+    })
+}
+
+fn parent_row(path: String, lines: usize, tokens: usize) -> FileRow {
+    let module = path
+        .split('/')
+        .next()
+        .map_or_else(|| "(root)".to_string(), String::from);
+    FileRow {
+        path,
+        module,
+        lang: "Rust".to_string(),
+        kind: FileKind::Parent,
+        code: lines,
+        comments: 0,
+        blanks: 0,
+        lines,
+        bytes: lines * 10,
+        tokens,
+    }
+}
+
+fn export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec!["crates".to_string()],
+        module_depth: 2,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+proptest! {
+    /// Handoff tree output never contains more indented lines than `max_depth` levels.
+    #[test]
+    fn handoff_depth_never_exceeds_limit(
+        paths in prop::collection::vec(path_strategy(), 1..32),
+        max_depth in 0usize..6,
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let tree = render_handoff_tree(&export(rows), max_depth);
+        for line in tree.lines() {
+            let leading_spaces = line.len() - line.trim_start().len();
+            let indent_level = leading_spaces / 2;
+            prop_assert!(
+                indent_level <= max_depth,
+                "indent_level={indent_level} > max_depth={max_depth} in line: {line}"
+            );
+        }
+    }
+
+    /// Handoff tree root file count always equals the number of Parent rows.
+    #[test]
+    fn handoff_root_files_eq_parent_count(
+        paths in prop::collection::vec(path_strategy(), 1..32),
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let count = rows.len();
+        let tree = render_handoff_tree(&export(rows), 10);
+        if let Some(first_line) = tree.lines().next() {
+            let expected = format!("(root) (files: {count},");
+            prop_assert!(
+                first_line.starts_with(&expected),
+                "expected '{expected}', got '{first_line}'"
+            );
+        }
+    }
+
+    /// Analysis tree is deterministic: same input ⇒ same output.
+    #[test]
+    fn analysis_tree_deterministic(
+        paths in prop::collection::vec(path_strategy(), 0..32),
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let e = export(rows);
+        let a = render_analysis_tree(&e);
+        let b = render_analysis_tree(&e);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Handoff tree is deterministic: same input ⇒ same output.
+    #[test]
+    fn handoff_tree_deterministic(
+        paths in prop::collection::vec(path_strategy(), 0..32),
+        depth in 0usize..8,
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let e = export(rows);
+        let a = render_handoff_tree(&e, depth);
+        let b = render_handoff_tree(&e, depth);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Reversing input rows produces identical output (order independence).
+    #[test]
+    fn order_independence(
+        paths in prop::collection::vec(path_strategy(), 0..32),
+        depth in 0usize..8,
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let mut rev = rows.clone();
+        rev.reverse();
+        prop_assert_eq!(
+            render_analysis_tree(&export(rows.clone())),
+            render_analysis_tree(&export(rev.clone())),
+        );
+        prop_assert_eq!(
+            render_handoff_tree(&export(rows), depth),
+            render_handoff_tree(&export(rev), depth),
+        );
+    }
+
+    /// Non-empty parent rows always produce non-empty analysis tree output.
+    #[test]
+    fn non_empty_parents_produce_non_empty_analysis(
+        paths in prop::collection::vec(path_strategy(), 1..16),
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let tree = render_analysis_tree(&export(rows));
+        prop_assert!(!tree.is_empty());
+    }
+
+    /// Non-empty parent rows always produce non-empty handoff tree output.
+    #[test]
+    fn non_empty_parents_produce_non_empty_handoff(
+        paths in prop::collection::vec(path_strategy(), 1..16),
+        depth in 0usize..8,
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let tree = render_handoff_tree(&export(rows), depth);
+        prop_assert!(!tree.is_empty());
+    }
+
+    /// Every non-empty analysis tree ends with a newline.
+    #[test]
+    fn analysis_tree_trailing_newline(
+        paths in prop::collection::vec(path_strategy(), 1..16),
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let tree = render_analysis_tree(&export(rows));
+        prop_assert!(tree.ends_with('\n'), "expected trailing newline");
+    }
+
+    /// Handoff tree `.rs` file leaves are never rendered.
+    #[test]
+    fn handoff_never_contains_rs_extension(
+        paths in prop::collection::vec(path_strategy(), 1..16),
+        depth in 0usize..8,
+    ) {
+        let rows: Vec<FileRow> = paths
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| parent_row(p, i + 1, (i + 1) * 2))
+            .collect();
+        let tree = render_handoff_tree(&export(rows), depth);
+        prop_assert!(!tree.contains(".rs"), "handoff should not show file leaves");
+    }
+}

--- a/crates/tokmd-export-tree/tests/tree_construction_w59.rs
+++ b/crates/tokmd-export-tree/tests/tree_construction_w59.rs
@@ -1,0 +1,323 @@
+//! W59 – Tree construction, depth limiting, sorting, determinism.
+
+use tokmd_export_tree::{render_analysis_tree, render_handoff_tree};
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn row(path: &str, kind: FileKind, lines: usize, tokens: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: path
+            .split('/')
+            .next()
+            .map_or_else(|| "(root)".to_string(), String::from),
+        lang: "Rust".to_string(),
+        kind,
+        code: lines,
+        comments: 0,
+        blanks: 0,
+        lines,
+        bytes: lines * 10,
+        tokens,
+    }
+}
+
+fn parent(path: &str, lines: usize, tokens: usize) -> FileRow {
+    row(path, FileKind::Parent, lines, tokens)
+}
+
+fn child(path: &str, lines: usize, tokens: usize) -> FileRow {
+    row(path, FileKind::Child, lines, tokens)
+}
+
+fn export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec!["crates".to_string()],
+        module_depth: 2,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+// ── Empty input ──────────────────────────────────────────────────────
+
+#[test]
+fn analysis_tree_empty_rows_returns_empty() {
+    assert!(render_analysis_tree(&export(vec![])).is_empty());
+}
+
+#[test]
+fn handoff_tree_empty_rows_returns_empty() {
+    assert!(render_handoff_tree(&export(vec![]), 5).is_empty());
+}
+
+// ── Single file ──────────────────────────────────────────────────────
+
+#[test]
+fn analysis_tree_single_root_file() {
+    let tree = render_analysis_tree(&export(vec![parent("README.md", 10, 20)]));
+    assert_eq!(tree.trim(), "README.md (lines: 10, tokens: 20)");
+    assert_eq!(tree.lines().count(), 1);
+}
+
+#[test]
+fn handoff_tree_single_root_file() {
+    let tree = render_handoff_tree(&export(vec![parent("README.md", 10, 20)]), 5);
+    assert_eq!(tree.trim(), "(root) (files: 1, lines: 10, tokens: 20)");
+    assert_eq!(tree.lines().count(), 1);
+}
+
+// ── Child filtering ──────────────────────────────────────────────────
+
+#[test]
+fn analysis_tree_ignores_child_kind_rows() {
+    let data = export(vec![
+        parent("src/main.rs", 50, 100),
+        child("src/main.rs::inline", 20, 40),
+    ]);
+    let tree = render_analysis_tree(&data);
+    assert!(tree.contains("main.rs (lines: 50, tokens: 100)"));
+    assert!(!tree.contains("inline"));
+}
+
+#[test]
+fn handoff_tree_ignores_child_kind_rows() {
+    let data = export(vec![
+        parent("src/main.rs", 50, 100),
+        child("src/main.rs::css", 5, 10),
+    ]);
+    let tree = render_handoff_tree(&data, 5);
+    assert!(tree.contains("(root) (files: 1, lines: 50, tokens: 100)"));
+}
+
+#[test]
+fn only_child_rows_produce_empty_trees() {
+    let data = export(vec![
+        child("src/a.rs::embedded", 10, 20),
+        child("src/b.rs::embedded", 30, 60),
+    ]);
+    assert!(render_analysis_tree(&data).is_empty());
+    assert!(render_handoff_tree(&data, 5).is_empty());
+}
+
+// ── Aggregation ──────────────────────────────────────────────────────
+
+#[test]
+fn analysis_tree_aggregates_parent_lines_and_tokens() {
+    let data = export(vec![
+        parent("src/a.rs", 10, 20),
+        parent("src/b.rs", 30, 60),
+    ]);
+    let tree = render_analysis_tree(&data);
+    assert!(tree.contains("src (lines: 40, tokens: 80)"));
+}
+
+#[test]
+fn handoff_tree_aggregates_file_count_lines_tokens() {
+    let data = export(vec![
+        parent("src/a.rs", 10, 20),
+        parent("src/b.rs", 30, 60),
+        parent("src/c.rs", 5, 10),
+    ]);
+    let tree = render_handoff_tree(&data, 5);
+    let root_line = tree.lines().next().unwrap();
+    assert_eq!(root_line, "(root) (files: 3, lines: 45, tokens: 90)");
+}
+
+#[test]
+fn analysis_tree_nested_aggregation() {
+    let data = export(vec![
+        parent("crates/a/src/lib.rs", 100, 200),
+        parent("crates/a/src/util.rs", 50, 100),
+        parent("crates/b/src/lib.rs", 30, 60),
+    ]);
+    let tree = render_analysis_tree(&data);
+    assert!(tree.contains("crates (lines: 180, tokens: 360)"));
+    assert!(tree.contains("a (lines: 150, tokens: 300)"));
+    assert!(tree.contains("b (lines: 30, tokens: 60)"));
+}
+
+// ── Depth limiting (handoff) ─────────────────────────────────────────
+
+#[test]
+fn handoff_depth_zero_emits_only_root() {
+    let data = export(vec![parent("a/b/c/d.rs", 10, 20)]);
+    let tree = render_handoff_tree(&data, 0);
+    assert_eq!(tree.lines().count(), 1);
+    assert!(tree.starts_with("(root)"));
+}
+
+#[test]
+fn handoff_depth_one_shows_first_level_dir() {
+    let data = export(vec![parent("a/b/c/d.rs", 10, 20)]);
+    let tree = render_handoff_tree(&data, 1);
+    assert!(tree.contains("a/"));
+    assert!(!tree.contains("b/"));
+}
+
+#[test]
+fn handoff_depth_two_shows_two_levels() {
+    let data = export(vec![parent("a/b/c/d.rs", 10, 20)]);
+    let tree = render_handoff_tree(&data, 2);
+    assert!(tree.contains("a/"));
+    assert!(tree.contains("b/"));
+    assert!(!tree.contains("c/"));
+}
+
+#[test]
+fn handoff_large_depth_shows_all_dirs() {
+    let data = export(vec![parent("a/b/c/d.rs", 10, 20)]);
+    let tree = render_handoff_tree(&data, 100);
+    assert!(tree.contains("a/"));
+    assert!(tree.contains("b/"));
+    assert!(tree.contains("c/"));
+    // File leaf never appears in handoff tree
+    assert!(!tree.contains("d.rs"));
+}
+
+// ── Deterministic ordering ───────────────────────────────────────────
+
+#[test]
+fn analysis_tree_lexicographic_sibling_order() {
+    let data = export(vec![
+        parent("src/z.rs", 1, 1),
+        parent("src/a.rs", 1, 1),
+        parent("src/m.rs", 1, 1),
+    ]);
+    let tree = render_analysis_tree(&data);
+    let names: Vec<&str> = tree
+        .lines()
+        .filter(|l| l.contains(".rs"))
+        .map(|l| l.trim().split(' ').next().unwrap())
+        .collect();
+    assert_eq!(names, vec!["a.rs", "m.rs", "z.rs"]);
+}
+
+#[test]
+fn handoff_tree_lexicographic_sibling_order() {
+    let data = export(vec![
+        parent("z/file.rs", 1, 1),
+        parent("a/file.rs", 1, 1),
+        parent("m/file.rs", 1, 1),
+    ]);
+    let tree = render_handoff_tree(&data, 5);
+    let dirs: Vec<&str> = tree
+        .lines()
+        .filter(|l| l.trim().ends_with('/') || l.trim().starts_with("a/") || l.trim().starts_with("m/") || l.trim().starts_with("z/"))
+        .map(|l| l.trim().split(' ').next().unwrap())
+        .collect();
+    assert_eq!(dirs, vec!["a/", "m/", "z/"]);
+}
+
+#[test]
+fn reversed_input_order_produces_identical_output() {
+    let rows = vec![
+        parent("b/x.rs", 10, 20),
+        parent("a/y.rs", 30, 60),
+    ];
+    let mut rev = rows.clone();
+    rev.reverse();
+    assert_eq!(
+        render_analysis_tree(&export(rows.clone())),
+        render_analysis_tree(&export(rev.clone())),
+    );
+    assert_eq!(
+        render_handoff_tree(&export(rows), 5),
+        render_handoff_tree(&export(rev), 5),
+    );
+}
+
+// ── Indentation ──────────────────────────────────────────────────────
+
+#[test]
+fn analysis_tree_indentation_per_depth() {
+    let data = export(vec![parent("a/b/c.rs", 5, 10)]);
+    let tree = render_analysis_tree(&data);
+    let lines: Vec<&str> = tree.lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines[0].starts_with("a "));
+    assert!(lines[1].starts_with("  b "));
+    assert!(lines[2].starts_with("    c.rs "));
+}
+
+#[test]
+fn handoff_tree_indentation_per_depth() {
+    let data = export(vec![parent("a/b/c/d.rs", 5, 10)]);
+    let tree = render_handoff_tree(&data, 10);
+    let lines: Vec<&str> = tree.lines().collect();
+    assert!(lines[0].starts_with("(root)"));
+    assert!(lines[1].starts_with("  a/"));
+    assert!(lines[2].starts_with("    b/"));
+    assert!(lines[3].starts_with("      c/"));
+}
+
+// ── Zero-value rows ─────────────────────────────────────────────────
+
+#[test]
+fn zero_lines_zero_tokens_still_rendered() {
+    let data = export(vec![parent("src/empty.rs", 0, 0)]);
+    let tree = render_analysis_tree(&data);
+    assert!(tree.contains("empty.rs (lines: 0, tokens: 0)"));
+}
+
+#[test]
+fn handoff_zero_values_in_root() {
+    let data = export(vec![parent("src/empty.rs", 0, 0)]);
+    let tree = render_handoff_tree(&data, 5);
+    assert!(tree.contains("(root) (files: 1, lines: 0, tokens: 0)"));
+}
+
+// ── Multiple top-level dirs ──────────────────────────────────────────
+
+#[test]
+fn analysis_tree_multiple_top_dirs_aggregated_independently() {
+    let data = export(vec![
+        parent("crates/a/lib.rs", 100, 200),
+        parent("packages/b/index.ts", 50, 100),
+    ]);
+    let tree = render_analysis_tree(&data);
+    assert!(tree.contains("crates (lines: 100, tokens: 200)"));
+    assert!(tree.contains("packages (lines: 50, tokens: 100)"));
+}
+
+#[test]
+fn handoff_tree_multiple_top_dirs() {
+    let data = export(vec![
+        parent("crates/a/lib.rs", 100, 200),
+        parent("packages/b/index.ts", 50, 100),
+    ]);
+    let tree = render_handoff_tree(&data, 3);
+    assert!(tree.contains("crates/"));
+    assert!(tree.contains("packages/"));
+}
+
+// ── Handoff never shows file leaves ──────────────────────────────────
+
+#[test]
+fn handoff_tree_never_shows_file_names() {
+    let data = export(vec![
+        parent("src/main.rs", 10, 20),
+        parent("src/lib.rs", 20, 40),
+        parent("tests/test_a.rs", 5, 10),
+    ]);
+    let tree = render_handoff_tree(&data, 10);
+    assert!(!tree.contains("main.rs"));
+    assert!(!tree.contains("lib.rs"));
+    assert!(!tree.contains("test_a.rs"));
+}
+
+// ── Large tree ───────────────────────────────────────────────────────
+
+#[test]
+fn large_tree_aggregation_is_consistent() {
+    let rows: Vec<FileRow> = (0..100)
+        .map(|i| parent(&format!("dir{}/sub{}/file{}.rs", i % 5, i % 10, i), i, i * 2))
+        .collect();
+    let total_lines: usize = rows.iter().map(|r| r.lines).sum();
+    let total_tokens: usize = rows.iter().map(|r| r.tokens).sum();
+
+    let handoff = render_handoff_tree(&export(rows), 10);
+    let root_line = handoff.lines().next().unwrap();
+    assert!(root_line.contains(&format!("files: 100, lines: {total_lines}, tokens: {total_tokens}")));
+}


### PR DESCRIPTION
## Wave 59 — exclude + export-tree depth tests

58 new tests across 4 files:
- pattern_matching_w59.rs: normalization, dedup, case sensitivity
- properties_w59.rs (exclude): re-evaluation stability, idempotency
- tree_construction_w59.rs: tree construction, depth limiting, sorting
- properties_w59.rs (export-tree): depth never exceeds limit, determinism

All tests pass locally.