### PR TITLE
test(w63): add deep tests for redact + scan-args crates (~99 tests)

### DIFF
--- a/crates/tokmd-redact/tests/redact_depth_w63.rs
+++ b/crates/tokmd-redact/tests/redact_depth_w63.rs
@@ -1,0 +1,460 @@
+//! Depth tests for tokmd-redact (W63).
+//!
+//! Covers BLAKE3-based path redaction, salt consistency, lexical normalization,
+//! dot/dot-dot resolution, Windows absolute paths, round-trip determinism,
+//! empty/single-segment paths, Unicode paths, and property-based tests.
+
+use tokmd_redact::{redact_path, short_hash};
+
+// ---------------------------------------------------------------------------
+// 1. short_hash basic properties
+// ---------------------------------------------------------------------------
+
+#[test]
+fn short_hash_always_16_chars() {
+    for input in &["", "a", "hello world", "crates/tokmd/src/lib.rs"] {
+        assert_eq!(short_hash(input).len(), 16, "input: {input}");
+    }
+}
+
+#[test]
+fn short_hash_hex_only() {
+    let h = short_hash("anything");
+    assert!(
+        h.chars().all(|c| c.is_ascii_hexdigit()),
+        "expected hex chars, got: {h}"
+    );
+}
+
+#[test]
+fn short_hash_empty_string() {
+    let h = short_hash("");
+    assert_eq!(h.len(), 16);
+    // Must be deterministic even for empty input.
+    assert_eq!(h, short_hash(""));
+}
+
+#[test]
+fn short_hash_single_char_inputs_differ() {
+    let h_a = short_hash("a");
+    let h_b = short_hash("b");
+    assert_ne!(h_a, h_b);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Separator normalization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hash_backslash_equals_forward_slash_deep() {
+    assert_eq!(
+        short_hash("a/b/c/d/e"),
+        short_hash("a\\b\\c\\d\\e")
+    );
+}
+
+#[test]
+fn hash_mixed_separators_normalized() {
+    assert_eq!(
+        short_hash("crates/tokmd\\src/lib.rs"),
+        short_hash("crates/tokmd/src/lib.rs")
+    );
+}
+
+#[test]
+fn redact_path_mixed_separators_same_output() {
+    assert_eq!(
+        redact_path("src\\main.rs"),
+        redact_path("src/main.rs")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Dot/dot-dot segment resolution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hash_leading_dot_slash_stripped() {
+    assert_eq!(short_hash("./src/lib.rs"), short_hash("src/lib.rs"));
+}
+
+#[test]
+fn hash_double_dot_slash_prefix_stripped() {
+    assert_eq!(short_hash("././src/lib.rs"), short_hash("src/lib.rs"));
+}
+
+#[test]
+fn hash_triple_dot_slash_prefix_stripped() {
+    assert_eq!(short_hash("./././src/lib.rs"), short_hash("src/lib.rs"));
+}
+
+#[test]
+fn hash_interior_dot_segment_resolved() {
+    assert_eq!(
+        short_hash("crates/./foo/./bar"),
+        short_hash("crates/foo/bar")
+    );
+}
+
+#[test]
+fn hash_trailing_dot_resolved() {
+    assert_eq!(short_hash("crates/foo/."), short_hash("crates/foo"));
+}
+
+#[test]
+fn redact_path_dot_prefix_stripped() {
+    assert_eq!(redact_path("./src/main.rs"), redact_path("src/main.rs"));
+}
+
+#[test]
+fn redact_path_interior_dot_resolved() {
+    assert_eq!(
+        redact_path("crates/./tokmd/src/lib.rs"),
+        redact_path("crates/tokmd/src/lib.rs")
+    );
+}
+
+#[test]
+fn hash_bare_dot_input() {
+    // "." and "./" should produce the same hash (trailing /. removal + strip)
+    let h = short_hash(".");
+    assert_eq!(h.len(), 16);
+}
+
+#[test]
+fn hash_dot_dot_not_special() {
+    // ".." is NOT collapsed (no parent resolution) – just literal
+    let h = short_hash("../foo");
+    assert_ne!(h, short_hash("foo"));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Windows absolute path handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hash_windows_absolute_path_backslashes() {
+    let h = short_hash("C:\\Users\\dev\\project\\src\\lib.rs");
+    assert_eq!(h.len(), 16);
+    // Normalised to forward slashes internally
+    assert_eq!(
+        h,
+        short_hash("C:/Users/dev/project/src/lib.rs")
+    );
+}
+
+#[test]
+fn redact_windows_absolute_preserves_extension() {
+    let r = redact_path("D:\\work\\project\\main.py");
+    assert!(r.ends_with(".py"), "got: {r}");
+}
+
+#[test]
+fn hash_unc_path_backslashes() {
+    assert_eq!(
+        short_hash("\\\\server\\share\\file.txt"),
+        short_hash("//server/share/file.txt")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Extension preservation in redact_path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redact_path_single_extension() {
+    let r = redact_path("foo/bar.rs");
+    assert!(r.ends_with(".rs"));
+    assert_eq!(r.len(), 16 + 1 + 2); // hash(16) + dot(1) + "rs"(2) = 19
+}
+
+#[test]
+fn redact_path_double_extension_keeps_last() {
+    let r = redact_path("backup.tar.gz");
+    assert!(r.ends_with(".gz"));
+    assert!(!r.contains("tar"));
+}
+
+#[test]
+fn redact_path_triple_extension_keeps_last() {
+    let r = redact_path("data.backup.tar.xz");
+    assert!(r.ends_with(".xz"));
+}
+
+#[test]
+fn redact_path_hidden_file_no_extension() {
+    // ".gitignore" has no extension per std::path::Path::extension
+    let r = redact_path(".gitignore");
+    assert_eq!(r.len(), 16, "got: {r}");
+    assert!(!r.contains('.'));
+}
+
+#[test]
+fn redact_path_dotfile_with_ext() {
+    let r = redact_path(".config.json");
+    assert!(r.ends_with(".json"));
+}
+
+#[test]
+fn redact_path_no_extension_file() {
+    let r = redact_path("Makefile");
+    assert_eq!(r.len(), 16);
+    assert!(!r.contains('.'));
+}
+
+#[test]
+fn redact_path_readme_no_ext() {
+    let r = redact_path("README");
+    assert_eq!(r.len(), 16);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Empty and single-segment path handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redact_path_empty_string() {
+    let r = redact_path("");
+    assert_eq!(r.len(), 16);
+    assert!(!r.contains('.'));
+}
+
+#[test]
+fn redact_path_single_segment_with_ext() {
+    let r = redact_path("lib.rs");
+    assert!(r.ends_with(".rs"));
+}
+
+#[test]
+fn redact_path_single_segment_no_ext() {
+    let r = redact_path("foobar");
+    assert_eq!(r.len(), 16);
+}
+
+#[test]
+fn redact_path_slash_only() {
+    let r = redact_path("/");
+    assert_eq!(r.len(), 16);
+}
+
+#[test]
+fn hash_whitespace_only() {
+    let h = short_hash("   ");
+    assert_eq!(h.len(), 16);
+    assert_ne!(h, short_hash(""));
+}
+
+// ---------------------------------------------------------------------------
+// 7. Unicode path redaction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hash_unicode_path() {
+    let h = short_hash("src/données/résumé.txt");
+    assert_eq!(h.len(), 16);
+}
+
+#[test]
+fn redact_unicode_path_preserves_extension() {
+    let r = redact_path("ディレクトリ/ファイル.rs");
+    assert!(r.ends_with(".rs"), "got: {r}");
+}
+
+#[test]
+fn hash_emoji_path() {
+    let h = short_hash("📁/📄.txt");
+    assert_eq!(h.len(), 16);
+}
+
+#[test]
+fn redact_chinese_path() {
+    let r = redact_path("项目/源代码/主.py");
+    assert!(r.ends_with(".py"));
+}
+
+#[test]
+fn hash_unicode_deterministic() {
+    let h1 = short_hash("données/café.rs");
+    let h2 = short_hash("données/café.rs");
+    assert_eq!(h1, h2);
+}
+
+// ---------------------------------------------------------------------------
+// 8. Round-trip / determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn short_hash_100_calls_identical() {
+    let expected = short_hash("stability-test");
+    for _ in 0..100 {
+        assert_eq!(short_hash("stability-test"), expected);
+    }
+}
+
+#[test]
+fn redact_path_100_calls_identical() {
+    let expected = redact_path("stability/test.rs");
+    for _ in 0..100 {
+        assert_eq!(redact_path("stability/test.rs"), expected);
+    }
+}
+
+#[test]
+fn different_paths_never_collide_sample() {
+    let paths = [
+        "a.rs",
+        "b.rs",
+        "a/b.rs",
+        "a/c.rs",
+        "x/y/z.rs",
+        "x/y/z/w.rs",
+        "main.rs",
+        "lib.rs",
+    ];
+    let hashes: Vec<String> = paths.iter().map(|p| short_hash(p)).collect();
+    for i in 0..hashes.len() {
+        for j in (i + 1)..hashes.len() {
+            assert_ne!(
+                hashes[i], hashes[j],
+                "collision between '{}' and '{}'",
+                paths[i], paths[j]
+            );
+        }
+    }
+}
+
+#[test]
+fn redact_path_different_ext_same_stem_differs() {
+    let r1 = redact_path("src/lib.rs");
+    let r2 = redact_path("src/lib.py");
+    assert_ne!(r1, r2);
+}
+
+#[test]
+fn redact_path_same_filename_different_dir() {
+    let r1 = redact_path("a/lib.rs");
+    let r2 = redact_path("b/lib.rs");
+    assert_ne!(r1, r2);
+}
+
+// ---------------------------------------------------------------------------
+// 9. Redacted output never leaks original path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redact_path_does_not_contain_original_segments() {
+    let r = redact_path("secrets/passwords/vault.json");
+    assert!(!r.contains("secrets"));
+    assert!(!r.contains("passwords"));
+    assert!(!r.contains("vault"));
+}
+
+#[test]
+fn short_hash_does_not_contain_input() {
+    let h = short_hash("my-secret");
+    assert!(!h.contains("my-secret"));
+}
+
+// ---------------------------------------------------------------------------
+// 10. Normalization edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hash_multiple_consecutive_slashes() {
+    // Double slashes are NOT collapsed by clean_path, so they differ
+    let h1 = short_hash("a//b");
+    let h2 = short_hash("a/b");
+    // Just verify both produce valid hashes (behaviour is documented)
+    assert_eq!(h1.len(), 16);
+    assert_eq!(h2.len(), 16);
+}
+
+#[test]
+fn hash_trailing_slash() {
+    let h1 = short_hash("src/");
+    let h2 = short_hash("src");
+    // Trailing slash is NOT stripped – distinct inputs
+    assert_eq!(h1.len(), 16);
+    assert_eq!(h2.len(), 16);
+}
+
+#[test]
+fn redact_path_trailing_slash_no_ext() {
+    let r = redact_path("some/dir/");
+    assert_eq!(r.len(), 16);
+}
+
+#[test]
+fn hash_only_dots() {
+    let h = short_hash("...");
+    assert_eq!(h.len(), 16);
+}
+
+#[test]
+fn hash_dot_slash_backslash_combo() {
+    // ./foo\bar -> foo/bar after normalization
+    assert_eq!(short_hash("./foo\\bar"), short_hash("foo/bar"));
+}
+
+// ---------------------------------------------------------------------------
+// 11. Property tests (proptest)
+// ---------------------------------------------------------------------------
+
+mod property_tests {
+    use proptest::prelude::*;
+    use tokmd_redact::{redact_path, short_hash};
+
+    proptest! {
+        #[test]
+        fn hash_always_16_hex_chars(input in "\\PC{0,200}") {
+            let h = short_hash(&input);
+            prop_assert_eq!(h.len(), 16);
+            prop_assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+
+        #[test]
+        fn hash_deterministic(input in "\\PC{0,100}") {
+            prop_assert_eq!(short_hash(&input), short_hash(&input));
+        }
+
+        #[test]
+        fn redact_path_deterministic(input in "[a-zA-Z0-9_/\\\\.]{1,80}") {
+            prop_assert_eq!(redact_path(&input), redact_path(&input));
+        }
+
+        #[test]
+        fn redact_path_hash_prefix_is_16_hex(input in "[a-z/]{1,40}\\.[a-z]{1,5}") {
+            let r = redact_path(&input);
+            // The hash prefix (before the first dot in the redacted output) is 16 hex chars
+            let prefix = r.split('.').next().unwrap();
+            prop_assert_eq!(prefix.len(), 16);
+            prop_assert!(prefix.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+
+        #[test]
+        fn separator_normalization_equivalence(path in "[a-z]{1,5}(/[a-z]{1,5}){0,4}") {
+            let with_backslash = path.replace('/', "\\");
+            prop_assert_eq!(short_hash(&path), short_hash(&with_backslash));
+        }
+
+        #[test]
+        fn dot_prefix_normalization(path in "[a-z]{1,5}(/[a-z]{1,5}){0,3}") {
+            let with_dot = format!("./{path}");
+            prop_assert_eq!(short_hash(&path), short_hash(&with_dot));
+        }
+
+        #[test]
+        fn interior_dot_normalization(a in "[a-z]{1,5}", b in "[a-z]{1,5}") {
+            let with_dot = format!("{a}/./{b}");
+            let without = format!("{a}/{b}");
+            prop_assert_eq!(short_hash(&with_dot), short_hash(&without));
+        }
+
+        #[test]
+        fn redact_no_extension_is_bare_hash(stem in "[a-zA-Z]{3,20}") {
+            let r = redact_path(&stem);
+            prop_assert_eq!(r.len(), 16);
+            prop_assert!(!r.contains('.'));
+        }
+    }
+}

--- a/crates/tokmd-scan-args/tests/scanargs_depth_w63.rs
+++ b/crates/tokmd-scan-args/tests/scanargs_depth_w63.rs
@@ -1,0 +1,530 @@
+//! Depth tests for tokmd-scan-args (W63).
+//!
+//! Covers ScanArgs construction, metadata field correctness, redaction wiring,
+//! default values, path normalization, deterministic generation, and property tests.
+
+use std::path::{Path, PathBuf};
+
+use tokmd_scan_args::{normalize_scan_input, scan_args};
+use tokmd_settings::ScanOptions;
+use tokmd_types::RedactMode;
+
+// ---------------------------------------------------------------------------
+// 1. normalize_scan_input basics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn normalize_plain_relative_path() {
+    assert_eq!(normalize_scan_input(Path::new("src/lib.rs")), "src/lib.rs");
+}
+
+#[test]
+fn normalize_strips_single_dot_slash() {
+    assert_eq!(normalize_scan_input(Path::new("./src")), "src");
+}
+
+#[test]
+fn normalize_strips_multiple_dot_slashes() {
+    assert_eq!(
+        normalize_scan_input(Path::new("./././foo/bar")),
+        "foo/bar"
+    );
+}
+
+#[test]
+fn normalize_bare_dot_becomes_dot() {
+    assert_eq!(normalize_scan_input(Path::new(".")), ".");
+}
+
+#[test]
+fn normalize_dot_slash_becomes_dot() {
+    assert_eq!(normalize_scan_input(Path::new("./")), ".");
+}
+
+#[test]
+fn normalize_preserves_absolute_unix_path() {
+    // On Windows this is a relative path but forward slashes are kept
+    let n = normalize_scan_input(Path::new("/usr/local/bin"));
+    assert!(n.contains("usr"));
+}
+
+#[test]
+fn normalize_forward_slashes_preserved() {
+    let n = normalize_scan_input(Path::new("a/b/c/d"));
+    assert_eq!(n, "a/b/c/d");
+}
+
+// ---------------------------------------------------------------------------
+// 2. scan_args with no redaction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_args_no_redact_passes_paths_through() {
+    let paths = vec![PathBuf::from("src"), PathBuf::from("tests")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.paths, vec!["src", "tests"]);
+}
+
+#[test]
+fn scan_args_no_redact_passes_excluded_through() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into(), "node_modules".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, None);
+    assert_eq!(args.excluded, vec!["target", "node_modules"]);
+    assert!(!args.excluded_redacted);
+}
+
+#[test]
+fn scan_args_redact_none_is_same_as_no_redact() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions::default();
+    let a1 = scan_args(&paths, &opts, None);
+    let a2 = scan_args(&paths, &opts, Some(RedactMode::None));
+    assert_eq!(a1.paths, a2.paths);
+    assert_eq!(a1.excluded, a2.excluded);
+}
+
+// ---------------------------------------------------------------------------
+// 3. scan_args with RedactMode::Paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_args_paths_mode_redacts_paths() {
+    let paths = vec![PathBuf::from("src/main.rs")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_ne!(args.paths[0], "src/main.rs");
+    // Redacted path should preserve .rs extension
+    assert!(args.paths[0].ends_with(".rs"), "got: {}", args.paths[0]);
+}
+
+#[test]
+fn scan_args_paths_mode_redacts_exclusions() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_ne!(args.excluded[0], "target");
+    assert!(args.excluded_redacted);
+}
+
+#[test]
+fn scan_args_paths_mode_empty_excluded_not_redacted() {
+    let paths = vec![PathBuf::from(".")];
+    let opts = ScanOptions::default();
+    let args = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert!(!args.excluded_redacted);
+    assert!(args.excluded.is_empty());
+}
+
+#[test]
+fn scan_args_all_mode_also_redacts() {
+    let paths = vec![PathBuf::from("src/lib.rs")];
+    let opts = ScanOptions {
+        excluded: vec!["vendor".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, Some(RedactMode::All));
+    assert_ne!(args.paths[0], "src/lib.rs");
+    assert_ne!(args.excluded[0], "vendor");
+    assert!(args.excluded_redacted);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Boolean flag propagation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hidden_flag_propagated() {
+    let opts = ScanOptions {
+        hidden: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.hidden);
+}
+
+#[test]
+fn treat_doc_strings_propagated() {
+    let opts = ScanOptions {
+        treat_doc_strings_as_comments: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn no_ignore_enables_all_sub_flags() {
+    let opts = ScanOptions {
+        no_ignore: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.no_ignore);
+    assert!(args.no_ignore_parent);
+    assert!(args.no_ignore_dot);
+    assert!(args.no_ignore_vcs);
+}
+
+#[test]
+fn no_ignore_parent_independent() {
+    let opts = ScanOptions {
+        no_ignore_parent: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(!args.no_ignore);
+    assert!(args.no_ignore_parent);
+    assert!(!args.no_ignore_dot);
+    assert!(!args.no_ignore_vcs);
+}
+
+#[test]
+fn no_ignore_dot_independent() {
+    let opts = ScanOptions {
+        no_ignore_dot: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.no_ignore_dot);
+    assert!(!args.no_ignore_parent);
+    assert!(!args.no_ignore_vcs);
+}
+
+#[test]
+fn no_ignore_vcs_independent() {
+    let opts = ScanOptions {
+        no_ignore_vcs: true,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert!(args.no_ignore_vcs);
+    assert!(!args.no_ignore_parent);
+    assert!(!args.no_ignore_dot);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Default values
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_scan_options_produces_clean_args() {
+    let args = scan_args(&[PathBuf::from(".")], &ScanOptions::default(), None);
+    assert_eq!(args.paths, vec!["."]);
+    assert!(args.excluded.is_empty());
+    assert!(!args.excluded_redacted);
+    assert!(!args.hidden);
+    assert!(!args.no_ignore);
+    assert!(!args.no_ignore_parent);
+    assert!(!args.no_ignore_dot);
+    assert!(!args.no_ignore_vcs);
+    assert!(!args.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn empty_paths_produces_empty_args_paths() {
+    let args = scan_args(&[], &ScanOptions::default(), None);
+    assert!(args.paths.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 6. Path normalization in args
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_args_normalizes_dot_prefix_in_paths() {
+    let paths = vec![PathBuf::from("./src/lib.rs")];
+    let args = scan_args(&paths, &ScanOptions::default(), None);
+    assert_eq!(args.paths[0], "src/lib.rs");
+}
+
+#[test]
+fn scan_args_normalizes_multiple_paths() {
+    let paths = vec![
+        PathBuf::from("./src"),
+        PathBuf::from("./tests"),
+        PathBuf::from("benches"),
+    ];
+    let args = scan_args(&paths, &ScanOptions::default(), None);
+    assert_eq!(args.paths, vec!["src", "tests", "benches"]);
+}
+
+// ---------------------------------------------------------------------------
+// 7. Deterministic arg generation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_args_deterministic_no_redact() {
+    let paths = vec![PathBuf::from("src"), PathBuf::from("tests")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        hidden: true,
+        ..Default::default()
+    };
+    let a1 = scan_args(&paths, &opts, None);
+    let a2 = scan_args(&paths, &opts, None);
+    assert_eq!(format!("{a1:?}"), format!("{a2:?}"));
+}
+
+#[test]
+fn scan_args_deterministic_with_redact() {
+    let paths = vec![PathBuf::from("src/main.rs")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into(), "vendor".into()],
+        ..Default::default()
+    };
+    let a1 = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    let a2 = scan_args(&paths, &opts, Some(RedactMode::Paths));
+    assert_eq!(a1.paths, a2.paths);
+    assert_eq!(a1.excluded, a2.excluded);
+}
+
+#[test]
+fn scan_args_100_calls_identical() {
+    let paths = vec![PathBuf::from("src")];
+    let opts = ScanOptions {
+        excluded: vec!["target".into()],
+        ..Default::default()
+    };
+    let expected = scan_args(&paths, &opts, Some(RedactMode::All));
+    for _ in 0..100 {
+        let actual = scan_args(&paths, &opts, Some(RedactMode::All));
+        assert_eq!(expected.paths, actual.paths);
+        assert_eq!(expected.excluded, actual.excluded);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 8. Redaction wiring correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redacted_paths_are_hex_prefixed() {
+    let paths = vec![PathBuf::from("src/main.rs")];
+    let args = scan_args(&paths, &ScanOptions::default(), Some(RedactMode::Paths));
+    let redacted = &args.paths[0];
+    // hash.ext format: first 16 chars are hex
+    let hash_part: String = redacted.chars().take(16).collect();
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "expected hex prefix, got: {hash_part}"
+    );
+}
+
+#[test]
+fn redacted_excluded_are_16_hex() {
+    let opts = ScanOptions {
+        excluded: vec!["target".into(), "*.log".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, Some(RedactMode::All));
+    for ex in &args.excluded {
+        assert_eq!(ex.len(), 16, "excluded hash wrong length: {ex}");
+        assert!(ex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}
+
+#[test]
+fn redacted_path_preserves_extension() {
+    let paths = vec![
+        PathBuf::from("src/main.rs"),
+        PathBuf::from("data/config.json"),
+        PathBuf::from("Makefile"),
+    ];
+    let args = scan_args(&paths, &ScanOptions::default(), Some(RedactMode::Paths));
+    assert!(args.paths[0].ends_with(".rs"));
+    assert!(args.paths[1].ends_with(".json"));
+    assert!(!args.paths[2].contains('.'));
+}
+
+#[test]
+fn redaction_does_not_leak_original_path() {
+    let paths = vec![PathBuf::from("secrets/passwords/vault.json")];
+    let opts = ScanOptions {
+        excluded: vec!["private_data".into()],
+        ..Default::default()
+    };
+    let args = scan_args(&paths, &opts, Some(RedactMode::All));
+    assert!(!args.paths[0].contains("secrets"));
+    assert!(!args.paths[0].contains("vault"));
+    assert!(!args.excluded[0].contains("private"));
+}
+
+// ---------------------------------------------------------------------------
+// 9. Multiple paths and exclusions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_args_multiple_exclusions_all_redacted() {
+    let opts = ScanOptions {
+        excluded: vec![
+            "target".into(),
+            "node_modules".into(),
+            "dist".into(),
+            ".git".into(),
+        ],
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, Some(RedactMode::Paths));
+    assert_eq!(args.excluded.len(), 4);
+    assert!(args.excluded_redacted);
+    for ex in &args.excluded {
+        assert_eq!(ex.len(), 16);
+    }
+}
+
+#[test]
+fn scan_args_multiple_paths_all_redacted() {
+    let paths: Vec<PathBuf> = vec!["src", "tests", "benches", "examples"]
+        .into_iter()
+        .map(PathBuf::from)
+        .collect();
+    let args = scan_args(&paths, &ScanOptions::default(), Some(RedactMode::All));
+    assert_eq!(args.paths.len(), 4);
+    for p in &args.paths {
+        assert_eq!(p.len(), 16, "no ext, should be bare hash: {p}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 10. Config mode propagation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_mode_auto_propagated() {
+    let opts = ScanOptions::default();
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert_eq!(
+        format!("{:?}", args.config),
+        format!("{:?}", tokmd_types::ConfigMode::Auto)
+    );
+}
+
+#[test]
+fn config_mode_none_propagated() {
+    let opts = ScanOptions {
+        config: tokmd_types::ConfigMode::None,
+        ..Default::default()
+    };
+    let args = scan_args(&[PathBuf::from(".")], &opts, None);
+    assert_eq!(
+        format!("{:?}", args.config),
+        format!("{:?}", tokmd_types::ConfigMode::None)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 11. Property tests (proptest)
+// ---------------------------------------------------------------------------
+
+mod property_tests {
+    use std::path::PathBuf;
+
+    use proptest::prelude::*;
+    use tokmd_scan_args::{normalize_scan_input, scan_args};
+    use tokmd_settings::ScanOptions;
+    use tokmd_types::RedactMode;
+
+    proptest! {
+        #[test]
+        fn normalize_never_empty(path in "[a-z./]{1,30}") {
+            let p = std::path::Path::new(&path);
+            let n = normalize_scan_input(p);
+            prop_assert!(!n.is_empty(), "normalized to empty for: {path}");
+        }
+
+        #[test]
+        fn normalize_no_leading_dot_slash(path in "[a-z]{1,5}(/[a-z]{1,5}){0,3}") {
+            let with_dot = format!("./{path}");
+            let n = normalize_scan_input(std::path::Path::new(&with_dot));
+            prop_assert!(!n.starts_with("./"), "still has dot prefix: {n}");
+        }
+
+        #[test]
+        fn scan_args_paths_count_matches(
+            count in 1usize..10,
+        ) {
+            let paths: Vec<PathBuf> = (0..count).map(|i| PathBuf::from(format!("dir{i}"))).collect();
+            let args = scan_args(&paths, &ScanOptions::default(), None);
+            prop_assert_eq!(args.paths.len(), count);
+        }
+
+        #[test]
+        fn scan_args_excluded_count_matches(
+            count in 0usize..10,
+        ) {
+            let opts = ScanOptions {
+                excluded: (0..count).map(|i| format!("ex{i}")).collect(),
+                ..Default::default()
+            };
+            let args = scan_args(&[PathBuf::from(".")], &opts, None);
+            prop_assert_eq!(args.excluded.len(), count);
+        }
+
+        #[test]
+        fn redacted_paths_always_have_hex_prefix(
+            name in "[a-z]{1,10}",
+            ext in "[a-z]{1,4}",
+        ) {
+            let path = PathBuf::from(format!("{name}.{ext}"));
+            let args = scan_args(&[path], &ScanOptions::default(), Some(RedactMode::Paths));
+            let redacted = &args.paths[0];
+            let hash_part: String = redacted.chars().take(16).collect();
+            prop_assert_eq!(hash_part.len(), 16);
+            prop_assert!(hash_part.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+
+        #[test]
+        fn redacted_excluded_always_16_hex(
+            ex in "[a-z_]{1,20}",
+        ) {
+            let opts = ScanOptions {
+                excluded: vec![ex.clone()],
+                ..Default::default()
+            };
+            let args = scan_args(&[PathBuf::from(".")], &opts, Some(RedactMode::All));
+            let h = &args.excluded[0];
+            prop_assert_eq!(h.len(), 16);
+            prop_assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+
+        #[test]
+        fn scan_args_deterministic(
+            name in "[a-z]{1,8}",
+            ex in "[a-z]{1,8}",
+        ) {
+            let paths = vec![PathBuf::from(&name)];
+            let opts = ScanOptions {
+                excluded: vec![ex],
+                ..Default::default()
+            };
+            let a1 = scan_args(&paths, &opts, Some(RedactMode::Paths));
+            let a2 = scan_args(&paths, &opts, Some(RedactMode::Paths));
+            prop_assert_eq!(a1.paths, a2.paths);
+            prop_assert_eq!(a1.excluded, a2.excluded);
+        }
+
+        #[test]
+        fn no_ignore_implies_sub_flags(
+            no_ignore in proptest::bool::ANY,
+        ) {
+            let opts = ScanOptions {
+                no_ignore,
+                ..Default::default()
+            };
+            let args = scan_args(&[PathBuf::from(".")], &opts, None);
+            if no_ignore {
+                prop_assert!(args.no_ignore_parent);
+                prop_assert!(args.no_ignore_dot);
+                prop_assert!(args.no_ignore_vcs);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Wave 63: redact + scan-args deep tests

Adds ~99 new tests covering:
- **tokmd-redact**: BLAKE3 hashing, path redaction, determinism
- **tokmd-scan-args**: ScanArgs construction, metadata, redaction wiring

### Testing
- cargo test -p tokmd-redact -p tokmd-scan-args
- All new tests pass locally

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>