### PR TITLE
test(w70): insta snapshot golden tests across 4 crates (~55 tests)

### DIFF
--- a/crates/tokmd-analysis-format/tests/snapshot_w70.rs
+++ b/crates/tokmd-analysis-format/tests/snapshot_w70.rs
@@ -1,0 +1,421 @@
+//! Golden snapshot tests for analysis format rendering (W70).
+//!
+//! Captures Markdown, JSON, JSON-LD, XML, SVG, Mermaid, Tree, and HTML
+//! output for analysis receipts with various enrichment combinations.
+
+use tokmd_analysis_format::{RenderedOutput, render};
+use tokmd_analysis_types::*;
+use tokmd_types::{AnalysisFormat, ScanStatus, ToolInfo};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: ToolInfo {
+            name: "tokmd".into(),
+            version: "0.0.0-test".into(),
+        },
+        mode: "analyze".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec![".".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "json".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_file_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 8,
+            code: 1200,
+            comments: 150,
+            blanks: 80,
+            lines: 1430,
+            bytes: 12_000,
+            tokens: 3_000,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 150,
+                denominator: 1350,
+                ratio: 0.1111,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 80,
+                denominator: 1430,
+                ratio: 0.0559,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 12_000,
+                denominator: 1430,
+                rate: 8.39,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: FileStatRow {
+                path: "src/engine.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 400,
+                comments: 60,
+                blanks: 30,
+                lines: 490,
+                bytes: 4_000,
+                tokens: 1_000,
+                doc_pct: Some(0.13),
+                bytes_per_line: Some(8.16),
+                depth: 1,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 5,
+            avg: 2.5,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 200,
+            prod_lines: 1000,
+            test_files: 3,
+            prod_files: 5,
+            ratio: 0.2,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 80,
+            logic_lines: 1350,
+            ratio: 0.0592,
+            infra_langs: vec!["TOML".into(), "YAML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 3,
+            entropy: 0.85,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 1100,
+            dominant_pct: 0.77,
+        },
+        distribution: DistributionReport {
+            count: 8,
+            min: 30,
+            max: 490,
+            mean: 178.75,
+            median: 150.0,
+            p90: 490.0,
+            p99: 490.0,
+            gini: 0.35,
+        },
+        histogram: vec![
+            HistogramBucket {
+                label: "Small".into(),
+                min: 0,
+                max: Some(100),
+                files: 4,
+                pct: 0.5,
+            },
+            HistogramBucket {
+                label: "Medium".into(),
+                min: 101,
+                max: Some(500),
+                files: 4,
+                pct: 0.5,
+            },
+        ],
+        top: TopOffenders {
+            largest_lines: vec![FileStatRow {
+                path: "src/engine.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 400,
+                comments: 60,
+                blanks: 30,
+                lines: 490,
+                bytes: 4_000,
+                tokens: 1_000,
+                doc_pct: Some(0.13),
+                bytes_per_line: Some(8.16),
+                depth: 1,
+            }],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 71.5,
+            lines_per_minute: 20,
+            basis_lines: 1430,
+        },
+        context_window: None,
+        cocomo: None,
+        todo: None,
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "b".repeat(64),
+            entries: 8,
+        },
+    }
+}
+
+fn text(output: RenderedOutput) -> String {
+    match output {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text output"),
+    }
+}
+
+fn redact_timestamp(html: &str) -> String {
+    let mut result = html.to_string();
+    while let Some(pos) = result.find(" UTC") {
+        if pos >= 19 {
+            let candidate = &result[pos - 19..pos + 4];
+            if candidate.len() == 23
+                && candidate.as_bytes()[4] == b'-'
+                && candidate.as_bytes()[7] == b'-'
+                && candidate.as_bytes()[10] == b' '
+            {
+                result.replace_range(pos - 19..pos + 4, "[TIMESTAMP]");
+                continue;
+            }
+        }
+        break;
+    }
+    result
+}
+
+// ===========================================================================
+// JSON snapshots
+// ===========================================================================
+
+#[test]
+fn w70_analysis_json_minimal() {
+    let receipt = minimal_receipt();
+    let out = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("w70_analysis_json_minimal", out);
+}
+
+#[test]
+fn w70_analysis_json_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("w70_analysis_json_with_derived", out);
+}
+
+#[test]
+fn w70_analysis_json_archetype_and_eco() {
+    let mut receipt = minimal_receipt();
+    receipt.archetype = Some(Archetype {
+        kind: "cli-tool".into(),
+        evidence: vec!["src/main.rs".into(), "Cargo.toml".into()],
+    });
+    receipt.fun = Some(FunReport {
+        eco_label: Some(EcoLabel {
+            score: 88.0,
+            label: "A".into(),
+            bytes: 300_000,
+            notes: "Size-based eco label (0.29 MB)".into(),
+        }),
+    });
+    let out = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("w70_analysis_json_archetype_eco", out);
+}
+
+// ===========================================================================
+// Markdown snapshots
+// ===========================================================================
+
+#[test]
+fn w70_analysis_md_minimal() {
+    let receipt = minimal_receipt();
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w70_analysis_md_minimal", out);
+}
+
+#[test]
+fn w70_analysis_md_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w70_analysis_md_with_derived", out);
+}
+
+#[test]
+fn w70_analysis_md_with_warnings() {
+    let mut receipt = minimal_receipt();
+    receipt.warnings = vec!["scan timed out".into(), "some files skipped".into()];
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w70_analysis_md_with_warnings", out);
+}
+
+#[test]
+fn w70_analysis_md_archetype_topics() {
+    let mut receipt = minimal_receipt();
+    receipt.archetype = Some(Archetype {
+        kind: "monorepo".into(),
+        evidence: vec!["Cargo.toml".into(), "package.json".into()],
+    });
+    receipt.topics = Some(TopicClouds {
+        per_module: std::collections::BTreeMap::new(),
+        overall: vec![
+            TopicTerm { term: "systems".into(), score: 0.85, tf: 12, df: 3 },
+            TopicTerm { term: "cli".into(), score: 0.72, tf: 8, df: 2 },
+        ],
+    });
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w70_analysis_md_archetype_topics", out);
+}
+
+// ===========================================================================
+// JSON-LD snapshot
+// ===========================================================================
+
+#[test]
+fn w70_analysis_jsonld_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Jsonld).unwrap());
+    insta::assert_snapshot!("w70_analysis_jsonld_with_derived", out);
+}
+
+// ===========================================================================
+// XML snapshots
+// ===========================================================================
+
+#[test]
+fn w70_analysis_xml_minimal() {
+    let receipt = minimal_receipt();
+    let out = text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    insta::assert_snapshot!("w70_analysis_xml_minimal", out);
+}
+
+#[test]
+fn w70_analysis_xml_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    insta::assert_snapshot!("w70_analysis_xml_with_derived", out);
+}
+
+// ===========================================================================
+// SVG snapshots
+// ===========================================================================
+
+#[test]
+fn w70_analysis_svg_minimal() {
+    let receipt = minimal_receipt();
+    let out = text(render(&receipt, AnalysisFormat::Svg).unwrap());
+    insta::assert_snapshot!("w70_analysis_svg_minimal", out);
+}
+
+#[test]
+fn w70_analysis_svg_with_context_window() {
+    let mut receipt = minimal_receipt();
+    let mut d = sample_derived();
+    d.context_window = Some(ContextWindowReport {
+        window_tokens: 128_000,
+        total_tokens: 3_000,
+        pct: 2.34,
+        fits: true,
+    });
+    receipt.derived = Some(d);
+    let out = text(render(&receipt, AnalysisFormat::Svg).unwrap());
+    insta::assert_snapshot!("w70_analysis_svg_with_context_window", out);
+}
+
+// ===========================================================================
+// Mermaid snapshot
+// ===========================================================================
+
+#[test]
+fn w70_analysis_mermaid_with_imports() {
+    let mut receipt = minimal_receipt();
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![
+            ImportEdge { from: "engine".into(), to: "api".into(), count: 5 },
+            ImportEdge { from: "api".into(), to: "types".into(), count: 3 },
+            ImportEdge { from: "engine".into(), to: "types".into(), count: 2 },
+        ],
+    });
+    let out = text(render(&receipt, AnalysisFormat::Mermaid).unwrap());
+    insta::assert_snapshot!("w70_analysis_mermaid_with_imports", out);
+}
+
+// ===========================================================================
+// Tree snapshot
+// ===========================================================================
+
+#[test]
+fn w70_analysis_tree_with_data() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Tree).unwrap());
+    insta::assert_snapshot!("w70_analysis_tree_with_data", out);
+}
+
+// ===========================================================================
+// HTML snapshot
+// ===========================================================================
+
+#[test]
+fn w70_analysis_html_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = redact_timestamp(&text(render(&receipt, AnalysisFormat::Html).unwrap()));
+    insta::assert_snapshot!("w70_analysis_html_with_derived", out);
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_html_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_html_with_derived.snap
@@ -1,0 +1,401 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tokmd Analysis Report</title>
+    <style>
+        :root {
+            --bg-primary: #1a1a2e;
+            --bg-secondary: #16213e;
+            --bg-card: #0f3460;
+            --text-primary: #e6e6e6;
+            --text-secondary: #a0a0a0;
+            --accent: #4c9aff;
+            --accent-hover: #357abd;
+            --success: #4caf50;
+            --warning: #ff9800;
+            --danger: #f44336;
+            --border: #2a2a4a;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
+        header {
+            text-align: center;
+            padding: 40px 20px;
+            background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card));
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 30px;
+        }
+        header h1 { font-size: 2.5rem; margin-bottom: 10px; }
+        header .timestamp { color: var(--text-secondary); font-size: 0.9rem; }
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .metric-card {
+            background: var(--bg-card);
+            border-radius: 12px;
+            padding: 20px;
+            text-align: center;
+            border: 1px solid var(--border);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .metric-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 20px rgba(76, 154, 255, 0.2);
+        }
+        .metric-card .value {
+            font-size: 2rem;
+            font-weight: bold;
+            color: var(--accent);
+            display: block;
+        }
+        .metric-card .label {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .section {
+            background: var(--bg-secondary);
+            border-radius: 12px;
+            padding: 24px;
+            margin-bottom: 24px;
+            border: 1px solid var(--border);
+        }
+        .section h2 {
+            font-size: 1.3rem;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--accent);
+            display: inline-block;
+        }
+        #treemap {
+            width: 100%;
+            height: 400px;
+            background: var(--bg-primary);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        .treemap-cell {
+            position: absolute;
+            overflow: hidden;
+            border: 1px solid var(--bg-primary);
+            transition: opacity 0.2s;
+            cursor: pointer;
+        }
+        .treemap-cell:hover { opacity: 0.85; }
+        .treemap-label {
+            padding: 4px 6px;
+            font-size: 11px;
+            color: white;
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .search-box {
+            width: 100%;
+            padding: 12px 16px;
+            font-size: 1rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text-primary);
+            margin-bottom: 16px;
+        }
+        .search-box:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(76, 154, 255, 0.2);
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+        th, td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        th {
+            background: var(--bg-card);
+            color: var(--accent);
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+        }
+        th:hover { background: var(--accent); color: white; }
+        tr:hover { background: rgba(76, 154, 255, 0.1); }
+        .num { text-align: right; font-family: 'SF Mono', Monaco, monospace; }
+        .path { font-family: 'SF Mono', Monaco, monospace; font-size: 0.85rem; }
+        .lang-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+        .hidden { display: none; }
+        footer {
+            text-align: center;
+            padding: 30px;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+        }
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>tokmd Analysis Report</h1>
+        <div class="timestamp">Generated: [TIMESTAMP]</div>
+    </header>
+
+    <div class="container">
+        <div class="metrics-grid">
+            <div class="metric-card"><span class="value">8</span><span class="label">Files</span></div><div class="metric-card"><span class="value">1.4K</span><span class="label">Lines</span></div><div class="metric-card"><span class="value">1.2K</span><span class="label">Code</span></div><div class="metric-card"><span class="value">3.0K</span><span class="label">Tokens</span></div><div class="metric-card"><span class="value">11.1%</span><span class="label">Doc%</span></div>
+        </div>
+
+        <div class="section">
+            <h2>Code Distribution</h2>
+            <div id="treemap"></div>
+        </div>
+
+        <div class="section">
+            <h2>Files</h2>
+            <input type="text" class="search-box" id="search" placeholder="Filter by path, module, or language...">
+            <table id="files-table">
+                <thead>
+                    <tr>
+                        <th data-sort="path">Path</th>
+                        <th data-sort="module">Module</th>
+                        <th data-sort="lang">Lang</th>
+                        <th data-sort="lines" class="num">Lines</th>
+                        <th data-sort="code" class="num">Code</th>
+                        <th data-sort="tokens" class="num">Tokens</th>
+                        <th data-sort="bytes" class="num">Bytes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td class="path" data-path="src/engine.rs">src/engine.rs</td><td data-module="src">src</td><td data-lang="Rust"><span class="lang-badge">Rust</span></td><td class="num" data-lines="490">490</td><td class="num" data-code="400">400</td><td class="num" data-tokens="1000">1.0K</td><td class="num" data-bytes="4000">4.0K</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <footer>
+        Generated by <a href="https://github.com/EffortlessMetrics/tokmd">tokmd</a>
+    </footer>
+
+    <script>
+    const REPORT_DATA = {"files":[{"code":400,"lang":"Rust","lines":490,"module":"src","path":"src/engine.rs","tokens":1000}]};
+
+    // Language colors
+    const LANG_COLORS = {
+        'Rust': '#dea584',
+        'JavaScript': '#f1e05a',
+        'TypeScript': '#3178c6',
+        'Python': '#3572A5',
+        'Go': '#00ADD8',
+        'Java': '#b07219',
+        'C': '#555555',
+        'C++': '#f34b7d',
+        'C#': '#178600',
+        'Ruby': '#701516',
+        'PHP': '#4F5D95',
+        'Swift': '#F05138',
+        'Kotlin': '#A97BFF',
+        'Scala': '#c22d40',
+        'HTML': '#e34c26',
+        'CSS': '#563d7c',
+        'SCSS': '#c6538c',
+        'JSON': '#292929',
+        'YAML': '#cb171e',
+        'TOML': '#9c4221',
+        'Markdown': '#083fa1',
+        'Shell': '#89e051',
+        'SQL': '#e38c00',
+    };
+
+    function getLangColor(lang) {
+        return LANG_COLORS[lang] || '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+    }
+
+    // Treemap implementation (squarify algorithm)
+    function squarify(data, x, y, width, height) {
+        if (data.length === 0 || width <= 0 || height <= 0) return [];
+
+        const total = data.reduce((sum, d) => sum + d.value, 0);
+        if (total === 0) return [];
+
+        const rects = [];
+        let remaining = [...data];
+        let cx = x, cy = y, cw = width, ch = height;
+
+        while (remaining.length > 0) {
+            const vertical = ch > cw;
+            const side = vertical ? ch : cw;
+            const scale = (cw * ch) / total;
+
+            let row = [];
+            let rowArea = 0;
+            let worst = Infinity;
+
+            for (const item of remaining) {
+                const testRow = [...row, item];
+                const testArea = rowArea + item.value * scale;
+                const testWorst = getWorst(testRow, testArea, side, scale);
+
+                if (testWorst <= worst) {
+                    row = testRow;
+                    rowArea = testArea;
+                    worst = testWorst;
+                } else {
+                    break;
+                }
+            }
+
+            // Layout row
+            const rowSide = rowArea / side;
+            let offset = 0;
+
+            for (const item of row) {
+                const itemSize = (item.value * scale) / rowSide;
+                if (vertical) {
+                    rects.push({ ...item, x: cx, y: cy + offset, w: rowSide, h: itemSize });
+                } else {
+                    rects.push({ ...item, x: cx + offset, y: cy, w: itemSize, h: rowSide });
+                }
+                offset += itemSize;
+            }
+
+            // Update remaining area
+            if (vertical) {
+                cx += rowSide;
+                cw -= rowSide;
+            } else {
+                cy += rowSide;
+                ch -= rowSide;
+            }
+
+            remaining = remaining.slice(row.length);
+        }
+
+        return rects;
+    }
+
+    function getWorst(row, area, side, scale) {
+        if (row.length === 0) return Infinity;
+        const s2 = side * side;
+        let min = Infinity, max = 0;
+        for (const item of row) {
+            const v = item.value * scale;
+            min = Math.min(min, v);
+            max = Math.max(max, v);
+        }
+        return Math.max((s2 * max) / (area * area), (area * area) / (s2 * min));
+    }
+
+    function renderTreemap() {
+        const container = document.getElementById('treemap');
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
+        container.innerHTML = '';
+        container.style.position = 'relative';
+
+        // Aggregate by module
+        const moduleData = {};
+        for (const file of REPORT_DATA.files || []) {
+            const mod = file.module || '(root)';
+            if (!moduleData[mod]) moduleData[mod] = { name: mod, value: 0, lang: file.lang };
+            moduleData[mod].value += file.code || file.lines || 1;
+        }
+
+        const data = Object.values(moduleData).sort((a, b) => b.value - a.value).slice(0, 50);
+        const rects = squarify(data, 0, 0, width, height);
+
+        for (const rect of rects) {
+            const div = document.createElement('div');
+            div.className = 'treemap-cell';
+            div.style.left = rect.x + 'px';
+            div.style.top = rect.y + 'px';
+            div.style.width = rect.w + 'px';
+            div.style.height = rect.h + 'px';
+            div.style.background = getLangColor(rect.lang);
+
+            const label = document.createElement('div');
+            label.className = 'treemap-label';
+            label.textContent = rect.name + ' (' + rect.value.toLocaleString() + ')';
+            div.appendChild(label);
+
+            div.title = rect.name + ': ' + rect.value.toLocaleString() + ' lines';
+            container.appendChild(div);
+        }
+    }
+
+    // Table filtering
+    document.getElementById('search').addEventListener('input', function(e) {
+        const filter = e.target.value.toLowerCase();
+        const rows = document.querySelectorAll('#files-table tbody tr');
+        rows.forEach(row => {
+            const text = row.textContent.toLowerCase();
+            row.classList.toggle('hidden', filter && !text.includes(filter));
+        });
+    });
+
+    // Table sorting
+    let sortCol = null, sortAsc = true;
+    document.querySelectorAll('#files-table th').forEach(th => {
+        th.addEventListener('click', function() {
+            const col = this.dataset.sort;
+            if (sortCol === col) sortAsc = !sortAsc;
+            else { sortCol = col; sortAsc = true; }
+
+            const tbody = document.querySelector('#files-table tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+
+            rows.sort((a, b) => {
+                const aVal = a.querySelector(`[data-${col}]`)?.dataset[col] || a.cells[getColIndex(col)].textContent;
+                const bVal = b.querySelector(`[data-${col}]`)?.dataset[col] || b.cells[getColIndex(col)].textContent;
+                const aNum = parseFloat(aVal.replace(/,/g, ''));
+                const bNum = parseFloat(bVal.replace(/,/g, ''));
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return sortAsc ? aNum - bNum : bNum - aNum;
+                }
+                return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+            });
+
+            rows.forEach(row => tbody.appendChild(row));
+        });
+    });
+
+    function getColIndex(col) {
+        const map = { path: 0, module: 1, lang: 2, lines: 3, code: 4, tokens: 5, bytes: 6 };
+        return map[col] || 0;
+    }
+
+    // Initialize
+    window.addEventListener('load', renderTreemap);
+    window.addEventListener('resize', renderTreemap);
+    </script>
+</body>
+</html>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_json_archetype_eco.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_json_archetype_eco.snap
@@ -1,0 +1,68 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "json",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": {
+    "kind": "cli-tool",
+    "evidence": [
+      "src/main.rs",
+      "Cargo.toml"
+    ]
+  },
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": null,
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": {
+    "eco_label": {
+      "score": 88.0,
+      "label": "A",
+      "bytes": 300000,
+      "notes": "Size-based eco label (0.29 MB)"
+    }
+  }
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_json_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_json_minimal.snap
@@ -1,0 +1,55 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "json",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": null,
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": null
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_json_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_json_with_derived.snap
@@ -1,0 +1,206 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "json",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": {
+    "totals": {
+      "files": 8,
+      "code": 1200,
+      "comments": 150,
+      "blanks": 80,
+      "lines": 1430,
+      "bytes": 12000,
+      "tokens": 3000
+    },
+    "doc_density": {
+      "total": {
+        "key": "total",
+        "numerator": 150,
+        "denominator": 1350,
+        "ratio": 0.1111
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "whitespace": {
+      "total": {
+        "key": "total",
+        "numerator": 80,
+        "denominator": 1430,
+        "ratio": 0.0559
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "verbosity": {
+      "total": {
+        "key": "total",
+        "numerator": 12000,
+        "denominator": 1430,
+        "rate": 8.39
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "max_file": {
+      "overall": {
+        "path": "src/engine.rs",
+        "module": "src",
+        "lang": "Rust",
+        "code": 400,
+        "comments": 60,
+        "blanks": 30,
+        "lines": 490,
+        "bytes": 4000,
+        "tokens": 1000,
+        "doc_pct": 0.13,
+        "bytes_per_line": 8.16,
+        "depth": 1
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "lang_purity": {
+      "rows": []
+    },
+    "nesting": {
+      "max": 5,
+      "avg": 2.5,
+      "by_module": []
+    },
+    "test_density": {
+      "test_lines": 200,
+      "prod_lines": 1000,
+      "test_files": 3,
+      "prod_files": 5,
+      "ratio": 0.2
+    },
+    "boilerplate": {
+      "infra_lines": 80,
+      "logic_lines": 1350,
+      "ratio": 0.0592,
+      "infra_langs": [
+        "TOML",
+        "YAML"
+      ]
+    },
+    "polyglot": {
+      "lang_count": 3,
+      "entropy": 0.85,
+      "dominant_lang": "Rust",
+      "dominant_lines": 1100,
+      "dominant_pct": 0.77
+    },
+    "distribution": {
+      "count": 8,
+      "min": 30,
+      "max": 490,
+      "mean": 178.75,
+      "median": 150.0,
+      "p90": 490.0,
+      "p99": 490.0,
+      "gini": 0.35
+    },
+    "histogram": [
+      {
+        "label": "Small",
+        "min": 0,
+        "max": 100,
+        "files": 4,
+        "pct": 0.5
+      },
+      {
+        "label": "Medium",
+        "min": 101,
+        "max": 500,
+        "files": 4,
+        "pct": 0.5
+      }
+    ],
+    "top": {
+      "largest_lines": [
+        {
+          "path": "src/engine.rs",
+          "module": "src",
+          "lang": "Rust",
+          "code": 400,
+          "comments": 60,
+          "blanks": 30,
+          "lines": 490,
+          "bytes": 4000,
+          "tokens": 1000,
+          "doc_pct": 0.13,
+          "bytes_per_line": 8.16,
+          "depth": 1
+        }
+      ],
+      "largest_tokens": [],
+      "largest_bytes": [],
+      "least_documented": [],
+      "most_dense": []
+    },
+    "tree": null,
+    "reading_time": {
+      "minutes": 71.5,
+      "lines_per_minute": 20,
+      "basis_lines": 1430
+    },
+    "context_window": null,
+    "cocomo": null,
+    "todo": null,
+    "integrity": {
+      "algo": "blake3",
+      "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "entries": 8
+    }
+  },
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": null
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_jsonld_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_jsonld_with_derived.snap
@@ -1,0 +1,18 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "codeLines": 1200,
+  "commentCount": 150,
+  "fileSize": 12000,
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "http://schema.org/ReadAction",
+    "userInteractionCount": 3000
+  },
+  "lineCount": 1430,
+  "name": "."
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_archetype_topics.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_archetype_topics.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Archetype
+
+- Kind: `monorepo`
+- Evidence: `Cargo.toml`, `package.json`
+
+## Topics
+
+- Overall: `systems, cli`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_minimal.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_with_derived.snap
@@ -1,0 +1,113 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Totals
+
+|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|
+|---:|---:|---:|---:|---:|---:|---:|
+|8|1200|150|80|1430|12000|3000|
+
+## Ratios
+
+|Metric|Value|
+|---|---:|
+|Doc density|11.1%|
+|Whitespace ratio|5.6%|
+|Bytes per line|8.39|
+
+### Doc density by language
+
+|Lang|Doc%|Comments|Code|
+|---|---:|---:|---:|
+
+### Whitespace ratio by language
+
+|Lang|Blank%|Blanks|Code+Comments|
+|---|---:|---:|---:|
+
+### Verbosity by language
+
+|Lang|Bytes/Line|Bytes|Lines|
+|---|---:|---:|---:|
+
+## Distribution
+
+|Count|Min|Max|Mean|Median|P90|P99|Gini|
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|8|30|490|178.75|150.00|490.00|490.00|0.3500|
+
+## File size histogram
+
+|Bucket|Min|Max|Files|Pct|
+|---|---:|---:|---:|---:|
+|Small|0|100|4|50.0%|
+|Medium|101|500|4|50.0%|
+
+## Top offenders
+
+### Largest files by lines
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|src/engine.rs|Rust|490|400|4000|1000|13.0%|8.16|
+
+### Largest files by tokens
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Largest files by bytes
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Least documented (min LOC)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Most dense (bytes/line)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+## Structure
+
+- Max depth: `5`
+- Avg depth: `2.50`
+
+## Test density
+
+- Test lines: `200`
+- Prod lines: `1000`
+- Test ratio: `20.0%`
+
+## Boilerplate ratio
+
+- Infra lines: `80`
+- Logic lines: `1350`
+- Infra ratio: `5.9%`
+
+## Polyglot
+
+- Languages: `3`
+- Dominant: `Rust` (77.0%)
+- Entropy: `0.8500`
+
+## Reading time
+
+- Minutes: `71.50` (20 lines/min)
+
+## Integrity
+
+- Hash: `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb` (`blake3`)
+- Entries: `8`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_with_warnings.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_md_with_warnings.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_mermaid_with_imports.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_mermaid_with_imports.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+graph TD
+  engine -->|5| api
+  api -->|3| types
+  engine -->|2| types

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_svg_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_svg_minimal.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="32" role="img"><rect width="80" height="32" fill="#555"/><rect x="80" width="160" height="32" fill="#4c9aff"/><text x="40" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">tokens</text><text x="160" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">0</text></svg>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_svg_with_context_window.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_svg_with_context_window.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="32" role="img"><rect width="80" height="32" fill="#555"/><rect x="80" width="160" height="32" fill="#4c9aff"/><text x="40" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">context</text><text x="160" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">234.0%</text></svg>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_tree_with_data.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_tree_with_data.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+(tree unavailable)

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_xml_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_xml_minimal.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+<analysis></analysis>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_xml_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w70__w70_analysis_xml_with_derived.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w70.rs
+expression: out
+---
+<analysis><totals files="8" code="1200" comments="150" blanks="80" lines="1430" bytes="12000" tokens="3000"/></analysis>

--- a/crates/tokmd-badge/tests/snapshot_w70.rs
+++ b/crates/tokmd-badge/tests/snapshot_w70.rs
@@ -1,0 +1,77 @@
+//! Golden snapshot tests for badge SVG output (W70).
+//!
+//! Pins exact SVG output for a range of badge configurations so that
+//! any rendering change is caught at review time.
+
+use tokmd_badge::badge_svg;
+
+// ===========================================================================
+// Basic badges
+// ===========================================================================
+
+#[test]
+fn w70_badge_lines_metric() {
+    insta::assert_snapshot!("w70_badge_lines_metric", badge_svg("lines", "9876"));
+}
+
+#[test]
+fn w70_badge_languages_metric() {
+    insta::assert_snapshot!("w70_badge_languages_metric", badge_svg("languages", "12"));
+}
+
+#[test]
+fn w70_badge_tokens_metric() {
+    insta::assert_snapshot!("w70_badge_tokens_metric", badge_svg("tokens", "180k"));
+}
+
+#[test]
+fn w70_badge_doc_density() {
+    insta::assert_snapshot!("w70_badge_doc_density", badge_svg("doc density", "34.2%"));
+}
+
+// ===========================================================================
+// Edge cases
+// ===========================================================================
+
+#[test]
+fn w70_badge_empty_both() {
+    insta::assert_snapshot!("w70_badge_empty_both", badge_svg("", ""));
+}
+
+#[test]
+fn w70_badge_single_char() {
+    insta::assert_snapshot!("w70_badge_single_char", badge_svg("x", "1"));
+}
+
+#[test]
+fn w70_badge_long_text() {
+    insta::assert_snapshot!(
+        "w70_badge_long_text",
+        badge_svg("cyclomatic complexity", "extremely high value here")
+    );
+}
+
+#[test]
+fn w70_badge_xml_special_chars() {
+    insta::assert_snapshot!(
+        "w70_badge_xml_special_chars",
+        badge_svg("a<b&c", "1>2\"3'4")
+    );
+}
+
+// ===========================================================================
+// Numeric formatting
+// ===========================================================================
+
+#[test]
+fn w70_badge_zero_value() {
+    insta::assert_snapshot!("w70_badge_zero_value", badge_svg("files", "0"));
+}
+
+#[test]
+fn w70_badge_large_number() {
+    insta::assert_snapshot!(
+        "w70_badge_large_number",
+        badge_svg("total bytes", "1,234,567,890")
+    );
+}

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_doc_density.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_doc_density.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"doc density\", \"34.2%\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="157" height="24" role="img"><rect width="97" height="24" fill="#555"/><rect x="97" width="60" height="24" fill="#4c9aff"/><text x="48" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">doc density</text><text x="127" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">34.2%</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_empty_both.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_empty_both.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"\", \"\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="60" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle"></text><text x="90" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle"></text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_languages_metric.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_languages_metric.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"languages\", \"12\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="143" height="24" role="img"><rect width="83" height="24" fill="#555"/><rect x="83" width="60" height="24" fill="#4c9aff"/><text x="41" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">languages</text><text x="113" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">12</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_large_number.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_large_number.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"total bytes\", \"1,234,567,890\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="208" height="24" role="img"><rect width="97" height="24" fill="#555"/><rect x="97" width="111" height="24" fill="#4c9aff"/><text x="48" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">total bytes</text><text x="152" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">1,234,567,890</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_lines_metric.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_lines_metric.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"lines\", \"9876\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="60" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">lines</text><text x="90" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">9876</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_long_text.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_long_text.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"cyclomatic complexity\", \"extremely high value here\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="362" height="24" role="img"><rect width="167" height="24" fill="#555"/><rect x="167" width="195" height="24" fill="#4c9aff"/><text x="83" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">cyclomatic complexity</text><text x="264" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">extremely high value here</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_single_char.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_single_char.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"x\", \"1\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="60" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">x</text><text x="90" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">1</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_tokens_metric.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_tokens_metric.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"tokens\", \"180k\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="122" height="24" role="img"><rect width="62" height="24" fill="#555"/><rect x="62" width="60" height="24" fill="#4c9aff"/><text x="31" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">tokens</text><text x="92" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">180k</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_xml_special_chars.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_xml_special_chars.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"a<b&c\", \"1>2\\\"3'4\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="129" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="69" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">a&lt;b&amp;c</text><text x="94" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">1&gt;2&quot;3&apos;4</text></svg>

--- a/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_zero_value.snap
+++ b/crates/tokmd-badge/tests/snapshots/snapshot_w70__w70_badge_zero_value.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-badge/tests/snapshot_w70.rs
+expression: "badge_svg(\"files\", \"0\")"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" role="img"><rect width="60" height="24" fill="#555"/><rect x="60" width="60" height="24" fill="#4c9aff"/><text x="30" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">files</text><text x="90" y="16" fill="#fff" font-family="Verdana" font-size="11" text-anchor="middle">0</text></svg>

--- a/crates/tokmd-format/tests/snapshot_w70.rs
+++ b/crates/tokmd-format/tests/snapshot_w70.rs
@@ -1,0 +1,539 @@
+//! Golden snapshot tests for output formats (W70).
+//!
+//! Captures Markdown, TSV, JSON, JSONL, and CSV renderings so that any
+//! accidental change to the output surface is caught at review time.
+
+use std::path::PathBuf;
+
+use tokmd_format::{
+    write_export_csv_to, write_export_jsonl_to, write_lang_report_to,
+    write_module_report_to,
+};
+use tokmd_settings::{ChildIncludeMode, ChildrenMode, ScanOptions};
+use tokmd_types::{
+    ExportArgs, ExportData, ExportFormat, FileKind, FileRow, LangArgs, LangReport, LangRow,
+    ModuleArgs, ModuleReport, ModuleRow, RedactMode, TableFormat, Totals,
+};
+
+// ===========================================================================
+// Fixtures
+// ===========================================================================
+
+fn two_lang_report(with_files: bool) -> LangReport {
+    LangReport {
+        rows: vec![
+            LangRow {
+                lang: "Rust".into(),
+                code: 4200,
+                lines: 5500,
+                files: 35,
+                bytes: 150_000,
+                tokens: 38_000,
+                avg_lines: 157,
+            },
+            LangRow {
+                lang: "Python".into(),
+                code: 1800,
+                lines: 2300,
+                files: 12,
+                bytes: 54_000,
+                tokens: 18_000,
+                avg_lines: 191,
+            },
+        ],
+        total: Totals {
+            code: 6000,
+            lines: 7800,
+            files: 47,
+            bytes: 204_000,
+            tokens: 56_000,
+            avg_lines: 165,
+        },
+        with_files,
+        children: ChildrenMode::Collapse,
+        top: 0,
+    }
+}
+
+fn single_lang_report() -> LangReport {
+    LangReport {
+        rows: vec![LangRow {
+            lang: "Go".into(),
+            code: 750,
+            lines: 950,
+            files: 6,
+            bytes: 22_500,
+            tokens: 7_500,
+            avg_lines: 158,
+        }],
+        total: Totals {
+            code: 750,
+            lines: 950,
+            files: 6,
+            bytes: 22_500,
+            tokens: 7_500,
+            avg_lines: 158,
+        },
+        with_files: true,
+        children: ChildrenMode::Collapse,
+        top: 0,
+    }
+}
+
+fn four_lang_report() -> LangReport {
+    let langs = [
+        ("Rust", 4000),
+        ("TypeScript", 2500),
+        ("Python", 1200),
+        ("Shell", 300),
+    ];
+    let rows: Vec<LangRow> = langs
+        .iter()
+        .map(|(name, code)| LangRow {
+            lang: name.to_string(),
+            code: *code,
+            lines: code + code / 5,
+            files: code / 200,
+            bytes: code * 25,
+            tokens: code * 7,
+            avg_lines: 140,
+        })
+        .collect();
+    let total = Totals {
+        code: rows.iter().map(|r| r.code).sum(),
+        lines: rows.iter().map(|r| r.lines).sum(),
+        files: rows.iter().map(|r| r.files).sum(),
+        bytes: rows.iter().map(|r| r.bytes).sum(),
+        tokens: rows.iter().map(|r| r.tokens).sum(),
+        avg_lines: 140,
+    };
+    LangReport {
+        rows,
+        total,
+        with_files: true,
+        children: ChildrenMode::Collapse,
+        top: 0,
+    }
+}
+
+fn empty_lang_report() -> LangReport {
+    LangReport {
+        rows: vec![],
+        total: Totals {
+            code: 0,
+            lines: 0,
+            files: 0,
+            bytes: 0,
+            tokens: 0,
+            avg_lines: 0,
+        },
+        with_files: false,
+        children: ChildrenMode::Collapse,
+        top: 0,
+    }
+}
+
+fn embedded_lang_report_separate() -> LangReport {
+    LangReport {
+        rows: vec![
+            LangRow {
+                lang: "HTML".into(),
+                code: 350,
+                lines: 450,
+                files: 4,
+                bytes: 10_500,
+                tokens: 3_500,
+                avg_lines: 112,
+            },
+            LangRow {
+                lang: "JavaScript (embedded)".into(),
+                code: 180,
+                lines: 220,
+                files: 4,
+                bytes: 5_400,
+                tokens: 1_800,
+                avg_lines: 55,
+            },
+            LangRow {
+                lang: "CSS (embedded)".into(),
+                code: 90,
+                lines: 110,
+                files: 3,
+                bytes: 2_700,
+                tokens: 900,
+                avg_lines: 36,
+            },
+        ],
+        total: Totals {
+            code: 620,
+            lines: 780,
+            files: 11,
+            bytes: 18_600,
+            tokens: 6_200,
+            avg_lines: 70,
+        },
+        with_files: true,
+        children: ChildrenMode::Separate,
+        top: 0,
+    }
+}
+
+fn top_limited_report() -> LangReport {
+    let mut report = four_lang_report();
+    report.top = 2;
+    report
+}
+
+fn three_module_report() -> ModuleReport {
+    ModuleReport {
+        rows: vec![
+            ModuleRow {
+                module: "crates/engine".into(),
+                code: 2800,
+                lines: 3500,
+                files: 14,
+                bytes: 84_000,
+                tokens: 22_400,
+                avg_lines: 250,
+            },
+            ModuleRow {
+                module: "crates/api".into(),
+                code: 1400,
+                lines: 1750,
+                files: 8,
+                bytes: 42_000,
+                tokens: 11_200,
+                avg_lines: 218,
+            },
+            ModuleRow {
+                module: "tests".into(),
+                code: 900,
+                lines: 1100,
+                files: 5,
+                bytes: 27_000,
+                tokens: 7_200,
+                avg_lines: 220,
+            },
+        ],
+        total: Totals {
+            code: 5100,
+            lines: 6350,
+            files: 27,
+            bytes: 153_000,
+            tokens: 40_800,
+            avg_lines: 235,
+        },
+        module_roots: vec!["crates".into()],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+        top: 0,
+    }
+}
+
+fn empty_module_report() -> ModuleReport {
+    ModuleReport {
+        rows: vec![],
+        total: Totals {
+            code: 0,
+            lines: 0,
+            files: 0,
+            bytes: 0,
+            tokens: 0,
+            avg_lines: 0,
+        },
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+        top: 0,
+    }
+}
+
+fn sample_file_rows() -> Vec<FileRow> {
+    vec![
+        FileRow {
+            path: "src/engine.rs".into(),
+            module: "src".into(),
+            lang: "Rust".into(),
+            kind: FileKind::Parent,
+            code: 320,
+            comments: 45,
+            blanks: 35,
+            lines: 400,
+            bytes: 9_600,
+            tokens: 3_200,
+        },
+        FileRow {
+            path: "src/api.rs".into(),
+            module: "src".into(),
+            lang: "Rust".into(),
+            kind: FileKind::Parent,
+            code: 210,
+            comments: 30,
+            blanks: 25,
+            lines: 265,
+            bytes: 6_300,
+            tokens: 2_100,
+        },
+        FileRow {
+            path: "tests/integration.rs".into(),
+            module: "tests".into(),
+            lang: "Rust".into(),
+            kind: FileKind::Parent,
+            code: 85,
+            comments: 10,
+            blanks: 12,
+            lines: 107,
+            bytes: 2_550,
+            tokens: 850,
+        },
+    ]
+}
+
+fn sample_export_data() -> ExportData {
+    ExportData {
+        rows: sample_file_rows(),
+        module_roots: vec!["src".into()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn default_scan() -> ScanOptions {
+    ScanOptions::default()
+}
+
+fn lang_args(format: TableFormat) -> LangArgs {
+    LangArgs {
+        paths: vec![PathBuf::from(".")],
+        format,
+        top: 0,
+        files: true,
+        children: ChildrenMode::Collapse,
+    }
+}
+
+fn module_args(format: TableFormat) -> ModuleArgs {
+    ModuleArgs {
+        paths: vec![PathBuf::from(".")],
+        format,
+        top: 0,
+        module_roots: vec![],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn export_args(format: ExportFormat) -> ExportArgs {
+    ExportArgs {
+        paths: vec![PathBuf::from(".")],
+        format,
+        output: None,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+        min_code: 0,
+        max_rows: 0,
+        redact: RedactMode::None,
+        meta: false,
+        strip_prefix: None,
+    }
+}
+
+// ===========================================================================
+// Helper: render to String
+// ===========================================================================
+
+fn render_lang(report: &LangReport, format: TableFormat) -> String {
+    let mut buf = Vec::new();
+    write_lang_report_to(&mut buf, report, &default_scan(), &lang_args(format)).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn render_module(report: &ModuleReport, format: TableFormat) -> String {
+    let mut buf = Vec::new();
+    write_module_report_to(&mut buf, report, &default_scan(), &module_args(format)).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn render_export_csv(data: &ExportData) -> String {
+    let mut buf = Vec::new();
+    write_export_csv_to(&mut buf, data, &export_args(ExportFormat::Csv)).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn render_export_jsonl(data: &ExportData) -> String {
+    let mut buf = Vec::new();
+    write_export_jsonl_to(
+        &mut buf,
+        data,
+        &default_scan(),
+        &export_args(ExportFormat::Jsonl),
+    )
+    .unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn normalize_json(raw: &str) -> String {
+    let mut v: serde_json::Value = serde_json::from_str(raw).unwrap();
+    if let Some(obj) = v.as_object_mut() {
+        obj.insert("generated_at_ms".into(), serde_json::json!(0));
+        obj.insert(
+            "tool".into(),
+            serde_json::json!({"name": "tokmd", "version": "0.0.0-test"}),
+        );
+        obj.remove("scan");
+    }
+    serde_json::to_string_pretty(&v).unwrap()
+}
+
+// ===========================================================================
+// Lang – Markdown
+// ===========================================================================
+
+#[test]
+fn w70_lang_md_two_langs_with_files() {
+    let out = render_lang(&two_lang_report(true), TableFormat::Md);
+    insta::assert_snapshot!("w70_lang_md_two_langs_with_files", out);
+}
+
+#[test]
+fn w70_lang_md_two_langs_without_files() {
+    let out = render_lang(&two_lang_report(false), TableFormat::Md);
+    insta::assert_snapshot!("w70_lang_md_two_langs_without_files", out);
+}
+
+#[test]
+fn w70_lang_md_single_lang() {
+    let out = render_lang(&single_lang_report(), TableFormat::Md);
+    insta::assert_snapshot!("w70_lang_md_single_lang", out);
+}
+
+#[test]
+fn w70_lang_md_four_langs() {
+    let out = render_lang(&four_lang_report(), TableFormat::Md);
+    insta::assert_snapshot!("w70_lang_md_four_langs", out);
+}
+
+#[test]
+fn w70_lang_md_empty() {
+    let out = render_lang(&empty_lang_report(), TableFormat::Md);
+    insta::assert_snapshot!("w70_lang_md_empty", out);
+}
+
+#[test]
+fn w70_lang_md_embedded_separate() {
+    let out = render_lang(&embedded_lang_report_separate(), TableFormat::Md);
+    insta::assert_snapshot!("w70_lang_md_embedded_separate", out);
+}
+
+#[test]
+fn w70_lang_md_top_limited() {
+    let out = render_lang(&top_limited_report(), TableFormat::Md);
+    insta::assert_snapshot!("w70_lang_md_top_limited", out);
+}
+
+// ===========================================================================
+// Lang – TSV
+// ===========================================================================
+
+#[test]
+fn w70_lang_tsv_with_files() {
+    let out = render_lang(&two_lang_report(true), TableFormat::Tsv);
+    insta::assert_snapshot!("w70_lang_tsv_with_files", out);
+}
+
+#[test]
+fn w70_lang_tsv_without_files() {
+    let out = render_lang(&two_lang_report(false), TableFormat::Tsv);
+    insta::assert_snapshot!("w70_lang_tsv_without_files", out);
+}
+
+#[test]
+fn w70_lang_tsv_empty() {
+    let out = render_lang(&empty_lang_report(), TableFormat::Tsv);
+    insta::assert_snapshot!("w70_lang_tsv_empty", out);
+}
+
+#[test]
+fn w70_lang_tsv_four_langs() {
+    let out = render_lang(&four_lang_report(), TableFormat::Tsv);
+    insta::assert_snapshot!("w70_lang_tsv_four_langs", out);
+}
+
+// ===========================================================================
+// Lang – JSON
+// ===========================================================================
+
+#[test]
+fn w70_lang_json_two_langs() {
+    let out = render_lang(&two_lang_report(true), TableFormat::Json);
+    insta::assert_snapshot!("w70_lang_json_two_langs", normalize_json(&out));
+}
+
+#[test]
+fn w70_lang_json_empty() {
+    let out = render_lang(&empty_lang_report(), TableFormat::Json);
+    insta::assert_snapshot!("w70_lang_json_empty", normalize_json(&out));
+}
+
+#[test]
+fn w70_lang_json_single_lang() {
+    let out = render_lang(&single_lang_report(), TableFormat::Json);
+    insta::assert_snapshot!("w70_lang_json_single_lang", normalize_json(&out));
+}
+
+// ===========================================================================
+// Module – Markdown
+// ===========================================================================
+
+#[test]
+fn w70_module_md_three_modules() {
+    let out = render_module(&three_module_report(), TableFormat::Md);
+    insta::assert_snapshot!("w70_module_md_three_modules", out);
+}
+
+#[test]
+fn w70_module_md_empty() {
+    let out = render_module(&empty_module_report(), TableFormat::Md);
+    insta::assert_snapshot!("w70_module_md_empty", out);
+}
+
+// ===========================================================================
+// Module – TSV
+// ===========================================================================
+
+#[test]
+fn w70_module_tsv_three_modules() {
+    let out = render_module(&three_module_report(), TableFormat::Tsv);
+    insta::assert_snapshot!("w70_module_tsv_three_modules", out);
+}
+
+// ===========================================================================
+// Module – JSON
+// ===========================================================================
+
+#[test]
+fn w70_module_json_three_modules() {
+    let out = render_module(&three_module_report(), TableFormat::Json);
+    insta::assert_snapshot!("w70_module_json_three_modules", normalize_json(&out));
+}
+
+// ===========================================================================
+// Export – CSV
+// ===========================================================================
+
+#[test]
+fn w70_export_csv_with_children() {
+    let out = render_export_csv(&sample_export_data());
+    insta::assert_snapshot!("w70_export_csv_with_children", out);
+}
+
+// ===========================================================================
+// Export – JSONL
+// ===========================================================================
+
+#[test]
+fn w70_export_jsonl_rows() {
+    let out = render_export_jsonl(&sample_export_data());
+    insta::assert_snapshot!("w70_export_jsonl_rows", out);
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_export_csv_with_children.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_export_csv_with_children.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+path,module,lang,kind,code,comments,blanks,lines,bytes,tokens
+src/engine.rs,src,Rust,parent,320,45,35,400,9600,3200
+src/api.rs,src,Rust,parent,210,30,25,265,6300,2100
+tests/integration.rs,tests,Rust,parent,85,10,12,107,2550,850

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_export_jsonl_rows.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_export_jsonl_rows.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+{"type":"row","path":"src/engine.rs","module":"src","lang":"Rust","kind":"parent","code":320,"comments":45,"blanks":35,"lines":400,"bytes":9600,"tokens":3200}
+{"type":"row","path":"src/api.rs","module":"src","lang":"Rust","kind":"parent","code":210,"comments":30,"blanks":25,"lines":265,"bytes":6300,"tokens":2100}
+{"type":"row","path":"tests/integration.rs","module":"tests","lang":"Rust","kind":"parent","code":85,"comments":10,"blanks":12,"lines":107,"bytes":2550,"tokens":850}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_json_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_json_empty.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": false
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 0,
+    "bytes": 0,
+    "code": 0,
+    "files": 0,
+    "lines": 0,
+    "tokens": 0
+  },
+  "warnings": [],
+  "with_files": false
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_json_single_lang.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_json_single_lang.snap
@@ -1,0 +1,43 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": true
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [
+    {
+      "avg_lines": 158,
+      "bytes": 22500,
+      "code": 750,
+      "files": 6,
+      "lang": "Go",
+      "lines": 950,
+      "tokens": 7500
+    }
+  ],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 158,
+    "bytes": 22500,
+    "code": 750,
+    "files": 6,
+    "lines": 950,
+    "tokens": 7500
+  },
+  "warnings": [],
+  "with_files": true
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_json_two_langs.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_json_two_langs.snap
@@ -1,0 +1,52 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": true
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [
+    {
+      "avg_lines": 157,
+      "bytes": 150000,
+      "code": 4200,
+      "files": 35,
+      "lang": "Rust",
+      "lines": 5500,
+      "tokens": 38000
+    },
+    {
+      "avg_lines": 191,
+      "bytes": 54000,
+      "code": 1800,
+      "files": 12,
+      "lang": "Python",
+      "lines": 2300,
+      "tokens": 18000
+    }
+  ],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 165,
+    "bytes": 204000,
+    "code": 6000,
+    "files": 47,
+    "lines": 7800,
+    "tokens": 56000
+  },
+  "warnings": [],
+  "with_files": true
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_embedded_separate.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_embedded_separate.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|HTML|350|450|4|10500|3500|112|
+|JavaScript (embedded)|180|220|4|5400|1800|55|
+|CSS (embedded)|90|110|3|2700|900|36|
+|**Total**|620|780|11|18600|6200|70|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_empty.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Lang|Code|Lines|Bytes|Tokens|
+|---|---:|---:|---:|---:|
+|**Total**|0|0|0|0|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_four_langs.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_four_langs.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|Rust|4000|4800|20|100000|28000|140|
+|TypeScript|2500|3000|12|62500|17500|140|
+|Python|1200|1440|6|30000|8400|140|
+|Shell|300|360|1|7500|2100|140|
+|**Total**|8000|9600|39|200000|56000|140|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_single_lang.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_single_lang.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|Go|750|950|6|22500|7500|158|
+|**Total**|750|950|6|22500|7500|158|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_top_limited.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_top_limited.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|Rust|4000|4800|20|100000|28000|140|
+|TypeScript|2500|3000|12|62500|17500|140|
+|Python|1200|1440|6|30000|8400|140|
+|Shell|300|360|1|7500|2100|140|
+|**Total**|8000|9600|39|200000|56000|140|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_two_langs_with_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_two_langs_with_files.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|Rust|4200|5500|35|150000|38000|157|
+|Python|1800|2300|12|54000|18000|191|
+|**Total**|6000|7800|47|204000|56000|165|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_two_langs_without_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_md_two_langs_without_files.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Lang|Code|Lines|Bytes|Tokens|
+|---|---:|---:|---:|---:|
+|Rust|4200|5500|150000|38000|
+|Python|1800|2300|54000|18000|
+|**Total**|6000|7800|204000|56000|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_empty.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+Lang	Code	Lines	Bytes	Tokens
+Total	0	0	0	0

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_four_langs.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_four_langs.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+Lang	Code	Lines	Files	Bytes	Tokens	Avg
+Rust	4000	4800	20	100000	28000	140
+TypeScript	2500	3000	12	62500	17500	140
+Python	1200	1440	6	30000	8400	140
+Shell	300	360	1	7500	2100	140
+Total	8000	9600	39	200000	56000	140

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_with_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_with_files.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+Lang	Code	Lines	Files	Bytes	Tokens	Avg
+Rust	4200	5500	35	150000	38000	157
+Python	1800	2300	12	54000	18000	191
+Total	6000	7800	47	204000	56000	165

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_without_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_lang_tsv_without_files.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+Lang	Code	Lines	Bytes	Tokens
+Rust	4200	5500	150000	38000
+Python	1800	2300	54000	18000
+Total	6000	7800	204000	56000

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_json_three_modules.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_json_three_modules.snap
@@ -1,0 +1,67 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "separate",
+    "format": "json",
+    "module_depth": 2,
+    "module_roots": [
+      "crates"
+    ],
+    "top": 0
+  },
+  "children": "separate",
+  "generated_at_ms": 0,
+  "mode": "module",
+  "module_depth": 2,
+  "module_roots": [
+    "crates"
+  ],
+  "rows": [
+    {
+      "avg_lines": 250,
+      "bytes": 84000,
+      "code": 2800,
+      "files": 14,
+      "lines": 3500,
+      "module": "crates/engine",
+      "tokens": 22400
+    },
+    {
+      "avg_lines": 218,
+      "bytes": 42000,
+      "code": 1400,
+      "files": 8,
+      "lines": 1750,
+      "module": "crates/api",
+      "tokens": 11200
+    },
+    {
+      "avg_lines": 220,
+      "bytes": 27000,
+      "code": 900,
+      "files": 5,
+      "lines": 1100,
+      "module": "tests",
+      "tokens": 7200
+    }
+  ],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 235,
+    "bytes": 153000,
+    "code": 5100,
+    "files": 27,
+    "lines": 6350,
+    "tokens": 40800
+  },
+  "warnings": []
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_md_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_md_empty.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Module|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|**Total**|0|0|0|0|0|0|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_md_three_modules.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_md_three_modules.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+|Module|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|crates/engine|2800|3500|14|84000|22400|250|
+|crates/api|1400|1750|8|42000|11200|218|
+|tests|900|1100|5|27000|7200|220|
+|**Total**|5100|6350|27|153000|40800|235|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_tsv_three_modules.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w70__w70_module_tsv_three_modules.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tokmd-format/tests/snapshot_w70.rs
+expression: out
+---
+Module	Code	Lines	Files	Bytes	Tokens	Avg
+crates/engine	2800	3500	14	84000	22400	250
+crates/api	1400	1750	8	42000	11200	218
+tests	900	1100	5	27000	7200	220
+Total	5100	6350	27	153000	40800	235

--- a/crates/tokmd-fun/tests/snapshot_w70.rs
+++ b/crates/tokmd-fun/tests/snapshot_w70.rs
@@ -1,0 +1,150 @@
+//! Golden snapshot tests for fun outputs (W70).
+//!
+//! Covers OBJ rendering (3D code city) and MIDI rendering (sonification).
+//! MIDI output is hex-encoded since insta snapshots are text-based.
+
+use tokmd_fun::{MidiNote, ObjBuilding, render_midi, render_obj};
+
+// ===========================================================================
+// OBJ – 3D code city
+// ===========================================================================
+
+#[test]
+fn w70_obj_empty_city() {
+    insta::assert_snapshot!("w70_obj_empty_city", render_obj(&[]));
+}
+
+#[test]
+fn w70_obj_single_building() {
+    let buildings = vec![ObjBuilding {
+        name: "core".to_string(),
+        x: 0.0,
+        y: 0.0,
+        w: 4.0,
+        d: 4.0,
+        h: 15.0,
+    }];
+    insta::assert_snapshot!("w70_obj_single_building", render_obj(&buildings));
+}
+
+#[test]
+fn w70_obj_three_buildings_grid() {
+    let buildings = vec![
+        ObjBuilding {
+            name: "Rust".to_string(),
+            x: 0.0,
+            y: 0.0,
+            w: 5.0,
+            d: 5.0,
+            h: 20.0,
+        },
+        ObjBuilding {
+            name: "Python".to_string(),
+            x: 6.0,
+            y: 0.0,
+            w: 3.0,
+            d: 3.0,
+            h: 8.0,
+        },
+        ObjBuilding {
+            name: "TOML".to_string(),
+            x: 10.0,
+            y: 0.0,
+            w: 2.0,
+            d: 2.0,
+            h: 1.5,
+        },
+    ];
+    insta::assert_snapshot!("w70_obj_three_buildings_grid", render_obj(&buildings));
+}
+
+#[test]
+fn w70_obj_special_chars() {
+    let buildings = vec![ObjBuilding {
+        name: "C++ (embedded)".to_string(),
+        x: 1.0,
+        y: 2.0,
+        w: 2.5,
+        d: 2.5,
+        h: 5.0,
+    }];
+    insta::assert_snapshot!("w70_obj_special_chars", render_obj(&buildings));
+}
+
+#[test]
+fn w70_obj_zero_height() {
+    let buildings = vec![ObjBuilding {
+        name: "empty".to_string(),
+        x: 0.0,
+        y: 0.0,
+        w: 3.0,
+        d: 3.0,
+        h: 0.0,
+    }];
+    insta::assert_snapshot!("w70_obj_zero_height", render_obj(&buildings));
+}
+
+#[test]
+fn w70_obj_fractional_coords() {
+    let buildings = vec![ObjBuilding {
+        name: "precise".to_string(),
+        x: 1.5,
+        y: 2.5,
+        w: 0.75,
+        d: 0.75,
+        h: 3.25,
+    }];
+    insta::assert_snapshot!("w70_obj_fractional_coords", render_obj(&buildings));
+}
+
+// ===========================================================================
+// MIDI – sonification (hex-encoded)
+// ===========================================================================
+
+fn midi_hex(notes: &[MidiNote], tempo: u16) -> String {
+    let bytes = render_midi(notes, tempo).unwrap();
+    bytes.iter().map(|b| format!("{:02x}", b)).collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn w70_midi_single_note() {
+    let notes = vec![MidiNote {
+        key: 60,
+        velocity: 100,
+        start: 0,
+        duration: 480,
+        channel: 0,
+    }];
+    insta::assert_snapshot!("w70_midi_single_note", midi_hex(&notes, 120));
+}
+
+#[test]
+fn w70_midi_chord() {
+    let notes = vec![
+        MidiNote { key: 60, velocity: 80, start: 0, duration: 960, channel: 0 },
+        MidiNote { key: 64, velocity: 80, start: 0, duration: 960, channel: 0 },
+        MidiNote { key: 67, velocity: 80, start: 0, duration: 960, channel: 0 },
+    ];
+    insta::assert_snapshot!("w70_midi_chord", midi_hex(&notes, 100));
+}
+
+#[test]
+fn w70_midi_scale_fragment() {
+    let notes: Vec<MidiNote> = [60, 62, 64, 65, 67]
+        .iter()
+        .enumerate()
+        .map(|(i, &key)| MidiNote {
+            key,
+            velocity: 90,
+            start: (i as u32) * 240,
+            duration: 240,
+            channel: 0,
+        })
+        .collect();
+    insta::assert_snapshot!("w70_midi_scale_fragment", midi_hex(&notes, 140));
+}
+
+#[test]
+fn w70_midi_empty_notes() {
+    insta::assert_snapshot!("w70_midi_empty_notes", midi_hex(&[], 120));
+}

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_chord.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_chord.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: "midi_hex(&notes, 100)"
+---
+4d 54 68 64 00 00 00 06 00 00 00 01 01 e0 4d 54 72 6b 00 00 00 20 00 ff 51 03 09 27 c0 00 90 3c 50 00 40 50 00 43 50 87 40 80 3c 00 00 40 00 00 43 00 00 ff 2f 00

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_empty_notes.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_empty_notes.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: "midi_hex(&[], 120)"
+---
+4d 54 68 64 00 00 00 06 00 00 00 01 01 e0 4d 54 72 6b 00 00 00 0b 00 ff 51 03 07 a1 20 00 ff 2f 00

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_scale_fragment.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_scale_fragment.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: "midi_hex(&notes, 140)"
+---
+4d 54 68 64 00 00 00 06 00 00 00 01 01 e0 4d 54 72 6b 00 00 00 38 00 ff 51 03 06 8a 1b 00 90 3c 5a 81 70 80 3c 00 00 90 3e 5a 81 70 80 3e 00 00 90 40 5a 81 70 80 40 00 00 90 41 5a 81 70 80 41 00 00 90 43 5a 81 70 80 43 00 00 ff 2f 00

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_single_note.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_midi_single_note.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: "midi_hex(&notes, 120)"
+---
+4d 54 68 64 00 00 00 06 00 00 00 01 01 e0 4d 54 72 6b 00 00 00 14 00 ff 51 03 07 a1 20 00 90 3c 64 83 60 80 3c 00 00 ff 2f 00

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_empty_city.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_empty_city.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: "render_obj(&[])"
+---
+# tokmd code city

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_fractional_coords.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_fractional_coords.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: render_obj(&buildings)
+---
+# tokmd code city
+o precise
+v 1.5 2.5 0
+v 2.25 2.5 0
+v 2.25 3.25 0
+v 1.5 3.25 0
+v 1.5 2.5 3.25
+v 2.25 2.5 3.25
+v 2.25 3.25 3.25
+v 1.5 3.25 3.25
+f 1 2 3 4
+f 5 6 7 8
+f 1 2 6 5
+f 2 3 7 6
+f 3 4 8 7
+f 4 1 5 8

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_single_building.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_single_building.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: render_obj(&buildings)
+---
+# tokmd code city
+o core
+v 0 0 0
+v 4 0 0
+v 4 4 0
+v 0 4 0
+v 0 0 15
+v 4 0 15
+v 4 4 15
+v 0 4 15
+f 1 2 3 4
+f 5 6 7 8
+f 1 2 6 5
+f 2 3 7 6
+f 3 4 8 7
+f 4 1 5 8

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_special_chars.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_special_chars.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: render_obj(&buildings)
+---
+# tokmd code city
+o C____embedded_
+v 1 2 0
+v 3.5 2 0
+v 3.5 4.5 0
+v 1 4.5 0
+v 1 2 5
+v 3.5 2 5
+v 3.5 4.5 5
+v 1 4.5 5
+f 1 2 3 4
+f 5 6 7 8
+f 1 2 6 5
+f 2 3 7 6
+f 3 4 8 7
+f 4 1 5 8

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_three_buildings_grid.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_three_buildings_grid.snap
@@ -1,0 +1,50 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: render_obj(&buildings)
+---
+# tokmd code city
+o Rust
+v 0 0 0
+v 5 0 0
+v 5 5 0
+v 0 5 0
+v 0 0 20
+v 5 0 20
+v 5 5 20
+v 0 5 20
+f 1 2 3 4
+f 5 6 7 8
+f 1 2 6 5
+f 2 3 7 6
+f 3 4 8 7
+f 4 1 5 8
+o Python
+v 6 0 0
+v 9 0 0
+v 9 3 0
+v 6 3 0
+v 6 0 8
+v 9 0 8
+v 9 3 8
+v 6 3 8
+f 9 10 11 12
+f 13 14 15 16
+f 9 10 14 13
+f 10 11 15 14
+f 11 12 16 15
+f 12 9 13 16
+o TOML
+v 10 0 0
+v 12 0 0
+v 12 2 0
+v 10 2 0
+v 10 0 1.5
+v 12 0 1.5
+v 12 2 1.5
+v 10 2 1.5
+f 17 18 19 20
+f 21 22 23 24
+f 17 18 22 21
+f 18 19 23 22
+f 19 20 24 23
+f 20 17 21 24

--- a/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_zero_height.snap
+++ b/crates/tokmd-fun/tests/snapshots/snapshot_w70__w70_obj_zero_height.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tokmd-fun/tests/snapshot_w70.rs
+expression: render_obj(&buildings)
+---
+# tokmd code city
+o empty
+v 0 0 0
+v 3 0 0
+v 3 3 0
+v 0 3 0
+v 0 0 0
+v 3 0 0
+v 3 3 0
+v 0 3 0
+f 1 2 3 4
+f 5 6 7 8
+f 1 2 6 5
+f 2 3 7 6
+f 3 4 8 7
+f 4 1 5 8


### PR DESCRIPTION
## Summary

Add comprehensive **insta snapshot golden tests** across 4 output-rendering crates to pin deterministic output and catch accidental regressions.

### Test Coverage

| Crate | Tests | Coverage |
|-------|-------|----------|
| **tokmd-format** | 20 | Lang md/tsv/json (7+4+3), module md/tsv/json (2+1+1), export csv/jsonl (1+1) |
| **tokmd-analysis-format** | 15 | JSON (3), Markdown (4), JSON-LD (1), XML (2), SVG (2), Mermaid (1), Tree (1), HTML (1) |
| **tokmd-badge** | 10 | Basic SVG badges (4), edge cases (4), numeric formatting (2) |
| **tokmd-fun** | 10 | OBJ 3D rendering (6), hex-encoded MIDI output (4) |
| **Total** | **55** | |

### Key Design Decisions

- All fixtures use deterministic data with stable ordering (BTreeMap)
- JSON timestamps normalized via \
ormalize_json()\ helper
- HTML timestamps redacted via \edact_timestamp()\ helper
- MIDI binary output hex-encoded for text-based snapshots
- Follows existing \w{NUMBER}_\ naming convention for snapshot names
- Each crate uses independent \snapshot_w70.rs\ test file

### Files Changed
- 4 test files (\snapshot_w70.rs\ in each crate)
- 55 snapshot files (\.snap\ in each crate's \	ests/snapshots/\ directory)