### PR TITLE
fix(ci): add 'tru' to typos allowlist

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -50,6 +50,8 @@ sloc = "sloc"
 # Mathematical abbreviations (numerator/denominator)
 numer = "numer"
 
+# Malformed JSON in FFI envelope error tests (e.g. `{"ok": tru"`)
+tru = "tru"
 # Test variable suffixes (ordering patterns: ab = a-then-b, ba = b-then-a)
 ba = "ba"
 bck = "bck"


### PR DESCRIPTION
The typos checker flags tru in crates/tokmd-ffi-envelope/tests/deep_w69.rs:36 where it appears as intentionally malformed JSON test data. Add tru to _typos.toml to suppress this false positive.