### PR TITLE
test(w62): analysis-format + analysis depth tests

### DIFF
--- a/crates/tokmd-analysis-format/tests/analysis_fmt_depth_w62.rs
+++ b/crates/tokmd-analysis-format/tests/analysis_fmt_depth_w62.rs
@@ -1,0 +1,903 @@
+//! Depth tests for tokmd-analysis-format (W62).
+//!
+//! Covers Markdown, JSON, TSV-style, empty results, section ordering,
+//! truncation behaviour, determinism, property tests, and insta snapshots.
+
+use proptest::prelude::*;
+use tokmd_analysis_types::{
+    AnalysisArgsMeta, AnalysisReceipt, AnalysisSource, BoilerplateReport, CocomoReport,
+    ContextWindowReport, DerivedReport, DerivedTotals, DistributionReport, FileStatRow,
+    HistogramBucket, IntegrityReport, LangPurityReport, LangPurityRow, MaxFileReport, MaxFileRow,
+    NestingReport, PolyglotReport, RateReport, RateRow, RatioReport, RatioRow, ReadingTimeReport,
+    TestDensityReport, TodoReport, TodoTagRow, TopOffenders, ANALYSIS_SCHEMA_VERSION,
+};
+use tokmd_types::{AnalysisFormat, ScanStatus, ToolInfo};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn tool() -> ToolInfo {
+    ToolInfo {
+        name: "tokmd".into(),
+        version: "0.0.0-test".into(),
+    }
+}
+
+fn source(inputs: Vec<&str>) -> AnalysisSource {
+    AnalysisSource {
+        inputs: inputs.into_iter().map(String::from).collect(),
+        export_path: None,
+        base_receipt_path: None,
+        export_schema_version: None,
+        export_generated_at_ms: None,
+        base_signature: None,
+        module_roots: vec![],
+        module_depth: 1,
+        children: "collapse".into(),
+    }
+}
+
+fn args(preset: &str, format: &str) -> AnalysisArgsMeta {
+    AnalysisArgsMeta {
+        preset: preset.into(),
+        format: format.into(),
+        window_tokens: None,
+        git: None,
+        max_files: None,
+        max_bytes: None,
+        max_commits: None,
+        max_commit_files: None,
+        max_file_bytes: None,
+        import_granularity: "module".into(),
+    }
+}
+
+fn empty_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: tool(),
+        mode: "analysis".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: source(vec![]),
+        args: args("receipt", "md"),
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 10,
+            code: 500,
+            comments: 50,
+            blanks: 100,
+            lines: 650,
+            bytes: 20000,
+            tokens: 3000,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 50,
+                denominator: 550,
+                ratio: 50.0 / 550.0,
+            },
+            by_lang: vec![RatioRow {
+                key: "Rust".into(),
+                numerator: 30,
+                denominator: 300,
+                ratio: 0.10,
+            }],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 100,
+                denominator: 550,
+                ratio: 100.0 / 550.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 20000,
+                denominator: 650,
+                rate: 20000.0 / 650.0,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: FileStatRow {
+                path: "src/main.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 200,
+                comments: 20,
+                blanks: 30,
+                lines: 250,
+                bytes: 8000,
+                tokens: 1200,
+                doc_pct: Some(0.10),
+                bytes_per_line: Some(32.0),
+                depth: 1,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport {
+            rows: vec![LangPurityRow {
+                module: "src".into(),
+                lang_count: 1,
+                dominant_lang: "Rust".into(),
+                dominant_lines: 500,
+                dominant_pct: 1.0,
+            }],
+        },
+        nesting: NestingReport {
+            max: 3,
+            avg: 1.5,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 100,
+            prod_lines: 400,
+            test_files: 2,
+            prod_files: 8,
+            ratio: 0.25,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 50,
+            logic_lines: 450,
+            ratio: 50.0 / 500.0,
+            infra_langs: vec!["TOML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 2,
+            entropy: 0.5,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 400,
+            dominant_pct: 0.80,
+        },
+        distribution: DistributionReport {
+            count: 10,
+            min: 10,
+            max: 200,
+            mean: 65.0,
+            median: 50.0,
+            p90: 180.0,
+            p99: 200.0,
+            gini: 0.35,
+        },
+        histogram: vec![
+            HistogramBucket {
+                label: "tiny".into(),
+                min: 0,
+                max: Some(50),
+                files: 4,
+                pct: 0.40,
+            },
+            HistogramBucket {
+                label: "large".into(),
+                min: 51,
+                max: None,
+                files: 6,
+                pct: 0.60,
+            },
+        ],
+        top: TopOffenders {
+            largest_lines: vec![FileStatRow {
+                path: "src/main.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 200,
+                comments: 20,
+                blanks: 30,
+                lines: 250,
+                bytes: 8000,
+                tokens: 1200,
+                doc_pct: Some(0.10),
+                bytes_per_line: Some(32.0),
+                depth: 1,
+            }],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 3.25,
+            lines_per_minute: 200,
+            basis_lines: 650,
+        },
+        context_window: Some(ContextWindowReport {
+            window_tokens: 128000,
+            total_tokens: 3000,
+            pct: 3000.0 / 128000.0,
+            fits: true,
+        }),
+        cocomo: Some(CocomoReport {
+            mode: "organic".into(),
+            kloc: 0.5,
+            effort_pm: 1.2,
+            duration_months: 2.5,
+            staff: 0.48,
+            a: 2.4,
+            b: 1.05,
+            c: 2.5,
+            d: 0.38,
+        }),
+        todo: Some(TodoReport {
+            total: 5,
+            density_per_kloc: 10.0,
+            tags: vec![
+                TodoTagRow {
+                    tag: "TODO".into(),
+                    count: 3,
+                },
+                TodoTagRow {
+                    tag: "FIXME".into(),
+                    count: 2,
+                },
+            ],
+        }),
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "abcdef1234567890".into(),
+            entries: 10,
+        },
+    }
+}
+
+fn receipt_with_derived() -> AnalysisReceipt {
+    let mut r = empty_receipt();
+    r.derived = Some(sample_derived());
+    r
+}
+
+fn render_text(receipt: &AnalysisReceipt, format: AnalysisFormat) -> String {
+    match tokmd_analysis_format::render(receipt, format).unwrap() {
+        tokmd_analysis_format::RenderedOutput::Text(t) => t,
+        tokmd_analysis_format::RenderedOutput::Binary(_) => panic!("expected text"),
+    }
+}
+
+// =========================================================================
+// 1. Markdown rendering
+// =========================================================================
+
+#[test]
+fn md_empty_receipt_has_header() {
+    let md = render_text(&empty_receipt(), AnalysisFormat::Md);
+    assert!(md.starts_with("# tokmd analysis"));
+}
+
+#[test]
+fn md_empty_receipt_shows_preset() {
+    let md = render_text(&empty_receipt(), AnalysisFormat::Md);
+    assert!(md.contains("Preset: `receipt`"));
+}
+
+#[test]
+fn md_with_inputs_shows_inputs_section() {
+    let mut r = empty_receipt();
+    r.source.inputs = vec!["src".into(), "lib".into()];
+    let md = render_text(&r, AnalysisFormat::Md);
+    assert!(md.contains("## Inputs"));
+    assert!(md.contains("- `src`"));
+    assert!(md.contains("- `lib`"));
+}
+
+#[test]
+fn md_no_inputs_omits_inputs_section() {
+    let md = render_text(&empty_receipt(), AnalysisFormat::Md);
+    assert!(!md.contains("## Inputs"));
+}
+
+#[test]
+fn md_derived_totals_table() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Totals"));
+    assert!(md.contains("|10|500|50|100|650|20000|3000|"));
+}
+
+#[test]
+fn md_ratios_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Ratios"));
+    assert!(md.contains("|Doc density|"));
+    assert!(md.contains("|Whitespace ratio|"));
+    assert!(md.contains("|Bytes per line|"));
+}
+
+#[test]
+fn md_distribution_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Distribution"));
+    assert!(md.contains("|10|10|200|"));
+}
+
+#[test]
+fn md_histogram_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## File size histogram"));
+    assert!(md.contains("|tiny|0|50|4|"));
+    // Unbounded max renders as ∞
+    assert!(md.contains("∞"));
+}
+
+#[test]
+fn md_top_offenders_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Top offenders"));
+    assert!(md.contains("### Largest files by lines"));
+    assert!(md.contains("src/main.rs"));
+}
+
+#[test]
+fn md_structure_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Structure"));
+    assert!(md.contains("Max depth: `3`"));
+    assert!(md.contains("Avg depth: `1.50`"));
+}
+
+#[test]
+fn md_test_density_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Test density"));
+    assert!(md.contains("Test lines: `100`"));
+    assert!(md.contains("Prod lines: `400`"));
+}
+
+#[test]
+fn md_todo_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## TODOs"));
+    assert!(md.contains("Total: `5`"));
+    assert!(md.contains("|TODO|3|"));
+    assert!(md.contains("|FIXME|2|"));
+}
+
+#[test]
+fn md_boilerplate_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Boilerplate ratio"));
+    assert!(md.contains("Infra lines: `50`"));
+}
+
+#[test]
+fn md_polyglot_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Polyglot"));
+    assert!(md.contains("Languages: `2`"));
+    assert!(md.contains("Dominant: `Rust`"));
+}
+
+#[test]
+fn md_reading_time_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Reading time"));
+    assert!(md.contains("Minutes: `3.25`"));
+}
+
+#[test]
+fn md_context_window_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Context window"));
+    assert!(md.contains("Window tokens: `128000`"));
+    assert!(md.contains("Fits: `true`"));
+}
+
+#[test]
+fn md_cocomo_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## COCOMO estimate"));
+    assert!(md.contains("Mode: `organic`"));
+    assert!(md.contains("KLOC: `0.5000`"));
+}
+
+#[test]
+fn md_integrity_section() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("## Integrity"));
+    assert!(md.contains("abcdef1234567890"));
+    assert!(md.contains("`blake3`"));
+}
+
+#[test]
+fn md_no_context_window_when_absent() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().context_window = None;
+    let md = render_text(&r, AnalysisFormat::Md);
+    assert!(!md.contains("## Context window"));
+}
+
+#[test]
+fn md_no_cocomo_when_absent() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().cocomo = None;
+    let md = render_text(&r, AnalysisFormat::Md);
+    assert!(!md.contains("## COCOMO estimate"));
+}
+
+#[test]
+fn md_no_todo_when_absent() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().todo = None;
+    let md = render_text(&r, AnalysisFormat::Md);
+    assert!(!md.contains("## TODOs"));
+}
+
+#[test]
+fn md_doc_density_by_lang_table() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("### Doc density by language"));
+    assert!(md.contains("|Rust|"));
+}
+
+// =========================================================================
+// 2. JSON rendering
+// =========================================================================
+
+#[test]
+fn json_empty_receipt_valid() {
+    let json = render_text(&empty_receipt(), AnalysisFormat::Json);
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema_version"], ANALYSIS_SCHEMA_VERSION);
+}
+
+#[test]
+fn json_derived_totals_present() {
+    let json = render_text(&receipt_with_derived(), AnalysisFormat::Json);
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["derived"]["totals"]["code"], 500);
+    assert_eq!(v["derived"]["totals"]["files"], 10);
+}
+
+#[test]
+fn json_cocomo_present() {
+    let json = render_text(&receipt_with_derived(), AnalysisFormat::Json);
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["derived"]["cocomo"]["mode"], "organic");
+}
+
+#[test]
+fn json_null_when_absent() {
+    let json = render_text(&empty_receipt(), AnalysisFormat::Json);
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(v["derived"].is_null());
+    assert!(v["git"].is_null());
+    assert!(v["assets"].is_null());
+}
+
+#[test]
+fn json_roundtrip_preserves_status() {
+    let json = render_text(&receipt_with_derived(), AnalysisFormat::Json);
+    let roundtrip: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert!(matches!(roundtrip.status, ScanStatus::Complete));
+}
+
+#[test]
+fn json_roundtrip_preserves_warnings() {
+    let mut r = receipt_with_derived();
+    r.warnings = vec!["warn1".into(), "warn2".into()];
+    r.status = ScanStatus::Partial;
+    let json = render_text(&r, AnalysisFormat::Json);
+    let roundtrip: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(roundtrip.warnings, vec!["warn1", "warn2"]);
+    assert!(matches!(roundtrip.status, ScanStatus::Partial));
+}
+
+#[test]
+fn json_integrity_hash_present() {
+    let json = render_text(&receipt_with_derived(), AnalysisFormat::Json);
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["derived"]["integrity"]["hash"], "abcdef1234567890");
+}
+
+// =========================================================================
+// 3. XML rendering
+// =========================================================================
+
+#[test]
+fn xml_empty_has_analysis_tag() {
+    let xml = render_text(&empty_receipt(), AnalysisFormat::Xml);
+    assert!(xml.contains("<analysis>"));
+    assert!(xml.contains("</analysis>"));
+}
+
+#[test]
+fn xml_totals_present() {
+    let xml = render_text(&receipt_with_derived(), AnalysisFormat::Xml);
+    assert!(xml.contains("code=\"500\""));
+    assert!(xml.contains("files=\"10\""));
+}
+
+#[test]
+fn xml_no_totals_when_derived_absent() {
+    let xml = render_text(&empty_receipt(), AnalysisFormat::Xml);
+    assert!(!xml.contains("code="));
+}
+
+// =========================================================================
+// 4. SVG rendering
+// =========================================================================
+
+#[test]
+fn svg_is_valid_svg() {
+    let svg = render_text(&receipt_with_derived(), AnalysisFormat::Svg);
+    assert!(svg.contains("<svg"));
+    assert!(svg.contains("</svg>"));
+}
+
+#[test]
+fn svg_shows_context_when_available() {
+    let svg = render_text(&receipt_with_derived(), AnalysisFormat::Svg);
+    // Context window is present so label should be "context"
+    assert!(svg.contains("context"));
+}
+
+#[test]
+fn svg_shows_tokens_when_no_context() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().context_window = None;
+    let svg = render_text(&r, AnalysisFormat::Svg);
+    assert!(svg.contains("tokens"));
+}
+
+// =========================================================================
+// 5. Mermaid rendering
+// =========================================================================
+
+#[test]
+fn mermaid_has_graph_header() {
+    let out = render_text(&empty_receipt(), AnalysisFormat::Mermaid);
+    assert!(out.starts_with("graph TD"));
+}
+
+#[test]
+fn mermaid_empty_imports_minimal() {
+    let out = render_text(&empty_receipt(), AnalysisFormat::Mermaid);
+    // Just the header line with no edges
+    assert_eq!(out.lines().count(), 1);
+}
+
+// =========================================================================
+// 6. JSON-LD rendering
+// =========================================================================
+
+#[test]
+fn jsonld_has_context() {
+    let ld = render_text(&empty_receipt(), AnalysisFormat::Jsonld);
+    let v: serde_json::Value = serde_json::from_str(&ld).unwrap();
+    assert_eq!(v["@context"], "https://schema.org");
+    assert_eq!(v["@type"], "SoftwareSourceCode");
+}
+
+#[test]
+fn jsonld_code_lines_from_derived() {
+    let ld = render_text(&receipt_with_derived(), AnalysisFormat::Jsonld);
+    let v: serde_json::Value = serde_json::from_str(&ld).unwrap();
+    assert_eq!(v["codeLines"], 500);
+}
+
+// =========================================================================
+// 7. Tree rendering
+// =========================================================================
+
+#[test]
+fn tree_unavailable_when_no_derived() {
+    let out = render_text(&empty_receipt(), AnalysisFormat::Tree);
+    assert!(out.contains("(tree unavailable)"));
+}
+
+#[test]
+fn tree_unavailable_when_tree_is_none() {
+    let r = receipt_with_derived();
+    // tree is None by default in our sample
+    let out = render_text(&r, AnalysisFormat::Tree);
+    assert!(out.contains("(tree unavailable)"));
+}
+
+#[test]
+fn tree_renders_when_set() {
+    let mut r = receipt_with_derived();
+    r.derived.as_mut().unwrap().tree = Some("root\n  src/\n    main.rs".into());
+    let out = render_text(&r, AnalysisFormat::Tree);
+    assert!(out.contains("root"));
+    assert!(out.contains("main.rs"));
+}
+
+// =========================================================================
+// 8. Empty results rendering
+// =========================================================================
+
+#[test]
+fn empty_receipt_md_has_no_tables() {
+    let md = render_text(&empty_receipt(), AnalysisFormat::Md);
+    // No derived means no totals table
+    assert!(!md.contains("## Totals"));
+    assert!(!md.contains("## Distribution"));
+}
+
+#[test]
+fn empty_receipt_json_is_well_formed() {
+    let json = render_text(&empty_receipt(), AnalysisFormat::Json);
+    let _v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+}
+
+#[test]
+fn empty_receipt_xml_is_minimal() {
+    let xml = render_text(&empty_receipt(), AnalysisFormat::Xml);
+    assert_eq!(xml, "<analysis></analysis>");
+}
+
+// =========================================================================
+// 9. Section ordering in Markdown
+// =========================================================================
+
+#[test]
+fn md_section_order_header_before_totals() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    let header_pos = md.find("# tokmd analysis").unwrap();
+    let totals_pos = md.find("## Totals").unwrap();
+    assert!(header_pos < totals_pos);
+}
+
+#[test]
+fn md_section_order_totals_before_distribution() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    let totals_pos = md.find("## Totals").unwrap();
+    let dist_pos = md.find("## Distribution").unwrap();
+    assert!(totals_pos < dist_pos);
+}
+
+#[test]
+fn md_section_order_distribution_before_histogram() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    let dist_pos = md.find("## Distribution").unwrap();
+    let hist_pos = md.find("## File size histogram").unwrap();
+    assert!(dist_pos < hist_pos);
+}
+
+#[test]
+fn md_section_order_integrity_after_cocomo() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    let cocomo_pos = md.find("## COCOMO estimate").unwrap();
+    let int_pos = md.find("## Integrity").unwrap();
+    assert!(cocomo_pos < int_pos);
+}
+
+#[test]
+fn md_section_order_polyglot_before_reading_time() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    let poly_pos = md.find("## Polyglot").unwrap();
+    let read_pos = md.find("## Reading time").unwrap();
+    assert!(poly_pos < read_pos);
+}
+
+// =========================================================================
+// 10. Truncation / limits
+// =========================================================================
+
+#[test]
+fn md_histogram_unbounded_max_renders_infinity() {
+    let md = render_text(&receipt_with_derived(), AnalysisFormat::Md);
+    assert!(md.contains("∞"));
+}
+
+#[test]
+fn md_doc_density_by_lang_limited_to_10() {
+    let mut r = receipt_with_derived();
+    let d = r.derived.as_mut().unwrap();
+    d.doc_density.by_lang = (0..20)
+        .map(|i| RatioRow {
+            key: format!("Lang{i}"),
+            numerator: i,
+            denominator: 100,
+            ratio: i as f64 / 100.0,
+        })
+        .collect();
+    let md = render_text(&r, AnalysisFormat::Md);
+    // take(10) means only first 10 appear
+    assert!(md.contains("Lang0"));
+    assert!(md.contains("Lang9"));
+    assert!(!md.contains("Lang10"));
+}
+
+// =========================================================================
+// 11. Determinism
+// =========================================================================
+
+#[test]
+fn md_deterministic_across_calls() {
+    let r = receipt_with_derived();
+    let a = render_text(&r, AnalysisFormat::Md);
+    let b = render_text(&r, AnalysisFormat::Md);
+    assert_eq!(a, b, "Markdown output must be deterministic");
+}
+
+#[test]
+fn json_deterministic_across_calls() {
+    let r = receipt_with_derived();
+    let a = render_text(&r, AnalysisFormat::Json);
+    let b = render_text(&r, AnalysisFormat::Json);
+    assert_eq!(a, b, "JSON output must be deterministic");
+}
+
+#[test]
+fn xml_deterministic_across_calls() {
+    let r = receipt_with_derived();
+    let a = render_text(&r, AnalysisFormat::Xml);
+    let b = render_text(&r, AnalysisFormat::Xml);
+    assert_eq!(a, b, "XML output must be deterministic");
+}
+
+#[test]
+fn svg_deterministic_across_calls() {
+    let r = receipt_with_derived();
+    let a = render_text(&r, AnalysisFormat::Svg);
+    let b = render_text(&r, AnalysisFormat::Svg);
+    assert_eq!(a, b, "SVG output must be deterministic");
+}
+
+#[test]
+fn mermaid_deterministic_across_calls() {
+    let r = receipt_with_derived();
+    let a = render_text(&r, AnalysisFormat::Mermaid);
+    let b = render_text(&r, AnalysisFormat::Mermaid);
+    assert_eq!(a, b, "Mermaid output must be deterministic");
+}
+
+// =========================================================================
+// 12. Property tests
+// =========================================================================
+
+proptest! {
+    #[test]
+    fn prop_md_always_starts_with_header(preset in "receipt|health|risk|deep") {
+        let mut r = empty_receipt();
+        r.args.preset = preset;
+        let md = render_text(&r, AnalysisFormat::Md);
+        prop_assert!(md.starts_with("# tokmd analysis"));
+    }
+
+    #[test]
+    fn prop_json_always_valid(code in 0usize..100_000, files in 1usize..1000) {
+        let mut r = receipt_with_derived();
+        let d = r.derived.as_mut().unwrap();
+        d.totals.code = code;
+        d.totals.files = files;
+        let json = render_text(&r, AnalysisFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(v["derived"]["totals"]["code"].as_u64().unwrap(), code as u64);
+    }
+
+    #[test]
+    fn prop_xml_always_well_formed(code in 0usize..100_000) {
+        let mut r = receipt_with_derived();
+        r.derived.as_mut().unwrap().totals.code = code;
+        let xml = render_text(&r, AnalysisFormat::Xml);
+        prop_assert!(xml.starts_with("<analysis>"));
+        prop_assert!(xml.ends_with("</analysis>"));
+    }
+
+    #[test]
+    fn prop_md_preset_appears(preset in "[a-z]{3,10}") {
+        let mut r = empty_receipt();
+        r.args.preset = preset.clone();
+        let md = render_text(&r, AnalysisFormat::Md);
+        let expected = format!("Preset: `{}`", preset);
+        prop_assert!(md.contains(&expected));
+    }
+
+    #[test]
+    fn prop_json_roundtrip(code in 0usize..50_000, comments in 0usize..10_000) {
+        let mut r = receipt_with_derived();
+        let d = r.derived.as_mut().unwrap();
+        d.totals.code = code;
+        d.totals.comments = comments;
+        let json = render_text(&r, AnalysisFormat::Json);
+        let rt: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(rt.derived.as_ref().unwrap().totals.code, code);
+        prop_assert_eq!(rt.derived.as_ref().unwrap().totals.comments, comments);
+    }
+}
+
+// =========================================================================
+// 13. Snapshot tests
+// =========================================================================
+
+#[test]
+fn snapshot_empty_receipt_md() {
+    let md = render_text(&empty_receipt(), AnalysisFormat::Md);
+    insta::assert_snapshot!("empty_receipt_md_w62", md);
+}
+
+#[test]
+fn snapshot_derived_receipt_md() {
+    let mut r = receipt_with_derived();
+    // Fix timestamp for deterministic snapshot
+    r.generated_at_ms = 1700000000000;
+    let md = render_text(&r, AnalysisFormat::Md);
+    insta::assert_snapshot!("derived_receipt_md_w62", md);
+}
+
+#[test]
+fn snapshot_empty_receipt_xml() {
+    let xml = render_text(&empty_receipt(), AnalysisFormat::Xml);
+    insta::assert_snapshot!("empty_receipt_xml_w62", xml);
+}
+
+#[test]
+fn snapshot_derived_receipt_xml() {
+    let xml = render_text(&receipt_with_derived(), AnalysisFormat::Xml);
+    insta::assert_snapshot!("derived_receipt_xml_w62", xml);
+}
+
+#[test]
+fn snapshot_derived_receipt_jsonld() {
+    let ld = render_text(&receipt_with_derived(), AnalysisFormat::Jsonld);
+    insta::assert_snapshot!("derived_receipt_jsonld_w62", ld);
+}
+
+// =========================================================================
+// 14. HTML rendering
+// =========================================================================
+
+#[test]
+fn html_empty_receipt_produces_output() {
+    let html = render_text(&empty_receipt(), AnalysisFormat::Html);
+    assert!(!html.is_empty());
+}
+
+#[test]
+fn html_contains_totals() {
+    let html = render_text(&receipt_with_derived(), AnalysisFormat::Html);
+    // HTML should reference code count somewhere
+    assert!(html.contains("500") || html.contains("code"));
+}
+
+// =========================================================================
+// 15. Warnings & status
+// =========================================================================
+
+#[test]
+fn json_warnings_reflected_in_output() {
+    let mut r = empty_receipt();
+    r.warnings = vec!["something went wrong".into()];
+    r.status = ScanStatus::Partial;
+    let json = render_text(&r, AnalysisFormat::Json);
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["warnings"][0], "something went wrong");
+    assert_eq!(v["status"], "partial");
+}
+
+#[test]
+fn json_complete_status_rendered() {
+    let json = render_text(&empty_receipt(), AnalysisFormat::Json);
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["status"], "complete");
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__derived_receipt_jsonld_w62.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__derived_receipt_jsonld_w62.snap
@@ -1,0 +1,18 @@
+---
+source: crates/tokmd-analysis-format/tests/analysis_fmt_depth_w62.rs
+expression: ld
+---
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "codeLines": 500,
+  "commentCount": 50,
+  "fileSize": 20000,
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "http://schema.org/ReadAction",
+    "userInteractionCount": 3000
+  },
+  "lineCount": 650,
+  "name": "tokmd"
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__derived_receipt_md_w62.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__derived_receipt_md_w62.snap
@@ -1,0 +1,135 @@
+---
+source: crates/tokmd-analysis-format/tests/analysis_fmt_depth_w62.rs
+expression: md
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Totals
+
+|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|
+|---:|---:|---:|---:|---:|---:|---:|
+|10|500|50|100|650|20000|3000|
+
+## Ratios
+
+|Metric|Value|
+|---|---:|
+|Doc density|9.1%|
+|Whitespace ratio|18.2%|
+|Bytes per line|30.77|
+
+### Doc density by language
+
+|Lang|Doc%|Comments|Code|
+|---|---:|---:|---:|
+|Rust|10.0%|30|270|
+
+### Whitespace ratio by language
+
+|Lang|Blank%|Blanks|Code+Comments|
+|---|---:|---:|---:|
+
+### Verbosity by language
+
+|Lang|Bytes/Line|Bytes|Lines|
+|---|---:|---:|---:|
+
+## Distribution
+
+|Count|Min|Max|Mean|Median|P90|P99|Gini|
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|10|10|200|65.00|50.00|180.00|200.00|0.3500|
+
+## File size histogram
+
+|Bucket|Min|Max|Files|Pct|
+|---|---:|---:|---:|---:|
+|tiny|0|50|4|40.0%|
+|large|51|∞|6|60.0%|
+
+## Top offenders
+
+### Largest files by lines
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|src/main.rs|Rust|250|200|8000|1200|10.0%|32.00|
+
+### Largest files by tokens
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Largest files by bytes
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Least documented (min LOC)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Most dense (bytes/line)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+## Structure
+
+- Max depth: `3`
+- Avg depth: `1.50`
+
+## Test density
+
+- Test lines: `100`
+- Prod lines: `400`
+- Test ratio: `25.0%`
+
+## TODOs
+
+- Total: `5`
+- Density (per KLOC): `10.00`
+
+|Tag|Count|
+|---|---:|
+|TODO|3|
+|FIXME|2|
+
+## Boilerplate ratio
+
+- Infra lines: `50`
+- Logic lines: `450`
+- Infra ratio: `10.0%`
+
+## Polyglot
+
+- Languages: `2`
+- Dominant: `Rust` (80.0%)
+- Entropy: `0.5000`
+
+## Reading time
+
+- Minutes: `3.25` (200 lines/min)
+
+## Context window
+
+- Window tokens: `128000`
+- Total tokens: `3000`
+- Utilization: `2.3%`
+- Fits: `true`
+
+## COCOMO estimate
+
+- Mode: `organic`
+- KLOC: `0.5000`
+- Effort (PM): `1.20`
+- Duration (months): `2.50`
+- Staff: `0.48`
+
+## Integrity
+
+- Hash: `abcdef1234567890` (`blake3`)
+- Entries: `10`

--- a/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__derived_receipt_xml_w62.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__derived_receipt_xml_w62.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/analysis_fmt_depth_w62.rs
+expression: xml
+---
+<analysis><totals files="10" code="500" comments="50" blanks="100" lines="650" bytes="20000" tokens="3000"/></analysis>

--- a/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__empty_receipt_md_w62.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__empty_receipt_md_w62.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-analysis-format/tests/analysis_fmt_depth_w62.rs
+expression: md
+---
+# tokmd analysis
+
+Preset: `receipt`

--- a/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__empty_receipt_xml_w62.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/analysis_fmt_depth_w62__empty_receipt_xml_w62.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/analysis_fmt_depth_w62.rs
+expression: xml
+---
+<analysis></analysis>

--- a/crates/tokmd-analysis/tests/analysis_depth_w62.rs
+++ b/crates/tokmd-analysis/tests/analysis_depth_w62.rs
@@ -1,0 +1,811 @@
+//! Depth tests for tokmd-analysis (W62).
+//!
+//! Covers preset selection, enricher activation, pipeline ordering,
+//! empty scan data, enricher composition, limits, property tests,
+//! and error handling.
+
+use std::path::PathBuf;
+
+use proptest::prelude::*;
+use tokmd_analysis::{
+    AnalysisContext, AnalysisLimits, AnalysisPreset, AnalysisRequest, ImportGranularity,
+    NearDupScope, analyze,
+};
+use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisSource, ANALYSIS_SCHEMA_VERSION};
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow, ScanStatus};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn file_row(path: &str, lang: &str, code: usize) -> FileRow {
+    FileRow {
+        path: path.into(),
+        module: path
+            .rsplit('/')
+            .nth(1)
+            .unwrap_or("(root)")
+            .to_string(),
+        lang: lang.into(),
+        kind: FileKind::Parent,
+        code,
+        comments: code / 5,
+        blanks: code / 10,
+        lines: code + code / 5 + code / 10,
+        bytes: code * 40,
+        tokens: code * 3,
+    }
+}
+
+fn sample_export() -> ExportData {
+    ExportData {
+        rows: vec![
+            file_row("src/main.rs", "Rust", 200),
+            file_row("src/lib.rs", "Rust", 150),
+            file_row("src/utils.rs", "Rust", 80),
+            file_row("tests/integration.rs", "Rust", 60),
+            file_row("Cargo.toml", "TOML", 30),
+        ],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn empty_export() -> ExportData {
+    ExportData {
+        rows: vec![],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn single_file_export(code: usize) -> ExportData {
+    ExportData {
+        rows: vec![file_row("src/main.rs", "Rust", code)],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn source() -> AnalysisSource {
+    AnalysisSource {
+        inputs: vec![".".into()],
+        export_path: None,
+        base_receipt_path: None,
+        export_schema_version: Some(2),
+        export_generated_at_ms: Some(1_700_000_000_000),
+        base_signature: None,
+        module_roots: vec![],
+        module_depth: 1,
+        children: "separate".into(),
+    }
+}
+
+fn args(preset: &str) -> AnalysisArgsMeta {
+    AnalysisArgsMeta {
+        preset: preset.into(),
+        format: "json".into(),
+        window_tokens: None,
+        git: None,
+        max_files: None,
+        max_bytes: None,
+        max_commits: None,
+        max_commit_files: None,
+        max_file_bytes: None,
+        import_granularity: "module".into(),
+    }
+}
+
+fn request(preset: AnalysisPreset) -> AnalysisRequest {
+    AnalysisRequest {
+        preset,
+        args: args(preset.as_str()),
+        limits: AnalysisLimits::default(),
+        window_tokens: None,
+        git: Some(false),
+        import_granularity: ImportGranularity::Module,
+        detail_functions: false,
+        near_dup: false,
+        near_dup_threshold: 0.8,
+        near_dup_max_files: 500,
+        near_dup_scope: NearDupScope::default(),
+        near_dup_max_pairs: None,
+        near_dup_exclude: vec![],
+    }
+}
+
+fn run(preset: AnalysisPreset) -> tokmd_analysis_types::AnalysisReceipt {
+    let ctx = AnalysisContext {
+        export: sample_export(),
+        root: PathBuf::from("."),
+        source: source(),
+    };
+    analyze(ctx, request(preset)).expect("analyze should succeed")
+}
+
+fn run_with_export(
+    preset: AnalysisPreset,
+    export: ExportData,
+) -> tokmd_analysis_types::AnalysisReceipt {
+    let ctx = AnalysisContext {
+        export,
+        root: PathBuf::from("."),
+        source: source(),
+    };
+    analyze(ctx, request(preset)).expect("analyze should succeed")
+}
+
+// =========================================================================
+// 1. Preset selection and enricher activation
+// =========================================================================
+
+#[test]
+fn receipt_preset_always_has_derived() {
+    let r = run(AnalysisPreset::Receipt);
+    assert!(r.derived.is_some());
+}
+
+#[test]
+fn receipt_preset_has_no_git() {
+    let r = run(AnalysisPreset::Receipt);
+    assert!(r.git.is_none());
+}
+
+#[test]
+fn receipt_preset_has_no_assets() {
+    let r = run(AnalysisPreset::Receipt);
+    assert!(r.assets.is_none());
+}
+
+#[test]
+fn receipt_preset_has_no_imports() {
+    let r = run(AnalysisPreset::Receipt);
+    assert!(r.imports.is_none());
+}
+
+#[test]
+fn fun_preset_has_fun_report() {
+    let r = run(AnalysisPreset::Fun);
+    // With the `fun` feature enabled (default), fun should be Some
+    assert!(r.fun.is_some(), "fun preset should produce a fun report");
+}
+
+#[test]
+fn all_presets_produce_derived() {
+    for preset in AnalysisPreset::all() {
+        let r = run(*preset);
+        assert!(
+            r.derived.is_some(),
+            "{:?} should always produce derived metrics",
+            preset
+        );
+    }
+}
+
+#[test]
+fn receipt_preset_no_fun() {
+    let r = run(AnalysisPreset::Receipt);
+    assert!(r.fun.is_none(), "receipt should not include fun");
+}
+
+#[test]
+fn health_preset_has_derived() {
+    let r = run(AnalysisPreset::Health);
+    assert!(r.derived.is_some());
+}
+
+#[test]
+fn all_presets_set_mode_analysis() {
+    for preset in AnalysisPreset::all() {
+        let r = run(*preset);
+        assert_eq!(r.mode, "analysis", "mode mismatch for {:?}", preset);
+    }
+}
+
+// =========================================================================
+// 2. Feature flag effects (without optional features)
+// =========================================================================
+
+#[test]
+fn git_disabled_produces_warning_for_risk_preset() {
+    // With git feature disabled at compile time but git=Some(true),
+    // we get a warning. Since we set git=Some(false), no warning.
+    let r = run(AnalysisPreset::Risk);
+    // Git is explicitly disabled in our request, so no git warning
+    assert!(r.git.is_none());
+}
+
+#[test]
+fn receipt_preset_no_warnings_without_optional_features() {
+    let r = run(AnalysisPreset::Receipt);
+    // Receipt doesn't need git/walk/content, so should be complete
+    assert!(matches!(r.status, ScanStatus::Complete));
+    assert!(r.warnings.is_empty());
+}
+
+#[test]
+fn identity_preset_produces_archetype() {
+    let r = run(AnalysisPreset::Identity);
+    // archetype feature is default-on; detection may return None for trivial samples
+    // but the pipeline should not error
+    assert!(r.derived.is_some());
+}
+
+#[test]
+fn topics_preset_produces_topics() {
+    let r = run(AnalysisPreset::Topics);
+    // topics feature is default-on
+    assert!(
+        r.topics.is_some(),
+        "topics preset should produce topic clouds"
+    );
+}
+
+// =========================================================================
+// 3. Analysis pipeline ordering
+// =========================================================================
+
+#[test]
+fn schema_version_matches_constant() {
+    let r = run(AnalysisPreset::Receipt);
+    assert_eq!(r.schema_version, ANALYSIS_SCHEMA_VERSION);
+}
+
+#[test]
+fn schema_version_consistent_across_presets() {
+    let versions: Vec<_> = AnalysisPreset::all()
+        .iter()
+        .map(|p| run(*p).schema_version)
+        .collect();
+    assert!(
+        versions.iter().all(|v| *v == ANALYSIS_SCHEMA_VERSION),
+        "all presets must produce the same schema version"
+    );
+}
+
+#[test]
+fn generated_at_ms_is_nonzero() {
+    let r = run(AnalysisPreset::Receipt);
+    assert!(r.generated_at_ms > 0, "timestamp should be set");
+}
+
+#[test]
+fn source_inputs_preserved() {
+    let r = run(AnalysisPreset::Receipt);
+    assert_eq!(r.source.inputs, vec!["."]);
+}
+
+#[test]
+fn base_signature_populated() {
+    let r = run(AnalysisPreset::Receipt);
+    assert!(
+        r.source.base_signature.is_some(),
+        "base_signature should be derived from integrity hash"
+    );
+}
+
+// =========================================================================
+// 4. Empty scan data handling
+// =========================================================================
+
+#[test]
+fn empty_export_receipt_succeeds() {
+    let r = run_with_export(AnalysisPreset::Receipt, empty_export());
+    assert!(r.derived.is_some());
+}
+
+#[test]
+fn empty_export_totals_are_zero() {
+    let r = run_with_export(AnalysisPreset::Receipt, empty_export());
+    let d = r.derived.unwrap();
+    assert_eq!(d.totals.files, 0);
+    assert_eq!(d.totals.code, 0);
+    assert_eq!(d.totals.lines, 0);
+}
+
+#[test]
+fn empty_export_distribution_count_zero() {
+    let r = run_with_export(AnalysisPreset::Receipt, empty_export());
+    let d = r.derived.unwrap();
+    assert_eq!(d.distribution.count, 0);
+}
+
+#[test]
+fn empty_export_polyglot_zero_langs() {
+    let r = run_with_export(AnalysisPreset::Receipt, empty_export());
+    let d = r.derived.unwrap();
+    assert_eq!(d.polyglot.lang_count, 0);
+}
+
+#[test]
+fn empty_export_no_top_offenders() {
+    let r = run_with_export(AnalysisPreset::Receipt, empty_export());
+    let d = r.derived.unwrap();
+    assert!(d.top.largest_lines.is_empty());
+    assert!(d.top.largest_tokens.is_empty());
+}
+
+#[test]
+fn single_file_export_totals_match() {
+    let r = run_with_export(AnalysisPreset::Receipt, single_file_export(100));
+    let d = r.derived.unwrap();
+    assert_eq!(d.totals.files, 1);
+    assert_eq!(d.totals.code, 100);
+}
+
+// =========================================================================
+// 5. Enricher composition
+// =========================================================================
+
+#[test]
+fn deep_preset_has_derived() {
+    let r = run(AnalysisPreset::Deep);
+    assert!(r.derived.is_some());
+}
+
+#[test]
+fn deep_preset_has_archetype() {
+    let r = run(AnalysisPreset::Deep);
+    // archetype is default-on; detection may return None for trivial samples
+    // but the pipeline should not error
+    assert!(r.derived.is_some());
+}
+
+#[test]
+fn deep_preset_has_topics() {
+    let r = run(AnalysisPreset::Deep);
+    // topics is default-on
+    assert!(r.topics.is_some());
+}
+
+#[test]
+fn fun_preset_no_git() {
+    let r = run(AnalysisPreset::Fun);
+    assert!(r.git.is_none());
+}
+
+#[test]
+fn fun_preset_no_assets() {
+    let r = run(AnalysisPreset::Fun);
+    assert!(r.assets.is_none());
+}
+
+#[test]
+fn derived_always_has_integrity() {
+    for preset in AnalysisPreset::all() {
+        let r = run(*preset);
+        let d = r.derived.as_ref().unwrap();
+        assert!(
+            !d.integrity.hash.is_empty(),
+            "{:?} should have integrity hash",
+            preset
+        );
+        assert_eq!(d.integrity.algo, "blake3");
+    }
+}
+
+#[test]
+fn derived_always_has_reading_time() {
+    let r = run(AnalysisPreset::Receipt);
+    let d = r.derived.unwrap();
+    assert!(d.reading_time.minutes >= 0.0);
+    assert!(d.reading_time.lines_per_minute > 0);
+}
+
+// =========================================================================
+// 6. Limits and caps
+// =========================================================================
+
+#[test]
+fn window_tokens_reflected_in_context_window() {
+    let ctx = AnalysisContext {
+        export: sample_export(),
+        root: PathBuf::from("."),
+        source: source(),
+    };
+    let mut req = request(AnalysisPreset::Receipt);
+    req.window_tokens = Some(8000);
+    let r = analyze(ctx, req).unwrap();
+    let cw = r.derived.unwrap().context_window.unwrap();
+    assert_eq!(cw.window_tokens, 8000);
+}
+
+#[test]
+fn no_window_tokens_means_no_context_window() {
+    let r = run(AnalysisPreset::Receipt);
+    let d = r.derived.unwrap();
+    assert!(
+        d.context_window.is_none(),
+        "no window_tokens => no context_window"
+    );
+}
+
+#[test]
+fn window_tokens_fits_when_small_codebase() {
+    let ctx = AnalysisContext {
+        export: single_file_export(10),
+        root: PathBuf::from("."),
+        source: source(),
+    };
+    let mut req = request(AnalysisPreset::Receipt);
+    req.window_tokens = Some(1_000_000);
+    let r = analyze(ctx, req).unwrap();
+    let cw = r.derived.unwrap().context_window.unwrap();
+    assert!(cw.fits, "small codebase should fit in large window");
+}
+
+#[test]
+fn cocomo_present_for_nonzero_code() {
+    let r = run(AnalysisPreset::Receipt);
+    let d = r.derived.unwrap();
+    assert!(d.cocomo.is_some(), "nonzero code => COCOMO estimate");
+}
+
+#[test]
+fn cocomo_kloc_reasonable() {
+    let r = run(AnalysisPreset::Receipt);
+    let cocomo = r.derived.unwrap().cocomo.unwrap();
+    // 520 lines of code total in sample => ~0.52 KLOC
+    assert!(cocomo.kloc > 0.0 && cocomo.kloc < 10.0);
+}
+
+#[test]
+fn cocomo_absent_for_empty_export() {
+    let r = run_with_export(AnalysisPreset::Receipt, empty_export());
+    let d = r.derived.unwrap();
+    // Zero code could produce None or kloc=0
+    if let Some(cocomo) = &d.cocomo {
+        assert!(cocomo.kloc <= 0.001);
+    }
+}
+
+// =========================================================================
+// 7. Deterministic enricher output ordering
+// =========================================================================
+
+#[test]
+fn deterministic_derived_across_runs() {
+    let r1 = run(AnalysisPreset::Receipt);
+    let r2 = run(AnalysisPreset::Receipt);
+    let d1 = r1.derived.unwrap();
+    let d2 = r2.derived.unwrap();
+    assert_eq!(d1.totals.code, d2.totals.code);
+    assert_eq!(d1.totals.files, d2.totals.files);
+    assert_eq!(d1.integrity.hash, d2.integrity.hash);
+}
+
+#[test]
+fn deterministic_doc_density_ordering() {
+    let r1 = run(AnalysisPreset::Receipt);
+    let r2 = run(AnalysisPreset::Receipt);
+    let keys1: Vec<_> = r1
+        .derived
+        .as_ref()
+        .unwrap()
+        .doc_density
+        .by_lang
+        .iter()
+        .map(|r| r.key.clone())
+        .collect();
+    let keys2: Vec<_> = r2
+        .derived
+        .as_ref()
+        .unwrap()
+        .doc_density
+        .by_lang
+        .iter()
+        .map(|r| r.key.clone())
+        .collect();
+    assert_eq!(keys1, keys2, "by_lang ordering must be deterministic");
+}
+
+#[test]
+fn deterministic_top_offenders() {
+    let r1 = run(AnalysisPreset::Receipt);
+    let r2 = run(AnalysisPreset::Receipt);
+    let paths1: Vec<_> = r1
+        .derived
+        .as_ref()
+        .unwrap()
+        .top
+        .largest_lines
+        .iter()
+        .map(|f| f.path.clone())
+        .collect();
+    let paths2: Vec<_> = r2
+        .derived
+        .as_ref()
+        .unwrap()
+        .top
+        .largest_lines
+        .iter()
+        .map(|f| f.path.clone())
+        .collect();
+    assert_eq!(
+        paths1, paths2,
+        "top offender ordering must be deterministic"
+    );
+}
+
+#[test]
+fn deterministic_histogram_ordering() {
+    let r1 = run(AnalysisPreset::Receipt);
+    let r2 = run(AnalysisPreset::Receipt);
+    let labels1: Vec<_> = r1
+        .derived
+        .as_ref()
+        .unwrap()
+        .histogram
+        .iter()
+        .map(|b| b.label.clone())
+        .collect();
+    let labels2: Vec<_> = r2
+        .derived
+        .as_ref()
+        .unwrap()
+        .histogram
+        .iter()
+        .map(|b| b.label.clone())
+        .collect();
+    assert_eq!(labels1, labels2);
+}
+
+#[test]
+fn deterministic_json_serialization() {
+    let r1 = run(AnalysisPreset::Receipt);
+    let r2 = run(AnalysisPreset::Receipt);
+    let j1 = serde_json::to_value(&r1.derived).unwrap();
+    let j2 = serde_json::to_value(&r2.derived).unwrap();
+    // Compare derived section (ignoring timestamps)
+    assert_eq!(j1, j2, "JSON-serialized derived must be identical");
+}
+
+// =========================================================================
+// 8. Error handling
+// =========================================================================
+
+#[test]
+fn git_explicitly_disabled_no_warning() {
+    // git=Some(false) should not produce a git warning
+    let r = run(AnalysisPreset::Risk);
+    let git_warnings: Vec<_> = r.warnings.iter().filter(|w| w.contains("git")).collect();
+    assert!(
+        git_warnings.is_empty(),
+        "explicitly disabling git should produce no git warnings"
+    );
+}
+
+#[test]
+fn near_dup_disabled_by_default() {
+    let r = run(AnalysisPreset::Deep);
+    // near_dup=false in our request, so dup.near should be None
+    if let Some(dup) = &r.dup {
+        assert!(dup.near.is_none());
+    }
+}
+
+#[test]
+fn analyze_never_panics_for_any_preset() {
+    for preset in AnalysisPreset::all() {
+        let ctx = AnalysisContext {
+            export: sample_export(),
+            root: PathBuf::from("."),
+            source: source(),
+        };
+        let result = analyze(ctx, request(*preset));
+        assert!(result.is_ok(), "analyze should not fail for {:?}", preset);
+    }
+}
+
+#[test]
+fn analyze_with_empty_export_never_panics() {
+    for preset in AnalysisPreset::all() {
+        let ctx = AnalysisContext {
+            export: empty_export(),
+            root: PathBuf::from("."),
+            source: source(),
+        };
+        let result = analyze(ctx, request(*preset));
+        assert!(
+            result.is_ok(),
+            "analyze with empty export should not fail for {:?}",
+            preset
+        );
+    }
+}
+
+// =========================================================================
+// 9. Derived metrics specifics
+// =========================================================================
+
+#[test]
+fn test_density_ratio_reasonable() {
+    let r = run(AnalysisPreset::Receipt);
+    let td = &r.derived.unwrap().test_density;
+    assert!(td.ratio >= 0.0 && td.ratio <= 1.0);
+}
+
+#[test]
+fn boilerplate_ratio_reasonable() {
+    let r = run(AnalysisPreset::Receipt);
+    let bp = &r.derived.unwrap().boilerplate;
+    assert!(bp.ratio >= 0.0 && bp.ratio <= 1.0);
+}
+
+#[test]
+fn doc_density_ratio_reasonable() {
+    let r = run(AnalysisPreset::Receipt);
+    let dd = &r.derived.unwrap().doc_density;
+    assert!(dd.total.ratio >= 0.0 && dd.total.ratio <= 1.0);
+}
+
+#[test]
+fn polyglot_dominant_pct_reasonable() {
+    let r = run(AnalysisPreset::Receipt);
+    let p = &r.derived.unwrap().polyglot;
+    assert!(p.dominant_pct >= 0.0 && p.dominant_pct <= 1.0);
+}
+
+#[test]
+fn nesting_avg_nonnegative() {
+    let r = run(AnalysisPreset::Receipt);
+    let n = &r.derived.unwrap().nesting;
+    assert!(n.avg >= 0.0);
+    assert!(n.max >= n.avg as usize || n.avg <= 1.0);
+}
+
+#[test]
+fn distribution_min_lte_max() {
+    let r = run(AnalysisPreset::Receipt);
+    let dist = &r.derived.unwrap().distribution;
+    if dist.count > 0 {
+        assert!(dist.min <= dist.max);
+        assert!(dist.mean >= 0.0);
+    }
+}
+
+#[test]
+fn distribution_gini_in_range() {
+    let r = run(AnalysisPreset::Receipt);
+    let dist = &r.derived.unwrap().distribution;
+    assert!(dist.gini >= 0.0 && dist.gini <= 1.0);
+}
+
+#[test]
+fn integrity_entries_match_file_count() {
+    let r = run(AnalysisPreset::Receipt);
+    let d = r.derived.unwrap();
+    // entries should match number of file rows in export
+    assert!(d.integrity.entries > 0);
+}
+
+// =========================================================================
+// 10. Property tests
+// =========================================================================
+
+proptest! {
+    #[test]
+    fn prop_receipt_always_succeeds(code in 1usize..10_000) {
+        let r = run_with_export(AnalysisPreset::Receipt, single_file_export(code));
+        prop_assert!(r.derived.is_some());
+    }
+
+    #[test]
+    fn prop_totals_code_matches_input(code in 1usize..50_000) {
+        let r = run_with_export(AnalysisPreset::Receipt, single_file_export(code));
+        let d = r.derived.unwrap();
+        prop_assert_eq!(d.totals.code, code);
+    }
+
+    #[test]
+    fn prop_tokens_proportional(code in 10usize..10_000) {
+        let r = run_with_export(AnalysisPreset::Receipt, single_file_export(code));
+        let d = r.derived.unwrap();
+        // tokens should be roughly proportional to code (our helper uses code*3)
+        prop_assert!(d.totals.tokens > 0);
+    }
+
+    #[test]
+    fn prop_integrity_hash_stable(code in 1usize..5_000) {
+        let r1 = run_with_export(AnalysisPreset::Receipt, single_file_export(code));
+        let r2 = run_with_export(AnalysisPreset::Receipt, single_file_export(code));
+        prop_assert_eq!(
+            r1.derived.as_ref().unwrap().integrity.hash.clone(),
+            r2.derived.as_ref().unwrap().integrity.hash.clone(),
+        );
+    }
+
+    #[test]
+    fn prop_cocomo_effort_nonnegative(code in 1usize..100_000) {
+        let r = run_with_export(AnalysisPreset::Receipt, single_file_export(code));
+        if let Some(cocomo) = &r.derived.unwrap().cocomo {
+            prop_assert!(cocomo.effort_pm >= 0.0);
+            prop_assert!(cocomo.duration_months >= 0.0);
+        }
+    }
+
+    #[test]
+    fn prop_distribution_median_between_min_max(code in 10usize..5_000) {
+        let export = ExportData {
+            rows: vec![
+                file_row("a.rs", "Rust", code),
+                file_row("b.rs", "Rust", code / 2),
+            ],
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+        };
+        let r = run_with_export(AnalysisPreset::Receipt, export);
+        let dist = &r.derived.unwrap().distribution;
+        if dist.count > 0 {
+            prop_assert!(dist.median >= dist.min as f64);
+            prop_assert!(dist.median <= dist.max as f64);
+        }
+    }
+}
+
+// =========================================================================
+// 11. Multi-language handling
+// =========================================================================
+
+#[test]
+fn polyglot_counts_languages() {
+    let export = ExportData {
+        rows: vec![
+            file_row("src/main.rs", "Rust", 100),
+            file_row("src/app.py", "Python", 80),
+            file_row("src/index.js", "JavaScript", 60),
+        ],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+    let r = run_with_export(AnalysisPreset::Receipt, export);
+    let p = &r.derived.unwrap().polyglot;
+    assert_eq!(p.lang_count, 3);
+}
+
+#[test]
+fn polyglot_dominant_is_largest() {
+    let export = ExportData {
+        rows: vec![
+            file_row("src/main.rs", "Rust", 300),
+            file_row("src/app.py", "Python", 50),
+        ],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+    let r = run_with_export(AnalysisPreset::Receipt, export);
+    let p = &r.derived.unwrap().polyglot;
+    assert_eq!(p.dominant_lang, "Rust");
+}
+
+#[test]
+fn child_rows_handled_without_panic() {
+    let export = ExportData {
+        rows: vec![
+            file_row("src/main.rs", "Rust", 100),
+            FileRow {
+                path: "src/main.rs".into(),
+                module: "src".into(),
+                lang: "Markdown".into(),
+                kind: FileKind::Child,
+                code: 10,
+                comments: 2,
+                blanks: 1,
+                lines: 13,
+                bytes: 0,
+                tokens: 0,
+            },
+        ],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+    let r = run_with_export(AnalysisPreset::Receipt, export);
+    assert!(r.derived.is_some());
+}


### PR DESCRIPTION
## Wave 62: analysis-format + analysis depth tests

Adds 134 new tests across tokmd-analysis-format and tokmd-analysis:
- Markdown/JSON/XML/SVG/Mermaid/JSON-LD/Tree rendering
- Preset selection and enricher activation
- Pipeline ordering and feature flag effects
- Property-based testing (11 properties)
- Insta snapshots (5)

**Agent receipt:**
- what changed: New test files analysis_fmt_depth_w62.rs and analysis_depth_w62.rs
- tests ran: cargo test -p tokmd-analysis-format -p tokmd-analysis
- determinism impact: none (test-only)
- contract impact: none
- disposition: A (MERGE NOW)