### PR TITLE
test(w68): topics + archetype + fingerprint deep tests (~55 tests)

### DIFF
--- a/crates/tokmd-analysis-archetype/tests/deep_w68.rs
+++ b/crates/tokmd-analysis-archetype/tests/deep_w68.rs
@@ -1,0 +1,288 @@
+//! Deep W68 tests for archetype inference.
+//!
+//! Covers: all archetype kinds, priority ordering, evidence content,
+//! edge cases (empty, single file, mixed kinds), multi-language repos,
+//! deterministic detection, and negative cases.
+
+use tokmd_analysis_archetype::detect_archetype;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn parent_row(path: &str) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: "(root)".to_string(),
+        lang: "Unknown".to_string(),
+        kind: FileKind::Parent,
+        code: 1,
+        comments: 0,
+        blanks: 0,
+        lines: 1,
+        bytes: 10,
+        tokens: 2,
+    }
+}
+
+fn child_row(path: &str) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: "(root)".to_string(),
+        lang: "Unknown".to_string(),
+        kind: FileKind::Child,
+        code: 1,
+        comments: 0,
+        blanks: 0,
+        lines: 1,
+        bytes: 10,
+        tokens: 2,
+    }
+}
+
+fn export_with(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ── 1. Empty repo returns None ──────────────────────────────────
+
+#[test]
+fn empty_repo_returns_none() {
+    let export = export_with(vec![]);
+    assert!(detect_archetype(&export).is_none());
+}
+
+// ── 2. Single generic file returns None ─────────────────────────
+
+#[test]
+fn single_generic_file_returns_none() {
+    let export = export_with(vec![parent_row("README.md")]);
+    assert!(detect_archetype(&export).is_none());
+}
+
+// ── 3. Rust workspace library ───────────────────────────────────
+
+#[test]
+fn rust_workspace_library() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("crates/core/src/lib.rs"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Rust workspace");
+    assert!(!a.kind.contains("CLI"));
+}
+
+// ── 4. Rust workspace CLI with main.rs ──────────────────────────
+
+#[test]
+fn rust_workspace_cli_main_rs() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("crates/core/src/lib.rs"),
+        parent_row("src/main.rs"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Rust workspace (CLI)");
+}
+
+// ── 5. Rust workspace CLI with bin dir ──────────────────────────
+
+#[test]
+fn rust_workspace_cli_bin_dir() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("crates/app/src/bin/run.rs"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert!(a.kind.contains("CLI"));
+}
+
+// ── 6. Rust workspace with packages/ dir ────────────────────────
+
+#[test]
+fn rust_workspace_packages_dir() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("packages/utils/src/lib.rs"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert!(a.kind.contains("Rust workspace"));
+    assert!(a.evidence.iter().any(|e| e.starts_with("packages/")));
+}
+
+// ── 7. Rust workspace evidence includes Cargo.toml ──────────────
+
+#[test]
+fn rust_workspace_evidence_includes_cargo_toml() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("crates/foo/src/lib.rs"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert!(a.evidence.contains(&"Cargo.toml".to_string()));
+}
+
+// ── 8. Next.js app detected ─────────────────────────────────────
+
+#[test]
+fn nextjs_app_detected() {
+    let export = export_with(vec![
+        parent_row("package.json"),
+        parent_row("next.config.js"),
+        parent_row("pages/index.tsx"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Next.js app");
+}
+
+// ── 9. Next.js with .mjs config ────────────────────────────────
+
+#[test]
+fn nextjs_mjs_config() {
+    let export = export_with(vec![
+        parent_row("package.json"),
+        parent_row("next.config.mjs"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Next.js app");
+}
+
+// ── 10. Containerized service ───────────────────────────────────
+
+#[test]
+fn containerized_service_detected() {
+    let export = export_with(vec![
+        parent_row("Dockerfile"),
+        parent_row("k8s/deployment.yaml"),
+        parent_row("src/main.go"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Containerized service");
+    assert!(a.evidence.contains(&"Dockerfile".to_string()));
+}
+
+// ── 11. Containerized service with kubernetes/ dir ──────────────
+
+#[test]
+fn containerized_service_kubernetes_dir() {
+    let export = export_with(vec![
+        parent_row("Dockerfile"),
+        parent_row("kubernetes/service.yaml"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Containerized service");
+}
+
+// ── 12. IaC with .tf file ───────────────────────────────────────
+
+#[test]
+fn iac_with_tf_file() {
+    let export = export_with(vec![parent_row("main.tf"), parent_row("variables.tf")]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Infrastructure as code");
+}
+
+// ── 13. IaC with terraform/ dir ─────────────────────────────────
+
+#[test]
+fn iac_with_terraform_dir() {
+    let export = export_with(vec![parent_row("terraform/main.tf")]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Infrastructure as code");
+}
+
+// ── 14. Python package ──────────────────────────────────────────
+
+#[test]
+fn python_package_detected() {
+    let export = export_with(vec![
+        parent_row("pyproject.toml"),
+        parent_row("src/mylib/__init__.py"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Python package");
+    assert!(a.evidence.contains(&"pyproject.toml".to_string()));
+}
+
+// ── 15. Node package ────────────────────────────────────────────
+
+#[test]
+fn node_package_detected() {
+    let export = export_with(vec![
+        parent_row("package.json"),
+        parent_row("src/index.js"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Node package");
+}
+
+// ── 16. Priority: Rust workspace > Node ─────────────────────────
+
+#[test]
+fn rust_workspace_priority_over_node() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("crates/lib/src/lib.rs"),
+        parent_row("package.json"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert!(a.kind.contains("Rust workspace"));
+}
+
+// ── 17. Priority: Next.js > Node ────────────────────────────────
+
+#[test]
+fn nextjs_priority_over_node() {
+    let export = export_with(vec![
+        parent_row("package.json"),
+        parent_row("next.config.ts"),
+        parent_row("src/index.ts"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Next.js app");
+}
+
+// ── 18. Child rows ignored in detection ─────────────────────────
+
+#[test]
+fn child_rows_ignored() {
+    // Only child rows with Cargo.toml and crates/ — should not detect workspace
+    let export = export_with(vec![
+        child_row("Cargo.toml"),
+        child_row("crates/core/src/lib.rs"),
+    ]);
+    assert!(detect_archetype(&export).is_none());
+}
+
+// ── 19. Detection is deterministic ──────────────────────────────
+
+#[test]
+fn detection_is_deterministic() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("crates/a/src/lib.rs"),
+        parent_row("package.json"),
+        parent_row("Dockerfile"),
+        parent_row("k8s/deploy.yaml"),
+    ]);
+    let a1 = detect_archetype(&export);
+    let a2 = detect_archetype(&export);
+    assert_eq!(a1.as_ref().map(|a| &a.kind), a2.as_ref().map(|a| &a.kind));
+}
+
+// ── 20. Backslash paths normalized in detection ─────────────────
+
+#[test]
+fn backslash_paths_normalized() {
+    let export = export_with(vec![
+        parent_row("Cargo.toml"),
+        parent_row("crates\\core\\src\\lib.rs"),
+    ]);
+    let a = detect_archetype(&export).unwrap();
+    assert!(a.kind.contains("Rust workspace"));
+}

--- a/crates/tokmd-analysis-fingerprint/tests/deep_w68.rs
+++ b/crates/tokmd-analysis-fingerprint/tests/deep_w68.rs
@@ -1,0 +1,210 @@
+//! Deep W68 tests for corporate fingerprint computation.
+//!
+//! Covers: domain extraction, public-email bucketing, ignored domains,
+//! normalization, deterministic output, sorting, percentage accuracy,
+//! edge cases (empty, single commit, no @), and serde round-trips.
+
+use tokmd_analysis_fingerprint::build_corporate_fingerprint;
+use tokmd_analysis_types::CorporateFingerprint;
+use tokmd_git::GitCommit;
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn commit(author: &str) -> GitCommit {
+    GitCommit {
+        timestamp: 0,
+        author: author.to_string(),
+        hash: None,
+        subject: String::new(),
+        files: vec![],
+    }
+}
+
+// ── 1. Empty commits produce empty fingerprint ──────────────────
+
+#[test]
+fn empty_commits_empty_fingerprint() {
+    let fp = build_corporate_fingerprint(&[]);
+    assert!(fp.domains.is_empty());
+}
+
+// ── 2. Single corporate domain ──────────────────────────────────
+
+#[test]
+fn single_corporate_domain() {
+    let fp = build_corporate_fingerprint(&[commit("dev@acme.com")]);
+    assert_eq!(fp.domains.len(), 1);
+    assert_eq!(fp.domains[0].domain, "acme.com");
+    assert_eq!(fp.domains[0].commits, 1);
+    assert!((fp.domains[0].pct - 1.0).abs() < f32::EPSILON);
+}
+
+// ── 3. Public domains bucketed together ─────────────────────────
+
+#[test]
+fn public_domains_bucketed() {
+    let commits = vec![
+        commit("a@gmail.com"),
+        commit("b@yahoo.com"),
+        commit("c@outlook.com"),
+        commit("d@hotmail.com"),
+        commit("e@icloud.com"),
+        commit("f@proton.me"),
+        commit("g@protonmail.com"),
+    ];
+    let fp = build_corporate_fingerprint(&commits);
+    assert_eq!(fp.domains.len(), 1);
+    assert_eq!(fp.domains[0].domain, "public-email");
+    assert_eq!(fp.domains[0].commits, 7);
+}
+
+// ── 4. Ignored: noreply.github.com ──────────────────────────────
+
+#[test]
+fn noreply_github_ignored() {
+    let fp = build_corporate_fingerprint(&[commit("bot@users.noreply.github.com")]);
+    assert!(fp.domains.is_empty());
+}
+
+// ── 5. Ignored: localhost ───────────────────────────────────────
+
+#[test]
+fn localhost_ignored() {
+    let fp = build_corporate_fingerprint(&[commit("dev@localhost")]);
+    assert!(fp.domains.is_empty());
+}
+
+// ── 6. Ignored: example.com ─────────────────────────────────────
+
+#[test]
+fn example_com_ignored() {
+    let fp = build_corporate_fingerprint(&[commit("test@example.com")]);
+    assert!(fp.domains.is_empty());
+}
+
+// ── 7. No @ sign skipped ────────────────────────────────────────
+
+#[test]
+fn no_at_sign_skipped() {
+    let fp = build_corporate_fingerprint(&[commit("noemail")]);
+    assert!(fp.domains.is_empty());
+}
+
+// ── 8. Multiple @ signs skipped ─────────────────────────────────
+
+#[test]
+fn multiple_at_signs_skipped() {
+    let fp = build_corporate_fingerprint(&[commit("bad@@domain.com")]);
+    assert!(fp.domains.is_empty());
+}
+
+// ── 9. Domain normalization lowercase ───────────────────────────
+
+#[test]
+fn domain_normalized_lowercase() {
+    let fp = build_corporate_fingerprint(&[
+        commit("a@ACME.COM"),
+        commit("b@Acme.Com"),
+    ]);
+    assert_eq!(fp.domains.len(), 1);
+    assert_eq!(fp.domains[0].domain, "acme.com");
+    assert_eq!(fp.domains[0].commits, 2);
+}
+
+// ── 10. Sorting by commit count descending ──────────────────────
+
+#[test]
+fn sorted_by_commits_descending() {
+    let commits = vec![
+        commit("a@small.co"),
+        commit("b@big.co"),
+        commit("c@big.co"),
+        commit("d@big.co"),
+    ];
+    let fp = build_corporate_fingerprint(&commits);
+    assert_eq!(fp.domains[0].domain, "big.co");
+    assert_eq!(fp.domains[1].domain, "small.co");
+}
+
+// ── 11. Tie-breaking by domain name alphabetically ──────────────
+
+#[test]
+fn tie_breaking_alphabetical() {
+    let commits = vec![
+        commit("a@beta.com"),
+        commit("b@alpha.com"),
+    ];
+    let fp = build_corporate_fingerprint(&commits);
+    // Both have 1 commit, sorted alphabetically
+    assert_eq!(fp.domains[0].domain, "alpha.com");
+    assert_eq!(fp.domains[1].domain, "beta.com");
+}
+
+// ── 12. Percentage accuracy ─────────────────────────────────────
+
+#[test]
+fn percentage_accuracy() {
+    let commits = vec![
+        commit("a@corp.io"),
+        commit("b@corp.io"),
+        commit("c@other.io"),
+    ];
+    let fp = build_corporate_fingerprint(&commits);
+    let corp = fp.domains.iter().find(|d| d.domain == "corp.io").unwrap();
+    let other = fp.domains.iter().find(|d| d.domain == "other.io").unwrap();
+    assert!((corp.pct - 2.0 / 3.0).abs() < 0.001);
+    assert!((other.pct - 1.0 / 3.0).abs() < 0.001);
+}
+
+// ── 13. Mixed corporate and public ──────────────────────────────
+
+#[test]
+fn mixed_corporate_and_public() {
+    let commits = vec![
+        commit("a@corp.com"),
+        commit("b@corp.com"),
+        commit("c@gmail.com"),
+    ];
+    let fp = build_corporate_fingerprint(&commits);
+    assert_eq!(fp.domains.len(), 2);
+    assert!(fp.domains.iter().any(|d| d.domain == "corp.com"));
+    assert!(fp.domains.iter().any(|d| d.domain == "public-email"));
+}
+
+// ── 14. Deterministic output ────────────────────────────────────
+
+#[test]
+fn deterministic_output() {
+    let commits = vec![
+        commit("a@x.com"),
+        commit("b@y.com"),
+        commit("c@z.com"),
+        commit("d@gmail.com"),
+    ];
+    let fp1 = build_corporate_fingerprint(&commits);
+    let fp2 = build_corporate_fingerprint(&commits);
+    assert_eq!(fp1.domains.len(), fp2.domains.len());
+    for (a, b) in fp1.domains.iter().zip(fp2.domains.iter()) {
+        assert_eq!(a.domain, b.domain);
+        assert_eq!(a.commits, b.commits);
+    }
+}
+
+// ── 15. Serde round-trip for CorporateFingerprint ───────────────
+
+#[test]
+fn serde_round_trip() {
+    let commits = vec![
+        commit("a@corp.com"),
+        commit("b@gmail.com"),
+    ];
+    let fp = build_corporate_fingerprint(&commits);
+    let json = serde_json::to_string(&fp).unwrap();
+    let deserialized: CorporateFingerprint = serde_json::from_str(&json).unwrap();
+    assert_eq!(fp.domains.len(), deserialized.domains.len());
+    for (a, b) in fp.domains.iter().zip(deserialized.domains.iter()) {
+        assert_eq!(a.domain, b.domain);
+        assert_eq!(a.commits, b.commits);
+        assert!((a.pct - b.pct).abs() < f32::EPSILON);
+    }
+}

--- a/crates/tokmd-analysis-topics/tests/deep_w68.rs
+++ b/crates/tokmd-analysis-topics/tests/deep_w68.rs
@@ -1,0 +1,428 @@
+//! Deep W68 tests for topic-cloud extraction.
+//!
+//! Covers: single-language repos, multi-language repos, TF-IDF scoring,
+//! deterministic ordering, stopword filtering, edge cases (empty, single file),
+//! module-level isolation, TOP_K truncation, and token weighting.
+
+use tokmd_analysis_topics::build_topic_clouds;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn row(path: &str, module: &str, lang: &str, tokens: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code: 10,
+        comments: 0,
+        blanks: 0,
+        lines: 10,
+        bytes: 100,
+        tokens,
+    }
+}
+
+fn child_row(path: &str, module: &str) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: "Rust".to_string(),
+        kind: FileKind::Child,
+        code: 5,
+        comments: 0,
+        blanks: 0,
+        lines: 5,
+        bytes: 50,
+        tokens: 25,
+    }
+}
+
+fn export(rows: Vec<FileRow>, roots: &[&str]) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: roots.iter().map(|r| r.to_string()).collect(),
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn overall_terms(data: &ExportData) -> Vec<String> {
+    build_topic_clouds(data)
+        .overall
+        .iter()
+        .map(|t| t.term.clone())
+        .collect()
+}
+
+// ── 1. Empty export produces empty clouds ───────────────────────
+
+#[test]
+fn empty_export_produces_empty_clouds() {
+    let data = export(vec![], &[]);
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.overall.is_empty());
+    assert!(clouds.per_module.is_empty());
+}
+
+// ── 2. Single file single module ────────────────────────────────
+
+#[test]
+fn single_file_produces_topic() {
+    let data = export(
+        vec![row("auth/login_handler.rs", "auth", "Rust", 100)],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    assert!(!clouds.overall.is_empty());
+    let terms = overall_terms(&data);
+    assert!(terms.contains(&"login".to_string()));
+    assert!(terms.contains(&"handler".to_string()));
+}
+
+// ── 3. Stopwords are filtered ───────────────────────────────────
+
+#[test]
+fn stopwords_filtered_from_topics() {
+    let data = export(
+        vec![row("src/lib/mod/main/index.rs", "app", "Rust", 50)],
+        &[],
+    );
+    let terms = overall_terms(&data);
+    assert!(!terms.contains(&"src".to_string()));
+    assert!(!terms.contains(&"lib".to_string()));
+    assert!(!terms.contains(&"mod".to_string()));
+    assert!(!terms.contains(&"main".to_string()));
+    assert!(!terms.contains(&"index".to_string()));
+}
+
+// ── 4. File extensions are filtered ─────────────────────────────
+
+#[test]
+fn file_extensions_filtered() {
+    let data = export(
+        vec![row("utils/parser.rs", "utils", "Rust", 50)],
+        &[],
+    );
+    let terms = overall_terms(&data);
+    assert!(!terms.contains(&"rs".to_string()));
+    assert!(terms.contains(&"parser".to_string()));
+}
+
+// ── 5. Module roots become stopwords ────────────────────────────
+
+#[test]
+fn module_roots_become_stopwords() {
+    let data = export(
+        vec![row("crates/auth/login.rs", "crates/auth", "Rust", 50)],
+        &["crates"],
+    );
+    let terms = overall_terms(&data);
+    assert!(!terms.contains(&"crates".to_string()));
+    assert!(terms.contains(&"auth".to_string()));
+}
+
+// ── 6. Deterministic ordering across runs ───────────────────────
+
+#[test]
+fn topic_ordering_is_deterministic() {
+    let rows = vec![
+        row("api/routes/users.rs", "api", "Rust", 100),
+        row("api/routes/orders.rs", "api", "Rust", 100),
+        row("api/routes/products.rs", "api", "Rust", 100),
+    ];
+    let data = export(rows, &[]);
+    let t1 = build_topic_clouds(&data);
+    let t2 = build_topic_clouds(&data);
+
+    let terms1: Vec<String> = t1.overall.iter().map(|t| t.term.clone()).collect();
+    let terms2: Vec<String> = t2.overall.iter().map(|t| t.term.clone()).collect();
+    assert_eq!(terms1, terms2);
+}
+
+// ── 7. Multi-module topics are isolated ─────────────────────────
+
+#[test]
+fn per_module_topics_isolated() {
+    let data = export(
+        vec![
+            row("auth/login.rs", "auth", "Rust", 50),
+            row("auth/token.rs", "auth", "Rust", 50),
+            row("billing/invoice.rs", "billing", "Rust", 50),
+            row("billing/payment.rs", "billing", "Rust", 50),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    let auth_terms: Vec<String> = clouds
+        .per_module
+        .get("auth")
+        .unwrap()
+        .iter()
+        .map(|t| t.term.clone())
+        .collect();
+    let billing_terms: Vec<String> = clouds
+        .per_module
+        .get("billing")
+        .unwrap()
+        .iter()
+        .map(|t| t.term.clone())
+        .collect();
+
+    assert!(auth_terms.contains(&"login".to_string()));
+    assert!(auth_terms.contains(&"token".to_string()));
+    assert!(billing_terms.contains(&"invoice".to_string()));
+    assert!(billing_terms.contains(&"payment".to_string()));
+    // Cross-module terms should not leak
+    assert!(!auth_terms.contains(&"invoice".to_string()));
+    assert!(!billing_terms.contains(&"login".to_string()));
+}
+
+// ── 8. Child rows are excluded ──────────────────────────────────
+
+#[test]
+fn child_rows_excluded_from_topics() {
+    let data = export(
+        vec![
+            row("app/server.rs", "app", "Rust", 50),
+            child_row("app/embedded.js", "app"),
+        ],
+        &[],
+    );
+    let terms = overall_terms(&data);
+    assert!(terms.contains(&"server".to_string()));
+    assert!(!terms.contains(&"embedded".to_string()));
+}
+
+// ── 9. Score is positive for valid terms ────────────────────────
+
+#[test]
+fn scores_are_positive() {
+    let data = export(
+        vec![row("core/engine.rs", "core", "Rust", 100)],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    for term in &clouds.overall {
+        assert!(term.score > 0.0, "score should be positive: {:?}", term);
+    }
+}
+
+// ── 10. TF field equals token weight sum ────────────────────────
+
+#[test]
+fn tf_reflects_token_weight() {
+    let data = export(
+        vec![
+            row("api/handler.rs", "api", "Rust", 100),
+            row("api/handler_utils.rs", "api", "Rust", 200),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    let handler_term = clouds
+        .overall
+        .iter()
+        .find(|t| t.term == "handler")
+        .expect("handler term should exist");
+    // handler appears in both files, tf = weight(file1) + weight(file2) = 100 + 200
+    assert_eq!(handler_term.tf, 300);
+}
+
+// ── 11. DF counts files where term appears ──────────────────────
+
+#[test]
+fn df_counts_files_where_term_appears() {
+    let data = export(
+        vec![
+            row("api/handler.rs", "api", "Rust", 50),
+            row("api/handler_v2.rs", "api", "Rust", 50),
+            row("core/handler.rs", "core", "Rust", 50),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    let handler_term = clouds
+        .overall
+        .iter()
+        .find(|t| t.term == "handler")
+        .expect("handler term should exist");
+    // "handler" appears in 3 files (df incremented per file)
+    assert_eq!(handler_term.df, 3);
+}
+
+// ── 12. TOP_K truncation (max 8 terms per module) ───────────────
+
+#[test]
+fn top_k_truncation_per_module() {
+    let rows: Vec<FileRow> = (0..20)
+        .map(|i| row(&format!("mod/term{i}.rs"), "mod", "Rust", 50))
+        .collect();
+    let data = export(rows, &[]);
+    let clouds = build_topic_clouds(&data);
+    let mod_terms = clouds.per_module.get("mod").unwrap();
+    assert!(mod_terms.len() <= 8, "per-module should be truncated to TOP_K=8");
+}
+
+// ── 13. TOP_K truncation on overall ─────────────────────────────
+
+#[test]
+fn top_k_truncation_overall() {
+    let rows: Vec<FileRow> = (0..20)
+        .map(|i| row(&format!("mod/term{i}.rs"), "mod", "Rust", 50))
+        .collect();
+    let data = export(rows, &[]);
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.overall.len() <= 8, "overall should be truncated to TOP_K=8");
+}
+
+// ── 14. Multi-language repo ─────────────────────────────────────
+
+#[test]
+fn multi_language_repo_produces_topics() {
+    let data = export(
+        vec![
+            row("frontend/app/dashboard.tsx", "frontend", "TypeScript", 200),
+            row("backend/api/controller.py", "backend", "Python", 150),
+            row("infra/deploy/terraform.tf", "infra", "HCL", 80),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    assert!(clouds.per_module.contains_key("frontend"));
+    assert!(clouds.per_module.contains_key("backend"));
+    assert!(clouds.per_module.contains_key("infra"));
+    assert!(!clouds.overall.is_empty());
+}
+
+// ── 15. Underscore and hyphen splitting ─────────────────────────
+
+#[test]
+fn underscores_and_hyphens_split_tokens() {
+    let data = export(
+        vec![row("utils/rate-limiter_config.rs", "utils", "Rust", 50)],
+        &[],
+    );
+    let terms = overall_terms(&data);
+    assert!(terms.contains(&"rate".to_string()));
+    assert!(terms.contains(&"limiter".to_string()));
+    assert!(terms.contains(&"config".to_string()));
+}
+
+// ── 16. Backslash paths normalized ──────────────────────────────
+
+#[test]
+fn backslash_paths_normalized() {
+    let data = export(
+        vec![row("utils\\crypto\\hash.rs", "utils", "Rust", 50)],
+        &[],
+    );
+    let terms = overall_terms(&data);
+    assert!(terms.contains(&"crypto".to_string()));
+    assert!(terms.contains(&"hash".to_string()));
+}
+
+// ── 17. Higher token weight increases score ─────────────────────
+
+#[test]
+fn higher_token_weight_increases_score() {
+    let data = export(
+        vec![
+            row("a/heavy.rs", "a", "Rust", 10000),
+            row("a/light.rs", "a", "Rust", 1),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    let heavy = clouds
+        .overall
+        .iter()
+        .find(|t| t.term == "heavy")
+        .expect("heavy");
+    let light = clouds
+        .overall
+        .iter()
+        .find(|t| t.term == "light")
+        .expect("light");
+    assert!(
+        heavy.score > light.score,
+        "heavy ({}) should score higher than light ({})",
+        heavy.score,
+        light.score
+    );
+}
+
+// ── 18. Overall scores sorted descending ────────────────────────
+
+#[test]
+fn overall_scores_sorted_descending() {
+    let rows: Vec<FileRow> = (0..10)
+        .map(|i| row(&format!("mod/widget{i}.rs"), "mod", "Rust", (i + 1) * 10))
+        .collect();
+    let data = export(rows, &[]);
+    let clouds = build_topic_clouds(&data);
+    for pair in clouds.overall.windows(2) {
+        assert!(
+            pair[0].score >= pair[1].score
+                || (pair[0].score == pair[1].score && pair[0].term <= pair[1].term),
+            "overall not sorted: {:?} vs {:?}",
+            pair[0],
+            pair[1]
+        );
+    }
+}
+
+// ── 19. Per-module scores sorted descending ─────────────────────
+
+#[test]
+fn per_module_scores_sorted_descending() {
+    let data = export(
+        vec![
+            row("api/auth.rs", "api", "Rust", 100),
+            row("api/cache.rs", "api", "Rust", 200),
+            row("api/db.rs", "api", "Rust", 50),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    let api_terms = clouds.per_module.get("api").unwrap();
+    for pair in api_terms.windows(2) {
+        assert!(
+            pair[0].score >= pair[1].score
+                || (pair[0].score == pair[1].score && pair[0].term <= pair[1].term),
+            "per-module not sorted: {:?} vs {:?}",
+            pair[0],
+            pair[1]
+        );
+    }
+}
+
+// ── 20. IDF boosts rare terms with equal per-module TF ──────────
+
+#[test]
+fn idf_boosts_rare_terms_same_tf() {
+    // Both terms appear in 1 file each within same module.
+    // "rare" appears in 1 file (df=1), "spread" in 2 files (df=2).
+    // Same module means same module_count=1 for scoring.
+    // Use per-module to compare terms with same tf but different df.
+    let data = export(
+        vec![
+            row("mod_a/rare.rs", "mod_a", "Rust", 50),
+            row("mod_a/spread.rs", "mod_a", "Rust", 50),
+            row("mod_b/spread.rs", "mod_b", "Rust", 50),
+        ],
+        &[],
+    );
+    let clouds = build_topic_clouds(&data);
+    let mod_a = clouds.per_module.get("mod_a").unwrap();
+    let rare = mod_a.iter().find(|t| t.term == "rare").expect("rare");
+    let spread = mod_a.iter().find(|t| t.term == "spread").expect("spread");
+    // rare has df=1, spread has df=2; same tf within mod_a => rare has higher IDF
+    assert!(
+        rare.score > spread.score,
+        "rare ({}) should score higher than spread ({}) in same module due to IDF",
+        rare.score,
+        spread.score
+    );
+}


### PR DESCRIPTION
## Summary

Adds deep_w68.rs integration tests for three analysis sub-crates:

### tokmd-analysis-topics (20 tests)
- Topic extraction from single-file and multi-language repos
- TF-IDF scoring semantics (TF weight, DF counting, IDF boost)
- Stopword and file extension filtering
- Module root stopword injection
- TOP_K truncation (per-module and overall)
- Deterministic ordering across runs
- Backslash path normalization
- Child row exclusion

### tokmd-analysis-archetype (20 tests)
- All archetype kinds: Rust workspace (lib/CLI), Next.js, containerized service, IaC, Python, Node
- Priority chain ordering (Rust > Next.js > Containerized > IaC > Python > Node)
- Evidence field content validation
- Child row exclusion from detection
- Edge cases: empty repo, single generic file
- Backslash path normalization

### tokmd-analysis-fingerprint (15 tests)
- Domain extraction and normalization (lowercase)
- Public-email bucketing (all 7 providers)
- Ignored domains (noreply, localhost, example.com)
- Invalid email handling (no @, multiple @)
- Sorting by commit count descending with alphabetical tie-breaking
- Percentage accuracy verification
- Serde round-trip for CorporateFingerprint
- Deterministic output

All 55 tests pass deterministically.