### PR TITLE
test(w72): mutation-hardening tests for math + redact + path (~45 tests)

### DIFF
--- a/crates/tokmd-math/tests/mutation_w72.rs
+++ b/crates/tokmd-math/tests/mutation_w72.rs
@@ -1,0 +1,152 @@
+//! Mutation-hardening tests for `tokmd-math`.
+//!
+//! Each test targets a known mutation-testing survivor pattern:
+//! boundary conditions, operator swaps, off-by-one errors, and
+//! boolean-logic flips.
+
+use tokmd_math::{gini_coefficient, percentile, round_f64, safe_ratio};
+
+// ── round_f64 ────────────────────────────────────────────────────────
+
+#[test]
+fn round_exact_half_rounds_up_zero_decimals() {
+    // 0.5 boundary: mutating `round` to `floor`/`ceil` would fail
+    assert_eq!(round_f64(0.5, 0), 1.0);
+    assert_eq!(round_f64(1.5, 0), 2.0);
+    assert_eq!(round_f64(-0.5, 0), -1.0);
+}
+
+#[test]
+fn round_just_below_half_stays_down() {
+    assert_eq!(round_f64(0.4999, 0), 0.0);
+    assert_eq!(round_f64(2.449, 1), 2.4);
+}
+
+#[test]
+fn round_zero_decimals_preserves_integer() {
+    assert_eq!(round_f64(7.0, 0), 7.0);
+    assert_eq!(round_f64(0.0, 5), 0.0);
+}
+
+#[test]
+fn round_large_decimal_places() {
+    // If `decimals as i32` were off-by-one, precision would differ
+    assert_eq!(round_f64(1.123456789, 8), 1.12345679);
+}
+
+// ── safe_ratio ───────────────────────────────────────────────────────
+
+#[test]
+fn safe_ratio_zero_divisor_returns_zero_not_panic() {
+    assert_eq!(safe_ratio(0, 0), 0.0);
+    assert_eq!(safe_ratio(100, 0), 0.0);
+}
+
+#[test]
+fn safe_ratio_identity() {
+    // n/n == 1.0 — swapping `==` to `!=` in the guard would break this
+    assert_eq!(safe_ratio(1, 1), 1.0);
+    assert_eq!(safe_ratio(999, 999), 1.0);
+}
+
+#[test]
+fn safe_ratio_rounds_to_four_decimals() {
+    assert_eq!(safe_ratio(1, 3), 0.3333);
+    assert_eq!(safe_ratio(2, 3), 0.6667);
+    assert_eq!(safe_ratio(1, 7), 0.1429);
+}
+
+#[test]
+fn safe_ratio_zero_numerator() {
+    assert_eq!(safe_ratio(0, 42), 0.0);
+}
+
+// ── percentile ───────────────────────────────────────────────────────
+
+#[test]
+fn percentile_empty_returns_zero() {
+    assert_eq!(percentile(&[], 0.0), 0.0);
+    assert_eq!(percentile(&[], 0.5), 0.0);
+    assert_eq!(percentile(&[], 1.0), 0.0);
+}
+
+#[test]
+fn percentile_single_element() {
+    // Any percentile of a single-element slice must return that element
+    assert_eq!(percentile(&[42], 0.0), 42.0);
+    assert_eq!(percentile(&[42], 0.5), 42.0);
+    assert_eq!(percentile(&[42], 1.0), 42.0);
+}
+
+#[test]
+fn percentile_0th_and_100th() {
+    let data = [10, 20, 30, 40, 50];
+    assert_eq!(percentile(&data, 0.0), 10.0);
+    assert_eq!(percentile(&data, 1.0), 50.0);
+}
+
+#[test]
+fn percentile_median_odd_len() {
+    assert_eq!(percentile(&[1, 2, 3, 4, 5], 0.5), 3.0);
+}
+
+#[test]
+fn percentile_median_even_len() {
+    // With ceil-based indexing, 0.5 of 4-element slice → idx ceil(1.5)=2 → 30
+    assert_eq!(percentile(&[10, 20, 30, 40], 0.5), 30.0);
+}
+
+// ── gini_coefficient ─────────────────────────────────────────────────
+
+#[test]
+fn gini_empty_returns_zero() {
+    assert_eq!(gini_coefficient(&[]), 0.0);
+}
+
+#[test]
+fn gini_single_element_returns_zero() {
+    assert_eq!(gini_coefficient(&[1]), 0.0);
+    assert_eq!(gini_coefficient(&[999]), 0.0);
+}
+
+#[test]
+fn gini_all_zeros_returns_zero() {
+    // Guards the `sum == 0.0` early-return path
+    assert_eq!(gini_coefficient(&[0, 0, 0, 0]), 0.0);
+}
+
+#[test]
+fn gini_uniform_returns_zero() {
+    let g = gini_coefficient(&[5, 5, 5, 5]);
+    assert!(g.abs() < 1e-10, "expected 0, got {g}");
+}
+
+#[test]
+fn gini_maximal_inequality() {
+    // [0, 0, 0, N] gives Gini close to 0.75 for 4 elements
+    let g = gini_coefficient(&[0, 0, 0, 100]);
+    assert!(g > 0.5, "expected high Gini, got {g}");
+    assert!(g <= 1.0, "Gini must be ≤1.0, got {g}");
+}
+
+#[test]
+fn gini_monotonically_increases_with_inequality() {
+    let equal = gini_coefficient(&[10, 10, 10, 10]);
+    let moderate = gini_coefficient(&[1, 5, 10, 20]);
+    let extreme = gini_coefficient(&[0, 0, 0, 100]);
+    assert!(
+        equal < moderate,
+        "equal ({equal}) should be < moderate ({moderate})"
+    );
+    assert!(
+        moderate < extreme,
+        "moderate ({moderate}) should be < extreme ({extreme})"
+    );
+}
+
+#[test]
+fn gini_two_elements_known_value() {
+    // [0, N] → Gini = 0.5 for any N>0 with 2 elements
+    let g = gini_coefficient(&[0, 10]);
+    assert!((g - 0.5).abs() < 1e-10, "expected 0.5, got {g}");
+}

--- a/crates/tokmd-path/tests/mutation_w72.rs
+++ b/crates/tokmd-path/tests/mutation_w72.rs
@@ -1,0 +1,100 @@
+//! Mutation-hardening tests for `tokmd-path`.
+//!
+//! Targets: operator-swap, boolean-flip, and boundary-condition
+//! mutation survivors in path normalization.
+
+use tokmd_path::{normalize_rel_path, normalize_slashes};
+
+// ── normalize_slashes ────────────────────────────────────────────────
+
+#[test]
+fn slashes_backslash_converted() {
+    assert_eq!(normalize_slashes(r"a\b\c"), "a/b/c");
+}
+
+#[test]
+fn slashes_forward_slash_unchanged() {
+    assert_eq!(normalize_slashes("a/b/c"), "a/b/c");
+}
+
+#[test]
+fn slashes_empty_string() {
+    assert_eq!(normalize_slashes(""), "");
+}
+
+#[test]
+fn slashes_single_backslash() {
+    assert_eq!(normalize_slashes("\\"), "/");
+}
+
+#[test]
+fn slashes_no_separators() {
+    assert_eq!(normalize_slashes("filename.rs"), "filename.rs");
+}
+
+#[test]
+fn slashes_mixed_separators() {
+    assert_eq!(normalize_slashes(r"a/b\c/d\e"), "a/b/c/d/e");
+}
+
+#[test]
+fn slashes_consecutive_backslashes() {
+    assert_eq!(normalize_slashes(r"a\\b"), "a//b");
+}
+
+#[test]
+fn slashes_idempotent() {
+    let input = r"x\y\z";
+    let once = normalize_slashes(input);
+    let twice = normalize_slashes(&once);
+    assert_eq!(once, twice);
+}
+
+// ── normalize_rel_path ───────────────────────────────────────────────
+
+#[test]
+fn rel_strips_leading_dot_slash() {
+    assert_eq!(normalize_rel_path("./src/lib.rs"), "src/lib.rs");
+}
+
+#[test]
+fn rel_strips_multiple_dot_slash() {
+    assert_eq!(normalize_rel_path("././src/lib.rs"), "src/lib.rs");
+}
+
+#[test]
+fn rel_strips_backslash_dot() {
+    assert_eq!(normalize_rel_path(r".\src\main.rs"), "src/main.rs");
+}
+
+#[test]
+fn rel_preserves_double_dot_prefix() {
+    // `../` must NOT be stripped — only `./`
+    assert_eq!(normalize_rel_path("../src/lib.rs"), "../src/lib.rs");
+}
+
+#[test]
+fn rel_empty_string() {
+    assert_eq!(normalize_rel_path(""), "");
+}
+
+#[test]
+fn rel_bare_dot_slash() {
+    // "./" alone → ""
+    assert_eq!(normalize_rel_path("./"), "");
+}
+
+#[test]
+fn rel_idempotent() {
+    let cases = [
+        r".\src\lib.rs",
+        "./a/b/c",
+        "already/normalized",
+        "../keep/this",
+    ];
+    for input in cases {
+        let once = normalize_rel_path(input);
+        let twice = normalize_rel_path(&once);
+        assert_eq!(once, twice, "not idempotent for: {input}");
+    }
+}

--- a/crates/tokmd-redact/tests/mutation_w72.rs
+++ b/crates/tokmd-redact/tests/mutation_w72.rs
@@ -1,0 +1,118 @@
+//! Mutation-hardening tests for `tokmd-redact`.
+//!
+//! Targets: constant-replacement, boolean-flip, and comparison-swap
+//! mutation survivors in hashing and path-cleaning logic.
+
+use tokmd_redact::{redact_path, short_hash};
+
+// ── short_hash basics ────────────────────────────────────────────────
+
+#[test]
+fn hash_always_16_chars() {
+    for input in ["", "a", "long/nested/path/to/file.rs", "🦀"] {
+        assert_eq!(short_hash(input).len(), 16, "failed for input: {input}");
+    }
+}
+
+#[test]
+fn hash_deterministic() {
+    assert_eq!(short_hash("hello"), short_hash("hello"));
+}
+
+#[test]
+fn hash_empty_string_is_deterministic_nonzero() {
+    let h = short_hash("");
+    assert_eq!(h.len(), 16);
+    // Must not be all zeros (that would indicate the hash was skipped)
+    assert!(h.chars().any(|c| c != '0'), "hash of empty string is all zeros");
+}
+
+#[test]
+fn hash_single_char_difference_produces_different_hash() {
+    assert_ne!(short_hash("a"), short_hash("b"));
+    assert_ne!(short_hash("file.rs"), short_hash("file.rr"));
+    assert_ne!(short_hash("src/lib"), short_hash("src/lib "));
+}
+
+// ── separator normalization ──────────────────────────────────────────
+
+#[test]
+fn hash_backslash_equals_forward_slash() {
+    assert_eq!(short_hash("a\\b\\c"), short_hash("a/b/c"));
+}
+
+#[test]
+fn hash_mixed_separators_normalize() {
+    assert_eq!(short_hash("a/b\\c/d"), short_hash("a/b/c/d"));
+}
+
+// ── dot-segment normalization ────────────────────────────────────────
+
+#[test]
+fn hash_leading_dot_slash_stripped() {
+    assert_eq!(short_hash("./foo"), short_hash("foo"));
+    assert_eq!(short_hash("././foo"), short_hash("foo"));
+}
+
+#[test]
+fn hash_interior_dot_segment_removed() {
+    assert_eq!(short_hash("a/./b"), short_hash("a/b"));
+}
+
+#[test]
+fn hash_trailing_dot_segment_removed() {
+    assert_eq!(short_hash("a/."), short_hash("a"));
+}
+
+// ── redact_path ──────────────────────────────────────────────────────
+
+#[test]
+fn redact_never_returns_original_path() {
+    let paths = [
+        "src/main.rs",
+        "Cargo.toml",
+        "deeply/nested/path/to/module.py",
+        "",
+        "Makefile",
+    ];
+    for p in paths {
+        let redacted = redact_path(p);
+        if !p.is_empty() {
+            assert_ne!(redacted, p, "redact_path returned original for: {p}");
+        }
+    }
+}
+
+#[test]
+fn redact_preserves_extension() {
+    assert!(redact_path("file.json").ends_with(".json"));
+    assert!(redact_path("a/b/c.tar.gz").ends_with(".gz"));
+    assert!(redact_path("index.html").ends_with(".html"));
+}
+
+#[test]
+fn redact_no_extension_bare_hash() {
+    let r = redact_path("Makefile");
+    assert_eq!(r.len(), 16);
+    assert!(!r.contains('.'));
+}
+
+#[test]
+fn redact_cross_platform_consistency() {
+    assert_eq!(redact_path("src\\main.rs"), redact_path("src/main.rs"));
+    assert_eq!(
+        redact_path("crates\\tokmd\\src\\lib.rs"),
+        redact_path("crates/tokmd/src/lib.rs")
+    );
+}
+
+#[test]
+fn redact_dot_prefix_normalization() {
+    assert_eq!(redact_path("./src/lib.rs"), redact_path("src/lib.rs"));
+}
+
+#[test]
+fn redact_different_paths_produce_different_hashes() {
+    assert_ne!(redact_path("src/a.rs"), redact_path("src/b.rs"));
+    assert_ne!(redact_path("file.rs"), redact_path("file.py"));
+}


### PR DESCRIPTION
## Summary

Add mutation-hardening integration tests targeting common mutation-testing survivor patterns across three crates.

### Test coverage

| Crate | Tests | Targets |
|-------|-------|---------|
| \	okmd-math\ | 20 | \ound_f64\ boundaries, \safe_ratio\ div-by-zero, \percentile\ edge cases, \gini_coefficient\ inequality ordering |
| \	okmd-redact\ | 15 | Hash length/determinism, separator normalization, dot-segment cleaning, redact never returns original |
| \	okmd-path\ | 15 | Backslash conversion, empty strings, idempotency, \../\ preservation, consecutive separators |

### Mutation patterns targeted
- **Boundary conditions**: exact .5 rounding, 0th/100th percentile, empty slices
- **Boolean-logic flips**: \== 0\ guard in safe_ratio, \is_empty()\ checks
- **Comparison-operator swaps**: Gini monotonicity ordering, inequality direction
- **Off-by-one errors**: percentile index computation, hash truncation length
- **Constant replacement**: zero-return paths, identity ratios