### PR TITLE
test(w62): derived + near-dup depth tests

### DIFF
--- a/crates/tokmd-analysis-derived/tests/derived_depth_w62.rs
+++ b/crates/tokmd-analysis-derived/tests/derived_depth_w62.rs
@@ -1,0 +1,803 @@
+//! Wave-62 depth tests for `tokmd-analysis-derived`.
+//!
+//! Covers density calculations, distribution metrics, COCOMO model,
+//! zero-input edge cases, single-file repos, large repos, property tests,
+//! determinism, and snapshot tests for formatted metric output.
+
+use proptest::prelude::*;
+use tokmd_analysis_derived::derive_report;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ───────────────────── helpers ─────────────────────
+
+fn row(path: &str, lang: &str, code: usize, comments: usize, blanks: usize) -> FileRow {
+    let lines = code + comments + blanks;
+    FileRow {
+        path: path.to_string(),
+        module: path
+            .rsplit_once('/')
+            .map(|(m, _)| m.to_string())
+            .unwrap_or_default(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments,
+        blanks,
+        lines,
+        bytes: lines * 40,
+        tokens: lines * 5,
+    }
+}
+
+fn row_with_bytes(
+    path: &str,
+    lang: &str,
+    code: usize,
+    comments: usize,
+    blanks: usize,
+    bytes: usize,
+) -> FileRow {
+    let lines = code + comments + blanks;
+    FileRow {
+        path: path.to_string(),
+        module: path
+            .rsplit_once('/')
+            .map(|(m, _)| m.to_string())
+            .unwrap_or_default(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments,
+        blanks,
+        lines,
+        bytes,
+        tokens: lines * 5,
+    }
+}
+
+fn export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 1. Density calculations
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn code_density_pure_code_file() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 100, 0, 0)]), None);
+    // doc_density = comments/(code+comments) = 0/100 = 0
+    assert_eq!(r.doc_density.total.ratio, 0.0);
+    // whitespace = blanks/(code+comments) = 0/100 = 0
+    assert_eq!(r.whitespace.total.ratio, 0.0);
+}
+
+#[test]
+fn comment_density_all_comments() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 0, 100, 0)]), None);
+    // comments/(code+comments) = 100/100 = 1.0
+    assert_eq!(r.doc_density.total.ratio, 1.0);
+}
+
+#[test]
+fn blank_density_calculation() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 60, 30, 10)]), None);
+    // whitespace = blanks/(code+comments) = 10/90
+    assert_eq!(r.whitespace.total.numerator, 10);
+    assert_eq!(r.whitespace.total.denominator, 90);
+    let expected = 10.0 / 90.0;
+    assert!((r.whitespace.total.ratio - expected).abs() < 0.001);
+}
+
+#[test]
+fn density_across_multiple_files() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 80, 20, 10),
+            row("b.rs", "Rust", 100, 0, 0),
+        ]),
+        None,
+    );
+    // total comments = 20, total code+comments = 200
+    assert_eq!(r.doc_density.total.numerator, 20);
+    assert_eq!(r.doc_density.total.denominator, 200);
+    assert!((r.doc_density.total.ratio - 0.1).abs() < 0.001);
+}
+
+#[test]
+fn density_by_lang_has_entries_for_each_language() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 80, 20, 5),
+            row("b.py", "Python", 50, 50, 10),
+            row("c.js", "JavaScript", 30, 10, 5),
+        ]),
+        None,
+    );
+    assert_eq!(r.doc_density.by_lang.len(), 3);
+}
+
+#[test]
+fn density_by_module_has_entries_for_each_module() {
+    let r = derive_report(
+        &export(vec![
+            row("src/a.rs", "Rust", 80, 20, 5),
+            row("lib/b.rs", "Rust", 50, 50, 10),
+        ]),
+        None,
+    );
+    assert!(r.doc_density.by_module.len() >= 2);
+}
+
+#[test]
+fn doc_density_half_and_half() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 50, 50, 0)]), None);
+    assert!((r.doc_density.total.ratio - 0.5).abs() < 0.001);
+}
+
+#[test]
+fn whitespace_zero_when_no_blanks() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 100, 50, 0)]), None);
+    assert_eq!(r.whitespace.total.numerator, 0);
+    assert_eq!(r.whitespace.total.ratio, 0.0);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 2. Distribution metrics
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn distribution_two_files_median() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 10, 0, 0),
+            row("b.rs", "Rust", 20, 0, 0),
+        ]),
+        None,
+    );
+    // Median of [10, 20] = (10+20)/2 = 15.0
+    assert_eq!(r.distribution.median, 15.0);
+}
+
+#[test]
+fn distribution_four_files_stats() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 10, 0, 0),
+            row("b.rs", "Rust", 20, 0, 0),
+            row("c.rs", "Rust", 30, 0, 0),
+            row("d.rs", "Rust", 40, 0, 0),
+        ]),
+        None,
+    );
+    assert_eq!(r.distribution.count, 4);
+    assert_eq!(r.distribution.min, 10);
+    assert_eq!(r.distribution.max, 40);
+    assert!((r.distribution.mean - 25.0).abs() < 0.01);
+}
+
+#[test]
+fn distribution_p90_p99_present() {
+    let rows: Vec<FileRow> = (1..=100)
+        .map(|i| row(&format!("f{i}.rs"), "Rust", i * 10, 0, 0))
+        .collect();
+    let r = derive_report(&export(rows), None);
+    assert!(r.distribution.p90 > 0.0);
+    assert!(r.distribution.p99 > 0.0);
+    assert!(r.distribution.p99 >= r.distribution.p90);
+}
+
+#[test]
+fn distribution_gini_max_inequality() {
+    // One file with all lines, rest with minimal
+    let mut rows = vec![row("big.rs", "Rust", 10000, 0, 0)];
+    for i in 0..99 {
+        rows.push(row(&format!("s{i}.rs"), "Rust", 1, 0, 0));
+    }
+    let r = derive_report(&export(rows), None);
+    assert!(r.distribution.gini > 0.5, "high inequality should give high gini");
+}
+
+#[test]
+fn distribution_identical_sizes_gini_zero() {
+    let rows: Vec<FileRow> = (0..10)
+        .map(|i| row(&format!("f{i}.rs"), "Rust", 50, 0, 0))
+        .collect();
+    let r = derive_report(&export(rows), None);
+    assert_eq!(r.distribution.gini, 0.0);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 3. COCOMO model calculations
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn cocomo_none_for_zero_code() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 0, 100, 50)]), None);
+    assert!(r.cocomo.is_none());
+}
+
+#[test]
+fn cocomo_small_project() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 500, 0, 0)]), None);
+    let c = r.cocomo.unwrap();
+    assert_eq!(c.kloc, 0.5);
+    // Manual: effort = 2.4 * 0.5^1.05
+    let expected_effort = 2.4 * 0.5_f64.powf(1.05);
+    assert!((c.effort_pm - expected_effort).abs() < 0.1);
+}
+
+#[test]
+fn cocomo_100k_loc() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 100_000, 0, 0)]), None);
+    let c = r.cocomo.unwrap();
+    assert_eq!(c.kloc, 100.0);
+    assert!(c.effort_pm > 200.0, "100 KLOC should require significant effort");
+    assert!(c.duration_months > 10.0);
+}
+
+#[test]
+fn cocomo_multi_file_aggregation() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 3000, 0, 0),
+            row("b.rs", "Rust", 2000, 0, 0),
+        ]),
+        None,
+    );
+    let c = r.cocomo.unwrap();
+    assert_eq!(c.kloc, 5.0);
+}
+
+#[test]
+fn cocomo_staff_positive() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 10000, 0, 0)]), None);
+    let c = r.cocomo.unwrap();
+    assert!(c.staff > 0.0);
+    // staff = effort / duration
+    let expected_staff = c.effort_pm / c.duration_months;
+    assert!((c.staff - expected_staff).abs() < 0.01);
+}
+
+#[test]
+fn cocomo_effort_superlinear() {
+    // Effort grows superlinearly with code size (b > 1)
+    let r1 = derive_report(&export(vec![row("a.rs", "Rust", 1000, 0, 0)]), None);
+    let r2 = derive_report(&export(vec![row("a.rs", "Rust", 2000, 0, 0)]), None);
+    let c1 = r1.cocomo.unwrap();
+    let c2 = r2.cocomo.unwrap();
+    // If linear, effort doubles. With b=1.05, it more than doubles.
+    assert!(c2.effort_pm > 2.0 * c1.effort_pm);
+}
+
+#[test]
+fn cocomo_1_loc() {
+    let r = derive_report(&export(vec![row("a.rs", "Rust", 1, 0, 0)]), None);
+    let c = r.cocomo.unwrap();
+    assert_eq!(c.kloc, 0.001);
+    // With 0.001 KLOC, effort = 2.4 * 0.001^1.05 ≈ 0.0018 which rounds to 0.0
+    assert!(c.effort_pm >= 0.0);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 4. Zero-input edge cases
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn empty_export_all_zeros() {
+    let r = derive_report(&export(vec![]), None);
+    assert_eq!(r.totals.files, 0);
+    assert_eq!(r.totals.code, 0);
+    assert_eq!(r.totals.lines, 0);
+    assert_eq!(r.totals.bytes, 0);
+    assert_eq!(r.totals.tokens, 0);
+}
+
+#[test]
+fn empty_export_reading_time_zero() {
+    let r = derive_report(&export(vec![]), None);
+    assert_eq!(r.reading_time.minutes, 0.0);
+}
+
+#[test]
+fn empty_export_polyglot_zero_langs() {
+    let r = derive_report(&export(vec![]), None);
+    assert_eq!(r.polyglot.lang_count, 0);
+    assert_eq!(r.polyglot.entropy, 0.0);
+}
+
+#[test]
+fn empty_export_histogram_all_zeros() {
+    let r = derive_report(&export(vec![]), None);
+    for bucket in &r.histogram {
+        assert_eq!(bucket.files, 0);
+    }
+}
+
+#[test]
+fn empty_export_integrity_zero_entries() {
+    let r = derive_report(&export(vec![]), None);
+    assert_eq!(r.integrity.entries, 0);
+    assert_eq!(r.integrity.algo, "blake3");
+}
+
+#[test]
+fn all_zero_line_files() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 0, 0, 0),
+            row("b.rs", "Rust", 0, 0, 0),
+        ]),
+        None,
+    );
+    assert_eq!(r.totals.files, 2);
+    assert_eq!(r.totals.lines, 0);
+    assert!(r.cocomo.is_none());
+    assert_eq!(r.distribution.min, 0);
+    assert_eq!(r.distribution.max, 0);
+}
+
+#[test]
+fn child_rows_excluded_from_totals() {
+    let mut child = row("child.rs", "Rust", 500, 0, 0);
+    child.kind = FileKind::Child;
+    let r = derive_report(
+        &export(vec![row("parent.rs", "Rust", 100, 0, 0), child]),
+        None,
+    );
+    assert_eq!(r.totals.files, 1);
+    assert_eq!(r.totals.code, 100);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 5. Single-file repos
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn single_file_all_metrics_populated() {
+    let r = derive_report(
+        &export(vec![row("src/main.rs", "Rust", 200, 50, 30)]),
+        Some(100_000),
+    );
+    assert_eq!(r.totals.files, 1);
+    assert!(r.cocomo.is_some());
+    assert!(r.context_window.is_some());
+    assert_eq!(r.distribution.count, 1);
+    assert_eq!(r.polyglot.lang_count, 1);
+    assert!(!r.integrity.hash.is_empty());
+}
+
+#[test]
+fn single_file_max_file_is_itself() {
+    let r = derive_report(
+        &export(vec![row("src/main.rs", "Rust", 100, 10, 5)]),
+        None,
+    );
+    assert_eq!(r.max_file.overall.path, "src/main.rs");
+}
+
+#[test]
+fn single_file_nesting_depth() {
+    let r = derive_report(
+        &export(vec![row("src/deep/nested/file.rs", "Rust", 100, 0, 0)]),
+        None,
+    );
+    assert!(r.nesting.max > 0);
+    assert!(r.nesting.avg > 0.0);
+}
+
+#[test]
+fn single_file_test_density() {
+    let r = derive_report(
+        &export(vec![row("tests/test_main.rs", "Rust", 100, 0, 0)]),
+        None,
+    );
+    assert_eq!(r.test_density.test_files, 1);
+    assert_eq!(r.test_density.prod_files, 0);
+    assert_eq!(r.test_density.test_lines, 100);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 6. Large repos with many files
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn large_repo_2000_files() {
+    let rows: Vec<FileRow> = (0..2000)
+        .map(|i| row(&format!("src/mod{}/file{}.rs", i / 50, i), "Rust", 10 + i % 200, i % 20, i % 10))
+        .collect();
+    let r = derive_report(&export(rows), None);
+    assert_eq!(r.totals.files, 2000);
+    assert_eq!(r.distribution.count, 2000);
+    assert!(r.cocomo.is_some());
+}
+
+#[test]
+fn large_repo_histogram_sums_to_total() {
+    let rows: Vec<FileRow> = (0..500)
+        .map(|i| row(&format!("f{i}.rs"), "Rust", 1 + i * 5, 0, 0))
+        .collect();
+    let r = derive_report(&export(rows), None);
+    let total_in_histogram: usize = r.histogram.iter().map(|b| b.files).sum();
+    assert_eq!(total_in_histogram, 500);
+}
+
+#[test]
+fn large_repo_top_offenders_capped() {
+    let rows: Vec<FileRow> = (0..100)
+        .map(|i| row(&format!("f{i}.rs"), "Rust", 100 + i * 10, i, 5))
+        .collect();
+    let r = derive_report(&export(rows), None);
+    assert!(r.top.largest_lines.len() <= 10);
+    assert!(r.top.largest_tokens.len() <= 10);
+    assert!(r.top.largest_bytes.len() <= 10);
+}
+
+#[test]
+fn large_repo_multi_language() {
+    let langs = ["Rust", "Python", "TypeScript", "Go", "Java"];
+    let rows: Vec<FileRow> = (0..250)
+        .map(|i| row(&format!("f{i}.rs"), langs[i % langs.len()], 50 + i, 10, 5))
+        .collect();
+    let r = derive_report(&export(rows), None);
+    assert_eq!(r.polyglot.lang_count, 5);
+    assert!(r.polyglot.entropy > 0.0);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 7. Property tests
+// ═══════════════════════════════════════════════════════════════
+
+fn arb_row() -> impl Strategy<Value = FileRow> {
+    (
+        "[a-z]{1,3}(/[a-z]{1,3}){0,2}\\.rs",
+        "(Rust|Python|Go|TypeScript|TOML)",
+        0..3000usize,
+        0..500usize,
+        0..300usize,
+    )
+        .prop_map(|(path, lang, code, comments, blanks)| {
+            let lines = code + comments + blanks;
+            FileRow {
+                path,
+                module: "root".to_string(),
+                lang,
+                kind: FileKind::Parent,
+                code,
+                comments,
+                blanks,
+                lines,
+                bytes: lines * 40,
+                tokens: lines * 5,
+            }
+        })
+}
+
+fn arb_rows() -> impl Strategy<Value = Vec<FileRow>> {
+    prop::collection::vec(arb_row(), 1..=15)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(150))]
+
+    #[test]
+    fn prop_doc_density_ratio_in_01(rows in arb_rows()) {
+        let r = derive_report(&export(rows), None);
+        prop_assert!(r.doc_density.total.ratio >= 0.0);
+        prop_assert!(r.doc_density.total.ratio <= 1.0);
+    }
+
+    #[test]
+    fn prop_whitespace_ratio_non_negative(rows in arb_rows()) {
+        let r = derive_report(&export(rows), None);
+        prop_assert!(r.whitespace.total.ratio >= 0.0);
+    }
+
+    #[test]
+    fn prop_cocomo_effort_positive_for_nonzero(rows in arb_rows()) {
+        let total_code: usize = rows.iter().map(|r| r.code).sum();
+        let r = derive_report(&export(rows), None);
+        if total_code > 0 {
+            let c = r.cocomo.unwrap();
+            prop_assert!(c.effort_pm > 0.0);
+            prop_assert!(c.duration_months > 0.0);
+        } else {
+            prop_assert!(r.cocomo.is_none());
+        }
+    }
+
+    #[test]
+    fn prop_gini_in_01(rows in arb_rows()) {
+        let r = derive_report(&export(rows), None);
+        prop_assert!(r.distribution.gini >= 0.0);
+        prop_assert!(r.distribution.gini <= 1.0);
+    }
+
+    #[test]
+    fn prop_histogram_pct_sums_approx_one(rows in arb_rows()) {
+        let r = derive_report(&export(rows), None);
+        let sum: f64 = r.histogram.iter().map(|b| b.pct).sum();
+        prop_assert!((sum - 1.0).abs() < 0.02, "histogram pct sum = {}", sum);
+    }
+
+    #[test]
+    fn prop_totals_match_row_sums(rows in arb_rows()) {
+        let expected_code: usize = rows.iter().map(|r| r.code).sum();
+        let expected_comments: usize = rows.iter().map(|r| r.comments).sum();
+        let expected_blanks: usize = rows.iter().map(|r| r.blanks).sum();
+        let r = derive_report(&export(rows.clone()), None);
+        prop_assert_eq!(r.totals.code, expected_code);
+        prop_assert_eq!(r.totals.comments, expected_comments);
+        prop_assert_eq!(r.totals.blanks, expected_blanks);
+        prop_assert_eq!(r.totals.files, rows.len());
+    }
+
+    #[test]
+    fn prop_reading_time_proportional_to_code(rows in arb_rows()) {
+        let total_code: usize = rows.iter().map(|r| r.code).sum();
+        let r = derive_report(&export(rows), None);
+        let expected = total_code as f64 / 20.0;
+        prop_assert!((r.reading_time.minutes - expected).abs() < 0.1);
+    }
+
+    #[test]
+    fn prop_polyglot_entropy_non_negative(rows in arb_rows()) {
+        let r = derive_report(&export(rows), None);
+        prop_assert!(r.polyglot.entropy >= 0.0);
+    }
+
+    #[test]
+    fn prop_distribution_mean_in_range(rows in arb_rows()) {
+        let r = derive_report(&export(rows), None);
+        let d = &r.distribution;
+        prop_assert!(d.mean >= d.min as f64);
+        prop_assert!(d.mean <= d.max as f64);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 8. Determinism: same scan produces same metrics
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn determinism_full_report() {
+    let data = export(vec![
+        row("src/a.rs", "Rust", 200, 50, 20),
+        row("src/b.py", "Python", 150, 30, 10),
+        row("lib/c.ts", "TypeScript", 80, 40, 15),
+    ]);
+    let r1 = derive_report(&data, Some(50_000));
+    let r2 = derive_report(&data, Some(50_000));
+
+    assert_eq!(r1.totals.code, r2.totals.code);
+    assert_eq!(r1.totals.comments, r2.totals.comments);
+    assert_eq!(r1.totals.blanks, r2.totals.blanks);
+    assert_eq!(r1.totals.lines, r2.totals.lines);
+    assert_eq!(r1.totals.bytes, r2.totals.bytes);
+    assert_eq!(r1.totals.tokens, r2.totals.tokens);
+    assert_eq!(r1.doc_density.total.ratio, r2.doc_density.total.ratio);
+    assert_eq!(r1.whitespace.total.ratio, r2.whitespace.total.ratio);
+    assert_eq!(r1.distribution.gini, r2.distribution.gini);
+    assert_eq!(r1.distribution.median, r2.distribution.median);
+    assert_eq!(r1.polyglot.entropy, r2.polyglot.entropy);
+    assert_eq!(r1.integrity.hash, r2.integrity.hash);
+
+    let c1 = r1.cocomo.unwrap();
+    let c2 = r2.cocomo.unwrap();
+    assert_eq!(c1.effort_pm, c2.effort_pm);
+    assert_eq!(c1.duration_months, c2.duration_months);
+    assert_eq!(c1.staff, c2.staff);
+}
+
+#[test]
+fn determinism_integrity_hash_stable() {
+    let data = export(vec![
+        row("a.rs", "Rust", 100, 10, 5),
+        row("b.rs", "Rust", 200, 20, 10),
+    ]);
+    let hashes: Vec<String> = (0..5)
+        .map(|_| derive_report(&data, None).integrity.hash)
+        .collect();
+    for h in &hashes {
+        assert_eq!(h, &hashes[0]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 9. Snapshot tests for JSON metric output
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn snapshot_totals_json() {
+    let r = derive_report(
+        &export(vec![row("src/main.rs", "Rust", 100, 20, 10)]),
+        None,
+    );
+    let json = serde_json::to_value(&r.totals).unwrap();
+    assert_eq!(json["files"], 1);
+    assert_eq!(json["code"], 100);
+    assert_eq!(json["comments"], 20);
+    assert_eq!(json["blanks"], 10);
+    assert_eq!(json["lines"], 130);
+}
+
+#[test]
+fn snapshot_cocomo_json() {
+    let r = derive_report(
+        &export(vec![row("a.rs", "Rust", 10000, 0, 0)]),
+        None,
+    );
+    let c = r.cocomo.unwrap();
+    let json = serde_json::to_value(&c).unwrap();
+    assert_eq!(json["mode"], "organic");
+    assert_eq!(json["kloc"], 10.0);
+    assert!(json["effort_pm"].as_f64().unwrap() > 0.0);
+    assert!(json["duration_months"].as_f64().unwrap() > 0.0);
+}
+
+#[test]
+fn snapshot_distribution_json() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 10, 0, 0),
+            row("b.rs", "Rust", 100, 0, 0),
+        ]),
+        None,
+    );
+    let json = serde_json::to_value(&r.distribution).unwrap();
+    assert_eq!(json["count"], 2);
+    assert_eq!(json["min"], 10);
+    assert_eq!(json["max"], 100);
+}
+
+#[test]
+fn snapshot_context_window_json() {
+    let r = derive_report(
+        &export(vec![row("a.rs", "Rust", 100, 0, 0)]),
+        Some(1000),
+    );
+    let cw = r.context_window.unwrap();
+    let json = serde_json::to_value(&cw).unwrap();
+    assert_eq!(json["window_tokens"], 1000);
+    assert_eq!(json["total_tokens"], 500);
+    assert_eq!(json["fits"], true);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 10. Additional edge cases and metrics
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn verbosity_rate_varies_by_bytes() {
+    let r = derive_report(
+        &export(vec![
+            row_with_bytes("a.rs", "Rust", 100, 0, 0, 8000),
+            row_with_bytes("b.rs", "Rust", 100, 0, 0, 2000),
+        ]),
+        None,
+    );
+    // total bytes = 10000, total lines = 200
+    assert_eq!(r.verbosity.total.numerator, 10000);
+    assert_eq!(r.verbosity.total.denominator, 200);
+    assert!((r.verbosity.total.rate - 50.0).abs() < 0.01);
+}
+
+#[test]
+fn test_density_mixed_test_and_prod() {
+    let r = derive_report(
+        &export(vec![
+            row("src/lib.rs", "Rust", 200, 0, 0),
+            row("tests/test_lib.rs", "Rust", 100, 0, 0),
+        ]),
+        None,
+    );
+    assert_eq!(r.test_density.test_files, 1);
+    assert_eq!(r.test_density.prod_files, 1);
+    assert_eq!(r.test_density.test_lines, 100);
+    assert_eq!(r.test_density.prod_lines, 200);
+    // ratio = 100 / 300
+    let expected = 100.0 / 300.0;
+    assert!((r.test_density.ratio - expected).abs() < 0.001);
+}
+
+#[test]
+fn polyglot_entropy_max_with_equal_split() {
+    // Equal split among N languages should give maximum entropy log2(N)
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 100, 0, 0),
+            row("b.py", "Python", 100, 0, 0),
+            row("c.go", "Go", 100, 0, 0),
+            row("d.ts", "TypeScript", 100, 0, 0),
+        ]),
+        None,
+    );
+    let expected_max = 4.0_f64.log2(); // 2.0
+    assert!((r.polyglot.entropy - expected_max).abs() < 0.001);
+}
+
+#[test]
+fn polyglot_dominant_is_largest_code() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 500, 0, 0),
+            row("b.py", "Python", 100, 0, 0),
+        ]),
+        None,
+    );
+    assert_eq!(r.polyglot.dominant_lang, "Rust");
+    assert_eq!(r.polyglot.dominant_lines, 500);
+}
+
+#[test]
+fn lang_purity_single_lang_module() {
+    let r = derive_report(
+        &export(vec![
+            row("src/a.rs", "Rust", 100, 0, 0),
+            row("src/b.rs", "Rust", 200, 0, 0),
+        ]),
+        None,
+    );
+    // Both files in "src" module, all Rust
+    let src_row = r.lang_purity.rows.iter().find(|p| p.module == "src");
+    assert!(src_row.is_some());
+    let src = src_row.unwrap();
+    assert_eq!(src.lang_count, 1);
+    assert_eq!(src.dominant_pct, 1.0);
+}
+
+#[test]
+fn nesting_report_multiple_depths() {
+    let r = derive_report(
+        &export(vec![
+            row("a.rs", "Rust", 100, 0, 0),              // depth 1
+            row("src/b.rs", "Rust", 100, 0, 0),           // depth 2
+            row("src/deep/c.rs", "Rust", 100, 0, 0),      // depth 3
+        ]),
+        None,
+    );
+    assert!(r.nesting.max >= 3);
+}
+
+#[test]
+fn context_window_exact_boundary() {
+    // tokens exactly equals window
+    let r = derive_report(
+        &export(vec![row("a.rs", "Rust", 20, 0, 0)]),  // 20 lines * 5 = 100 tokens
+        Some(100),
+    );
+    let cw = r.context_window.unwrap();
+    assert!(cw.fits); // total_tokens <= window_tokens
+    assert_eq!(cw.total_tokens, 100);
+    assert!((cw.pct - 1.0).abs() < 0.001);
+}
+
+#[test]
+fn histogram_huge_file_classification() {
+    let r = derive_report(
+        &export(vec![row("big.rs", "Rust", 2000, 0, 0)]),
+        None,
+    );
+    // 2000 lines > 1000 => "Huge"
+    assert_eq!(r.histogram[4].files, 1);
+    assert_eq!(r.histogram[4].label, "Huge");
+}
+
+#[test]
+fn boilerplate_report_with_infra_lang() {
+    let r = derive_report(
+        &export(vec![
+            row("src/main.rs", "Rust", 200, 0, 0),
+            row("Cargo.toml", "TOML", 50, 0, 0),
+        ]),
+        None,
+    );
+    // TOML is typically an infra lang
+    assert!(r.boilerplate.infra_lines > 0 || r.boilerplate.logic_lines > 0);
+    assert!(r.boilerplate.ratio >= 0.0 && r.boilerplate.ratio <= 1.0);
+}

--- a/crates/tokmd-analysis-near-dup/tests/neardup_depth_w62.rs
+++ b/crates/tokmd-analysis-near-dup/tests/neardup_depth_w62.rs
@@ -1,0 +1,949 @@
+//! Wave-62 depth tests for `tokmd-analysis-near-dup`.
+//!
+//! Covers exact duplicate detection, similarity thresholds, scope partitioning,
+//! empty/single-file handling, performance with many files, property tests,
+//! and determinism of duplicate grouping.
+
+use std::io::Write;
+
+use proptest::prelude::*;
+use tempfile::TempDir;
+use tokmd_analysis_near_dup::{NearDupLimits, build_near_dup_report};
+use tokmd_analysis_types::NearDupScope;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ───────────────────── helpers ─────────────────────
+
+fn frow(path: &str, module: &str, lang: &str, code: usize, bytes: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments: 0,
+        blanks: 0,
+        lines: code,
+        bytes,
+        tokens: code * 5,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+fn write_file(dir: &TempDir, path: &str, content: &str) {
+    let full = dir.path().join(path);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut f = std::fs::File::create(&full).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+}
+
+/// Generate deterministic source with `n` lines and `seed`-based variation.
+fn gen_source(n: usize, seed: usize) -> String {
+    (0..n)
+        .map(|i| format!("fn func_{}_{}_impl() {{ let val = {}; }}", seed, i, i * seed))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn default_limits() -> NearDupLimits {
+    NearDupLimits {
+        max_bytes: None,
+        max_file_bytes: None,
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 1. Exact duplicate detection
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn exact_duplicates_two_files() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "mod", "Rust", 60, sz), frow("b.rs", "mod", "Rust", 60, sz)]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert_eq!(report.pairs.len(), 1);
+    assert!((report.pairs[0].similarity - 1.0).abs() < 1e-4);
+}
+
+#[test]
+fn exact_duplicates_three_files_form_one_cluster() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    for name in ["x.rs", "y.rs", "z.rs"] {
+        write_file(&dir, name, &content);
+    }
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![
+            frow("x.rs", "mod", "Rust", 60, sz),
+            frow("y.rs", "mod", "Rust", 60, sz),
+            frow("z.rs", "mod", "Rust", 60, sz),
+        ]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert_eq!(report.pairs.len(), 3); // 3 choose 2
+    let clusters = report.clusters.as_ref().unwrap();
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0].files.len(), 3);
+}
+
+#[test]
+fn exact_duplicates_similarity_is_one() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(80, 42);
+    write_file(&dir, "left.rs", &content);
+    write_file(&dir, "right.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("left.rs", "m", "Rust", 80, sz), frow("right.rs", "m", "Rust", 80, sz)]),
+        NearDupScope::Global, 0.99, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(!report.pairs.is_empty());
+    assert!((report.pairs[0].similarity - 1.0).abs() < 1e-4);
+}
+
+#[test]
+fn exact_dup_shared_fingerprints_equal_total() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 7);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, sz), frow("b.rs", "m", "Rust", 60, sz)]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    let p = &report.pairs[0];
+    assert_eq!(p.shared_fingerprints, p.left_fingerprints);
+    assert_eq!(p.shared_fingerprints, p.right_fingerprints);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 2. Near-duplicate similarity thresholds
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn threshold_0_catches_all_pairs() {
+    let dir = TempDir::new().unwrap();
+    let c1 = gen_source(60, 1);
+    let c2 = gen_source(60, 2);
+    write_file(&dir, "a.rs", &c1);
+    write_file(&dir, "b.rs", &c2);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, c1.len()), frow("b.rs", "m", "Rust", 60, c2.len())]),
+        NearDupScope::Global, 0.0, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    // With threshold 0, any files with shared fingerprints are pairs
+    // (may or may not produce pairs depending on content overlap)
+    assert!(report.files_analyzed == 2);
+}
+
+#[test]
+fn threshold_1_only_exact_matches() {
+    let dir = TempDir::new().unwrap();
+    let base = gen_source(60, 1);
+    let variant = format!("{}\nfn extra_variant_function() {{ let z = 123456; }}", &base);
+    write_file(&dir, "a.rs", &base);
+    write_file(&dir, "b.rs", &variant);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, base.len()), frow("b.rs", "m", "Rust", 61, variant.len())]),
+        NearDupScope::Global, 1.0, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    // Non-identical files should not match at threshold 1.0
+    assert!(report.pairs.is_empty());
+}
+
+#[test]
+fn higher_threshold_fewer_or_equal_pairs() {
+    let dir = TempDir::new().unwrap();
+    let c1 = gen_source(60, 1);
+    let c2 = gen_source(60, 1); // identical
+    let c3 = gen_source(60, 3);
+    write_file(&dir, "a.rs", &c1);
+    write_file(&dir, "b.rs", &c2);
+    write_file(&dir, "c.rs", &c3);
+
+    let rows = vec![
+        frow("a.rs", "m", "Rust", 60, c1.len()),
+        frow("b.rs", "m", "Rust", 60, c2.len()),
+        frow("c.rs", "m", "Rust", 60, c3.len()),
+    ];
+
+    let r_low = build_near_dup_report(
+        dir.path(), &make_export(rows.clone()),
+        NearDupScope::Global, 0.1, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    let r_high = build_near_dup_report(
+        dir.path(), &make_export(rows),
+        NearDupScope::Global, 0.99, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(r_high.pairs.len() <= r_low.pairs.len());
+}
+
+#[test]
+fn moderate_similarity_detected_at_low_threshold() {
+    let dir = TempDir::new().unwrap();
+    let base = gen_source(60, 1);
+    // Keep first 40 lines identical, change last 20
+    let lines: Vec<&str> = base.lines().collect();
+    let modified = format!(
+        "{}\n{}",
+        lines[..40].join("\n"),
+        gen_source(20, 999)
+    );
+    write_file(&dir, "a.rs", &base);
+    write_file(&dir, "b.rs", &modified);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, base.len()), frow("b.rs", "m", "Rust", 60, modified.len())]),
+        NearDupScope::Global, 0.2, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    if !report.pairs.is_empty() {
+        assert!(report.pairs[0].similarity >= 0.2);
+        assert!(report.pairs[0].similarity < 1.0);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 3. Scope-based partitioning
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn global_scope_finds_cross_module_dups() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "mod_a", "Rust", 60, sz), frow("b.rs", "mod_b", "Rust", 60, sz)]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(!report.pairs.is_empty());
+}
+
+#[test]
+fn module_scope_isolates_modules() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "alpha", "Rust", 60, sz), frow("b.rs", "beta", "Rust", 60, sz)]),
+        NearDupScope::Module, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+}
+
+#[test]
+fn module_scope_finds_dups_within_same_module() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "same", "Rust", 60, sz), frow("b.rs", "same", "Rust", 60, sz)]),
+        NearDupScope::Module, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(!report.pairs.is_empty());
+}
+
+#[test]
+fn lang_scope_isolates_languages() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.py", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, sz), frow("b.py", "m", "Python", 60, sz)]),
+        NearDupScope::Lang, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+}
+
+#[test]
+fn lang_scope_finds_dups_within_same_lang() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, sz), frow("b.rs", "m", "Rust", 60, sz)]),
+        NearDupScope::Lang, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(!report.pairs.is_empty());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 4. Empty file handling
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn empty_export_no_pairs() {
+    let dir = TempDir::new().unwrap();
+    let report = build_near_dup_report(
+        dir.path(), &make_export(vec![]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+    assert_eq!(report.files_analyzed, 0);
+    assert!(report.clusters.is_none());
+}
+
+#[test]
+fn empty_files_no_fingerprints() {
+    let dir = TempDir::new().unwrap();
+    write_file(&dir, "a.rs", "");
+    write_file(&dir, "b.rs", "");
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 0, 0), frow("b.rs", "m", "Rust", 0, 0)]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+}
+
+#[test]
+fn whitespace_only_files_no_pairs() {
+    let dir = TempDir::new().unwrap();
+    write_file(&dir, "a.rs", "   \n\n  \t  \n");
+    write_file(&dir, "b.rs", "   \n\n  \t  \n");
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 0, 12), frow("b.rs", "m", "Rust", 0, 12)]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+}
+
+#[test]
+fn very_short_files_below_kgram() {
+    let dir = TempDir::new().unwrap();
+    write_file(&dir, "a.rs", "fn f() { 1 }");
+    write_file(&dir, "b.rs", "fn f() { 1 }");
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 1, 13), frow("b.rs", "m", "Rust", 1, 13)]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    // < 25 tokens, so no k-grams → no fingerprints → no pairs
+    assert!(report.pairs.is_empty());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 5. Single file (no duplicates possible)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn single_file_no_pairs() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "only.rs", &content);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("only.rs", "m", "Rust", 60, content.len())]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+    assert_eq!(report.files_analyzed, 1);
+    assert!(report.clusters.is_none());
+}
+
+#[test]
+fn single_file_with_module_scope() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "only.rs", &content);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("only.rs", "mod", "Rust", 60, content.len())]),
+        NearDupScope::Module, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 6. Performance with many files
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn twenty_identical_files() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    let n = 20;
+    for i in 0..n {
+        write_file(&dir, &format!("f{i}.rs"), &content);
+    }
+
+    let rows: Vec<FileRow> = (0..n)
+        .map(|i| frow(&format!("f{i}.rs"), "m", "Rust", 60, content.len()))
+        .collect();
+
+    let report = build_near_dup_report(
+        dir.path(), &make_export(rows),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    // 20 choose 2 = 190 pairs
+    assert_eq!(report.pairs.len(), 190);
+    let clusters = report.clusters.as_ref().unwrap();
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0].files.len(), 20);
+}
+
+#[test]
+fn max_files_limits_analysis() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    for i in 0..15 {
+        write_file(&dir, &format!("f{i}.rs"), &content);
+    }
+
+    let rows: Vec<FileRow> = (0..15)
+        .map(|i| frow(&format!("f{i}.rs"), "m", "Rust", 60, content.len()))
+        .collect();
+
+    let report = build_near_dup_report(
+        dir.path(), &make_export(rows),
+        NearDupScope::Global, 0.5, 5, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert_eq!(report.files_analyzed, 5);
+    assert_eq!(report.files_skipped, 10);
+}
+
+#[test]
+fn max_pairs_truncation() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    for i in 0..6 {
+        write_file(&dir, &format!("f{i}.rs"), &content);
+    }
+
+    let rows: Vec<FileRow> = (0..6)
+        .map(|i| frow(&format!("f{i}.rs"), "m", "Rust", 60, content.len()))
+        .collect();
+
+    let report = build_near_dup_report(
+        dir.path(), &make_export(rows),
+        NearDupScope::Global, 0.5, 100, Some(3), &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.len() <= 3);
+    assert!(report.truncated);
+}
+
+#[test]
+fn many_unique_files_no_pairs() {
+    let dir = TempDir::new().unwrap();
+    for i in 0..30 {
+        let content = gen_source(60, i + 1000); // all different seeds
+        write_file(&dir, &format!("f{i}.rs"), &content);
+    }
+
+    let rows: Vec<FileRow> = (0..30)
+        .map(|i| {
+            let content = gen_source(60, i + 1000);
+            frow(&format!("f{i}.rs"), "m", "Rust", 60, content.len())
+        })
+        .collect();
+
+    let report = build_near_dup_report(
+        dir.path(), &make_export(rows),
+        NearDupScope::Global, 0.8, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    // Unique content should produce few or no pairs at high threshold
+    assert_eq!(report.files_analyzed, 30);
+}
+
+#[test]
+fn exclude_patterns_reduce_analyzed() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    write_file(&dir, "gen_output.rs", &content);
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![
+            frow("a.rs", "m", "Rust", 60, content.len()),
+            frow("b.rs", "m", "Rust", 60, content.len()),
+            frow("gen_output.rs", "m", "Rust", 60, content.len()),
+        ]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &["gen_*".to_string()],
+    ).unwrap();
+
+    assert_eq!(report.excluded_by_pattern, Some(1));
+    assert_eq!(report.files_analyzed, 2);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 7. Property tests
+// ═══════════════════════════════════════════════════════════════
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(30))]
+
+    #[test]
+    fn prop_similarity_in_0_1(seed1 in 1..100usize, seed2 in 1..100usize) {
+        let dir = TempDir::new().unwrap();
+        let c1 = gen_source(60, seed1);
+        let c2 = gen_source(60, seed2);
+        write_file(&dir, "a.rs", &c1);
+        write_file(&dir, "b.rs", &c2);
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(vec![frow("a.rs", "m", "Rust", 60, c1.len()), frow("b.rs", "m", "Rust", 60, c2.len())]),
+            NearDupScope::Global, 0.0, 100, None, &default_limits(), &[],
+        ).unwrap();
+
+        for pair in &report.pairs {
+            prop_assert!(pair.similarity >= 0.0 && pair.similarity <= 1.0,
+                "similarity {} out of [0,1]", pair.similarity);
+        }
+    }
+
+    #[test]
+    fn prop_similarity_symmetric(seed in 1..50usize) {
+        let dir = TempDir::new().unwrap();
+        let c1 = gen_source(60, seed);
+        let c2 = gen_source(60, seed + 500);
+        write_file(&dir, "a.rs", &c1);
+        write_file(&dir, "b.rs", &c2);
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(vec![frow("a.rs", "m", "Rust", 60, c1.len()), frow("b.rs", "m", "Rust", 60, c2.len())]),
+            NearDupScope::Global, 0.0, 100, None, &default_limits(), &[],
+        ).unwrap();
+
+        // Jaccard is inherently symmetric: J(A,B) = J(B,A)
+        // The report always puts left < right alphabetically, so just check it exists once
+        if !report.pairs.is_empty() {
+            let p = &report.pairs[0];
+            prop_assert!(p.left <= p.right, "left should be <= right for determinism");
+        }
+    }
+
+    #[test]
+    fn prop_identical_similarity_is_one(seed in 1..200usize) {
+        let dir = TempDir::new().unwrap();
+        let content = gen_source(60, seed);
+        write_file(&dir, "a.rs", &content);
+        write_file(&dir, "b.rs", &content);
+        let sz = content.len();
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(vec![frow("a.rs", "m", "Rust", 60, sz), frow("b.rs", "m", "Rust", 60, sz)]),
+            NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+        ).unwrap();
+
+        prop_assert_eq!(report.pairs.len(), 1);
+        prop_assert!((report.pairs[0].similarity - 1.0).abs() < 1e-4,
+            "identical files should have similarity 1.0, got {}", report.pairs[0].similarity);
+    }
+
+    #[test]
+    fn prop_cluster_file_count_ge_pair_files(seed in 1..100usize) {
+        let dir = TempDir::new().unwrap();
+        let content = gen_source(60, seed);
+        write_file(&dir, "a.rs", &content);
+        write_file(&dir, "b.rs", &content);
+        write_file(&dir, "c.rs", &content);
+        let sz = content.len();
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(vec![
+                frow("a.rs", "m", "Rust", 60, sz),
+                frow("b.rs", "m", "Rust", 60, sz),
+                frow("c.rs", "m", "Rust", 60, sz),
+            ]),
+            NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+        ).unwrap();
+
+        if let Some(clusters) = &report.clusters {
+            let total_clustered: usize = clusters.iter().map(|c| c.files.len()).sum();
+            // Each pair references 2 files, so cluster should have >= 2 files
+            prop_assert!(total_clustered >= 2);
+        }
+    }
+
+    #[test]
+    fn prop_pairs_sorted_by_similarity_desc(seed in 1..50usize) {
+        let dir = TempDir::new().unwrap();
+        let c1 = gen_source(60, seed);
+        let c2 = gen_source(60, seed);       // identical to c1
+        let c3 = gen_source(60, seed + 500); // different
+        write_file(&dir, "a.rs", &c1);
+        write_file(&dir, "b.rs", &c2);
+        write_file(&dir, "c.rs", &c3);
+
+        let report = build_near_dup_report(
+            dir.path(),
+            &make_export(vec![
+                frow("a.rs", "m", "Rust", 60, c1.len()),
+                frow("b.rs", "m", "Rust", 60, c2.len()),
+                frow("c.rs", "m", "Rust", 60, c3.len()),
+            ]),
+            NearDupScope::Global, 0.0, 100, None, &default_limits(), &[],
+        ).unwrap();
+
+        for window in report.pairs.windows(2) {
+            prop_assert!(window[0].similarity >= window[1].similarity,
+                "pairs should be sorted by similarity desc");
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 8. Determinism: same files always produce same groups
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn determinism_same_pairs() {
+    let dir = TempDir::new().unwrap();
+    let c1 = gen_source(60, 1);
+    let c2 = gen_source(60, 1); // identical
+    let c3 = gen_source(60, 3);
+    write_file(&dir, "a.rs", &c1);
+    write_file(&dir, "b.rs", &c2);
+    write_file(&dir, "c.rs", &c3);
+
+    let exp = make_export(vec![
+        frow("a.rs", "m", "Rust", 60, c1.len()),
+        frow("b.rs", "m", "Rust", 60, c2.len()),
+        frow("c.rs", "m", "Rust", 60, c3.len()),
+    ]);
+
+    let r1 = build_near_dup_report(dir.path(), &exp, NearDupScope::Global, 0.5, 100, None, &default_limits(), &[]).unwrap();
+    let r2 = build_near_dup_report(dir.path(), &exp, NearDupScope::Global, 0.5, 100, None, &default_limits(), &[]).unwrap();
+
+    assert_eq!(r1.pairs.len(), r2.pairs.len());
+    for (a, b) in r1.pairs.iter().zip(r2.pairs.iter()) {
+        assert_eq!(a.left, b.left);
+        assert_eq!(a.right, b.right);
+        assert!((a.similarity - b.similarity).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn determinism_same_clusters() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    for name in ["a.rs", "b.rs", "c.rs"] {
+        write_file(&dir, name, &content);
+    }
+    let sz = content.len();
+
+    let exp = make_export(vec![
+        frow("a.rs", "m", "Rust", 60, sz),
+        frow("b.rs", "m", "Rust", 60, sz),
+        frow("c.rs", "m", "Rust", 60, sz),
+    ]);
+
+    let r1 = build_near_dup_report(dir.path(), &exp, NearDupScope::Global, 0.5, 100, None, &default_limits(), &[]).unwrap();
+    let r2 = build_near_dup_report(dir.path(), &exp, NearDupScope::Global, 0.5, 100, None, &default_limits(), &[]).unwrap();
+
+    let c1 = r1.clusters.unwrap();
+    let c2 = r2.clusters.unwrap();
+    assert_eq!(c1.len(), c2.len());
+    for (a, b) in c1.iter().zip(c2.iter()) {
+        assert_eq!(a.files, b.files);
+        assert_eq!(a.representative, b.representative);
+    }
+}
+
+#[test]
+fn determinism_serialization_stable() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let exp = make_export(vec![
+        frow("a.rs", "m", "Rust", 60, sz),
+        frow("b.rs", "m", "Rust", 60, sz),
+    ]);
+
+    let r1 = build_near_dup_report(dir.path(), &exp, NearDupScope::Global, 0.5, 100, None, &default_limits(), &[]).unwrap();
+    let r2 = build_near_dup_report(dir.path(), &exp, NearDupScope::Global, 0.5, 100, None, &default_limits(), &[]).unwrap();
+
+    let j1 = serde_json::to_string(&r1).unwrap();
+    let j2 = serde_json::to_string(&r2).unwrap();
+    // Ignore timing stats which may differ
+    // Compare pairs section only
+    assert_eq!(r1.pairs.len(), r2.pairs.len());
+    assert_eq!(
+        serde_json::to_string(&r1.pairs).unwrap(),
+        serde_json::to_string(&r2.pairs).unwrap()
+    );
+    // Clusters should also be identical
+    assert_eq!(
+        serde_json::to_string(&r1.clusters).unwrap(),
+        serde_json::to_string(&r2.clusters).unwrap()
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 9. Additional edge cases
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn child_rows_filtered_out() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+
+    let mut child = frow("b.rs", "m", "Rust", 60, content.len());
+    child.kind = FileKind::Child;
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, content.len()), child]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert_eq!(report.files_analyzed, 1);
+    assert!(report.pairs.is_empty());
+}
+
+#[test]
+fn max_file_bytes_excludes_large_files() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+
+    let limits = NearDupLimits {
+        max_bytes: None,
+        max_file_bytes: Some(5), // extremely small
+    };
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![
+            frow("a.rs", "m", "Rust", 60, content.len()),
+            frow("b.rs", "m", "Rust", 60, content.len()),
+        ]),
+        NearDupScope::Global, 0.5, 100, None, &limits, &[],
+    ).unwrap();
+
+    assert_eq!(report.files_analyzed, 0);
+}
+
+#[test]
+fn missing_file_on_disk_graceful() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    // b.rs does NOT exist
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![
+            frow("a.rs", "m", "Rust", 60, content.len()),
+            frow("b.rs", "m", "Rust", 60, content.len()),
+        ]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert!(report.pairs.is_empty());
+}
+
+#[test]
+fn params_recorded_in_report() {
+    let dir = TempDir::new().unwrap();
+    let report = build_near_dup_report(
+        dir.path(), &make_export(vec![]),
+        NearDupScope::Global, 0.75, 50, Some(10), &default_limits(), &["*.gen".to_string()],
+    ).unwrap();
+
+    assert_eq!(report.params.threshold, 0.75);
+    assert_eq!(report.params.max_files, 50);
+    assert_eq!(report.params.max_pairs, Some(10));
+    assert_eq!(report.params.exclude_patterns, vec!["*.gen".to_string()]);
+}
+
+#[test]
+fn algorithm_params_recorded() {
+    let dir = TempDir::new().unwrap();
+    let report = build_near_dup_report(
+        dir.path(), &make_export(vec![]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    let algo = report.params.algorithm.as_ref().unwrap();
+    assert_eq!(algo.k_gram_size, 25);
+    assert_eq!(algo.window_size, 4);
+    assert_eq!(algo.max_postings, 50);
+}
+
+#[test]
+fn stats_timing_populated() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    write_file(&dir, "a.rs", &content);
+    write_file(&dir, "b.rs", &content);
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![frow("a.rs", "m", "Rust", 60, sz), frow("b.rs", "m", "Rust", 60, sz)]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    let stats = report.stats.unwrap();
+    assert!(stats.bytes_processed > 0);
+    // Timing may be 0ms for fast operations, that's ok
+}
+
+#[test]
+fn cluster_representative_most_connected() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    // a, b, c all identical → all connected equally
+    for name in ["a.rs", "b.rs", "c.rs"] {
+        write_file(&dir, name, &content);
+    }
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![
+            frow("a.rs", "m", "Rust", 60, sz),
+            frow("b.rs", "m", "Rust", 60, sz),
+            frow("c.rs", "m", "Rust", 60, sz),
+        ]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    let clusters = report.clusters.as_ref().unwrap();
+    assert_eq!(clusters.len(), 1);
+    // Representative should be one of the files
+    assert!(["a.rs", "b.rs", "c.rs"].contains(&clusters[0].representative.as_str()));
+}
+
+#[test]
+fn cluster_files_sorted() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    for name in ["z.rs", "a.rs", "m.rs"] {
+        write_file(&dir, name, &content);
+    }
+    let sz = content.len();
+
+    let report = build_near_dup_report(
+        dir.path(),
+        &make_export(vec![
+            frow("z.rs", "m", "Rust", 60, sz),
+            frow("a.rs", "m", "Rust", 60, sz),
+            frow("m.rs", "m", "Rust", 60, sz),
+        ]),
+        NearDupScope::Global, 0.5, 100, None, &default_limits(), &[],
+    ).unwrap();
+
+    if let Some(clusters) = &report.clusters {
+        for c in clusters {
+            let mut sorted = c.files.clone();
+            sorted.sort();
+            assert_eq!(c.files, sorted, "cluster files should be sorted");
+        }
+    }
+}
+
+#[test]
+fn eligible_files_reflects_pre_cap_count() {
+    let dir = TempDir::new().unwrap();
+    let content = gen_source(60, 1);
+    for i in 0..8 {
+        write_file(&dir, &format!("f{i}.rs"), &content);
+    }
+
+    let rows: Vec<FileRow> = (0..8)
+        .map(|i| frow(&format!("f{i}.rs"), "m", "Rust", 60, content.len()))
+        .collect();
+
+    let report = build_near_dup_report(
+        dir.path(), &make_export(rows),
+        NearDupScope::Global, 0.5, 3, None, &default_limits(), &[],
+    ).unwrap();
+
+    assert_eq!(report.eligible_files, Some(8));
+    assert_eq!(report.files_analyzed, 3);
+    assert_eq!(report.files_skipped, 5);
+}


### PR DESCRIPTION
## Wave 62: derived + near-dup depth tests

Adds 100 new tests across tokmd-analysis-derived and tokmd-analysis-near-dup:
- Density calculations, distribution metrics, COCOMO edge cases
- Near-duplicate detection, similarity thresholds, scope partitioning
- Property-based testing (14 properties)
- JSON snapshot tests

**Agent receipt:**
- what changed: New test files derived_depth_w62.rs and neardup_depth_w62.rs
- tests ran: cargo test -p tokmd-analysis-derived -p tokmd-analysis-near-dup
- determinism impact: none (test-only)
- contract impact: none
- disposition: A (MERGE NOW)