### PR TITLE
test(w73): context + handoff deep tests (~45 tests)

### DIFF
--- a/crates/tokmd-context-policy/tests/policy_w73.rs
+++ b/crates/tokmd-context-policy/tests/policy_w73.rs
@@ -1,0 +1,302 @@
+//! Deep tests for tokmd-context-policy crate (W73).
+
+use tokmd_context_policy::{
+    assign_policy, classify_file, compute_file_cap, is_spine_file, smart_exclude_reason,
+    DEFAULT_DENSE_THRESHOLD, DEFAULT_MAX_FILE_PCT, DEFAULT_MAX_FILE_TOKENS,
+};
+use tokmd_types::{FileClassification, InclusionPolicy};
+
+// ---------------------------------------------------------------------------
+// smart_exclude_reason
+// ---------------------------------------------------------------------------
+
+#[test]
+fn smart_exclude_cargo_lock() {
+    assert_eq!(smart_exclude_reason("Cargo.lock"), Some("lockfile"));
+}
+
+#[test]
+fn smart_exclude_nested_lockfile() {
+    assert_eq!(
+        smart_exclude_reason("subdir/package-lock.json"),
+        Some("lockfile")
+    );
+}
+
+#[test]
+fn smart_exclude_all_lockfiles() {
+    let lockfiles = [
+        "Cargo.lock",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "poetry.lock",
+        "Pipfile.lock",
+        "go.sum",
+        "composer.lock",
+        "Gemfile.lock",
+    ];
+    for lf in &lockfiles {
+        assert_eq!(
+            smart_exclude_reason(lf),
+            Some("lockfile"),
+            "{lf} should be detected as lockfile"
+        );
+    }
+}
+
+#[test]
+fn smart_exclude_minified_js() {
+    assert_eq!(smart_exclude_reason("dist/app.min.js"), Some("minified"));
+}
+
+#[test]
+fn smart_exclude_minified_css() {
+    assert_eq!(
+        smart_exclude_reason("assets/style.min.css"),
+        Some("minified")
+    );
+}
+
+#[test]
+fn smart_exclude_sourcemap_js() {
+    assert_eq!(smart_exclude_reason("dist/app.js.map"), Some("sourcemap"));
+}
+
+#[test]
+fn smart_exclude_sourcemap_css() {
+    assert_eq!(
+        smart_exclude_reason("assets/style.css.map"),
+        Some("sourcemap")
+    );
+}
+
+#[test]
+fn smart_exclude_regular_file_none() {
+    assert_eq!(smart_exclude_reason("src/main.rs"), None);
+    assert_eq!(smart_exclude_reason("README.md"), None);
+    assert_eq!(smart_exclude_reason("lib/utils.ts"), None);
+}
+
+// ---------------------------------------------------------------------------
+// is_spine_file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn spine_readme_variants() {
+    assert!(is_spine_file("README.md"));
+    assert!(is_spine_file("README"));
+    assert!(is_spine_file("README.rst"));
+    assert!(is_spine_file("README.txt"));
+}
+
+#[test]
+fn spine_manifest_files() {
+    assert!(is_spine_file("Cargo.toml"));
+    assert!(is_spine_file("package.json"));
+    assert!(is_spine_file("pyproject.toml"));
+    assert!(is_spine_file("go.mod"));
+}
+
+#[test]
+fn spine_nested_docs() {
+    assert!(is_spine_file("docs/architecture.md"));
+    assert!(is_spine_file("docs/design.md"));
+    assert!(is_spine_file("myrepo/docs/architecture.md"));
+}
+
+#[test]
+fn spine_non_spine_files() {
+    assert!(!is_spine_file("src/main.rs"));
+    assert!(!is_spine_file("tests/integration.rs"));
+    assert!(!is_spine_file("docs/random.md"));
+}
+
+// ---------------------------------------------------------------------------
+// classify_file – individual classifications
+// ---------------------------------------------------------------------------
+
+#[test]
+fn classify_lockfile() {
+    let classes = classify_file("Cargo.lock", 5000, 500, DEFAULT_DENSE_THRESHOLD);
+    assert!(classes.contains(&FileClassification::Lockfile));
+    assert!(!classes.contains(&FileClassification::Generated));
+}
+
+#[test]
+fn classify_minified() {
+    let classes = classify_file("dist/app.min.js", 100, 100, DEFAULT_DENSE_THRESHOLD);
+    assert!(classes.contains(&FileClassification::Minified));
+}
+
+#[test]
+fn classify_sourcemap() {
+    let classes = classify_file("dist/app.js.map", 100, 100, DEFAULT_DENSE_THRESHOLD);
+    assert!(classes.contains(&FileClassification::Sourcemap));
+}
+
+#[test]
+fn classify_generated_patterns() {
+    let generated = [
+        "src/node-types.json",
+        "proto/service.pb.go",
+        "proto/msg.pb.rs",
+        "gen/api_pb2.py",
+        "lib/model.g.dart",
+        "lib/model.freezed.dart",
+        "src/foo.generated.ts",
+    ];
+    for path in &generated {
+        let classes = classify_file(path, 100, 100, DEFAULT_DENSE_THRESHOLD);
+        assert!(
+            classes.contains(&FileClassification::Generated),
+            "{path} should be classified as Generated"
+        );
+    }
+}
+
+#[test]
+fn classify_vendored_dirs() {
+    let vendored = [
+        "vendor/lib/foo.c",
+        "third_party/zlib/zlib.h",
+        "third-party/openssl/ssl.c",
+        "node_modules/lodash/index.js",
+    ];
+    for path in &vendored {
+        let classes = classify_file(path, 100, 100, DEFAULT_DENSE_THRESHOLD);
+        assert!(
+            classes.contains(&FileClassification::Vendored),
+            "{path} should be classified as Vendored"
+        );
+    }
+}
+
+#[test]
+fn classify_fixture_dirs() {
+    let fixtures = [
+        "fixtures/sample.json",
+        "testdata/input.txt",
+        "test_data/expected.csv",
+        "__snapshots__/foo.snap",
+        "golden/expected_output.txt",
+    ];
+    for path in &fixtures {
+        let classes = classify_file(path, 100, 100, DEFAULT_DENSE_THRESHOLD);
+        assert!(
+            classes.contains(&FileClassification::Fixture),
+            "{path} should be classified as Fixture"
+        );
+    }
+}
+
+#[test]
+fn classify_data_blob_high_density() {
+    // 10000 tokens / 10 lines = 1000 tokens_per_line >> threshold
+    let classes = classify_file("data/big.json", 10_000, 10, DEFAULT_DENSE_THRESHOLD);
+    assert!(classes.contains(&FileClassification::DataBlob));
+}
+
+#[test]
+fn classify_data_blob_below_threshold() {
+    // 100 tokens / 100 lines = 1.0, well below threshold
+    let classes = classify_file("data/normal.json", 100, 100, DEFAULT_DENSE_THRESHOLD);
+    assert!(!classes.contains(&FileClassification::DataBlob));
+}
+
+#[test]
+fn classify_regular_source_file_empty() {
+    let classes = classify_file("src/lib.rs", 500, 100, DEFAULT_DENSE_THRESHOLD);
+    assert!(classes.is_empty(), "normal source file should have no classifications");
+}
+
+#[test]
+fn classify_deduplicates_and_sorts() {
+    // A file in vendor/ that also has high density — should get both, sorted & deduped
+    let classes = classify_file("vendor/big.js", 50_000, 5, DEFAULT_DENSE_THRESHOLD);
+    assert!(classes.contains(&FileClassification::Vendored));
+    assert!(classes.contains(&FileClassification::DataBlob));
+    // Verify sorted (Vendored > DataBlob in the PartialOrd)
+    let positions: Vec<_> = classes.iter().collect();
+    for w in positions.windows(2) {
+        assert!(w[0] <= w[1], "classifications should be sorted");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// compute_file_cap
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compute_file_cap_default_budget() {
+    let cap = compute_file_cap(128_000, DEFAULT_MAX_FILE_PCT, None);
+    // 128_000 * 0.15 = 19_200, min with DEFAULT_MAX_FILE_TOKENS (16_000)
+    assert_eq!(cap, DEFAULT_MAX_FILE_TOKENS);
+}
+
+#[test]
+fn compute_file_cap_small_budget() {
+    let cap = compute_file_cap(10_000, DEFAULT_MAX_FILE_PCT, None);
+    // 10_000 * 0.15 = 1_500, which is < 16_000
+    assert_eq!(cap, 1_500);
+}
+
+#[test]
+fn compute_file_cap_explicit_hard_cap() {
+    let cap = compute_file_cap(128_000, DEFAULT_MAX_FILE_PCT, Some(5_000));
+    // 128_000 * 0.15 = 19_200, min with 5_000 = 5_000
+    assert_eq!(cap, 5_000);
+}
+
+#[test]
+fn compute_file_cap_unlimited_budget() {
+    let cap = compute_file_cap(usize::MAX, DEFAULT_MAX_FILE_PCT, None);
+    assert_eq!(cap, usize::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// assign_policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_policy_full_when_under_cap() {
+    let (policy, reason) = assign_policy(500, 16_000, &[]);
+    assert_eq!(policy, InclusionPolicy::Full);
+    assert!(reason.is_none());
+}
+
+#[test]
+fn assign_policy_head_tail_when_over_cap_normal_file() {
+    let (policy, reason) = assign_policy(20_000, 16_000, &[]);
+    assert_eq!(policy, InclusionPolicy::HeadTail);
+    assert!(reason.is_some());
+    assert!(reason.unwrap().contains("head+tail"));
+}
+
+#[test]
+fn assign_policy_skip_generated_over_cap() {
+    let (policy, reason) = assign_policy(20_000, 16_000, &[FileClassification::Generated]);
+    assert_eq!(policy, InclusionPolicy::Skip);
+    assert!(reason.unwrap().contains("generated"));
+}
+
+#[test]
+fn assign_policy_skip_data_blob_over_cap() {
+    let (policy, reason) = assign_policy(20_000, 16_000, &[FileClassification::DataBlob]);
+    assert_eq!(policy, InclusionPolicy::Skip);
+    assert!(reason.unwrap().contains("data_blob"));
+}
+
+#[test]
+fn assign_policy_skip_vendored_over_cap() {
+    let (policy, reason) = assign_policy(20_000, 16_000, &[FileClassification::Vendored]);
+    assert_eq!(policy, InclusionPolicy::Skip);
+    assert!(reason.unwrap().contains("vendored"));
+}
+
+#[test]
+fn assign_policy_fixture_not_skip_class() {
+    // Fixtures over cap get HeadTail, not Skip
+    let (policy, _reason) = assign_policy(20_000, 16_000, &[FileClassification::Fixture]);
+    assert_eq!(policy, InclusionPolicy::HeadTail);
+}

--- a/crates/tokmd-types/tests/context_types_w73.rs
+++ b/crates/tokmd-types/tests/context_types_w73.rs
@@ -1,0 +1,320 @@
+//! Deep tests for context and handoff types in tokmd-types (W73).
+
+use serde_json;
+use tokmd_types::*;
+
+// ---------------------------------------------------------------------------
+// Schema version constants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn context_schema_version_is_4() {
+    assert_eq!(CONTEXT_SCHEMA_VERSION, 4);
+}
+
+#[test]
+fn context_bundle_schema_version_is_2() {
+    assert_eq!(CONTEXT_BUNDLE_SCHEMA_VERSION, 2);
+}
+
+#[test]
+fn handoff_schema_version_is_5() {
+    assert_eq!(HANDOFF_SCHEMA_VERSION, 5);
+}
+
+// ---------------------------------------------------------------------------
+// InclusionPolicy defaults and serde
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inclusion_policy_default_is_full() {
+    assert_eq!(InclusionPolicy::default(), InclusionPolicy::Full);
+}
+
+#[test]
+fn inclusion_policy_serde_roundtrip() {
+    for policy in [
+        InclusionPolicy::Full,
+        InclusionPolicy::HeadTail,
+        InclusionPolicy::Summary,
+        InclusionPolicy::Skip,
+    ] {
+        let json = serde_json::to_string(&policy).unwrap();
+        let back: InclusionPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, policy);
+    }
+}
+
+#[test]
+fn inclusion_policy_snake_case_serialization() {
+    assert_eq!(serde_json::to_string(&InclusionPolicy::Full).unwrap(), "\"full\"");
+    assert_eq!(
+        serde_json::to_string(&InclusionPolicy::HeadTail).unwrap(),
+        "\"head_tail\""
+    );
+    assert_eq!(serde_json::to_string(&InclusionPolicy::Skip).unwrap(), "\"skip\"");
+}
+
+// ---------------------------------------------------------------------------
+// FileClassification serde
+// ---------------------------------------------------------------------------
+
+#[test]
+fn file_classification_serde_roundtrip() {
+    for class in [
+        FileClassification::Generated,
+        FileClassification::Fixture,
+        FileClassification::Vendored,
+        FileClassification::Lockfile,
+        FileClassification::Minified,
+        FileClassification::DataBlob,
+        FileClassification::Sourcemap,
+    ] {
+        let json = serde_json::to_string(&class).unwrap();
+        let back: FileClassification = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, class);
+    }
+}
+
+#[test]
+fn file_classification_snake_case_names() {
+    assert_eq!(
+        serde_json::to_string(&FileClassification::DataBlob).unwrap(),
+        "\"data_blob\""
+    );
+    assert_eq!(
+        serde_json::to_string(&FileClassification::Sourcemap).unwrap(),
+        "\"sourcemap\""
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ContextFileRow construction and serialization
+// ---------------------------------------------------------------------------
+
+fn sample_context_file_row() -> ContextFileRow {
+    ContextFileRow {
+        path: "src/main.rs".to_string(),
+        module: "src".to_string(),
+        lang: "Rust".to_string(),
+        tokens: 500,
+        code: 120,
+        lines: 150,
+        bytes: 3200,
+        value: 120,
+        rank_reason: String::new(),
+        policy: InclusionPolicy::Full,
+        effective_tokens: None,
+        policy_reason: None,
+        classifications: vec![],
+    }
+}
+
+#[test]
+fn context_file_row_full_policy_serialization() {
+    let row = sample_context_file_row();
+    let json = serde_json::to_value(&row).unwrap();
+
+    assert_eq!(json["path"], "src/main.rs");
+    assert_eq!(json["tokens"], 500);
+    assert_eq!(json["code"], 120);
+    // Default policy (Full) is skipped by skip_serializing_if
+    assert!(json.get("policy").is_none());
+    // Empty rank_reason is skipped
+    assert!(json.get("rank_reason").is_none());
+    // None effective_tokens is skipped
+    assert!(json.get("effective_tokens").is_none());
+    // Empty classifications is skipped
+    assert!(json.get("classifications").is_none());
+}
+
+#[test]
+fn context_file_row_with_head_tail_policy() {
+    let mut row = sample_context_file_row();
+    row.policy = InclusionPolicy::HeadTail;
+    row.effective_tokens = Some(200);
+    row.policy_reason = Some("file exceeds cap".to_string());
+
+    let json = serde_json::to_value(&row).unwrap();
+    assert_eq!(json["policy"], "head_tail");
+    assert_eq!(json["effective_tokens"], 200);
+    assert_eq!(json["policy_reason"], "file exceeds cap");
+}
+
+#[test]
+fn context_file_row_with_classifications() {
+    let mut row = sample_context_file_row();
+    row.classifications = vec![FileClassification::Generated, FileClassification::DataBlob];
+
+    let json = serde_json::to_value(&row).unwrap();
+    let classes = json["classifications"].as_array().unwrap();
+    assert_eq!(classes.len(), 2);
+    assert_eq!(classes[0], "generated");
+    assert_eq!(classes[1], "data_blob");
+}
+
+#[test]
+fn context_file_row_effective_tokens_relationship() {
+    let mut row = sample_context_file_row();
+    row.tokens = 5000;
+    row.effective_tokens = Some(1000);
+
+    // effective_tokens < tokens when HeadTail
+    assert!(row.effective_tokens.unwrap() < row.tokens);
+    // When Full, effective_tokens is None (same as tokens)
+    row.effective_tokens = None;
+    assert!(row.effective_tokens.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// ContextReceipt
+// ---------------------------------------------------------------------------
+
+#[test]
+fn context_receipt_json_roundtrip() {
+    let receipt = ContextReceipt {
+        schema_version: CONTEXT_SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo {
+            name: "tokmd".to_string(),
+            version: "0.1.0".to_string(),
+        },
+        mode: "context".to_string(),
+        budget_tokens: 128_000,
+        used_tokens: 50_000,
+        utilization_pct: 39.06,
+        strategy: "greedy".to_string(),
+        rank_by: "code".to_string(),
+        file_count: 10,
+        files: vec![sample_context_file_row()],
+        rank_by_effective: None,
+        fallback_reason: None,
+        excluded_by_policy: vec![],
+        token_estimation: None,
+        bundle_audit: None,
+    };
+
+    let json_str = serde_json::to_string(&receipt).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(parsed["schema_version"], CONTEXT_SCHEMA_VERSION);
+    assert_eq!(parsed["mode"], "context");
+    assert_eq!(parsed["budget_tokens"], 128_000);
+    assert_eq!(parsed["used_tokens"], 50_000);
+    assert_eq!(parsed["file_count"], 10);
+    assert!(parsed["files"].is_array());
+    assert_eq!(parsed["files"].as_array().unwrap().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// HandoffManifest
+// ---------------------------------------------------------------------------
+
+#[test]
+fn handoff_manifest_required_fields_present() {
+    let manifest = HandoffManifest {
+        schema_version: HANDOFF_SCHEMA_VERSION,
+        generated_at_ms: 1_700_000_000_000,
+        tool: ToolInfo {
+            name: "tokmd".to_string(),
+            version: "0.1.0".to_string(),
+        },
+        mode: "handoff".to_string(),
+        inputs: vec![".".to_string()],
+        output_dir: ".handoff".to_string(),
+        budget_tokens: 128_000,
+        used_tokens: 40_000,
+        utilization_pct: 31.25,
+        strategy: "greedy".to_string(),
+        rank_by: "hotspot".to_string(),
+        capabilities: vec![],
+        artifacts: vec![],
+        included_files: vec![],
+        excluded_paths: vec![],
+        excluded_patterns: vec![],
+        smart_excluded_files: vec![],
+        total_files: 50,
+        bundled_files: 30,
+        intelligence_preset: "risk".to_string(),
+        rank_by_effective: None,
+        fallback_reason: None,
+        excluded_by_policy: vec![],
+        token_estimation: None,
+        code_audit: None,
+    };
+
+    let json = serde_json::to_value(&manifest).unwrap();
+    assert_eq!(json["schema_version"], HANDOFF_SCHEMA_VERSION);
+    assert_eq!(json["mode"], "handoff");
+    assert_eq!(json["output_dir"], ".handoff");
+    assert_eq!(json["intelligence_preset"], "risk");
+    assert_eq!(json["total_files"], 50);
+    assert_eq!(json["bundled_files"], 30);
+}
+
+#[test]
+fn handoff_manifest_optional_fields_skipped_when_empty() {
+    let manifest = HandoffManifest {
+        schema_version: HANDOFF_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: ToolInfo {
+            name: "tokmd".to_string(),
+            version: "0.1.0".to_string(),
+        },
+        mode: "handoff".to_string(),
+        inputs: vec![],
+        output_dir: ".handoff".to_string(),
+        budget_tokens: 0,
+        used_tokens: 0,
+        utilization_pct: 0.0,
+        strategy: "greedy".to_string(),
+        rank_by: "code".to_string(),
+        capabilities: vec![],
+        artifacts: vec![],
+        included_files: vec![],
+        excluded_paths: vec![],
+        excluded_patterns: vec![],
+        smart_excluded_files: vec![],
+        total_files: 0,
+        bundled_files: 0,
+        intelligence_preset: "minimal".to_string(),
+        rank_by_effective: None,
+        fallback_reason: None,
+        excluded_by_policy: vec![],
+        token_estimation: None,
+        code_audit: None,
+    };
+
+    let json = serde_json::to_value(&manifest).unwrap();
+    assert!(json.get("rank_by_effective").is_none());
+    assert!(json.get("fallback_reason").is_none());
+    assert!(json.get("excluded_by_policy").is_none());
+    assert!(json.get("token_estimation").is_none());
+    assert!(json.get("code_audit").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// TokenEstimationMeta
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_estimation_invariant_min_le_est_le_max() {
+    let est = TokenEstimationMeta::from_bytes(4000, 4.0);
+    assert!(est.tokens_min <= est.tokens_est);
+    assert!(est.tokens_est <= est.tokens_max);
+    assert_eq!(est.source_bytes, 4000);
+    assert_eq!(est.tokens_est, 1000);
+}
+
+// ---------------------------------------------------------------------------
+// TokenAudit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_audit_overhead_calculation() {
+    let audit = TokenAudit::from_output(5000, 4500);
+    assert_eq!(audit.output_bytes, 5000);
+    assert_eq!(audit.overhead_bytes, 500);
+    let expected_pct = 500.0 / 5000.0;
+    assert!((audit.overhead_pct - expected_pct).abs() < 1e-10);
+}

--- a/crates/tokmd/tests/context_cli_w73.rs
+++ b/crates/tokmd/tests/context_cli_w73.rs
@@ -1,0 +1,296 @@
+//! CLI integration tests for context and handoff commands (W73).
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn tokmd_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(common::fixture_root());
+    cmd
+}
+
+// ---------------------------------------------------------------------------
+// context --mode list
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w73_context_list_on_temp_dir() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("hello.rs"), "fn main() { println!(\"hello\"); }\n").unwrap();
+    fs::write(root.join("lib.rs"), "pub fn add(a: i32, b: i32) -> i32 { a + b }\n").unwrap();
+    fs::create_dir_all(root.join(".git")).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(root)
+        .arg("context")
+        .arg("--mode")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello.rs").or(predicate::str::contains("lib.rs")));
+}
+
+#[test]
+fn w73_context_list_includes_all_source_files() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("main.py"), "print('hello')\n").unwrap();
+    fs::write(root.join("app.js"), "console.log('hi');\n").unwrap();
+    fs::create_dir_all(root.join(".git")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(root)
+        .arg("context")
+        .arg("--mode")
+        .arg("list")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("main.py") || stdout.contains("app.js"));
+}
+
+// ---------------------------------------------------------------------------
+// context --mode json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w73_context_json_has_required_structure() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+    fs::create_dir_all(root.join(".git")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(root)
+        .arg("context")
+        .arg("--mode")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON output");
+
+    assert_eq!(parsed["schema_version"].as_u64(), Some(4));
+    assert_eq!(parsed["mode"].as_str(), Some("context"));
+    assert!(parsed["budget_tokens"].is_number());
+    assert!(parsed["used_tokens"].is_number());
+    assert!(parsed["utilization_pct"].is_number());
+    assert!(parsed["strategy"].is_string());
+    assert!(parsed["rank_by"].is_string());
+    assert!(parsed["file_count"].is_number());
+    assert!(parsed["files"].is_array());
+    assert_eq!(parsed["tool"]["name"].as_str(), Some("tokmd"));
+}
+
+#[test]
+fn w73_context_json_file_rows_have_fields() {
+    let output = tokmd_cmd()
+        .arg("context")
+        .arg("--mode")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let files = parsed["files"].as_array().unwrap();
+
+    if let Some(first) = files.first() {
+        assert!(first["path"].is_string());
+        assert!(first["module"].is_string());
+        assert!(first["lang"].is_string());
+        assert!(first["tokens"].is_number());
+        assert!(first["code"].is_number());
+        assert!(first["lines"].is_number());
+        assert!(first["bytes"].is_number());
+        assert!(first["value"].is_number());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// context --budget
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w73_context_budget_respected() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    // Write several files to exceed a small budget
+    for i in 0..10 {
+        fs::write(
+            root.join(format!("file_{i}.rs")),
+            format!("pub fn f{i}() {{ let x = {i}; println!(\"{{x}}\"); }}\n"),
+        )
+        .unwrap();
+    }
+    fs::create_dir_all(root.join(".git")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(root)
+        .arg("context")
+        .arg("--mode")
+        .arg("json")
+        .arg("--budget")
+        .arg("1000")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let budget = parsed["budget_tokens"].as_u64().unwrap();
+    let used = parsed["used_tokens"].as_u64().unwrap();
+    assert_eq!(budget, 1000);
+    assert!(
+        used <= budget,
+        "used_tokens ({used}) should not exceed budget_tokens ({budget})"
+    );
+}
+
+#[test]
+fn w73_context_budget_unlimited() {
+    let output = tokmd_cmd()
+        .arg("context")
+        .arg("--mode")
+        .arg("json")
+        .arg("--budget")
+        .arg("unlimited")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let budget = parsed["budget_tokens"].as_u64().unwrap();
+    // Unlimited budget is represented as a very large number
+    assert!(budget > 1_000_000);
+}
+
+// ---------------------------------------------------------------------------
+// handoff --preset minimal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w73_handoff_preset_minimal_output() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("handoff_w73_minimal");
+
+    tokmd_cmd()
+        .arg("handoff")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--preset")
+        .arg("minimal")
+        .arg("--no-git")
+        .assert()
+        .success();
+
+    assert!(out_dir.join("manifest.json").exists());
+    assert!(out_dir.join("intelligence.json").exists());
+    assert!(out_dir.join("code.txt").exists());
+    assert!(out_dir.join("map.jsonl").exists());
+
+    let intel: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_dir.join("intelligence.json")).unwrap())
+            .unwrap();
+    assert!(intel["tree"].is_string());
+    // Minimal: no complexity or derived
+    assert!(intel["complexity"].is_null());
+    assert!(intel["derived"].is_null());
+}
+
+#[test]
+fn w73_handoff_preset_in_manifest() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("handoff_w73_preset");
+
+    tokmd_cmd()
+        .arg("handoff")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--preset")
+        .arg("minimal")
+        .arg("--no-git")
+        .assert()
+        .success();
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_dir.join("manifest.json")).unwrap()).unwrap();
+
+    assert_eq!(manifest["intelligence_preset"].as_str(), Some("minimal"));
+}
+
+// ---------------------------------------------------------------------------
+// handoff --format json (manifest structure)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w73_handoff_manifest_json_structure() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("handoff_w73_json");
+
+    tokmd_cmd()
+        .arg("handoff")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--no-git")
+        .assert()
+        .success();
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_dir.join("manifest.json")).unwrap()).unwrap();
+
+    assert_eq!(manifest["schema_version"].as_u64(), Some(5));
+    assert_eq!(manifest["mode"].as_str(), Some("handoff"));
+    assert!(manifest["generated_at_ms"].is_number());
+    assert_eq!(manifest["tool"]["name"].as_str(), Some("tokmd"));
+    assert!(manifest["budget_tokens"].is_number());
+    assert!(manifest["used_tokens"].is_number());
+    assert!(manifest["utilization_pct"].is_number());
+    assert!(manifest["strategy"].is_string());
+    assert!(manifest["rank_by"].is_string());
+    assert!(manifest["capabilities"].is_array());
+    assert!(manifest["artifacts"].is_array());
+    assert!(manifest["included_files"].is_array());
+    assert!(manifest["total_files"].is_number());
+    assert!(manifest["bundled_files"].is_number());
+}
+
+#[test]
+fn w73_handoff_artifacts_have_integrity_hashes() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("handoff_w73_hashes");
+
+    tokmd_cmd()
+        .arg("handoff")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--no-git")
+        .assert()
+        .success();
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_dir.join("manifest.json")).unwrap()).unwrap();
+
+    let artifacts = manifest["artifacts"].as_array().unwrap();
+    assert!(!artifacts.is_empty());
+
+    for artifact in artifacts {
+        assert!(artifact["name"].is_string());
+        assert!(artifact["path"].is_string());
+        assert!(artifact["bytes"].is_number());
+        // All artifacts should have blake3 hashes
+        if let Some(hash) = artifact.get("hash") {
+            assert_eq!(hash["algo"].as_str(), Some("blake3"));
+            assert!(hash["hash"].is_string());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Deep test coverage for context and handoff subsystems across three crates.

### Test Files

| File | Tests | Coverage |
|------|-------|----------|
| \crates/tokmd-context-policy/tests/policy_w73.rs\ | 32 | smart_exclude_reason, is_spine_file, classify_file (all classifications), compute_file_cap, assign_policy |
| \crates/tokmd-types/tests/context_types_w73.rs\ | 17 | Schema constants, InclusionPolicy/FileClassification serde, ContextFileRow serialization, ContextReceipt/HandoffManifest roundtrips, TokenEstimationMeta/TokenAudit |
| \crates/tokmd/tests/context_cli_w73.rs\ | 10 | context --mode list/json on temp dirs, budget enforcement, unlimited budget, handoff --preset minimal, manifest structure, artifact hashes |

### What's Tested

- **Smart excludes**: All 9 lockfile patterns, minified JS/CSS, sourcemaps, regular files returning None
- **Spine detection**: README variants, manifest files (Cargo.toml, package.json, etc.), nested doc paths
- **Classification**: Generated, Vendored, Fixture, Lockfile, Minified, Sourcemap, DataBlob detection; dedup + sort invariant
- **File cap**: Default budget, small budget, explicit hard cap, unlimited budget
- **Inclusion policy**: Full/HeadTail/Skip transitions based on cap and classification
- **Type serde**: snake_case serialization, skip_serializing_if behavior, optional field omission
- **CLI integration**: Temp dir isolation, JSON schema validation, budget enforcement, handoff preset behavior

**Total: 59 tests** (all passing, all deterministic)