### PR TITLE
test(w68): license + halstead + near-dup deep tests (~55 tests)

### DIFF
--- a/crates/tokmd-analysis-halstead/tests/deep_w68.rs
+++ b/crates/tokmd-analysis-halstead/tests/deep_w68.rs
@@ -1,0 +1,274 @@
+//! Deep tests for tokmd-analysis-halstead (w68).
+
+use tokmd_analysis_halstead::{
+    is_halstead_lang, operators_for_lang, round_f64, tokenize_for_halstead,
+};
+
+// ---------------------------------------------------------------------------
+// Language support
+// ---------------------------------------------------------------------------
+
+#[test]
+fn supported_languages() {
+    for lang in &[
+        "Rust",
+        "JavaScript",
+        "TypeScript",
+        "Python",
+        "Go",
+        "C",
+        "C++",
+        "Java",
+        "C#",
+        "PHP",
+        "Ruby",
+    ] {
+        assert!(is_halstead_lang(lang), "expected {lang} to be supported");
+    }
+}
+
+#[test]
+fn unsupported_languages() {
+    for lang in &["Haskell", "Elixir", "COBOL", ""] {
+        assert!(!is_halstead_lang(lang), "expected {lang} to be unsupported");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Operator tables
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rust_operators_contain_fn_and_arrow() {
+    let ops = operators_for_lang("rust");
+    assert!(ops.contains(&"fn"));
+    assert!(ops.contains(&"->"));
+    assert!(ops.contains(&"=>"));
+    assert!(ops.contains(&"::"));
+}
+
+#[test]
+fn python_operators_contain_def_and_walrus() {
+    let ops = operators_for_lang("python");
+    assert!(ops.contains(&"def"));
+    assert!(ops.contains(&":="));
+    assert!(ops.contains(&"lambda"));
+}
+
+#[test]
+fn javascript_operators_contain_arrow_and_spread() {
+    let ops = operators_for_lang("javascript");
+    assert!(ops.contains(&"=>"));
+    assert!(ops.contains(&"..."));
+    assert!(ops.contains(&"==="));
+}
+
+#[test]
+fn go_operators_contain_short_decl() {
+    let ops = operators_for_lang("go");
+    assert!(ops.contains(&":="));
+    assert!(ops.contains(&"<-"));
+    assert!(ops.contains(&"func"));
+}
+
+#[test]
+fn unknown_lang_returns_empty_ops() {
+    let ops = operators_for_lang("brainfuck");
+    assert!(ops.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer – Rust
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tokenize_rust_simple_fn() {
+    let code = "fn main() { let x = 42; }";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert!(counts.operators.contains_key("fn"));
+    assert!(counts.operators.contains_key("let"));
+    assert!(counts.operators.contains_key("="));
+    assert!(counts.operands.contains("main"));
+    assert!(counts.operands.contains("x"));
+    assert!(counts.total_operators > 0);
+    assert!(counts.total_operands > 0);
+}
+
+#[test]
+fn tokenize_rust_if_else() {
+    let code = "if a > b { a + b } else { a - b }";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert!(counts.operators.contains_key("if"));
+    assert!(counts.operators.contains_key("else"));
+    assert!(counts.operators.contains_key(">"));
+    assert!(counts.operators.contains_key("+"));
+    assert!(counts.operators.contains_key("-"));
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer – Python
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tokenize_python_function() {
+    let code = "def greet(name):\n    return name";
+    let counts = tokenize_for_halstead(code, "python");
+    assert!(counts.operators.contains_key("def"));
+    assert!(counts.operators.contains_key("return"));
+    assert!(counts.operands.contains("greet"));
+    assert!(counts.operands.contains("name"));
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer – JavaScript
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tokenize_js_arrow() {
+    let code = "const add = (a, b) => a + b;";
+    let counts = tokenize_for_halstead(code, "javascript");
+    assert!(counts.operators.contains_key("const"));
+    assert!(counts.operators.contains_key("=>"));
+    assert!(counts.operators.contains_key("="));
+    assert!(counts.operators.contains_key("+"));
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_source_yields_zero_counts() {
+    let counts = tokenize_for_halstead("", "rust");
+    assert_eq!(counts.total_operators, 0);
+    assert_eq!(counts.total_operands, 0);
+    assert!(counts.operators.is_empty());
+    assert!(counts.operands.is_empty());
+}
+
+#[test]
+fn only_comments_yields_zero() {
+    let code = "// this is a comment\n// another comment";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert_eq!(counts.total_operators, 0);
+    assert_eq!(counts.total_operands, 0);
+}
+
+#[test]
+fn only_blank_lines_yields_zero() {
+    let code = "\n\n\n   \n\t\n";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert_eq!(counts.total_operators, 0);
+    assert_eq!(counts.total_operands, 0);
+}
+
+#[test]
+fn string_literal_counted_as_operand() {
+    let code = r#"let s = "hello world";"#;
+    let counts = tokenize_for_halstead(code, "rust");
+    assert!(counts.operands.contains("<string>"));
+    assert!(counts.total_operands >= 1);
+}
+
+#[test]
+fn unknown_lang_counts_only_operands() {
+    let code = "fn main() { let x = 1; }";
+    let counts = tokenize_for_halstead(code, "unknown_lang");
+    // All words become operands since there are no known operators
+    assert_eq!(counts.total_operators, 0);
+    assert!(counts.total_operands > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Halstead formulas
+// ---------------------------------------------------------------------------
+
+#[test]
+fn volume_computation_manual() {
+    // n1=3, n2=4, N1=5, N2=8 => vocab=7, length=13
+    // volume = 13 * log2(7) ≈ 36.5
+    let vocab: f64 = 7.0;
+    let length: f64 = 13.0;
+    let volume = length * vocab.log2();
+    assert!((volume - 36.5).abs() < 0.5);
+}
+
+#[test]
+fn difficulty_computation_manual() {
+    // n1=4, n2=5, N2=10 => difficulty = (4/2) * (10/5) = 4.0
+    let n1 = 4.0_f64;
+    let n2 = 5.0_f64;
+    let total_opds = 10.0_f64;
+    let difficulty = (n1 / 2.0) * (total_opds / n2);
+    assert!((difficulty - 4.0).abs() < 1e-10);
+}
+
+#[test]
+fn effort_is_difficulty_times_volume() {
+    let code = "fn add(a: i32, b: i32) -> i32 { a + b }";
+    let counts = tokenize_for_halstead(code, "rust");
+    let n1 = counts.operators.len();
+    let n2 = counts.operands.len();
+    let vocab = n1 + n2;
+    let length = counts.total_operators + counts.total_operands;
+    let volume = if vocab > 0 {
+        length as f64 * (vocab as f64).log2()
+    } else {
+        0.0
+    };
+    let difficulty = if n2 > 0 {
+        (n1 as f64 / 2.0) * (counts.total_operands as f64 / n2 as f64)
+    } else {
+        0.0
+    };
+    let effort = difficulty * volume;
+    assert!(effort >= 0.0);
+    assert_eq!(effort, difficulty * volume);
+}
+
+#[test]
+fn zero_operands_yields_zero_difficulty() {
+    // Hypothetical: only operators, no operands => difficulty should be 0
+    let n2 = 0usize;
+    let difficulty = if n2 > 0 { 1.0 } else { 0.0 };
+    assert_eq!(difficulty, 0.0);
+}
+
+#[test]
+fn zero_vocabulary_yields_zero_volume() {
+    let vocab = 0usize;
+    let length = 0usize;
+    let volume = if vocab > 0 {
+        length as f64 * (vocab as f64).log2()
+    } else {
+        0.0
+    };
+    assert_eq!(volume, 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// round_f64
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_f64_basic() {
+    assert_eq!(round_f64(3.14159, 2), 3.14);
+    assert_eq!(round_f64(2.005, 2), 2.01); // banker's rounding in IEEE 754
+    assert_eq!(round_f64(0.0, 4), 0.0);
+    assert_eq!(round_f64(1.23456789, 4), 1.2346);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tokenize_deterministic_across_runs() {
+    let code = "fn main() {\n    let x = 1;\n    let y = x + 2;\n    if x > y { return; }\n}";
+    let c1 = tokenize_for_halstead(code, "rust");
+    let c2 = tokenize_for_halstead(code, "rust");
+    assert_eq!(c1.total_operators, c2.total_operators);
+    assert_eq!(c1.total_operands, c2.total_operands);
+    assert_eq!(c1.operators, c2.operators);
+    assert_eq!(c1.operands, c2.operands);
+}

--- a/crates/tokmd-analysis-license/tests/deep_w68.rs
+++ b/crates/tokmd-analysis-license/tests/deep_w68.rs
@@ -1,0 +1,377 @@
+//! Deep tests for tokmd-analysis-license (w68).
+
+use std::fs;
+use std::path::PathBuf;
+use tempfile::tempdir;
+use tokmd_analysis_license::build_license_report;
+use tokmd_analysis_types::LicenseSourceKind;
+use tokmd_analysis_util::AnalysisLimits;
+
+fn default_limits() -> AnalysisLimits {
+    AnalysisLimits::default()
+}
+
+// ---------------------------------------------------------------------------
+// Metadata detection – Cargo.toml
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cargo_toml_mit_license() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("Cargo.toml")], &default_limits())
+            .unwrap();
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.findings[0].spdx, "MIT");
+    assert_eq!(report.findings[0].source_kind, LicenseSourceKind::Metadata);
+    assert_eq!(report.effective, Some("MIT".to_string()));
+}
+
+#[test]
+fn cargo_toml_apache2_license() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"y\"\nlicense = \"Apache-2.0\"\n",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("Cargo.toml")], &default_limits())
+            .unwrap();
+    assert!(report.findings.iter().any(|f| f.spdx == "Apache-2.0"));
+}
+
+#[test]
+fn cargo_toml_dual_license_expression() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"z\"\nlicense = \"MIT OR Apache-2.0\"\n",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("Cargo.toml")], &default_limits())
+            .unwrap();
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.findings[0].spdx, "MIT OR Apache-2.0");
+}
+
+#[test]
+fn cargo_toml_single_quoted_license() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"q\"\nlicense = 'BSD-3-Clause'\n",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("Cargo.toml")], &default_limits())
+            .unwrap();
+    assert_eq!(report.findings[0].spdx, "BSD-3-Clause");
+}
+
+// ---------------------------------------------------------------------------
+// Metadata detection – package.json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn package_json_string_license() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{"name":"x","license":"ISC"}"#,
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("package.json")], &default_limits())
+            .unwrap();
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.findings[0].spdx, "ISC");
+    assert_eq!(report.findings[0].source_kind, LicenseSourceKind::Metadata);
+}
+
+#[test]
+fn package_json_object_license() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{"name":"x","license":{"type":"MIT","url":"https://mit.example"}}"#,
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("package.json")], &default_limits())
+            .unwrap();
+    assert_eq!(report.findings[0].spdx, "MIT");
+}
+
+// ---------------------------------------------------------------------------
+// Metadata detection – pyproject.toml
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pyproject_toml_project_section() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("pyproject.toml"),
+        "[project]\nname = \"pkg\"\nlicense = \"GPL-3.0-or-later\"\n",
+    )
+    .unwrap();
+    let report = build_license_report(
+        dir.path(),
+        &[PathBuf::from("pyproject.toml")],
+        &default_limits(),
+    )
+    .unwrap();
+    assert_eq!(report.findings[0].spdx, "GPL-3.0-or-later");
+}
+
+#[test]
+fn pyproject_toml_poetry_section() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("pyproject.toml"),
+        "[tool.poetry]\nname = \"pkg\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+    let report = build_license_report(
+        dir.path(),
+        &[PathBuf::from("pyproject.toml")],
+        &default_limits(),
+    )
+    .unwrap();
+    assert_eq!(report.findings[0].spdx, "MIT");
+}
+
+// ---------------------------------------------------------------------------
+// Text-based license detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn license_text_mit() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Permission is hereby granted, free of charge, to any person obtaining \
+         a copy of this software. THE SOFTWARE IS PROVIDED \"AS IS\".",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("LICENSE")], &default_limits()).unwrap();
+    let text_finding = report
+        .findings
+        .iter()
+        .find(|f| f.source_kind == LicenseSourceKind::Text)
+        .unwrap();
+    assert_eq!(text_finding.spdx, "MIT");
+    assert!(text_finding.confidence >= 0.6);
+}
+
+#[test]
+fn license_text_apache2() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Apache License\nVersion 2.0\nhttp://www.apache.org/licenses/\n\
+         limitations under the license",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("LICENSE")], &default_limits()).unwrap();
+    assert!(report.findings.iter().any(|f| f.spdx == "Apache-2.0"));
+}
+
+#[test]
+fn license_text_gpl3() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "GNU General Public License\nVersion 3\nany later version",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("LICENSE")], &default_limits()).unwrap();
+    assert!(report.findings.iter().any(|f| f.spdx == "GPL-3.0-or-later"));
+}
+
+#[test]
+fn license_text_bsd3() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Redistribution and use in source and binary forms, with or without modification.\n\
+         Neither the name of\n\
+         contributors may be used",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("LICENSE")], &default_limits()).unwrap();
+    assert!(report.findings.iter().any(|f| f.spdx == "BSD-3-Clause"));
+}
+
+#[test]
+fn license_text_mpl2() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Mozilla Public License\nVersion 2.0\nhttp://mozilla.org/MPL/2.0/",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("LICENSE")], &default_limits()).unwrap();
+    assert!(report.findings.iter().any(|f| f.spdx == "MPL-2.0"));
+}
+
+// ---------------------------------------------------------------------------
+// Empty / missing / edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_license_file_no_findings() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("LICENSE"), "").unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("LICENSE")], &default_limits()).unwrap();
+    assert!(report.findings.is_empty());
+    assert_eq!(report.effective, None);
+}
+
+#[test]
+fn no_files_yields_empty_report() {
+    let dir = tempdir().unwrap();
+    let report = build_license_report(dir.path(), &[], &default_limits()).unwrap();
+    assert!(report.findings.is_empty());
+    assert_eq!(report.effective, None);
+}
+
+#[test]
+fn unrecognized_text_no_finding() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "This is a custom proprietary license with no matching phrases.",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("LICENSE")], &default_limits()).unwrap();
+    assert!(report
+        .findings
+        .iter()
+        .all(|f| f.source_kind != LicenseSourceKind::Text));
+}
+
+// ---------------------------------------------------------------------------
+// Sorting / determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn findings_sorted_by_confidence_desc() {
+    let dir = tempdir().unwrap();
+    // Metadata findings have 0.95 confidence; text findings vary.
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Permission is hereby granted, free of charge, to any person. \
+         THE SOFTWARE IS PROVIDED \"AS IS\".",
+    )
+    .unwrap();
+    let files = vec![PathBuf::from("Cargo.toml"), PathBuf::from("LICENSE")];
+    let report = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    assert!(report.findings.len() >= 2);
+    for w in report.findings.windows(2) {
+        assert!(w[0].confidence >= w[1].confidence);
+    }
+}
+
+#[test]
+fn effective_is_highest_confidence() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+    let report =
+        build_license_report(dir.path(), &[PathBuf::from("Cargo.toml")], &default_limits())
+            .unwrap();
+    assert_eq!(report.effective, Some("MIT".to_string()));
+}
+
+#[test]
+fn deterministic_across_runs() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nlicense = \"MIT\"\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("LICENSE"),
+        "Permission is hereby granted, free of charge. \
+         The software is provided \"as is\".",
+    )
+    .unwrap();
+    let files = vec![PathBuf::from("Cargo.toml"), PathBuf::from("LICENSE")];
+    let r1 = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    let r2 = build_license_report(dir.path(), &files, &default_limits()).unwrap();
+    assert_eq!(r1.findings.len(), r2.findings.len());
+    for (a, b) in r1.findings.iter().zip(&r2.findings) {
+        assert_eq!(a.spdx, b.spdx);
+        assert_eq!(a.confidence, b.confidence);
+        assert_eq!(a.source_path, b.source_path);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Confidence scoring
+// ---------------------------------------------------------------------------
+
+#[test]
+fn confidence_increases_with_more_phrase_hits() {
+    let dir = tempdir().unwrap();
+    // One-phrase MIT hit
+    fs::write(
+        dir.path().join("LICENSE-A"),
+        "Permission is hereby granted, free of charge.",
+    )
+    .unwrap();
+    // Two-phrase MIT hit (higher confidence)
+    fs::write(
+        dir.path().join("LICENSE-B"),
+        "Permission is hereby granted, free of charge. The software is provided \"as is\".",
+    )
+    .unwrap();
+    let r_a = build_license_report(
+        dir.path(),
+        &[PathBuf::from("LICENSE-A")],
+        &default_limits(),
+    )
+    .unwrap();
+    let r_b = build_license_report(
+        dir.path(),
+        &[PathBuf::from("LICENSE-B")],
+        &default_limits(),
+    )
+    .unwrap();
+    let conf_a = r_a
+        .findings
+        .iter()
+        .find(|f| f.spdx == "MIT")
+        .map(|f| f.confidence)
+        .unwrap_or(0.0);
+    let conf_b = r_b
+        .findings
+        .iter()
+        .find(|f| f.spdx == "MIT")
+        .map(|f| f.confidence)
+        .unwrap_or(0.0);
+    assert!(conf_b >= conf_a);
+}

--- a/crates/tokmd-analysis-near-dup/tests/deep_w68.rs
+++ b/crates/tokmd-analysis-near-dup/tests/deep_w68.rs
@@ -1,0 +1,523 @@
+//! Deep tests for tokmd-analysis-near-dup (w68).
+
+use std::fs;
+use tempfile::tempdir;
+use tokmd_analysis_near_dup::{build_near_dup_report, NearDupLimits};
+use tokmd_analysis_types::NearDupScope;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+fn make_row(path: &str, lang: &str, module: &str, code: usize, bytes: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments: 0,
+        blanks: 0,
+        lines: code,
+        bytes,
+        tokens: code * 5,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+fn default_limits() -> NearDupLimits {
+    NearDupLimits {
+        max_bytes: None,
+        max_file_bytes: Some(512_000),
+    }
+}
+
+/// Generate reproducible source text with N distinct tokens.
+fn gen_source(n: usize, seed: usize) -> String {
+    (0..n)
+        .map(|i| format!("token_{}_{}", seed, i))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ---------------------------------------------------------------------------
+// Basic: identical files produce high similarity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn identical_files_detected() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.rs"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.rs", "Rust", "src", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert!(!report.pairs.is_empty(), "identical files should produce pairs");
+    assert!(report.pairs[0].similarity >= 0.99);
+}
+
+// ---------------------------------------------------------------------------
+// Completely different files produce no pairs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn different_files_no_pairs() {
+    let dir = tempdir().unwrap();
+    let a = gen_source(100, 1);
+    let b = gen_source(100, 9999);
+    fs::write(dir.path().join("a.rs"), &a).unwrap();
+    fs::write(dir.path().join("b.rs"), &b).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, a.len()),
+        make_row("b.rs", "Rust", "src", 100, b.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert!(
+        report.pairs.is_empty(),
+        "completely different files should not be paired"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Empty export produces empty report
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_export_empty_report() {
+    let dir = tempdir().unwrap();
+    let export = make_export(vec![]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert_eq!(report.files_analyzed, 0);
+    assert!(report.pairs.is_empty());
+    assert!(report.clusters.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Single file: nothing to compare
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_file_no_pairs() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 42);
+    fs::write(dir.path().join("only.rs"), &body).unwrap();
+    let export = make_export(vec![make_row("only.rs", "Rust", "src", 100, body.len())]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert!(report.pairs.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Pairs sorted by similarity desc
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pairs_sorted_by_similarity_desc() {
+    let dir = tempdir().unwrap();
+    let base = gen_source(100, 0);
+    // a == b (identical), c shares ~50% with a
+    let half: String = base.split_whitespace().take(50).collect::<Vec<_>>().join(" ");
+    let other_half = gen_source(50, 7777);
+    let c_body = format!("{half} {other_half}");
+    fs::write(dir.path().join("a.rs"), &base).unwrap();
+    fs::write(dir.path().join("b.rs"), &base).unwrap();
+    fs::write(dir.path().join("c.rs"), &c_body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, base.len()),
+        make_row("b.rs", "Rust", "src", 100, base.len()),
+        make_row("c.rs", "Rust", "src", 100, c_body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.1,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    for w in report.pairs.windows(2) {
+        assert!(w[0].similarity >= w[1].similarity);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Truncation via max_pairs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn max_pairs_truncates() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    // 3 identical files = 3 pairs
+    for name in &["a.rs", "b.rs", "c.rs"] {
+        fs::write(dir.path().join(name), &body).unwrap();
+    }
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.rs", "Rust", "src", 100, body.len()),
+        make_row("c.rs", "Rust", "src", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        Some(1),
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert!(report.pairs.len() <= 1);
+    assert!(report.truncated);
+}
+
+// ---------------------------------------------------------------------------
+// Exclude patterns filter files
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exclude_patterns_filter_files() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.rs"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.rs", "Rust", "src", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &["a.*".to_string()],
+    )
+    .unwrap();
+    // After excluding a.rs, only b.rs left => no pairs
+    assert!(report.pairs.is_empty());
+    assert_eq!(report.excluded_by_pattern, Some(1));
+}
+
+// ---------------------------------------------------------------------------
+// max_files cap
+// ---------------------------------------------------------------------------
+
+#[test]
+fn max_files_caps_analysis() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    for name in &["a.rs", "b.rs", "c.rs"] {
+        fs::write(dir.path().join(name), &body).unwrap();
+    }
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.rs", "Rust", "src", 100, body.len()),
+        make_row("c.rs", "Rust", "src", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        2, // only analyze 2 files
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert_eq!(report.files_analyzed, 2);
+    assert_eq!(report.files_skipped, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deterministic_across_runs() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.rs"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.rs", "Rust", "src", 100, body.len()),
+    ]);
+    let r1 = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    let r2 = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert_eq!(r1.pairs.len(), r2.pairs.len());
+    for (a, b) in r1.pairs.iter().zip(&r2.pairs) {
+        assert_eq!(a.left, b.left);
+        assert_eq!(a.right, b.right);
+        assert_eq!(a.similarity, b.similarity);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scope: Module isolates comparisons
+// ---------------------------------------------------------------------------
+
+#[test]
+fn module_scope_isolates() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.rs"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "mod_a", 100, body.len()),
+        make_row("b.rs", "Rust", "mod_b", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Module,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    // Different modules => no cross-module comparison
+    assert!(report.pairs.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Scope: Lang isolates comparisons
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lang_scope_isolates() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.py"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.py", "Python", "src", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Lang,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert!(report.pairs.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Clusters produced from pairs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clusters_formed_from_identical_files() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    for name in &["a.rs", "b.rs", "c.rs"] {
+        fs::write(dir.path().join(name), &body).unwrap();
+    }
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.rs", "Rust", "src", 100, body.len()),
+        make_row("c.rs", "Rust", "src", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    assert!(report.clusters.is_some());
+    let clusters = report.clusters.unwrap();
+    // All 3 identical files should form 1 cluster
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0].files.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Child rows are excluded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn child_rows_excluded() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.rs"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        FileRow {
+            path: "b.rs".to_string(),
+            module: "src".to_string(),
+            lang: "Rust".to_string(),
+            kind: FileKind::Child,
+            code: 100,
+            comments: 0,
+            blanks: 0,
+            lines: 100,
+            bytes: body.len(),
+            tokens: 500,
+        },
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    // Only 1 parent file => no pairs possible
+    assert!(report.pairs.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Files over max_file_bytes excluded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn large_files_excluded_by_byte_limit() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.rs"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        // Declare b.rs as very large in the export row
+        make_row("b.rs", "Rust", "src", 100, 1_000_000),
+    ]);
+    let limits = NearDupLimits {
+        max_bytes: None,
+        max_file_bytes: Some(512_000),
+    };
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits,
+        &[],
+    )
+    .unwrap();
+    // b.rs is over the byte limit so only 1 file eligible => no pairs
+    assert!(report.pairs.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Threshold boundary: similarity exactly at threshold
+// ---------------------------------------------------------------------------
+
+#[test]
+fn threshold_at_one_requires_perfect_match() {
+    let dir = tempdir().unwrap();
+    let body = gen_source(100, 0);
+    fs::write(dir.path().join("a.rs"), &body).unwrap();
+    fs::write(dir.path().join("b.rs"), &body).unwrap();
+    let export = make_export(vec![
+        make_row("a.rs", "Rust", "src", 100, body.len()),
+        make_row("b.rs", "Rust", "src", 100, body.len()),
+    ]);
+    let report = build_near_dup_report(
+        dir.path(),
+        &export,
+        NearDupScope::Global,
+        1.0,
+        100,
+        None,
+        &default_limits(),
+        &[],
+    )
+    .unwrap();
+    // Identical files should have similarity == 1.0 and meet threshold
+    assert!(!report.pairs.is_empty());
+    assert!((report.pairs[0].similarity - 1.0).abs() < 1e-4);
+}


### PR DESCRIPTION
## Summary

Deep integration tests for three analysis sub-crates (58 tests total):

### tokmd-analysis-license (20 tests)
- Metadata detection: Cargo.toml, package.json, pyproject.toml
- Text-based license matching: MIT, Apache-2.0, GPL-3.0, BSD-3, MPL-2.0
- SPDX identifier mapping, confidence scoring
- Edge cases: empty files, unrecognized text, no files
- Deterministic output verification

### tokmd-analysis-halstead (23 tests)
- Language support matrix (11 languages)
- Operator tables for Rust, Python, JS, Go
- Tokenizer coverage: Rust, Python, JavaScript
- Halstead formula verification (volume, difficulty, effort)
- Edge cases: empty source, comments-only, blank lines, unknown lang
- round_f64 utility, determinism

### tokmd-analysis-near-dup (15 tests)
- Identical/different file detection
- Scope isolation: module, lang, global
- Cluster formation from identical files
- Truncation via max_pairs, max_files cap
- Exclude patterns, byte limits, threshold boundary
- Child-row exclusion, determinism
