### PR TITLE
test(w69): analysis-format + html + explain + imports deep tests (~70 tests)

### DIFF
--- a/crates/tokmd-analysis-explain/tests/deep_w69.rs
+++ b/crates/tokmd-analysis-explain/tests/deep_w69.rs
@@ -1,0 +1,197 @@
+//! Deep tests for tokmd-analysis-explain (W69).
+//!
+//! Covers: lookup by canonical key, lookup by alias, normalization,
+//! catalog determinism, unknown keys, edge cases.
+
+use tokmd_analysis_explain::{catalog, lookup};
+
+// ===================================================================
+// 1. Canonical key lookups
+// ===================================================================
+
+#[test]
+fn lookup_doc_density() {
+    let result = lookup("doc_density").unwrap();
+    assert!(result.starts_with("doc_density:"));
+    assert!(result.contains("comment"));
+}
+
+#[test]
+fn lookup_whitespace_ratio() {
+    let result = lookup("whitespace_ratio").unwrap();
+    assert!(result.starts_with("whitespace_ratio:"));
+    assert!(result.contains("blank"));
+}
+
+#[test]
+fn lookup_verbosity() {
+    let result = lookup("verbosity").unwrap();
+    assert!(result.starts_with("verbosity:"));
+}
+
+#[test]
+fn lookup_test_density() {
+    let result = lookup("test_density").unwrap();
+    assert!(result.starts_with("test_density:"));
+    assert!(result.contains("test"));
+}
+
+#[test]
+fn lookup_todo_density() {
+    let result = lookup("todo_density").unwrap();
+    assert!(result.starts_with("todo_density:"));
+}
+
+#[test]
+fn lookup_gini() {
+    let result = lookup("gini").unwrap();
+    assert!(result.starts_with("gini:"));
+    assert!(result.contains("file"));
+}
+
+#[test]
+fn lookup_hotspots() {
+    let result = lookup("hotspots").unwrap();
+    assert!(result.starts_with("hotspots:"));
+}
+
+#[test]
+fn lookup_bus_factor() {
+    let result = lookup("bus_factor").unwrap();
+    assert!(result.starts_with("bus_factor:"));
+    assert!(result.contains("author"));
+}
+
+#[test]
+fn lookup_coupling() {
+    let result = lookup("coupling").unwrap();
+    assert!(result.starts_with("coupling:"));
+}
+
+#[test]
+fn lookup_imports() {
+    let result = lookup("imports").unwrap();
+    assert!(result.starts_with("imports:"));
+}
+
+// ===================================================================
+// 2. Alias lookups
+// ===================================================================
+
+#[test]
+fn lookup_alias_docs() {
+    let result = lookup("docs").unwrap();
+    assert!(result.starts_with("doc_density:"));
+}
+
+#[test]
+fn lookup_alias_todo() {
+    let result = lookup("todo").unwrap();
+    assert!(result.starts_with("todo_density:"));
+}
+
+#[test]
+fn lookup_alias_churn() {
+    let result = lookup("churn").unwrap();
+    assert!(result.starts_with("predictive_churn:"));
+}
+
+// ===================================================================
+// 3. Normalization
+// ===================================================================
+
+#[test]
+fn lookup_normalizes_dashes() {
+    let result = lookup("doc-density").unwrap();
+    assert!(result.starts_with("doc_density:"));
+}
+
+#[test]
+fn lookup_normalizes_spaces() {
+    let result = lookup("doc density").unwrap();
+    assert!(result.starts_with("doc_density:"));
+}
+
+#[test]
+fn lookup_normalizes_case() {
+    let result = lookup("DOC_DENSITY").unwrap();
+    assert!(result.starts_with("doc_density:"));
+}
+
+#[test]
+fn lookup_normalizes_dots() {
+    let result = lookup("doc.density").unwrap();
+    assert!(result.starts_with("doc_density:"));
+}
+
+#[test]
+fn lookup_normalizes_leading_trailing_whitespace() {
+    let result = lookup("  doc_density  ").unwrap();
+    assert!(result.starts_with("doc_density:"));
+}
+
+// ===================================================================
+// 4. Unknown keys
+// ===================================================================
+
+#[test]
+fn lookup_unknown_key_returns_none() {
+    assert!(lookup("nonexistent_metric").is_none());
+}
+
+#[test]
+fn lookup_empty_string_returns_none() {
+    assert!(lookup("").is_none());
+}
+
+// ===================================================================
+// 5. Catalog
+// ===================================================================
+
+#[test]
+fn catalog_starts_with_header() {
+    let cat = catalog();
+    assert!(cat.starts_with("Available metric/finding keys:"));
+}
+
+#[test]
+fn catalog_contains_known_keys() {
+    let cat = catalog();
+    assert!(cat.contains("doc_density"));
+    assert!(cat.contains("gini"));
+    assert!(cat.contains("hotspots"));
+    assert!(cat.contains("imports"));
+}
+
+#[test]
+fn catalog_is_sorted() {
+    let cat = catalog();
+    let keys: Vec<&str> = cat
+        .lines()
+        .skip(1)
+        .filter_map(|l| l.strip_prefix("- "))
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort_unstable();
+    assert_eq!(keys, sorted);
+}
+
+#[test]
+fn catalog_has_no_duplicates() {
+    let cat = catalog();
+    let keys: Vec<&str> = cat
+        .lines()
+        .skip(1)
+        .filter_map(|l| l.strip_prefix("- "))
+        .collect();
+    let mut deduped = keys.clone();
+    deduped.dedup();
+    assert_eq!(keys, deduped);
+}
+
+#[test]
+fn catalog_is_deterministic() {
+    let a = catalog();
+    let b = catalog();
+    assert_eq!(a, b, "catalog() must be deterministic");
+}

--- a/crates/tokmd-analysis-format/tests/deep_w69.rs
+++ b/crates/tokmd-analysis-format/tests/deep_w69.rs
@@ -1,0 +1,555 @@
+//! Deep tests for tokmd-analysis-format rendering (W69).
+//!
+//! Covers: Markdown rendering, JSON rendering, section formatting,
+//! deterministic output, empty/minimal data, XML, JSON-LD, SVG, Mermaid, Tree.
+
+use tokmd_analysis_format::{RenderedOutput, render};
+use tokmd_analysis_types::*;
+use tokmd_types::{AnalysisFormat, ScanStatus, ToolInfo};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: ToolInfo {
+            name: "tokmd".to_string(),
+            version: "0.0.0".to_string(),
+        },
+        mode: "analysis".to_string(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec!["test".to_string()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".to_string(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".to_string(),
+            format: "md".to_string(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            max_file_bytes: None,
+            import_granularity: "module".to_string(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 10,
+            code: 1000,
+            comments: 200,
+            blanks: 100,
+            lines: 1300,
+            bytes: 50000,
+            tokens: 2500,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 200,
+                denominator: 1200,
+                ratio: 0.1667,
+            },
+            by_lang: vec![RatioRow {
+                key: "Rust".into(),
+                numerator: 150,
+                denominator: 900,
+                ratio: 0.1667,
+            }],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 100,
+                denominator: 1300,
+                ratio: 0.0769,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 50000,
+                denominator: 1300,
+                rate: 38.46,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: FileStatRow {
+                path: "src/lib.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 500,
+                comments: 100,
+                blanks: 50,
+                lines: 650,
+                bytes: 25000,
+                tokens: 1250,
+                doc_pct: Some(0.167),
+                bytes_per_line: Some(38.46),
+                depth: 1,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 3,
+            avg: 1.5,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 200,
+            prod_lines: 1000,
+            test_files: 5,
+            prod_files: 5,
+            ratio: 0.2,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 100,
+            logic_lines: 1100,
+            ratio: 0.083,
+            infra_langs: vec!["TOML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 2,
+            entropy: 0.5,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 1000,
+            dominant_pct: 0.833,
+        },
+        distribution: DistributionReport {
+            count: 10,
+            min: 50,
+            max: 650,
+            mean: 130.0,
+            median: 100.0,
+            p90: 400.0,
+            p99: 650.0,
+            gini: 0.3,
+        },
+        histogram: vec![HistogramBucket {
+            label: "Small".into(),
+            min: 0,
+            max: Some(100),
+            files: 5,
+            pct: 0.5,
+        }],
+        top: TopOffenders {
+            largest_lines: vec![FileStatRow {
+                path: "src/lib.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 500,
+                comments: 100,
+                blanks: 50,
+                lines: 650,
+                bytes: 25000,
+                tokens: 1250,
+                doc_pct: Some(0.167),
+                bytes_per_line: Some(38.46),
+                depth: 1,
+            }],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: Some("test-tree".into()),
+        reading_time: ReadingTimeReport {
+            minutes: 65.0,
+            lines_per_minute: 20,
+            basis_lines: 1300,
+        },
+        context_window: Some(ContextWindowReport {
+            window_tokens: 100000,
+            total_tokens: 2500,
+            pct: 0.025,
+            fits: true,
+        }),
+        cocomo: Some(CocomoReport {
+            mode: "organic".into(),
+            kloc: 1.0,
+            effort_pm: 2.4,
+            duration_months: 2.5,
+            staff: 1.0,
+            a: 2.4,
+            b: 1.05,
+            c: 2.5,
+            d: 0.38,
+        }),
+        todo: Some(TodoReport {
+            total: 5,
+            density_per_kloc: 5.0,
+            tags: vec![TodoTagRow {
+                tag: "TODO".into(),
+                count: 5,
+            }],
+        }),
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "abc123".into(),
+            entries: 10,
+        },
+    }
+}
+
+fn extract_text(output: RenderedOutput) -> String {
+    match output {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text, got binary"),
+    }
+}
+
+// ===================================================================
+// 1. Markdown rendering — minimal receipt
+// ===================================================================
+
+#[test]
+fn md_minimal_receipt_starts_with_header() {
+    let receipt = minimal_receipt();
+    let out = render(&receipt, AnalysisFormat::Md).unwrap();
+    let text = extract_text(out);
+    assert!(text.starts_with("# tokmd analysis"));
+}
+
+#[test]
+fn md_minimal_receipt_shows_preset() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("Preset: `receipt`"));
+}
+
+#[test]
+fn md_minimal_receipt_shows_inputs() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("- `test`"));
+}
+
+#[test]
+fn md_minimal_receipt_no_derived_sections() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(!text.contains("## Totals"));
+    assert!(!text.contains("## Distribution"));
+}
+
+// ===================================================================
+// 2. Markdown rendering — derived sections
+// ===================================================================
+
+#[test]
+fn md_derived_totals_table() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## Totals"));
+    assert!(text.contains("|10|1000|200|100|1300|50000|2500|"));
+}
+
+#[test]
+fn md_derived_ratios_section() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## Ratios"));
+    assert!(text.contains("|Doc density|"));
+    assert!(text.contains("|Whitespace ratio|"));
+}
+
+#[test]
+fn md_derived_distribution_section() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## Distribution"));
+    assert!(text.contains("|10|50|650|"));
+}
+
+#[test]
+fn md_derived_cocomo_section() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## COCOMO estimate"));
+    assert!(text.contains("Mode: `organic`"));
+}
+
+#[test]
+fn md_derived_context_window_section() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## Context window"));
+    assert!(text.contains("Fits: `true`"));
+}
+
+#[test]
+fn md_derived_todo_section() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## TODOs"));
+    assert!(text.contains("|TODO|5|"));
+}
+
+#[test]
+fn md_derived_integrity_section() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## Integrity"));
+    assert!(text.contains("abc123"));
+}
+
+// ===================================================================
+// 3. Markdown — optional sections
+// ===================================================================
+
+#[test]
+fn md_archetype_section() {
+    let mut receipt = minimal_receipt();
+    receipt.archetype = Some(Archetype {
+        kind: "cli-tool".into(),
+        evidence: vec!["Cargo.toml".into(), "main.rs".into()],
+    });
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## Archetype"));
+    assert!(text.contains("Kind: `cli-tool`"));
+    assert!(text.contains("Cargo.toml`, `main.rs"));
+}
+
+#[test]
+fn md_imports_section() {
+    let mut receipt = minimal_receipt();
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![ImportEdge {
+            from: "src".into(),
+            to: "serde".into(),
+            count: 3,
+        }],
+    });
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("## Imports"));
+    assert!(text.contains("|src|serde|3|"));
+}
+
+#[test]
+fn md_entropy_no_suspects() {
+    let mut receipt = minimal_receipt();
+    receipt.entropy = Some(EntropyReport {
+        suspects: vec![],
+    });
+    let text = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert!(text.contains("No entropy outliers detected"));
+}
+
+// ===================================================================
+// 4. JSON rendering
+// ===================================================================
+
+#[test]
+fn json_minimal_receipt_is_valid() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Json).unwrap());
+    let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        parsed["schema_version"].as_u64().unwrap(),
+        ANALYSIS_SCHEMA_VERSION as u64
+    );
+}
+
+#[test]
+fn json_round_trip_preserves_fields() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Json).unwrap());
+    let parsed: AnalysisReceipt = serde_json::from_str(&text).unwrap();
+    assert_eq!(parsed.derived.as_ref().unwrap().totals.code, 1000);
+    assert_eq!(parsed.args.preset, "receipt");
+}
+
+#[test]
+fn json_with_derived_includes_cocomo() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Json).unwrap());
+    let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(parsed["derived"]["cocomo"]["mode"], "organic");
+}
+
+// ===================================================================
+// 5. JSON-LD rendering
+// ===================================================================
+
+#[test]
+fn jsonld_has_schema_org_context() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Jsonld).unwrap());
+    let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(parsed["@context"], "https://schema.org");
+    assert_eq!(parsed["@type"], "SoftwareSourceCode");
+}
+
+#[test]
+fn jsonld_uses_first_input_as_name() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Jsonld).unwrap());
+    let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(parsed["name"], "test");
+}
+
+// ===================================================================
+// 6. XML rendering
+// ===================================================================
+
+#[test]
+fn xml_minimal_receipt_wraps_analysis() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    assert!(text.starts_with("<analysis>"));
+    assert!(text.ends_with("</analysis>"));
+}
+
+#[test]
+fn xml_with_derived_includes_totals() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    assert!(text.contains("files=\"10\""));
+    assert!(text.contains("code=\"1000\""));
+}
+
+// ===================================================================
+// 7. SVG rendering
+// ===================================================================
+
+#[test]
+fn svg_minimal_receipt_is_valid_svg() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Svg).unwrap());
+    assert!(text.starts_with("<svg"));
+    assert!(text.ends_with("</svg>"));
+}
+
+#[test]
+fn svg_with_context_window_shows_pct() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Svg).unwrap());
+    assert!(text.contains("context"));
+    assert!(text.contains("2.5%"));
+}
+
+// ===================================================================
+// 8. Mermaid rendering
+// ===================================================================
+
+#[test]
+fn mermaid_starts_with_graph_td() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Mermaid).unwrap());
+    assert!(text.starts_with("graph TD\n"));
+}
+
+#[test]
+fn mermaid_includes_import_edges() {
+    let mut receipt = minimal_receipt();
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![ImportEdge {
+            from: "src/main".into(),
+            to: "lib/utils".into(),
+            count: 2,
+        }],
+    });
+    let text = extract_text(render(&receipt, AnalysisFormat::Mermaid).unwrap());
+    assert!(text.contains("-->|2|"));
+}
+
+// ===================================================================
+// 9. Tree rendering
+// ===================================================================
+
+#[test]
+fn tree_unavailable_without_derived() {
+    let receipt = minimal_receipt();
+    let text = extract_text(render(&receipt, AnalysisFormat::Tree).unwrap());
+    assert_eq!(text, "(tree unavailable)");
+}
+
+#[test]
+fn tree_returns_derived_tree() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let text = extract_text(render(&receipt, AnalysisFormat::Tree).unwrap());
+    assert_eq!(text, "test-tree");
+}
+
+// ===================================================================
+// 10. Determinism
+// ===================================================================
+
+#[test]
+fn md_rendering_is_deterministic() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let a = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    let b = extract_text(render(&receipt, AnalysisFormat::Md).unwrap());
+    assert_eq!(a, b, "Markdown output must be deterministic");
+}
+
+#[test]
+fn json_rendering_is_deterministic() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let a = extract_text(render(&receipt, AnalysisFormat::Json).unwrap());
+    let b = extract_text(render(&receipt, AnalysisFormat::Json).unwrap());
+    assert_eq!(a, b, "JSON output must be deterministic");
+}
+
+#[test]
+fn xml_rendering_is_deterministic() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let a = extract_text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    let b = extract_text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    assert_eq!(a, b, "XML output must be deterministic");
+}

--- a/crates/tokmd-analysis-html/tests/deep_w69.rs
+++ b/crates/tokmd-analysis-html/tests/deep_w69.rs
@@ -1,0 +1,370 @@
+//! Deep tests for tokmd-analysis-html rendering (W69).
+//!
+//! Covers: HTML output generation, escaping, structure validation,
+//! metric cards, table rows, report JSON, determinism.
+
+use tokmd_analysis_html::render;
+use tokmd_analysis_types::*;
+use tokmd_types::{ScanStatus, ToolInfo};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: ToolInfo {
+            name: "tokmd".into(),
+            version: "0.0.0".into(),
+        },
+        mode: "analysis".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec!["test".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "html".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            max_file_bytes: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 10,
+            code: 1000,
+            comments: 200,
+            blanks: 100,
+            lines: 1300,
+            bytes: 50000,
+            tokens: 2500,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 200,
+                denominator: 1200,
+                ratio: 0.1667,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 100,
+                denominator: 1300,
+                ratio: 0.0769,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 50000,
+                denominator: 1300,
+                rate: 38.46,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: FileStatRow {
+                path: "src/lib.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 500,
+                comments: 100,
+                blanks: 50,
+                lines: 650,
+                bytes: 25000,
+                tokens: 1250,
+                doc_pct: Some(0.167),
+                bytes_per_line: Some(38.46),
+                depth: 1,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 3,
+            avg: 1.5,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 200,
+            prod_lines: 1000,
+            test_files: 5,
+            prod_files: 5,
+            ratio: 0.2,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 100,
+            logic_lines: 1100,
+            ratio: 0.083,
+            infra_langs: vec!["TOML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 2,
+            entropy: 0.5,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 1000,
+            dominant_pct: 0.833,
+        },
+        distribution: DistributionReport {
+            count: 10,
+            min: 50,
+            max: 650,
+            mean: 130.0,
+            median: 100.0,
+            p90: 400.0,
+            p99: 650.0,
+            gini: 0.3,
+        },
+        histogram: vec![],
+        top: TopOffenders {
+            largest_lines: vec![FileStatRow {
+                path: "src/lib.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 500,
+                comments: 100,
+                blanks: 50,
+                lines: 650,
+                bytes: 25000,
+                tokens: 1250,
+                doc_pct: Some(0.167),
+                bytes_per_line: Some(38.46),
+                depth: 1,
+            }],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 65.0,
+            lines_per_minute: 20,
+            basis_lines: 1300,
+        },
+        context_window: Some(ContextWindowReport {
+            window_tokens: 100000,
+            total_tokens: 2500,
+            pct: 0.025,
+            fits: true,
+        }),
+        cocomo: None,
+        todo: None,
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "abc123".into(),
+            entries: 10,
+        },
+    }
+}
+
+// ===================================================================
+// 1. HTML structure
+// ===================================================================
+
+#[test]
+fn html_starts_with_doctype() {
+    let receipt = minimal_receipt();
+    let html = render(&receipt);
+    assert!(html.starts_with("<!DOCTYPE html>"));
+}
+
+#[test]
+fn html_contains_closing_tags() {
+    let receipt = minimal_receipt();
+    let html = render(&receipt);
+    assert!(html.contains("</html>"));
+    assert!(html.contains("</head>"));
+    assert!(html.contains("</body>"));
+}
+
+#[test]
+fn html_contains_timestamp() {
+    let receipt = minimal_receipt();
+    let html = render(&receipt);
+    assert!(html.contains("UTC"));
+}
+
+// ===================================================================
+// 2. Metric cards
+// ===================================================================
+
+#[test]
+fn html_no_metric_cards_without_derived() {
+    let receipt = minimal_receipt();
+    let html = render(&receipt);
+    assert!(!html.contains("class=\"metric-card\""));
+}
+
+#[test]
+fn html_metric_cards_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let html = render(&receipt);
+    assert!(html.contains("class=\"metric-card\""));
+    assert!(html.contains("Files"));
+    assert!(html.contains("Code"));
+    assert!(html.contains("Tokens"));
+}
+
+#[test]
+fn html_context_fit_card_present() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let html = render(&receipt);
+    assert!(html.contains("Context Fit"));
+}
+
+// ===================================================================
+// 3. Table rows
+// ===================================================================
+
+#[test]
+fn html_table_rows_present_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let html = render(&receipt);
+    assert!(html.contains("src/lib.rs"));
+    assert!(html.contains("<tr>"));
+}
+
+#[test]
+fn html_no_table_rows_without_derived() {
+    let receipt = minimal_receipt();
+    let html = render(&receipt);
+    assert!(!html.contains("data-path="));
+}
+
+// ===================================================================
+// 4. HTML escaping of special characters
+// ===================================================================
+
+#[test]
+fn html_escapes_angle_brackets_in_paths() {
+    let mut receipt = minimal_receipt();
+    let mut derived = sample_derived();
+    derived.top.largest_lines[0].path = "<script>alert('xss')</script>".into();
+    receipt.derived = Some(derived);
+    let html = render(&receipt);
+    assert!(html.contains("&lt;script&gt;"));
+    assert!(!html.contains("<script>alert"));
+}
+
+#[test]
+fn html_escapes_ampersands() {
+    let mut receipt = minimal_receipt();
+    let mut derived = sample_derived();
+    derived.top.largest_lines[0].module = "mod&test".into();
+    receipt.derived = Some(derived);
+    let html = render(&receipt);
+    assert!(html.contains("mod&amp;test"));
+}
+
+#[test]
+fn html_escapes_quotes_in_lang() {
+    let mut receipt = minimal_receipt();
+    let mut derived = sample_derived();
+    derived.top.largest_lines[0].lang = "Ru\"st".into();
+    receipt.derived = Some(derived);
+    let html = render(&receipt);
+    assert!(html.contains("Ru&quot;st"));
+}
+
+// ===================================================================
+// 5. Report JSON (XSS prevention)
+// ===================================================================
+
+#[test]
+fn html_report_json_no_raw_angle_brackets() {
+    let mut receipt = minimal_receipt();
+    let mut derived = sample_derived();
+    derived.top.largest_lines[0].path = "</script><img onerror=alert(1)>".into();
+    receipt.derived = Some(derived);
+    let html = render(&receipt);
+    let json_start = html.find("const REPORT_DATA =");
+    assert!(json_start.is_some());
+    let json_section = &html[json_start.unwrap()..];
+    let json_end = json_section.find(';').unwrap();
+    let json_fragment = &json_section[..json_end];
+    assert!(!json_fragment.contains("</script>"));
+}
+
+// ===================================================================
+// 6. Determinism
+// ===================================================================
+
+#[test]
+fn html_rendering_is_deterministic_ignoring_timestamp() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let a = render(&receipt);
+    let b = render(&receipt);
+    // Timestamp varies, so strip it
+    let strip_ts = |s: String| {
+        s.lines()
+            .filter(|l| !l.contains("UTC"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    assert_eq!(strip_ts(a), strip_ts(b));
+}
+
+#[test]
+fn html_empty_derived_produces_no_rows_deterministically() {
+    let mut receipt = minimal_receipt();
+    let mut derived = sample_derived();
+    derived.top.largest_lines.clear();
+    receipt.derived = Some(derived);
+    let a = render(&receipt);
+    let b = render(&receipt);
+    let strip_ts = |s: String| {
+        s.lines()
+            .filter(|l| !l.contains("UTC"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    assert_eq!(strip_ts(a), strip_ts(b));
+}

--- a/crates/tokmd-analysis-imports/tests/deep_w69.rs
+++ b/crates/tokmd-analysis-imports/tests/deep_w69.rs
@@ -1,0 +1,228 @@
+//! Deep tests for tokmd-analysis-imports (W69).
+//!
+//! Covers: import extraction for all languages, normalization,
+//! supports_language, deterministic ordering, edge cases.
+
+use tokmd_analysis_imports::{normalize_import_target, parse_imports, supports_language};
+
+// ===================================================================
+// 1. supports_language
+// ===================================================================
+
+#[test]
+fn supports_all_documented_languages() {
+    for lang in &["Rust", "JavaScript", "TypeScript", "Python", "Go"] {
+        assert!(supports_language(lang), "{lang} should be supported");
+    }
+}
+
+#[test]
+fn supports_language_is_case_insensitive() {
+    assert!(supports_language("rust"));
+    assert!(supports_language("RUST"));
+    assert!(supports_language("Rust"));
+}
+
+#[test]
+fn unsupported_languages_return_false() {
+    for lang in &["Java", "C", "C++", "Ruby", "Haskell", ""] {
+        assert!(!supports_language(lang), "{lang} should not be supported");
+    }
+}
+
+// ===================================================================
+// 2. Rust imports
+// ===================================================================
+
+#[test]
+fn rust_use_extracts_crate_root() {
+    let lines = ["use std::collections::HashMap;"];
+    let result = parse_imports("Rust", &lines);
+    assert_eq!(result, vec!["std"]);
+}
+
+#[test]
+fn rust_mod_extracts_module_name() {
+    let lines = ["mod config;"];
+    let result = parse_imports("Rust", &lines);
+    assert_eq!(result, vec!["config"]);
+}
+
+#[test]
+fn rust_mixed_use_and_mod() {
+    let lines = [
+        "use serde::Deserialize;",
+        "mod utils;",
+        "use anyhow::Result;",
+    ];
+    let result = parse_imports("Rust", &lines);
+    assert_eq!(result, vec!["serde", "utils", "anyhow"]);
+}
+
+#[test]
+fn rust_ignores_non_import_lines() {
+    let lines = [
+        "fn main() {}",
+        "// use fake;",
+        "let x = 42;",
+    ];
+    let result = parse_imports("Rust", &lines);
+    assert!(result.is_empty());
+}
+
+// ===================================================================
+// 3. JavaScript/TypeScript imports
+// ===================================================================
+
+#[test]
+fn js_import_from_single_quotes() {
+    let lines = ["import React from 'react';"];
+    let result = parse_imports("JavaScript", &lines);
+    assert_eq!(result, vec!["react"]);
+}
+
+#[test]
+fn js_import_from_double_quotes() {
+    let lines = ["import { useState } from \"react\";"];
+    let result = parse_imports("JavaScript", &lines);
+    assert_eq!(result, vec!["react"]);
+}
+
+#[test]
+fn js_require_extracts_target() {
+    let lines = ["const fs = require('fs');"];
+    let result = parse_imports("JavaScript", &lines);
+    assert_eq!(result, vec!["fs"]);
+}
+
+#[test]
+fn ts_type_import() {
+    let lines = ["import type { Config } from 'config';"];
+    let result = parse_imports("TypeScript", &lines);
+    assert_eq!(result, vec!["config"]);
+}
+
+// ===================================================================
+// 4. Python imports
+// ===================================================================
+
+#[test]
+fn python_import_statement() {
+    let lines = ["import os", "import sys"];
+    let result = parse_imports("Python", &lines);
+    assert_eq!(result, vec!["os", "sys"]);
+}
+
+#[test]
+fn python_from_import() {
+    let lines = ["from pathlib import Path"];
+    let result = parse_imports("Python", &lines);
+    assert_eq!(result, vec!["pathlib"]);
+}
+
+#[test]
+fn python_ignores_comments() {
+    let lines = ["# import fake", "import os"];
+    let result = parse_imports("Python", &lines);
+    assert_eq!(result, vec!["os"]);
+}
+
+// ===================================================================
+// 5. Go imports
+// ===================================================================
+
+#[test]
+fn go_single_import() {
+    let lines = ["import \"fmt\""];
+    let result = parse_imports("Go", &lines);
+    assert_eq!(result, vec!["fmt"]);
+}
+
+#[test]
+fn go_block_import() {
+    let lines = ["import (", "\t\"fmt\"", "\t\"os\"", ")"];
+    let result = parse_imports("Go", &lines);
+    assert_eq!(result, vec!["fmt", "os"]);
+}
+
+#[test]
+fn go_external_import() {
+    let lines = ["import (", "\t\"github.com/pkg/errors\"", ")"];
+    let result = parse_imports("Go", &lines);
+    assert_eq!(result, vec!["github.com/pkg/errors"]);
+}
+
+// ===================================================================
+// 6. normalize_import_target
+// ===================================================================
+
+#[test]
+fn normalize_relative_imports_to_local() {
+    assert_eq!(normalize_import_target("./utils"), "local");
+    assert_eq!(normalize_import_target("../lib"), "local");
+    assert_eq!(normalize_import_target("."), "local");
+}
+
+#[test]
+fn normalize_extracts_package_root() {
+    assert_eq!(normalize_import_target("react/dom"), "react");
+    assert_eq!(normalize_import_target("std::collections"), "std");
+    assert_eq!(normalize_import_target("os.path"), "os");
+}
+
+#[test]
+fn normalize_strips_quotes() {
+    assert_eq!(normalize_import_target("\"react\""), "react");
+    assert_eq!(normalize_import_target("'lodash'"), "lodash");
+}
+
+#[test]
+fn normalize_trims_whitespace() {
+    assert_eq!(normalize_import_target("  react  "), "react");
+}
+
+// ===================================================================
+// 7. Deterministic ordering
+// ===================================================================
+
+#[test]
+fn parse_preserves_insertion_order() {
+    let lines = [
+        "use z_crate::Foo;",
+        "use a_crate::Bar;",
+        "use m_crate::Baz;",
+    ];
+    let result = parse_imports("Rust", &lines);
+    assert_eq!(result, vec!["z_crate", "a_crate", "m_crate"]);
+}
+
+#[test]
+fn parse_is_deterministic() {
+    let lines = [
+        "import os",
+        "from pathlib import Path",
+        "import sys",
+    ];
+    let a = parse_imports("Python", &lines);
+    let b = parse_imports("Python", &lines);
+    assert_eq!(a, b, "parse_imports must be deterministic");
+}
+
+// ===================================================================
+// 8. Edge cases
+// ===================================================================
+
+#[test]
+fn empty_input_returns_empty() {
+    let lines: Vec<&str> = vec![];
+    assert!(parse_imports("Rust", &lines).is_empty());
+    assert!(parse_imports("Python", &lines).is_empty());
+    assert!(parse_imports("JavaScript", &lines).is_empty());
+    assert!(parse_imports("Go", &lines).is_empty());
+}
+
+#[test]
+fn unsupported_language_returns_empty() {
+    let lines = ["#include <stdio.h>"];
+    assert!(parse_imports("C", &lines).is_empty());
+}


### PR DESCRIPTION
## Summary

Deep integration tests across four analysis output crates (94 tests total).

### tokmd-analysis-format (30 tests)
- Markdown rendering: minimal receipt, derived sections (totals, ratios, distribution, COCOMO, context window, TODOs, integrity), optional sections (archetype, imports, entropy)
- JSON rendering: validation, round-trip fidelity, field preservation
- JSON-LD, XML, SVG, Mermaid, Tree format rendering
- Determinism verification across Markdown, JSON, XML

### tokmd-analysis-html (14 tests)
- HTML structure (DOCTYPE, closing tags, timestamp)
- Metric cards presence/absence
- Table row rendering
- XSS prevention: HTML escaping (angle brackets, ampersands, quotes), report JSON angle bracket sanitization
- Deterministic output (timestamp-independent)

### tokmd-analysis-explain (25 tests)
- Canonical key lookups (doc_density, whitespace, gini, hotspots, etc.)
- Alias resolution (docs->doc_density, churn->predictive_churn, etc.)
- Normalization (dashes, spaces, dots, case, whitespace trimming)
- Catalog: header, known keys, sort order, uniqueness, determinism
- Edge cases: unknown keys, empty strings

### tokmd-analysis-imports (25 tests)
- Language support matrix
- Rust: use statements, mod statements, mixed, non-import filtering
- JavaScript/TypeScript: import from, require, type imports
- Python: import, from-import, comment filtering
- Go: single import, block import, external packages
- Normalization: relative->local, package root extraction, quote stripping
- Deterministic ordering and edge cases

All 94 tests pass.