### PR TITLE
test(w66): CLI edge case + error handling tests (~65 tests)

### DIFF
--- a/crates/tokmd/tests/cli_errors_w66.rs
+++ b/crates/tokmd/tests/cli_errors_w66.rs
@@ -1,0 +1,310 @@
+//! CLI error handling and edge-case tests (w66).
+//!
+//! Validates that tokmd produces helpful error messages for invalid arguments,
+//! nonexistent paths, unknown subcommands, and that --help/--version work for
+//! every subcommand.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn tokmd_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tokmd"))
+}
+
+fn tokmd_cmd_fixture() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+fn nonexistent_path() -> std::path::PathBuf {
+    std::env::temp_dir().join("tokmd_w66_nonexistent_path_that_does_not_exist")
+}
+
+// ===========================================================================
+// 1. Invalid argument tests
+// ===========================================================================
+
+#[test]
+fn invalid_format_value_for_lang_produces_error() {
+    tokmd_cmd_fixture()
+        .args(["lang", "--format", "yaml"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn invalid_format_value_for_module_produces_error() {
+    tokmd_cmd_fixture()
+        .args(["module", "--format", "xml"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn invalid_format_value_for_export_produces_error() {
+    tokmd_cmd_fixture()
+        .args(["export", "--format", "parquet"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn analyze_invalid_preset_value_produces_error() {
+    tokmd_cmd_fixture()
+        .args(["analyze", "--preset", "bogus_preset"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn non_numeric_top_flag_fails() {
+    tokmd_cmd_fixture()
+        .args(["lang", "--top", "abc"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn negative_top_flag_fails() {
+    tokmd_cmd_fixture()
+        .args(["lang", "--top", "-5"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn module_non_numeric_depth_fails() {
+    tokmd_cmd_fixture()
+        .args(["module", "--module-depth", "xyz"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn badge_invalid_metric_fails() {
+    tokmd_cmd_fixture()
+        .args(["badge", "--metric", "nonexistent_metric"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn completions_invalid_shell_fails() {
+    tokmd_cmd()
+        .args(["completions", "invalid_shell"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+// ===========================================================================
+// 2. Non-existent path tests
+// ===========================================================================
+
+#[test]
+fn lang_with_nonexistent_path_produces_error() {
+    let p = nonexistent_path();
+    tokmd_cmd()
+        .arg(p.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn module_with_nonexistent_path_produces_error() {
+    let p = nonexistent_path();
+    tokmd_cmd()
+        .args(["module"])
+        .arg(p.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn export_with_nonexistent_path_produces_error() {
+    let p = nonexistent_path();
+    tokmd_cmd()
+        .args(["export"])
+        .arg(p.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn analyze_with_nonexistent_path_produces_error() {
+    let p = nonexistent_path();
+    tokmd_cmd()
+        .args(["analyze"])
+        .arg(p.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn run_with_nonexistent_path_produces_error() {
+    let p = nonexistent_path();
+    tokmd_cmd()
+        .args(["run"])
+        .arg(p.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn diff_with_nonexistent_files_produces_error() {
+    let p = nonexistent_path();
+    tokmd_cmd()
+        .args(["diff", "--from"])
+        .arg(p.join("a.json").as_os_str())
+        .arg("--to")
+        .arg(p.join("b.json").as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+// ===========================================================================
+// 3. --help works for every subcommand
+// ===========================================================================
+
+#[test]
+fn help_flag_for_all_subcommands() {
+    let subcommands = [
+        "lang",
+        "module",
+        "export",
+        "run",
+        "analyze",
+        "badge",
+        "diff",
+        "cockpit",
+        "gate",
+        "tools",
+        "context",
+        "init",
+        "check-ignore",
+        "completions",
+        "baseline",
+        "handoff",
+        "sensor",
+    ];
+    for sub in subcommands {
+        tokmd_cmd()
+            .args([sub, "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Usage").or(predicate::str::contains("usage")));
+    }
+}
+
+#[test]
+fn root_help_mentions_subcommands() {
+    tokmd_cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lang"))
+        .stdout(predicate::str::contains("module"))
+        .stdout(predicate::str::contains("export"))
+        .stdout(predicate::str::contains("analyze"));
+}
+
+// ===========================================================================
+// 4. --version output format
+// ===========================================================================
+
+#[test]
+fn version_flag_contains_tokmd_and_semver() {
+    let output = tokmd_cmd()
+        .arg("--version")
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("tokmd"), "should contain 'tokmd'");
+    // Semver pattern: at least X.Y.Z
+    let re = regex::Regex::new(r"\d+\.\d+\.\d+").unwrap();
+    assert!(
+        re.is_match(&stdout),
+        "version output should contain semver: {stdout}"
+    );
+}
+
+// ===========================================================================
+// 5. Unknown subcommand
+// ===========================================================================
+
+#[test]
+fn unknown_subcommand_produces_helpful_error() {
+    tokmd_cmd()
+        .arg("not-a-real-command")
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn empty_string_subcommand_fails_or_defaults() {
+    tokmd_cmd()
+        .arg("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+// ===========================================================================
+// 6. Commands that require arguments fail without them
+// ===========================================================================
+
+#[test]
+fn diff_without_required_args_fails() {
+    tokmd_cmd()
+        .arg("diff")
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn gate_without_required_args_fails() {
+    tokmd_cmd()
+        .arg("gate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn cockpit_with_nonexistent_base_ref_fails() {
+    tokmd_cmd_fixture()
+        .args(["cockpit", "--base", "nonexistent_ref_w66_abc"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+
+#[test]
+fn unknown_global_flag_fails() {
+    tokmd_cmd_fixture()
+        .arg("--does-not-exist")
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}

--- a/crates/tokmd/tests/cli_output_formats_w66.rs
+++ b/crates/tokmd/tests/cli_output_formats_w66.rs
@@ -1,0 +1,367 @@
+//! CLI output-format validation tests (w66).
+//!
+//! Verifies that each output format flag produces well-formed output:
+//! JSON parses, TSV has consistent columns, Markdown contains table markers,
+//! and --output writes to files correctly.
+
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ===========================================================================
+// 1. lang format variants
+// ===========================================================================
+
+#[test]
+fn lang_json_parses_as_valid_json() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("lang --format json should produce valid JSON");
+    assert!(json.is_object());
+}
+
+#[test]
+fn lang_json_has_required_envelope_fields() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["schema_version"].is_number(), "must have schema_version");
+    assert!(json["rows"].is_array(), "must have rows array");
+    assert!(json["mode"].is_string(), "must have mode field");
+}
+
+#[test]
+fn lang_tsv_has_header_and_consistent_columns() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "tsv"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.len() >= 2, "need header + at least one data row");
+
+    let header_cols = lines[0].split('\t').count();
+    assert!(header_cols >= 3, "header should have at least 3 columns");
+
+    for (i, line) in lines[1..].iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cols = line.split('\t').count();
+        assert_eq!(
+            cols, header_cols,
+            "row {} has {cols} cols, header has {header_cols}",
+            i + 1
+        );
+    }
+}
+
+#[test]
+fn lang_markdown_contains_table_markers() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "md"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains('|'),
+        "Markdown output should contain pipe characters for tables"
+    );
+    assert!(
+        stdout.contains("---"),
+        "Markdown output should contain separator row"
+    );
+}
+
+// ===========================================================================
+// 2. module format variants
+// ===========================================================================
+
+#[test]
+fn module_json_parses_and_has_rows() {
+    let output = tokmd_cmd()
+        .args(["module", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("module --format json should produce valid JSON");
+    assert!(json["rows"].is_array());
+    assert_eq!(json["mode"], "module");
+}
+
+#[test]
+fn module_tsv_has_consistent_columns() {
+    let output = tokmd_cmd()
+        .args(["module", "--format", "tsv"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.len() >= 2, "need header + data");
+
+    let header_cols = lines[0].split('\t').count();
+    for (i, line) in lines[1..].iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cols = line.split('\t').count();
+        assert_eq!(
+            cols, header_cols,
+            "module TSV row {} has {cols} cols, header has {header_cols}",
+            i + 1
+        );
+    }
+}
+
+#[test]
+fn module_markdown_contains_table() {
+    let output = tokmd_cmd()
+        .args(["module", "--format", "md"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains('|'), "module markdown should have table");
+}
+
+// ===========================================================================
+// 3. export format variants
+// ===========================================================================
+
+#[test]
+fn export_json_parses_and_has_mode_export() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("export --format json should produce valid JSON");
+    assert_eq!(json["mode"], "export");
+    assert!(json["rows"].is_array());
+}
+
+#[test]
+fn export_csv_has_header_and_consistent_columns() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "csv"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.len() >= 2, "need header + data");
+
+    let header_cols = lines[0].split(',').count();
+    for (i, line) in lines[1..].iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cols = line.split(',').count();
+        assert_eq!(
+            cols, header_cols,
+            "export CSV row {} has {cols} cols, header has {header_cols}",
+            i + 1
+        );
+    }
+}
+
+#[test]
+fn export_jsonl_each_line_is_valid_json() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "jsonl"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(!lines.is_empty(), "should have at least one line");
+
+    for (i, line) in lines.iter().enumerate() {
+        let _: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("JSONL line {} is not valid JSON: {e}", i + 1));
+    }
+}
+
+// ===========================================================================
+// 4. analyze JSON output
+// ===========================================================================
+
+#[test]
+fn analyze_json_parses_as_valid_json() {
+    let output = tokmd_cmd()
+        .args(["analyze", "--format", "json", "--preset", "receipt"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("analyze --format json should produce valid JSON");
+    assert!(json.is_object());
+}
+
+#[test]
+fn analyze_markdown_produces_readable_output() {
+    let output = tokmd_cmd()
+        .args(["analyze", "--format", "md", "--preset", "receipt"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.trim().is_empty(), "analyze md should produce output");
+}
+
+// ===========================================================================
+// 5. badge output
+// ===========================================================================
+
+#[test]
+fn badge_produces_valid_svg() {
+    let output = tokmd_cmd()
+        .args(["badge", "--metric", "lines"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("<svg"), "badge should produce SVG");
+    assert!(stdout.contains("</svg>"), "badge SVG should be complete");
+}
+
+// ===========================================================================
+// 6. --output flag writes to file
+// ===========================================================================
+
+#[test]
+fn export_output_flag_writes_to_file() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let outfile = dir.path().join("export_output.csv");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd.args(["export", "--format", "csv", "--output"])
+        .arg(outfile.as_os_str())
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&outfile).expect("read output file");
+    assert!(
+        content.contains(','),
+        "output file should contain CSV content"
+    );
+}
+
+// ===========================================================================
+// 7. --no-progress flag
+// ===========================================================================
+
+#[test]
+fn no_progress_flag_suppresses_spinners() {
+    tokmd_cmd()
+        .args(["lang", "--no-progress"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn no_progress_with_json_produces_clean_output() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json", "--no-progress"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let _: Value = serde_json::from_slice(&output.stdout)
+        .expect("JSON output with --no-progress should be valid");
+}
+
+// ===========================================================================
+// 8. verbose flag (global, placed before subcommand)
+// ===========================================================================
+
+#[test]
+fn verbose_flag_does_not_break_output() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd.args(["-v", "lang"]).assert().success();
+}
+
+// ===========================================================================
+// 9. context JSON mode
+// ===========================================================================
+
+#[test]
+fn context_json_parses() {
+    let output = tokmd_cmd()
+        .args(["context", "--mode", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let _: Value = serde_json::from_slice(&output.stdout)
+        .expect("context --mode json should produce valid JSON");
+}
+
+#[test]
+fn context_list_mode_produces_output() {
+    let output = tokmd_cmd()
+        .args(["context", "--mode", "list"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        !stdout.trim().is_empty(),
+        "context list mode should produce output"
+    );
+}
+
+// ===========================================================================
+// 10. handoff writes to directory
+// ===========================================================================
+
+#[test]
+fn handoff_writes_to_output_dir() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let out_dir = dir.path().join("handoff_out");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd.args(["handoff", "--out-dir"])
+        .arg(out_dir.as_os_str())
+        .args(["--force"])
+        .assert()
+        .success();
+
+    assert!(out_dir.exists(), "handoff should create output directory");
+}

--- a/crates/tokmd/tests/cli_scan_options_w66.rs
+++ b/crates/tokmd/tests/cli_scan_options_w66.rs
@@ -1,0 +1,338 @@
+//! CLI scan-option tests (w66).
+//!
+//! Validates that scan-related flags (--exclude, --module-depth, --children,
+//! --hidden, --no-ignore, etc.) work correctly, including edge cases like
+//! empty directories and self-referential scans.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ===========================================================================
+// 1. --exclude pattern tests
+// ===========================================================================
+
+#[test]
+fn exclude_pattern_reduces_output() {
+    let baseline = tokmd_cmd()
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("baseline run");
+    assert!(baseline.status.success());
+    let base_json: Value = serde_json::from_slice(&baseline.stdout).unwrap();
+    let base_total: u64 = base_json["total"]["code"]
+        .as_u64()
+        .or_else(|| base_json["totals"]["code"].as_u64())
+        .unwrap_or(0);
+
+    let excluded = tokmd_cmd()
+        .args(["lang", "--format", "json", "--exclude", "*.rs"])
+        .output()
+        .expect("excluded run");
+    assert!(excluded.status.success());
+    let excl_json: Value = serde_json::from_slice(&excluded.stdout).unwrap();
+    let excl_total: u64 = excl_json["total"]["code"]
+        .as_u64()
+        .or_else(|| excl_json["totals"]["code"].as_u64())
+        .unwrap_or(0);
+
+    assert!(
+        excl_total <= base_total,
+        "excluding *.rs should not increase code count: excluded={excl_total} baseline={base_total}"
+    );
+}
+
+#[test]
+fn exclude_multiple_patterns() {
+    tokmd_cmd()
+        .args([
+            "lang",
+            "--format",
+            "json",
+            "--exclude",
+            "*.rs",
+            "--exclude",
+            "*.js",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn exclude_all_files_produces_zero_rows() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json", "--exclude", "*"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows array");
+    assert!(
+        rows.is_empty(),
+        "excluding everything should produce zero rows"
+    );
+}
+
+#[test]
+fn export_exclude_filters_files() {
+    let output = tokmd_cmd()
+        .args(["export", "--format", "json", "--exclude", "*.js"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows array");
+
+    for row in rows {
+        let path = row["path"].as_str().unwrap_or("");
+        assert!(
+            !path.ends_with(".js"),
+            "excluded .js file still appears: {path}"
+        );
+    }
+}
+
+// ===========================================================================
+// 2. --module-depth tests
+// ===========================================================================
+
+#[test]
+fn module_depth_one_groups_at_top_level() {
+    let output = tokmd_cmd()
+        .args(["module", "--format", "json", "--module-depth", "1"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows array");
+
+    for row in rows {
+        let module = row["module"].as_str().unwrap_or("");
+        // At depth 1, module keys should have at most one path separator
+        let depth = module.matches('/').count();
+        assert!(
+            depth <= 1,
+            "module-depth 1 should produce shallow keys, got: {module}"
+        );
+    }
+}
+
+#[test]
+fn module_depth_large_value_succeeds() {
+    tokmd_cmd()
+        .args(["module", "--format", "json", "--module-depth", "100"])
+        .assert()
+        .success();
+}
+
+// ===========================================================================
+// 3. Scanning empty directories
+// ===========================================================================
+
+#[test]
+fn scan_empty_directory_succeeds_with_zero_results() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::create_dir(dir.path().join(".git")).expect("create .git");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path());
+    let output = cmd
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows array");
+    assert!(rows.is_empty(), "empty dir should have zero rows");
+}
+
+#[test]
+fn export_empty_directory_succeeds() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::create_dir(dir.path().join(".git")).expect("create .git");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path());
+    cmd.args(["export", "--format", "json"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn module_empty_directory_succeeds() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::create_dir(dir.path().join(".git")).expect("create .git");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path());
+    cmd.args(["module", "--format", "json"])
+        .assert()
+        .success();
+}
+
+// ===========================================================================
+// 4. Self-referential scan (scan the tokmd repo itself)
+// ===========================================================================
+
+#[test]
+fn self_scan_succeeds() {
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(&repo_root);
+    cmd.args(["lang", "--format", "json", "--exclude", "target"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn self_scan_finds_rust_language() {
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(&repo_root);
+    let output = cmd
+        .args(["lang", "--format", "json", "--exclude", "target"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows array");
+
+    let has_rust = rows.iter().any(|r| r["lang"].as_str() == Some("Rust"));
+    assert!(has_rust, "self-scan should find Rust language");
+}
+
+// ===========================================================================
+// 5. --children mode flags
+// ===========================================================================
+
+#[test]
+fn lang_children_collapse_succeeds() {
+    tokmd_cmd()
+        .args(["lang", "--format", "json", "--children", "collapse"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn lang_children_separate_succeeds() {
+    tokmd_cmd()
+        .args(["lang", "--format", "json", "--children", "separate"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn module_children_separate_succeeds() {
+    tokmd_cmd()
+        .args(["module", "--format", "json", "--children", "separate"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn export_children_separate_succeeds() {
+    tokmd_cmd()
+        .args(["export", "--format", "json", "--children", "separate"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn lang_children_invalid_value_fails() {
+    tokmd_cmd()
+        .args(["lang", "--children", "invalid"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+// ===========================================================================
+// 6. --hidden and --no-ignore flags (global, placed before subcommand)
+// ===========================================================================
+
+#[test]
+fn hidden_flag_succeeds() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd.args(["--hidden", "lang", "--format", "json"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn no_ignore_flag_succeeds() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd.args(["--no-ignore", "lang", "--format", "json"])
+        .assert()
+        .success();
+}
+
+// ===========================================================================
+// 7. --top flag
+// ===========================================================================
+
+#[test]
+fn top_flag_limits_output() {
+    let full = tokmd_cmd()
+        .args(["lang", "--format", "json"])
+        .output()
+        .expect("full run");
+    assert!(full.status.success());
+    let full_json: Value = serde_json::from_slice(&full.stdout).unwrap();
+    let full_rows = full_json["rows"].as_array().expect("rows array").len();
+
+    let limited = tokmd_cmd()
+        .args(["lang", "--format", "json", "--top", "1"])
+        .output()
+        .expect("limited run");
+    assert!(limited.status.success());
+    let lim_json: Value = serde_json::from_slice(&limited.stdout).unwrap();
+    let lim_rows = lim_json["rows"].as_array().expect("rows array").len();
+
+    assert!(
+        lim_rows <= full_rows,
+        "--top 1 should produce <= full rows: limited={lim_rows} full={full_rows}"
+    );
+}
+
+#[test]
+fn top_zero_shows_all_languages() {
+    let output = tokmd_cmd()
+        .args(["lang", "--format", "json", "--top", "0"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let rows = json["rows"].as_array().expect("rows array");
+    assert!(
+        !rows.is_empty(),
+        "--top 0 should show all languages (fixture has code)"
+    );
+}


### PR DESCRIPTION
## Summary

Adds 64 new CLI integration tests across three test files covering error handling, output format validation, and scan option edge cases.

### Test files

| File | Tests | Coverage |
|------|-------|----------|
| \cli_errors_w66.rs\ | 24 | Invalid args, nonexistent paths, --help for all 17 subcommands, --version format, unknown subcommands, required-arg failures |
| \cli_output_formats_w66.rs\ | 20 | JSON/TSV/MD/CSV/JSONL format validation, badge SVG completeness, --output file write, --no-progress, verbose flag, context/handoff output |
| \cli_scan_options_w66.rs\ | 20 | --exclude patterns, --module-depth, empty directory scans, self-referential repo scan, --children modes, --hidden, --no-ignore, --top flag |

### Key patterns
- All tests use \ssert_cmd::Command::cargo_bin\ for e2e execution
- Tests run against the fixture directory or temp directories for speed
- JSON outputs validated with \serde_json\ parsing
- TSV/CSV outputs validated for column consistency
- Self-scan tests use \--exclude target\ for fast execution

### Verification
\\\
cargo test -p tokmd --test cli_errors_w66 --test cli_output_formats_w66 --test cli_scan_options_w66
\\\
All 64 tests pass.