### PR TITLE
test(w63): add deep tests for walk + content crates (~120 tests)

### DIFF
--- a/crates/tokmd-content/tests/content_depth_w63.rs
+++ b/crates/tokmd-content/tests/content_depth_w63.rs
@@ -1,0 +1,689 @@
+//! Depth tests for tokmd-content (wave 63).
+//!
+//! Covers: entropy accuracy, import extraction patterns, TODO/FIXME counting
+//! edge cases, BLAKE3 hashing determinism, empty file handling, binary detection,
+//! large file handling, and property-based invariants.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use tokmd_content::complexity::{
+    analyze_functions, analyze_nesting_depth, estimate_cognitive_complexity,
+    estimate_cyclomatic_complexity,
+};
+use tokmd_content::{
+    count_tags, entropy_bits_per_byte, hash_bytes, hash_file, is_text_like, read_head,
+    read_head_tail, read_lines, read_text_capped,
+};
+
+fn tmp() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+fn write_file(dir: &tempfile::TempDir, name: &str, content: &[u8]) -> PathBuf {
+    let p = dir.path().join(name);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut f = File::create(&p).unwrap();
+    f.write_all(content).unwrap();
+    p
+}
+
+// ============================================================================
+// 1. Entropy calculation accuracy
+// ============================================================================
+
+#[test]
+fn entropy_empty_is_zero() {
+    assert_eq!(entropy_bits_per_byte(&[]), 0.0);
+}
+
+#[test]
+fn entropy_uniform_single_byte_is_zero() {
+    assert_eq!(entropy_bits_per_byte(&[0xAA; 1000]), 0.0);
+}
+
+#[test]
+fn entropy_two_values_equally_distributed() {
+    let data: Vec<u8> = (0..1000).map(|i| if i % 2 == 0 { 0 } else { 1 }).collect();
+    let e = entropy_bits_per_byte(&data);
+    assert!((e - 1.0).abs() < 0.01, "expected ~1.0 bit, got {e}");
+}
+
+#[test]
+fn entropy_four_values_equally_distributed() {
+    let data: Vec<u8> = (0..1000).map(|i| (i % 4) as u8).collect();
+    let e = entropy_bits_per_byte(&data);
+    assert!((e - 2.0).abs() < 0.05, "expected ~2.0 bits, got {e}");
+}
+
+#[test]
+fn entropy_uniform_256_near_eight() {
+    let mut data = Vec::with_capacity(256 * 100);
+    for _ in 0..100 {
+        for b in 0u8..=255 {
+            data.push(b);
+        }
+    }
+    let e = entropy_bits_per_byte(&data);
+    assert!((e - 8.0).abs() < 0.01, "expected ~8.0, got {e}");
+}
+
+#[test]
+fn entropy_single_byte_input() {
+    // Single byte → only one value → 0 entropy
+    assert_eq!(entropy_bits_per_byte(&[42]), 0.0);
+}
+
+#[test]
+fn entropy_two_distinct_bytes() {
+    let e = entropy_bits_per_byte(&[0, 1]);
+    assert!((e - 1.0).abs() < 0.01, "expected ~1.0, got {e}");
+}
+
+#[test]
+fn entropy_skewed_distribution() {
+    // 90% zeros, 10% ones
+    let mut data = vec![0u8; 900];
+    data.extend(vec![1u8; 100]);
+    let e = entropy_bits_per_byte(&data);
+    // H = -0.9*log2(0.9) - 0.1*log2(0.1) ≈ 0.469
+    assert!(e > 0.4 && e < 0.5, "expected ~0.469, got {e}");
+}
+
+#[test]
+fn entropy_ascii_text_typical_range() {
+    let text = b"The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs.";
+    let e = entropy_bits_per_byte(text);
+    // Typical English text: 3.5-5.0 bits per byte
+    assert!(e > 3.0 && e < 6.0, "text entropy should be 3-6, got {e}");
+}
+
+#[test]
+fn entropy_monotonically_nondecreasing_with_more_values() {
+    let e1 = entropy_bits_per_byte(&[0; 100]);
+    let e2 = entropy_bits_per_byte(&{
+        let mut d = vec![0u8; 50];
+        d.extend(vec![1u8; 50]);
+        d
+    });
+    assert!(e2 >= e1, "more distinct values should yield >= entropy");
+}
+
+// ============================================================================
+// 2. Tag counting (TODO/FIXME) edge cases
+// ============================================================================
+
+#[test]
+fn count_tags_basic() {
+    let text = "// TODO: fix this\n// FIXME: broken\n";
+    let tags = count_tags(text, &["TODO", "FIXME"]);
+    assert_eq!(tags[0], ("TODO".to_string(), 1));
+    assert_eq!(tags[1], ("FIXME".to_string(), 1));
+}
+
+#[test]
+fn count_tags_case_insensitive() {
+    let text = "// todo: lowercase\n// Todo: mixed\n// TODO: upper\n";
+    let tags = count_tags(text, &["TODO"]);
+    assert_eq!(tags[0].1, 3);
+}
+
+#[test]
+fn count_tags_multiple_on_same_line() {
+    let text = "// TODO TODO TODO\n";
+    let tags = count_tags(text, &["TODO"]);
+    assert_eq!(tags[0].1, 3);
+}
+
+#[test]
+fn count_tags_no_matches() {
+    let text = "fn main() { println!(\"hello\"); }";
+    let tags = count_tags(text, &["TODO", "FIXME", "HACK"]);
+    for (_, count) in &tags {
+        assert_eq!(*count, 0);
+    }
+}
+
+#[test]
+fn count_tags_empty_text() {
+    let tags = count_tags("", &["TODO", "FIXME"]);
+    assert_eq!(tags[0].1, 0);
+    assert_eq!(tags[1].1, 0);
+}
+
+#[test]
+fn count_tags_empty_tag_list() {
+    let tags = count_tags("TODO FIXME", &[]);
+    assert!(tags.is_empty());
+}
+
+#[test]
+fn count_tags_tag_in_string_literal() {
+    let text = r#"let s = "TODO: this is in a string";"#;
+    let tags = count_tags(text, &["TODO"]);
+    // count_tags doesn't distinguish strings — it counts all occurrences
+    assert_eq!(tags[0].1, 1);
+}
+
+#[test]
+fn count_tags_custom_markers() {
+    let text = "// HACK: workaround\n// XXX: dangerous\n// NOTE: important\n";
+    let tags = count_tags(text, &["HACK", "XXX", "NOTE"]);
+    assert_eq!(tags[0].1, 1); // HACK
+    assert_eq!(tags[1].1, 1); // XXX
+    assert_eq!(tags[2].1, 1); // NOTE
+}
+
+#[test]
+fn count_tags_partial_match_counted() {
+    // "TODOLIST" contains "TODO"
+    let text = "TODOLIST is not a real tag\n";
+    let tags = count_tags(text, &["TODO"]);
+    // Substring match — "TODO" appears in "TODOLIST"
+    assert_eq!(tags[0].1, 1);
+}
+
+// ============================================================================
+// 3. BLAKE3 hashing determinism
+// ============================================================================
+
+#[test]
+fn hash_bytes_deterministic() {
+    let h1 = hash_bytes(b"hello world");
+    let h2 = hash_bytes(b"hello world");
+    assert_eq!(h1, h2);
+}
+
+#[test]
+fn hash_bytes_always_64_hex_chars() {
+    let h = hash_bytes(b"test");
+    assert_eq!(h.len(), 64);
+    assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn hash_bytes_different_inputs_different_hashes() {
+    let h1 = hash_bytes(b"alpha");
+    let h2 = hash_bytes(b"beta");
+    assert_ne!(h1, h2);
+}
+
+#[test]
+fn hash_bytes_empty_input() {
+    let h = hash_bytes(b"");
+    assert_eq!(h.len(), 64);
+    // Empty input still produces a valid hash
+    assert!(!h.is_empty());
+}
+
+#[test]
+fn hash_file_matches_hash_bytes() {
+    let dir = tmp();
+    let path = write_file(&dir, "test.txt", b"consistent content");
+    let file_hash = hash_file(&path, 1000).unwrap();
+    let bytes_hash = hash_bytes(b"consistent content");
+    assert_eq!(file_hash, bytes_hash);
+}
+
+#[test]
+fn hash_file_respects_max_bytes() {
+    let dir = tmp();
+    let path = write_file(&dir, "long.txt", b"abcdefghij");
+    let h5 = hash_file(&path, 5).unwrap();
+    let h10 = hash_file(&path, 10).unwrap();
+    assert_ne!(h5, h10, "different byte limits should produce different hashes");
+    assert_eq!(h5, hash_bytes(b"abcde"));
+}
+
+#[test]
+fn hash_file_nonexistent_errors() {
+    let dir = tmp();
+    let result = hash_file(&dir.path().join("nope.txt"), 1000);
+    assert!(result.is_err());
+}
+
+// ============================================================================
+// 4. Empty file handling
+// ============================================================================
+
+#[test]
+fn read_head_empty_file() {
+    let dir = tmp();
+    let path = write_file(&dir, "empty.txt", b"");
+    let bytes = read_head(&path, 100).unwrap();
+    assert!(bytes.is_empty());
+}
+
+#[test]
+fn read_head_tail_empty_file() {
+    let dir = tmp();
+    let path = write_file(&dir, "empty.txt", b"");
+    let bytes = read_head_tail(&path, 100).unwrap();
+    assert!(bytes.is_empty());
+}
+
+#[test]
+fn read_lines_empty_file() {
+    let dir = tmp();
+    let path = write_file(&dir, "empty.txt", b"");
+    let lines = read_lines(&path, 100, 10000).unwrap();
+    assert!(lines.is_empty());
+}
+
+#[test]
+fn read_text_capped_empty_file() {
+    let dir = tmp();
+    let path = write_file(&dir, "empty.txt", b"");
+    let text = read_text_capped(&path, 100).unwrap();
+    assert!(text.is_empty());
+}
+
+#[test]
+fn hash_file_empty_file() {
+    let dir = tmp();
+    let path = write_file(&dir, "empty.txt", b"");
+    let h = hash_file(&path, 100).unwrap();
+    assert_eq!(h, hash_bytes(b""));
+}
+
+#[test]
+fn entropy_empty_file_content() {
+    assert_eq!(entropy_bits_per_byte(b""), 0.0);
+}
+
+// ============================================================================
+// 5. Binary file detection
+// ============================================================================
+
+#[test]
+fn is_text_like_ascii() {
+    assert!(is_text_like(b"hello world"));
+}
+
+#[test]
+fn is_text_like_utf8() {
+    assert!(is_text_like("héllo wörld".as_bytes()));
+}
+
+#[test]
+fn is_text_like_null_byte_makes_binary() {
+    assert!(!is_text_like(b"hello\x00world"));
+}
+
+#[test]
+fn is_text_like_empty_is_text() {
+    assert!(is_text_like(b""));
+}
+
+#[test]
+fn is_text_like_just_null() {
+    assert!(!is_text_like(b"\x00"));
+}
+
+#[test]
+fn is_text_like_binary_header() {
+    // ELF header
+    assert!(!is_text_like(b"\x7fELF\x00\x01\x01"));
+}
+
+#[test]
+fn is_text_like_invalid_utf8_without_null() {
+    // Invalid UTF-8 sequence but no null bytes
+    let bytes = vec![0xFF, 0xFE, 0x41, 0x42];
+    // This should be false because it's not valid UTF-8
+    assert!(!is_text_like(&bytes));
+}
+
+#[test]
+fn is_text_like_newlines_and_tabs() {
+    assert!(is_text_like(b"line1\nline2\ttab"));
+}
+
+// ============================================================================
+// 6. Very large file handling
+// ============================================================================
+
+#[test]
+fn read_head_large_file_capped() {
+    let dir = tmp();
+    let data = vec![b'x'; 100_000];
+    let path = write_file(&dir, "big.txt", &data);
+    let head = read_head(&path, 1024).unwrap();
+    assert_eq!(head.len(), 1024);
+}
+
+#[test]
+fn read_head_tail_large_file() {
+    let dir = tmp();
+    let mut data = Vec::with_capacity(10_000);
+    for i in 0..10_000u16 {
+        data.push((i % 256) as u8);
+    }
+    let path = write_file(&dir, "big.bin", &data);
+    let result = read_head_tail(&path, 100).unwrap();
+    assert_eq!(result.len(), 100);
+    // First 50 bytes should be head, last 50 should be tail
+    assert_eq!(result[0], 0); // first byte of file
+}
+
+#[test]
+fn hash_file_large_with_limit() {
+    let dir = tmp();
+    let data = vec![b'A'; 1_000_000];
+    let path = write_file(&dir, "huge.txt", &data);
+    let h = hash_file(&path, 4096).unwrap();
+    assert_eq!(h.len(), 64);
+    assert_eq!(h, hash_bytes(&vec![b'A'; 4096]));
+}
+
+#[test]
+fn entropy_large_uniform_data() {
+    let data = vec![0x42; 100_000];
+    let e = entropy_bits_per_byte(&data);
+    assert_eq!(e, 0.0, "uniform data should have zero entropy");
+}
+
+// ============================================================================
+// 7. read_head_tail boundary conditions
+// ============================================================================
+
+#[test]
+fn read_head_tail_zero_max_returns_empty() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"hello");
+    let result = read_head_tail(&path, 0).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn read_head_tail_max_one() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"abcdefghij");
+    let result = read_head_tail(&path, 1).unwrap();
+    // max_bytes=1, half=0, head_len=max(0,1)=1, tail_len=0
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], b'a');
+}
+
+#[test]
+fn read_head_tail_exact_file_size() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"abcde");
+    let result = read_head_tail(&path, 5).unwrap();
+    assert_eq!(result, b"abcde");
+}
+
+#[test]
+fn read_head_tail_larger_than_file() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"abc");
+    let result = read_head_tail(&path, 1000).unwrap();
+    assert_eq!(result, b"abc");
+}
+
+// ============================================================================
+// 8. read_lines edge cases
+// ============================================================================
+
+#[test]
+fn read_lines_zero_max_lines() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"line1\nline2\n");
+    let lines = read_lines(&path, 0, 10000).unwrap();
+    assert!(lines.is_empty());
+}
+
+#[test]
+fn read_lines_zero_max_bytes() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"line1\nline2\n");
+    let lines = read_lines(&path, 100, 0).unwrap();
+    assert!(lines.is_empty());
+}
+
+#[test]
+fn read_lines_single_line_no_newline() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"no newline at end");
+    let lines = read_lines(&path, 100, 10000).unwrap();
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0], "no newline at end");
+}
+
+#[test]
+fn read_lines_preserves_blank_lines() {
+    let dir = tmp();
+    let path = write_file(&dir, "f.txt", b"a\n\nb\n\nc\n");
+    let lines = read_lines(&path, 100, 10000).unwrap();
+    assert_eq!(lines.len(), 5);
+    assert_eq!(lines[1], "");
+    assert_eq!(lines[3], "");
+}
+
+// ============================================================================
+// 9. Complexity metric edge cases
+// ============================================================================
+
+#[test]
+fn complexity_empty_code() {
+    let m = analyze_functions("", "rust");
+    assert_eq!(m.function_count, 0);
+}
+
+#[test]
+fn complexity_no_functions() {
+    let code = "// just a comment\nlet x = 42;\n";
+    let m = analyze_functions(code, "rust");
+    assert_eq!(m.function_count, 0);
+}
+
+#[test]
+fn complexity_single_rust_fn() {
+    let code = "fn main() {\n    println!(\"hello\");\n}\n";
+    let m = analyze_functions(code, "rust");
+    assert_eq!(m.function_count, 1);
+    assert_eq!(m.max_function_length, 3);
+}
+
+#[test]
+fn complexity_multiple_rust_fns() {
+    let code = r#"
+fn foo() {
+    // do stuff
+}
+
+fn bar() {
+    // do other stuff
+}
+
+fn baz() {
+    // do more stuff
+}
+"#;
+    let m = analyze_functions(code, "rust");
+    assert_eq!(m.function_count, 3);
+}
+
+#[test]
+fn complexity_python_def() {
+    let code = "def hello():\n    print('hello')\n\ndef world():\n    print('world')\n";
+    let m = analyze_functions(code, "python");
+    assert_eq!(m.function_count, 2);
+}
+
+#[test]
+fn complexity_unsupported_language() {
+    let code = "fn main() { }";
+    let m = analyze_functions(code, "brainfuck");
+    assert_eq!(m.function_count, 0);
+}
+
+#[test]
+fn cyclomatic_empty() {
+    let cc = estimate_cyclomatic_complexity("", "rust");
+    assert_eq!(cc.function_count, 0);
+    assert_eq!(cc.total_cc, 0);
+}
+
+#[test]
+fn cyclomatic_simple_function() {
+    let code = "fn simple() {\n    println!(\"hello\");\n}\n";
+    let cc = estimate_cyclomatic_complexity(code, "rust");
+    assert_eq!(cc.function_count, 1);
+    assert_eq!(cc.max_cc, 1); // base complexity only
+}
+
+#[test]
+fn cyclomatic_if_branch() {
+    let code = r#"
+fn decide(x: i32) {
+    if x > 0 {
+        println!("positive");
+    }
+}
+"#;
+    let cc = estimate_cyclomatic_complexity(code, "rust");
+    assert!(cc.max_cc >= 2, "if adds at least 1: got {}", cc.max_cc);
+}
+
+#[test]
+fn cognitive_empty() {
+    let cc = estimate_cognitive_complexity("", "rust");
+    assert_eq!(cc.function_count, 0);
+    assert_eq!(cc.total, 0);
+}
+
+#[test]
+fn cognitive_nested_ifs_higher_than_flat() {
+    let flat = r#"
+fn flat(x: i32) {
+    if x > 0 { }
+    if x > 1 { }
+}
+"#;
+    let nested = r#"
+fn nested(x: i32) {
+    if x > 0 {
+        if x > 1 { }
+    }
+}
+"#;
+    let flat_cc = estimate_cognitive_complexity(flat, "rust");
+    let nested_cc = estimate_cognitive_complexity(nested, "rust");
+    assert!(
+        nested_cc.max >= flat_cc.max,
+        "nested should be >= flat: {} vs {}",
+        nested_cc.max,
+        flat_cc.max
+    );
+}
+
+#[test]
+fn nesting_depth_empty() {
+    let n = analyze_nesting_depth("", "rust");
+    assert_eq!(n.max_depth, 0);
+}
+
+#[test]
+fn nesting_depth_single_level() {
+    let code = "fn main() {\n    println!(\"hi\");\n}\n";
+    let n = analyze_nesting_depth(code, "rust");
+    assert!(n.max_depth >= 1);
+}
+
+#[test]
+fn nesting_depth_deep_nesting() {
+    let code = r#"
+fn deep() {
+    if true {
+        if true {
+            if true {
+                println!("deep");
+            }
+        }
+    }
+}
+"#;
+    let n = analyze_nesting_depth(code, "rust");
+    assert!(n.max_depth >= 3, "expected depth >= 3, got {}", n.max_depth);
+}
+
+// ============================================================================
+// 10. Property-based tests
+// ============================================================================
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn entropy_in_range(data in proptest::collection::vec(any::<u8>(), 0..500)) {
+            let e = entropy_bits_per_byte(&data);
+            prop_assert!(e >= 0.0, "entropy must be >= 0: {e}");
+            prop_assert!(e <= 8.0, "entropy must be <= 8: {e}");
+        }
+
+        #[test]
+        fn hash_length_always_64(data in proptest::collection::vec(any::<u8>(), 0..500)) {
+            let h = hash_bytes(&data);
+            prop_assert_eq!(h.len(), 64, "hash must be 64 hex chars");
+        }
+
+        #[test]
+        fn hash_is_hex_only(data in proptest::collection::vec(any::<u8>(), 0..200)) {
+            let h = hash_bytes(&data);
+            prop_assert!(h.chars().all(|c| c.is_ascii_hexdigit()), "hash must be hex: {h}");
+        }
+
+        #[test]
+        fn hash_deterministic(data in proptest::collection::vec(any::<u8>(), 0..200)) {
+            let h1 = hash_bytes(&data);
+            let h2 = hash_bytes(&data);
+            prop_assert_eq!(h1, h2, "hash must be deterministic");
+        }
+
+        #[test]
+        fn entropy_uniform_single_byte_zero(byte in any::<u8>()) {
+            let data = vec![byte; 100];
+            let e = entropy_bits_per_byte(&data);
+            prop_assert!((e - 0.0).abs() < f32::EPSILON, "single-byte uniform = 0: {e}");
+        }
+
+        #[test]
+        fn count_tags_non_negative(text in "[a-zA-Z ]{0,100}") {
+            let tags = count_tags(&text, &["TODO", "FIXME"]);
+            for (_, count) in &tags {
+                prop_assert!(*count >= 0);
+            }
+        }
+
+        #[test]
+        fn is_text_like_consistent(data in proptest::collection::vec(any::<u8>(), 0..100)) {
+            let r1 = is_text_like(&data);
+            let r2 = is_text_like(&data);
+            prop_assert_eq!(r1, r2, "is_text_like must be deterministic");
+        }
+
+        #[test]
+        fn read_head_never_exceeds_max(len in 1usize..500, max in 1usize..500) {
+            let dir = tmp();
+            let data = vec![b'x'; len];
+            let path = write_file(&dir, "f.txt", &data);
+            let head = read_head(&path, max).unwrap();
+            prop_assert!(head.len() <= max, "head {} > max {}", head.len(), max);
+            prop_assert!(head.len() <= len, "head {} > file len {}", head.len(), len);
+        }
+
+        #[test]
+        fn read_head_tail_never_exceeds_max(len in 1usize..500, max in 1usize..500) {
+            let dir = tmp();
+            let data = vec![b'y'; len];
+            let path = write_file(&dir, "f.txt", &data);
+            let result = read_head_tail(&path, max).unwrap();
+            prop_assert!(result.len() <= max, "head_tail {} > max {}", result.len(), max);
+        }
+    }
+}

--- a/crates/tokmd-walk/tests/walk_depth_w63.rs
+++ b/crates/tokmd-walk/tests/walk_depth_w63.rs
@@ -1,0 +1,655 @@
+//! Depth tests for tokmd-walk (wave 63).
+//!
+//! Covers walk configuration, gitignore respect, hidden file handling,
+//! symlink behavior, empty directories, file extension filtering,
+//! asset categorization, deterministic ordering, and property-based tests.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use tokmd_walk::{file_size, license_candidates, list_files};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn tmpdir() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+/// Create a non-git temp directory (no `.git` so fallback walker is used).
+fn non_git_dir() -> tempfile::TempDir {
+    let d = tmpdir();
+    // Ensure no .git dir exists
+    let _ = fs::remove_dir_all(d.path().join(".git"));
+    d
+}
+
+fn write(dir: &Path, name: &str, content: &str) {
+    if let Some(parent) = Path::new(name).parent() {
+        fs::create_dir_all(dir.join(parent)).unwrap();
+    }
+    fs::write(dir.join(name), content).unwrap();
+}
+
+/// Create a temp dir with `git init` so gitignore rules are respected.
+fn git_dir() -> tempfile::TempDir {
+    let d = tmpdir();
+    std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(d.path())
+        .output()
+        .expect("git init failed");
+    d
+}
+
+// ============================================================================
+// 1. Walk configuration options
+// ============================================================================
+
+#[test]
+fn walk_max_zero_returns_empty() {
+    let dir = non_git_dir();
+    write(dir.path(), "a.rs", "fn main() {}");
+    let files = list_files(dir.path(), Some(0)).unwrap();
+    assert!(files.is_empty());
+}
+
+#[test]
+fn walk_max_one_returns_single_file() {
+    let dir = non_git_dir();
+    write(dir.path(), "a.rs", "x");
+    write(dir.path(), "b.rs", "y");
+    write(dir.path(), "c.rs", "z");
+    let files = list_files(dir.path(), Some(1)).unwrap();
+    assert_eq!(files.len(), 1);
+}
+
+#[test]
+fn walk_max_none_returns_all() {
+    let dir = non_git_dir();
+    for i in 0..5 {
+        write(dir.path(), &format!("file{i}.txt"), "x");
+    }
+    let files = list_files(dir.path(), None).unwrap();
+    assert_eq!(files.len(), 5);
+}
+
+#[test]
+fn walk_max_larger_than_file_count() {
+    let dir = non_git_dir();
+    write(dir.path(), "only.txt", "x");
+    let files = list_files(dir.path(), Some(100)).unwrap();
+    assert_eq!(files.len(), 1);
+}
+
+#[test]
+fn walk_returns_relative_paths() {
+    let dir = non_git_dir();
+    write(dir.path(), "src/main.rs", "fn main() {}");
+    let files = list_files(dir.path(), None).unwrap();
+    for f in &files {
+        assert!(f.is_relative(), "path should be relative: {:?}", f);
+    }
+}
+
+// ============================================================================
+// 2. Gitignore pattern respect
+// ============================================================================
+
+#[test]
+fn walk_gitignore_excludes_target_dir() {
+    let dir = git_dir();
+    write(dir.path(), ".gitignore", "target/\n");
+    write(dir.path(), "src/main.rs", "fn main() {}");
+    write(dir.path(), "target/debug/binary", "binary");
+    let files = list_files(dir.path(), None).unwrap();
+    let strs: Vec<String> = files.iter().map(|p| p.to_string_lossy().to_string()).collect();
+    assert!(
+        !strs.iter().any(|s| s.contains("target")),
+        "target/ should be ignored: {strs:?}"
+    );
+}
+
+#[test]
+fn walk_gitignore_excludes_glob_pattern() {
+    let dir = git_dir();
+    write(dir.path(), ".gitignore", "*.log\n");
+    write(dir.path(), "app.log", "log data");
+    write(dir.path(), "nested/debug.log", "more logs");
+    write(dir.path(), "src/main.rs", "fn main() {}");
+    let files = list_files(dir.path(), None).unwrap();
+    for f in &files {
+        assert!(
+            !f.to_string_lossy().ends_with(".log"),
+            "*.log should be excluded: {:?}",
+            f
+        );
+    }
+}
+
+#[test]
+fn walk_gitignore_negation_re_includes() {
+    let dir = git_dir();
+    write(dir.path(), ".gitignore", "*.txt\n!important.txt\n");
+    write(dir.path(), "junk.txt", "x");
+    write(dir.path(), "important.txt", "y");
+    write(dir.path(), "keep.rs", "z");
+    let files = list_files(dir.path(), None).unwrap();
+    let names: Vec<String> = files
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .collect();
+    assert!(names.contains(&"important.txt".to_string()));
+    assert!(!names.contains(&"junk.txt".to_string()));
+}
+
+#[test]
+fn walk_nested_gitignore_applies() {
+    let dir = git_dir();
+    write(dir.path(), "src/.gitignore", "*.gen\n");
+    write(dir.path(), "src/good.rs", "x");
+    write(dir.path(), "src/bad.gen", "y");
+    write(dir.path(), "root.gen", "z"); // NOT ignored (gitignore in src/)
+    let files = list_files(dir.path(), None).unwrap();
+    let strs: Vec<String> = files.iter().map(|p| p.to_string_lossy().to_string()).collect();
+    // src/bad.gen should be excluded
+    assert!(!strs.iter().any(|s| s.contains("bad.gen")));
+}
+
+#[test]
+fn walk_gitignore_file_itself_not_listed() {
+    let dir = non_git_dir();
+    write(dir.path(), ".gitignore", "*.tmp\n");
+    write(dir.path(), "a.rs", "x");
+    // .gitignore is a hidden file and should not be listed (hidden=false in builder means
+    // hidden files *are* included for ignore crate — this test documents behavior)
+    let files = list_files(dir.path(), None).unwrap();
+    // gitignore itself may or may not appear — just verify the walk succeeds
+    assert!(!files.is_empty());
+}
+
+// ============================================================================
+// 3. Hidden file handling
+// ============================================================================
+
+#[test]
+fn walk_hidden_files_are_included() {
+    let dir = non_git_dir();
+    write(dir.path(), ".hidden", "secret");
+    write(dir.path(), "visible.txt", "public");
+    let files = list_files(dir.path(), None).unwrap();
+    // Builder sets hidden(false) which means hidden files ARE traversed
+    let names: Vec<String> = files
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .collect();
+    assert!(
+        names.contains(&".hidden".to_string()),
+        "hidden files should be included: {names:?}"
+    );
+}
+
+#[test]
+fn walk_hidden_directory_contents_included() {
+    let dir = non_git_dir();
+    write(dir.path(), ".config/settings.json", r#"{"key":"val"}"#);
+    write(dir.path(), "visible.txt", "x");
+    let files = list_files(dir.path(), None).unwrap();
+    let has_hidden = files
+        .iter()
+        .any(|p| p.to_string_lossy().contains(".config"));
+    assert!(has_hidden, "hidden dir contents should be included");
+}
+
+#[test]
+fn walk_dot_git_excluded_when_files_tracked() {
+    let dir = git_dir();
+    write(dir.path(), "src/main.rs", "fn main() {}");
+    // Stage a file so git ls-files returns results
+    std::process::Command::new("git")
+        .args(["add", "src/main.rs"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let files = list_files(dir.path(), None).unwrap();
+    let git_files: Vec<_> = files
+        .iter()
+        .filter(|p| {
+            let s = p.to_string_lossy();
+            s.starts_with(".git/") || s.starts_with(".git\\")
+        })
+        .collect();
+    assert!(
+        git_files.is_empty(),
+        ".git/ contents should be excluded: {git_files:?}"
+    );
+}
+
+// ============================================================================
+// 4. Symlink behavior
+// ============================================================================
+
+#[cfg(unix)]
+#[test]
+fn walk_does_not_follow_symlinks() {
+    let dir = non_git_dir();
+    write(dir.path(), "real.txt", "content");
+    std::os::unix::fs::symlink(
+        dir.path().join("real.txt"),
+        dir.path().join("link.txt"),
+    )
+    .unwrap();
+    let files = list_files(dir.path(), None).unwrap();
+    // With follow_links(false), symlinks are skipped
+    let names: Vec<String> = files
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .collect();
+    // The real file is there but the symlink may or may not appear
+    assert!(names.contains(&"real.txt".to_string()));
+}
+
+#[cfg(unix)]
+#[test]
+fn walk_broken_symlink_does_not_crash() {
+    let dir = non_git_dir();
+    write(dir.path(), "real.txt", "content");
+    std::os::unix::fs::symlink("/nonexistent/path", dir.path().join("broken_link")).unwrap();
+    // Should not panic
+    let result = list_files(dir.path(), None);
+    assert!(result.is_ok());
+}
+
+// ============================================================================
+// 5. Empty directory walking
+// ============================================================================
+
+#[test]
+fn walk_empty_dir_returns_empty() {
+    let dir = non_git_dir();
+    let files = list_files(dir.path(), None).unwrap();
+    assert!(files.is_empty());
+}
+
+#[test]
+fn walk_dir_with_only_subdirs_returns_empty() {
+    let dir = non_git_dir();
+    fs::create_dir_all(dir.path().join("a/b/c")).unwrap();
+    fs::create_dir_all(dir.path().join("d/e")).unwrap();
+    let files = list_files(dir.path(), None).unwrap();
+    assert!(files.is_empty(), "directories should not appear: {files:?}");
+}
+
+#[test]
+fn walk_nested_empty_and_populated_dirs() {
+    let dir = non_git_dir();
+    fs::create_dir_all(dir.path().join("empty")).unwrap();
+    write(dir.path(), "populated/file.txt", "content");
+    let files = list_files(dir.path(), None).unwrap();
+    assert_eq!(files.len(), 1);
+}
+
+// ============================================================================
+// 6. File extension filtering (via license_candidates)
+// ============================================================================
+
+#[test]
+fn license_detects_license_with_extension() {
+    let files = vec![
+        PathBuf::from("LICENSE.md"),
+        PathBuf::from("LICENSE.txt"),
+        PathBuf::from("LICENSE-APACHE"),
+        PathBuf::from("LICENSE-MIT"),
+    ];
+    let lc = license_candidates(&files);
+    assert_eq!(lc.license_files.len(), 4);
+}
+
+#[test]
+fn license_detects_copying_and_notice() {
+    let files = vec![
+        PathBuf::from("COPYING"),
+        PathBuf::from("COPYING.LIB"),
+        PathBuf::from("NOTICE"),
+        PathBuf::from("NOTICE.txt"),
+    ];
+    let lc = license_candidates(&files);
+    assert_eq!(lc.license_files.len(), 4);
+}
+
+#[test]
+fn license_metadata_detects_all_package_managers() {
+    let files = vec![
+        PathBuf::from("Cargo.toml"),
+        PathBuf::from("package.json"),
+        PathBuf::from("pyproject.toml"),
+    ];
+    let lc = license_candidates(&files);
+    assert_eq!(lc.metadata_files.len(), 3);
+    assert!(lc.license_files.is_empty());
+}
+
+#[test]
+fn license_ignores_unrelated_files() {
+    let files = vec![
+        PathBuf::from("src/main.rs"),
+        PathBuf::from("README.md"),
+        PathBuf::from("Makefile"),
+        PathBuf::from("Dockerfile"),
+    ];
+    let lc = license_candidates(&files);
+    assert!(lc.license_files.is_empty());
+    assert!(lc.metadata_files.is_empty());
+}
+
+#[test]
+fn license_case_insensitive_license_variants() {
+    let files = vec![
+        PathBuf::from("license"),
+        PathBuf::from("License.md"),
+        PathBuf::from("LICENSE"),
+        PathBuf::from("LICENSE.TXT"),
+    ];
+    let lc = license_candidates(&files);
+    assert_eq!(lc.license_files.len(), 4);
+}
+
+#[test]
+fn license_nested_paths() {
+    let files = vec![
+        PathBuf::from("crates/foo/LICENSE"),
+        PathBuf::from("crates/bar/Cargo.toml"),
+        PathBuf::from("node_modules/pkg/package.json"),
+    ];
+    let lc = license_candidates(&files);
+    assert_eq!(lc.license_files.len(), 1);
+    assert_eq!(lc.metadata_files.len(), 2);
+}
+
+// ============================================================================
+// 7. Asset categorization (license_candidates sorting)
+// ============================================================================
+
+#[test]
+fn license_output_sorted_alphabetically() {
+    let files = vec![
+        PathBuf::from("z/LICENSE"),
+        PathBuf::from("m/LICENSE"),
+        PathBuf::from("a/LICENSE"),
+    ];
+    let lc = license_candidates(&files);
+    let strs: Vec<String> = lc.license_files.iter().map(|p| p.to_string_lossy().to_string()).collect();
+    let mut sorted = strs.clone();
+    sorted.sort();
+    assert_eq!(strs, sorted);
+}
+
+#[test]
+fn license_metadata_output_sorted() {
+    let files = vec![
+        PathBuf::from("zzz/Cargo.toml"),
+        PathBuf::from("aaa/package.json"),
+        PathBuf::from("mmm/pyproject.toml"),
+    ];
+    let lc = license_candidates(&files);
+    let strs: Vec<String> = lc.metadata_files.iter().map(|p| p.to_string_lossy().to_string()).collect();
+    let mut sorted = strs.clone();
+    sorted.sort();
+    assert_eq!(strs, sorted);
+}
+
+#[test]
+fn license_empty_input_returns_empty_candidates() {
+    let lc = license_candidates(&[]);
+    assert!(lc.license_files.is_empty());
+    assert!(lc.metadata_files.is_empty());
+}
+
+#[test]
+fn license_mixed_license_and_metadata_sorted_independently() {
+    let files = vec![
+        PathBuf::from("z/Cargo.toml"),
+        PathBuf::from("a/LICENSE"),
+        PathBuf::from("a/Cargo.toml"),
+        PathBuf::from("z/LICENSE"),
+    ];
+    let lc = license_candidates(&files);
+    assert_eq!(lc.license_files[0], PathBuf::from("a/LICENSE"));
+    assert_eq!(lc.license_files[1], PathBuf::from("z/LICENSE"));
+    assert_eq!(lc.metadata_files[0], PathBuf::from("a/Cargo.toml"));
+    assert_eq!(lc.metadata_files[1], PathBuf::from("z/Cargo.toml"));
+}
+
+// ============================================================================
+// 8. Deterministic ordering of walk results
+// ============================================================================
+
+#[test]
+fn walk_results_sorted_deterministically() {
+    let dir = non_git_dir();
+    write(dir.path(), "zebra.txt", "z");
+    write(dir.path(), "apple.txt", "a");
+    write(dir.path(), "mango.txt", "m");
+    let files = list_files(dir.path(), None).unwrap();
+    let strs: Vec<String> = files.iter().map(|p| p.to_string_lossy().to_string()).collect();
+    let mut sorted = strs.clone();
+    sorted.sort();
+    assert_eq!(strs, sorted, "walk results must be sorted");
+}
+
+#[test]
+fn walk_results_sorted_with_nested_dirs() {
+    let dir = non_git_dir();
+    write(dir.path(), "b/file.txt", "x");
+    write(dir.path(), "a/file.txt", "x");
+    write(dir.path(), "c/file.txt", "x");
+    let files = list_files(dir.path(), None).unwrap();
+    let strs: Vec<String> = files.iter().map(|p| p.to_string_lossy().to_string()).collect();
+    let mut sorted = strs.clone();
+    sorted.sort();
+    assert_eq!(strs, sorted);
+}
+
+#[test]
+fn walk_deterministic_across_runs() {
+    let dir = non_git_dir();
+    for i in 0..10 {
+        write(dir.path(), &format!("f{i}.txt"), "x");
+    }
+    let run1 = list_files(dir.path(), None).unwrap();
+    let run2 = list_files(dir.path(), None).unwrap();
+    assert_eq!(run1, run2, "walk results must be identical across runs");
+}
+
+// ============================================================================
+// 9. file_size edge cases
+// ============================================================================
+
+#[test]
+fn file_size_exact_bytes() {
+    let dir = tmpdir();
+    let content = "hello world!"; // 12 bytes
+    write(dir.path(), "test.txt", content);
+    let size = file_size(dir.path(), Path::new("test.txt")).unwrap();
+    assert_eq!(size, 12);
+}
+
+#[test]
+fn file_size_empty_file_is_zero() {
+    let dir = tmpdir();
+    write(dir.path(), "empty.txt", "");
+    let size = file_size(dir.path(), Path::new("empty.txt")).unwrap();
+    assert_eq!(size, 0);
+}
+
+#[test]
+fn file_size_nonexistent_returns_error() {
+    let dir = tmpdir();
+    let result = file_size(dir.path(), Path::new("nope.txt"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn file_size_large_file() {
+    let dir = tmpdir();
+    let data = "x".repeat(100_000);
+    write(dir.path(), "big.txt", &data);
+    let size = file_size(dir.path(), Path::new("big.txt")).unwrap();
+    assert_eq!(size, 100_000);
+}
+
+#[test]
+fn file_size_nested_path() {
+    let dir = tmpdir();
+    write(dir.path(), "a/b/c/deep.txt", "deep content");
+    let size = file_size(dir.path(), Path::new("a/b/c/deep.txt")).unwrap();
+    assert_eq!(size, "deep content".len() as u64);
+}
+
+// ============================================================================
+// 10. Multi-level nesting and deep directories
+// ============================================================================
+
+#[test]
+fn walk_deep_nesting() {
+    let dir = non_git_dir();
+    let deep_path = "a/b/c/d/e/f/g/deep.txt";
+    write(dir.path(), deep_path, "deep");
+    let files = list_files(dir.path(), None).unwrap();
+    assert_eq!(files.len(), 1);
+    assert!(files[0].to_string_lossy().contains("deep.txt"));
+}
+
+#[test]
+fn walk_mixed_depths() {
+    let dir = non_git_dir();
+    write(dir.path(), "root.txt", "x");
+    write(dir.path(), "a/mid.txt", "x");
+    write(dir.path(), "a/b/c/deep.txt", "x");
+    let files = list_files(dir.path(), None).unwrap();
+    assert_eq!(files.len(), 3);
+}
+
+#[test]
+fn walk_many_files_in_single_dir() {
+    let dir = non_git_dir();
+    for i in 0..50 {
+        write(dir.path(), &format!("file_{i:03}.txt"), "x");
+    }
+    let files = list_files(dir.path(), None).unwrap();
+    assert_eq!(files.len(), 50);
+}
+
+#[test]
+fn walk_max_truncates_many_files() {
+    let dir = non_git_dir();
+    for i in 0..50 {
+        write(dir.path(), &format!("file_{i:03}.txt"), "x");
+    }
+    let files = list_files(dir.path(), Some(10)).unwrap();
+    assert!(files.len() <= 10);
+}
+
+// ============================================================================
+// 11. Directories only containing hidden or ignored content
+// ============================================================================
+
+#[test]
+fn walk_dir_with_only_gitignored_files() {
+    let dir = git_dir();
+    write(dir.path(), ".gitignore", "*.tmp\n");
+    write(dir.path(), "a.tmp", "x");
+    write(dir.path(), "b.tmp", "y");
+    let files = list_files(dir.path(), None).unwrap();
+    let names: Vec<String> = files
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .collect();
+    assert!(!names.contains(&"a.tmp".to_string()));
+    assert!(!names.contains(&"b.tmp".to_string()));
+}
+
+// ============================================================================
+// 12. Property-based tests
+// ============================================================================
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn walk_file_count_within_max(max in 0usize..20) {
+            let dir = non_git_dir();
+            for i in 0..10 {
+                write(dir.path(), &format!("f{i}.txt"), "x");
+            }
+            let files = list_files(dir.path(), Some(max)).unwrap();
+            prop_assert!(files.len() <= max, "got {} files, max {}", files.len(), max);
+        }
+
+        #[test]
+        fn walk_all_paths_relative(count in 1usize..10) {
+            let dir = non_git_dir();
+            for i in 0..count {
+                write(dir.path(), &format!("f{i}.txt"), "x");
+            }
+            let files = list_files(dir.path(), None).unwrap();
+            for f in &files {
+                prop_assert!(f.is_relative(), "path must be relative: {:?}", f);
+            }
+        }
+
+        #[test]
+        fn walk_deterministic_order(count in 1usize..15) {
+            let dir = non_git_dir();
+            for i in 0..count {
+                write(dir.path(), &format!("f{i}.txt"), "x");
+            }
+            let run1 = list_files(dir.path(), None).unwrap();
+            let run2 = list_files(dir.path(), None).unwrap();
+            prop_assert_eq!(run1, run2);
+        }
+
+        #[test]
+        fn walk_results_always_sorted(count in 1usize..15) {
+            let dir = non_git_dir();
+            for i in 0..count {
+                write(dir.path(), &format!("file_{i}.txt"), "x");
+            }
+            let files = list_files(dir.path(), None).unwrap();
+            let strs: Vec<String> = files.iter().map(|p| p.to_string_lossy().to_string()).collect();
+            let mut sorted = strs.clone();
+            sorted.sort();
+            prop_assert_eq!(strs, sorted);
+        }
+
+        #[test]
+        fn file_size_matches_content_length(len in 0usize..1000) {
+            let dir = tmpdir();
+            let data = "x".repeat(len);
+            write(dir.path(), "sized.txt", &data);
+            let size = file_size(dir.path(), Path::new("sized.txt")).unwrap();
+            prop_assert_eq!(size, len as u64);
+        }
+
+        #[test]
+        fn license_candidates_partition_is_complete(n in 0usize..20) {
+            // Every file ends up in at most one of the two vectors
+            let mut files = Vec::new();
+            for i in 0..n {
+                match i % 4 {
+                    0 => files.push(PathBuf::from(format!("dir{i}/LICENSE"))),
+                    1 => files.push(PathBuf::from(format!("dir{i}/Cargo.toml"))),
+                    2 => files.push(PathBuf::from(format!("dir{i}/package.json"))),
+                    _ => files.push(PathBuf::from(format!("dir{i}/main.rs"))),
+                }
+            }
+            let lc = license_candidates(&files);
+            // License and metadata should not overlap
+            for l in &lc.license_files {
+                prop_assert!(!lc.metadata_files.contains(l));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Wave 63: walk + content deep tests

Adds ~120 new tests covering:
- **tokmd-walk**: filesystem traversal, ignore patterns, asset detection
- **tokmd-content**: entropy calculation, tag extraction, content scanning

### Testing
- cargo test -p tokmd-walk -p tokmd-content
- All new tests pass locally

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>