### PR TITLE
test(w62): html + progress depth tests

### DIFF
--- a/crates/tokmd-analysis-html/tests/html_depth_w62.rs
+++ b/crates/tokmd-analysis-html/tests/html_depth_w62.rs
@@ -1,0 +1,801 @@
+//! Depth tests for tokmd-analysis-html rendering.
+
+use tokmd_analysis_html::render;
+use tokmd_analysis_types::*;
+
+// ── helpers ────────────────────────────────────────────────────────
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: 2,
+        generated_at_ms: 0,
+        tool: tokmd_types::ToolInfo {
+            name: "tokmd".into(),
+            version: "0.0.0".into(),
+        },
+        mode: "analysis".into(),
+        status: tokmd_types::ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec!["test".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "html".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            max_file_bytes: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn make_file_row(path: &str, lang: &str, code: usize) -> FileStatRow {
+    FileStatRow {
+        path: path.into(),
+        module: "src".into(),
+        lang: lang.into(),
+        code,
+        comments: code / 5,
+        blanks: code / 10,
+        lines: code + code / 5 + code / 10,
+        bytes: code * 50,
+        tokens: code * 2,
+        doc_pct: Some(0.15),
+        bytes_per_line: Some(38.0),
+        depth: 1,
+    }
+}
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 10,
+            code: 1000,
+            comments: 200,
+            blanks: 100,
+            lines: 1300,
+            bytes: 50000,
+            tokens: 2500,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 200,
+                denominator: 1200,
+                ratio: 0.1667,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 100,
+                denominator: 1300,
+                ratio: 0.0769,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 50000,
+                denominator: 1300,
+                rate: 38.46,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: make_file_row("src/lib.rs", "Rust", 500),
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 3,
+            avg: 1.5,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 200,
+            prod_lines: 1000,
+            test_files: 5,
+            prod_files: 5,
+            ratio: 0.2,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 100,
+            logic_lines: 1100,
+            ratio: 0.083,
+            infra_langs: vec!["TOML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 2,
+            entropy: 0.5,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 1000,
+            dominant_pct: 0.833,
+        },
+        distribution: DistributionReport {
+            count: 10,
+            min: 50,
+            max: 650,
+            mean: 130.0,
+            median: 100.0,
+            p90: 400.0,
+            p99: 650.0,
+            gini: 0.3,
+        },
+        histogram: vec![HistogramBucket {
+            label: "Small".into(),
+            min: 0,
+            max: Some(100),
+            files: 5,
+            pct: 0.5,
+        }],
+        top: TopOffenders {
+            largest_lines: vec![make_file_row("src/lib.rs", "Rust", 500)],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: Some("test-tree".into()),
+        reading_time: ReadingTimeReport {
+            minutes: 65.0,
+            lines_per_minute: 20,
+            basis_lines: 1300,
+        },
+        context_window: Some(ContextWindowReport {
+            window_tokens: 100000,
+            total_tokens: 2500,
+            pct: 0.025,
+            fits: true,
+        }),
+        cocomo: Some(CocomoReport {
+            mode: "organic".into(),
+            kloc: 1.0,
+            effort_pm: 2.4,
+            duration_months: 2.5,
+            staff: 1.0,
+            a: 2.4,
+            b: 1.05,
+            c: 2.5,
+            d: 0.38,
+        }),
+        todo: Some(TodoReport {
+            total: 5,
+            density_per_kloc: 5.0,
+            tags: vec![TodoTagRow {
+                tag: "TODO".into(),
+                count: 5,
+            }],
+        }),
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "abc123".into(),
+            entries: 10,
+        },
+    }
+}
+
+fn receipt_with_derived() -> AnalysisReceipt {
+    let mut r = minimal_receipt();
+    r.derived = Some(sample_derived());
+    r
+}
+
+// ── 1. Basic HTML structure ────────────────────────────────────────
+
+#[test]
+fn render_produces_valid_doctype() {
+    let html = render(&minimal_receipt());
+    assert!(html.starts_with("<!DOCTYPE html>"));
+}
+
+#[test]
+fn render_contains_html_lang_attribute() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains(r#"<html lang="en">"#));
+}
+
+#[test]
+fn render_contains_meta_charset() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains(r#"<meta charset="UTF-8">"#));
+}
+
+#[test]
+fn render_contains_viewport_meta() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("viewport"));
+}
+
+#[test]
+fn render_contains_title() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<title>tokmd Analysis Report</title>"));
+}
+
+#[test]
+fn render_contains_closing_tags() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("</html>"));
+    assert!(html.contains("</head>"));
+    assert!(html.contains("</body>"));
+}
+
+#[test]
+fn render_contains_header_section() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<header>"));
+    assert!(html.contains("</header>"));
+}
+
+#[test]
+fn render_contains_footer() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<footer>"));
+    assert!(html.contains("</footer>"));
+}
+
+// ── 2. Empty / no-derived rendering ───────────────────────────────
+
+#[test]
+fn render_empty_receipt_no_metric_cards() {
+    let html = render(&minimal_receipt());
+    assert!(!html.contains("class=\"metric-card\""));
+}
+
+#[test]
+fn render_empty_receipt_no_table_rows() {
+    let html = render(&minimal_receipt());
+    // Table header exists, but no data rows
+    assert!(html.contains("<thead>"));
+    assert!(!html.contains("data-path="));
+}
+
+#[test]
+fn render_empty_receipt_report_json_empty_files() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains(r#"{"files":[]}"#));
+}
+
+// ── 3. Metrics cards with derived data ────────────────────────────
+
+#[test]
+fn render_with_derived_has_metric_cards() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains("class=\"metric-card\""));
+}
+
+#[test]
+fn metric_card_shows_files_count() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains(">10<"));
+    assert!(html.contains(">Files<"));
+}
+
+#[test]
+fn metric_card_shows_lines_formatted() {
+    let html = render(&receipt_with_derived());
+    // 1300 lines → "1.3K"
+    assert!(html.contains("1.3K"));
+    assert!(html.contains(">Lines<"));
+}
+
+#[test]
+fn metric_card_shows_code_formatted() {
+    let html = render(&receipt_with_derived());
+    // 1000 code → "1.0K"
+    assert!(html.contains("1.0K"));
+    assert!(html.contains(">Code<"));
+}
+
+#[test]
+fn metric_card_shows_tokens_formatted() {
+    let html = render(&receipt_with_derived());
+    // 2500 tokens → "2.5K"
+    assert!(html.contains("2.5K"));
+    assert!(html.contains(">Tokens<"));
+}
+
+#[test]
+fn metric_card_shows_doc_pct() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains("16.7%"));
+    assert!(html.contains(">Doc%<"));
+}
+
+#[test]
+fn metric_card_shows_context_fit() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains("2.5%"));
+    assert!(html.contains(">Context Fit<"));
+}
+
+#[test]
+fn metric_card_no_context_fit_when_absent() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().context_window = None;
+    let html = render(&r);
+    assert!(!html.contains("Context Fit"));
+}
+
+// ── 4. Table rows ─────────────────────────────────────────────────
+
+#[test]
+fn table_row_contains_path() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains("src/lib.rs"));
+}
+
+#[test]
+fn table_row_contains_module() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains(r#"data-module="src""#));
+}
+
+#[test]
+fn table_row_contains_lang_badge() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains("class=\"lang-badge\""));
+    assert!(html.contains("Rust"));
+}
+
+#[test]
+fn table_row_contains_data_attributes() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains("data-lines="));
+    assert!(html.contains("data-code="));
+    assert!(html.contains("data-tokens="));
+    assert!(html.contains("data-bytes="));
+}
+
+#[test]
+fn table_row_code_formatted() {
+    let html = render(&receipt_with_derived());
+    // code=500 → "500" (below 1000, raw number)
+    assert!(html.contains(">500<"));
+}
+
+// ── 5. HTML escaping ──────────────────────────────────────────────
+
+#[test]
+fn escape_html_in_path_xss() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().top.largest_lines[0].path =
+        "<script>alert('xss')</script>".into();
+    let html = render(&r);
+    assert!(html.contains("&lt;script&gt;"));
+    assert!(!html.contains("<script>alert"));
+}
+
+#[test]
+fn escape_html_ampersand_in_module() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().top.largest_lines[0].module = "a&b".into();
+    let html = render(&r);
+    assert!(html.contains("a&amp;b"));
+}
+
+#[test]
+fn escape_html_quotes_in_lang() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().top.largest_lines[0].lang = r#"C"plus""#.into();
+    let html = render(&r);
+    assert!(html.contains("C&quot;plus&quot;"));
+}
+
+#[test]
+fn escape_html_single_quote() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().top.largest_lines[0].path = "it's.rs".into();
+    let html = render(&r);
+    assert!(html.contains("it&#x27;s.rs"));
+}
+
+#[test]
+fn escape_combined_special_chars() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().top.largest_lines[0].path =
+        r#"<a href="x">&'"#.into();
+    let html = render(&r);
+    assert!(html.contains("&lt;a href=&quot;x&quot;&gt;&amp;&#x27;"));
+}
+
+// ── 6. Report JSON safety ─────────────────────────────────────────
+
+#[test]
+fn report_json_no_raw_angle_brackets() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().top.largest_lines[0].path =
+        "</script><img onerror=alert(1)>".into();
+    let html = render(&r);
+    // The JSON section must not contain raw < or >
+    let json_start = html.find("const REPORT_DATA =").unwrap();
+    let json_section = &html[json_start..json_start + 500];
+    assert!(!json_section.contains("</script>"));
+}
+
+#[test]
+fn report_json_uses_unicode_escapes() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().top.largest_lines[0].path = "<>".into();
+    let html = render(&r);
+    assert!(html.contains("\\u003c"));
+    assert!(html.contains("\\u003e"));
+}
+
+#[test]
+fn report_json_preserves_valid_json_structure() {
+    let r = receipt_with_derived();
+    let html = render(&r);
+    let json_start = html.find("const REPORT_DATA = ").unwrap() + "const REPORT_DATA = ".len();
+    let json_end = html[json_start..].find(";\n").unwrap() + json_start;
+    let json_str = &html[json_start..json_end];
+    // Undo the angle-bracket escaping for parse validation
+    let json_str = json_str.replace("\\u003c", "<").replace("\\u003e", ">");
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+    assert!(parsed.get("files").unwrap().is_array());
+}
+
+// ── 7. Large dataset rendering ────────────────────────────────────
+
+#[test]
+fn table_rows_capped_at_100() {
+    let mut r = receipt_with_derived();
+    let d = r.derived.as_mut().unwrap();
+    d.top.largest_lines = (0..150)
+        .map(|i| make_file_row(&format!("src/file_{i}.rs"), "Rust", 100 + i))
+        .collect();
+    let html = render(&r);
+    let count = html.matches("data-path=").count();
+    assert_eq!(count, 100, "table rows should be capped at 100");
+}
+
+#[test]
+fn large_dataset_report_json_has_all_files() {
+    let mut r = receipt_with_derived();
+    let d = r.derived.as_mut().unwrap();
+    d.top.largest_lines = (0..200)
+        .map(|i| make_file_row(&format!("src/file_{i}.rs"), "Rust", 100))
+        .collect();
+    let html = render(&r);
+    // JSON section contains all files (no cap)
+    let json_start = html.find("const REPORT_DATA = ").unwrap() + "const REPORT_DATA = ".len();
+    let json_end = html[json_start..].find(";\n").unwrap() + json_start;
+    let json_str = &html[json_start..json_end];
+    let json_str = json_str.replace("\\u003c", "<").replace("\\u003e", ">");
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(parsed["files"].as_array().unwrap().len(), 200);
+}
+
+// ── 8. Number formatting ──────────────────────────────────────────
+
+#[test]
+fn format_number_small_values() {
+    let mut r = receipt_with_derived();
+    let d = r.derived.as_mut().unwrap();
+    d.totals.files = 3;
+    let html = render(&r);
+    assert!(html.contains(">3<"));
+}
+
+#[test]
+fn format_number_thousands() {
+    let mut r = receipt_with_derived();
+    let d = r.derived.as_mut().unwrap();
+    d.totals.code = 5500;
+    let html = render(&r);
+    assert!(html.contains("5.5K"));
+}
+
+#[test]
+fn format_number_millions() {
+    let mut r = receipt_with_derived();
+    let d = r.derived.as_mut().unwrap();
+    d.totals.lines = 3_200_000;
+    let html = render(&r);
+    assert!(html.contains("3.2M"));
+}
+
+#[test]
+fn format_pct_renders_one_decimal() {
+    let mut r = receipt_with_derived();
+    let d = r.derived.as_mut().unwrap();
+    d.doc_density.total.ratio = 0.3333;
+    let html = render(&r);
+    assert!(html.contains("33.3%"));
+}
+
+// ── 9. CSS classes ────────────────────────────────────────────────
+
+#[test]
+fn css_num_class_on_numeric_cells() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains(r#"class="num""#));
+}
+
+#[test]
+fn css_path_class_on_path_cell() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains(r#"class="path""#));
+}
+
+#[test]
+fn css_metric_card_class() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains(r#"class="metric-card""#));
+}
+
+#[test]
+fn css_value_and_label_spans() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains(r#"class="value""#));
+    assert!(html.contains(r#"class="label""#));
+}
+
+#[test]
+fn css_search_box_present() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains(r#"class="search-box""#));
+}
+
+#[test]
+fn css_lang_badge_class() {
+    let html = render(&receipt_with_derived());
+    assert!(html.contains(r#"class="lang-badge""#));
+}
+
+// ── 10. Accessibility ─────────────────────────────────────────────
+
+#[test]
+fn table_has_thead_and_tbody() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<thead>"));
+    assert!(html.contains("</thead>"));
+    assert!(html.contains("<tbody>"));
+    assert!(html.contains("</tbody>"));
+}
+
+#[test]
+fn table_header_cells_use_th() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<th "));
+    assert!(html.contains("</th>"));
+}
+
+#[test]
+fn search_input_has_placeholder() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("placeholder="));
+}
+
+#[test]
+fn data_sort_attributes_on_headers() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains(r#"data-sort="path""#));
+    assert!(html.contains(r#"data-sort="lines""#));
+    assert!(html.contains(r#"data-sort="code""#));
+    assert!(html.contains(r#"data-sort="tokens""#));
+    assert!(html.contains(r#"data-sort="bytes""#));
+}
+
+// ── 11. Timestamp ─────────────────────────────────────────────────
+
+#[test]
+fn timestamp_is_embedded() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("Generated:"));
+    assert!(html.contains("UTC"));
+}
+
+// ── 12. JavaScript embedded ───────────────────────────────────────
+
+#[test]
+fn javascript_block_present() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains("<script>"));
+    assert!(html.contains("const REPORT_DATA ="));
+    assert!(html.contains("</script>"));
+}
+
+#[test]
+fn treemap_container_present() {
+    let html = render(&minimal_receipt());
+    assert!(html.contains(r#"id="treemap""#));
+}
+
+// ── 13. Determinism ───────────────────────────────────────────────
+
+#[test]
+fn deterministic_same_input_same_output() {
+    let r = receipt_with_derived();
+    let a = render(&r);
+    let b = render(&r);
+    // Replace timestamps since they may differ by a second
+    let strip = |s: String| {
+        let start = s.find("Generated: ").unwrap();
+        let end = s[start..].find("</div>").unwrap() + start;
+        format!("{}{}", &s[..start], &s[end..])
+    };
+    assert_eq!(strip(a), strip(b));
+}
+
+#[test]
+fn deterministic_no_derived_identical() {
+    let r = minimal_receipt();
+    let a = render(&r);
+    let b = render(&r);
+    let strip = |s: String| {
+        let start = s.find("Generated: ").unwrap();
+        let end = s[start..].find("</div>").unwrap() + start;
+        format!("{}{}", &s[..start], &s[end..])
+    };
+    assert_eq!(strip(a), strip(b));
+}
+
+// ── 14. Snapshot tests ────────────────────────────────────────────
+
+#[test]
+fn snapshot_empty_receipt_structure() {
+    let html = render(&minimal_receipt());
+    // Redact the timestamp for stable snapshots
+    let redacted = html
+        .lines()
+        .map(|l| {
+            if l.contains("Generated:") {
+                "        <div class=\"timestamp\">Generated: [REDACTED]</div>"
+            } else {
+                l
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    insta::assert_snapshot!("empty_receipt", redacted);
+}
+
+#[test]
+fn snapshot_derived_receipt_metrics_section() {
+    let r = receipt_with_derived();
+    let html = render(&r);
+    // Extract the metrics-grid div from the rendered HTML body
+    let marker = r#"<div class="metrics-grid">"#;
+    let start = html.find(marker).unwrap();
+    // Find the closing </div> that matches the metrics-grid div
+    let inner_start = start + marker.len();
+    let end = html[inner_start..].find("</div>").unwrap() + inner_start + 6;
+    let section = &html[start..end];
+    insta::assert_snapshot!("derived_metrics_grid", section);
+}
+
+// ── 15. Property tests ────────────────────────────────────────────
+
+mod property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn html_always_starts_with_doctype(
+            files in 0usize..10,
+            code in 1usize..10000,
+        ) {
+            let mut r = minimal_receipt();
+            if files > 0 {
+                let mut d = sample_derived();
+                d.top.largest_lines = (0..files)
+                    .map(|i| make_file_row(&format!("f{i}.rs"), "Rust", code))
+                    .collect();
+                d.totals.files = files;
+                d.totals.code = code * files;
+                r.derived = Some(d);
+            }
+            let html = render(&r);
+            prop_assert!(html.starts_with("<!DOCTYPE html>"));
+        }
+
+        #[test]
+        fn html_always_has_closing_tags(
+            files in 0usize..5,
+        ) {
+            let mut r = minimal_receipt();
+            if files > 0 {
+                let mut d = sample_derived();
+                d.top.largest_lines = (0..files)
+                    .map(|i| make_file_row(&format!("f{i}.rs"), "Rust", 100))
+                    .collect();
+                r.derived = Some(d);
+            }
+            let html = render(&r);
+            prop_assert!(html.contains("</html>"));
+            prop_assert!(html.contains("</body>"));
+        }
+
+        #[test]
+        fn json_section_never_contains_raw_script_close(
+            path in "[a-zA-Z0-9/<>\"'& ]{1,50}",
+        ) {
+            let mut r = receipt_with_derived();
+            r.derived.as_mut().unwrap().top.largest_lines[0].path = path;
+            let html = render(&r);
+            let json_start = html.find("const REPORT_DATA =").unwrap();
+            let json_end = html[json_start..].find(";\n").unwrap() + json_start;
+            let json_section = &html[json_start..json_end];
+            prop_assert!(!json_section.contains("</script>"));
+        }
+
+        #[test]
+        fn table_rows_never_contain_raw_angle_brackets_in_data(
+            path in "[a-zA-Z0-9/<>\"'& ]{1,30}",
+        ) {
+            let mut r = receipt_with_derived();
+            r.derived.as_mut().unwrap().top.largest_lines[0].path = path;
+            let html = render(&r);
+            // Extract tbody content
+            let tbody_start = html.find("<tbody>").unwrap() + 7;
+            let tbody_end = html[tbody_start..].find("</tbody>").unwrap() + tbody_start;
+            let tbody = &html[tbody_start..tbody_end];
+            // After stripping known HTML tags, no raw < or > should remain as data
+            let stripped = tbody
+                .replace("<tr>", "").replace("</tr>", "")
+                .replace("<td", "").replace("</td>", "");
+            // Every remaining < should be from &lt; escaping, not raw
+            for (i, c) in stripped.char_indices() {
+                if c == '<' {
+                    // Must be part of an attribute close or known pattern
+                    let before = &stripped[..i];
+                    prop_assert!(
+                        before.ends_with('=')
+                            || before.ends_with('"')
+                            || before.ends_with(' ')
+                            || stripped[i..].starts_with("<span")
+                            || stripped[i..].starts_with("</span"),
+                        "unexpected raw < at position {i}"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn format_number_never_panics(n in 0usize..usize::MAX / 2) {
+            let mut r = minimal_receipt();
+            let mut d = sample_derived();
+            d.totals.code = n;
+            r.derived = Some(d);
+            let html = render(&r);
+            prop_assert!(!html.is_empty());
+        }
+    }
+}

--- a/crates/tokmd-analysis-html/tests/snapshots/html_depth_w62__derived_metrics_grid.snap
+++ b/crates/tokmd-analysis-html/tests/snapshots/html_depth_w62__derived_metrics_grid.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tokmd-analysis-html/tests/html_depth_w62.rs
+expression: section
+---
+<div class="metrics-grid">
+            <div class="metric-card"><span class="value">10</span><span class="label">Files</span></div>

--- a/crates/tokmd-analysis-html/tests/snapshots/html_depth_w62__empty_receipt.snap
+++ b/crates/tokmd-analysis-html/tests/snapshots/html_depth_w62__empty_receipt.snap
@@ -1,0 +1,401 @@
+---
+source: crates/tokmd-analysis-html/tests/html_depth_w62.rs
+expression: redacted
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tokmd Analysis Report</title>
+    <style>
+        :root {
+            --bg-primary: #1a1a2e;
+            --bg-secondary: #16213e;
+            --bg-card: #0f3460;
+            --text-primary: #e6e6e6;
+            --text-secondary: #a0a0a0;
+            --accent: #4c9aff;
+            --accent-hover: #357abd;
+            --success: #4caf50;
+            --warning: #ff9800;
+            --danger: #f44336;
+            --border: #2a2a4a;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
+        header {
+            text-align: center;
+            padding: 40px 20px;
+            background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card));
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 30px;
+        }
+        header h1 { font-size: 2.5rem; margin-bottom: 10px; }
+        header .timestamp { color: var(--text-secondary); font-size: 0.9rem; }
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .metric-card {
+            background: var(--bg-card);
+            border-radius: 12px;
+            padding: 20px;
+            text-align: center;
+            border: 1px solid var(--border);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .metric-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 20px rgba(76, 154, 255, 0.2);
+        }
+        .metric-card .value {
+            font-size: 2rem;
+            font-weight: bold;
+            color: var(--accent);
+            display: block;
+        }
+        .metric-card .label {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .section {
+            background: var(--bg-secondary);
+            border-radius: 12px;
+            padding: 24px;
+            margin-bottom: 24px;
+            border: 1px solid var(--border);
+        }
+        .section h2 {
+            font-size: 1.3rem;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--accent);
+            display: inline-block;
+        }
+        #treemap {
+            width: 100%;
+            height: 400px;
+            background: var(--bg-primary);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        .treemap-cell {
+            position: absolute;
+            overflow: hidden;
+            border: 1px solid var(--bg-primary);
+            transition: opacity 0.2s;
+            cursor: pointer;
+        }
+        .treemap-cell:hover { opacity: 0.85; }
+        .treemap-label {
+            padding: 4px 6px;
+            font-size: 11px;
+            color: white;
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .search-box {
+            width: 100%;
+            padding: 12px 16px;
+            font-size: 1rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text-primary);
+            margin-bottom: 16px;
+        }
+        .search-box:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(76, 154, 255, 0.2);
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+        th, td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        th {
+            background: var(--bg-card);
+            color: var(--accent);
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+        }
+        th:hover { background: var(--accent); color: white; }
+        tr:hover { background: rgba(76, 154, 255, 0.1); }
+        .num { text-align: right; font-family: 'SF Mono', Monaco, monospace; }
+        .path { font-family: 'SF Mono', Monaco, monospace; font-size: 0.85rem; }
+        .lang-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+        .hidden { display: none; }
+        footer {
+            text-align: center;
+            padding: 30px;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+        }
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>tokmd Analysis Report</h1>
+        <div class="timestamp">Generated: [REDACTED]</div>
+    </header>
+
+    <div class="container">
+        <div class="metrics-grid">
+            
+        </div>
+
+        <div class="section">
+            <h2>Code Distribution</h2>
+            <div id="treemap"></div>
+        </div>
+
+        <div class="section">
+            <h2>Files</h2>
+            <input type="text" class="search-box" id="search" placeholder="Filter by path, module, or language...">
+            <table id="files-table">
+                <thead>
+                    <tr>
+                        <th data-sort="path">Path</th>
+                        <th data-sort="module">Module</th>
+                        <th data-sort="lang">Lang</th>
+                        <th data-sort="lines" class="num">Lines</th>
+                        <th data-sort="code" class="num">Code</th>
+                        <th data-sort="tokens" class="num">Tokens</th>
+                        <th data-sort="bytes" class="num">Bytes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <footer>
+        Generated by <a href="https://github.com/EffortlessMetrics/tokmd">tokmd</a>
+    </footer>
+
+    <script>
+    const REPORT_DATA = {"files":[]};
+
+    // Language colors
+    const LANG_COLORS = {
+        'Rust': '#dea584',
+        'JavaScript': '#f1e05a',
+        'TypeScript': '#3178c6',
+        'Python': '#3572A5',
+        'Go': '#00ADD8',
+        'Java': '#b07219',
+        'C': '#555555',
+        'C++': '#f34b7d',
+        'C#': '#178600',
+        'Ruby': '#701516',
+        'PHP': '#4F5D95',
+        'Swift': '#F05138',
+        'Kotlin': '#A97BFF',
+        'Scala': '#c22d40',
+        'HTML': '#e34c26',
+        'CSS': '#563d7c',
+        'SCSS': '#c6538c',
+        'JSON': '#292929',
+        'YAML': '#cb171e',
+        'TOML': '#9c4221',
+        'Markdown': '#083fa1',
+        'Shell': '#89e051',
+        'SQL': '#e38c00',
+    };
+
+    function getLangColor(lang) {
+        return LANG_COLORS[lang] || '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+    }
+
+    // Treemap implementation (squarify algorithm)
+    function squarify(data, x, y, width, height) {
+        if (data.length === 0 || width <= 0 || height <= 0) return [];
+
+        const total = data.reduce((sum, d) => sum + d.value, 0);
+        if (total === 0) return [];
+
+        const rects = [];
+        let remaining = [...data];
+        let cx = x, cy = y, cw = width, ch = height;
+
+        while (remaining.length > 0) {
+            const vertical = ch > cw;
+            const side = vertical ? ch : cw;
+            const scale = (cw * ch) / total;
+
+            let row = [];
+            let rowArea = 0;
+            let worst = Infinity;
+
+            for (const item of remaining) {
+                const testRow = [...row, item];
+                const testArea = rowArea + item.value * scale;
+                const testWorst = getWorst(testRow, testArea, side, scale);
+
+                if (testWorst <= worst) {
+                    row = testRow;
+                    rowArea = testArea;
+                    worst = testWorst;
+                } else {
+                    break;
+                }
+            }
+
+            // Layout row
+            const rowSide = rowArea / side;
+            let offset = 0;
+
+            for (const item of row) {
+                const itemSize = (item.value * scale) / rowSide;
+                if (vertical) {
+                    rects.push({ ...item, x: cx, y: cy + offset, w: rowSide, h: itemSize });
+                } else {
+                    rects.push({ ...item, x: cx + offset, y: cy, w: itemSize, h: rowSide });
+                }
+                offset += itemSize;
+            }
+
+            // Update remaining area
+            if (vertical) {
+                cx += rowSide;
+                cw -= rowSide;
+            } else {
+                cy += rowSide;
+                ch -= rowSide;
+            }
+
+            remaining = remaining.slice(row.length);
+        }
+
+        return rects;
+    }
+
+    function getWorst(row, area, side, scale) {
+        if (row.length === 0) return Infinity;
+        const s2 = side * side;
+        let min = Infinity, max = 0;
+        for (const item of row) {
+            const v = item.value * scale;
+            min = Math.min(min, v);
+            max = Math.max(max, v);
+        }
+        return Math.max((s2 * max) / (area * area), (area * area) / (s2 * min));
+    }
+
+    function renderTreemap() {
+        const container = document.getElementById('treemap');
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
+        container.innerHTML = '';
+        container.style.position = 'relative';
+
+        // Aggregate by module
+        const moduleData = {};
+        for (const file of REPORT_DATA.files || []) {
+            const mod = file.module || '(root)';
+            if (!moduleData[mod]) moduleData[mod] = { name: mod, value: 0, lang: file.lang };
+            moduleData[mod].value += file.code || file.lines || 1;
+        }
+
+        const data = Object.values(moduleData).sort((a, b) => b.value - a.value).slice(0, 50);
+        const rects = squarify(data, 0, 0, width, height);
+
+        for (const rect of rects) {
+            const div = document.createElement('div');
+            div.className = 'treemap-cell';
+            div.style.left = rect.x + 'px';
+            div.style.top = rect.y + 'px';
+            div.style.width = rect.w + 'px';
+            div.style.height = rect.h + 'px';
+            div.style.background = getLangColor(rect.lang);
+
+            const label = document.createElement('div');
+            label.className = 'treemap-label';
+            label.textContent = rect.name + ' (' + rect.value.toLocaleString() + ')';
+            div.appendChild(label);
+
+            div.title = rect.name + ': ' + rect.value.toLocaleString() + ' lines';
+            container.appendChild(div);
+        }
+    }
+
+    // Table filtering
+    document.getElementById('search').addEventListener('input', function(e) {
+        const filter = e.target.value.toLowerCase();
+        const rows = document.querySelectorAll('#files-table tbody tr');
+        rows.forEach(row => {
+            const text = row.textContent.toLowerCase();
+            row.classList.toggle('hidden', filter && !text.includes(filter));
+        });
+    });
+
+    // Table sorting
+    let sortCol = null, sortAsc = true;
+    document.querySelectorAll('#files-table th').forEach(th => {
+        th.addEventListener('click', function() {
+            const col = this.dataset.sort;
+            if (sortCol === col) sortAsc = !sortAsc;
+            else { sortCol = col; sortAsc = true; }
+
+            const tbody = document.querySelector('#files-table tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+
+            rows.sort((a, b) => {
+                const aVal = a.querySelector(`[data-${col}]`)?.dataset[col] || a.cells[getColIndex(col)].textContent;
+                const bVal = b.querySelector(`[data-${col}]`)?.dataset[col] || b.cells[getColIndex(col)].textContent;
+                const aNum = parseFloat(aVal.replace(/,/g, ''));
+                const bNum = parseFloat(bVal.replace(/,/g, ''));
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return sortAsc ? aNum - bNum : bNum - aNum;
+                }
+                return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+            });
+
+            rows.forEach(row => tbody.appendChild(row));
+        });
+    });
+
+    function getColIndex(col) {
+        const map = { path: 0, module: 1, lang: 2, lines: 3, code: 4, tokens: 5, bytes: 6 };
+        return map[col] || 0;
+    }
+
+    // Initialize
+    window.addEventListener('load', renderTreemap);
+    window.addEventListener('resize', renderTreemap);
+    </script>
+</body>
+</html>

--- a/crates/tokmd-progress/tests/progress_depth_w62.rs
+++ b/crates/tokmd-progress/tests/progress_depth_w62.rs
@@ -1,0 +1,417 @@
+//! Depth tests for tokmd-progress crate.
+
+use tokmd_progress::{Progress, ProgressBarWithEta};
+
+// ── 1. Progress spinner – creation ────────────────────────────────
+
+#[test]
+fn progress_new_disabled_does_not_panic() {
+    let _p = Progress::new(false);
+}
+
+#[test]
+fn progress_new_enabled_does_not_panic() {
+    // In CI / non-TTY, `enabled=true` still creates the struct (noop spinner)
+    let _p = Progress::new(true);
+}
+
+// ── 2. Progress spinner – set_message ─────────────────────────────
+
+#[test]
+fn progress_set_message_empty() {
+    let p = Progress::new(false);
+    p.set_message("");
+}
+
+#[test]
+fn progress_set_message_normal() {
+    let p = Progress::new(false);
+    p.set_message("scanning files…");
+}
+
+#[test]
+fn progress_set_message_unicode() {
+    let p = Progress::new(false);
+    p.set_message("分析中 🔍");
+}
+
+#[test]
+fn progress_set_message_long_string() {
+    let p = Progress::new(false);
+    p.set_message(&"x".repeat(10_000));
+}
+
+#[test]
+fn progress_set_message_with_newlines() {
+    let p = Progress::new(false);
+    p.set_message("line1\nline2\nline3");
+}
+
+#[test]
+fn progress_set_message_special_chars() {
+    let p = Progress::new(false);
+    p.set_message("<script>alert('xss')</script>");
+}
+
+#[test]
+fn progress_set_message_multiple_times() {
+    let p = Progress::new(false);
+    for i in 0..100 {
+        p.set_message(format!("step {i}"));
+    }
+}
+
+#[test]
+fn progress_set_message_accepts_string() {
+    let p = Progress::new(false);
+    p.set_message(String::from("owned string"));
+}
+
+#[test]
+fn progress_set_message_accepts_str() {
+    let p = Progress::new(false);
+    p.set_message("borrowed str");
+}
+
+// ── 3. Progress spinner – finish/clear lifecycle ──────────────────
+
+#[test]
+fn progress_finish_and_clear_disabled() {
+    let p = Progress::new(false);
+    p.finish_and_clear();
+}
+
+#[test]
+fn progress_finish_after_message() {
+    let p = Progress::new(false);
+    p.set_message("working…");
+    p.finish_and_clear();
+}
+
+#[test]
+fn progress_double_finish_no_panic() {
+    let p = Progress::new(false);
+    p.finish_and_clear();
+    p.finish_and_clear();
+}
+
+#[test]
+fn progress_message_after_finish_no_panic() {
+    let p = Progress::new(false);
+    p.finish_and_clear();
+    p.set_message("after finish");
+}
+
+#[test]
+fn progress_drop_cleans_up() {
+    {
+        let p = Progress::new(false);
+        p.set_message("will be dropped");
+    }
+    // No panic during drop
+}
+
+// ── 4. ProgressBarWithEta – creation ──────────────────────────────
+
+#[test]
+fn bar_new_disabled_does_not_panic() {
+    let _b = ProgressBarWithEta::new(false, 100, "scan");
+}
+
+#[test]
+fn bar_new_enabled_does_not_panic() {
+    let _b = ProgressBarWithEta::new(true, 100, "scan");
+}
+
+#[test]
+fn bar_new_zero_total() {
+    let b = ProgressBarWithEta::new(false, 0, "empty");
+    b.inc();
+    b.finish_and_clear();
+}
+
+#[test]
+fn bar_new_large_total() {
+    let b = ProgressBarWithEta::new(false, u64::MAX, "huge");
+    b.inc();
+    b.finish_and_clear();
+}
+
+#[test]
+fn bar_new_empty_message() {
+    let _b = ProgressBarWithEta::new(false, 10, "");
+}
+
+// ── 5. ProgressBarWithEta – inc ───────────────────────────────────
+
+#[test]
+fn bar_inc_once() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.inc();
+}
+
+#[test]
+fn bar_inc_to_completion() {
+    let b = ProgressBarWithEta::new(false, 5, "scan");
+    for _ in 0..5 {
+        b.inc();
+    }
+    b.finish_and_clear();
+}
+
+#[test]
+fn bar_inc_past_total() {
+    let b = ProgressBarWithEta::new(false, 3, "scan");
+    for _ in 0..10 {
+        b.inc();
+    }
+}
+
+#[test]
+fn bar_inc_by_zero() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.inc_by(0);
+}
+
+#[test]
+fn bar_inc_by_large_delta() {
+    let b = ProgressBarWithEta::new(false, 100, "scan");
+    b.inc_by(50);
+    b.inc_by(50);
+}
+
+#[test]
+fn bar_inc_by_past_total() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.inc_by(100);
+}
+
+// ── 6. ProgressBarWithEta – set_position ──────────────────────────
+
+#[test]
+fn bar_set_position_zero() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_position(0);
+}
+
+#[test]
+fn bar_set_position_middle() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_position(5);
+}
+
+#[test]
+fn bar_set_position_at_total() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_position(10);
+}
+
+#[test]
+fn bar_set_position_past_total() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_position(999);
+}
+
+#[test]
+fn bar_set_position_backwards() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_position(8);
+    b.set_position(3);
+}
+
+// ── 7. ProgressBarWithEta – set_message ───────────────────────────
+
+#[test]
+fn bar_set_message_normal() {
+    let b = ProgressBarWithEta::new(false, 10, "init");
+    b.set_message("updated");
+}
+
+#[test]
+fn bar_set_message_empty() {
+    let b = ProgressBarWithEta::new(false, 10, "init");
+    b.set_message("");
+}
+
+#[test]
+fn bar_set_message_unicode() {
+    let b = ProgressBarWithEta::new(false, 10, "init");
+    b.set_message("処理中 ⏳");
+}
+
+// ── 8. ProgressBarWithEta – set_length ────────────────────────────
+
+#[test]
+fn bar_set_length_increase() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_length(20);
+}
+
+#[test]
+fn bar_set_length_decrease() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_length(5);
+}
+
+#[test]
+fn bar_set_length_zero() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.set_length(0);
+}
+
+// ── 9. ProgressBarWithEta – finish ────────────────────────────────
+
+#[test]
+fn bar_finish_with_message() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.inc_by(10);
+    b.finish_with_message("done!");
+}
+
+#[test]
+fn bar_finish_and_clear() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.finish_and_clear();
+}
+
+#[test]
+fn bar_double_finish_no_panic() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.finish_and_clear();
+    b.finish_and_clear();
+}
+
+#[test]
+fn bar_finish_then_inc_no_panic() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.finish_and_clear();
+    b.inc();
+}
+
+#[test]
+fn bar_finish_with_message_then_clear_no_panic() {
+    let b = ProgressBarWithEta::new(false, 10, "scan");
+    b.finish_with_message("done");
+    b.finish_and_clear();
+}
+
+// ── 10. ProgressBarWithEta – drop ─────────────────────────────────
+
+#[test]
+fn bar_drop_without_finish() {
+    {
+        let b = ProgressBarWithEta::new(false, 10, "scan");
+        b.inc_by(5);
+    }
+    // No panic during drop
+}
+
+#[test]
+fn bar_drop_after_finish() {
+    {
+        let b = ProgressBarWithEta::new(false, 10, "scan");
+        b.finish_and_clear();
+    }
+}
+
+// ── 11. Silent/quiet mode ─────────────────────────────────────────
+
+#[test]
+fn progress_disabled_full_lifecycle() {
+    let p = Progress::new(false);
+    p.set_message("step 1");
+    p.set_message("step 2");
+    p.set_message("step 3");
+    p.finish_and_clear();
+}
+
+#[test]
+fn bar_disabled_full_lifecycle() {
+    let b = ProgressBarWithEta::new(false, 100, "scan");
+    b.set_message("phase 1");
+    b.inc_by(25);
+    b.set_message("phase 2");
+    b.inc_by(25);
+    b.set_position(75);
+    b.set_length(200);
+    b.set_message("phase 3");
+    b.inc_by(125);
+    b.finish_with_message("complete");
+}
+
+// ── 12. Stress tests ──────────────────────────────────────────────
+
+#[test]
+fn progress_rapid_message_updates() {
+    let p = Progress::new(false);
+    for i in 0..1_000 {
+        p.set_message(format!("iteration {i}"));
+    }
+    p.finish_and_clear();
+}
+
+#[test]
+fn bar_rapid_increments() {
+    let b = ProgressBarWithEta::new(false, 10_000, "stress");
+    for _ in 0..10_000 {
+        b.inc();
+    }
+    b.finish_and_clear();
+}
+
+// ── 13. Property tests ────────────────────────────────────────────
+
+mod property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn progress_set_message_never_panics(msg in ".*") {
+            let p = Progress::new(false);
+            p.set_message(msg);
+            p.finish_and_clear();
+        }
+
+        #[test]
+        fn bar_any_total_never_panics(total in 0u64..1_000_000) {
+            let b = ProgressBarWithEta::new(false, total, "test");
+            b.inc();
+            b.finish_and_clear();
+        }
+
+        #[test]
+        fn bar_any_position_never_panics(pos in 0u64..1_000_000) {
+            let b = ProgressBarWithEta::new(false, 100, "test");
+            b.set_position(pos);
+            b.finish_and_clear();
+        }
+
+        #[test]
+        fn bar_any_delta_never_panics(delta in 0u64..1_000_000) {
+            let b = ProgressBarWithEta::new(false, 100, "test");
+            b.inc_by(delta);
+            b.finish_and_clear();
+        }
+
+        #[test]
+        fn bar_any_length_never_panics(len in 0u64..1_000_000) {
+            let b = ProgressBarWithEta::new(false, 100, "test");
+            b.set_length(len);
+            b.finish_and_clear();
+        }
+
+        #[test]
+        fn bar_any_message_never_panics(msg in ".*") {
+            let b = ProgressBarWithEta::new(false, 10, "test");
+            b.set_message(&msg);
+            b.finish_and_clear();
+        }
+
+        #[test]
+        fn bar_finish_message_never_panics(msg in ".*") {
+            let b = ProgressBarWithEta::new(false, 10, "test");
+            b.finish_with_message(&msg);
+        }
+    }
+}


### PR DESCRIPTION
## Wave 62: html + progress depth tests

Adds ~106 new tests across tokmd-analysis-html and tokmd-progress:
- HTML rendering, escaping (XSS), accessibility, metric cards
- Progress bar operations, spinner lifecycle, silent mode
- Insta snapshots for HTML output
- Property-based testing

**Agent receipt:**
- what changed: New test files html_depth_w62.rs and progress_depth_w62.rs + 2 snapshots
- tests ran: cargo test -p tokmd-analysis-html -p tokmd-progress
- determinism impact: none (test-only)
- contract impact: none
- disposition: A (MERGE NOW)