### PR TITLE
test(w60): depth tests for gate policy evaluation and config loading

### DIFF
--- a/crates/tokmd-config/tests/config_depth_w60.rs
+++ b/crates/tokmd-config/tests/config_depth_w60.rs
@@ -1,0 +1,892 @@
+//! Depth tests for tokmd-config (w60).
+//!
+//! BDD-style tests covering:
+//! - TOML configuration loading and parsing
+//! - Config merging (file + CLI overrides)
+//! - Default values, missing fields, extra fields
+//! - Profile system (UserConfig, ViewProfile)
+//! - Config serialization roundtrips
+//! - Enum serde coverage
+//! - GlobalArgs → ScanOptions conversion
+//! - Property tests for config determinism
+
+use tokmd_config::{
+    AnalysisPreset, BadgeMetric, ColorMode, ConfigMode, ContextOutput, ContextStrategy,
+    CockpitFormat, DiffFormat, DiffRangeMode, GateFormat, GlobalArgs, HandoffPreset,
+    ImportGranularity, NearDupScope, Profile, RedactMode, SensorFormat, TomlConfig, UserConfig,
+    ValueMetric, ViewProfile,
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. TOML Parsing — Valid configs
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_empty_toml_when_parsed_then_all_defaults() {
+    let config = TomlConfig::parse("").expect("empty TOML parses");
+    assert_eq!(config.scan.hidden, None);
+    assert_eq!(config.scan.no_ignore, None);
+    assert_eq!(config.module.depth, None);
+    assert_eq!(config.module.roots, None);
+    assert_eq!(config.export.min_code, None);
+    assert_eq!(config.export.max_rows, None);
+    assert_eq!(config.analyze.preset, None);
+    assert_eq!(config.context.budget, None);
+    assert_eq!(config.badge.metric, None);
+    assert_eq!(config.gate.policy, None);
+    assert!(config.view.is_empty());
+}
+
+#[test]
+fn given_scan_section_when_parsed_then_fields_populated() {
+    let toml_str = r#"
+[scan]
+hidden = true
+no_ignore = true
+no_ignore_parent = false
+no_ignore_vcs = true
+doc_comments = true
+paths = ["src", "lib"]
+exclude = ["target", "node_modules"]
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.scan.hidden, Some(true));
+    assert_eq!(config.scan.no_ignore, Some(true));
+    assert_eq!(config.scan.no_ignore_parent, Some(false));
+    assert_eq!(config.scan.no_ignore_vcs, Some(true));
+    assert_eq!(config.scan.doc_comments, Some(true));
+    assert_eq!(config.scan.paths, Some(vec!["src".into(), "lib".into()]));
+    assert_eq!(
+        config.scan.exclude,
+        Some(vec!["target".into(), "node_modules".into()])
+    );
+}
+
+#[test]
+fn given_module_section_when_parsed_then_roots_and_depth_loaded() {
+    let toml_str = r#"
+[module]
+roots = ["crates", "packages"]
+depth = 3
+children = "collapse"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(
+        config.module.roots,
+        Some(vec!["crates".into(), "packages".into()])
+    );
+    assert_eq!(config.module.depth, Some(3));
+    assert_eq!(config.module.children, Some("collapse".into()));
+}
+
+#[test]
+fn given_export_section_when_parsed_then_limits_set() {
+    let toml_str = r#"
+[export]
+min_code = 5
+max_rows = 500
+redact = "paths"
+format = "csv"
+children = "separate"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.export.min_code, Some(5));
+    assert_eq!(config.export.max_rows, Some(500));
+    assert_eq!(config.export.redact, Some("paths".into()));
+    assert_eq!(config.export.format, Some("csv".into()));
+    assert_eq!(config.export.children, Some("separate".into()));
+}
+
+#[test]
+fn given_analyze_section_when_parsed_then_all_fields_set() {
+    let toml_str = r#"
+[analyze]
+preset = "deep"
+window = 128000
+format = "json"
+git = true
+max_files = 10000
+max_bytes = 50000000
+max_file_bytes = 1000000
+max_commits = 500
+max_commit_files = 200
+granularity = "file"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.analyze.preset, Some("deep".into()));
+    assert_eq!(config.analyze.window, Some(128_000));
+    assert_eq!(config.analyze.format, Some("json".into()));
+    assert_eq!(config.analyze.git, Some(true));
+    assert_eq!(config.analyze.max_files, Some(10000));
+    assert_eq!(config.analyze.max_bytes, Some(50_000_000));
+    assert_eq!(config.analyze.max_file_bytes, Some(1_000_000));
+    assert_eq!(config.analyze.max_commits, Some(500));
+    assert_eq!(config.analyze.max_commit_files, Some(200));
+    assert_eq!(config.analyze.granularity, Some("file".into()));
+}
+
+#[test]
+fn given_context_section_when_parsed_then_strategy_and_budget_set() {
+    let toml_str = r#"
+[context]
+budget = "256k"
+strategy = "spread"
+rank_by = "hotspot"
+output = "bundle"
+compress = true
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.context.budget, Some("256k".into()));
+    assert_eq!(config.context.strategy, Some("spread".into()));
+    assert_eq!(config.context.rank_by, Some("hotspot".into()));
+    assert_eq!(config.context.output, Some("bundle".into()));
+    assert_eq!(config.context.compress, Some(true));
+}
+
+#[test]
+fn given_gate_section_when_parsed_then_policy_fields_set() {
+    let toml_str = r#"
+[gate]
+policy = "policy.toml"
+baseline = "baseline.json"
+preset = "health"
+fail_fast = true
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.gate.policy, Some("policy.toml".into()));
+    assert_eq!(config.gate.baseline, Some("baseline.json".into()));
+    assert_eq!(config.gate.preset, Some("health".into()));
+    assert_eq!(config.gate.fail_fast, Some(true));
+}
+
+#[test]
+fn given_badge_section_when_parsed_then_metric_set() {
+    let toml_str = r#"
+[badge]
+metric = "tokens"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.badge.metric, Some("tokens".into()));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. TOML Parsing — View profiles
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_view_profile_when_parsed_then_all_fields_available() {
+    let toml_str = r#"
+[view.ci]
+format = "json"
+top = 10
+files = true
+redact = "paths"
+module_roots = ["crates"]
+module_depth = 2
+min_code = 1
+max_rows = 100
+meta = true
+children = "collapse"
+preset = "health"
+window = 64000
+budget = "64k"
+strategy = "greedy"
+rank_by = "code"
+output = "list"
+compress = false
+metric = "lines"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    let ci = &config.view["ci"];
+    assert_eq!(ci.format, Some("json".into()));
+    assert_eq!(ci.top, Some(10));
+    assert_eq!(ci.files, Some(true));
+    assert_eq!(ci.redact, Some("paths".into()));
+    assert_eq!(ci.module_roots, Some(vec!["crates".into()]));
+    assert_eq!(ci.module_depth, Some(2));
+    assert_eq!(ci.min_code, Some(1));
+    assert_eq!(ci.max_rows, Some(100));
+    assert_eq!(ci.meta, Some(true));
+    assert_eq!(ci.children, Some("collapse".into()));
+    assert_eq!(ci.preset, Some("health".into()));
+    assert_eq!(ci.window, Some(64000));
+    assert_eq!(ci.budget, Some("64k".into()));
+    assert_eq!(ci.strategy, Some("greedy".into()));
+    assert_eq!(ci.rank_by, Some("code".into()));
+    assert_eq!(ci.output, Some("list".into()));
+    assert_eq!(ci.compress, Some(false));
+    assert_eq!(ci.metric, Some("lines".into()));
+}
+
+#[test]
+fn given_multiple_view_profiles_when_parsed_then_all_accessible() {
+    let toml_str = r#"
+[view.ci]
+format = "json"
+top = 5
+
+[view.llm]
+format = "md"
+redact = "all"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.view.len(), 2);
+    assert_eq!(config.view["ci"].format, Some("json".into()));
+    assert_eq!(config.view["ci"].top, Some(5));
+    assert_eq!(config.view["llm"].format, Some("md".into()));
+    assert_eq!(config.view["llm"].redact, Some("all".into()));
+}
+
+#[test]
+fn given_empty_view_profile_when_parsed_then_all_fields_none() {
+    let toml_str = r#"
+[view.empty]
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    let empty = &config.view["empty"];
+    assert!(empty.format.is_none());
+    assert!(empty.top.is_none());
+    assert!(empty.files.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. TOML Parsing — Error cases
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_invalid_toml_syntax_when_parsed_then_error() {
+    let result = TomlConfig::parse("[[[ not valid toml");
+    assert!(result.is_err());
+}
+
+#[test]
+fn given_wrong_type_for_field_when_parsed_then_error() {
+    let result = TomlConfig::parse(r#"
+[scan]
+hidden = "not_a_bool"
+"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn given_wrong_type_for_depth_when_parsed_then_error() {
+    let result = TomlConfig::parse(r#"
+[module]
+depth = "three"
+"#);
+    assert!(result.is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 4. Extra fields (TOML serde default allows unknown fields)
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_unknown_top_level_keys_when_parsed_then_no_error() {
+    // serde(default) on all sections means unknown sections are silently ignored
+    let toml_str = r#"
+[scan]
+hidden = true
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.scan.hidden, Some(true));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 5. UserConfig and Profile
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_default_user_config_then_empty() {
+    let c = UserConfig::default();
+    assert!(c.profiles.is_empty());
+    assert!(c.repos.is_empty());
+}
+
+#[test]
+fn given_user_config_with_profiles_then_profiles_accessible() {
+    let mut c = UserConfig::default();
+    c.profiles.insert(
+        "llm_safe".into(),
+        Profile {
+            format: Some("json".into()),
+            top: Some(10),
+            redact: Some(RedactMode::All),
+            ..Profile::default()
+        },
+    );
+    c.repos.insert("owner/repo".into(), "llm_safe".into());
+    assert_eq!(c.profiles.len(), 1);
+    assert_eq!(c.repos.len(), 1);
+    assert_eq!(c.profiles["llm_safe"].top, Some(10));
+}
+
+#[test]
+fn given_profile_default_then_all_fields_none() {
+    let p = Profile::default();
+    assert!(p.format.is_none());
+    assert!(p.top.is_none());
+    assert!(p.files.is_none());
+    assert!(p.module_roots.is_none());
+    assert!(p.module_depth.is_none());
+    assert!(p.min_code.is_none());
+    assert!(p.max_rows.is_none());
+    assert!(p.redact.is_none());
+    assert!(p.meta.is_none());
+    assert!(p.children.is_none());
+}
+
+#[test]
+fn given_profile_with_all_fields_then_serde_roundtrip() {
+    let p = Profile {
+        format: Some("json".into()),
+        top: Some(20),
+        files: Some(true),
+        module_roots: Some(vec!["crates".into(), "packages".into()]),
+        module_depth: Some(3),
+        min_code: Some(5),
+        max_rows: Some(1000),
+        redact: Some(RedactMode::Paths),
+        meta: Some(true),
+        children: Some("collapse".into()),
+    };
+    let json = serde_json::to_string(&p).unwrap();
+    let back: Profile = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.format, p.format);
+    assert_eq!(back.top, p.top);
+    assert_eq!(back.files, p.files);
+    assert_eq!(back.module_roots, p.module_roots);
+    assert_eq!(back.module_depth, p.module_depth);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 6. GlobalArgs → ScanOptions conversion
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_global_args_with_defaults_when_converted_then_scan_options_defaults() {
+    let g = GlobalArgs::default();
+    let opts: tokmd_settings::ScanOptions = (&g).into();
+    assert!(opts.excluded.is_empty());
+    assert!(!opts.hidden);
+    assert!(!opts.no_ignore);
+    assert!(!opts.no_ignore_parent);
+    assert!(!opts.no_ignore_dot);
+    assert!(!opts.no_ignore_vcs);
+    assert!(!opts.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn given_global_args_with_custom_values_when_converted_then_all_propagated() {
+    let g = GlobalArgs {
+        excluded: vec!["target".into(), "vendor".into()],
+        config: ConfigMode::None,
+        hidden: true,
+        no_ignore: true,
+        no_ignore_parent: true,
+        no_ignore_dot: true,
+        no_ignore_vcs: true,
+        treat_doc_strings_as_comments: true,
+        verbose: 2,
+        no_progress: true,
+    };
+    let opts: tokmd_settings::ScanOptions = (&g).into();
+    assert_eq!(opts.excluded.len(), 2);
+    assert_eq!(opts.config, ConfigMode::None);
+    assert!(opts.hidden);
+    assert!(opts.no_ignore);
+    assert!(opts.no_ignore_parent);
+    assert!(opts.no_ignore_dot);
+    assert!(opts.no_ignore_vcs);
+    assert!(opts.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn given_global_args_owned_when_converted_then_same_as_borrowed() {
+    let g = GlobalArgs {
+        excluded: vec!["node_modules".into()],
+        config: ConfigMode::Auto,
+        hidden: false,
+        no_ignore: false,
+        no_ignore_parent: false,
+        no_ignore_dot: false,
+        no_ignore_vcs: false,
+        treat_doc_strings_as_comments: false,
+        verbose: 0,
+        no_progress: false,
+    };
+    let opts_borrowed: tokmd_settings::ScanOptions = (&g).into();
+    let opts_owned: tokmd_settings::ScanOptions = g.into();
+    assert_eq!(opts_borrowed.excluded, opts_owned.excluded);
+    assert_eq!(opts_borrowed.hidden, opts_owned.hidden);
+    assert_eq!(opts_borrowed.config, opts_owned.config);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 7. Enum defaults
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn diff_format_default_md() {
+    assert_eq!(DiffFormat::default(), DiffFormat::Md);
+}
+
+#[test]
+fn color_mode_default_auto() {
+    assert_eq!(ColorMode::default(), ColorMode::Auto);
+}
+
+#[test]
+fn context_strategy_default_greedy() {
+    assert_eq!(ContextStrategy::default(), ContextStrategy::Greedy);
+}
+
+#[test]
+fn value_metric_default_code() {
+    assert_eq!(ValueMetric::default(), ValueMetric::Code);
+}
+
+#[test]
+fn context_output_default_list() {
+    assert_eq!(ContextOutput::default(), ContextOutput::List);
+}
+
+#[test]
+fn gate_format_default_text() {
+    assert_eq!(GateFormat::default(), GateFormat::Text);
+}
+
+#[test]
+fn cockpit_format_default_json() {
+    assert_eq!(CockpitFormat::default(), CockpitFormat::Json);
+}
+
+#[test]
+fn handoff_preset_default_risk() {
+    assert_eq!(HandoffPreset::default(), HandoffPreset::Risk);
+}
+
+#[test]
+fn sensor_format_default_json() {
+    assert_eq!(SensorFormat::default(), SensorFormat::Json);
+}
+
+#[test]
+fn near_dup_scope_default_module() {
+    assert_eq!(NearDupScope::default(), NearDupScope::Module);
+}
+
+#[test]
+fn diff_range_mode_default_two_dot() {
+    assert_eq!(DiffRangeMode::default(), DiffRangeMode::TwoDot);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 8. Enum serde roundtrips
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn analysis_preset_all_variants_roundtrip() {
+    let variants = [
+        AnalysisPreset::Receipt,
+        AnalysisPreset::Health,
+        AnalysisPreset::Risk,
+        AnalysisPreset::Supply,
+        AnalysisPreset::Architecture,
+        AnalysisPreset::Topics,
+        AnalysisPreset::Security,
+        AnalysisPreset::Identity,
+        AnalysisPreset::Git,
+        AnalysisPreset::Deep,
+        AnalysisPreset::Fun,
+    ];
+    for variant in variants {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: AnalysisPreset = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn diff_format_all_variants_roundtrip() {
+    for variant in [DiffFormat::Md, DiffFormat::Json] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: DiffFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn color_mode_all_variants_roundtrip() {
+    for variant in [ColorMode::Auto, ColorMode::Always, ColorMode::Never] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: ColorMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn context_strategy_all_variants_roundtrip() {
+    for variant in [ContextStrategy::Greedy, ContextStrategy::Spread] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: ContextStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn value_metric_all_variants_roundtrip() {
+    for variant in [
+        ValueMetric::Code,
+        ValueMetric::Tokens,
+        ValueMetric::Churn,
+        ValueMetric::Hotspot,
+    ] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: ValueMetric = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn badge_metric_all_variants_roundtrip() {
+    for variant in [
+        BadgeMetric::Lines,
+        BadgeMetric::Tokens,
+        BadgeMetric::Bytes,
+        BadgeMetric::Doc,
+        BadgeMetric::Blank,
+        BadgeMetric::Hotspot,
+    ] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: BadgeMetric = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn handoff_preset_all_variants_roundtrip() {
+    for variant in [
+        HandoffPreset::Minimal,
+        HandoffPreset::Standard,
+        HandoffPreset::Risk,
+        HandoffPreset::Deep,
+    ] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: HandoffPreset = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn import_granularity_all_variants_roundtrip() {
+    for variant in [ImportGranularity::Module, ImportGranularity::File] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: ImportGranularity = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 9. Enum kebab-case naming
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn analysis_preset_uses_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&AnalysisPreset::Receipt).unwrap(),
+        "\"receipt\""
+    );
+    assert_eq!(
+        serde_json::to_string(&AnalysisPreset::Deep).unwrap(),
+        "\"deep\""
+    );
+}
+
+#[test]
+fn context_strategy_uses_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&ContextStrategy::Greedy).unwrap(),
+        "\"greedy\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ContextStrategy::Spread).unwrap(),
+        "\"spread\""
+    );
+}
+
+#[test]
+fn value_metric_uses_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&ValueMetric::Hotspot).unwrap(),
+        "\"hotspot\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ValueMetric::Code).unwrap(),
+        "\"code\""
+    );
+}
+
+#[test]
+fn handoff_preset_uses_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&HandoffPreset::Risk).unwrap(),
+        "\"risk\""
+    );
+    assert_eq!(
+        serde_json::to_string(&HandoffPreset::Deep).unwrap(),
+        "\"deep\""
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 10. UserConfig serde roundtrip
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn user_config_full_roundtrip() {
+    let mut c = UserConfig::default();
+    c.profiles.insert(
+        "ci".into(),
+        Profile {
+            format: Some("json".into()),
+            top: Some(5),
+            files: Some(true),
+            redact: Some(RedactMode::Paths),
+            ..Profile::default()
+        },
+    );
+    c.profiles.insert(
+        "llm".into(),
+        Profile {
+            format: Some("md".into()),
+            redact: Some(RedactMode::All),
+            ..Profile::default()
+        },
+    );
+    c.repos.insert("owner/repo".into(), "ci".into());
+    c.repos.insert("org/project".into(), "llm".into());
+
+    let json = serde_json::to_string(&c).unwrap();
+    let back: UserConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.profiles.len(), 2);
+    assert_eq!(back.repos.len(), 2);
+    assert_eq!(back.profiles["ci"].top, Some(5));
+    assert_eq!(back.profiles["llm"].format, Some("md".into()));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 11. ViewProfile default and field coverage
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn view_profile_default_all_none() {
+    let v = ViewProfile::default();
+    assert!(v.format.is_none());
+    assert!(v.top.is_none());
+    assert!(v.files.is_none());
+    assert!(v.module_roots.is_none());
+    assert!(v.module_depth.is_none());
+    assert!(v.min_code.is_none());
+    assert!(v.max_rows.is_none());
+    assert!(v.redact.is_none());
+    assert!(v.meta.is_none());
+    assert!(v.children.is_none());
+    assert!(v.preset.is_none());
+    assert!(v.window.is_none());
+    assert!(v.budget.is_none());
+    assert!(v.strategy.is_none());
+    assert!(v.rank_by.is_none());
+    assert!(v.output.is_none());
+    assert!(v.compress.is_none());
+    assert!(v.metric.is_none());
+}
+
+#[test]
+fn view_profile_serde_roundtrip() {
+    let v = ViewProfile {
+        format: Some("json".into()),
+        top: Some(10),
+        files: Some(true),
+        module_roots: Some(vec!["crates".into()]),
+        module_depth: Some(2),
+        min_code: Some(1),
+        max_rows: Some(500),
+        redact: Some("paths".into()),
+        meta: Some(true),
+        children: Some("separate".into()),
+        preset: Some("health".into()),
+        window: Some(128_000),
+        budget: Some("128k".into()),
+        strategy: Some("greedy".into()),
+        rank_by: Some("code".into()),
+        output: Some("list".into()),
+        compress: Some(false),
+        metric: Some("lines".into()),
+    };
+    let json = serde_json::to_string(&v).unwrap();
+    let back: ViewProfile = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.format, v.format);
+    assert_eq!(back.top, v.top);
+    assert_eq!(back.budget, v.budget);
+    assert_eq!(back.metric, v.metric);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 12. TomlConfig serialization roundtrip
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn toml_config_full_json_roundtrip() {
+    let toml_str = r#"
+[scan]
+hidden = true
+paths = ["src"]
+
+[module]
+roots = ["crates"]
+depth = 2
+
+[export]
+min_code = 1
+max_rows = 100
+
+[analyze]
+preset = "risk"
+window = 64000
+
+[context]
+budget = "64k"
+
+[badge]
+metric = "lines"
+
+[gate]
+fail_fast = true
+
+[view.ci]
+format = "json"
+top = 5
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    let json = serde_json::to_string(&config).unwrap();
+    let back: TomlConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.scan.hidden, Some(true));
+    assert_eq!(back.module.depth, Some(2));
+    assert_eq!(back.export.min_code, Some(1));
+    assert_eq!(back.analyze.preset, Some("risk".into()));
+    assert_eq!(back.context.budget, Some("64k".into()));
+    assert_eq!(back.badge.metric, Some("lines".into()));
+    assert_eq!(back.gate.fail_fast, Some(true));
+    assert_eq!(back.view["ci"].top, Some(5));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 13. Gate config inline rules
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_gate_with_inline_rules_when_parsed_then_rules_available() {
+    let toml_str = r#"
+[gate]
+fail_fast = true
+
+[[gate.rules]]
+name = "max_tokens"
+pointer = "/tokens"
+op = "lte"
+value = 100000
+
+[[gate.rules]]
+name = "has_license"
+pointer = "/license"
+op = "exists"
+level = "warn"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    let rules = config.gate.rules.as_ref().unwrap();
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0].name, "max_tokens");
+    assert_eq!(rules[0].op, "lte");
+    assert_eq!(rules[1].name, "has_license");
+    assert_eq!(rules[1].op, "exists");
+}
+
+#[test]
+fn given_gate_with_ratchet_rules_when_parsed_then_ratchet_available() {
+    let toml_str = r#"
+[gate]
+allow_missing_baseline = true
+
+[[gate.ratchet]]
+pointer = "/complexity/avg"
+max_increase_pct = 5.0
+level = "error"
+description = "Complexity gate"
+"#;
+    let config = TomlConfig::parse(toml_str).unwrap();
+    assert_eq!(config.gate.allow_missing_baseline, Some(true));
+    let ratchet = config.gate.ratchet.as_ref().unwrap();
+    assert_eq!(ratchet.len(), 1);
+    assert_eq!(ratchet[0].pointer, "/complexity/avg");
+    assert_eq!(ratchet[0].max_increase_pct, Some(5.0));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 14. Property tests for config determinism
+// ═══════════════════════════════════════════════════════════════════
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn toml_parse_empty_always_succeeds(s in "[ \t\n]*") {
+            // ASCII whitespace-only TOML (no bare CR) should always parse
+            let result = TomlConfig::parse(&s);
+            prop_assert!(result.is_ok());
+        }
+
+        #[test]
+        fn user_config_json_roundtrip_deterministic(
+            name in "[a-z]{1,10}",
+            top in 1usize..100,
+        ) {
+            let mut c = UserConfig::default();
+            c.profiles.insert(
+                name.clone(),
+                Profile {
+                    top: Some(top),
+                    ..Profile::default()
+                },
+            );
+            let json1 = serde_json::to_string(&c).unwrap();
+            let json2 = serde_json::to_string(&c).unwrap();
+            prop_assert_eq!(&json1, &json2);
+        }
+
+        #[test]
+        fn global_args_scan_options_conversion_deterministic(
+            hidden in proptest::bool::ANY,
+            no_ignore in proptest::bool::ANY,
+        ) {
+            let g = GlobalArgs {
+                hidden,
+                no_ignore,
+                ..GlobalArgs::default()
+            };
+            let a: tokmd_settings::ScanOptions = (&g).into();
+            let b: tokmd_settings::ScanOptions = (&g).into();
+            prop_assert_eq!(a.hidden, b.hidden);
+            prop_assert_eq!(a.no_ignore, b.no_ignore);
+        }
+
+        #[test]
+        fn view_profile_default_always_empty(_dummy in 0u8..1) {
+            let v = ViewProfile::default();
+            prop_assert!(v.format.is_none());
+            prop_assert!(v.top.is_none());
+        }
+    }
+}

--- a/crates/tokmd-gate/tests/gate_depth_w60.rs
+++ b/crates/tokmd-gate/tests/gate_depth_w60.rs
@@ -1,0 +1,876 @@
+//! Depth tests for tokmd-gate (w60).
+//!
+//! BDD-style tests covering:
+//! - Policy evaluation rules with all comparison operators
+//! - JSON pointer navigation edge cases
+//! - Ratchet logic (baseline comparison, degradation detection)
+//! - Complex nested policies
+//! - Negation, fail-fast, allow-missing semantics
+//! - Property-based tests for gate evaluation determinism
+
+use serde_json::{json, Value};
+use tokmd_gate::{
+    GateResult, PolicyConfig, PolicyRule, RatchetConfig, RatchetGateResult, RatchetRule,
+    RuleLevel, RuleOperator, RuleResult, evaluate_policy, evaluate_ratchet_policy,
+    resolve_pointer,
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════
+
+fn rule(name: &str, pointer: &str, op: RuleOperator, value: Value) -> PolicyRule {
+    PolicyRule {
+        name: name.into(),
+        pointer: pointer.into(),
+        op,
+        value: Some(value),
+        values: None,
+        negate: false,
+        level: RuleLevel::Error,
+        message: None,
+    }
+}
+
+fn warn_rule(name: &str, pointer: &str, op: RuleOperator, value: Value) -> PolicyRule {
+    PolicyRule {
+        name: name.into(),
+        pointer: pointer.into(),
+        op,
+        value: Some(value),
+        values: None,
+        negate: false,
+        level: RuleLevel::Warn,
+        message: None,
+    }
+}
+
+fn policy(rules: Vec<PolicyRule>) -> PolicyConfig {
+    PolicyConfig {
+        rules,
+        fail_fast: false,
+        allow_missing: false,
+    }
+}
+
+fn eval(receipt: &Value, rules: Vec<PolicyRule>) -> GateResult {
+    evaluate_policy(receipt, &policy(rules))
+}
+
+fn ratchet_rule(pointer: &str, max_increase_pct: Option<f64>, max_value: Option<f64>) -> RatchetRule {
+    RatchetRule {
+        pointer: pointer.into(),
+        max_increase_pct,
+        max_value,
+        level: RuleLevel::Error,
+        description: None,
+    }
+}
+
+fn ratchet_config(rules: Vec<RatchetRule>) -> RatchetConfig {
+    RatchetConfig {
+        rules,
+        fail_fast: false,
+        allow_missing_baseline: false,
+        allow_missing_current: false,
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. JSON Pointer resolution edge cases
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_empty_pointer_when_resolved_then_whole_doc_returned() {
+    let doc = json!({"a": 1, "b": 2});
+    assert_eq!(resolve_pointer(&doc, ""), Some(&doc));
+}
+
+#[test]
+fn given_pointer_to_null_value_when_resolved_then_null_returned() {
+    let doc = json!({"key": null});
+    assert_eq!(resolve_pointer(&doc, "/key"), Some(&Value::Null));
+}
+
+#[test]
+fn given_pointer_to_boolean_when_resolved_then_bool_returned() {
+    let doc = json!({"enabled": true, "disabled": false});
+    assert_eq!(resolve_pointer(&doc, "/enabled"), Some(&json!(true)));
+    assert_eq!(resolve_pointer(&doc, "/disabled"), Some(&json!(false)));
+}
+
+#[test]
+fn given_deeply_nested_path_when_resolved_then_leaf_found() {
+    let doc = json!({"a": {"b": {"c": {"d": {"e": 42}}}}});
+    assert_eq!(resolve_pointer(&doc, "/a/b/c/d/e"), Some(&json!(42)));
+}
+
+#[test]
+fn given_array_of_objects_when_index_resolved_then_object_returned() {
+    let doc = json!({"items": [{"id": 1}, {"id": 2}]});
+    assert_eq!(resolve_pointer(&doc, "/items/0/id"), Some(&json!(1)));
+    assert_eq!(resolve_pointer(&doc, "/items/1/id"), Some(&json!(2)));
+}
+
+#[test]
+fn given_nested_array_when_multi_index_resolved_then_value_found() {
+    let doc = json!({"matrix": [[10, 20], [30, 40]]});
+    assert_eq!(resolve_pointer(&doc, "/matrix/1/0"), Some(&json!(30)));
+}
+
+#[test]
+fn given_missing_intermediate_key_when_resolved_then_none() {
+    let doc = json!({"a": {"b": 1}});
+    assert_eq!(resolve_pointer(&doc, "/a/missing/deep"), None);
+}
+
+#[test]
+fn given_pointer_without_leading_slash_when_resolved_then_none() {
+    let doc = json!({"key": 1});
+    assert_eq!(resolve_pointer(&doc, "key"), None);
+}
+
+#[test]
+fn given_array_out_of_bounds_when_resolved_then_none() {
+    let doc = json!({"arr": [1, 2, 3]});
+    assert_eq!(resolve_pointer(&doc, "/arr/5"), None);
+}
+
+#[test]
+fn given_escaped_tilde_in_key_when_resolved_then_correct_value() {
+    let doc = json!({"a~b": 99});
+    assert_eq!(resolve_pointer(&doc, "/a~0b"), Some(&json!(99)));
+}
+
+#[test]
+fn given_escaped_slash_in_key_when_resolved_then_correct_value() {
+    let doc = json!({"a/b": 77});
+    assert_eq!(resolve_pointer(&doc, "/a~1b"), Some(&json!(77)));
+}
+
+#[test]
+fn given_empty_string_key_when_resolved_via_slash_then_found() {
+    let doc = json!({"": 42});
+    assert_eq!(resolve_pointer(&doc, "/"), Some(&json!(42)));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. Comparison operators (gt, lt, eq, gte, lte, ne)
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_gt_when_actual_above_threshold_then_pass() {
+    let receipt = json!({"score": 90});
+    let result = eval(&receipt, vec![rule("high_score", "/score", RuleOperator::Gt, json!(50))]);
+    assert!(result.passed);
+    assert_eq!(result.errors, 0);
+}
+
+#[test]
+fn given_gt_when_actual_equals_threshold_then_fail() {
+    let receipt = json!({"score": 50});
+    let result = eval(&receipt, vec![rule("score_check", "/score", RuleOperator::Gt, json!(50))]);
+    assert!(!result.passed);
+    assert_eq!(result.errors, 1);
+}
+
+#[test]
+fn given_lt_when_actual_below_threshold_then_pass() {
+    let receipt = json!({"errors": 3});
+    let result = eval(&receipt, vec![rule("low_errors", "/errors", RuleOperator::Lt, json!(10))]);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_lt_when_actual_equals_threshold_then_fail() {
+    let receipt = json!({"errors": 10});
+    let result = eval(&receipt, vec![rule("err", "/errors", RuleOperator::Lt, json!(10))]);
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_gte_when_actual_equals_threshold_then_pass() {
+    let receipt = json!({"coverage": 80.0});
+    let result = eval(&receipt, vec![rule("cov", "/coverage", RuleOperator::Gte, json!(80.0))]);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_lte_when_actual_equals_threshold_then_pass() {
+    let receipt = json!({"tokens": 1000});
+    let result = eval(&receipt, vec![rule("tok", "/tokens", RuleOperator::Lte, json!(1000))]);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_lte_when_actual_above_threshold_then_fail() {
+    let receipt = json!({"tokens": 1001});
+    let result = eval(&receipt, vec![rule("tok", "/tokens", RuleOperator::Lte, json!(1000))]);
+    assert!(!result.passed);
+    assert_eq!(result.errors, 1);
+}
+
+#[test]
+fn given_eq_when_values_match_then_pass() {
+    let receipt = json!({"lang": "Rust"});
+    let result = eval(&receipt, vec![rule("lang", "/lang", RuleOperator::Eq, json!("Rust"))]);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_eq_when_values_differ_then_fail() {
+    let receipt = json!({"lang": "Python"});
+    let result = eval(&receipt, vec![rule("lang", "/lang", RuleOperator::Eq, json!("Rust"))]);
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_ne_when_values_differ_then_pass() {
+    let receipt = json!({"status": "ok"});
+    let result = eval(&receipt, vec![rule("no_err", "/status", RuleOperator::Ne, json!("error"))]);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_ne_when_values_match_then_fail() {
+    let receipt = json!({"status": "error"});
+    let result = eval(&receipt, vec![rule("no_err", "/status", RuleOperator::Ne, json!("error"))]);
+    assert!(!result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. In / Contains / Exists operators
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_in_op_when_value_in_list_then_pass() {
+    let receipt = json!({"format": "json"});
+    let r = PolicyRule {
+        name: "fmt_check".into(),
+        pointer: "/format".into(),
+        op: RuleOperator::In,
+        value: None,
+        values: Some(vec![json!("json"), json!("csv"), json!("jsonl")]),
+        negate: false,
+        level: RuleLevel::Error,
+        message: None,
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(result.passed);
+}
+
+#[test]
+fn given_in_op_when_value_not_in_list_then_fail() {
+    let receipt = json!({"format": "xml"});
+    let r = PolicyRule {
+        name: "fmt_check".into(),
+        pointer: "/format".into(),
+        op: RuleOperator::In,
+        value: None,
+        values: Some(vec![json!("json"), json!("csv")]),
+        negate: false,
+        level: RuleLevel::Error,
+        message: None,
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_contains_op_when_string_has_substring_then_pass() {
+    let receipt = json!({"path": "src/main.rs"});
+    let result = eval(&receipt, vec![rule("has_src", "/path", RuleOperator::Contains, json!("src"))]);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_contains_op_when_array_has_element_then_pass() {
+    let receipt = json!({"langs": ["Rust", "Python", "Go"]});
+    let result = eval(&receipt, vec![rule("has_rust", "/langs", RuleOperator::Contains, json!("Rust"))]);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_exists_op_when_key_present_then_pass() {
+    let receipt = json!({"license": "MIT"});
+    let r = PolicyRule {
+        name: "has_license".into(),
+        pointer: "/license".into(),
+        op: RuleOperator::Exists,
+        value: None,
+        values: None,
+        negate: false,
+        level: RuleLevel::Error,
+        message: None,
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(result.passed);
+}
+
+#[test]
+fn given_exists_op_when_key_absent_then_fail() {
+    let receipt = json!({"name": "test"});
+    let r = PolicyRule {
+        name: "has_license".into(),
+        pointer: "/license".into(),
+        op: RuleOperator::Exists,
+        value: None,
+        values: None,
+        negate: false,
+        level: RuleLevel::Error,
+        message: None,
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(!result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 4. Negation semantics
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_negated_lte_when_below_threshold_then_fail() {
+    let receipt = json!({"tokens": 500});
+    let r = PolicyRule {
+        name: "not_low".into(),
+        pointer: "/tokens".into(),
+        op: RuleOperator::Lte,
+        value: Some(json!(1000)),
+        values: None,
+        negate: true,
+        level: RuleLevel::Error,
+        message: None,
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_negated_exists_when_key_absent_then_pass() {
+    let receipt = json!({"name": "test"});
+    let r = PolicyRule {
+        name: "no_secret".into(),
+        pointer: "/secret".into(),
+        op: RuleOperator::Exists,
+        value: None,
+        values: None,
+        negate: true,
+        level: RuleLevel::Error,
+        message: None,
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 5. Fail-fast and allow-missing
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_fail_fast_when_first_rule_fails_then_remaining_skipped() {
+    let receipt = json!({"a": 100, "b": 200});
+    let pol = PolicyConfig {
+        rules: vec![
+            rule("fail_a", "/a", RuleOperator::Lt, json!(50)),
+            rule("check_b", "/b", RuleOperator::Lt, json!(300)),
+        ],
+        fail_fast: true,
+        allow_missing: false,
+    };
+    let result = evaluate_policy(&receipt, &pol);
+    assert!(!result.passed);
+    // With fail_fast, only first rule should be evaluated
+    assert_eq!(result.rule_results.len(), 1);
+}
+
+#[test]
+fn given_no_fail_fast_when_first_fails_then_all_evaluated() {
+    let receipt = json!({"a": 100, "b": 200});
+    let pol = PolicyConfig {
+        rules: vec![
+            rule("fail_a", "/a", RuleOperator::Lt, json!(50)),
+            rule("check_b", "/b", RuleOperator::Lt, json!(300)),
+        ],
+        fail_fast: false,
+        allow_missing: false,
+    };
+    let result = evaluate_policy(&receipt, &pol);
+    assert!(!result.passed);
+    assert_eq!(result.rule_results.len(), 2);
+}
+
+#[test]
+fn given_allow_missing_when_pointer_absent_then_pass() {
+    let receipt = json!({"a": 1});
+    let pol = PolicyConfig {
+        rules: vec![rule("miss", "/nonexistent", RuleOperator::Lte, json!(100))],
+        fail_fast: false,
+        allow_missing: true,
+    };
+    let result = evaluate_policy(&receipt, &pol);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_no_allow_missing_when_pointer_absent_then_fail() {
+    let receipt = json!({"a": 1});
+    let pol = PolicyConfig {
+        rules: vec![rule("miss", "/nonexistent", RuleOperator::Lte, json!(100))],
+        fail_fast: false,
+        allow_missing: false,
+    };
+    let result = evaluate_policy(&receipt, &pol);
+    assert!(!result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 6. Warning rules don't fail the gate
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_warn_rule_when_fails_then_gate_still_passes() {
+    let receipt = json!({"tokens": 2000});
+    let result = evaluate_policy(
+        &receipt,
+        &policy(vec![warn_rule("warn_tok", "/tokens", RuleOperator::Lte, json!(1000))]),
+    );
+    assert!(result.passed);
+    assert_eq!(result.warnings, 1);
+    assert_eq!(result.errors, 0);
+}
+
+#[test]
+fn given_mixed_warn_and_error_when_only_warn_fails_then_pass() {
+    let receipt = json!({"tokens": 2000, "files": 5});
+    let rules = vec![
+        warn_rule("w_tok", "/tokens", RuleOperator::Lte, json!(1000)),
+        rule("e_files", "/files", RuleOperator::Lte, json!(100)),
+    ];
+    let result = evaluate_policy(&receipt, &policy(rules));
+    assert!(result.passed);
+    assert_eq!(result.warnings, 1);
+    assert_eq!(result.errors, 0);
+}
+
+#[test]
+fn given_mixed_warn_and_error_when_error_fails_then_gate_fails() {
+    let receipt = json!({"tokens": 2000, "files": 200});
+    let rules = vec![
+        warn_rule("w_tok", "/tokens", RuleOperator::Lte, json!(1000)),
+        rule("e_files", "/files", RuleOperator::Lte, json!(100)),
+    ];
+    let result = evaluate_policy(&receipt, &policy(rules));
+    assert!(!result.passed);
+    assert_eq!(result.warnings, 1);
+    assert_eq!(result.errors, 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 7. Complex nested policy evaluation
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_nested_receipt_when_multiple_deep_rules_then_correct_outcome() {
+    let receipt = json!({
+        "derived": {
+            "totals": { "code": 5000, "tokens": 15000 },
+            "density": { "comment_ratio": 0.25 }
+        },
+        "meta": { "schema_version": 2 }
+    });
+    let rules = vec![
+        rule("max_code", "/derived/totals/code", RuleOperator::Lte, json!(10000)),
+        rule("max_tokens", "/derived/totals/tokens", RuleOperator::Lte, json!(500000)),
+        rule("min_comment", "/derived/density/comment_ratio", RuleOperator::Gte, json!(0.1)),
+        rule("schema_v", "/meta/schema_version", RuleOperator::Eq, json!(2)),
+    ];
+    let result = evaluate_policy(&receipt, &policy(rules));
+    assert!(result.passed);
+    assert_eq!(result.rule_results.len(), 4);
+}
+
+#[test]
+fn given_complex_receipt_when_one_nested_rule_fails_then_gate_fails() {
+    let receipt = json!({
+        "analysis": {
+            "complexity": { "avg_cyclomatic": 15.0, "max_cyclomatic": 50 },
+            "coverage": { "line_pct": 0.45 }
+        }
+    });
+    let rules = vec![
+        rule("avg_cx", "/analysis/complexity/avg_cyclomatic", RuleOperator::Lte, json!(20.0)),
+        rule("max_cx", "/analysis/complexity/max_cyclomatic", RuleOperator::Lte, json!(30)),
+        rule("cov", "/analysis/coverage/line_pct", RuleOperator::Gte, json!(0.50)),
+    ];
+    let result = evaluate_policy(&receipt, &policy(rules));
+    assert!(!result.passed);
+    // max_cx (50 > 30) and cov (0.45 < 0.50) both fail
+    assert_eq!(result.errors, 2);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 8. Ratchet logic: baseline comparison
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_ratchet_within_threshold_when_evaluated_then_pass() {
+    let baseline = json!({"complexity": 10.0});
+    let current = json!({"complexity": 10.5}); // 5% increase
+    let config = ratchet_config(vec![ratchet_rule("/complexity", Some(10.0), None)]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(result.passed);
+    assert_eq!(result.errors, 0);
+}
+
+#[test]
+fn given_ratchet_exceeds_threshold_when_evaluated_then_fail() {
+    let baseline = json!({"complexity": 10.0});
+    let current = json!({"complexity": 12.0}); // 20% increase
+    let config = ratchet_config(vec![ratchet_rule("/complexity", Some(10.0), None)]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(!result.passed);
+    assert_eq!(result.errors, 1);
+}
+
+#[test]
+fn given_ratchet_max_value_exceeded_when_evaluated_then_fail() {
+    let baseline = json!({"complexity": 10.0});
+    let current = json!({"complexity": 25.0});
+    let config = ratchet_config(vec![ratchet_rule("/complexity", None, Some(20.0))]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_ratchet_max_value_not_exceeded_when_evaluated_then_pass() {
+    let baseline = json!({"complexity": 10.0});
+    let current = json!({"complexity": 18.0});
+    let config = ratchet_config(vec![ratchet_rule("/complexity", None, Some(20.0))]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_ratchet_both_constraints_when_pct_fails_then_fail() {
+    let baseline = json!({"complexity": 10.0});
+    let current = json!({"complexity": 15.0}); // 50% increase, but under max_value
+    let config = ratchet_config(vec![ratchet_rule("/complexity", Some(10.0), Some(20.0))]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_ratchet_improvement_when_metric_decreases_then_pass() {
+    let baseline = json!({"complexity": 20.0});
+    let current = json!({"complexity": 15.0}); // decreased
+    let config = ratchet_config(vec![ratchet_rule("/complexity", Some(10.0), None)]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_ratchet_missing_baseline_when_strict_then_fail() {
+    let baseline = json!({});
+    let current = json!({"complexity": 10.0});
+    let config = ratchet_config(vec![ratchet_rule("/complexity", Some(10.0), None)]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_ratchet_missing_baseline_when_allowed_then_pass() {
+    let baseline = json!({});
+    let current = json!({"complexity": 10.0});
+    let config = RatchetConfig {
+        rules: vec![ratchet_rule("/complexity", Some(10.0), None)],
+        fail_fast: false,
+        allow_missing_baseline: true,
+        allow_missing_current: false,
+    };
+    // allow_missing_baseline only affects evaluate_ratchet_with_options, not the main policy fn
+    // The main evaluate_ratchet_policy uses the config's flags
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(result.passed);
+}
+
+#[test]
+fn given_ratchet_missing_current_when_strict_then_fail() {
+    let baseline = json!({"complexity": 10.0});
+    let current = json!({});
+    let config = ratchet_config(vec![ratchet_rule("/complexity", Some(10.0), None)]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(!result.passed);
+}
+
+#[test]
+fn given_ratchet_zero_baseline_with_zero_current_then_pass() {
+    let baseline = json!({"complexity": 0.0});
+    let current = json!({"complexity": 0.0});
+    let config = ratchet_config(vec![ratchet_rule("/complexity", Some(10.0), None)]);
+    let result = evaluate_ratchet_policy(&config, &baseline, &current);
+    assert!(result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 9. GateResult / RatchetGateResult construction
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn gate_result_from_all_passing_rules() {
+    let results = vec![
+        RuleResult { name: "r1".into(), passed: true, level: RuleLevel::Error, actual: None, expected: "x".into(), message: None },
+        RuleResult { name: "r2".into(), passed: true, level: RuleLevel::Warn, actual: None, expected: "y".into(), message: None },
+    ];
+    let gate = GateResult::from_results(results);
+    assert!(gate.passed);
+    assert_eq!(gate.errors, 0);
+    assert_eq!(gate.warnings, 0);
+}
+
+#[test]
+fn gate_result_counts_errors_and_warnings_separately() {
+    let results = vec![
+        RuleResult { name: "e1".into(), passed: false, level: RuleLevel::Error, actual: None, expected: "x".into(), message: None },
+        RuleResult { name: "w1".into(), passed: false, level: RuleLevel::Warn, actual: None, expected: "y".into(), message: None },
+        RuleResult { name: "w2".into(), passed: false, level: RuleLevel::Warn, actual: None, expected: "z".into(), message: None },
+    ];
+    let gate = GateResult::from_results(results);
+    assert!(!gate.passed);
+    assert_eq!(gate.errors, 1);
+    assert_eq!(gate.warnings, 2);
+}
+
+#[test]
+fn ratchet_gate_result_from_empty_is_pass() {
+    let result = RatchetGateResult::from_results(vec![]);
+    assert!(result.passed);
+    assert_eq!(result.errors, 0);
+    assert_eq!(result.warnings, 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 10. TOML parsing
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_valid_policy_toml_when_parsed_then_all_fields_set() {
+    let toml = r#"
+fail_fast = true
+allow_missing = true
+
+[[rules]]
+name = "max_tokens"
+pointer = "/tokens"
+op = "lte"
+value = 100000
+level = "error"
+message = "Too many tokens"
+
+[[rules]]
+name = "has_license"
+pointer = "/license"
+op = "exists"
+level = "warn"
+"#;
+    let config = PolicyConfig::from_toml(toml).unwrap();
+    assert!(config.fail_fast);
+    assert!(config.allow_missing);
+    assert_eq!(config.rules.len(), 2);
+    assert_eq!(config.rules[0].name, "max_tokens");
+    assert_eq!(config.rules[0].op, RuleOperator::Lte);
+    assert_eq!(config.rules[1].op, RuleOperator::Exists);
+    assert_eq!(config.rules[1].level, RuleLevel::Warn);
+}
+
+#[test]
+fn given_empty_toml_when_parsed_then_defaults_applied() {
+    let config = PolicyConfig::from_toml("").unwrap();
+    assert!(config.rules.is_empty());
+    assert!(!config.fail_fast);
+    assert!(!config.allow_missing);
+}
+
+#[test]
+fn given_invalid_toml_when_parsed_then_error() {
+    let result = PolicyConfig::from_toml("not valid [[[ toml");
+    assert!(result.is_err());
+}
+
+#[test]
+fn given_ratchet_toml_when_parsed_then_all_fields_set() {
+    let toml = r#"
+fail_fast = true
+allow_missing_baseline = true
+allow_missing_current = false
+
+[[rules]]
+pointer = "/complexity/avg"
+max_increase_pct = 5.0
+max_value = 25.0
+level = "error"
+description = "Complexity must not regress"
+"#;
+    let config = RatchetConfig::from_toml(toml).unwrap();
+    assert!(config.fail_fast);
+    assert!(config.allow_missing_baseline);
+    assert!(!config.allow_missing_current);
+    assert_eq!(config.rules.len(), 1);
+    assert_eq!(config.rules[0].pointer, "/complexity/avg");
+    assert_eq!(config.rules[0].max_increase_pct, Some(5.0));
+    assert_eq!(config.rules[0].max_value, Some(25.0));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 11. Serde roundtrip tests
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn rule_operator_serde_roundtrip_all_variants() {
+    let variants = [
+        RuleOperator::Gt,
+        RuleOperator::Gte,
+        RuleOperator::Lt,
+        RuleOperator::Lte,
+        RuleOperator::Eq,
+        RuleOperator::Ne,
+        RuleOperator::In,
+        RuleOperator::Contains,
+        RuleOperator::Exists,
+    ];
+    for variant in variants {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: RuleOperator = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn rule_level_serde_roundtrip() {
+    for variant in [RuleLevel::Warn, RuleLevel::Error] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: RuleLevel = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn gate_result_json_roundtrip() {
+    let gate = GateResult::from_results(vec![
+        RuleResult { name: "r1".into(), passed: true, level: RuleLevel::Error, actual: Some(json!(42)), expected: "lte 100".into(), message: None },
+    ]);
+    let json = serde_json::to_string(&gate).unwrap();
+    let back: GateResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.passed, gate.passed);
+    assert_eq!(back.errors, gate.errors);
+    assert_eq!(back.rule_results.len(), 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 12. Custom message propagation
+// ═══════════════════════════════════════════════════════════════════
+
+#[test]
+fn given_custom_message_when_rule_fails_then_message_in_result() {
+    let receipt = json!({"tokens": 9999});
+    let r = PolicyRule {
+        name: "tok".into(),
+        pointer: "/tokens".into(),
+        op: RuleOperator::Lte,
+        value: Some(json!(100)),
+        values: None,
+        negate: false,
+        level: RuleLevel::Error,
+        message: Some("Way too many tokens!".into()),
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(!result.passed);
+    assert_eq!(
+        result.rule_results[0].message.as_deref(),
+        Some("Way too many tokens!")
+    );
+}
+
+#[test]
+fn given_custom_message_when_rule_passes_then_message_is_none() {
+    let receipt = json!({"tokens": 5});
+    let r = PolicyRule {
+        name: "tok".into(),
+        pointer: "/tokens".into(),
+        op: RuleOperator::Lte,
+        value: Some(json!(100)),
+        values: None,
+        negate: false,
+        level: RuleLevel::Error,
+        message: Some("Way too many tokens!".into()),
+    };
+    let result = evaluate_policy(&receipt, &policy(vec![r]));
+    assert!(result.passed);
+    assert!(result.rule_results[0].message.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 13. Property tests for determinism
+// ═══════════════════════════════════════════════════════════════════
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn arb_op() -> impl Strategy<Value = RuleOperator> {
+        prop_oneof![
+            Just(RuleOperator::Gt),
+            Just(RuleOperator::Gte),
+            Just(RuleOperator::Lt),
+            Just(RuleOperator::Lte),
+            Just(RuleOperator::Eq),
+            Just(RuleOperator::Ne),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn evaluate_same_input_gives_same_output(val in 0i64..10000) {
+            let receipt = json!({"v": val});
+            let r = rule("check", "/v", RuleOperator::Lte, json!(5000));
+            let a = evaluate_policy(&receipt, &policy(vec![r.clone()]));
+            let b = evaluate_policy(&receipt, &policy(vec![r]));
+            prop_assert_eq!(a.passed, b.passed);
+            prop_assert_eq!(a.errors, b.errors);
+            prop_assert_eq!(a.warnings, b.warnings);
+        }
+
+        #[test]
+        fn ratchet_deterministic(base in 1.0f64..100.0, curr in 1.0f64..100.0) {
+            let baseline = json!({"m": base});
+            let current = json!({"m": curr});
+            let config = ratchet_config(vec![ratchet_rule("/m", Some(20.0), None)]);
+            let a = evaluate_ratchet_policy(&config, &baseline, &current);
+            let b = evaluate_ratchet_policy(&config, &baseline, &current);
+            prop_assert_eq!(a.passed, b.passed);
+            prop_assert_eq!(a.errors, b.errors);
+        }
+
+        #[test]
+        fn empty_policy_always_passes(val in 0i64..10000) {
+            let receipt = json!({"v": val});
+            let result = evaluate_policy(&receipt, &PolicyConfig::default());
+            prop_assert!(result.passed);
+            prop_assert_eq!(result.errors, 0);
+        }
+
+        #[test]
+        fn pointer_resolution_deterministic(idx in 0usize..5) {
+            let doc = json!({"arr": [0, 1, 2, 3, 4]});
+            let ptr = format!("/arr/{idx}");
+            let a = resolve_pointer(&doc, &ptr);
+            let b = resolve_pointer(&doc, &ptr);
+            prop_assert_eq!(a, b);
+        }
+
+        #[test]
+        fn operator_display_roundtrip(op in arb_op()) {
+            let display = op.to_string();
+            prop_assert!(!display.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
Wave 60 test expansion.

## Changes
- Add 67 tests for tokmd-gate (JSON pointer, comparison ops, ratchet logic, TOML parsing, proptest)
- Add 55 tests for tokmd-config (TOML sections, profiles, enum defaults/serde, proptest)

## Total: ~122 new tests

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>