### PR TITLE
test(w66): io-port comprehensive tests + cross-crate integration (~100 tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,6 +3524,7 @@ dependencies = [
 name = "tokmd-io-port"
 version = "1.7.2"
 dependencies = [
+ "proptest",
  "tempfile",
 ]
 

--- a/crates/tokmd-io-port/Cargo.toml
+++ b/crates/tokmd-io-port/Cargo.toml
@@ -14,4 +14,5 @@ documentation = "https://docs.rs/tokmd-io-port"
 [dependencies]
 
 [dev-dependencies]
+proptest = "1.10.0"
 tempfile = "3"

--- a/crates/tokmd-io-port/tests/integration_w66.rs
+++ b/crates/tokmd-io-port/tests/integration_w66.rs
@@ -1,0 +1,145 @@
+//! Integration tests: filesystem snapshots and bulk operations.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use tokmd_io_port::{MemFs, ReadFs};
+
+fn project_snapshot() -> MemFs {
+    let mut fs = MemFs::new();
+    fs.add_file("Cargo.toml", "[package]\nname = \"demo\"\nversion = \"0.1.0\"");
+    fs.add_file("src/lib.rs", "pub fn add(a: i32, b: i32) -> i32 { a + b }");
+    fs.add_file("src/main.rs", "fn main() { println!(\"{}\", demo::add(1, 2)); }");
+    fs.add_file("tests/test_add.rs", "#[test] fn it_works() { assert_eq!(demo::add(2, 2), 4); }");
+    fs.add_file("README.md", "# Demo\nA sample project.");
+    fs.add_file(".gitignore", "/target\n");
+    fs.add_bytes("assets/icon.png", vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+    fs
+}
+
+#[test]
+fn snapshot_all_files_readable() {
+    let fs = project_snapshot();
+    let expected_files = [
+        "Cargo.toml", "src/lib.rs", "src/main.rs", "tests/test_add.rs",
+        "README.md", ".gitignore", "assets/icon.png",
+    ];
+    for path in expected_files {
+        assert!(fs.exists(Path::new(path)), "expected {path} to exist");
+        assert!(fs.is_file(Path::new(path)), "expected {path} to be a file");
+        assert!(fs.read_bytes(Path::new(path)).is_ok(), "expected {path} to be readable");
+    }
+}
+
+#[test]
+fn snapshot_directories_inferred() {
+    let fs = project_snapshot();
+    let expected_dirs = ["src", "tests", "assets"];
+    for dir in expected_dirs {
+        assert!(fs.is_dir(Path::new(dir)), "expected {dir} to be a directory");
+    }
+}
+
+#[test]
+fn snapshot_text_files_are_valid_utf8() {
+    let fs = project_snapshot();
+    let text_files = ["Cargo.toml", "src/lib.rs", "src/main.rs", "tests/test_add.rs", "README.md", ".gitignore"];
+    for path in text_files {
+        assert!(fs.read_to_string(Path::new(path)).is_ok(), "expected {path} to be valid UTF-8");
+    }
+}
+
+#[test]
+fn snapshot_binary_file_is_not_utf8() {
+    let fs = project_snapshot();
+    assert!(fs.read_to_string(Path::new("assets/icon.png")).is_err());
+}
+
+#[test]
+fn bulk_insert_from_btreemap() {
+    let mut entries = BTreeMap::new();
+    entries.insert("a/1.txt", "one");
+    entries.insert("a/2.txt", "two");
+    entries.insert("b/3.txt", "three");
+    entries.insert("c.txt", "four");
+
+    let mut fs = MemFs::new();
+    for (path, content) in &entries {
+        fs.add_file(*path, *content);
+    }
+    for (path, content) in &entries {
+        assert_eq!(fs.read_to_string(Path::new(path)).unwrap(), *content, "mismatch for {path}");
+    }
+}
+
+#[test]
+fn bulk_overwrite_cycle() {
+    let mut fs = MemFs::new();
+    let path = "data/file.txt";
+    for i in 0..50 {
+        let content = format!("version {i}");
+        fs.add_file(path, &content);
+        assert_eq!(fs.read_to_string(Path::new(path)).unwrap(), content);
+    }
+}
+
+#[test]
+fn bulk_many_directories() {
+    let mut fs = MemFs::new();
+    for i in 0..50 {
+        let path = format!("modules/mod_{i}/lib.rs");
+        fs.add_file(&path, format!("mod {i}"));
+    }
+    assert!(fs.is_dir(Path::new("modules")));
+    for i in 0..50 {
+        let dir = format!("modules/mod_{i}");
+        let file = format!("modules/mod_{i}/lib.rs");
+        assert!(fs.is_dir(Path::new(&dir)), "dir {dir} should exist");
+        assert!(fs.is_file(Path::new(&file)), "file {file} should exist");
+    }
+}
+
+#[test]
+fn clone_is_independent() {
+    let mut fs = project_snapshot();
+    let fs2 = fs.clone();
+    fs.add_file("src/lib.rs", "MODIFIED");
+    assert_eq!(fs2.read_to_string(Path::new("src/lib.rs")).unwrap(), "pub fn add(a: i32, b: i32) -> i32 { a + b }");
+    assert_eq!(fs.read_to_string(Path::new("src/lib.rs")).unwrap(), "MODIFIED");
+}
+
+#[test]
+fn mixed_text_and_binary_same_directory() {
+    let mut fs = MemFs::new();
+    fs.add_file("data/config.json", "{\"key\": \"value\"}");
+    fs.add_bytes("data/blob.dat", vec![0x00; 256]);
+    assert!(fs.is_dir(Path::new("data")));
+    assert_eq!(fs.read_to_string(Path::new("data/config.json")).unwrap(), "{\"key\": \"value\"}");
+    assert_eq!(fs.read_bytes(Path::new("data/blob.dat")).unwrap().len(), 256);
+}
+
+#[test]
+fn root_level_files_no_directories() {
+    let mut fs = MemFs::new();
+    fs.add_file("a.txt", "a");
+    fs.add_file("b.txt", "b");
+    assert!(fs.is_file(Path::new("a.txt")));
+    assert!(fs.is_file(Path::new("b.txt")));
+    assert!(!fs.is_dir(Path::new("a.txt")));
+    assert!(!fs.is_dir(Path::new("b.txt")));
+}
+
+#[test]
+fn memfs_debug_impl() {
+    let fs = MemFs::new();
+    let debug = format!("{:?}", fs);
+    assert!(debug.contains("MemFs"));
+}
+
+#[test]
+fn error_display_and_error_trait() {
+    let fs = MemFs::new();
+    let err = fs.read_to_string(Path::new("missing")).unwrap_err();
+    let display = format!("{err}");
+    assert!(!display.is_empty());
+    let _: &dyn std::error::Error = &err;
+}

--- a/crates/tokmd-io-port/tests/memfs_bdd.rs
+++ b/crates/tokmd-io-port/tests/memfs_bdd.rs
@@ -1,0 +1,237 @@
+//! BDD-style scenario tests for `MemFs`.
+//!
+//! Each test follows the Given/When/Then pattern exercising a single behaviour.
+
+use std::path::Path;
+use tokmd_io_port::{MemFs, ReadFs};
+
+// ---------------------------------------------------------------------------
+// Scenario: empty filesystem
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_fs_has_no_files() {
+    let fs = MemFs::new();
+    assert!(!fs.exists(Path::new("anything.txt")));
+    assert!(!fs.is_file(Path::new("anything.txt")));
+    assert!(!fs.is_dir(Path::new("anything.txt")));
+}
+
+#[test]
+fn empty_fs_read_to_string_returns_not_found() {
+    let fs = MemFs::new();
+    let err = fs.read_to_string(Path::new("missing.txt")).unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn empty_fs_read_bytes_returns_not_found() {
+    let fs = MemFs::new();
+    let err = fs.read_bytes(Path::new("missing.bin")).unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn default_fs_is_empty() {
+    let fs = MemFs::default();
+    assert!(!fs.exists(Path::new("x")));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: add a single file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_file_then_read_to_string() {
+    let mut fs = MemFs::new();
+    fs.add_file("hello.txt", "world");
+    assert_eq!(fs.read_to_string(Path::new("hello.txt")).unwrap(), "world");
+}
+
+#[test]
+fn add_file_then_read_bytes() {
+    let mut fs = MemFs::new();
+    fs.add_file("hello.txt", "world");
+    assert_eq!(
+        fs.read_bytes(Path::new("hello.txt")).unwrap(),
+        b"world".to_vec()
+    );
+}
+
+#[test]
+fn added_file_exists() {
+    let mut fs = MemFs::new();
+    fs.add_file("a.rs", "fn main() {}");
+    assert!(fs.exists(Path::new("a.rs")));
+    assert!(fs.is_file(Path::new("a.rs")));
+    assert!(!fs.is_dir(Path::new("a.rs")));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: overwrite an existing file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overwrite_replaces_content() {
+    let mut fs = MemFs::new();
+    fs.add_file("f.txt", "original");
+    fs.add_file("f.txt", "replaced");
+    assert_eq!(fs.read_to_string(Path::new("f.txt")).unwrap(), "replaced");
+}
+
+#[test]
+fn overwrite_with_bytes_replaces_content() {
+    let mut fs = MemFs::new();
+    fs.add_file("f.bin", "text");
+    fs.add_bytes("f.bin", vec![0xCA, 0xFE]);
+    assert_eq!(fs.read_bytes(Path::new("f.bin")).unwrap(), vec![0xCA, 0xFE]);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: large files
+// ---------------------------------------------------------------------------
+
+#[test]
+fn large_text_file_roundtrips() {
+    let mut fs = MemFs::new();
+    let big = "x".repeat(1_000_000);
+    fs.add_file("big.txt", big.clone());
+    assert_eq!(fs.read_to_string(Path::new("big.txt")).unwrap(), big);
+}
+
+#[test]
+fn large_binary_file_roundtrips() {
+    let mut fs = MemFs::new();
+    let big: Vec<u8> = (0..=255).cycle().take(500_000).collect();
+    fs.add_bytes("big.bin", big.clone());
+    assert_eq!(fs.read_bytes(Path::new("big.bin")).unwrap(), big);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: nested paths and directory inference
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_path_creates_implicit_directory() {
+    let mut fs = MemFs::new();
+    fs.add_file("src/lib.rs", "// lib");
+    assert!(fs.is_dir(Path::new("src")));
+    assert!(fs.exists(Path::new("src")));
+    assert!(!fs.is_file(Path::new("src")));
+}
+
+#[test]
+fn deeply_nested_path_creates_all_ancestor_dirs() {
+    let mut fs = MemFs::new();
+    fs.add_file("a/b/c/d/e.txt", "deep");
+    assert!(fs.is_dir(Path::new("a")));
+    assert!(fs.is_dir(Path::new("a/b")));
+    assert!(fs.is_dir(Path::new("a/b/c")));
+    assert!(fs.is_dir(Path::new("a/b/c/d")));
+    assert!(fs.is_file(Path::new("a/b/c/d/e.txt")));
+}
+
+#[test]
+fn multiple_files_share_directory() {
+    let mut fs = MemFs::new();
+    fs.add_file("src/a.rs", "a");
+    fs.add_file("src/b.rs", "b");
+    assert!(fs.is_dir(Path::new("src")));
+    assert_eq!(fs.read_to_string(Path::new("src/a.rs")).unwrap(), "a");
+    assert_eq!(fs.read_to_string(Path::new("src/b.rs")).unwrap(), "b");
+}
+
+#[test]
+fn sibling_directories_are_independent() {
+    let mut fs = MemFs::new();
+    fs.add_file("src/main.rs", "main");
+    fs.add_file("tests/test.rs", "test");
+    assert!(fs.is_dir(Path::new("src")));
+    assert!(fs.is_dir(Path::new("tests")));
+    assert!(!fs.is_dir(Path::new("lib")));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_content_file() {
+    let mut fs = MemFs::new();
+    fs.add_file("empty.txt", "");
+    assert!(fs.is_file(Path::new("empty.txt")));
+    assert_eq!(fs.read_to_string(Path::new("empty.txt")).unwrap(), "");
+    assert_eq!(fs.read_bytes(Path::new("empty.txt")).unwrap(), Vec::<u8>::new());
+}
+
+#[test]
+fn empty_bytes_file() {
+    let mut fs = MemFs::new();
+    fs.add_bytes("empty.bin", Vec::<u8>::new());
+    assert!(fs.is_file(Path::new("empty.bin")));
+    assert_eq!(fs.read_bytes(Path::new("empty.bin")).unwrap().len(), 0);
+}
+
+#[test]
+fn binary_content_invalid_utf8() {
+    let mut fs = MemFs::new();
+    fs.add_bytes("bad.bin", vec![0xFF, 0xFE, 0x00]);
+    let err = fs.read_to_string(Path::new("bad.bin")).unwrap_err();
+    assert!(err.to_string().contains("invalid UTF-8"));
+    assert_eq!(fs.read_bytes(Path::new("bad.bin")).unwrap(), vec![0xFF, 0xFE, 0x00]);
+}
+
+#[test]
+fn unicode_content_roundtrips() {
+    let mut fs = MemFs::new();
+    let text = "\u{3053}\u{3093}\u{306b}\u{3061}\u{306f}\u{4e16}\u{754c} \u{1f30d}";
+    fs.add_file("uni.txt", text);
+    assert_eq!(fs.read_to_string(Path::new("uni.txt")).unwrap(), text);
+}
+
+#[test]
+fn path_with_special_characters() {
+    let mut fs = MemFs::new();
+    fs.add_file("dir with spaces/file (1).txt", "ok");
+    assert!(fs.is_file(Path::new("dir with spaces/file (1).txt")));
+    assert!(fs.is_dir(Path::new("dir with spaces")));
+}
+
+#[test]
+fn forward_slash_paths_consistency() {
+    let mut fs = MemFs::new();
+    fs.add_file("a/b/c.txt", "content");
+    assert!(fs.exists(Path::new("a/b/c.txt")));
+    assert!(fs.is_dir(Path::new("a/b")));
+    assert!(fs.is_dir(Path::new("a")));
+}
+
+#[test]
+fn nonexistent_sibling_does_not_exist() {
+    let mut fs = MemFs::new();
+    fs.add_file("src/lib.rs", "");
+    assert!(!fs.exists(Path::new("src/main.rs")));
+    assert!(!fs.is_file(Path::new("src/main.rs")));
+}
+
+#[test]
+fn file_is_not_directory_even_with_similar_prefix() {
+    let mut fs = MemFs::new();
+    fs.add_file("src", "I am a file named src");
+    fs.add_file("src2/lib.rs", "");
+    assert!(fs.is_file(Path::new("src")));
+}
+
+#[test]
+fn many_files_in_one_directory() {
+    let mut fs = MemFs::new();
+    for i in 0..100 {
+        fs.add_file(format!("dir/file_{i}.txt"), format!("content {i}"));
+    }
+    assert!(fs.is_dir(Path::new("dir")));
+    for i in 0..100 {
+        let path_str = format!("dir/file_{i}.txt");
+        let expected = format!("content {i}");
+        assert_eq!(fs.read_to_string(Path::new(&path_str)).unwrap(), expected);
+    }
+}

--- a/crates/tokmd-io-port/tests/properties.rs
+++ b/crates/tokmd-io-port/tests/properties.rs
@@ -1,0 +1,165 @@
+//! Property-based tests for `MemFs` using proptest.
+
+use std::path::Path;
+use tokmd_io_port::{MemFs, ReadFs};
+
+use proptest::prelude::*;
+use proptest::collection::vec as pvec;
+
+fn path_segment() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_]{0,7}".prop_map(|s| s)
+}
+
+fn forward_slash_path() -> impl Strategy<Value = String> {
+    pvec(path_segment(), 1..=4).prop_map(|segments| segments.join("/"))
+}
+
+proptest! {
+    #[test]
+    fn prop_insert_bytes_roundtrip(
+        path in forward_slash_path(),
+        content in pvec(any::<u8>(), 0..1024),
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_bytes(&path, content.clone());
+        let read_back = fs.read_bytes(Path::new(&path)).unwrap();
+        prop_assert_eq!(read_back, content);
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_insert_string_roundtrip(
+        path in forward_slash_path(),
+        content in ".*",
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_file(&path, content.clone());
+        let read_back = fs.read_to_string(Path::new(&path)).unwrap();
+        prop_assert_eq!(read_back, content);
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_exists_consistency(
+        path in forward_slash_path(),
+        content in ".*",
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_file(&path, content);
+        let p = Path::new(&path);
+        prop_assert_eq!(fs.exists(p), fs.is_file(p) || fs.is_dir(p));
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_file_dir_exclusive(
+        path in forward_slash_path(),
+        content in ".*",
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_file(&path, content);
+        let p = Path::new(&path);
+        prop_assert!(!(fs.is_file(p) && fs.is_dir(p)));
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_stored_path_is_file(
+        path in forward_slash_path(),
+        content in pvec(any::<u8>(), 0..512),
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_bytes(&path, content);
+        prop_assert!(fs.is_file(Path::new(&path)));
+        prop_assert!(fs.exists(Path::new(&path)));
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_overwrite_preserves_file(
+        path in forward_slash_path(),
+        content1 in pvec(any::<u8>(), 0..256),
+        content2 in pvec(any::<u8>(), 0..256),
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_bytes(&path, content1);
+        fs.add_bytes(&path, content2.clone());
+        prop_assert!(fs.is_file(Path::new(&path)));
+        let read_back = fs.read_bytes(Path::new(&path)).unwrap();
+        prop_assert_eq!(read_back, content2);
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_parent_dirs_exist(
+        segments in pvec(path_segment(), 2..=4),
+        content in ".*",
+    ) {
+        let path = segments.join("/");
+        let mut fs = MemFs::new();
+        fs.add_file(&path, content);
+        for i in 1..segments.len() {
+            let prefix = segments[..i].join("/");
+            prop_assert!(
+                fs.is_dir(Path::new(&prefix)),
+                "expected {} to be a directory",
+                prefix
+            );
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_bytes_string_consistency(
+        path in forward_slash_path(),
+        content in "[ -~]{0,200}",
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_file(&path, content.clone());
+        let as_string = fs.read_to_string(Path::new(&path)).unwrap();
+        let as_bytes = fs.read_bytes(Path::new(&path)).unwrap();
+        prop_assert_eq!(as_bytes, as_string.as_bytes().to_vec());
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_missing_path_errors(
+        existing in forward_slash_path(),
+        missing in forward_slash_path(),
+    ) {
+        prop_assume!(existing != missing);
+        let mut fs = MemFs::new();
+        fs.add_file(&existing, "exists");
+        prop_assert!(fs.read_to_string(Path::new(&missing)).is_err());
+        prop_assert!(fs.read_bytes(Path::new(&missing)).is_err());
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+    #[test]
+    fn prop_bulk_insert_all_retrievable(
+        entries in pvec((forward_slash_path(), pvec(any::<u8>(), 0..128)), 1..20),
+    ) {
+        let mut fs = MemFs::new();
+        for (path, content) in &entries {
+            fs.add_bytes(path, content.clone());
+        }
+        let mut expected = std::collections::BTreeMap::new();
+        for (path, content) in &entries {
+            expected.insert(path.clone(), content.clone());
+        }
+        for (path, content) in &expected {
+            let read_back = fs.read_bytes(Path::new(path)).unwrap();
+            prop_assert_eq!(read_back, content.clone());
+        }
+    }
+}

--- a/crates/tokmd-io-port/tests/readfs_contract.rs
+++ b/crates/tokmd-io-port/tests/readfs_contract.rs
@@ -1,0 +1,164 @@
+//! Contract tests for the `ReadFs` trait.
+//!
+//! Any correct `ReadFs` implementation must pass these tests.
+//! We verify with `MemFs` as the concrete backend.
+
+use std::path::Path;
+use tokmd_io_port::{MemFs, ReadFs};
+
+/// Build a populated `MemFs` used by most contract tests.
+fn sample_fs() -> MemFs {
+    let mut fs = MemFs::new();
+    fs.add_file("src/lib.rs", "pub fn hello() {}");
+    fs.add_file("src/main.rs", "fn main() {}");
+    fs.add_file("README.md", "# Hello");
+    fs.add_bytes("assets/logo.png", vec![0x89, 0x50, 0x4E, 0x47]);
+    fs
+}
+
+#[test]
+fn contract_read_to_string_exact() {
+    let fs = sample_fs();
+    assert_eq!(fs.read_to_string(Path::new("src/lib.rs")).unwrap(), "pub fn hello() {}");
+    assert_eq!(fs.read_to_string(Path::new("README.md")).unwrap(), "# Hello");
+}
+
+#[test]
+fn contract_read_bytes_exact() {
+    let fs = sample_fs();
+    assert_eq!(fs.read_bytes(Path::new("assets/logo.png")).unwrap(), vec![0x89, 0x50, 0x4E, 0x47]);
+}
+
+#[test]
+fn contract_read_bytes_matches_read_to_string_for_utf8() {
+    let fs = sample_fs();
+    let as_string = fs.read_to_string(Path::new("src/main.rs")).unwrap();
+    let as_bytes = fs.read_bytes(Path::new("src/main.rs")).unwrap();
+    assert_eq!(as_bytes, as_string.as_bytes());
+}
+
+#[test]
+fn contract_read_to_string_errors_on_binary() {
+    let fs = sample_fs();
+    let err = fs.read_to_string(Path::new("assets/logo.png")).unwrap_err();
+    assert!(err.to_string().contains("invalid UTF-8"));
+}
+
+#[test]
+fn contract_read_to_string_missing() {
+    let fs = sample_fs();
+    assert!(fs.read_to_string(Path::new("nope.txt")).is_err());
+}
+
+#[test]
+fn contract_read_bytes_missing() {
+    let fs = sample_fs();
+    assert!(fs.read_bytes(Path::new("nope.txt")).is_err());
+}
+
+#[test]
+fn contract_exists_file() {
+    let fs = sample_fs();
+    assert!(fs.exists(Path::new("src/lib.rs")));
+}
+
+#[test]
+fn contract_exists_directory() {
+    let fs = sample_fs();
+    assert!(fs.exists(Path::new("src")));
+}
+
+#[test]
+fn contract_not_exists() {
+    let fs = sample_fs();
+    assert!(!fs.exists(Path::new("not/here")));
+}
+
+#[test]
+fn contract_is_file_true() {
+    let fs = sample_fs();
+    assert!(fs.is_file(Path::new("src/lib.rs")));
+}
+
+#[test]
+fn contract_is_file_false_for_directory() {
+    let fs = sample_fs();
+    assert!(!fs.is_file(Path::new("src")));
+}
+
+#[test]
+fn contract_is_file_false_for_missing() {
+    let fs = sample_fs();
+    assert!(!fs.is_file(Path::new("missing.rs")));
+}
+
+#[test]
+fn contract_is_dir_true() {
+    let fs = sample_fs();
+    assert!(fs.is_dir(Path::new("src")));
+    assert!(fs.is_dir(Path::new("assets")));
+}
+
+#[test]
+fn contract_is_dir_false_for_file() {
+    let fs = sample_fs();
+    assert!(!fs.is_dir(Path::new("README.md")));
+}
+
+#[test]
+fn contract_is_dir_false_for_missing() {
+    let fs = sample_fs();
+    assert!(!fs.is_dir(Path::new("nonexistent")));
+}
+
+#[test]
+fn contract_exists_equals_file_or_dir() {
+    let fs = sample_fs();
+    let paths = [
+        "src/lib.rs", "src/main.rs", "README.md", "assets/logo.png",
+        "src", "assets", "nope", "also/nope",
+    ];
+    for p in paths {
+        let path = Path::new(p);
+        assert_eq!(
+            fs.exists(path),
+            fs.is_file(path) || fs.is_dir(path),
+            "exists consistency failed for {p}"
+        );
+    }
+}
+
+#[test]
+fn contract_file_and_dir_mutually_exclusive() {
+    let fs = sample_fs();
+    let paths = ["src/lib.rs", "src", "README.md", "assets", "assets/logo.png", "nothing"];
+    for p in paths {
+        let path = Path::new(p);
+        assert!(!(fs.is_file(path) && fs.is_dir(path)), "is_file and is_dir both true for {p}");
+    }
+}
+
+#[test]
+fn contract_error_contains_path() {
+    let fs = MemFs::new();
+    let err = fs.read_to_string(Path::new("some/path.txt")).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("some") || msg.contains("path.txt"), "error should mention the path: {msg}");
+}
+
+#[test]
+fn contract_overwrite_text_with_binary() {
+    let mut fs = MemFs::new();
+    fs.add_file("data", "text content");
+    fs.add_bytes("data", vec![0x00, 0xFF]);
+    assert!(fs.read_to_string(Path::new("data")).is_err());
+    assert_eq!(fs.read_bytes(Path::new("data")).unwrap(), vec![0x00, 0xFF]);
+}
+
+#[test]
+fn contract_overwrite_binary_with_text() {
+    let mut fs = MemFs::new();
+    fs.add_bytes("data", vec![0x00, 0xFF]);
+    fs.add_file("data", "now text");
+    assert_eq!(fs.read_to_string(Path::new("data")).unwrap(), "now text");
+}

--- a/crates/tokmd/tests/cross_crate_w66.rs
+++ b/crates/tokmd/tests/cross_crate_w66.rs
@@ -1,0 +1,354 @@
+//! Cross-crate integration tests (w66) exercising the pipeline:
+//! types -> model -> format, verifying that types flow correctly between crates.
+
+mod common;
+
+use tempfile::TempDir;
+use tokmd_model::{create_lang_report, create_module_report};
+use tokmd_scan::scan;
+use tokmd_settings::ScanOptions;
+use tokmd_types::{
+    ChildIncludeMode, ChildrenMode, ConfigMode, LangArgs, LangReceipt, LangReport, LangRow,
+    ModuleArgs, ModuleReceipt, ModuleReport, ModuleRow, TableFormat, Totals, SCHEMA_VERSION,
+};
+
+fn make_project() -> TempDir {
+    let dir = TempDir::new().expect("create tempdir");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join(".git")).unwrap();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/main.rs"), "fn main() {\n    println!(\"hello\");\n}\n").unwrap();
+    std::fs::write(root.join("src/lib.rs"), "/// Doc\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n").unwrap();
+    std::fs::create_dir_all(root.join("lib")).unwrap();
+    std::fs::write(root.join("lib/util.py"), "# util\ndef greet(name):\n    return f\"Hello, {name}\"\n").unwrap();
+    dir
+}
+
+fn opts() -> ScanOptions {
+    ScanOptions { config: ConfigMode::None, no_ignore_vcs: true, ..Default::default() }
+}
+
+fn scan_lang(dir: &std::path::Path) -> LangReport {
+    let langs = scan(&[dir.to_path_buf()], &opts()).expect("scan");
+    create_lang_report(&langs, 0, true, ChildrenMode::Collapse)
+}
+
+fn scan_module(dir: &std::path::Path) -> ModuleReport {
+    let langs = scan(&[dir.to_path_buf()], &opts()).expect("scan");
+    create_module_report(&langs, &[], 1, ChildIncludeMode::Separate, 0)
+}
+
+fn synthetic_lang_report() -> LangReport {
+    LangReport {
+        rows: vec![
+            LangRow { lang: "Rust".to_string(), code: 500, lines: 650, files: 10, bytes: 20_000, tokens: 5_000, avg_lines: 65 },
+            LangRow { lang: "Python".to_string(), code: 300, lines: 400, files: 5, bytes: 12_000, tokens: 3_000, avg_lines: 80 },
+        ],
+        total: Totals { code: 800, lines: 1050, files: 15, bytes: 32_000, tokens: 8_000, avg_lines: 70 },
+        with_files: true, children: ChildrenMode::Collapse, top: 0,
+    }
+}
+
+fn synthetic_module_report() -> ModuleReport {
+    ModuleReport {
+        rows: vec![
+            ModuleRow { module: "src".to_string(), code: 500, lines: 650, files: 10, bytes: 20_000, tokens: 5_000, avg_lines: 65 },
+            ModuleRow { module: "lib".to_string(), code: 300, lines: 400, files: 5, bytes: 12_000, tokens: 3_000, avg_lines: 80 },
+        ],
+        total: Totals { code: 800, lines: 1050, files: 15, bytes: 32_000, tokens: 8_000, avg_lines: 70 },
+        module_roots: vec![], module_depth: 1, children: ChildIncludeMode::Separate, top: 0,
+    }
+}
+
+fn lang_args(dir: &std::path::Path, fmt: TableFormat) -> LangArgs {
+    LangArgs { paths: vec![dir.to_path_buf()], format: fmt, top: 0, files: true, children: ChildrenMode::Collapse }
+}
+
+fn module_args(dir: &std::path::Path, fmt: TableFormat) -> ModuleArgs {
+    ModuleArgs { paths: vec![dir.to_path_buf()], format: fmt, top: 0, module_roots: vec![], module_depth: 1, children: ChildIncludeMode::Separate }
+}
+
+// ===========================================================================
+// 1. LangRow -> Markdown rendering
+// ===========================================================================
+
+#[test]
+fn lang_to_md_has_table_header_and_total() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    let args = lang_args(proj.path(), TableFormat::Md);
+    let mut buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("|Lang|"), "must have Lang header");
+    assert!(out.contains("|**Total**|"), "must have Total row");
+}
+
+#[test]
+fn lang_md_includes_all_languages() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    let args = lang_args(proj.path(), TableFormat::Md);
+    let mut buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    for row in &report.rows {
+        assert!(out.contains(&row.lang), "MD should contain language {}", row.lang);
+    }
+}
+
+#[test]
+fn synthetic_lang_md_produces_valid_table() {
+    let report = synthetic_lang_report();
+    let args = LangArgs { paths: vec![".".into()], format: TableFormat::Md, top: 0, files: true, children: ChildrenMode::Collapse };
+    let mut buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("|Rust|500|"));
+    assert!(out.contains("|Python|300|"));
+    assert!(out.contains("|**Total**|800|"));
+}
+
+// ===========================================================================
+// 2. ModuleRow -> TSV rendering roundtrips
+// ===========================================================================
+
+#[test]
+fn module_to_tsv_has_correct_columns() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    let args = module_args(proj.path(), TableFormat::Tsv);
+    let mut buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    for line in out.lines().filter(|l| !l.is_empty()) {
+        let cols: Vec<&str> = line.split('\t').collect();
+        assert_eq!(cols.len(), 7, "TSV should have 7 columns: {line}");
+    }
+}
+
+#[test]
+fn module_tsv_header_is_correct() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    let args = module_args(proj.path(), TableFormat::Tsv);
+    let mut buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    let header = out.lines().next().unwrap();
+    assert_eq!(header, "Module\tCode\tLines\tFiles\tBytes\tTokens\tAvg");
+}
+
+#[test]
+fn synthetic_module_tsv_roundtrip_values() {
+    let report = synthetic_module_report();
+    let args = ModuleArgs { paths: vec![".".into()], format: TableFormat::Tsv, top: 0, module_roots: vec![], module_depth: 1, children: ChildIncludeMode::Separate };
+    let mut buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    let lines: Vec<&str> = out.lines().collect();
+    assert!(lines.len() >= 4, "expected at least 4 TSV lines");
+    let row1: Vec<&str> = lines[1].split('\t').collect();
+    assert_eq!(row1[0], "src");
+    assert_eq!(row1[1], "500");
+    assert_eq!(row1[2], "650");
+    let row2: Vec<&str> = lines[2].split('\t').collect();
+    assert_eq!(row2[0], "lib");
+    assert_eq!(row2[1], "300");
+}
+
+// ===========================================================================
+// 3. Totals consistency across format outputs
+// ===========================================================================
+
+#[test]
+fn totals_consistent_between_md_and_tsv_lang() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    let md_args = lang_args(proj.path(), TableFormat::Md);
+    let mut md_buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut md_buf, &report, &opts(), &md_args).unwrap();
+    let md_out = String::from_utf8(md_buf).unwrap();
+    let tsv_args = lang_args(proj.path(), TableFormat::Tsv);
+    let mut tsv_buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut tsv_buf, &report, &opts(), &tsv_args).unwrap();
+    let tsv_out = String::from_utf8(tsv_buf).unwrap();
+    let total_code = report.total.code.to_string();
+    assert!(md_out.contains(&total_code), "MD must contain total code {total_code}");
+    assert!(tsv_out.contains(&total_code), "TSV must contain total code {total_code}");
+}
+
+#[test]
+fn totals_consistent_between_md_and_tsv_module() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    let md_args = module_args(proj.path(), TableFormat::Md);
+    let mut md_buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut md_buf, &report, &opts(), &md_args).unwrap();
+    let md_out = String::from_utf8(md_buf).unwrap();
+    let tsv_args = module_args(proj.path(), TableFormat::Tsv);
+    let mut tsv_buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut tsv_buf, &report, &opts(), &tsv_args).unwrap();
+    let tsv_out = String::from_utf8(tsv_buf).unwrap();
+    let total_code = report.total.code.to_string();
+    assert!(md_out.contains(&total_code));
+    assert!(tsv_out.contains(&total_code));
+}
+
+#[test]
+fn totals_consistent_between_md_and_json_lang() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    let json_args = lang_args(proj.path(), TableFormat::Json);
+    let mut json_buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut json_buf, &report, &opts(), &json_args).unwrap();
+    let receipt: LangReceipt = serde_json::from_slice(&json_buf).unwrap();
+    assert_eq!(receipt.report.total.code, report.total.code);
+    assert_eq!(receipt.report.total.lines, report.total.lines);
+    assert_eq!(receipt.report.total.files, report.total.files);
+}
+
+#[test]
+fn totals_consistent_between_md_and_json_module() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    let json_args = module_args(proj.path(), TableFormat::Json);
+    let mut json_buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut json_buf, &report, &opts(), &json_args).unwrap();
+    let receipt: ModuleReceipt = serde_json::from_slice(&json_buf).unwrap();
+    assert_eq!(receipt.report.total.code, report.total.code);
+    assert_eq!(receipt.report.total.lines, report.total.lines);
+    assert_eq!(receipt.report.total.files, report.total.files);
+}
+
+// ===========================================================================
+// 4. Schema version consistency
+// ===========================================================================
+
+#[test]
+fn lang_json_has_correct_schema_version() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    let args = lang_args(proj.path(), TableFormat::Json);
+    let mut buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let receipt: LangReceipt = serde_json::from_slice(&buf).unwrap();
+    assert_eq!(receipt.schema_version, SCHEMA_VERSION);
+}
+
+#[test]
+fn module_json_has_correct_schema_version() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    let args = module_args(proj.path(), TableFormat::Json);
+    let mut buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let receipt: ModuleReceipt = serde_json::from_slice(&buf).unwrap();
+    assert_eq!(receipt.schema_version, SCHEMA_VERSION);
+}
+
+// ===========================================================================
+// 5. Synthetic data: Totals sum matches row sums
+// ===========================================================================
+
+#[test]
+fn synthetic_lang_totals_match_row_sums() {
+    let report = synthetic_lang_report();
+    let sum_code: usize = report.rows.iter().map(|r| r.code).sum();
+    let sum_lines: usize = report.rows.iter().map(|r| r.lines).sum();
+    let sum_files: usize = report.rows.iter().map(|r| r.files).sum();
+    assert_eq!(report.total.code, sum_code);
+    assert_eq!(report.total.lines, sum_lines);
+    assert_eq!(report.total.files, sum_files);
+}
+
+#[test]
+fn synthetic_module_totals_match_row_sums() {
+    let report = synthetic_module_report();
+    let sum_code: usize = report.rows.iter().map(|r| r.code).sum();
+    let sum_lines: usize = report.rows.iter().map(|r| r.lines).sum();
+    let sum_files: usize = report.rows.iter().map(|r| r.files).sum();
+    assert_eq!(report.total.code, sum_code);
+    assert_eq!(report.total.lines, sum_lines);
+    assert_eq!(report.total.files, sum_files);
+}
+
+// ===========================================================================
+// 6. Row data flows correctly through format pipeline
+// ===========================================================================
+
+#[test]
+fn lang_json_rows_match_original_report() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    let args = lang_args(proj.path(), TableFormat::Json);
+    let mut buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let receipt: LangReceipt = serde_json::from_slice(&buf).unwrap();
+    assert_eq!(receipt.report.rows.len(), report.rows.len());
+    for (orig, parsed) in report.rows.iter().zip(receipt.report.rows.iter()) {
+        assert_eq!(orig.lang, parsed.lang);
+        assert_eq!(orig.code, parsed.code);
+        assert_eq!(orig.lines, parsed.lines);
+        assert_eq!(orig.files, parsed.files);
+    }
+}
+
+#[test]
+fn module_json_rows_match_original_report() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    let args = module_args(proj.path(), TableFormat::Json);
+    let mut buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    let receipt: ModuleReceipt = serde_json::from_slice(&buf).unwrap();
+    assert_eq!(receipt.report.rows.len(), report.rows.len());
+    for (orig, parsed) in report.rows.iter().zip(receipt.report.rows.iter()) {
+        assert_eq!(orig.module, parsed.module);
+        assert_eq!(orig.code, parsed.code);
+    }
+}
+
+// ===========================================================================
+// 7. Scan produces non-empty data for known project
+// ===========================================================================
+
+#[test]
+fn scan_produces_nonempty_lang_report() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    assert!(!report.rows.is_empty(), "lang report should have rows");
+    assert!(report.total.code > 0, "total code should be positive");
+}
+
+#[test]
+fn scan_produces_nonempty_module_report() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    assert!(!report.rows.is_empty(), "module report should have rows");
+    assert!(report.total.code > 0, "total code should be positive");
+}
+
+// ===========================================================================
+// 8. MD and TSV outputs are non-empty
+// ===========================================================================
+
+#[test]
+fn lang_md_output_is_nonempty() {
+    let proj = make_project();
+    let report = scan_lang(proj.path());
+    let args = lang_args(proj.path(), TableFormat::Md);
+    let mut buf = Vec::new();
+    tokmd_format::write_lang_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    assert!(!buf.is_empty());
+}
+
+#[test]
+fn module_tsv_output_is_nonempty() {
+    let proj = make_project();
+    let report = scan_module(proj.path());
+    let args = module_args(proj.path(), TableFormat::Tsv);
+    let mut buf = Vec::new();
+    tokmd_format::write_module_report_to(&mut buf, &report, &opts(), &args).unwrap();
+    assert!(!buf.is_empty());
+}


### PR DESCRIPTION
## What changed
Adds 100 tests across tokmd-io-port and cross-crate integration:

| File | Tests | Type |
|------|-------|------|
| tokmd-io-port/tests/memfs_bdd.rs | 24 | BDD-style MemFs CRUD |
| tokmd-io-port/tests/readfs_contract.rs | 20 | ReadFs trait contracts |
| tokmd-io-port/tests/properties.rs | 10 | Proptest invariants |
| tokmd-io-port/tests/integration_w66.rs | 12 | Snapshots, bulk ops, cloning |
| tokmd/tests/cross_crate_w66.rs | 20 | scan->model->format pipeline |

## Tests
- All 100 tests pass locally
- cargo test -p tokmd-io-port && cargo test -p tokmd --test cross_crate_w66

## Disposition: MERGE NOW (A)