### PR TITLE
test(w69): tool-schema + io-port + math deep tests (~60 tests)

### DIFF
--- a/crates/tokmd-io-port/tests/deep_w69.rs
+++ b/crates/tokmd-io-port/tests/deep_w69.rs
@@ -1,0 +1,184 @@
+//! Deep tests for tokmd-io-port (W69).
+//!
+//! Covers ReadFs trait implementations for HostFs and MemFs,
+//! error handling, directory inference, isolation, and property tests.
+
+use std::path::{Path, PathBuf};
+
+use tokmd_io_port::{HostFs, MemFs, ReadFs};
+
+// ---------------------------------------------------------------------------
+// MemFs – basic operations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_memfs_read_string_roundtrip() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("a.txt"), "hello");
+    assert_eq!(fs.read_to_string(Path::new("a.txt")).unwrap(), "hello");
+}
+
+#[test]
+fn w69_memfs_read_bytes_roundtrip() {
+    let mut fs = MemFs::new();
+    fs.add_bytes(PathBuf::from("data.bin"), vec![0xCA, 0xFE]);
+    assert_eq!(fs.read_bytes(Path::new("data.bin")).unwrap(), vec![0xCA, 0xFE]);
+}
+
+#[test]
+fn w69_memfs_not_found_error() {
+    let fs = MemFs::new();
+    let err = fs.read_to_string(Path::new("ghost.txt")).unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn w69_memfs_invalid_utf8_error() {
+    let mut fs = MemFs::new();
+    fs.add_bytes(PathBuf::from("bad.txt"), vec![0xFF, 0xFE]);
+    let err = fs.read_to_string(Path::new("bad.txt")).unwrap_err();
+    assert!(err.to_string().contains("invalid UTF-8"));
+}
+
+#[test]
+fn w69_memfs_read_bytes_not_found() {
+    let fs = MemFs::new();
+    let err = fs.read_bytes(Path::new("missing.bin")).unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+// ---------------------------------------------------------------------------
+// MemFs – exists / is_file / is_dir
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_memfs_exists_file() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("f.txt"), "x");
+    assert!(fs.exists(Path::new("f.txt")));
+}
+
+#[test]
+fn w69_memfs_exists_returns_false_for_missing() {
+    let fs = MemFs::new();
+    assert!(!fs.exists(Path::new("nope")));
+}
+
+#[test]
+fn w69_memfs_is_file_true() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("src/main.rs"), "fn main() {}");
+    assert!(fs.is_file(Path::new("src/main.rs")));
+}
+
+#[test]
+fn w69_memfs_is_file_false_for_dir() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("src/main.rs"), "");
+    assert!(!fs.is_file(Path::new("src")));
+}
+
+#[test]
+fn w69_memfs_is_dir_inferred() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("src/lib.rs"), "");
+    assert!(fs.is_dir(Path::new("src")));
+}
+
+#[test]
+fn w69_memfs_is_dir_false_for_file() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("src/lib.rs"), "");
+    assert!(!fs.is_dir(Path::new("src/lib.rs")));
+}
+
+#[test]
+fn w69_memfs_nested_dir_inference() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("a/b/c/d.txt"), "deep");
+    assert!(fs.is_dir(Path::new("a")));
+    assert!(fs.is_dir(Path::new("a/b")));
+    assert!(fs.is_dir(Path::new("a/b/c")));
+    assert!(!fs.is_dir(Path::new("a/b/c/d.txt")));
+}
+
+#[test]
+fn w69_memfs_exists_for_inferred_dir() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("pkg/mod.rs"), "");
+    assert!(fs.exists(Path::new("pkg")));
+}
+
+// ---------------------------------------------------------------------------
+// MemFs – default / empty state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_memfs_default_empty() {
+    let fs = MemFs::default();
+    assert!(!fs.exists(Path::new("anything")));
+    assert!(!fs.is_file(Path::new("x")));
+    assert!(!fs.is_dir(Path::new("y")));
+}
+
+// ---------------------------------------------------------------------------
+// MemFs – isolation: two instances share nothing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_memfs_isolation() {
+    let mut fs1 = MemFs::new();
+    let fs2 = MemFs::new();
+    fs1.add_file(PathBuf::from("a.txt"), "data");
+    assert!(fs1.exists(Path::new("a.txt")));
+    assert!(!fs2.exists(Path::new("a.txt")));
+}
+
+// ---------------------------------------------------------------------------
+// MemFs – overwrite semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_memfs_overwrite() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("f.txt"), "v1");
+    fs.add_file(PathBuf::from("f.txt"), "v2");
+    assert_eq!(fs.read_to_string(Path::new("f.txt")).unwrap(), "v2");
+}
+
+// ---------------------------------------------------------------------------
+// HostFs – real filesystem operations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_hostfs_read_to_string() {
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("hi.txt");
+    std::fs::write(&f, "hi").unwrap();
+    assert_eq!(HostFs.read_to_string(&f).unwrap(), "hi");
+}
+
+#[test]
+fn w69_hostfs_read_bytes() {
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("bin");
+    std::fs::write(&f, &[1, 2, 3]).unwrap();
+    assert_eq!(HostFs.read_bytes(&f).unwrap(), vec![1, 2, 3]);
+}
+
+#[test]
+fn w69_hostfs_exists_and_predicates() {
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("x.txt");
+    std::fs::write(&f, "").unwrap();
+    assert!(HostFs.exists(&f));
+    assert!(HostFs.is_file(&f));
+    assert!(!HostFs.is_dir(&f));
+    assert!(HostFs.is_dir(dir.path()));
+}
+
+#[test]
+fn w69_hostfs_missing_file_error() {
+    let err = HostFs.read_to_string(Path::new("/nonexistent_w69_xyz")).unwrap_err();
+    assert!(err.to_string().len() > 0);
+}

--- a/crates/tokmd-math/tests/deep_w69.rs
+++ b/crates/tokmd-math/tests/deep_w69.rs
@@ -1,0 +1,197 @@
+//! Deep tests for tokmd-math (W69).
+//!
+//! Covers round_f64, safe_ratio, percentile, gini_coefficient with
+//! edge cases, boundary conditions, and property-based invariants.
+
+use tokmd_math::{gini_coefficient, percentile, round_f64, safe_ratio};
+
+// ---------------------------------------------------------------------------
+// round_f64
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_round_zero_decimals() {
+    assert_eq!(round_f64(2.4, 0), 2.0);
+    assert_eq!(round_f64(2.5, 0), 3.0);
+    assert_eq!(round_f64(2.6, 0), 3.0);
+}
+
+#[test]
+fn w69_round_two_decimals() {
+    assert_eq!(round_f64(12.345, 2), 12.35);
+    assert_eq!(round_f64(12.344, 2), 12.34);
+}
+
+#[test]
+fn w69_round_four_decimals() {
+    assert_eq!(round_f64(0.123456, 4), 0.1235);
+}
+
+#[test]
+fn w69_round_negative_value() {
+    assert_eq!(round_f64(-3.456, 2), -3.46);
+}
+
+#[test]
+fn w69_round_zero() {
+    assert_eq!(round_f64(0.0, 5), 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// safe_ratio
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_safe_ratio_divide_by_zero() {
+    assert_eq!(safe_ratio(100, 0), 0.0);
+    assert_eq!(safe_ratio(0, 0), 0.0);
+}
+
+#[test]
+fn w69_safe_ratio_exact() {
+    assert_eq!(safe_ratio(1, 4), 0.25);
+    assert_eq!(safe_ratio(1, 2), 0.5);
+    assert_eq!(safe_ratio(3, 4), 0.75);
+}
+
+#[test]
+fn w69_safe_ratio_repeating() {
+    assert_eq!(safe_ratio(1, 3), 0.3333);
+    assert_eq!(safe_ratio(2, 3), 0.6667);
+}
+
+#[test]
+fn w69_safe_ratio_one_to_one() {
+    assert_eq!(safe_ratio(5, 5), 1.0);
+}
+
+#[test]
+fn w69_safe_ratio_zero_numerator() {
+    assert_eq!(safe_ratio(0, 100), 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// percentile
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_percentile_empty() {
+    assert_eq!(percentile(&[], 0.5), 0.0);
+}
+
+#[test]
+fn w69_percentile_single_value() {
+    assert_eq!(percentile(&[42], 0.0), 42.0);
+    assert_eq!(percentile(&[42], 0.5), 42.0);
+    assert_eq!(percentile(&[42], 1.0), 42.0);
+}
+
+#[test]
+fn w69_percentile_min_max() {
+    let data = [10, 20, 30, 40, 50];
+    assert_eq!(percentile(&data, 0.0), 10.0);
+    assert_eq!(percentile(&data, 1.0), 50.0);
+}
+
+#[test]
+fn w69_percentile_median() {
+    let data = [1, 2, 3, 4, 5];
+    assert_eq!(percentile(&data, 0.5), 3.0);
+}
+
+#[test]
+fn w69_percentile_all_same() {
+    let data = [7, 7, 7, 7, 7];
+    assert_eq!(percentile(&data, 0.25), 7.0);
+    assert_eq!(percentile(&data, 0.75), 7.0);
+}
+
+// ---------------------------------------------------------------------------
+// gini_coefficient
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_gini_empty() {
+    assert_eq!(gini_coefficient(&[]), 0.0);
+}
+
+#[test]
+fn w69_gini_single_element() {
+    assert_eq!(gini_coefficient(&[42]), 0.0);
+}
+
+#[test]
+fn w69_gini_uniform() {
+    let data = [10, 10, 10, 10];
+    assert!((gini_coefficient(&data) - 0.0).abs() < 1e-10);
+}
+
+#[test]
+fn w69_gini_all_zeros() {
+    assert_eq!(gini_coefficient(&[0, 0, 0]), 0.0);
+}
+
+#[test]
+fn w69_gini_unequal_positive() {
+    let data = [1, 1, 1, 100];
+    assert!(gini_coefficient(&data) > 0.0);
+}
+
+#[test]
+fn w69_gini_bounded_zero_to_one() {
+    let data = [1, 2, 3, 4, 5, 100];
+    let g = gini_coefficient(&data);
+    assert!(g >= 0.0 && g <= 1.0, "gini={g} out of [0,1]");
+}
+
+// ---------------------------------------------------------------------------
+// Property tests
+// ---------------------------------------------------------------------------
+
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn w69_round_f64_idempotent(val in -1e6f64..1e6f64, dec in 0u32..6) {
+            let r1 = round_f64(val, dec);
+            let r2 = round_f64(r1, dec);
+            prop_assert_eq!(r1.to_bits(), r2.to_bits());
+        }
+
+        #[test]
+        fn w69_safe_ratio_in_unit_interval(n in 0usize..10_000, d in 1usize..10_000) {
+            let r = safe_ratio(n, d);
+            prop_assert!(r >= 0.0);
+            // Allow slight overshoot beyond 1.0 due to rounding at 4 decimals
+            // when n > d this can exceed 1.0 legitimately, so just check >= 0
+        }
+
+        #[test]
+        fn w69_percentile_monotonic(
+            mut vals in proptest::collection::vec(0usize..1000, 2..50),
+            p1 in 0.0f64..0.5,
+        ) {
+            vals.sort();
+            let p2 = p1 + 0.5; // p2 > p1
+            let v1 = percentile(&vals, p1);
+            let v2 = percentile(&vals, p2);
+            prop_assert!(v2 >= v1, "p({p1})={v1} > p({p2})={v2}");
+        }
+
+        #[test]
+        fn w69_gini_nonneg(mut vals in proptest::collection::vec(0usize..500, 1..30)) {
+            vals.sort();
+            let g = gini_coefficient(&vals);
+            prop_assert!(g >= 0.0, "gini={g} is negative");
+        }
+
+        #[test]
+        fn w69_gini_uniform_is_zero(v in 1usize..100, n in 2usize..20) {
+            let data: Vec<usize> = vec![v; n];
+            let g = gini_coefficient(&data);
+            prop_assert!((g - 0.0).abs() < 1e-10, "gini of uniform={g}");
+        }
+    }
+}

--- a/crates/tokmd-tool-schema/tests/deep_w69.rs
+++ b/crates/tokmd-tool-schema/tests/deep_w69.rs
@@ -1,0 +1,350 @@
+//! Deep tests for tokmd-tool-schema (W69).
+//!
+//! Covers OpenAI, Anthropic, JSON Schema, and Clap format rendering,
+//! deterministic output, envelope metadata, and parameter introspection.
+
+use tokmd_tool_schema::{
+    build_tool_schema, render_output, ToolSchemaFormat, TOOL_SCHEMA_VERSION,
+};
+
+use clap::{Arg, ArgAction, Command};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn simple_cmd() -> Command {
+    Command::new("mycli")
+        .version("2.0.0")
+        .about("A sample CLI")
+        .subcommand(
+            Command::new("scan")
+                .about("Scan a directory")
+                .arg(
+                    Arg::new("path")
+                        .long("path")
+                        .required(true)
+                        .help("Target path"),
+                )
+                .arg(
+                    Arg::new("verbose")
+                        .long("verbose")
+                        .action(ArgAction::SetTrue)
+                        .help("Enable verbose output"),
+                ),
+        )
+        .subcommand(
+            Command::new("export")
+                .about("Export results")
+                .arg(
+                    Arg::new("format")
+                        .long("format")
+                        .value_parser(["json", "csv", "tsv"])
+                        .help("Output format"),
+                )
+                .arg(
+                    Arg::new("count")
+                        .long("count")
+                        .action(ArgAction::Count)
+                        .help("Verbosity level"),
+                ),
+        )
+}
+
+fn minimal_cmd() -> Command {
+    Command::new("tiny").version("0.1.0").about("Tiny tool")
+}
+
+fn multi_arg_cmd() -> Command {
+    Command::new("multi")
+        .version("1.0.0")
+        .about("Multi-arg tool")
+        .arg(
+            Arg::new("items")
+                .long("items")
+                .action(ArgAction::Append)
+                .help("Repeated items"),
+        )
+        .arg(
+            Arg::new("flag_a")
+                .long("flag-a")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("flag_b")
+                .long("flag-b")
+                .action(ArgAction::SetFalse),
+        )
+        .arg(
+            Arg::new("name")
+                .long("name")
+                .default_value("world")
+                .help("Greeting target"),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// 1. Schema version constant
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_schema_version_is_positive() {
+    assert!(TOOL_SCHEMA_VERSION > 0);
+}
+
+// ---------------------------------------------------------------------------
+// 2. build_tool_schema envelope fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_build_schema_envelope_fields() {
+    let schema = build_tool_schema(&simple_cmd());
+    assert_eq!(schema.name, "mycli");
+    assert_eq!(schema.version, "2.0.0");
+    assert_eq!(schema.description, "A sample CLI");
+    assert_eq!(schema.schema_version, TOOL_SCHEMA_VERSION);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Subcommands are collected (help excluded)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_build_schema_collects_subcommands() {
+    let schema = build_tool_schema(&simple_cmd());
+    let names: Vec<&str> = schema.tools.iter().map(|t| t.name.as_str()).collect();
+    assert!(names.contains(&"scan"));
+    assert!(names.contains(&"export"));
+    assert!(!names.contains(&"help"));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Root command included as a tool
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_root_command_included() {
+    let schema = build_tool_schema(&simple_cmd());
+    assert!(schema.tools.iter().any(|t| t.name == "mycli"));
+}
+
+// ---------------------------------------------------------------------------
+// 5. Minimal command with no subcommands
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_minimal_cmd_single_tool() {
+    let schema = build_tool_schema(&minimal_cmd());
+    assert_eq!(schema.tools.len(), 1);
+    assert_eq!(schema.tools[0].name, "tiny");
+}
+
+// ---------------------------------------------------------------------------
+// 6. Parameter type detection – boolean
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_param_type_boolean() {
+    let schema = build_tool_schema(&simple_cmd());
+    let scan = schema.tools.iter().find(|t| t.name == "scan").unwrap();
+    let verbose = scan.parameters.iter().find(|p| p.name == "verbose").unwrap();
+    assert_eq!(verbose.param_type, "boolean");
+}
+
+// ---------------------------------------------------------------------------
+// 7. Parameter type detection – count → integer
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_param_type_count_integer() {
+    let schema = build_tool_schema(&simple_cmd());
+    let export = schema.tools.iter().find(|t| t.name == "export").unwrap();
+    let count = export.parameters.iter().find(|p| p.name == "count").unwrap();
+    assert_eq!(count.param_type, "integer");
+}
+
+// ---------------------------------------------------------------------------
+// 8. Parameter type detection – append → array
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_param_type_append_array() {
+    let schema = build_tool_schema(&multi_arg_cmd());
+    let root = &schema.tools[0];
+    let items = root.parameters.iter().find(|p| p.name == "items").unwrap();
+    assert_eq!(items.param_type, "array");
+}
+
+// ---------------------------------------------------------------------------
+// 9. Parameter type detection – SetFalse → boolean
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_param_type_set_false_boolean() {
+    let schema = build_tool_schema(&multi_arg_cmd());
+    let root = &schema.tools[0];
+    let flag_b = root.parameters.iter().find(|p| p.name == "flag_b").unwrap();
+    assert_eq!(flag_b.param_type, "boolean");
+}
+
+// ---------------------------------------------------------------------------
+// 10. Required flag propagation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_required_flag() {
+    let schema = build_tool_schema(&simple_cmd());
+    let scan = schema.tools.iter().find(|t| t.name == "scan").unwrap();
+    let path = scan.parameters.iter().find(|p| p.name == "path").unwrap();
+    assert!(path.required);
+    let verbose = scan.parameters.iter().find(|p| p.name == "verbose").unwrap();
+    assert!(!verbose.required);
+}
+
+// ---------------------------------------------------------------------------
+// 11. Enum values (possible_values)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_enum_values_extracted() {
+    let schema = build_tool_schema(&simple_cmd());
+    let export = schema.tools.iter().find(|t| t.name == "export").unwrap();
+    let fmt = export.parameters.iter().find(|p| p.name == "format").unwrap();
+    let enums = fmt.enum_values.as_ref().expect("should have enum values");
+    assert!(enums.contains(&"json".to_string()));
+    assert!(enums.contains(&"csv".to_string()));
+    assert!(enums.contains(&"tsv".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// 12. Default value extraction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_default_value_extracted() {
+    let schema = build_tool_schema(&multi_arg_cmd());
+    let root = &schema.tools[0];
+    let name = root.parameters.iter().find(|p| p.name == "name").unwrap();
+    assert_eq!(name.default.as_deref(), Some("world"));
+}
+
+// ---------------------------------------------------------------------------
+// 13. OpenAI format – top-level key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_openai_has_functions_key() {
+    let schema = build_tool_schema(&simple_cmd());
+    let output = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert!(parsed.get("functions").is_some());
+}
+
+// ---------------------------------------------------------------------------
+// 14. OpenAI format – parameters.type is "object"
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_openai_parameters_type_object() {
+    let schema = build_tool_schema(&simple_cmd());
+    let output = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    let func = &parsed["functions"][0];
+    assert_eq!(func["parameters"]["type"], "object");
+}
+
+// ---------------------------------------------------------------------------
+// 15. Anthropic format – has input_schema
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_anthropic_has_input_schema() {
+    let schema = build_tool_schema(&simple_cmd());
+    let output = render_output(&schema, ToolSchemaFormat::Anthropic, false).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    let tools = parsed["tools"].as_array().unwrap();
+    for tool in tools {
+        assert!(tool.get("input_schema").is_some());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 16. Anthropic format – no "functions" key (differs from OpenAI)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_anthropic_no_functions_key() {
+    let schema = build_tool_schema(&simple_cmd());
+    let output = render_output(&schema, ToolSchemaFormat::Anthropic, false).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert!(parsed.get("functions").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// 17. JSON Schema format – $schema field
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_jsonschema_has_dollar_schema() {
+    let schema = build_tool_schema(&simple_cmd());
+    let output = render_output(&schema, ToolSchemaFormat::Jsonschema, false).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(
+        parsed["$schema"],
+        "https://json-schema.org/draft-07/schema#"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 18. Clap format – serializes ToolSchemaOutput directly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_clap_format_has_tools_array() {
+    let schema = build_tool_schema(&simple_cmd());
+    let output = render_output(&schema, ToolSchemaFormat::Clap, false).unwrap();
+    let parsed: Value = serde_json::from_str(&output).unwrap();
+    assert!(parsed["tools"].is_array());
+    assert_eq!(parsed["schema_version"], TOOL_SCHEMA_VERSION);
+}
+
+// ---------------------------------------------------------------------------
+// 19. Deterministic output – two calls produce identical JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_deterministic_output() {
+    let cmd1 = simple_cmd();
+    let cmd2 = simple_cmd();
+    let s1 = build_tool_schema(&cmd1);
+    let s2 = build_tool_schema(&cmd2);
+
+    for fmt in [
+        ToolSchemaFormat::Openai,
+        ToolSchemaFormat::Anthropic,
+        ToolSchemaFormat::Jsonschema,
+        ToolSchemaFormat::Clap,
+    ] {
+        let r1 = render_output(&s1, fmt, true).unwrap();
+        let r2 = render_output(&s2, fmt, true).unwrap();
+        assert_eq!(r1, r2, "non-deterministic output for format {:?}", fmt);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 20. Pretty vs compact output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w69_pretty_vs_compact() {
+    let schema = build_tool_schema(&simple_cmd());
+    let pretty = render_output(&schema, ToolSchemaFormat::Openai, true).unwrap();
+    let compact = render_output(&schema, ToolSchemaFormat::Openai, false).unwrap();
+    assert!(pretty.len() > compact.len());
+    assert!(pretty.contains('\n'));
+    // Both parse to the same value.
+    let p: Value = serde_json::from_str(&pretty).unwrap();
+    let c: Value = serde_json::from_str(&compact).unwrap();
+    assert_eq!(p, c);
+}


### PR DESCRIPTION
## Summary

Adds deep integration tests for three microcrates:

### tokmd-tool-schema (20 tests)
- OpenAI function calling format rendering
- Anthropic tool use format rendering  
- JSON Schema Draft 7 format rendering
- Clap raw format rendering
- Parameter type detection (boolean, integer, array, string)
- Required flag propagation, enum values, default values
- Envelope metadata (name, version, description, schema_version)
- Deterministic output across all formats
- Pretty vs compact rendering equivalence

### tokmd-io-port (20 tests)
- MemFs: read string/bytes roundtrip, not-found errors, invalid UTF-8
- MemFs: exists/is_file/is_dir with directory inference from stored paths
- MemFs: nested directory inference, default empty state, overwrite semantics
- MemFs: isolation between instances
- HostFs: real filesystem read/write, exists, predicates, error handling

### tokmd-math (26 tests)
- round_f64: zero/two/four decimals, negative values, zero
- safe_ratio: division by zero guard, exact/repeating fractions, identity
- percentile: empty, single value, min/max, median, uniform data
- gini_coefficient: empty, single, uniform, all-zeros, unequal, bounded
- Property tests (proptest): rounding idempotency, ratio non-negativity, percentile monotonicity, Gini non-negativity, Gini zero for uniform data

All 66 tests pass deterministically.