### PR TITLE
test(w66): schema contract tests for receipt families (~75 tests)

### DIFF
--- a/crates/tokmd-analysis-types/tests/schema_contract_w66.rs
+++ b/crates/tokmd-analysis-types/tests/schema_contract_w66.rs
@@ -1,0 +1,393 @@
+//! Schema contract tests for `tokmd-analysis-types` receipt family.
+//!
+//! These tests verify that analysis receipt schemas are correct, stable,
+//! and backwards-compatible.
+
+use serde_json::Value;
+use std::collections::BTreeMap;
+use tokmd_analysis_types::*;
+use tokmd_types::{ScanStatus, ToolInfo};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_analysis_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo::current(),
+        mode: "analyze".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec![".".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "json".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            max_file_bytes: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+// ===========================================================================
+// 1. Schema version constant
+// ===========================================================================
+
+#[test]
+fn analysis_schema_version_is_positive() {
+    assert!(ANALYSIS_SCHEMA_VERSION > 0);
+}
+
+#[test]
+fn analysis_schema_version_value() {
+    assert_eq!(ANALYSIS_SCHEMA_VERSION, 8);
+}
+
+#[test]
+fn baseline_version_is_positive() {
+    assert!(BASELINE_VERSION > 0);
+}
+
+// ===========================================================================
+// 2. JSON roundtrip for AnalysisReceipt
+// ===========================================================================
+
+#[test]
+fn analysis_receipt_json_roundtrip() {
+    let receipt = make_analysis_receipt();
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, ANALYSIS_SCHEMA_VERSION);
+    assert_eq!(back.mode, "analyze");
+}
+
+#[test]
+fn analysis_receipt_envelope_has_schema_version() {
+    let receipt = make_analysis_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(val["schema_version"], ANALYSIS_SCHEMA_VERSION);
+}
+
+#[test]
+fn analysis_receipt_with_all_optional_sections_roundtrip() {
+    let mut receipt = make_analysis_receipt();
+    receipt.archetype = Some(Archetype {
+        kind: "library".into(),
+        evidence: vec!["Cargo.toml".into()],
+    });
+    receipt.entropy = Some(EntropyReport {
+        suspects: vec![EntropyFinding {
+            path: "secrets.bin".into(),
+            module: "src".into(),
+            entropy_bits_per_byte: 7.8,
+            sample_bytes: 1024,
+            class: EntropyClass::High,
+        }],
+    });
+    receipt.fun = Some(FunReport {
+        eco_label: Some(EcoLabel {
+            score: 0.9,
+            label: "Green".into(),
+            bytes: 1000,
+            notes: "Eco-friendly".into(),
+        }),
+    });
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: AnalysisReceipt = serde_json::from_str(&json).unwrap();
+    assert!(back.archetype.is_some());
+    assert!(back.entropy.is_some());
+    assert!(back.fun.is_some());
+}
+
+// ===========================================================================
+// 3. Optional fields don't break deserialization of old format
+// ===========================================================================
+
+#[test]
+fn analysis_receipt_ignores_extra_fields() {
+    let receipt = make_analysis_receipt();
+    let mut json: Value = serde_json::to_value(&receipt).unwrap();
+    json["future_enricher"] = Value::String("new_data".into());
+    json["v9_section"] = serde_json::json!({"score": 42});
+    let back: AnalysisReceipt = serde_json::from_value(json).unwrap();
+    assert_eq!(back.schema_version, ANALYSIS_SCHEMA_VERSION);
+}
+
+#[test]
+fn analysis_receipt_missing_optional_sections_ok() {
+    let receipt = make_analysis_receipt();
+    let mut json: Value = serde_json::to_value(&receipt).unwrap();
+    let obj = json.as_object_mut().unwrap();
+    obj.remove("api_surface");
+    obj.remove("fun");
+    obj.remove("complexity");
+    let back: AnalysisReceipt = serde_json::from_value(json).unwrap();
+    assert!(back.api_surface.is_none());
+    assert!(back.fun.is_none());
+    assert!(back.complexity.is_none());
+}
+
+// ===========================================================================
+// 4. Enum variants serialize to expected case
+// ===========================================================================
+
+#[test]
+fn entropy_class_serializes_snake_case() {
+    assert_eq!(serde_json::to_string(&EntropyClass::Low).unwrap(), "\"low\"");
+    assert_eq!(serde_json::to_string(&EntropyClass::Normal).unwrap(), "\"normal\"");
+    assert_eq!(
+        serde_json::to_string(&EntropyClass::Suspicious).unwrap(),
+        "\"suspicious\""
+    );
+    assert_eq!(serde_json::to_string(&EntropyClass::High).unwrap(), "\"high\"");
+}
+
+#[test]
+fn trend_class_serializes_snake_case() {
+    assert_eq!(serde_json::to_string(&TrendClass::Rising).unwrap(), "\"rising\"");
+    assert_eq!(serde_json::to_string(&TrendClass::Flat).unwrap(), "\"flat\"");
+    assert_eq!(serde_json::to_string(&TrendClass::Falling).unwrap(), "\"falling\"");
+}
+
+#[test]
+fn license_source_kind_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&LicenseSourceKind::Metadata).unwrap(),
+        "\"metadata\""
+    );
+    assert_eq!(
+        serde_json::to_string(&LicenseSourceKind::Text).unwrap(),
+        "\"text\""
+    );
+}
+
+#[test]
+fn complexity_risk_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&ComplexityRisk::Low).unwrap(),
+        "\"low\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ComplexityRisk::Moderate).unwrap(),
+        "\"moderate\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ComplexityRisk::Critical).unwrap(),
+        "\"critical\""
+    );
+}
+
+#[test]
+fn technical_debt_level_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&TechnicalDebtLevel::Low).unwrap(),
+        "\"low\""
+    );
+    assert_eq!(
+        serde_json::to_string(&TechnicalDebtLevel::Moderate).unwrap(),
+        "\"moderate\""
+    );
+    assert_eq!(
+        serde_json::to_string(&TechnicalDebtLevel::High).unwrap(),
+        "\"high\""
+    );
+    assert_eq!(
+        serde_json::to_string(&TechnicalDebtLevel::Critical).unwrap(),
+        "\"critical\""
+    );
+}
+
+#[test]
+fn near_dup_scope_serializes_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&NearDupScope::Module).unwrap(),
+        "\"module\""
+    );
+    assert_eq!(
+        serde_json::to_string(&NearDupScope::Lang).unwrap(),
+        "\"lang\""
+    );
+    assert_eq!(
+        serde_json::to_string(&NearDupScope::Global).unwrap(),
+        "\"global\""
+    );
+}
+
+// ===========================================================================
+// 5. Nested type roundtrips
+// ===========================================================================
+
+#[test]
+fn complexity_baseline_json_roundtrip() {
+    let baseline = ComplexityBaseline::new();
+    let json = serde_json::to_string_pretty(&baseline).unwrap();
+    let back: ComplexityBaseline = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.baseline_version, BASELINE_VERSION);
+}
+
+#[test]
+fn topic_clouds_json_roundtrip() {
+    let clouds = TopicClouds {
+        per_module: {
+            let mut m = BTreeMap::new();
+            m.insert(
+                "src".into(),
+                vec![TopicTerm {
+                    term: "parser".into(),
+                    score: 0.85,
+                    tf: 10,
+                    df: 2,
+                }],
+            );
+            m
+        },
+        overall: vec![TopicTerm {
+            term: "analysis".into(),
+            score: 0.9,
+            tf: 20,
+            df: 5,
+        }],
+    };
+    let json = serde_json::to_string_pretty(&clouds).unwrap();
+    let back: TopicClouds = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.overall.len(), 1);
+    assert_eq!(back.per_module.len(), 1);
+}
+
+#[test]
+fn near_duplicate_report_json_roundtrip() {
+    let report = NearDuplicateReport {
+        params: NearDupParams {
+            scope: NearDupScope::Module,
+            threshold: 0.8,
+            max_files: 500,
+            max_pairs: Some(1000),
+            max_file_bytes: None,
+            selection_method: None,
+            algorithm: None,
+            exclude_patterns: vec![],
+        },
+        pairs: vec![NearDupPairRow {
+            left: "a.rs".into(),
+            right: "b.rs".into(),
+            similarity: 0.92,
+            shared_fingerprints: 100,
+            left_fingerprints: 110,
+            right_fingerprints: 105,
+        }],
+        files_analyzed: 50,
+        files_skipped: 2,
+        eligible_files: Some(52),
+        clusters: None,
+        truncated: false,
+        excluded_by_pattern: None,
+        stats: None,
+    };
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let back: NearDuplicateReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.pairs.len(), 1);
+    assert!(!back.truncated);
+}
+
+// ===========================================================================
+// 6. Field name stability
+// ===========================================================================
+
+#[test]
+fn analysis_receipt_required_fields_present() {
+    let receipt = make_analysis_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    let obj = val.as_object().unwrap();
+    let expected_keys = [
+        "schema_version",
+        "generated_at_ms",
+        "tool",
+        "mode",
+        "status",
+        "warnings",
+        "source",
+        "args",
+    ];
+    for key in &expected_keys {
+        assert!(obj.contains_key(*key), "Missing expected key: {key}");
+    }
+}
+
+#[test]
+fn analysis_args_meta_field_names_stable() {
+    let args = AnalysisArgsMeta {
+        preset: "receipt".into(),
+        format: "json".into(),
+        window_tokens: Some(128_000),
+        git: Some(true),
+        max_files: None,
+        max_bytes: None,
+        max_commits: None,
+        max_commit_files: None,
+        max_file_bytes: None,
+        import_granularity: "module".into(),
+    };
+    let json = serde_json::to_string(&args).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    let obj = val.as_object().unwrap();
+    assert!(obj.contains_key("preset"));
+    assert!(obj.contains_key("format"));
+    assert!(obj.contains_key("import_granularity"));
+}
+
+#[test]
+fn commit_intent_kind_all_variants_roundtrip() {
+    let variants = [
+        CommitIntentKind::Feat,
+        CommitIntentKind::Fix,
+        CommitIntentKind::Refactor,
+        CommitIntentKind::Docs,
+        CommitIntentKind::Test,
+        CommitIntentKind::Chore,
+        CommitIntentKind::Ci,
+        CommitIntentKind::Build,
+        CommitIntentKind::Perf,
+        CommitIntentKind::Style,
+        CommitIntentKind::Revert,
+        CommitIntentKind::Other,
+    ];
+    for variant in variants {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: CommitIntentKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}

--- a/crates/tokmd-envelope/tests/schema_contract_w66.rs
+++ b/crates/tokmd-envelope/tests/schema_contract_w66.rs
@@ -1,0 +1,261 @@
+//! Schema contract tests for `tokmd-envelope` (SensorReport envelope).
+//!
+//! These tests verify that the SensorReport envelope structure is correct,
+//! stable, and backwards-compatible.
+
+use serde_json::Value;
+use std::collections::BTreeMap;
+use tokmd_envelope::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_sensor_report() -> SensorReport {
+    SensorReport::new(
+        ToolMeta::tokmd("1.5.0", "cockpit"),
+        "2024-01-15T10:30:00Z".into(),
+        Verdict::Pass,
+        "All checks passed".into(),
+    )
+}
+
+fn make_finding() -> Finding {
+    Finding::new(
+        "risk",
+        "hotspot",
+        FindingSeverity::Warn,
+        "High-churn file",
+        "src/lib.rs modified 42 times in 30 days",
+    )
+    .with_location(FindingLocation::path_line("src/lib.rs", 1))
+}
+
+// ===========================================================================
+// 1. Schema constant
+// ===========================================================================
+
+#[test]
+fn sensor_report_schema_constant_is_set() {
+    assert_eq!(SENSOR_REPORT_SCHEMA, "sensor.report.v1");
+}
+
+// ===========================================================================
+// 2. JSON roundtrip for envelope types
+// ===========================================================================
+
+#[test]
+fn sensor_report_json_roundtrip() {
+    let report = make_sensor_report();
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema, SENSOR_REPORT_SCHEMA);
+    assert_eq!(back.verdict, Verdict::Pass);
+    assert!(back.findings.is_empty());
+}
+
+#[test]
+fn sensor_report_with_findings_roundtrip() {
+    let mut report = make_sensor_report();
+    report.add_finding(make_finding());
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.findings.len(), 1);
+    assert_eq!(back.findings[0].check_id, "risk");
+    assert_eq!(back.findings[0].code, "hotspot");
+}
+
+#[test]
+fn finding_json_roundtrip() {
+    let finding = make_finding();
+    let json = serde_json::to_string_pretty(&finding).unwrap();
+    let back: Finding = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.check_id, "risk");
+    assert_eq!(back.code, "hotspot");
+    assert_eq!(back.severity, FindingSeverity::Warn);
+    assert!(back.location.is_some());
+}
+
+#[test]
+fn gate_results_json_roundtrip() {
+    let gates = GateResults::new(
+        Verdict::Pass,
+        vec![
+            GateItem::new("mutation", Verdict::Pass),
+            GateItem::new("coverage", Verdict::Warn)
+                .with_threshold(80.0, 75.5)
+                .with_reason("Below target"),
+        ],
+    );
+    let json = serde_json::to_string_pretty(&gates).unwrap();
+    let back: GateResults = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.status, Verdict::Pass);
+    assert_eq!(back.items.len(), 2);
+}
+
+#[test]
+fn artifact_json_roundtrip() {
+    let art = Artifact::receipt("output/receipt.json")
+        .with_id("analysis")
+        .with_mime("application/json");
+    let json = serde_json::to_string_pretty(&art).unwrap();
+    let back: Artifact = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.artifact_type, "receipt");
+    assert_eq!(back.id.as_deref(), Some("analysis"));
+    assert_eq!(back.mime.as_deref(), Some("application/json"));
+}
+
+#[test]
+fn tool_meta_json_roundtrip() {
+    let meta = ToolMeta::new("my-sensor", "0.2.0", "scan");
+    let json = serde_json::to_string_pretty(&meta).unwrap();
+    let back: ToolMeta = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.name, "my-sensor");
+    assert_eq!(back.version, "0.2.0");
+    assert_eq!(back.mode, "scan");
+}
+
+// ===========================================================================
+// 3. Finding IDs are present and unique
+// ===========================================================================
+
+#[test]
+fn finding_fingerprint_is_deterministic() {
+    let f1 = make_finding().with_fingerprint("tokmd");
+    let f2 = make_finding().with_fingerprint("tokmd");
+    assert_eq!(f1.fingerprint, f2.fingerprint);
+    assert!(f1.fingerprint.is_some());
+    assert_eq!(f1.fingerprint.as_ref().unwrap().len(), 32);
+}
+
+#[test]
+fn different_findings_have_different_fingerprints() {
+    let f1 = Finding::new("risk", "hotspot", FindingSeverity::Warn, "A", "B")
+        .with_location(FindingLocation::path("src/a.rs"))
+        .with_fingerprint("tokmd");
+    let f2 = Finding::new("risk", "coupling", FindingSeverity::Warn, "C", "D")
+        .with_location(FindingLocation::path("src/b.rs"))
+        .with_fingerprint("tokmd");
+    assert_ne!(f1.fingerprint, f2.fingerprint);
+}
+
+// ===========================================================================
+// 4. Envelope metadata fields
+// ===========================================================================
+
+#[test]
+fn sensor_report_envelope_has_required_fields() {
+    let report = make_sensor_report();
+    let json = serde_json::to_string(&report).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    let obj = val.as_object().unwrap();
+    let expected_keys = ["schema", "tool", "generated_at", "verdict", "summary", "findings"];
+    for key in &expected_keys {
+        assert!(obj.contains_key(*key), "Missing expected key: {key}");
+    }
+}
+
+#[test]
+fn sensor_report_schema_field_is_correct() {
+    let report = make_sensor_report();
+    let json = serde_json::to_string(&report).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(val["schema"], "sensor.report.v1");
+}
+
+// ===========================================================================
+// 5. Enum variants serialize to lowercase
+// ===========================================================================
+
+#[test]
+fn verdict_serializes_lowercase() {
+    assert_eq!(serde_json::to_string(&Verdict::Pass).unwrap(), "\"pass\"");
+    assert_eq!(serde_json::to_string(&Verdict::Fail).unwrap(), "\"fail\"");
+    assert_eq!(serde_json::to_string(&Verdict::Warn).unwrap(), "\"warn\"");
+    assert_eq!(serde_json::to_string(&Verdict::Skip).unwrap(), "\"skip\"");
+    assert_eq!(serde_json::to_string(&Verdict::Pending).unwrap(), "\"pending\"");
+}
+
+#[test]
+fn finding_severity_serializes_lowercase() {
+    assert_eq!(
+        serde_json::to_string(&FindingSeverity::Error).unwrap(),
+        "\"error\""
+    );
+    assert_eq!(
+        serde_json::to_string(&FindingSeverity::Warn).unwrap(),
+        "\"warn\""
+    );
+    assert_eq!(
+        serde_json::to_string(&FindingSeverity::Info).unwrap(),
+        "\"info\""
+    );
+}
+
+#[test]
+fn capability_state_serializes_lowercase() {
+    assert_eq!(
+        serde_json::to_string(&CapabilityState::Available).unwrap(),
+        "\"available\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CapabilityState::Unavailable).unwrap(),
+        "\"unavailable\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CapabilityState::Skipped).unwrap(),
+        "\"skipped\""
+    );
+}
+
+// ===========================================================================
+// 6. Backward compat: extra fields don't break deserialization
+// ===========================================================================
+
+#[test]
+fn sensor_report_ignores_extra_fields() {
+    let report = make_sensor_report();
+    let mut json: Value = serde_json::to_value(&report).unwrap();
+    json["v2_addition"] = Value::String("new".into());
+    json["extra_metrics"] = serde_json::json!({"score": 100});
+    let back: SensorReport = serde_json::from_value(json).unwrap();
+    assert_eq!(back.schema, SENSOR_REPORT_SCHEMA);
+}
+
+// ===========================================================================
+// 7. Capabilities (No Green By Omission)
+// ===========================================================================
+
+#[test]
+fn sensor_report_with_capabilities_roundtrip() {
+    let mut report = make_sensor_report();
+    let mut caps = BTreeMap::new();
+    caps.insert("mutation".into(), CapabilityStatus::available());
+    caps.insert(
+        "coverage".into(),
+        CapabilityStatus::unavailable("No coverage data"),
+    );
+    caps.insert(
+        "complexity".into(),
+        CapabilityStatus::skipped("No relevant files"),
+    );
+    report = report.with_capabilities(caps);
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    let caps = back.capabilities.unwrap();
+    assert_eq!(caps.len(), 3);
+    assert_eq!(caps["mutation"].status, CapabilityState::Available);
+    assert_eq!(caps["coverage"].status, CapabilityState::Unavailable);
+}
+
+#[test]
+fn sensor_report_with_data_payload_roundtrip() {
+    let report = make_sensor_report().with_data(serde_json::json!({
+        "custom_metric": 42,
+        "details": ["a", "b"]
+    }));
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    let data = back.data.unwrap();
+    assert_eq!(data["custom_metric"], 42);
+}

--- a/crates/tokmd-ffi-envelope/tests/schema_contract_w66.rs
+++ b/crates/tokmd-ffi-envelope/tests/schema_contract_w66.rs
@@ -1,0 +1,148 @@
+//! Schema contract tests for `tokmd-ffi-envelope` (FFI response envelope).
+//!
+//! These tests verify that the FFI JSON envelope structure `{"ok": bool, "data": ..., "error": ...}`
+//! is correct, stable, and backwards-compatible.
+
+use serde_json::{json, Value};
+use tokmd_ffi_envelope::*;
+
+// ===========================================================================
+// 1. Success envelope structure: {"ok": true, "data": ...}
+// ===========================================================================
+
+#[test]
+fn success_envelope_has_ok_true() {
+    let envelope = json!({"ok": true, "data": {"mode": "lang"}});
+    let val = parse_envelope(&envelope.to_string()).unwrap();
+    assert_eq!(val["ok"], true);
+}
+
+#[test]
+fn success_envelope_data_extraction() {
+    let envelope = json!({"ok": true, "data": {"schema_version": 2, "mode": "lang"}});
+    let data = extract_data(envelope).unwrap();
+    assert_eq!(data["schema_version"], 2);
+    assert_eq!(data["mode"], "lang");
+}
+
+#[test]
+fn success_envelope_without_data_returns_full_envelope() {
+    let envelope = json!({"ok": true, "schema_version": 2});
+    let data = extract_data(envelope.clone()).unwrap();
+    assert_eq!(data, envelope);
+}
+
+// ===========================================================================
+// 2. Error envelope structure: {"ok": false, "error": {"code": ..., "message": ...}}
+// ===========================================================================
+
+#[test]
+fn error_envelope_has_ok_false() {
+    let envelope = json!({
+        "ok": false,
+        "error": {"code": "scan_failed", "message": "Path not found"}
+    });
+    let err = extract_data(envelope).unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::Upstream(_)));
+}
+
+#[test]
+fn error_envelope_message_format() {
+    let envelope = json!({
+        "ok": false,
+        "error": {"code": "unknown_mode", "message": "Unknown mode: nope"}
+    });
+    let err = extract_data(envelope).unwrap_err();
+    assert_eq!(err.to_string(), "[unknown_mode] Unknown mode: nope");
+}
+
+#[test]
+fn error_envelope_missing_code_defaults() {
+    let err = json!({"message": "Something broke"});
+    let msg = format_error_message(Some(&err));
+    assert_eq!(msg, "[unknown] Something broke");
+}
+
+#[test]
+fn error_envelope_missing_message_defaults() {
+    let err = json!({"code": "my_code"});
+    let msg = format_error_message(Some(&err));
+    assert_eq!(msg, "[my_code] Unknown error");
+}
+
+#[test]
+fn error_envelope_null_error_defaults() {
+    let msg = format_error_message(None);
+    assert_eq!(msg, "Unknown error");
+}
+
+// ===========================================================================
+// 3. Invalid envelope handling
+// ===========================================================================
+
+#[test]
+fn non_object_envelope_is_invalid_format() {
+    let err = extract_data(json!(["not", "an", "envelope"])).unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::InvalidResponseFormat));
+}
+
+#[test]
+fn non_json_input_returns_parse_error() {
+    let err = parse_envelope("{invalid json").unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::JsonParse(_)));
+}
+
+#[test]
+fn missing_ok_field_treated_as_false() {
+    let envelope = json!({"data": {"mode": "lang"}});
+    let err = extract_data(envelope).unwrap_err();
+    assert!(matches!(err, EnvelopeExtractError::Upstream(_)));
+}
+
+// ===========================================================================
+// 4. JSON output stability
+// ===========================================================================
+
+#[test]
+fn extract_data_json_returns_valid_json() {
+    let input = json!({"ok": true, "data": {"v": 1, "mode": "export"}});
+    let json_str = extract_data_json(&input.to_string()).unwrap();
+    let parsed: Value = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(parsed["v"], 1);
+    assert_eq!(parsed["mode"], "export");
+}
+
+#[test]
+fn extract_data_from_json_convenience() {
+    let input = r#"{"ok": true, "data": {"schema_version": 2}}"#;
+    let data = extract_data_from_json(input).unwrap();
+    assert_eq!(data["schema_version"], 2);
+}
+
+#[test]
+fn error_envelope_error_variants_are_eq() {
+    let err1 = EnvelopeExtractError::Upstream("boom".into());
+    let err2 = EnvelopeExtractError::Upstream("boom".into());
+    assert_eq!(err1, err2);
+
+    let err3 = EnvelopeExtractError::InvalidResponseFormat;
+    let err4 = EnvelopeExtractError::InvalidResponseFormat;
+    assert_eq!(err3, err4);
+}
+
+#[test]
+fn envelope_preserves_nested_data_types() {
+    let envelope = json!({
+        "ok": true,
+        "data": {
+            "schema_version": 2,
+            "generated_at_ms": 1700000000000_u64,
+            "rows": [{"lang": "Rust", "code": 100}],
+            "nested": {"deep": true}
+        }
+    });
+    let data = extract_data(envelope).unwrap();
+    assert_eq!(data["schema_version"], 2);
+    assert!(data["rows"].is_array());
+    assert_eq!(data["nested"]["deep"], true);
+}

--- a/crates/tokmd-types/tests/schema_contract_w66.rs
+++ b/crates/tokmd-types/tests/schema_contract_w66.rs
@@ -1,0 +1,511 @@
+//! Schema contract tests for `tokmd-types` receipt families.
+//!
+//! These tests verify that receipt JSON schemas are correct, stable,
+//! and backwards-compatible. They guard against accidental breaking
+//! changes to the serialized contract consumed by downstream tools.
+
+use serde_json::Value;
+use tokmd_types::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_scan_args() -> ScanArgs {
+    ScanArgs {
+        paths: vec![".".into()],
+        excluded: vec![],
+        excluded_redacted: false,
+        config: ConfigMode::Auto,
+        hidden: false,
+        no_ignore: false,
+        no_ignore_parent: false,
+        no_ignore_dot: false,
+        no_ignore_vcs: false,
+        treat_doc_strings_as_comments: false,
+    }
+}
+
+fn make_totals() -> Totals {
+    Totals {
+        code: 100,
+        lines: 150,
+        files: 5,
+        bytes: 4000,
+        tokens: 1000,
+        avg_lines: 30,
+    }
+}
+
+fn make_lang_receipt() -> LangReceipt {
+    LangReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo::current(),
+        mode: "lang".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        scan: make_scan_args(),
+        args: LangArgsMeta {
+            format: "json".into(),
+            top: 10,
+            with_files: false,
+            children: ChildrenMode::Collapse,
+        },
+        report: LangReport {
+            rows: vec![LangRow {
+                lang: "Rust".into(),
+                code: 100,
+                lines: 150,
+                files: 5,
+                bytes: 4000,
+                tokens: 1000,
+                avg_lines: 30,
+            }],
+            total: make_totals(),
+            with_files: false,
+            children: ChildrenMode::Collapse,
+            top: 10,
+        },
+    }
+}
+
+fn make_module_receipt() -> ModuleReceipt {
+    ModuleReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo::current(),
+        mode: "module".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        scan: make_scan_args(),
+        args: ModuleArgsMeta {
+            format: "json".into(),
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+            top: 10,
+        },
+        report: ModuleReport {
+            rows: vec![ModuleRow {
+                module: "src".into(),
+                code: 100,
+                lines: 150,
+                files: 5,
+                bytes: 4000,
+                tokens: 1000,
+                avg_lines: 30,
+            }],
+            total: make_totals(),
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+            top: 10,
+        },
+    }
+}
+
+fn make_export_receipt() -> ExportReceipt {
+    ExportReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo::current(),
+        mode: "export".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        scan: make_scan_args(),
+        args: ExportArgsMeta {
+            format: ExportFormat::Json,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+            min_code: 0,
+            max_rows: 1000,
+            redact: RedactMode::None,
+            strip_prefix: None,
+            strip_prefix_redacted: false,
+        },
+        data: ExportData {
+            rows: vec![FileRow {
+                path: "src/main.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                kind: FileKind::Parent,
+                code: 100,
+                comments: 20,
+                blanks: 30,
+                lines: 150,
+                bytes: 4000,
+                tokens: 1000,
+            }],
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+        },
+    }
+}
+
+fn make_diff_receipt() -> DiffReceipt {
+    DiffReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo::current(),
+        mode: "diff".into(),
+        from_source: "old.json".into(),
+        to_source: "new.json".into(),
+        diff_rows: vec![],
+        totals: DiffTotals::default(),
+    }
+}
+
+fn make_context_receipt() -> ContextReceipt {
+    ContextReceipt {
+        schema_version: CONTEXT_SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo::current(),
+        mode: "context".into(),
+        budget_tokens: 128_000,
+        used_tokens: 50_000,
+        utilization_pct: 39.06,
+        strategy: "greedy".into(),
+        rank_by: "tokens".into(),
+        file_count: 10,
+        files: vec![],
+        rank_by_effective: None,
+        fallback_reason: None,
+        excluded_by_policy: vec![],
+        token_estimation: None,
+        bundle_audit: None,
+    }
+}
+
+fn make_handoff_manifest() -> HandoffManifest {
+    HandoffManifest {
+        schema_version: HANDOFF_SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo::current(),
+        mode: "handoff".into(),
+        inputs: vec![".".into()],
+        output_dir: "output".into(),
+        budget_tokens: 128_000,
+        used_tokens: 50_000,
+        utilization_pct: 39.06,
+        strategy: "greedy".into(),
+        rank_by: "tokens".into(),
+        capabilities: vec![],
+        artifacts: vec![],
+        included_files: vec![],
+        excluded_paths: vec![],
+        excluded_patterns: vec![],
+        smart_excluded_files: vec![],
+        total_files: 10,
+        bundled_files: 5,
+        intelligence_preset: "none".into(),
+        rank_by_effective: None,
+        fallback_reason: None,
+        excluded_by_policy: vec![],
+        token_estimation: None,
+        code_audit: None,
+    }
+}
+
+// ===========================================================================
+// 1. Schema version constants are positive integers
+// ===========================================================================
+
+#[test]
+fn schema_version_is_positive() {
+    assert!(SCHEMA_VERSION > 0);
+}
+
+#[test]
+fn context_schema_version_is_positive() {
+    assert!(CONTEXT_SCHEMA_VERSION > 0);
+}
+
+#[test]
+fn context_bundle_schema_version_is_positive() {
+    assert!(CONTEXT_BUNDLE_SCHEMA_VERSION > 0);
+}
+
+#[test]
+fn cockpit_schema_version_is_positive() {
+    assert!(cockpit::COCKPIT_SCHEMA_VERSION > 0);
+}
+
+#[test]
+fn handoff_schema_version_is_positive() {
+    assert!(HANDOFF_SCHEMA_VERSION > 0);
+}
+
+// ===========================================================================
+// 2. JSON roundtrip for every receipt type
+// ===========================================================================
+
+#[test]
+fn lang_receipt_json_roundtrip() {
+    let receipt = make_lang_receipt();
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: LangReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.mode, "lang");
+}
+
+#[test]
+fn module_receipt_json_roundtrip() {
+    let receipt = make_module_receipt();
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: ModuleReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.mode, "module");
+}
+
+#[test]
+fn export_receipt_json_roundtrip() {
+    let receipt = make_export_receipt();
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: ExportReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.mode, "export");
+}
+
+#[test]
+fn diff_receipt_json_roundtrip() {
+    let receipt = make_diff_receipt();
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: DiffReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+    assert_eq!(back.mode, "diff");
+}
+
+#[test]
+fn context_receipt_json_roundtrip() {
+    let receipt = make_context_receipt();
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: ContextReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, CONTEXT_SCHEMA_VERSION);
+    assert_eq!(back.mode, "context");
+}
+
+#[test]
+fn handoff_manifest_json_roundtrip() {
+    let manifest = make_handoff_manifest();
+    let json = serde_json::to_string_pretty(&manifest).unwrap();
+    let back: HandoffManifest = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, HANDOFF_SCHEMA_VERSION);
+    assert_eq!(back.mode, "handoff");
+}
+
+#[test]
+fn run_receipt_json_roundtrip() {
+    let receipt = RunReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        lang_file: "lang.json".into(),
+        module_file: "module.json".into(),
+        export_file: "export.json".into(),
+    };
+    let json = serde_json::to_string_pretty(&receipt).unwrap();
+    let back: RunReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+}
+
+// ===========================================================================
+// 3. Receipt envelope metadata includes schema_version in JSON output
+// ===========================================================================
+
+#[test]
+fn lang_receipt_envelope_has_schema_version() {
+    let receipt = make_lang_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(val["schema_version"], SCHEMA_VERSION);
+}
+
+#[test]
+fn export_receipt_envelope_has_schema_version() {
+    let receipt = make_export_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(val["schema_version"], SCHEMA_VERSION);
+}
+
+#[test]
+fn context_receipt_envelope_has_schema_version() {
+    let receipt = make_context_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(val["schema_version"], CONTEXT_SCHEMA_VERSION);
+}
+
+#[test]
+fn handoff_manifest_envelope_has_schema_version() {
+    let manifest = make_handoff_manifest();
+    let json = serde_json::to_string(&manifest).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(val["schema_version"], HANDOFF_SCHEMA_VERSION);
+}
+
+// ===========================================================================
+// 4. Serde field names match expected snake_case contract
+// ===========================================================================
+
+#[test]
+fn lang_receipt_field_names_are_snake_case() {
+    let receipt = make_lang_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    let obj = val.as_object().unwrap();
+    for key in obj.keys() {
+        assert!(
+            !key.contains('-') || key == "treat-doc-strings-as-comments",
+            "Unexpected non-snake_case key in lang receipt: {key}"
+        );
+        assert!(
+            *key == key.to_lowercase() || key.contains('_'),
+            "Key should be lowercase or snake_case: {key}"
+        );
+    }
+}
+
+#[test]
+fn diff_receipt_field_names_stable() {
+    let receipt = make_diff_receipt();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    let obj = val.as_object().unwrap();
+    let expected_keys = [
+        "schema_version",
+        "generated_at_ms",
+        "tool",
+        "mode",
+        "from_source",
+        "to_source",
+        "diff_rows",
+        "totals",
+    ];
+    for key in &expected_keys {
+        assert!(obj.contains_key(*key), "Missing expected key: {key}");
+    }
+}
+
+// ===========================================================================
+// 5. Backward compat: extra fields don't break deserialization
+// ===========================================================================
+
+#[test]
+fn lang_receipt_ignores_extra_fields() {
+    let receipt = make_lang_receipt();
+    let mut json: Value = serde_json::to_value(&receipt).unwrap();
+    json["new_future_field"] = Value::String("hello".into());
+    json["another_field"] = Value::Number(42.into());
+    let back: LangReceipt = serde_json::from_value(json).unwrap();
+    assert_eq!(back.schema_version, SCHEMA_VERSION);
+}
+
+#[test]
+fn export_receipt_ignores_extra_fields() {
+    let receipt = make_export_receipt();
+    let mut json: Value = serde_json::to_value(&receipt).unwrap();
+    json["future_v3_field"] = Value::Bool(true);
+    let back: ExportReceipt = serde_json::from_value(json).unwrap();
+    assert_eq!(back.mode, "export");
+}
+
+#[test]
+fn diff_receipt_ignores_extra_fields() {
+    let receipt = make_diff_receipt();
+    let mut json: Value = serde_json::to_value(&receipt).unwrap();
+    json["extra"] = Value::Null;
+    let back: DiffReceipt = serde_json::from_value(json).unwrap();
+    assert_eq!(back.mode, "diff");
+}
+
+#[test]
+fn context_receipt_ignores_extra_fields() {
+    let receipt = make_context_receipt();
+    let mut json: Value = serde_json::to_value(&receipt).unwrap();
+    json["v5_addition"] = Value::String("compat".into());
+    let back: ContextReceipt = serde_json::from_value(json).unwrap();
+    assert_eq!(back.mode, "context");
+}
+
+// ===========================================================================
+// 6. Enum variants serialize to expected case
+// ===========================================================================
+
+#[test]
+fn scan_status_serializes_snake_case() {
+    assert_eq!(serde_json::to_string(&ScanStatus::Complete).unwrap(), "\"complete\"");
+    assert_eq!(serde_json::to_string(&ScanStatus::Partial).unwrap(), "\"partial\"");
+}
+
+#[test]
+fn children_mode_serializes_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&ChildrenMode::Collapse).unwrap(),
+        "\"collapse\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ChildrenMode::Separate).unwrap(),
+        "\"separate\""
+    );
+}
+
+#[test]
+fn file_classification_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&FileClassification::Generated).unwrap(),
+        "\"generated\""
+    );
+    assert_eq!(
+        serde_json::to_string(&FileClassification::DataBlob).unwrap(),
+        "\"data_blob\""
+    );
+    assert_eq!(
+        serde_json::to_string(&FileClassification::Sourcemap).unwrap(),
+        "\"sourcemap\""
+    );
+}
+
+#[test]
+fn inclusion_policy_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&InclusionPolicy::Full).unwrap(),
+        "\"full\""
+    );
+    assert_eq!(
+        serde_json::to_string(&InclusionPolicy::HeadTail).unwrap(),
+        "\"head_tail\""
+    );
+    assert_eq!(
+        serde_json::to_string(&InclusionPolicy::Skip).unwrap(),
+        "\"skip\""
+    );
+}
+
+#[test]
+fn commit_intent_kind_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&CommitIntentKind::Feat).unwrap(),
+        "\"feat\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CommitIntentKind::Fix).unwrap(),
+        "\"fix\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CommitIntentKind::Refactor).unwrap(),
+        "\"refactor\""
+    );
+}
+
+#[test]
+fn export_format_serializes_kebab_case() {
+    assert_eq!(serde_json::to_string(&ExportFormat::Csv).unwrap(), "\"csv\"");
+    assert_eq!(serde_json::to_string(&ExportFormat::Jsonl).unwrap(), "\"jsonl\"");
+    assert_eq!(
+        serde_json::to_string(&ExportFormat::Cyclonedx).unwrap(),
+        "\"cyclonedx\""
+    );
+}


### PR DESCRIPTION
## Summary

Add comprehensive schema contract tests that verify receipt schemas are correct, stable, and backwards-compatible across four crates (~80 tests total).

### Test Files

| Crate | File | Tests |
|-------|------|-------|
| \	okmd-types\ | \	ests/schema_contract_w66.rs\ | 28 |
| \	okmd-analysis-types\ | \	ests/schema_contract_w66.rs\ | 20 |
| \	okmd-envelope\ | \	ests/schema_contract_w66.rs\ | 17 |
| \	okmd-ffi-envelope\ | \	ests/schema_contract_w66.rs\ | 15 |

### What's Tested

- **Schema version constants** are positive integers and match expected values
- **JSON roundtrip** for every receipt type (serialize → deserialize → verify)
- **Envelope metadata** includes \schema_version\ in JSON output
- **Field name stability** — required fields are present with expected names
- **Backward compatibility** — extra fields don't break deserialization (\deny_unknown_fields\ NOT set)
- **Enum serialization contracts** — variants serialize to expected case (lowercase/snake_case/kebab-case)
- **Finding fingerprints** are deterministic and unique across different findings
- **FFI envelope** structure (\ok\/\data\/\rror\) is stable

### Verification

\\\ash
cargo test -p tokmd-types --test schema_contract_w66
cargo test -p tokmd-analysis-types --test schema_contract_w66
cargo test -p tokmd-envelope --test schema_contract_w66
cargo test -p tokmd-ffi-envelope --test schema_contract_w66
\\\

All 80 tests pass.