### PR TITLE
test(w67): sensor + substrate + envelope deep tests (~60 tests)

### DIFF
--- a/crates/tokmd-envelope/tests/deep_w67.rs
+++ b/crates/tokmd-envelope/tests/deep_w67.rs
@@ -1,0 +1,383 @@
+//! Deep tests for tokmd-envelope: SensorReport contract (W67)
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use tokmd_envelope::{
+    findings, Artifact, CapabilityStatus, Finding, FindingLocation,
+    FindingSeverity, GateItem, GateResults, SensorReport, ToolMeta, Verdict,
+    SENSOR_REPORT_SCHEMA,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn base_report() -> SensorReport {
+    SensorReport::new(
+        ToolMeta::tokmd("1.5.0", "cockpit"),
+        "2025-01-01T00:00:00Z".to_string(),
+        Verdict::Pass,
+        "All good".to_string(),
+    )
+}
+
+fn sample_finding(check_id: &str, code: &str, path: &str) -> Finding {
+    Finding::new(check_id, code, FindingSeverity::Warn, "Title", "Message")
+        .with_location(FindingLocation::path(path))
+}
+
+// ---------------------------------------------------------------------------
+// Tests: report construction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_report_has_schema_v1() {
+    let r = base_report();
+    assert_eq!(r.schema, SENSOR_REPORT_SCHEMA);
+    assert_eq!(r.schema, "sensor.report.v1");
+}
+
+#[test]
+fn new_report_has_empty_findings() {
+    let r = base_report();
+    assert!(r.findings.is_empty());
+}
+
+#[test]
+fn new_report_has_no_artifacts() {
+    let r = base_report();
+    assert!(r.artifacts.is_none());
+}
+
+#[test]
+fn new_report_has_no_capabilities() {
+    let r = base_report();
+    assert!(r.capabilities.is_none());
+}
+
+#[test]
+fn new_report_has_no_data() {
+    let r = base_report();
+    assert!(r.data.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: serialization round-trips
+// ---------------------------------------------------------------------------
+
+#[test]
+fn minimal_report_serde_roundtrip() {
+    let r = base_report();
+    let json = serde_json::to_string(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema, r.schema);
+    assert_eq!(back.verdict, r.verdict);
+    assert_eq!(back.summary, r.summary);
+    assert_eq!(back.tool.name, r.tool.name);
+}
+
+#[test]
+fn full_report_serde_roundtrip() {
+    let mut r = SensorReport::new(
+        ToolMeta::new("custom-tool", "2.0.0", "analyze"),
+        "2025-06-01T12:00:00Z".to_string(),
+        Verdict::Warn,
+        "Warnings found".to_string(),
+    );
+    r.add_finding(
+        sample_finding("risk", "hotspot", "src/lib.rs").with_fingerprint("custom-tool"),
+    );
+    r.add_capability("git", CapabilityStatus::available());
+    r.add_capability("coverage", CapabilityStatus::unavailable("missing"));
+    let r = r
+        .with_artifacts(vec![
+            Artifact::receipt("out/receipt.json").with_id("main"),
+            Artifact::badge("out/badge.svg"),
+        ])
+        .with_data(serde_json::json!({"extra": 42}));
+
+    let json = serde_json::to_string_pretty(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.findings.len(), 1);
+    assert_eq!(back.findings[0].fingerprint.as_ref().unwrap().len(), 32);
+    assert_eq!(back.artifacts.as_ref().unwrap().len(), 2);
+    assert_eq!(back.capabilities.as_ref().unwrap().len(), 2);
+    assert_eq!(back.data.as_ref().unwrap()["extra"], 42);
+}
+
+#[test]
+fn none_fields_omitted_from_json() {
+    let r = base_report();
+    let json = serde_json::to_string(&r).unwrap();
+    assert!(!json.contains("\"artifacts\""));
+    assert!(!json.contains("\"capabilities\""));
+    assert!(!json.contains("\"data\""));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: finding IDs are unique
+// ---------------------------------------------------------------------------
+
+#[test]
+fn finding_fingerprints_unique_for_different_paths() {
+    let f1 = sample_finding("risk", "hotspot", "src/a.rs");
+    let f2 = sample_finding("risk", "hotspot", "src/b.rs");
+    assert_ne!(
+        f1.compute_fingerprint("tokmd"),
+        f2.compute_fingerprint("tokmd")
+    );
+}
+
+#[test]
+fn finding_fingerprints_unique_for_different_codes() {
+    let f1 = sample_finding("risk", "hotspot", "src/a.rs");
+    let f2 = sample_finding("risk", "coupling", "src/a.rs");
+    assert_ne!(
+        f1.compute_fingerprint("tokmd"),
+        f2.compute_fingerprint("tokmd")
+    );
+}
+
+#[test]
+fn finding_fingerprints_unique_for_different_tools() {
+    let f = sample_finding("risk", "hotspot", "src/a.rs");
+    assert_ne!(f.compute_fingerprint("tokmd"), f.compute_fingerprint("other-tool"));
+}
+
+#[test]
+fn finding_fingerprint_deterministic() {
+    let f = sample_finding("risk", "hotspot", "src/lib.rs");
+    let fp1 = f.compute_fingerprint("tokmd");
+    let fp2 = f.compute_fingerprint("tokmd");
+    assert_eq!(fp1, fp2);
+    assert_eq!(fp1.len(), 32, "fingerprint must be 32 hex chars");
+}
+
+#[test]
+fn many_findings_all_unique_fingerprints() {
+    let paths = ["a.rs", "b.rs", "c.rs", "d.rs", "e.rs"];
+    let codes = ["hotspot", "coupling", "bus_factor"];
+    let mut fps = BTreeSet::new();
+    for path in &paths {
+        for code in &codes {
+            let f = sample_finding("risk", code, path);
+            fps.insert(f.compute_fingerprint("tokmd"));
+        }
+    }
+    assert_eq!(fps.len(), 15, "all 15 combinations must produce unique fingerprints");
+}
+
+#[test]
+fn finding_id_composition() {
+    let id = findings::finding_id("tokmd", "risk", "hotspot");
+    assert_eq!(id, "tokmd.risk.hotspot");
+}
+
+#[test]
+fn finding_id_constants_available() {
+    assert_eq!(findings::risk::CHECK_ID, "risk");
+    assert_eq!(findings::risk::HOTSPOT, "hotspot");
+    assert_eq!(findings::contract::CHECK_ID, "contract");
+    assert_eq!(findings::supply::CHECK_ID, "supply");
+    assert_eq!(findings::gate::CHECK_ID, "gate");
+    assert_eq!(findings::security::CHECK_ID, "security");
+    assert_eq!(findings::architecture::CHECK_ID, "architecture");
+    assert_eq!(findings::sensor::CHECK_ID, "sensor");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: gate results
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gate_results_pass() {
+    let g = GateResults::new(
+        Verdict::Pass,
+        vec![GateItem::new("coverage", Verdict::Pass).with_threshold(80.0, 90.0)],
+    );
+    assert_eq!(g.status, Verdict::Pass);
+    assert_eq!(g.items.len(), 1);
+    assert_eq!(g.items[0].actual, Some(90.0));
+}
+
+#[test]
+fn gate_results_fail() {
+    let g = GateResults::new(
+        Verdict::Fail,
+        vec![
+            GateItem::new("mutation", Verdict::Fail)
+                .with_threshold(80.0, 60.0)
+                .with_reason("Below threshold"),
+        ],
+    );
+    assert_eq!(g.status, Verdict::Fail);
+    assert_eq!(g.items[0].reason.as_deref(), Some("Below threshold"));
+}
+
+#[test]
+fn gate_results_serde_roundtrip() {
+    let g = GateResults::new(
+        Verdict::Warn,
+        vec![
+            GateItem::new("coverage", Verdict::Pass).with_threshold(80.0, 85.0),
+            GateItem::new("mutation", Verdict::Fail)
+                .with_threshold(70.0, 50.0)
+                .with_source("ci"),
+        ],
+    );
+    let json = serde_json::to_string(&g).unwrap();
+    let back: GateResults = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.items.len(), 2);
+    assert_eq!(back.items[1].source.as_deref(), Some("ci"));
+}
+
+#[test]
+fn gate_item_all_builders() {
+    let g = GateItem::new("test-gate", Verdict::Pending)
+        .with_threshold(90.0, 88.0)
+        .with_reason("Awaiting CI")
+        .with_source("github-actions")
+        .with_artifact_path("coverage/lcov.info");
+    assert_eq!(g.id, "test-gate");
+    assert_eq!(g.status, Verdict::Pending);
+    assert_eq!(g.threshold, Some(90.0));
+    assert_eq!(g.actual, Some(88.0));
+    assert_eq!(g.reason.as_deref(), Some("Awaiting CI"));
+    assert_eq!(g.source.as_deref(), Some("github-actions"));
+    assert_eq!(g.artifact_path.as_deref(), Some("coverage/lcov.info"));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: artifact inclusion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn artifact_type_constructors() {
+    assert_eq!(Artifact::comment("x").artifact_type, "comment");
+    assert_eq!(Artifact::receipt("x").artifact_type, "receipt");
+    assert_eq!(Artifact::badge("x").artifact_type, "badge");
+    assert_eq!(Artifact::new("custom", "x").artifact_type, "custom");
+}
+
+#[test]
+fn artifact_builders() {
+    let a = Artifact::receipt("out/r.json")
+        .with_id("main-receipt")
+        .with_mime("application/json");
+    assert_eq!(a.id.as_deref(), Some("main-receipt"));
+    assert_eq!(a.mime.as_deref(), Some("application/json"));
+    assert_eq!(a.path, "out/r.json");
+}
+
+#[test]
+fn artifacts_serde_roundtrip() {
+    let arts = vec![
+        Artifact::comment("out/comment.md").with_id("pr-comment"),
+        Artifact::badge("out/badge.svg"),
+    ];
+    let json = serde_json::to_string(&arts).unwrap();
+    let back: Vec<Artifact> = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.len(), 2);
+    assert_eq!(back[0].id.as_deref(), Some("pr-comment"));
+    assert!(back[1].id.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: tool metadata
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tool_meta_tokmd_shortcut() {
+    let t = ToolMeta::tokmd("1.5.0", "cockpit");
+    assert_eq!(t.name, "tokmd");
+    assert_eq!(t.version, "1.5.0");
+    assert_eq!(t.mode, "cockpit");
+}
+
+#[test]
+fn tool_meta_custom() {
+    let t = ToolMeta::new("my-sensor", "0.1.0", "analyze");
+    assert_eq!(t.name, "my-sensor");
+    assert_eq!(t.version, "0.1.0");
+    assert_eq!(t.mode, "analyze");
+}
+
+#[test]
+fn tool_meta_serde_roundtrip() {
+    let t = ToolMeta::new("test", "3.0.0", "mode");
+    let json = serde_json::to_string(&t).unwrap();
+    let back: ToolMeta = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.name, "test");
+    assert_eq!(back.version, "3.0.0");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: verdict
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verdict_default_is_pass() {
+    assert_eq!(Verdict::default(), Verdict::Pass);
+}
+
+#[test]
+fn verdict_display_all_variants() {
+    assert_eq!(Verdict::Pass.to_string(), "pass");
+    assert_eq!(Verdict::Fail.to_string(), "fail");
+    assert_eq!(Verdict::Warn.to_string(), "warn");
+    assert_eq!(Verdict::Skip.to_string(), "skip");
+    assert_eq!(Verdict::Pending.to_string(), "pending");
+}
+
+#[test]
+fn verdict_serde_lowercase() {
+    for (v, expected) in [
+        (Verdict::Pass, "\"pass\""),
+        (Verdict::Fail, "\"fail\""),
+        (Verdict::Warn, "\"warn\""),
+        (Verdict::Skip, "\"skip\""),
+        (Verdict::Pending, "\"pending\""),
+    ] {
+        assert_eq!(serde_json::to_string(&v).unwrap(), expected);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: envelope output determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn envelope_json_deterministic() {
+    let build = || {
+        let mut r = SensorReport::new(
+            ToolMeta::tokmd("1.5.0", "cockpit"),
+            "2025-01-01T00:00:00Z".to_string(),
+            Verdict::Warn,
+            "Warnings".to_string(),
+        );
+        r.add_finding(sample_finding("risk", "hotspot", "src/a.rs").with_fingerprint("tokmd"));
+        r.add_finding(sample_finding("risk", "coupling", "src/b.rs").with_fingerprint("tokmd"));
+        let mut caps = BTreeMap::new();
+        caps.insert("git".to_string(), CapabilityStatus::available());
+        caps.insert("coverage".to_string(), CapabilityStatus::unavailable("n/a"));
+        r.with_capabilities(caps)
+            .with_artifacts(vec![Artifact::receipt("out/r.json")])
+    };
+    let j1 = serde_json::to_string(&build()).unwrap();
+    let j2 = serde_json::to_string(&build()).unwrap();
+    assert_eq!(j1, j2, "identical builds must produce identical JSON");
+}
+
+#[test]
+fn capabilities_sorted_by_key_in_json() {
+    let mut caps = BTreeMap::new();
+    caps.insert("z-last".to_string(), CapabilityStatus::available());
+    caps.insert("a-first".to_string(), CapabilityStatus::skipped("n/a"));
+    caps.insert("m-middle".to_string(), CapabilityStatus::unavailable("x"));
+    let r = base_report().with_capabilities(caps);
+    let json = serde_json::to_string(&r).unwrap();
+    let a_pos = json.find("a-first").unwrap();
+    let m_pos = json.find("m-middle").unwrap();
+    let z_pos = json.find("z-last").unwrap();
+    assert!(a_pos < m_pos && m_pos < z_pos, "capabilities must be sorted");
+}

--- a/crates/tokmd-sensor/tests/deep_w67.rs
+++ b/crates/tokmd-sensor/tests/deep_w67.rs
@@ -1,0 +1,428 @@
+//! Deep tests for tokmd-sensor: EffortlessSensor trait + substrate builder (W67)
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokmd_envelope::{
+    Artifact, CapabilityStatus, Finding, FindingLocation, FindingSeverity, SensorReport, ToolMeta,
+    Verdict,
+};
+use tokmd_sensor::EffortlessSensor;
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_file(path: &str, lang: &str, code: usize, in_diff: bool) -> SubstrateFile {
+    SubstrateFile {
+        path: path.to_string(),
+        lang: lang.to_string(),
+        code,
+        lines: code + 20,
+        bytes: code * 30,
+        tokens: code * 8,
+        module: path
+            .rsplit_once('/')
+            .map(|(m, _)| m)
+            .unwrap_or(".")
+            .to_string(),
+        in_diff,
+    }
+}
+
+fn make_substrate(files: Vec<SubstrateFile>, diff: Option<DiffRange>) -> RepoSubstrate {
+    let mut lang_summary: BTreeMap<String, LangSummary> = BTreeMap::new();
+    for f in &files {
+        let e = lang_summary
+            .entry(f.lang.clone())
+            .or_insert(LangSummary {
+                files: 0,
+                code: 0,
+                lines: 0,
+                bytes: 0,
+                tokens: 0,
+            });
+        e.files += 1;
+        e.code += f.code;
+        e.lines += f.lines;
+        e.bytes += f.bytes;
+        e.tokens += f.tokens;
+    }
+    let total_tokens = files.iter().map(|f| f.tokens).sum();
+    let total_bytes = files.iter().map(|f| f.bytes).sum();
+    let total_code_lines = files.iter().map(|f| f.code).sum();
+    RepoSubstrate {
+        repo_root: "/repo".to_string(),
+        files,
+        lang_summary,
+        diff_range: diff,
+        total_tokens,
+        total_bytes,
+        total_code_lines,
+    }
+}
+
+fn sample_substrate() -> RepoSubstrate {
+    make_substrate(
+        vec![
+            make_file("src/lib.rs", "Rust", 100, false),
+            make_file("src/main.rs", "Rust", 50, true),
+            make_file("tests/test.py", "Python", 30, false),
+        ],
+        None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Test sensors
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize)]
+struct ThresholdSettings {
+    max_code_lines: usize,
+}
+
+struct LineSensor;
+
+impl EffortlessSensor for LineSensor {
+    type Settings = ThresholdSettings;
+    fn name(&self) -> &str {
+        "line-sensor"
+    }
+    fn version(&self) -> &str {
+        "0.2.0"
+    }
+    fn run(&self, s: &ThresholdSettings, sub: &RepoSubstrate) -> Result<SensorReport> {
+        let verdict = if sub.total_code_lines > s.max_code_lines {
+            Verdict::Fail
+        } else {
+            Verdict::Pass
+        };
+        Ok(SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "check"),
+            "2025-01-01T00:00:00Z".to_string(),
+            verdict,
+            format!("{} code lines", sub.total_code_lines),
+        ))
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct EmptySettings;
+
+struct AlwaysPassSensor;
+
+impl EffortlessSensor for AlwaysPassSensor {
+    type Settings = EmptySettings;
+    fn name(&self) -> &str {
+        "always-pass"
+    }
+    fn version(&self) -> &str {
+        "1.0.0"
+    }
+    fn run(&self, _: &EmptySettings, _sub: &RepoSubstrate) -> Result<SensorReport> {
+        Ok(SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "noop"),
+            "2025-01-01T00:00:00Z".to_string(),
+            Verdict::Pass,
+            "Nothing to report".to_string(),
+        ))
+    }
+}
+
+struct FindingSensor;
+
+impl EffortlessSensor for FindingSensor {
+    type Settings = EmptySettings;
+    fn name(&self) -> &str {
+        "finding-sensor"
+    }
+    fn version(&self) -> &str {
+        "0.3.0"
+    }
+    fn run(&self, _: &EmptySettings, sub: &RepoSubstrate) -> Result<SensorReport> {
+        let mut report = SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "scan"),
+            "2025-01-01T00:00:00Z".to_string(),
+            Verdict::Warn,
+            format!("Found {} files", sub.files.len()),
+        );
+        for f in &sub.files {
+            report.add_finding(
+                Finding::new(
+                    "review",
+                    "file-found",
+                    FindingSeverity::Info,
+                    &f.path,
+                    format!("{} lines of {}", f.code, f.lang),
+                )
+                .with_location(FindingLocation::path(&f.path)),
+            );
+        }
+        Ok(report)
+    }
+}
+
+struct DiffAwareSensor;
+
+impl EffortlessSensor for DiffAwareSensor {
+    type Settings = EmptySettings;
+    fn name(&self) -> &str {
+        "diff-aware"
+    }
+    fn version(&self) -> &str {
+        "0.1.0"
+    }
+    fn run(&self, _: &EmptySettings, sub: &RepoSubstrate) -> Result<SensorReport> {
+        let diff_count = sub.diff_files().count();
+        let verdict = if diff_count > 0 {
+            Verdict::Warn
+        } else {
+            Verdict::Pass
+        };
+        Ok(SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "diff"),
+            "2025-01-01T00:00:00Z".to_string(),
+            verdict,
+            format!("{diff_count} files in diff"),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: trait identity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sensor_name_returns_correct_id() {
+    assert_eq!(LineSensor.name(), "line-sensor");
+    assert_eq!(AlwaysPassSensor.name(), "always-pass");
+    assert_eq!(FindingSensor.name(), "finding-sensor");
+    assert_eq!(DiffAwareSensor.name(), "diff-aware");
+}
+
+#[test]
+fn sensor_version_returns_semver() {
+    let v = LineSensor.version();
+    assert_eq!(v.split('.').count(), 3, "version must be semver");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: threshold sensor verdicts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn line_sensor_pass_under_threshold() {
+    let sub = sample_substrate(); // 180 total code lines
+    let settings = ThresholdSettings {
+        max_code_lines: 500,
+    };
+    let report = LineSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+#[test]
+fn line_sensor_fail_over_threshold() {
+    let sub = sample_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 100,
+    };
+    let report = LineSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Fail);
+}
+
+#[test]
+fn line_sensor_pass_at_exact_threshold() {
+    let sub = sample_substrate(); // total = 180
+    let settings = ThresholdSettings {
+        max_code_lines: 180,
+    };
+    let report = LineSensor.run(&settings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: always-pass sensor
+// ---------------------------------------------------------------------------
+
+#[test]
+fn always_pass_returns_pass_with_empty_substrate() {
+    let sub = make_substrate(vec![], None);
+    let report = AlwaysPassSensor.run(&EmptySettings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+    assert!(report.findings.is_empty());
+}
+
+#[test]
+fn always_pass_schema_is_sensor_report_v1() {
+    let sub = sample_substrate();
+    let report = AlwaysPassSensor.run(&EmptySettings, &sub).unwrap();
+    assert_eq!(report.schema, "sensor.report.v1");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: finding sensor
+// ---------------------------------------------------------------------------
+
+#[test]
+fn finding_sensor_creates_one_finding_per_file() {
+    let sub = sample_substrate();
+    let report = FindingSensor.run(&EmptySettings, &sub).unwrap();
+    assert_eq!(report.findings.len(), sub.files.len());
+}
+
+#[test]
+fn finding_sensor_each_finding_has_location() {
+    let sub = sample_substrate();
+    let report = FindingSensor.run(&EmptySettings, &sub).unwrap();
+    for finding in &report.findings {
+        assert!(finding.location.is_some(), "every finding must have a location");
+    }
+}
+
+#[test]
+fn finding_sensor_locations_match_file_paths() {
+    let sub = sample_substrate();
+    let report = FindingSensor.run(&EmptySettings, &sub).unwrap();
+    let file_paths: Vec<&str> = sub.files.iter().map(|f| f.path.as_str()).collect();
+    for finding in &report.findings {
+        let loc_path = &finding.location.as_ref().unwrap().path;
+        assert!(file_paths.contains(&loc_path.as_str()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: diff-aware sensor
+// ---------------------------------------------------------------------------
+
+#[test]
+fn diff_aware_sensor_pass_when_no_diff_files() {
+    let sub = make_substrate(
+        vec![make_file("a.rs", "Rust", 10, false)],
+        None,
+    );
+    let report = DiffAwareSensor.run(&EmptySettings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+#[test]
+fn diff_aware_sensor_warn_when_diff_files_exist() {
+    let sub = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 10, true),
+            make_file("b.rs", "Rust", 20, false),
+        ],
+        None,
+    );
+    let report = DiffAwareSensor.run(&EmptySettings, &sub).unwrap();
+    assert_eq!(report.verdict, Verdict::Warn);
+    assert!(report.summary.contains("1 files in diff"));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: tool metadata propagation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn report_tool_meta_matches_sensor() {
+    let sub = sample_substrate();
+    let report = LineSensor
+        .run(&ThresholdSettings { max_code_lines: 999 }, &sub)
+        .unwrap();
+    assert_eq!(report.tool.name, "line-sensor");
+    assert_eq!(report.tool.version, "0.2.0");
+    assert_eq!(report.tool.mode, "check");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sensor_output_deterministic_across_runs() {
+    let sub = sample_substrate();
+    let settings = ThresholdSettings {
+        max_code_lines: 500,
+    };
+    let r1 = serde_json::to_string(&LineSensor.run(&settings, &sub).unwrap()).unwrap();
+    let r2 = serde_json::to_string(&LineSensor.run(&settings, &sub).unwrap()).unwrap();
+    assert_eq!(r1, r2, "same input must produce identical JSON");
+}
+
+#[test]
+fn finding_sensor_deterministic_across_runs() {
+    let sub = sample_substrate();
+    let r1 = serde_json::to_string(&FindingSensor.run(&EmptySettings, &sub).unwrap()).unwrap();
+    let r2 = serde_json::to_string(&FindingSensor.run(&EmptySettings, &sub).unwrap()).unwrap();
+    assert_eq!(r1, r2);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: settings serde round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn threshold_settings_serde_roundtrip() {
+    let s = ThresholdSettings {
+        max_code_lines: 42,
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let back: ThresholdSettings = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.max_code_lines, 42);
+}
+
+#[test]
+fn empty_settings_serde_roundtrip() {
+    let s = EmptySettings;
+    let json = serde_json::to_string(&s).unwrap();
+    let back: EmptySettings = serde_json::from_str(&json).unwrap();
+    let _ = back; // just confirm deserialization succeeded
+}
+
+// ---------------------------------------------------------------------------
+// Tests: capability reporting through sensors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sensor_can_attach_capabilities_to_report() {
+    let sub = sample_substrate();
+    let mut report = AlwaysPassSensor.run(&EmptySettings, &sub).unwrap();
+    report.add_capability("loc-check", CapabilityStatus::available());
+    report.add_capability("git-analysis", CapabilityStatus::unavailable("no git"));
+    let caps = report.capabilities.unwrap();
+    assert_eq!(caps.len(), 2);
+    assert_eq!(
+        caps["loc-check"].status,
+        tokmd_envelope::CapabilityState::Available
+    );
+    assert_eq!(
+        caps["git-analysis"].status,
+        tokmd_envelope::CapabilityState::Unavailable
+    );
+}
+
+#[test]
+fn sensor_can_attach_artifacts_to_report() {
+    let sub = sample_substrate();
+    let report = AlwaysPassSensor
+        .run(&EmptySettings, &sub)
+        .unwrap()
+        .with_artifacts(vec![Artifact::receipt("out/receipt.json")]);
+    let arts = report.artifacts.unwrap();
+    assert_eq!(arts.len(), 1);
+    assert_eq!(arts[0].artifact_type, "receipt");
+}
+
+#[test]
+fn sensor_report_serde_roundtrip_preserves_all_fields() {
+    let sub = sample_substrate();
+    let report = FindingSensor.run(&EmptySettings, &sub).unwrap();
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.tool.name, "finding-sensor");
+    assert_eq!(back.verdict, Verdict::Warn);
+    assert_eq!(back.findings.len(), sub.files.len());
+    assert_eq!(back.schema, "sensor.report.v1");
+}

--- a/crates/tokmd-substrate/tests/deep_w67.rs
+++ b/crates/tokmd-substrate/tests/deep_w67.rs
@@ -1,0 +1,344 @@
+//! Deep tests for tokmd-substrate: RepoSubstrate data types (W67)
+
+use std::collections::BTreeMap;
+
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_file(path: &str, lang: &str, code: usize, in_diff: bool) -> SubstrateFile {
+    SubstrateFile {
+        path: path.to_string(),
+        lang: lang.to_string(),
+        code,
+        lines: code + 20,
+        bytes: code * 30,
+        tokens: code * 8,
+        module: path
+            .rsplit_once('/')
+            .map(|(m, _)| m)
+            .unwrap_or(".")
+            .to_string(),
+        in_diff,
+    }
+}
+
+fn make_substrate(files: Vec<SubstrateFile>, diff: Option<DiffRange>) -> RepoSubstrate {
+    let mut lang_summary: BTreeMap<String, LangSummary> = BTreeMap::new();
+    for f in &files {
+        let e = lang_summary
+            .entry(f.lang.clone())
+            .or_insert(LangSummary {
+                files: 0,
+                code: 0,
+                lines: 0,
+                bytes: 0,
+                tokens: 0,
+            });
+        e.files += 1;
+        e.code += f.code;
+        e.lines += f.lines;
+        e.bytes += f.bytes;
+        e.tokens += f.tokens;
+    }
+    let total_tokens = files.iter().map(|f| f.tokens).sum();
+    let total_bytes = files.iter().map(|f| f.bytes).sum();
+    let total_code_lines = files.iter().map(|f| f.code).sum();
+    RepoSubstrate {
+        repo_root: "/repo".to_string(),
+        files,
+        lang_summary,
+        diff_range: diff,
+        total_tokens,
+        total_bytes,
+        total_code_lines,
+    }
+}
+
+fn sample_diff() -> DiffRange {
+    DiffRange {
+        base: "main".to_string(),
+        head: "HEAD".to_string(),
+        changed_files: vec!["src/lib.rs".to_string(), "src/utils.rs".to_string()],
+        commit_count: 5,
+        insertions: 40,
+        deletions: 10,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: construction and field access
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_substrate_has_zero_totals() {
+    let sub = make_substrate(vec![], None);
+    assert_eq!(sub.total_code_lines, 0);
+    assert_eq!(sub.total_bytes, 0);
+    assert_eq!(sub.total_tokens, 0);
+    assert!(sub.files.is_empty());
+    assert!(sub.lang_summary.is_empty());
+}
+
+#[test]
+fn single_file_substrate_totals_match() {
+    let sub = make_substrate(vec![make_file("a.rs", "Rust", 100, false)], None);
+    assert_eq!(sub.total_code_lines, 100);
+    assert_eq!(sub.total_bytes, 3000);
+    assert_eq!(sub.total_tokens, 800);
+    assert_eq!(sub.files.len(), 1);
+}
+
+#[test]
+fn multi_file_substrate_aggregates_correctly() {
+    let sub = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 100, false),
+            make_file("b.rs", "Rust", 50, false),
+            make_file("c.py", "Python", 30, false),
+        ],
+        None,
+    );
+    assert_eq!(sub.total_code_lines, 180);
+    assert_eq!(sub.files.len(), 3);
+    assert_eq!(sub.lang_summary.len(), 2);
+    assert_eq!(sub.lang_summary["Rust"].files, 2);
+    assert_eq!(sub.lang_summary["Rust"].code, 150);
+    assert_eq!(sub.lang_summary["Python"].files, 1);
+    assert_eq!(sub.lang_summary["Python"].code, 30);
+}
+
+#[test]
+fn repo_root_is_preserved() {
+    let sub = make_substrate(vec![], None);
+    assert_eq!(sub.repo_root, "/repo");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: diff_files filter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn diff_files_returns_only_in_diff() {
+    let sub = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 10, true),
+            make_file("b.rs", "Rust", 20, false),
+            make_file("c.rs", "Rust", 30, true),
+        ],
+        None,
+    );
+    let diff: Vec<_> = sub.diff_files().collect();
+    assert_eq!(diff.len(), 2);
+    assert_eq!(diff[0].path, "a.rs");
+    assert_eq!(diff[1].path, "c.rs");
+}
+
+#[test]
+fn diff_files_empty_when_none_in_diff() {
+    let sub = make_substrate(
+        vec![make_file("a.rs", "Rust", 10, false)],
+        None,
+    );
+    assert_eq!(sub.diff_files().count(), 0);
+}
+
+#[test]
+fn diff_files_all_when_all_in_diff() {
+    let sub = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 10, true),
+            make_file("b.rs", "Rust", 20, true),
+        ],
+        None,
+    );
+    assert_eq!(sub.diff_files().count(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: files_for_lang filter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn files_for_lang_filters_correctly() {
+    let sub = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 10, false),
+            make_file("b.py", "Python", 20, false),
+            make_file("c.rs", "Rust", 30, false),
+        ],
+        None,
+    );
+    let rust: Vec<_> = sub.files_for_lang("Rust").collect();
+    assert_eq!(rust.len(), 2);
+    let py: Vec<_> = sub.files_for_lang("Python").collect();
+    assert_eq!(py.len(), 1);
+}
+
+#[test]
+fn files_for_lang_returns_empty_for_missing_lang() {
+    let sub = make_substrate(vec![make_file("a.rs", "Rust", 10, false)], None);
+    assert_eq!(sub.files_for_lang("Go").count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: DiffRange
+// ---------------------------------------------------------------------------
+
+#[test]
+fn diff_range_fields_accessible() {
+    let d = sample_diff();
+    assert_eq!(d.base, "main");
+    assert_eq!(d.head, "HEAD");
+    assert_eq!(d.changed_files.len(), 2);
+    assert_eq!(d.commit_count, 5);
+    assert_eq!(d.insertions, 40);
+    assert_eq!(d.deletions, 10);
+}
+
+#[test]
+fn substrate_with_diff_range_preserves_it() {
+    let sub = make_substrate(vec![], Some(sample_diff()));
+    assert!(sub.diff_range.is_some());
+    let dr = sub.diff_range.unwrap();
+    assert_eq!(dr.base, "main");
+}
+
+#[test]
+fn substrate_without_diff_range_is_none() {
+    let sub = make_substrate(vec![], None);
+    assert!(sub.diff_range.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: serde round-trips
+// ---------------------------------------------------------------------------
+
+#[test]
+fn substrate_serde_roundtrip_without_diff() {
+    let sub = make_substrate(
+        vec![make_file("a.rs", "Rust", 100, false)],
+        None,
+    );
+    let json = serde_json::to_string(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.files.len(), 1);
+    assert_eq!(back.total_code_lines, 100);
+    assert!(back.diff_range.is_none());
+}
+
+#[test]
+fn substrate_serde_roundtrip_with_diff() {
+    let sub = make_substrate(
+        vec![make_file("a.rs", "Rust", 100, true)],
+        Some(sample_diff()),
+    );
+    let json = serde_json::to_string(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert!(back.diff_range.is_some());
+    assert_eq!(back.diff_range.unwrap().commit_count, 5);
+}
+
+#[test]
+fn diff_range_omitted_from_json_when_none() {
+    let sub = make_substrate(vec![], None);
+    let json = serde_json::to_string(&sub).unwrap();
+    assert!(!json.contains("diff_range"), "None diff_range should be omitted");
+}
+
+#[test]
+fn substrate_file_serde_roundtrip() {
+    let f = make_file("src/main.rs", "Rust", 50, true);
+    let json = serde_json::to_string(&f).unwrap();
+    let back: SubstrateFile = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.path, "src/main.rs");
+    assert_eq!(back.lang, "Rust");
+    assert_eq!(back.code, 50);
+    assert!(back.in_diff);
+}
+
+#[test]
+fn lang_summary_serde_roundtrip() {
+    let ls = LangSummary {
+        files: 3,
+        code: 200,
+        lines: 300,
+        bytes: 9000,
+        tokens: 1600,
+    };
+    let json = serde_json::to_string(&ls).unwrap();
+    let back: LangSummary = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.files, 3);
+    assert_eq!(back.code, 200);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: BTreeMap ordering (determinism)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lang_summary_keys_sorted_alphabetically() {
+    let sub = make_substrate(
+        vec![
+            make_file("z.go", "Go", 10, false),
+            make_file("a.rs", "Rust", 20, false),
+            make_file("b.py", "Python", 30, false),
+        ],
+        None,
+    );
+    let keys: Vec<&String> = sub.lang_summary.keys().collect();
+    assert_eq!(keys, vec!["Go", "Python", "Rust"]);
+}
+
+#[test]
+fn substrate_json_deterministic_across_builds() {
+    let sub1 = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 10, false),
+            make_file("b.py", "Python", 20, false),
+        ],
+        Some(sample_diff()),
+    );
+    let sub2 = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 10, false),
+            make_file("b.py", "Python", 20, false),
+        ],
+        Some(sample_diff()),
+    );
+    let j1 = serde_json::to_string(&sub1).unwrap();
+    let j2 = serde_json::to_string(&sub2).unwrap();
+    assert_eq!(j1, j2, "identical inputs must produce identical JSON");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: substrate shareability (Clone)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn substrate_is_cloneable_for_multi_sensor_sharing() {
+    let sub = make_substrate(
+        vec![make_file("a.rs", "Rust", 10, false)],
+        None,
+    );
+    let clone = sub.clone();
+    assert_eq!(clone.total_code_lines, sub.total_code_lines);
+    assert_eq!(clone.files.len(), sub.files.len());
+}
+
+#[test]
+fn cloned_substrate_json_matches_original() {
+    let sub = make_substrate(
+        vec![
+            make_file("a.rs", "Rust", 10, true),
+            make_file("b.py", "Python", 20, false),
+        ],
+        Some(sample_diff()),
+    );
+    let clone = sub.clone();
+    let j1 = serde_json::to_string(&sub).unwrap();
+    let j2 = serde_json::to_string(&clone).unwrap();
+    assert_eq!(j1, j2);
+}


### PR DESCRIPTION
Deep tests for the sensor/envelope pipeline across three crates (71 tests total).

### tokmd-sensor (20 tests)
- EffortlessSensor trait identity, threshold/finding/diff-aware sensors, determinism, capability/artifact attachment

### tokmd-substrate (21 tests)
- Construction, diff_files/files_for_lang filters, serde round-trips, BTreeMap ordering, clone shareability

### tokmd-envelope (30 tests)
- Report construction/serde, finding fingerprint uniqueness, gate results, artifact builders, tool metadata, verdict variants, determinism