### PR TITLE
test(w73): analysis orchestration deep tests (~50 tests)

### DIFF
--- a/crates/tokmd-analysis-grid/tests/grid_w73.rs
+++ b/crates/tokmd-analysis-grid/tests/grid_w73.rs
@@ -1,0 +1,280 @@
+//! W73 deep tests for `tokmd-analysis-grid` preset/feature matrix.
+//!
+//! Covers:
+//! - All presets represented in PRESET_GRID
+//! - PresetKind roundtrip stability
+//! - PresetPlan needs_files correctness
+//! - DisabledFeature warning catalog completeness
+//! - Grid formatting and field correctness
+//! - Preset name validation
+//! - Deep preset superset property
+
+use tokmd_analysis_grid::{
+    DisabledFeature, PRESET_GRID, PRESET_KINDS, PresetKind, PresetPlan, preset_plan_for,
+    preset_plan_for_name,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. All presets represented in grid
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn grid_has_exactly_eleven_entries() {
+    assert_eq!(PRESET_GRID.len(), 11);
+}
+
+#[test]
+fn grid_covers_every_preset_kind() {
+    for kind in PresetKind::all() {
+        let found = PRESET_GRID.iter().any(|row| row.preset == *kind);
+        assert!(found, "{:?} not found in PRESET_GRID", kind);
+    }
+}
+
+#[test]
+fn preset_kinds_array_has_eleven_entries() {
+    assert_eq!(PRESET_KINDS.len(), 11);
+}
+
+#[test]
+fn preset_kinds_no_duplicates() {
+    for (i, a) in PRESET_KINDS.iter().enumerate() {
+        for (j, b) in PRESET_KINDS.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "Duplicate preset at indices {} and {}", i, j);
+            }
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. PresetKind roundtrip and naming
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn from_str_roundtrip_all_presets() {
+    for kind in PresetKind::all() {
+        let name = kind.as_str();
+        let parsed = PresetKind::from_str(name);
+        assert_eq!(parsed, Some(*kind), "Roundtrip failed for {:?}", kind);
+    }
+}
+
+#[test]
+fn from_str_rejects_unknown_names() {
+    assert!(PresetKind::from_str("unknown").is_none());
+    assert!(PresetKind::from_str("").is_none());
+    assert!(PresetKind::from_str("RECEIPT").is_none());
+    assert!(PresetKind::from_str("Deep").is_none());
+    assert!(PresetKind::from_str("all").is_none());
+    assert!(PresetKind::from_str("none").is_none());
+}
+
+#[test]
+fn as_str_all_lowercase() {
+    for kind in PresetKind::all() {
+        let name = kind.as_str();
+        assert!(
+            name.chars().all(|c| c.is_ascii_lowercase()),
+            "as_str for {:?} should be all lowercase: {}",
+            kind,
+            name
+        );
+    }
+}
+
+#[test]
+fn as_str_non_empty() {
+    for kind in PresetKind::all() {
+        assert!(!kind.as_str().is_empty(), "{:?} has empty name", kind);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. preset_plan_for and preset_plan_for_name
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn preset_plan_for_name_matches_direct_lookup() {
+    for kind in PresetKind::all() {
+        let by_name = preset_plan_for_name(kind.as_str()).unwrap();
+        let direct = preset_plan_for(*kind);
+        assert_eq!(by_name, direct, "Plans differ for {:?}", kind);
+    }
+}
+
+#[test]
+fn preset_plan_for_name_returns_none_for_unknown() {
+    assert!(preset_plan_for_name("nonexistent").is_none());
+    assert!(preset_plan_for_name("").is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. PresetPlan needs_files correctness
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn receipt_plan_does_not_need_files() {
+    let plan = preset_plan_for(PresetKind::Receipt);
+    assert!(!plan.needs_files(), "Receipt should not need files");
+}
+
+#[test]
+fn supply_plan_needs_files() {
+    let plan = preset_plan_for(PresetKind::Supply);
+    assert!(
+        plan.needs_files(),
+        "Supply should need files (assets + deps)"
+    );
+}
+
+#[test]
+fn health_plan_needs_files() {
+    let plan = preset_plan_for(PresetKind::Health);
+    assert!(
+        plan.needs_files(),
+        "Health should need files (todo + complexity)"
+    );
+}
+
+#[test]
+fn deep_plan_needs_files() {
+    let plan = preset_plan_for(PresetKind::Deep);
+    assert!(plan.needs_files(), "Deep should need files");
+}
+
+#[test]
+fn fun_plan_does_not_need_files() {
+    let plan = preset_plan_for(PresetKind::Fun);
+    assert!(!plan.needs_files(), "Fun should not need files");
+}
+
+#[test]
+fn git_plan_does_not_need_files() {
+    let plan = preset_plan_for(PresetKind::Git);
+    assert!(!plan.needs_files(), "Git preset should not need files");
+}
+
+#[test]
+fn topics_plan_does_not_need_files() {
+    let plan = preset_plan_for(PresetKind::Topics);
+    assert!(!plan.needs_files(), "Topics should not need files");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. DisabledFeature warning catalog
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn all_disabled_features_have_nonempty_warnings() {
+    let features = [
+        DisabledFeature::FileInventory,
+        DisabledFeature::TodoScan,
+        DisabledFeature::DuplicationScan,
+        DisabledFeature::NearDuplicateScan,
+        DisabledFeature::ImportScan,
+        DisabledFeature::GitMetrics,
+        DisabledFeature::EntropyProfiling,
+        DisabledFeature::LicenseRadar,
+        DisabledFeature::ComplexityAnalysis,
+        DisabledFeature::ApiSurfaceAnalysis,
+        DisabledFeature::Archetype,
+        DisabledFeature::Topics,
+        DisabledFeature::Fun,
+    ];
+    for f in &features {
+        let msg = f.warning();
+        assert!(!msg.is_empty(), "{:?} has empty warning", f);
+        assert!(
+            msg.contains("disabled") || msg.contains("skipping"),
+            "{:?} warning should mention 'disabled' or 'skipping': {}",
+            f,
+            msg
+        );
+    }
+}
+
+#[test]
+fn disabled_feature_warnings_are_distinct() {
+    let features = [
+        DisabledFeature::FileInventory,
+        DisabledFeature::TodoScan,
+        DisabledFeature::DuplicationScan,
+        DisabledFeature::NearDuplicateScan,
+        DisabledFeature::ImportScan,
+        DisabledFeature::GitMetrics,
+        DisabledFeature::EntropyProfiling,
+        DisabledFeature::LicenseRadar,
+        DisabledFeature::ComplexityAnalysis,
+        DisabledFeature::ApiSurfaceAnalysis,
+        DisabledFeature::Archetype,
+        DisabledFeature::Topics,
+        DisabledFeature::Fun,
+    ];
+    let msgs: Vec<&str> = features.iter().map(|f| f.warning()).collect();
+    for (i, a) in msgs.iter().enumerate() {
+        for (j, b) in msgs.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "Duplicate warning at indices {} and {}", i, j);
+            }
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. Deep preset superset property
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn deep_plan_is_superset_of_every_non_fun_preset_base_fields() {
+    let deep = preset_plan_for(PresetKind::Deep);
+    for kind in PresetKind::all() {
+        if *kind == PresetKind::Deep || *kind == PresetKind::Fun {
+            continue;
+        }
+        let plan = preset_plan_for(*kind);
+        // For each base field, if any preset enables it, Deep must also enable it
+        if plan.assets {
+            assert!(deep.assets, "Deep missing assets from {:?}", kind);
+        }
+        if plan.deps {
+            assert!(deep.deps, "Deep missing deps from {:?}", kind);
+        }
+        if plan.todo {
+            assert!(deep.todo, "Deep missing todo from {:?}", kind);
+        }
+        if plan.dup {
+            assert!(deep.dup, "Deep missing dup from {:?}", kind);
+        }
+        if plan.imports {
+            assert!(deep.imports, "Deep missing imports from {:?}", kind);
+        }
+        if plan.git {
+            assert!(deep.git, "Deep missing git from {:?}", kind);
+        }
+        if plan.archetype {
+            assert!(deep.archetype, "Deep missing archetype from {:?}", kind);
+        }
+        if plan.topics {
+            assert!(deep.topics, "Deep missing topics from {:?}", kind);
+        }
+        if plan.entropy {
+            assert!(deep.entropy, "Deep missing entropy from {:?}", kind);
+        }
+        if plan.license {
+            assert!(deep.license, "Deep missing license from {:?}", kind);
+        }
+        if plan.complexity {
+            assert!(deep.complexity, "Deep missing complexity from {:?}", kind);
+        }
+        if plan.api_surface {
+            assert!(deep.api_surface, "Deep missing api_surface from {:?}", kind);
+        }
+    }
+}
+
+#[test]
+fn deep_plan_does_not_enable_fun() {
+    let deep = preset_plan_for(PresetKind::Deep);
+    assert!(!deep.fun, "Deep should not enable fun");
+}

--- a/crates/tokmd-analysis-util/tests/util_w73.rs
+++ b/crates/tokmd-analysis-util/tests/util_w73.rs
@@ -1,0 +1,319 @@
+//! W73 deep tests for `tokmd-analysis-util` shared utilities.
+//!
+//! Covers edge cases, boundary values, and interaction scenarios across:
+//! - normalize_path with complex root/backslash combinations
+//! - path_depth with special segments and delimiters
+//! - is_test_path with tricky substring matches
+//! - is_infra_lang boundary detection
+//! - empty_file_row invariants
+//! - AnalysisLimits field independence
+//! - Math helpers: round_f64, safe_ratio, percentile, gini_coefficient
+
+use std::path::{Path, PathBuf};
+
+use tokmd_analysis_util::{
+    AnalysisLimits, empty_file_row, gini_coefficient, is_infra_lang, is_test_path, normalize_path,
+    normalize_root, now_ms, path_depth, percentile, round_f64, safe_ratio,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. normalize_path — complex root/path interactions
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn normalize_path_strips_root_then_dot_slash() {
+    let root = PathBuf::from("repo");
+    // Input doesn't start with "./" but matches root prefix
+    assert_eq!(normalize_path("repo/src/lib.rs", &root), "src/lib.rs");
+}
+
+#[test]
+fn normalize_path_only_backslashes() {
+    let root = PathBuf::from("x");
+    assert_eq!(normalize_path(r"a\b\c\d.rs", &root), "a/b/c/d.rs");
+}
+
+#[test]
+fn normalize_path_empty_input() {
+    let root = PathBuf::from("repo");
+    assert_eq!(normalize_path("", &root), "");
+}
+
+#[test]
+fn normalize_path_just_dot_slash() {
+    let root = PathBuf::from("repo");
+    assert_eq!(normalize_path("./", &root), "");
+}
+
+#[test]
+fn normalize_path_deeply_nested_backslashes() {
+    let root = PathBuf::from("project");
+    let input = r"project\a\b\c\d\e\f.rs";
+    assert_eq!(normalize_path(input, &root), "a/b/c/d/e/f.rs");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. path_depth — special segment types
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn path_depth_empty_string_returns_one() {
+    assert_eq!(path_depth(""), 1);
+}
+
+#[test]
+fn path_depth_only_slashes() {
+    // "///" has no non-empty segments → max(0, 1) = 1
+    assert_eq!(path_depth("///"), 1);
+}
+
+#[test]
+fn path_depth_single_segment_no_slash() {
+    assert_eq!(path_depth("file.rs"), 1);
+}
+
+#[test]
+fn path_depth_deeply_nested() {
+    assert_eq!(path_depth("a/b/c/d/e/f/g/h/i/j"), 10);
+}
+
+#[test]
+fn path_depth_trailing_slash_ignored() {
+    assert_eq!(path_depth("a/b/c/"), 3);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. is_test_path — tricky substring detection
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn is_test_path_rejects_protestant() {
+    assert!(!is_test_path("src/protestant.rs"));
+}
+
+#[test]
+fn is_test_path_detects_nested_tests_dir() {
+    assert!(is_test_path("packages/core/tests/integration/setup.ts"));
+}
+
+#[test]
+fn is_test_path_detects_spec_dir_case_insensitive() {
+    assert!(is_test_path("app/Spec/models/user_spec.rb"));
+}
+
+#[test]
+fn is_test_path_rejects_testimony_file() {
+    assert!(!is_test_path("docs/testimony.md"));
+}
+
+#[test]
+fn is_test_path_file_ending_with_test_dot_rs() {
+    assert!(is_test_path("src/parser_test.rs"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. is_infra_lang — boundary values
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn is_infra_lang_rejects_empty_string() {
+    assert!(!is_infra_lang(""));
+}
+
+#[test]
+fn is_infra_lang_rejects_whitespace() {
+    assert!(!is_infra_lang(" "));
+    assert!(!is_infra_lang("\t"));
+}
+
+#[test]
+fn is_infra_lang_accepts_all_known_infra_langs() {
+    let known = [
+        "json",
+        "yaml",
+        "toml",
+        "markdown",
+        "xml",
+        "html",
+        "css",
+        "scss",
+        "less",
+        "makefile",
+        "dockerfile",
+        "hcl",
+        "terraform",
+        "nix",
+        "cmake",
+        "ini",
+        "properties",
+        "gitignore",
+        "gitconfig",
+        "editorconfig",
+        "csv",
+        "tsv",
+        "svg",
+    ];
+    for lang in &known {
+        assert!(is_infra_lang(lang), "should accept: {}", lang);
+    }
+}
+
+#[test]
+fn is_infra_lang_rejects_programming_langs() {
+    let code_langs = [
+        "rust",
+        "python",
+        "javascript",
+        "typescript",
+        "go",
+        "java",
+        "c",
+        "cpp",
+        "ruby",
+        "kotlin",
+        "swift",
+        "haskell",
+    ];
+    for lang in &code_langs {
+        assert!(!is_infra_lang(lang), "should reject code lang: {}", lang);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. empty_file_row — field invariants
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn empty_file_row_all_numeric_fields_zero() {
+    let row = empty_file_row();
+    assert_eq!(row.code, 0);
+    assert_eq!(row.comments, 0);
+    assert_eq!(row.blanks, 0);
+    assert_eq!(row.lines, 0);
+    assert_eq!(row.bytes, 0);
+    assert_eq!(row.tokens, 0);
+    assert_eq!(row.depth, 0);
+}
+
+#[test]
+fn empty_file_row_all_string_fields_empty() {
+    let row = empty_file_row();
+    assert!(row.path.is_empty());
+    assert!(row.module.is_empty());
+    assert!(row.lang.is_empty());
+}
+
+#[test]
+fn empty_file_row_optional_fields_none() {
+    let row = empty_file_row();
+    assert!(row.doc_pct.is_none());
+    assert!(row.bytes_per_line.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. AnalysisLimits — defaults and field independence
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn analysis_limits_default_all_none() {
+    let limits = AnalysisLimits::default();
+    assert!(limits.max_files.is_none());
+    assert!(limits.max_bytes.is_none());
+    assert!(limits.max_file_bytes.is_none());
+    assert!(limits.max_commits.is_none());
+    assert!(limits.max_commit_files.is_none());
+}
+
+#[test]
+fn analysis_limits_partial_override_preserves_others() {
+    let limits = AnalysisLimits {
+        max_files: Some(50),
+        max_bytes: Some(1_000_000),
+        ..Default::default()
+    };
+    assert_eq!(limits.max_files, Some(50));
+    assert_eq!(limits.max_bytes, Some(1_000_000));
+    assert!(limits.max_file_bytes.is_none());
+    assert!(limits.max_commits.is_none());
+    assert!(limits.max_commit_files.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Math helpers — edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn safe_ratio_zero_denominator_returns_zero() {
+    assert_eq!(safe_ratio(100, 0), 0.0);
+}
+
+#[test]
+fn safe_ratio_zero_numerator_returns_zero() {
+    assert_eq!(safe_ratio(0, 100), 0.0);
+}
+
+#[test]
+fn safe_ratio_equal_values_returns_one() {
+    assert_eq!(safe_ratio(42, 42), 1.0);
+}
+
+#[test]
+fn round_f64_zero_decimals() {
+    assert_eq!(round_f64(3.7, 0), 4.0);
+    assert_eq!(round_f64(3.2, 0), 3.0);
+}
+
+#[test]
+fn round_f64_negative_values() {
+    assert_eq!(round_f64(-2.345, 2), -2.35);
+}
+
+#[test]
+fn percentile_single_element() {
+    assert_eq!(percentile(&[42], 0.0), 42.0);
+    assert_eq!(percentile(&[42], 0.5), 42.0);
+    assert_eq!(percentile(&[42], 1.0), 42.0);
+}
+
+#[test]
+fn gini_coefficient_perfect_equality() {
+    let vals = [100, 100, 100, 100, 100];
+    let g = gini_coefficient(&vals);
+    assert!(
+        g.abs() < 1e-10,
+        "Perfect equality should have gini ≈ 0, got {}",
+        g
+    );
+}
+
+#[test]
+fn gini_coefficient_single_element_is_zero() {
+    let g = gini_coefficient(&[42]);
+    assert_eq!(g, 0.0, "Single element should have gini = 0");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. now_ms — temporal invariants
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn now_ms_returns_positive() {
+    assert!(now_ms() > 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. normalize_root — path canonicalization
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn normalize_root_existing_dir_is_absolute() {
+    let result = normalize_root(Path::new("."));
+    assert!(result.is_absolute());
+}
+
+#[test]
+fn normalize_root_nonexistent_returns_original() {
+    let fake = Path::new("definitely_not_a_real_directory_xyz123");
+    let result = normalize_root(fake);
+    assert_eq!(result, fake.to_path_buf());
+}

--- a/crates/tokmd-analysis/tests/orchestration_w73.rs
+++ b/crates/tokmd-analysis/tests/orchestration_w73.rs
@@ -1,0 +1,471 @@
+//! W73 deep tests for analysis orchestration.
+//!
+//! Covers:
+//! - Preset→enricher mapping correctness for all 11 presets
+//! - Enricher execution determinism (multiple runs yield identical receipts)
+//! - Missing capability reporting (feature-gated warnings)
+//! - Preset composition (deep = everything except fun)
+//! - AnalysisRequest field propagation
+
+use std::path::PathBuf;
+
+use tokmd_analysis::{
+    AnalysisContext, AnalysisLimits, AnalysisPreset, AnalysisRequest, ImportGranularity,
+    NearDupScope, analyze,
+};
+use tokmd_analysis_grid::{PresetKind, preset_plan_for};
+use tokmd_analysis_types::{ANALYSIS_SCHEMA_VERSION, AnalysisArgsMeta, AnalysisSource};
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow, ScanStatus};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn make_source() -> AnalysisSource {
+    AnalysisSource {
+        inputs: vec![".".to_string()],
+        export_path: None,
+        base_receipt_path: None,
+        export_schema_version: None,
+        export_generated_at_ms: None,
+        base_signature: None,
+        module_roots: vec!["crates".to_string()],
+        module_depth: 2,
+        children: "separate".to_string(),
+    }
+}
+
+fn make_ctx(export: ExportData) -> AnalysisContext {
+    AnalysisContext {
+        export,
+        root: PathBuf::from("."),
+        source: make_source(),
+    }
+}
+
+fn make_req(preset: AnalysisPreset) -> AnalysisRequest {
+    AnalysisRequest {
+        preset,
+        args: AnalysisArgsMeta {
+            preset: preset.as_str().to_string(),
+            format: "json".to_string(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_file_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            import_granularity: "module".to_string(),
+        },
+        limits: AnalysisLimits::default(),
+        window_tokens: None,
+        git: None,
+        import_granularity: ImportGranularity::Module,
+        detail_functions: false,
+        near_dup: false,
+        near_dup_threshold: 0.80,
+        near_dup_max_files: 2000,
+        near_dup_scope: NearDupScope::Module,
+        near_dup_max_pairs: None,
+        near_dup_exclude: Vec::new(),
+    }
+}
+
+fn row(path: &str, module: &str, lang: &str, code: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code,
+        comments: code / 5,
+        blanks: code / 10,
+        lines: code + code / 5 + code / 10,
+        bytes: code * 10,
+        tokens: code * 2,
+    }
+}
+
+fn sample_export() -> ExportData {
+    ExportData {
+        rows: vec![
+            row("src/main.rs", "src", "Rust", 200),
+            row("src/lib.rs", "src", "Rust", 150),
+            row("tests/test.rs", "tests", "Rust", 80),
+            row("Cargo.toml", "(root)", "TOML", 30),
+        ],
+        module_roots: vec!["crates".to_string()],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn empty_export() -> ExportData {
+    ExportData {
+        rows: vec![],
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::ParentsOnly,
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Preset → enricher plan correctness
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn receipt_preset_enables_no_optional_enrichers() {
+    let plan = preset_plan_for(PresetKind::Receipt);
+    assert!(!plan.assets);
+    assert!(!plan.deps);
+    assert!(!plan.todo);
+    assert!(!plan.dup);
+    assert!(!plan.imports);
+    assert!(!plan.git);
+    assert!(!plan.fun);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+    assert!(!plan.complexity);
+    assert!(!plan.api_surface);
+}
+
+#[test]
+fn health_preset_enables_todo_and_complexity() {
+    let plan = preset_plan_for(PresetKind::Health);
+    assert!(plan.todo, "health should enable todo");
+    assert!(plan.complexity, "health should enable complexity");
+    assert!(!plan.git, "health should not enable git");
+    assert!(!plan.assets, "health should not enable assets");
+    assert!(!plan.imports, "health should not enable imports");
+    assert!(!plan.fun, "health should not enable fun");
+}
+
+#[test]
+fn risk_preset_enables_git_and_complexity() {
+    let plan = preset_plan_for(PresetKind::Risk);
+    assert!(plan.git, "risk should enable git");
+    assert!(plan.complexity, "risk should enable complexity");
+    assert!(!plan.todo, "risk should not enable todo");
+    assert!(!plan.assets, "risk should not enable assets");
+    assert!(!plan.fun, "risk should not enable fun");
+}
+
+#[test]
+fn supply_preset_enables_assets_and_deps() {
+    let plan = preset_plan_for(PresetKind::Supply);
+    assert!(plan.assets, "supply should enable assets");
+    assert!(plan.deps, "supply should enable deps");
+    assert!(!plan.git, "supply should not enable git");
+    assert!(!plan.todo, "supply should not enable todo");
+    assert!(!plan.imports, "supply should not enable imports");
+}
+
+#[test]
+fn architecture_preset_enables_imports_and_api_surface() {
+    let plan = preset_plan_for(PresetKind::Architecture);
+    assert!(plan.imports, "architecture should enable imports");
+    assert!(plan.api_surface, "architecture should enable api_surface");
+    assert!(!plan.git, "architecture should not enable git");
+    assert!(!plan.assets, "architecture should not enable assets");
+    assert!(!plan.todo, "architecture should not enable todo");
+}
+
+#[test]
+fn topics_preset_enables_only_topics() {
+    let plan = preset_plan_for(PresetKind::Topics);
+    assert!(plan.topics, "topics preset should enable topics");
+    assert!(!plan.git);
+    assert!(!plan.assets);
+    assert!(!plan.todo);
+    assert!(!plan.imports);
+    assert!(!plan.dup);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+}
+
+#[test]
+fn security_preset_enables_entropy_and_license() {
+    let plan = preset_plan_for(PresetKind::Security);
+    assert!(plan.entropy, "security should enable entropy");
+    assert!(plan.license, "security should enable license");
+    assert!(!plan.git);
+    assert!(!plan.assets);
+    assert!(!plan.todo);
+    assert!(!plan.imports);
+}
+
+#[test]
+fn identity_preset_enables_archetype_git_and_fingerprint() {
+    let plan = preset_plan_for(PresetKind::Identity);
+    assert!(plan.archetype, "identity should enable archetype");
+    assert!(plan.git, "identity should enable git");
+    assert!(!plan.assets);
+    assert!(!plan.todo);
+    assert!(!plan.imports);
+    assert!(!plan.entropy);
+}
+
+#[test]
+fn git_preset_enables_git_only() {
+    let plan = preset_plan_for(PresetKind::Git);
+    assert!(plan.git, "git preset should enable git");
+    assert!(!plan.assets);
+    assert!(!plan.deps);
+    assert!(!plan.todo);
+    assert!(!plan.imports);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+}
+
+#[test]
+fn fun_preset_enables_only_fun() {
+    let plan = preset_plan_for(PresetKind::Fun);
+    assert!(plan.fun, "fun preset should enable fun");
+    assert!(!plan.git);
+    assert!(!plan.assets);
+    assert!(!plan.todo);
+    assert!(!plan.imports);
+    assert!(!plan.dup);
+    assert!(!plan.archetype);
+    assert!(!plan.topics);
+    assert!(!plan.entropy);
+    assert!(!plan.license);
+    assert!(!plan.complexity);
+    assert!(!plan.api_surface);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Deep preset = everything except fun
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn deep_preset_enables_all_base_enrichers_except_fun() {
+    let plan = preset_plan_for(PresetKind::Deep);
+    assert!(plan.assets, "deep should enable assets");
+    assert!(plan.deps, "deep should enable deps");
+    assert!(plan.todo, "deep should enable todo");
+    assert!(plan.dup, "deep should enable dup");
+    assert!(plan.imports, "deep should enable imports");
+    assert!(plan.git, "deep should enable git");
+    assert!(plan.archetype, "deep should enable archetype");
+    assert!(plan.topics, "deep should enable topics");
+    assert!(plan.entropy, "deep should enable entropy");
+    assert!(plan.license, "deep should enable license");
+    assert!(plan.complexity, "deep should enable complexity");
+    assert!(plan.api_surface, "deep should enable api_surface");
+    assert!(!plan.fun, "deep should NOT enable fun");
+}
+
+#[test]
+fn deep_is_superset_of_all_non_fun_presets() {
+    let deep = preset_plan_for(PresetKind::Deep);
+    for kind in PresetKind::all() {
+        if *kind == PresetKind::Deep || *kind == PresetKind::Fun {
+            continue;
+        }
+        let plan = preset_plan_for(*kind);
+        if plan.assets {
+            assert!(deep.assets, "{:?} has assets but deep doesn't", kind);
+        }
+        if plan.deps {
+            assert!(deep.deps, "{:?} has deps but deep doesn't", kind);
+        }
+        if plan.todo {
+            assert!(deep.todo, "{:?} has todo but deep doesn't", kind);
+        }
+        if plan.dup {
+            assert!(deep.dup, "{:?} has dup but deep doesn't", kind);
+        }
+        if plan.imports {
+            assert!(deep.imports, "{:?} has imports but deep doesn't", kind);
+        }
+        if plan.git {
+            assert!(deep.git, "{:?} has git but deep doesn't", kind);
+        }
+        if plan.archetype {
+            assert!(deep.archetype, "{:?} has archetype but deep doesn't", kind);
+        }
+        if plan.topics {
+            assert!(deep.topics, "{:?} has topics but deep doesn't", kind);
+        }
+        if plan.entropy {
+            assert!(deep.entropy, "{:?} has entropy but deep doesn't", kind);
+        }
+        if plan.license {
+            assert!(deep.license, "{:?} has license but deep doesn't", kind);
+        }
+        if plan.complexity {
+            assert!(
+                deep.complexity,
+                "{:?} has complexity but deep doesn't",
+                kind
+            );
+        }
+        if plan.api_surface {
+            assert!(
+                deep.api_surface,
+                "{:?} has api_surface but deep doesn't",
+                kind
+            );
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Enricher execution determinism
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn analyze_receipt_deterministic_across_runs() {
+    let export = sample_export();
+    let r1 = analyze(make_ctx(export.clone()), make_req(AnalysisPreset::Receipt)).unwrap();
+    let r2 = analyze(make_ctx(export), make_req(AnalysisPreset::Receipt)).unwrap();
+
+    let d1 = r1.derived.as_ref().unwrap();
+    let d2 = r2.derived.as_ref().unwrap();
+
+    assert_eq!(d1.totals.code, d2.totals.code);
+    assert_eq!(d1.totals.lines, d2.totals.lines);
+    assert_eq!(d1.totals.files, d2.totals.files);
+    assert_eq!(d1.integrity.hash, d2.integrity.hash);
+    assert_eq!(d1.distribution.count, d2.distribution.count);
+}
+
+#[test]
+fn analyze_deterministic_warnings_for_same_preset() {
+    let export = sample_export();
+    let r1 = analyze(make_ctx(export.clone()), make_req(AnalysisPreset::Health)).unwrap();
+    let r2 = analyze(make_ctx(export), make_req(AnalysisPreset::Health)).unwrap();
+
+    assert_eq!(r1.warnings.len(), r2.warnings.len());
+    for (w1, w2) in r1.warnings.iter().zip(r2.warnings.iter()) {
+        assert_eq!(w1, w2, "Warnings should be identical across runs");
+    }
+}
+
+#[test]
+fn analyze_all_presets_produce_valid_receipts() {
+    let export = sample_export();
+    for kind in PresetKind::all() {
+        let receipt = analyze(make_ctx(export.clone()), make_req(*kind)).unwrap();
+        assert_eq!(receipt.schema_version, ANALYSIS_SCHEMA_VERSION);
+        assert_eq!(receipt.mode, "analysis");
+        assert!(receipt.generated_at_ms > 0);
+        assert!(receipt.derived.is_some(), "{:?} should have derived", kind);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Missing capability reporting
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn receipt_preset_produces_no_warnings() {
+    let receipt = analyze(make_ctx(sample_export()), make_req(AnalysisPreset::Receipt)).unwrap();
+    assert!(
+        receipt.warnings.is_empty(),
+        "Receipt should have no warnings but got: {:?}",
+        receipt.warnings
+    );
+    assert!(matches!(receipt.status, ScanStatus::Complete));
+}
+
+#[test]
+fn empty_export_still_produces_valid_receipt() {
+    let receipt = analyze(make_ctx(empty_export()), make_req(AnalysisPreset::Receipt)).unwrap();
+    assert_eq!(receipt.schema_version, ANALYSIS_SCHEMA_VERSION);
+    let derived = receipt.derived.unwrap();
+    assert_eq!(derived.totals.code, 0);
+    assert_eq!(derived.totals.files, 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. base_signature backfill
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn base_signature_backfilled_from_integrity_hash() {
+    let receipt = analyze(make_ctx(sample_export()), make_req(AnalysisPreset::Receipt)).unwrap();
+    let derived = receipt.derived.as_ref().unwrap();
+    assert!(
+        receipt.source.base_signature.is_some(),
+        "base_signature should be backfilled"
+    );
+    assert_eq!(
+        receipt.source.base_signature.as_deref(),
+        Some(derived.integrity.hash.as_str()),
+    );
+}
+
+#[test]
+fn base_signature_not_overwritten_when_provided() {
+    let mut source = make_source();
+    source.base_signature = Some("custom-sig-123".to_string());
+    let ctx = AnalysisContext {
+        export: sample_export(),
+        root: PathBuf::from("."),
+        source,
+    };
+    let receipt = analyze(ctx, make_req(AnalysisPreset::Receipt)).unwrap();
+    assert_eq!(
+        receipt.source.base_signature.as_deref(),
+        Some("custom-sig-123"),
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. Git override flag
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn git_override_false_suppresses_git_on_risk_preset() {
+    let mut req = make_req(AnalysisPreset::Risk);
+    req.git = Some(false);
+    let receipt = analyze(make_ctx(sample_export()), req).unwrap();
+    // Git is disabled by override, so no git report
+    assert!(
+        receipt.git.is_none(),
+        "git should be suppressed by override"
+    );
+}
+
+#[test]
+fn git_override_true_on_receipt_preset_attempts_git() {
+    let mut req = make_req(AnalysisPreset::Receipt);
+    req.git = Some(true);
+    let receipt = analyze(make_ctx(sample_export()), req).unwrap();
+    // Without the git feature compiled, this will produce a warning.
+    // With git feature, it may fail (not in a git repo) producing a warning.
+    // Either way the receipt is valid.
+    assert_eq!(receipt.schema_version, ANALYSIS_SCHEMA_VERSION);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Tree building via format string
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn tree_format_populates_tree_field() {
+    let mut req = make_req(AnalysisPreset::Receipt);
+    req.args.format = "json+tree".to_string();
+    let receipt = analyze(make_ctx(sample_export()), req).unwrap();
+    let derived = receipt.derived.unwrap();
+    assert!(
+        derived.tree.is_some(),
+        "format containing 'tree' should populate tree field"
+    );
+}
+
+#[test]
+fn non_tree_format_leaves_tree_none() {
+    let req = make_req(AnalysisPreset::Receipt);
+    let receipt = analyze(make_ctx(sample_export()), req).unwrap();
+    let derived = receipt.derived.unwrap();
+    assert!(
+        derived.tree.is_none(),
+        "default format should not build tree"
+    );
+}


### PR DESCRIPTION
Deep integration tests for analysis orchestration crates covering ~79 test functions across three test files.

Test files:
- orchestration_w73.rs (23 tests): Preset-enricher mapping for all 11 presets, deep=superset, determinism, base_signature backfill, git override, tree format
- util_w73.rs (35 tests): normalize_path, path_depth, is_test_path, is_infra_lang, empty_file_row, AnalysisLimits, math helpers
- grid_w73.rs (21 tests): Grid completeness, PresetKind roundtrip, needs_files, DisabledFeature warnings, deep superset

All tests pass locally with cargo test and cargo fmt.