### PR TITLE
test(w72): exhaustive type + serde tests (~55 tests)

### DIFF
--- a/crates/tokmd-envelope/tests/exhaustive_w72.rs
+++ b/crates/tokmd-envelope/tests/exhaustive_w72.rs
@@ -1,0 +1,442 @@
+//! Exhaustive serde and invariant tests for tokmd-envelope (w72).
+
+use std::collections::BTreeMap;
+use tokmd_envelope::findings;
+use tokmd_envelope::*;
+
+// =============================================================================
+// Schema constant
+// =============================================================================
+
+#[test]
+fn sensor_report_schema_is_v1() {
+    assert_eq!(SENSOR_REPORT_SCHEMA, "sensor.report.v1");
+    assert!(!SENSOR_REPORT_SCHEMA.is_empty());
+}
+
+// =============================================================================
+// SensorReport: all fields
+// =============================================================================
+
+#[test]
+fn sensor_report_new_has_correct_defaults() {
+    let r = SensorReport::new(
+        ToolMeta::tokmd("1.0.0", "test"),
+        "2024-01-01T00:00:00Z".into(),
+        Verdict::Pass,
+        "ok".into(),
+    );
+    assert_eq!(r.schema, SENSOR_REPORT_SCHEMA);
+    assert_eq!(r.verdict, Verdict::Pass);
+    assert!(r.findings.is_empty());
+    assert!(r.artifacts.is_none());
+    assert!(r.capabilities.is_none());
+    assert!(r.data.is_none());
+}
+
+#[test]
+fn sensor_report_full_roundtrip() {
+    let mut r = SensorReport::new(
+        ToolMeta::tokmd("1.5.0", "cockpit"),
+        "2024-06-01T12:00:00Z".into(),
+        Verdict::Warn,
+        "warnings found".into(),
+    );
+    r.add_finding(Finding::new(
+        "risk",
+        "hotspot",
+        FindingSeverity::Warn,
+        "High churn",
+        "src/lib.rs",
+    ));
+    let r = r
+        .with_artifacts(vec![Artifact::receipt("out/receipt.json")])
+        .with_data(serde_json::json!({"key": "value"}));
+
+    let json = serde_json::to_string(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema, SENSOR_REPORT_SCHEMA);
+    assert_eq!(back.findings.len(), 1);
+    assert!(back.artifacts.is_some());
+    assert!(back.data.is_some());
+}
+
+#[test]
+fn sensor_report_with_capabilities() {
+    let mut caps = BTreeMap::new();
+    caps.insert("mutation".into(), CapabilityStatus::available());
+    caps.insert(
+        "coverage".into(),
+        CapabilityStatus::unavailable("no artifact"),
+    );
+    caps.insert("semver".into(), CapabilityStatus::skipped("not applicable"));
+
+    let r = SensorReport::new(
+        ToolMeta::tokmd("1.0.0", "test"),
+        "2024-01-01T00:00:00Z".into(),
+        Verdict::Pass,
+        "ok".into(),
+    )
+    .with_capabilities(caps);
+
+    let json = serde_json::to_string(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    let caps = back.capabilities.unwrap();
+    assert_eq!(caps.len(), 3);
+    assert_eq!(caps["mutation"].status, CapabilityState::Available);
+    assert_eq!(caps["coverage"].status, CapabilityState::Unavailable);
+    assert_eq!(caps["semver"].status, CapabilityState::Skipped);
+}
+
+#[test]
+fn sensor_report_add_capability_incremental() {
+    let mut r = SensorReport::new(
+        ToolMeta::tokmd("1.0.0", "test"),
+        "2024-01-01T00:00:00Z".into(),
+        Verdict::Pass,
+        "ok".into(),
+    );
+    assert!(r.capabilities.is_none());
+    r.add_capability("a", CapabilityStatus::available());
+    r.add_capability("b", CapabilityStatus::unavailable("missing"));
+    assert_eq!(r.capabilities.as_ref().unwrap().len(), 2);
+}
+
+// =============================================================================
+// ToolMeta
+// =============================================================================
+
+#[test]
+fn tool_meta_new_and_tokmd() {
+    let generic = ToolMeta::new("my-sensor", "0.1.0", "analyze");
+    assert_eq!(generic.name, "my-sensor");
+    assert_eq!(generic.version, "0.1.0");
+    assert_eq!(generic.mode, "analyze");
+
+    let tokmd = ToolMeta::tokmd("2.0.0", "cockpit");
+    assert_eq!(tokmd.name, "tokmd");
+    assert_eq!(tokmd.version, "2.0.0");
+    assert_eq!(tokmd.mode, "cockpit");
+}
+
+#[test]
+fn tool_meta_serde_roundtrip() {
+    let tm = ToolMeta::new("test", "1.0.0", "scan");
+    let json = serde_json::to_string(&tm).unwrap();
+    let back: ToolMeta = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.name, "test");
+    assert_eq!(back.version, "1.0.0");
+    assert_eq!(back.mode, "scan");
+}
+
+// =============================================================================
+// Verdict: all variants
+// =============================================================================
+
+#[test]
+fn verdict_all_variants_serde() {
+    for (v, expected) in [
+        (Verdict::Pass, "pass"),
+        (Verdict::Fail, "fail"),
+        (Verdict::Warn, "warn"),
+        (Verdict::Skip, "skip"),
+        (Verdict::Pending, "pending"),
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, format!("\"{}\"", expected));
+        let back: Verdict = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn verdict_default_is_pass() {
+    assert_eq!(Verdict::default(), Verdict::Pass);
+}
+
+#[test]
+fn verdict_display_matches_serde() {
+    for v in [
+        Verdict::Pass,
+        Verdict::Fail,
+        Verdict::Warn,
+        Verdict::Skip,
+        Verdict::Pending,
+    ] {
+        let display = v.to_string();
+        let serde_str = serde_json::to_value(v).unwrap();
+        assert_eq!(display, serde_str.as_str().unwrap());
+    }
+}
+
+// =============================================================================
+// Finding and FindingCode
+// =============================================================================
+
+#[test]
+fn finding_new_and_builders() {
+    let f = Finding::new(
+        "risk",
+        "hotspot",
+        FindingSeverity::Warn,
+        "Churn",
+        "high churn",
+    )
+    .with_location(FindingLocation::path_line("src/lib.rs", 10))
+    .with_evidence(serde_json::json!({"commits": 42}))
+    .with_docs_url("https://example.com");
+
+    assert_eq!(f.check_id, "risk");
+    assert_eq!(f.code, "hotspot");
+    assert!(f.location.is_some());
+    assert!(f.evidence.is_some());
+    assert_eq!(f.docs_url.as_deref(), Some("https://example.com"));
+}
+
+#[test]
+fn finding_serde_roundtrip() {
+    let f = Finding::new(
+        "gate",
+        "mutation",
+        FindingSeverity::Error,
+        "Fail",
+        "below threshold",
+    )
+    .with_location(FindingLocation::path("src/main.rs"));
+    let json = serde_json::to_string(&f).unwrap();
+    let back: Finding = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.check_id, "gate");
+    assert_eq!(back.code, "mutation");
+    assert_eq!(back.severity, FindingSeverity::Error);
+}
+
+#[test]
+fn finding_severity_all_variants() {
+    for (v, expected) in [
+        (FindingSeverity::Error, "error"),
+        (FindingSeverity::Warn, "warn"),
+        (FindingSeverity::Info, "info"),
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, format!("\"{}\"", expected));
+        let back: FindingSeverity = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+        assert_eq!(v.to_string(), expected);
+    }
+}
+
+#[test]
+fn finding_fingerprint_deterministic() {
+    let f1 = Finding::new("risk", "hotspot", FindingSeverity::Warn, "A", "B")
+        .with_location(FindingLocation::path("src/lib.rs"));
+    let f2 = Finding::new("risk", "hotspot", FindingSeverity::Info, "C", "D")
+        .with_location(FindingLocation::path("src/lib.rs"));
+    // Fingerprint depends on (tool, check_id, code, path) — not title/message/severity
+    assert_eq!(
+        f1.compute_fingerprint("tokmd"),
+        f2.compute_fingerprint("tokmd")
+    );
+}
+
+#[test]
+fn finding_fingerprint_differs_on_path() {
+    let f1 = Finding::new("risk", "hotspot", FindingSeverity::Warn, "A", "B")
+        .with_location(FindingLocation::path("src/a.rs"));
+    let f2 = Finding::new("risk", "hotspot", FindingSeverity::Warn, "A", "B")
+        .with_location(FindingLocation::path("src/b.rs"));
+    assert_ne!(
+        f1.compute_fingerprint("tokmd"),
+        f2.compute_fingerprint("tokmd")
+    );
+}
+
+// =============================================================================
+// FindingLocation
+// =============================================================================
+
+#[test]
+fn finding_location_constructors() {
+    let p = FindingLocation::path("a.rs");
+    assert_eq!(p.path, "a.rs");
+    assert!(p.line.is_none());
+    assert!(p.column.is_none());
+
+    let pl = FindingLocation::path_line("b.rs", 42);
+    assert_eq!(pl.line, Some(42));
+    assert!(pl.column.is_none());
+
+    let plc = FindingLocation::path_line_column("c.rs", 10, 5);
+    assert_eq!(plc.line, Some(10));
+    assert_eq!(plc.column, Some(5));
+}
+
+// =============================================================================
+// GateResults and GateItem
+// =============================================================================
+
+#[test]
+fn gate_results_serde_roundtrip() {
+    let gr = GateResults::new(
+        Verdict::Fail,
+        vec![
+            GateItem::new("mutation", Verdict::Fail)
+                .with_threshold(80.0, 70.0)
+                .with_reason("below threshold")
+                .with_source("ci_artifact")
+                .with_artifact_path("coverage/lcov.info"),
+            GateItem::new("coverage", Verdict::Pass),
+        ],
+    );
+    let json = serde_json::to_string(&gr).unwrap();
+    let back: GateResults = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.status, Verdict::Fail);
+    assert_eq!(back.items.len(), 2);
+    assert_eq!(back.items[0].threshold, Some(80.0));
+    assert_eq!(back.items[0].actual, Some(70.0));
+    assert_eq!(back.items[0].reason.as_deref(), Some("below threshold"));
+    assert_eq!(back.items[0].source.as_deref(), Some("ci_artifact"));
+}
+
+// =============================================================================
+// Artifact
+// =============================================================================
+
+#[test]
+fn artifact_factory_methods() {
+    let c = Artifact::comment("out/comment.md");
+    assert_eq!(c.artifact_type, "comment");
+
+    let r = Artifact::receipt("out/receipt.json");
+    assert_eq!(r.artifact_type, "receipt");
+
+    let b = Artifact::badge("out/badge.svg");
+    assert_eq!(b.artifact_type, "badge");
+}
+
+#[test]
+fn artifact_builders_roundtrip() {
+    let a = Artifact::receipt("out/r.json")
+        .with_id("analysis")
+        .with_mime("application/json");
+    let json = serde_json::to_string(&a).unwrap();
+    let back: Artifact = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.id.as_deref(), Some("analysis"));
+    assert_eq!(back.mime.as_deref(), Some("application/json"));
+    assert_eq!(back.artifact_type, "receipt");
+}
+
+// =============================================================================
+// CapabilityStatus / CapabilityState
+// =============================================================================
+
+#[test]
+fn capability_state_all_variants() {
+    for (v, expected) in [
+        (CapabilityState::Available, "available"),
+        (CapabilityState::Unavailable, "unavailable"),
+        (CapabilityState::Skipped, "skipped"),
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, format!("\"{}\"", expected));
+        let back: CapabilityState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn capability_status_builders() {
+    let a = CapabilityStatus::available();
+    assert_eq!(a.status, CapabilityState::Available);
+    assert!(a.reason.is_none());
+
+    let u = CapabilityStatus::unavailable("missing tool");
+    assert_eq!(u.status, CapabilityState::Unavailable);
+    assert_eq!(u.reason.as_deref(), Some("missing tool"));
+
+    let s = CapabilityStatus::skipped("not applicable");
+    assert_eq!(s.status, CapabilityState::Skipped);
+
+    let wr = CapabilityStatus::available().with_reason("context");
+    assert_eq!(wr.reason.as_deref(), Some("context"));
+}
+
+// =============================================================================
+// Findings module: ID constants and composition
+// =============================================================================
+
+#[test]
+fn findings_check_ids_non_empty() {
+    assert!(!findings::risk::CHECK_ID.is_empty());
+    assert!(!findings::contract::CHECK_ID.is_empty());
+    assert!(!findings::supply::CHECK_ID.is_empty());
+    assert!(!findings::gate::CHECK_ID.is_empty());
+    assert!(!findings::security::CHECK_ID.is_empty());
+    assert!(!findings::architecture::CHECK_ID.is_empty());
+    assert!(!findings::sensor::CHECK_ID.is_empty());
+}
+
+#[test]
+fn findings_code_constants_non_empty() {
+    // Spot-check codes from each category
+    assert!(!findings::risk::HOTSPOT.is_empty());
+    assert!(!findings::risk::COUPLING.is_empty());
+    assert!(!findings::risk::BUS_FACTOR.is_empty());
+    assert!(!findings::risk::COMPLEXITY_HIGH.is_empty());
+    assert!(!findings::risk::COGNITIVE_HIGH.is_empty());
+    assert!(!findings::risk::NESTING_DEEP.is_empty());
+
+    assert!(!findings::contract::SCHEMA_CHANGED.is_empty());
+    assert!(!findings::contract::API_CHANGED.is_empty());
+    assert!(!findings::contract::CLI_CHANGED.is_empty());
+
+    assert!(!findings::supply::LOCKFILE_CHANGED.is_empty());
+    assert!(!findings::supply::NEW_DEPENDENCY.is_empty());
+    assert!(!findings::supply::VULNERABILITY.is_empty());
+
+    assert!(!findings::gate::MUTATION_FAILED.is_empty());
+    assert!(!findings::gate::COVERAGE_FAILED.is_empty());
+    assert!(!findings::gate::COMPLEXITY_FAILED.is_empty());
+
+    assert!(!findings::security::ENTROPY_HIGH.is_empty());
+    assert!(!findings::security::LICENSE_CONFLICT.is_empty());
+
+    assert!(!findings::architecture::CIRCULAR_DEP.is_empty());
+    assert!(!findings::architecture::LAYER_VIOLATION.is_empty());
+
+    assert!(!findings::sensor::DIFF_SUMMARY.is_empty());
+}
+
+#[test]
+fn finding_id_composition() {
+    let id = findings::finding_id("tokmd", "risk", "hotspot");
+    assert_eq!(id, "tokmd.risk.hotspot");
+
+    let id2 = findings::finding_id("my-tool", "gate", "coverage_failed");
+    assert_eq!(id2, "my-tool.gate.coverage_failed");
+}
+
+// =============================================================================
+// Backward compat: unknown fields tolerated
+// =============================================================================
+
+#[test]
+fn sensor_report_ignores_unknown_fields() {
+    let json = r#"{
+        "schema": "sensor.report.v1",
+        "tool": {"name": "x", "version": "1", "mode": "m"},
+        "generated_at": "2024-01-01T00:00:00Z",
+        "verdict": "pass",
+        "summary": "ok",
+        "findings": [],
+        "unknown_future_field": 42
+    }"#;
+    let r: SensorReport = serde_json::from_str(json).unwrap();
+    assert_eq!(r.verdict, Verdict::Pass);
+}
+
+#[test]
+fn tool_meta_ignores_unknown_fields() {
+    let json = r#"{"name":"x","version":"1","mode":"m","extra":true}"#;
+    let tm: ToolMeta = serde_json::from_str(json).unwrap();
+    assert_eq!(tm.name, "x");
+}

--- a/crates/tokmd-settings/tests/exhaustive_w72.rs
+++ b/crates/tokmd-settings/tests/exhaustive_w72.rs
@@ -1,0 +1,212 @@
+//! Exhaustive serde and invariant tests for tokmd-settings (w72).
+
+use tokmd_settings::*;
+
+// =============================================================================
+// ScanOptions: every field has a reasonable default
+// =============================================================================
+
+#[test]
+fn scan_options_defaults_all_false_or_empty() {
+    let opts = ScanOptions::default();
+    assert!(opts.excluded.is_empty());
+    assert_eq!(opts.config, ConfigMode::Auto);
+    assert!(!opts.hidden);
+    assert!(!opts.no_ignore);
+    assert!(!opts.no_ignore_parent);
+    assert!(!opts.no_ignore_dot);
+    assert!(!opts.no_ignore_vcs);
+    assert!(!opts.treat_doc_strings_as_comments);
+}
+
+#[test]
+fn scan_options_serde_roundtrip() {
+    let opts = ScanOptions {
+        excluded: vec!["target".into(), "*.bak".into()],
+        config: ConfigMode::None,
+        hidden: true,
+        no_ignore: true,
+        no_ignore_parent: true,
+        no_ignore_dot: true,
+        no_ignore_vcs: true,
+        treat_doc_strings_as_comments: true,
+    };
+    let json = serde_json::to_string(&opts).unwrap();
+    let back: ScanOptions = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.excluded.len(), 2);
+    assert!(back.hidden);
+    assert!(back.no_ignore_vcs);
+}
+
+// =============================================================================
+// ScanSettings
+// =============================================================================
+
+#[test]
+fn scan_settings_default_paths_empty() {
+    let s = ScanSettings::default();
+    assert!(s.paths.is_empty());
+}
+
+#[test]
+fn scan_settings_current_dir() {
+    let s = ScanSettings::current_dir();
+    assert_eq!(s.paths, vec!["."]);
+}
+
+#[test]
+fn scan_settings_for_paths() {
+    let s = ScanSettings::for_paths(vec!["src".into(), "lib".into()]);
+    assert_eq!(s.paths.len(), 2);
+}
+
+// =============================================================================
+// LangSettings
+// =============================================================================
+
+#[test]
+fn lang_settings_default_values() {
+    let s = LangSettings::default();
+    assert_eq!(s.top, 0);
+    assert!(!s.files);
+    assert_eq!(s.children, ChildrenMode::Collapse);
+    assert!(s.redact.is_none());
+}
+
+#[test]
+fn lang_settings_serde_roundtrip() {
+    let s = LangSettings {
+        top: 5,
+        files: true,
+        children: ChildrenMode::Separate,
+        redact: Some(RedactMode::Paths),
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let back: LangSettings = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.top, 5);
+    assert!(back.files);
+    assert_eq!(back.children, ChildrenMode::Separate);
+}
+
+// =============================================================================
+// ChildrenMode enum complete coverage
+// =============================================================================
+
+#[test]
+fn children_mode_collapse_and_separate() {
+    let variants = [ChildrenMode::Collapse, ChildrenMode::Separate];
+    assert_eq!(variants.len(), 2);
+    for v in variants {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: ChildrenMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+// =============================================================================
+// ModuleSettings
+// =============================================================================
+
+#[test]
+fn module_settings_default_values() {
+    let s = ModuleSettings::default();
+    assert_eq!(s.top, 0);
+    assert_eq!(s.module_roots, vec!["crates", "packages"]);
+    assert_eq!(s.module_depth, 2);
+    assert_eq!(s.children, ChildIncludeMode::Separate);
+    assert!(s.redact.is_none());
+}
+
+// =============================================================================
+// ExportSettings
+// =============================================================================
+
+#[test]
+fn export_settings_default_values() {
+    let s = ExportSettings::default();
+    assert_eq!(s.format, ExportFormat::Jsonl);
+    assert_eq!(s.module_roots, vec!["crates", "packages"]);
+    assert_eq!(s.module_depth, 2);
+    assert_eq!(s.children, ChildIncludeMode::Separate);
+    assert_eq!(s.min_code, 0);
+    assert_eq!(s.max_rows, 0);
+    assert_eq!(s.redact, RedactMode::None);
+    assert!(s.meta);
+    assert!(s.strip_prefix.is_none());
+}
+
+// =============================================================================
+// AnalyzeSettings
+// =============================================================================
+
+#[test]
+fn analyze_settings_default_values() {
+    let s = AnalyzeSettings::default();
+    assert_eq!(s.preset, "receipt");
+    assert_eq!(s.granularity, "module");
+    assert!(s.window.is_none());
+    assert!(s.git.is_none());
+    assert!(s.max_files.is_none());
+    assert!(s.max_bytes.is_none());
+    assert!(s.max_file_bytes.is_none());
+    assert!(s.max_commits.is_none());
+    assert!(s.max_commit_files.is_none());
+}
+
+// =============================================================================
+// CockpitSettings
+// =============================================================================
+
+#[test]
+fn cockpit_settings_default_values() {
+    let s = CockpitSettings::default();
+    assert_eq!(s.base, "main");
+    assert_eq!(s.head, "HEAD");
+    assert_eq!(s.range_mode, "two-dot");
+    assert!(s.baseline.is_none());
+}
+
+// =============================================================================
+// DiffSettings
+// =============================================================================
+
+#[test]
+fn diff_settings_default_empty_strings() {
+    let s = DiffSettings::default();
+    assert!(s.from.is_empty());
+    assert!(s.to.is_empty());
+}
+
+// =============================================================================
+// TomlConfig: roundtrip and view profiles
+// =============================================================================
+
+#[test]
+fn toml_config_default_all_sections() {
+    let cfg = TomlConfig::default();
+    assert!(cfg.scan.paths.is_none());
+    assert!(cfg.module.roots.is_none());
+    assert!(cfg.export.format.is_none());
+    assert!(cfg.analyze.preset.is_none());
+    assert!(cfg.context.budget.is_none());
+    assert!(cfg.badge.metric.is_none());
+    assert!(cfg.gate.policy.is_none());
+    assert!(cfg.view.is_empty());
+}
+
+#[test]
+fn toml_config_parse_with_view_profile() {
+    let toml_str = r#"
+[scan]
+hidden = true
+
+[view.ci]
+format = "json"
+top = 20
+"#;
+    let config = TomlConfig::parse(toml_str).expect("parse config");
+    assert_eq!(config.scan.hidden, Some(true));
+    let ci = config.view.get("ci").expect("ci profile");
+    assert_eq!(ci.format.as_deref(), Some("json"));
+    assert_eq!(ci.top, Some(20));
+}

--- a/crates/tokmd-types/tests/exhaustive_w72.rs
+++ b/crates/tokmd-types/tests/exhaustive_w72.rs
@@ -1,0 +1,651 @@
+//! Exhaustive serde and invariant tests for tokmd-types (w72).
+
+use tokmd_types::cockpit::*;
+use tokmd_types::*;
+
+// =============================================================================
+// Schema version constants
+// =============================================================================
+
+#[test]
+fn schema_version_positive() {
+    // Use runtime values to avoid clippy::assertions_on_constants
+    let sv: u32 = SCHEMA_VERSION;
+    let hv: u32 = HANDOFF_SCHEMA_VERSION;
+    let csv: u32 = CONTEXT_SCHEMA_VERSION;
+    let cbv: u32 = CONTEXT_BUNDLE_SCHEMA_VERSION;
+    let ckv: u32 = COCKPIT_SCHEMA_VERSION;
+    assert!(sv > 0);
+    assert!(hv > 0);
+    assert!(csv > 0);
+    assert!(cbv > 0);
+    assert!(ckv > 0);
+}
+
+// =============================================================================
+// Struct construction + JSON roundtrip
+// =============================================================================
+
+#[test]
+fn totals_construct_and_serialize() {
+    let t = Totals {
+        code: 10,
+        lines: 20,
+        files: 3,
+        bytes: 500,
+        tokens: 50,
+        avg_lines: 6,
+    };
+    let json = serde_json::to_string(&t).unwrap();
+    let back: Totals = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, t);
+}
+
+#[test]
+fn lang_row_construct_and_serialize() {
+    let r = LangRow {
+        lang: "Python".into(),
+        code: 42,
+        lines: 60,
+        files: 2,
+        bytes: 1200,
+        tokens: 100,
+        avg_lines: 30,
+    };
+    let json = serde_json::to_string(&r).unwrap();
+    let back: LangRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.lang, "Python");
+}
+
+#[test]
+fn module_row_construct_and_serialize() {
+    let r = ModuleRow {
+        module: "crates/core".into(),
+        code: 500,
+        lines: 700,
+        files: 5,
+        bytes: 20000,
+        tokens: 5000,
+        avg_lines: 140,
+    };
+    let json = serde_json::to_string(&r).unwrap();
+    let back: ModuleRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.module, "crates/core");
+}
+
+#[test]
+fn file_row_construct_and_serialize() {
+    let r = FileRow {
+        path: "src/main.rs".into(),
+        module: "src".into(),
+        lang: "Rust".into(),
+        kind: FileKind::Parent,
+        code: 50,
+        comments: 10,
+        blanks: 5,
+        lines: 65,
+        bytes: 2000,
+        tokens: 100,
+    };
+    let json = serde_json::to_string(&r).unwrap();
+    let back: FileRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, r);
+}
+
+#[test]
+fn diff_row_construct_and_serialize() {
+    let r = DiffRow {
+        lang: "Go".into(),
+        old_code: 100,
+        new_code: 110,
+        delta_code: 10,
+        old_lines: 200,
+        new_lines: 210,
+        delta_lines: 10,
+        old_files: 5,
+        new_files: 6,
+        delta_files: 1,
+        old_bytes: 4000,
+        new_bytes: 4400,
+        delta_bytes: 400,
+        old_tokens: 1000,
+        new_tokens: 1100,
+        delta_tokens: 100,
+    };
+    let json = serde_json::to_string(&r).unwrap();
+    let back: DiffRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, r);
+}
+
+#[test]
+fn diff_totals_default_all_zero() {
+    let dt = DiffTotals::default();
+    assert_eq!(dt.old_code, 0);
+    assert_eq!(dt.delta_code, 0);
+    assert_eq!(dt.delta_tokens, 0);
+}
+
+#[test]
+fn tool_info_construct_and_serialize() {
+    let ti = ToolInfo {
+        name: "test".into(),
+        version: "0.1.0".into(),
+    };
+    let json = serde_json::to_string(&ti).unwrap();
+    let back: ToolInfo = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.name, "test");
+}
+
+#[test]
+fn tool_info_current_has_name_and_version() {
+    let ti = ToolInfo::current();
+    assert_eq!(ti.name, "tokmd");
+    assert!(!ti.version.is_empty());
+}
+
+#[test]
+fn scan_args_construct_and_serialize() {
+    let sa = ScanArgs {
+        paths: vec![".".into()],
+        excluded: vec![],
+        excluded_redacted: false,
+        config: ConfigMode::Auto,
+        hidden: false,
+        no_ignore: false,
+        no_ignore_parent: false,
+        no_ignore_dot: false,
+        no_ignore_vcs: false,
+        treat_doc_strings_as_comments: false,
+    };
+    let json = serde_json::to_string(&sa).unwrap();
+    let back: ScanArgs = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.paths, vec!["."]);
+}
+
+#[test]
+fn context_receipt_construct_and_serialize() {
+    let cr = ContextReceipt {
+        schema_version: CONTEXT_SCHEMA_VERSION,
+        generated_at_ms: 1000,
+        tool: ToolInfo::current(),
+        mode: "context".into(),
+        budget_tokens: 8000,
+        used_tokens: 5000,
+        utilization_pct: 62.5,
+        strategy: "greedy".into(),
+        rank_by: "code".into(),
+        file_count: 3,
+        files: vec![],
+        rank_by_effective: None,
+        fallback_reason: None,
+        excluded_by_policy: vec![],
+        token_estimation: None,
+        bundle_audit: None,
+    };
+    let json = serde_json::to_string(&cr).unwrap();
+    let back: ContextReceipt = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, CONTEXT_SCHEMA_VERSION);
+    assert_eq!(back.mode, "context");
+}
+
+// =============================================================================
+// ContextFileRow: tokens vs effective_tokens
+// =============================================================================
+
+#[test]
+fn context_file_row_effective_tokens_none_means_same_as_tokens() {
+    let row = ContextFileRow {
+        path: "src/lib.rs".into(),
+        module: "src".into(),
+        lang: "Rust".into(),
+        tokens: 500,
+        code: 100,
+        lines: 120,
+        bytes: 2000,
+        value: 500,
+        rank_reason: String::new(),
+        policy: InclusionPolicy::Full,
+        effective_tokens: None,
+        policy_reason: None,
+        classifications: vec![],
+    };
+    // When effective_tokens is None, the effective count equals tokens
+    assert!(row.effective_tokens.is_none());
+    let effective = row.effective_tokens.unwrap_or(row.tokens);
+    assert_eq!(effective, 500);
+}
+
+#[test]
+fn context_file_row_effective_tokens_reduced_by_policy() {
+    let row = ContextFileRow {
+        path: "vendor/lib.js".into(),
+        module: "vendor".into(),
+        lang: "JavaScript".into(),
+        tokens: 10000,
+        code: 3000,
+        lines: 3500,
+        bytes: 40000,
+        value: 100,
+        rank_reason: String::new(),
+        policy: InclusionPolicy::HeadTail,
+        effective_tokens: Some(200),
+        policy_reason: Some("Per-file cap".into()),
+        classifications: vec![FileClassification::Vendored],
+    };
+    let effective = row.effective_tokens.unwrap_or(row.tokens);
+    assert!(effective < row.tokens);
+    assert_eq!(effective, 200);
+}
+
+// =============================================================================
+// Enum serde coverage — every variant
+// =============================================================================
+
+#[test]
+fn file_kind_all_variants() {
+    for variant in [FileKind::Parent, FileKind::Child] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: FileKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, variant);
+    }
+}
+
+#[test]
+fn scan_status_all_variants() {
+    for json_str in [r#""complete""#, r#""partial""#] {
+        let _v: ScanStatus = serde_json::from_str(json_str).unwrap();
+    }
+}
+
+#[test]
+fn commit_intent_kind_all_variants() {
+    let all = [
+        CommitIntentKind::Feat,
+        CommitIntentKind::Fix,
+        CommitIntentKind::Refactor,
+        CommitIntentKind::Docs,
+        CommitIntentKind::Test,
+        CommitIntentKind::Chore,
+        CommitIntentKind::Ci,
+        CommitIntentKind::Build,
+        CommitIntentKind::Perf,
+        CommitIntentKind::Style,
+        CommitIntentKind::Revert,
+        CommitIntentKind::Other,
+    ];
+    assert_eq!(all.len(), 12, "CommitIntentKind should have 12 variants");
+    for v in all {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: CommitIntentKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn table_format_all_variants() {
+    for v in [TableFormat::Md, TableFormat::Tsv, TableFormat::Json] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: TableFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn export_format_all_variants() {
+    for v in [
+        ExportFormat::Csv,
+        ExportFormat::Jsonl,
+        ExportFormat::Json,
+        ExportFormat::Cyclonedx,
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: ExportFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn config_mode_all_variants() {
+    for v in [ConfigMode::Auto, ConfigMode::None] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: ConfigMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+    assert_eq!(ConfigMode::default(), ConfigMode::Auto);
+}
+
+#[test]
+fn children_mode_all_variants() {
+    for v in [ChildrenMode::Collapse, ChildrenMode::Separate] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: ChildrenMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn child_include_mode_all_variants() {
+    for v in [ChildIncludeMode::Separate, ChildIncludeMode::ParentsOnly] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: ChildIncludeMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn redact_mode_all_variants() {
+    for v in [RedactMode::None, RedactMode::Paths, RedactMode::All] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: RedactMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn analysis_format_all_variants() {
+    let all = [
+        AnalysisFormat::Md,
+        AnalysisFormat::Json,
+        AnalysisFormat::Jsonld,
+        AnalysisFormat::Xml,
+        AnalysisFormat::Svg,
+        AnalysisFormat::Mermaid,
+        AnalysisFormat::Obj,
+        AnalysisFormat::Midi,
+        AnalysisFormat::Tree,
+        AnalysisFormat::Html,
+    ];
+    assert_eq!(all.len(), 10, "AnalysisFormat should have 10 variants");
+    for v in all {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: AnalysisFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn file_classification_all_variants() {
+    let all = [
+        FileClassification::Generated,
+        FileClassification::Fixture,
+        FileClassification::Vendored,
+        FileClassification::Lockfile,
+        FileClassification::Minified,
+        FileClassification::DataBlob,
+        FileClassification::Sourcemap,
+    ];
+    assert_eq!(all.len(), 7, "FileClassification should have 7 variants");
+    for v in all {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: FileClassification = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn inclusion_policy_all_variants_and_default() {
+    let all = [
+        InclusionPolicy::Full,
+        InclusionPolicy::HeadTail,
+        InclusionPolicy::Summary,
+        InclusionPolicy::Skip,
+    ];
+    assert_eq!(all.len(), 4, "InclusionPolicy should have 4 variants");
+    for v in all {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: InclusionPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+    assert_eq!(InclusionPolicy::default(), InclusionPolicy::Full);
+}
+
+#[test]
+fn capability_state_all_variants() {
+    for v in [
+        CapabilityState::Available,
+        CapabilityState::Skipped,
+        CapabilityState::Unavailable,
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: CapabilityState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+// =============================================================================
+// Backward compatibility: unknown fields tolerated
+// =============================================================================
+
+#[test]
+fn totals_ignores_unknown_fields() {
+    let json =
+        r#"{"code":1,"lines":2,"files":1,"bytes":10,"tokens":3,"avg_lines":2,"extra_field":42}"#;
+    let t: Totals = serde_json::from_str(json).unwrap();
+    assert_eq!(t.code, 1);
+}
+
+#[test]
+fn lang_row_ignores_unknown_fields() {
+    let json = r#"{"lang":"Rust","code":1,"lines":2,"files":1,"bytes":10,"tokens":3,"avg_lines":2,"future_field":true}"#;
+    let r: LangRow = serde_json::from_str(json).unwrap();
+    assert_eq!(r.lang, "Rust");
+}
+
+#[test]
+fn tool_info_ignores_unknown_fields() {
+    let json = r#"{"name":"x","version":"0.1","unknown":"ok"}"#;
+    let ti: ToolInfo = serde_json::from_str(json).unwrap();
+    assert_eq!(ti.name, "x");
+}
+
+// =============================================================================
+// Receipt families: metadata / envelope / schema_version
+// =============================================================================
+
+fn make_scan_args() -> ScanArgs {
+    ScanArgs {
+        paths: vec![".".into()],
+        excluded: vec![],
+        excluded_redacted: false,
+        config: ConfigMode::Auto,
+        hidden: false,
+        no_ignore: false,
+        no_ignore_parent: false,
+        no_ignore_dot: false,
+        no_ignore_vcs: false,
+        treat_doc_strings_as_comments: false,
+    }
+}
+
+#[test]
+fn lang_receipt_has_schema_and_tool() {
+    let receipt = LangReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 123,
+        tool: ToolInfo::current(),
+        mode: "lang".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        scan: make_scan_args(),
+        args: LangArgsMeta {
+            format: "md".into(),
+            top: 0,
+            with_files: false,
+            children: ChildrenMode::Collapse,
+        },
+        report: LangReport {
+            rows: vec![],
+            total: Totals {
+                code: 0,
+                lines: 0,
+                files: 0,
+                bytes: 0,
+                tokens: 0,
+                avg_lines: 0,
+            },
+            with_files: false,
+            children: ChildrenMode::Collapse,
+            top: 0,
+        },
+    };
+    let json = serde_json::to_string(&receipt).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema_version"], SCHEMA_VERSION);
+    assert_eq!(v["mode"], "lang");
+    assert!(v["tool"]["name"].is_string());
+}
+
+#[test]
+fn diff_receipt_has_schema_and_tool() {
+    let receipt = DiffReceipt {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: 456,
+        tool: ToolInfo::current(),
+        mode: "diff".into(),
+        from_source: "a.json".into(),
+        to_source: "b.json".into(),
+        diff_rows: vec![],
+        totals: DiffTotals::default(),
+    };
+    let json = serde_json::to_string(&receipt).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["schema_version"], SCHEMA_VERSION);
+    assert_eq!(v["mode"], "diff");
+}
+
+// =============================================================================
+// Cockpit types
+// =============================================================================
+
+#[test]
+fn cockpit_gate_status_all_variants() {
+    let all = [
+        GateStatus::Pass,
+        GateStatus::Warn,
+        GateStatus::Fail,
+        GateStatus::Skipped,
+        GateStatus::Pending,
+    ];
+    assert_eq!(all.len(), 5);
+    for v in all {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: GateStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn cockpit_evidence_source_all_variants() {
+    for v in [
+        EvidenceSource::CiArtifact,
+        EvidenceSource::Cached,
+        EvidenceSource::RanLocal,
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: EvidenceSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn cockpit_commit_match_all_variants() {
+    for v in [
+        CommitMatch::Exact,
+        CommitMatch::Partial,
+        CommitMatch::Stale,
+        CommitMatch::Unknown,
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: CommitMatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn cockpit_complexity_indicator_all_variants() {
+    for v in [
+        ComplexityIndicator::Low,
+        ComplexityIndicator::Medium,
+        ComplexityIndicator::High,
+        ComplexityIndicator::Critical,
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: ComplexityIndicator = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn cockpit_warning_type_all_variants() {
+    for v in [
+        WarningType::LargeFile,
+        WarningType::HighChurn,
+        WarningType::LowTestCoverage,
+        WarningType::ComplexChange,
+        WarningType::BusFactor,
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: WarningType = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn cockpit_risk_level_all_variants_and_display() {
+    for (v, expected) in [
+        (RiskLevel::Low, "low"),
+        (RiskLevel::Medium, "medium"),
+        (RiskLevel::High, "high"),
+        (RiskLevel::Critical, "critical"),
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: RiskLevel = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+        assert_eq!(v.to_string(), expected);
+    }
+}
+
+#[test]
+fn cockpit_trend_direction_all_variants() {
+    for v in [
+        TrendDirection::Improving,
+        TrendDirection::Stable,
+        TrendDirection::Degrading,
+    ] {
+        let json = serde_json::to_string(&v).unwrap();
+        let back: TrendDirection = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+// =============================================================================
+// TokenEstimationMeta invariants
+// =============================================================================
+
+#[test]
+fn token_estimation_invariant_min_le_est_le_max() {
+    for bytes in [0, 1, 100, 4000, 99999] {
+        let est = TokenEstimationMeta::from_bytes(bytes, TokenEstimationMeta::DEFAULT_BPT_EST);
+        assert!(
+            est.tokens_min <= est.tokens_est,
+            "min={} > est={} for bytes={}",
+            est.tokens_min,
+            est.tokens_est,
+            bytes
+        );
+        assert!(
+            est.tokens_est <= est.tokens_max,
+            "est={} > max={} for bytes={}",
+            est.tokens_est,
+            est.tokens_max,
+            bytes
+        );
+    }
+}
+
+#[test]
+fn token_audit_overhead_invariant() {
+    let audit = TokenAudit::from_output(1000, 800);
+    assert_eq!(audit.overhead_bytes, 200);
+    assert!(audit.overhead_pct >= 0.0 && audit.overhead_pct <= 1.0);
+}


### PR DESCRIPTION
Add exhaustive serde roundtrip, invariant, and backward-compatibility tests for core Tier 0 type crates: tokmd-types (40 tests), tokmd-settings (15 tests), tokmd-envelope (26 tests). Total: 81 tests. All pass clippy -D warnings.