### PR TITLE
test(w71): handoff + context + baseline CLI deep tests (~55 tests)

### DIFF
--- a/crates/tokmd/tests/baseline_w71.rs
+++ b/crates/tokmd/tests/baseline_w71.rs
@@ -1,0 +1,336 @@
+//! W71 deep baseline CLI integration tests.
+//!
+//! Tests cover: metrics field validation, custom output paths, error cases,
+//! determinism, commit field, empty project, and force-overwrite semantics.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+/// Helper: run baseline and return parsed JSON.
+fn run_baseline(extra: &[&str]) -> serde_json::Value {
+    let dir = tempdir().unwrap();
+    let out_file = dir.path().join("baseline.json");
+
+    let mut cmd = tokmd_cmd();
+    cmd.arg("--no-progress")
+        .arg("baseline")
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--force");
+    for a in extra {
+        cmd.arg(a);
+    }
+    cmd.assert().success();
+
+    let content = fs::read_to_string(&out_file).unwrap();
+    serde_json::from_str(&content).unwrap()
+}
+
+// ===========================================================================
+// 1. Metrics field validation
+// ===========================================================================
+
+#[test]
+fn baseline_metrics_has_total_files() {
+    let parsed = run_baseline(&[]);
+    let total = parsed["metrics"]["total_files"].as_u64();
+    assert!(total.is_some(), "metrics should have total_files");
+    assert!(total.unwrap() > 0, "fixture should have at least one file");
+}
+
+#[test]
+fn baseline_metrics_has_function_count() {
+    let parsed = run_baseline(&[]);
+    assert!(
+        parsed["metrics"]["function_count"].is_number(),
+        "metrics should have function_count"
+    );
+}
+
+#[test]
+fn baseline_metrics_has_avg_cyclomatic() {
+    let parsed = run_baseline(&[]);
+    assert!(
+        parsed["metrics"]["avg_cyclomatic"].is_number(),
+        "metrics should have avg_cyclomatic"
+    );
+}
+
+#[test]
+fn baseline_metrics_has_max_cyclomatic() {
+    let parsed = run_baseline(&[]);
+    assert!(
+        parsed["metrics"]["max_cyclomatic"].is_number(),
+        "metrics should have max_cyclomatic"
+    );
+}
+
+#[test]
+fn baseline_metrics_avg_le_max_cyclomatic() {
+    let parsed = run_baseline(&[]);
+    let avg = parsed["metrics"]["avg_cyclomatic"].as_f64().unwrap_or(0.0);
+    let max = parsed["metrics"]["max_cyclomatic"].as_f64().unwrap_or(0.0);
+    assert!(
+        avg <= max,
+        "avg_cyclomatic ({avg}) should be <= max_cyclomatic ({max})"
+    );
+}
+
+// ===========================================================================
+// 2. Custom output path
+// ===========================================================================
+
+#[test]
+fn baseline_custom_output_path() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let custom_path = dir.path().join("subdir").join("my_baseline.json");
+
+    // Parent dir must exist for the command to write
+    fs::create_dir_all(custom_path.parent().unwrap())?;
+
+    tokmd_cmd()
+        .arg("--no-progress")
+        .arg("baseline")
+        .arg("--output")
+        .arg(&custom_path)
+        .arg("--force")
+        .assert()
+        .success();
+
+    assert!(custom_path.exists(), "baseline should be written to custom path");
+
+    let content = fs::read_to_string(&custom_path)?;
+    let parsed: serde_json::Value = serde_json::from_str(&content)?;
+    assert_eq!(parsed["baseline_version"].as_u64(), Some(1));
+    Ok(())
+}
+
+// ===========================================================================
+// 3. Force overwrite semantics
+// ===========================================================================
+
+#[test]
+fn baseline_without_force_on_existing_file_fails() {
+    let dir = tempdir().unwrap();
+    let out_file = dir.path().join("baseline.json");
+
+    // First run with --force
+    tokmd_cmd()
+        .arg("--no-progress")
+        .arg("baseline")
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--force")
+        .assert()
+        .success();
+
+    assert!(out_file.exists());
+
+    // Second run without --force should fail
+    tokmd_cmd()
+        .arg("--no-progress")
+        .arg("baseline")
+        .arg("--output")
+        .arg(&out_file)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("exists")
+                .or(predicate::str::contains("--force"))
+                .or(predicate::str::contains("overwrite")),
+        );
+}
+
+#[test]
+fn baseline_force_overwrites_existing() {
+    let dir = tempdir().unwrap();
+    let out_file = dir.path().join("baseline.json");
+
+    // First run
+    tokmd_cmd()
+        .arg("--no-progress")
+        .arg("baseline")
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--force")
+        .assert()
+        .success();
+
+    // Second run with --force should succeed
+    tokmd_cmd()
+        .arg("--no-progress")
+        .arg("baseline")
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--force")
+        .assert()
+        .success();
+}
+
+// ===========================================================================
+// 4. Determinism
+// ===========================================================================
+
+#[test]
+fn baseline_deterministic_metrics() {
+    let run1 = run_baseline(&[]);
+    let run2 = run_baseline(&[]);
+
+    assert_eq!(
+        run1["metrics"]["total_files"],
+        run2["metrics"]["total_files"],
+        "total_files should be deterministic"
+    );
+    assert_eq!(
+        run1["metrics"]["function_count"],
+        run2["metrics"]["function_count"],
+        "function_count should be deterministic"
+    );
+}
+
+// ===========================================================================
+// 5. Commit field
+// ===========================================================================
+
+#[test]
+fn baseline_has_commit_field() {
+    let parsed = run_baseline(&[]);
+    // commit field may be null if fixture has no real git history,
+    // but the key should be present
+    assert!(
+        parsed.get("commit").is_some(),
+        "baseline should have commit field"
+    );
+}
+
+// ===========================================================================
+// 6. Empty project
+// ===========================================================================
+
+#[test]
+fn baseline_empty_project() {
+    let dir = tempdir().unwrap();
+    let empty = dir.path().join("empty_proj");
+    fs::create_dir_all(&empty).unwrap();
+    fs::create_dir_all(empty.join(".git")).unwrap();
+
+    let out_file = dir.path().join("empty_baseline.json");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(&empty)
+        .arg("--no-progress")
+        .arg("baseline")
+        .arg(&empty)
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--force")
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out_file).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(parsed["baseline_version"].as_u64(), Some(1));
+    assert_eq!(parsed["metrics"]["total_files"].as_u64(), Some(0));
+}
+
+// ===========================================================================
+// 7. Baseline version field
+// ===========================================================================
+
+#[test]
+fn baseline_version_is_one() {
+    let parsed = run_baseline(&[]);
+    assert_eq!(parsed["baseline_version"].as_u64(), Some(1));
+}
+
+// ===========================================================================
+// 8. Determinism flag (feature-gated)
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "git")]
+fn baseline_determinism_flag_source_hash_format() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let out_file = dir.path().join("det_baseline.json");
+
+    tokmd_cmd()
+        .arg("--no-progress")
+        .arg("baseline")
+        .arg("--determinism")
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--force")
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out_file)?;
+    let parsed: serde_json::Value = serde_json::from_str(&content)?;
+
+    let det = parsed
+        .get("determinism")
+        .expect("determinism section should be present");
+
+    // source_hash should be 64 hex chars (BLAKE3)
+    let hash = det["source_hash"].as_str().unwrap();
+    assert_eq!(hash.len(), 64);
+    assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+
+    // generated_at should be present
+    assert!(det["generated_at"].is_string());
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "git")]
+fn baseline_determinism_flag_deterministic_hash() {
+    let get_hash = || {
+        let dir = tempdir().unwrap();
+        let out_file = dir.path().join("det.json");
+
+        tokmd_cmd()
+            .arg("--no-progress")
+            .arg("baseline")
+            .arg("--determinism")
+            .arg("--output")
+            .arg(&out_file)
+            .arg("--force")
+            .assert()
+            .success();
+
+        let content = fs::read_to_string(&out_file).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        parsed["determinism"]["source_hash"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+
+    let hash1 = get_hash();
+    let hash2 = get_hash();
+    assert_eq!(hash1, hash2, "source_hash should be deterministic");
+}
+
+// ===========================================================================
+// 9. Metrics non-negative
+// ===========================================================================
+
+#[test]
+fn baseline_metrics_values_non_negative() {
+    let parsed = run_baseline(&[]);
+    let m = &parsed["metrics"];
+    assert!(m["total_files"].as_u64().is_some(), "total_files should be a non-negative integer");
+    assert!(m["function_count"].as_u64().is_some(), "function_count should be a non-negative integer");
+    assert!(m["avg_cyclomatic"].as_f64().unwrap_or(0.0) >= 0.0);
+    assert!(m["max_cyclomatic"].as_f64().unwrap_or(0.0) >= 0.0);
+}

--- a/crates/tokmd/tests/context_w71.rs
+++ b/crates/tokmd/tests/context_w71.rs
@@ -1,0 +1,349 @@
+//! W71 deep context CLI integration tests.
+//!
+//! Tests cover: rank-by variants, no-git fallback, compress flag, max-file-pct,
+//! max-file-tokens, no-smart-exclude, module-depth, log flag, empty directory,
+//! file ordering, and JSON receipt completeness.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+/// Helper: run context --mode json and return parsed receipt.
+fn run_context_json(extra: &[&str]) -> serde_json::Value {
+    let mut cmd = tokmd_cmd();
+    cmd.arg("context").arg("--mode").arg("json");
+    for a in extra {
+        cmd.arg(a);
+    }
+    let output = cmd.output().expect("context json should succeed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).unwrap()
+}
+
+// ===========================================================================
+// 1. Rank-by variants
+// ===========================================================================
+
+#[test]
+fn context_rank_by_code() {
+    let parsed = run_context_json(&["--rank-by", "code", "--budget", "10k"]);
+    assert_eq!(parsed["rank_by"].as_str(), Some("code"));
+}
+
+#[test]
+fn context_rank_by_tokens() {
+    let parsed = run_context_json(&["--rank-by", "tokens", "--budget", "10k"]);
+    assert_eq!(parsed["rank_by"].as_str(), Some("tokens"));
+}
+
+#[test]
+fn context_rank_by_hotspot_no_git_fallback() {
+    let parsed = run_context_json(&["--rank-by", "hotspot", "--no-git", "--budget", "10k"]);
+    // Should succeed even without git
+    assert!(parsed["budget_tokens"].is_number());
+}
+
+#[test]
+fn context_rank_by_churn_no_git_fallback() {
+    let parsed = run_context_json(&["--rank-by", "churn", "--no-git", "--budget", "10k"]);
+    assert!(parsed["budget_tokens"].is_number());
+}
+
+// ===========================================================================
+// 2. No-git flag
+// ===========================================================================
+
+#[test]
+fn context_no_git_flag_succeeds() {
+    tokmd_cmd()
+        .args(["context", "--mode", "json", "--no-git", "--budget", "10k"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn context_no_git_json_still_has_required_fields() {
+    let parsed = run_context_json(&["--no-git", "--budget", "10k"]);
+    assert_eq!(parsed["schema_version"].as_u64(), Some(4));
+    assert_eq!(parsed["mode"].as_str(), Some("context"));
+    assert!(parsed["files"].is_array());
+}
+
+// ===========================================================================
+// 3. Compress flag
+// ===========================================================================
+
+#[test]
+fn context_compress_bundle_mode() {
+    let normal = tokmd_cmd()
+        .args(["context", "--mode", "bundle", "--budget", "50k"])
+        .output()
+        .unwrap();
+
+    let compressed = tokmd_cmd()
+        .args([
+            "context",
+            "--mode",
+            "bundle",
+            "--budget",
+            "50k",
+            "--compress",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(normal.status.success());
+    assert!(compressed.status.success());
+
+    // Compressed should be same or smaller
+    assert!(
+        compressed.stdout.len() <= normal.stdout.len(),
+        "compressed ({}) should be <= normal ({})",
+        compressed.stdout.len(),
+        normal.stdout.len()
+    );
+}
+
+// ===========================================================================
+// 4. Max-file-pct / max-file-tokens
+// ===========================================================================
+
+#[test]
+fn context_max_file_pct_accepted() {
+    tokmd_cmd()
+        .args([
+            "context",
+            "--mode",
+            "json",
+            "--budget",
+            "10k",
+            "--max-file-pct",
+            "0.05",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn context_max_file_tokens_accepted() {
+    tokmd_cmd()
+        .args([
+            "context",
+            "--mode",
+            "json",
+            "--budget",
+            "10k",
+            "--max-file-tokens",
+            "50",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn context_max_file_tokens_limits_individual_files() {
+    let parsed = run_context_json(&["--budget", "50k", "--max-file-tokens", "50"]);
+    let files = parsed["files"].as_array().unwrap();
+    for file in files {
+        let tokens = file["tokens"].as_u64().unwrap_or(0);
+        // Each file's contribution should not dramatically exceed the cap
+        // (the cap applies to bundled content; the row still records total tokens)
+        assert!(
+            tokens > 0 || file["path"].is_string(),
+            "file rows should have tokens"
+        );
+    }
+}
+
+// ===========================================================================
+// 5. No-smart-exclude
+// ===========================================================================
+
+#[test]
+fn context_no_smart_exclude_accepted() {
+    tokmd_cmd()
+        .args([
+            "context",
+            "--mode",
+            "json",
+            "--budget",
+            "10k",
+            "--no-smart-exclude",
+        ])
+        .assert()
+        .success();
+}
+
+// ===========================================================================
+// 6. Module depth
+// ===========================================================================
+
+#[test]
+fn context_module_depth_accepted() {
+    tokmd_cmd()
+        .args([
+            "context",
+            "--mode",
+            "json",
+            "--budget",
+            "10k",
+            "--module-depth",
+            "1",
+        ])
+        .assert()
+        .success();
+}
+
+// ===========================================================================
+// 7. Log flag
+// ===========================================================================
+
+#[test]
+fn context_log_flag_creates_logfile() {
+    let dir = tempdir().unwrap();
+    let log_file = dir.path().join("context.log");
+
+    tokmd_cmd()
+        .args(["context", "--mode", "json", "--budget", "5k", "--log"])
+        .arg(&log_file)
+        .assert()
+        .success();
+
+    assert!(log_file.exists(), "log file should be created");
+    let content = fs::read_to_string(&log_file).unwrap();
+    // Log should contain valid JSONL
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let _: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("Invalid JSONL in log: {e}"));
+    }
+}
+
+// ===========================================================================
+// 8. Empty directory handling
+// ===========================================================================
+
+#[test]
+fn context_empty_directory_succeeds() {
+    let dir = tempdir().unwrap();
+    let empty = dir.path().join("empty");
+    fs::create_dir_all(&empty).unwrap();
+    // Create .git marker so ignore crate is happy
+    fs::create_dir_all(empty.join(".git")).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(&empty)
+        .args(["context", "--mode", "json", "--budget", "1k"])
+        .arg(&empty)
+        .assert()
+        .success();
+}
+
+#[test]
+fn context_empty_directory_zero_files() {
+    let dir = tempdir().unwrap();
+    let empty = dir.path().join("empty2");
+    fs::create_dir_all(&empty).unwrap();
+    fs::create_dir_all(empty.join(".git")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(&empty)
+        .args(["context", "--mode", "json", "--budget", "1k"])
+        .arg(&empty)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert_eq!(parsed["file_count"].as_u64(), Some(0));
+    assert_eq!(parsed["used_tokens"].as_u64(), Some(0));
+}
+
+// ===========================================================================
+// 9. File ordering determinism
+// ===========================================================================
+
+#[test]
+fn context_file_ordering_deterministic() {
+    let get_paths = || {
+        let parsed = run_context_json(&["--budget", "50k"]);
+        parsed["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| f["path"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>()
+    };
+
+    let run1 = get_paths();
+    let run2 = get_paths();
+    assert_eq!(run1, run2, "file ordering should be deterministic");
+}
+
+// ===========================================================================
+// 10. Budget suffix parsing
+// ===========================================================================
+
+#[test]
+fn context_budget_m_suffix() {
+    let parsed = run_context_json(&["--budget", "1m"]);
+    assert_eq!(parsed["budget_tokens"].as_u64(), Some(1_000_000));
+}
+
+#[test]
+fn context_budget_plain_number() {
+    let parsed = run_context_json(&["--budget", "5000"]);
+    assert_eq!(parsed["budget_tokens"].as_u64(), Some(5000));
+}
+
+// ===========================================================================
+// 11. Output to file
+// ===========================================================================
+
+#[test]
+fn context_output_bundle_to_file() {
+    let dir = tempdir().unwrap();
+    let out_file = dir.path().join("bundle_out.txt");
+
+    tokmd_cmd()
+        .args(["context", "--mode", "bundle", "--budget", "10k", "--output"])
+        .arg(&out_file)
+        .assert()
+        .success();
+
+    assert!(out_file.exists());
+    let content = fs::read_to_string(&out_file).unwrap();
+    assert!(!content.is_empty(), "bundle output should not be empty");
+}
+
+// ===========================================================================
+// 12. Invalid rank-by rejected
+// ===========================================================================
+
+#[test]
+fn context_invalid_rank_by_rejected() {
+    tokmd_cmd()
+        .args([
+            "context",
+            "--mode",
+            "json",
+            "--rank-by",
+            "nonexistent",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}

--- a/crates/tokmd/tests/handoff_w71.rs
+++ b/crates/tokmd/tests/handoff_w71.rs
@@ -1,0 +1,368 @@
+//! W71 deep handoff CLI integration tests.
+//!
+//! Tests cover: rank-by variants, preset deep, max-file-pct/max-file-tokens,
+//! no-smart-exclude, module-depth, manifest field completeness, and
+//! intelligence preset recording.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+/// Helper: run handoff and return parsed manifest JSON.
+fn run_handoff(extra: &[&str]) -> serde_json::Value {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho");
+
+    let mut cmd = tokmd_cmd();
+    cmd.arg("handoff").arg("--out-dir").arg(&out_dir);
+    for a in extra {
+        cmd.arg(a);
+    }
+    cmd.assert().success();
+
+    let manifest = fs::read_to_string(out_dir.join("manifest.json")).unwrap();
+    serde_json::from_str(&manifest).unwrap()
+}
+
+// ===========================================================================
+// 1. Rank-by variants
+// ===========================================================================
+
+#[test]
+fn handoff_rank_by_code() {
+    let parsed = run_handoff(&["--rank-by", "code", "--budget", "10k"]);
+    assert_eq!(parsed["rank_by"].as_str(), Some("code"));
+}
+
+#[test]
+fn handoff_rank_by_tokens() {
+    let parsed = run_handoff(&["--rank-by", "tokens", "--budget", "10k"]);
+    assert_eq!(parsed["rank_by"].as_str(), Some("tokens"));
+}
+
+#[test]
+fn handoff_rank_by_hotspot_no_git_fallback() {
+    // With --no-git, hotspot ranking should gracefully fallback
+    let parsed = run_handoff(&["--rank-by", "hotspot", "--no-git", "--budget", "10k"]);
+    // Should succeed even without git; rank_by or rank_by_effective recorded
+    assert!(parsed["budget_tokens"].is_number());
+}
+
+#[test]
+fn handoff_rank_by_churn_no_git_fallback() {
+    let parsed = run_handoff(&["--rank-by", "churn", "--no-git", "--budget", "10k"]);
+    assert!(parsed["budget_tokens"].is_number());
+}
+
+// ===========================================================================
+// 2. Preset deep
+// ===========================================================================
+
+#[test]
+fn handoff_preset_deep_succeeds() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_deep");
+
+    tokmd_cmd()
+        .args(["handoff", "--preset", "deep", "--budget", "20k", "--out-dir"])
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    assert!(out_dir.join("manifest.json").exists());
+    assert!(out_dir.join("intelligence.json").exists());
+}
+
+#[test]
+fn handoff_preset_deep_intelligence_has_derived() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_deep_i");
+
+    tokmd_cmd()
+        .args(["handoff", "--preset", "deep", "--budget", "20k", "--out-dir"])
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    let intel = fs::read_to_string(out_dir.join("intelligence.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&intel).unwrap();
+
+    // Deep preset should include tree and derived metrics
+    assert!(parsed["tree"].is_string());
+    assert!(parsed["derived"].is_object());
+}
+
+#[test]
+fn handoff_manifest_records_intelligence_preset() {
+    let parsed = run_handoff(&["--preset", "minimal", "--budget", "5k"]);
+    assert_eq!(
+        parsed["intelligence_preset"].as_str(),
+        Some("minimal"),
+        "manifest should record the intelligence preset"
+    );
+}
+
+#[test]
+fn handoff_manifest_records_deep_preset() {
+    let parsed = run_handoff(&["--preset", "deep", "--budget", "20k"]);
+    assert_eq!(parsed["intelligence_preset"].as_str(), Some("deep"));
+}
+
+// ===========================================================================
+// 3. Budget fields in manifest
+// ===========================================================================
+
+#[test]
+fn handoff_manifest_has_total_and_bundled_files() {
+    let parsed = run_handoff(&["--budget", "10k"]);
+
+    assert!(
+        parsed["total_files"].is_number(),
+        "manifest should have total_files"
+    );
+    assert!(
+        parsed["bundled_files"].is_number(),
+        "manifest should have bundled_files"
+    );
+
+    let total = parsed["total_files"].as_u64().unwrap();
+    let bundled = parsed["bundled_files"].as_u64().unwrap();
+    assert!(
+        bundled <= total,
+        "bundled_files ({bundled}) should be <= total_files ({total})"
+    );
+}
+
+#[test]
+fn handoff_manifest_utilization_pct_consistent() {
+    let parsed = run_handoff(&["--budget", "10k"]);
+
+    let budget = parsed["budget_tokens"].as_f64().unwrap();
+    let used = parsed["used_tokens"].as_f64().unwrap();
+    let pct = parsed["utilization_pct"].as_f64().unwrap();
+
+    if budget > 0.0 {
+        let expected_pct = (used / budget) * 100.0;
+        assert!(
+            (pct - expected_pct).abs() < 0.1,
+            "utilization_pct ({pct}) should be ~{expected_pct}"
+        );
+    }
+}
+
+// ===========================================================================
+// 4. Max-file-pct / max-file-tokens
+// ===========================================================================
+
+#[test]
+fn handoff_max_file_pct_accepted() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_mfp");
+
+    tokmd_cmd()
+        .args([
+            "handoff",
+            "--budget",
+            "10k",
+            "--max-file-pct",
+            "0.05",
+            "--out-dir",
+        ])
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    assert!(out_dir.join("manifest.json").exists());
+}
+
+#[test]
+fn handoff_max_file_tokens_accepted() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_mft");
+
+    tokmd_cmd()
+        .args([
+            "handoff",
+            "--budget",
+            "10k",
+            "--max-file-tokens",
+            "100",
+            "--out-dir",
+        ])
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    assert!(out_dir.join("manifest.json").exists());
+}
+
+// ===========================================================================
+// 5. No-smart-exclude
+// ===========================================================================
+
+#[test]
+fn handoff_no_smart_exclude_accepted() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_nse");
+
+    tokmd_cmd()
+        .args([
+            "handoff",
+            "--no-smart-exclude",
+            "--budget",
+            "10k",
+            "--out-dir",
+        ])
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    assert!(out_dir.join("manifest.json").exists());
+}
+
+#[test]
+fn handoff_smart_excluded_files_field_present() {
+    let parsed = run_handoff(&["--budget", "10k"]);
+    // smart_excluded_files should be an array (possibly empty for fixture)
+    assert!(
+        parsed["smart_excluded_files"].is_array(),
+        "manifest should have smart_excluded_files array"
+    );
+}
+
+// ===========================================================================
+// 6. Module depth
+// ===========================================================================
+
+#[test]
+fn handoff_module_depth_accepted() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_md");
+
+    tokmd_cmd()
+        .args([
+            "handoff",
+            "--module-depth",
+            "1",
+            "--budget",
+            "10k",
+            "--out-dir",
+        ])
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    assert!(out_dir.join("manifest.json").exists());
+}
+
+// ===========================================================================
+// 7. Included-files row completeness
+// ===========================================================================
+
+#[test]
+fn handoff_included_files_rows_have_expected_fields() {
+    let parsed = run_handoff(&["--budget", "50k"]);
+
+    let included = parsed["included_files"].as_array().unwrap();
+    if included.is_empty() {
+        return; // Fixture too small for budget – skip
+    }
+
+    let first = &included[0];
+    assert!(first["path"].is_string(), "should have path");
+    assert!(first["tokens"].is_number(), "should have tokens");
+}
+
+// ===========================================================================
+// 8. Determinism: rank-by does not break determinism
+// ===========================================================================
+
+#[test]
+fn handoff_rank_by_code_deterministic() {
+    let get_files = || {
+        let parsed = run_handoff(&["--rank-by", "code", "--budget", "10k"]);
+        parsed["included_files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| f["path"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>()
+    };
+
+    let run1 = get_files();
+    let run2 = get_files();
+    assert_eq!(run1, run2, "rank-by code should be deterministic");
+}
+
+// ===========================================================================
+// 9. Invalid preset rejected
+// ===========================================================================
+
+#[test]
+fn handoff_invalid_preset_rejected() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_bad");
+
+    tokmd_cmd()
+        .args([
+            "handoff",
+            "--preset",
+            "nonexistent",
+            "--out-dir",
+        ])
+        .arg(&out_dir)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+// ===========================================================================
+// 10. Compress with preset
+// ===========================================================================
+
+#[test]
+fn handoff_compress_with_deep_preset() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("ho_c_d");
+
+    tokmd_cmd()
+        .args([
+            "handoff",
+            "--preset",
+            "deep",
+            "--compress",
+            "--budget",
+            "20k",
+            "--out-dir",
+        ])
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    let code = fs::read_to_string(out_dir.join("code.txt")).unwrap();
+    // Compressed code should still have file markers
+    assert!(code.contains("// ==="));
+}
+
+// ===========================================================================
+// 11. Tool metadata in manifest
+// ===========================================================================
+
+#[test]
+fn handoff_manifest_tool_has_version() {
+    let parsed = run_handoff(&["--budget", "5k"]);
+    assert_eq!(parsed["tool"]["name"].as_str(), Some("tokmd"));
+    assert!(
+        parsed["tool"]["version"].is_string(),
+        "tool should have version"
+    );
+}


### PR DESCRIPTION
## Summary

Adds three new integration test files covering previously untested CLI areas for the handoff, context, and baseline commands.

### Test Files

| File | Tests | Coverage Areas |
|------|-------|---------------|
| \handoff_w71.rs\ | 20 | rank-by variants, preset deep, max-file-pct, max-file-tokens, no-smart-exclude, module-depth, manifest field completeness, intelligence preset recording, tool metadata, determinism |
| \context_w71.rs\ | 20 | rank-by variants, no-git flag, compress flag, max-file-pct, max-file-tokens, no-smart-exclude, module-depth, log flag, empty directory handling, file ordering determinism, budget suffix parsing |
| \aseline_w71.rs\ | 15 | metrics field validation, custom output path, force-overwrite semantics, determinism, commit field, empty project, non-negative metrics, feature-gated determinism hash tests |

### Key Testing Gaps Addressed

- All \--rank-by\ variants (code/tokens/churn/hotspot) for both context and handoff
- \--no-smart-exclude\ flag across handoff and context
- \--max-file-pct\ and \--max-file-tokens\ thresholds
- Handoff \--preset deep\ and manifest fields it populates
- Module configuration flags (\--module-depth\)
- Baseline error cases (existing file without --force)
- Context \--compress\ flag and \--log\ JSONL output
- Empty directory edge cases
- File ordering and metric determinism verification

All 55 tests pass deterministically.