### PR TITLE
fix(ci): cross-platform lockfile path test

### DIFF
--- a/crates/tokmd-analysis-assets/tests/deep_w66.rs
+++ b/crates/tokmd-analysis-assets/tests/deep_w66.rs
@@ -237,9 +237,10 @@ mod edge_cases_w66 {
     #[test]
     fn lockfile_path_normalized_to_forward_slashes() {
         let tmp = TempDir::new().unwrap();
-        let f = write_file(tmp.path(), "sub\\Cargo.lock", b"[[package]]\nname=\"x\"\n");
+        let f = write_file(tmp.path(), "sub/Cargo.lock", b"[[package]]\nname=\"x\"\n");
         let r = build_dependency_report(tmp.path(), &[f]).unwrap();
-        assert!(!r.lockfiles[0].path.contains('\\'));
+        assert!(r.lockfiles[0].path.contains('/'), "path should use forward slashes: {}", r.lockfiles[0].path);
+        assert!(!r.lockfiles[0].path.contains('\\'), "path should not contain backslashes: {}", r.lockfiles[0].path);
     }
 }
 


### PR DESCRIPTION
Replace backslash path separator with forward slash in \lockfile_path_normalized_to_forward_slashes\ test so it works on Linux/macOS where backslash is a literal filename character, not a path separator.

Adds explicit assertions verifying the output path uses forward slashes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>