### PR TITLE
test(w73): fuzz-like proptest expansion (~40 tests)

### DIFF
--- a/crates/tokmd-format/tests/fuzz_w73.rs
+++ b/crates/tokmd-format/tests/fuzz_w73.rs
@@ -1,0 +1,462 @@
+//! Fuzz-like property tests for tokmd-format.
+//!
+//! These tests exercise formatting functions with large, random input spaces
+//! to ensure no panics occur regardless of input content.
+
+use std::path::PathBuf;
+
+use proptest::prelude::*;
+
+use tokmd_format::{
+    compute_diff_rows, compute_diff_totals, render_diff_md, render_diff_md_with_options,
+    write_export_csv_to, write_export_json_to, write_export_jsonl_to, write_lang_report_to,
+    write_module_report_to, DiffColorMode, DiffRenderOptions,
+};
+use tokmd_settings::{ChildIncludeMode, ChildrenMode, ScanOptions};
+use tokmd_types::{
+    DiffRow, DiffTotals, ExportArgs, ExportData, ExportFormat, FileKind, FileRow, LangArgs,
+    LangReport, LangRow, ModuleArgs, ModuleReport, ModuleRow, RedactMode, TableFormat, Totals,
+};
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_unicode_string() -> impl Strategy<Value = String> {
+    prop::string::string_regex(".{0,100}").unwrap()
+}
+
+fn arb_lang_row_unicode() -> impl Strategy<Value = LangRow> {
+    (
+        arb_unicode_string(),
+        0usize..50_000,
+        0usize..100_000,
+        0usize..500,
+    )
+        .prop_map(|(lang, code, lines, files)| {
+            let files = files.max(1);
+            LangRow {
+                lang,
+                code,
+                lines: lines.max(code),
+                files,
+                bytes: code.saturating_mul(10),
+                tokens: code / 4,
+                avg_lines: lines.checked_div(files).unwrap_or(0),
+            }
+        })
+}
+
+fn arb_lang_report_unicode() -> impl Strategy<Value = LangReport> {
+    prop::collection::vec(arb_lang_row_unicode(), 0..10).prop_map(|rows| {
+        let total = Totals {
+            code: rows.iter().map(|r| r.code).sum(),
+            lines: rows.iter().map(|r| r.lines).sum(),
+            files: rows.iter().map(|r| r.files).sum(),
+            bytes: rows.iter().map(|r| r.bytes).sum(),
+            tokens: rows.iter().map(|r| r.tokens).sum(),
+            avg_lines: 0,
+        };
+        LangReport {
+            rows,
+            total,
+            with_files: false,
+            children: ChildrenMode::Collapse,
+            top: 0,
+        }
+    })
+}
+
+fn arb_module_row_unicode() -> impl Strategy<Value = ModuleRow> {
+    (
+        arb_unicode_string(),
+        0usize..50_000,
+        0usize..100_000,
+        0usize..200,
+    )
+        .prop_map(|(module, code, lines, files)| {
+            let files = files.max(1);
+            ModuleRow {
+                module,
+                code,
+                lines: lines.max(code),
+                files,
+                bytes: code.saturating_mul(10),
+                tokens: code / 4,
+                avg_lines: lines.checked_div(files).unwrap_or(0),
+            }
+        })
+}
+
+fn arb_module_report_unicode() -> impl Strategy<Value = ModuleReport> {
+    prop::collection::vec(arb_module_row_unicode(), 0..8).prop_map(|rows| {
+        let total = Totals {
+            code: rows.iter().map(|r| r.code).sum(),
+            lines: rows.iter().map(|r| r.lines).sum(),
+            files: rows.iter().map(|r| r.files).sum(),
+            bytes: rows.iter().map(|r| r.bytes).sum(),
+            tokens: rows.iter().map(|r| r.tokens).sum(),
+            avg_lines: 0,
+        };
+        ModuleReport {
+            rows,
+            total,
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+            top: 0,
+        }
+    })
+}
+
+fn arb_file_row_unicode() -> impl Strategy<Value = FileRow> {
+    (
+        arb_unicode_string(),
+        arb_unicode_string(),
+        arb_unicode_string(),
+        0usize..10_000,
+        0usize..2_000,
+        0usize..1_000,
+    )
+        .prop_map(|(path, module, lang, code, comments, blanks)| FileRow {
+            path,
+            module,
+            lang,
+            kind: FileKind::Parent,
+            code,
+            comments,
+            blanks,
+            lines: code + comments + blanks,
+            bytes: code.saturating_mul(10),
+            tokens: code / 4,
+        })
+}
+
+fn arb_diff_row() -> impl Strategy<Value = DiffRow> {
+    (
+        arb_unicode_string(),
+        0usize..50_000,
+        0usize..50_000,
+        0usize..50_000,
+        0usize..50_000,
+        0usize..500,
+        0usize..500,
+    )
+        .prop_map(
+            |(lang, old_code, new_code, old_lines, new_lines, old_files, new_files)| DiffRow {
+                lang,
+                old_code,
+                new_code,
+                delta_code: new_code as i64 - old_code as i64,
+                old_lines,
+                new_lines,
+                delta_lines: new_lines as i64 - old_lines as i64,
+                old_files,
+                new_files,
+                delta_files: new_files as i64 - old_files as i64,
+                old_bytes: old_code * 10,
+                new_bytes: new_code * 10,
+                delta_bytes: (new_code as i64 - old_code as i64) * 10,
+                old_tokens: old_code / 4,
+                new_tokens: new_code / 4,
+                delta_tokens: new_code as i64 / 4 - old_code as i64 / 4,
+            },
+        )
+}
+
+fn arb_diff_totals() -> impl Strategy<Value = DiffTotals> {
+    (0usize..100_000, 0usize..100_000).prop_map(|(old_code, new_code)| DiffTotals {
+        old_code,
+        new_code,
+        delta_code: new_code as i64 - old_code as i64,
+        old_lines: old_code * 2,
+        new_lines: new_code * 2,
+        delta_lines: (new_code as i64 - old_code as i64) * 2,
+        old_files: 10,
+        new_files: 12,
+        delta_files: 2,
+        old_bytes: old_code * 10,
+        new_bytes: new_code * 10,
+        delta_bytes: (new_code as i64 - old_code as i64) * 10,
+        old_tokens: old_code / 4,
+        new_tokens: new_code / 4,
+        delta_tokens: new_code as i64 / 4 - old_code as i64 / 4,
+    })
+}
+
+fn default_global() -> ScanOptions {
+    ScanOptions::default()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Markdown rendering never panics with arbitrary Unicode
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_lang_md_no_panic(report in arb_lang_report_unicode()) {
+        let args = LangArgs {
+            paths: vec![PathBuf::from(".")],
+            format: TableFormat::Md,
+            top: 0,
+            files: false,
+            children: ChildrenMode::Collapse,
+        };
+        let mut buf = Vec::new();
+        let _ = write_lang_report_to(&mut buf, &report, &default_global(), &args);
+    }
+
+    #[test]
+    fn fuzz_lang_tsv_no_panic(report in arb_lang_report_unicode()) {
+        let args = LangArgs {
+            paths: vec![PathBuf::from(".")],
+            format: TableFormat::Tsv,
+            top: 0,
+            files: false,
+            children: ChildrenMode::Collapse,
+        };
+        let mut buf = Vec::new();
+        let _ = write_lang_report_to(&mut buf, &report, &default_global(), &args);
+    }
+
+    #[test]
+    fn fuzz_lang_json_no_panic(report in arb_lang_report_unicode()) {
+        let args = LangArgs {
+            paths: vec![PathBuf::from(".")],
+            format: TableFormat::Json,
+            top: 0,
+            files: false,
+            children: ChildrenMode::Collapse,
+        };
+        let mut buf = Vec::new();
+        let _ = write_lang_report_to(&mut buf, &report, &default_global(), &args);
+    }
+
+    #[test]
+    fn fuzz_module_md_no_panic(report in arb_module_report_unicode()) {
+        let args = ModuleArgs {
+            paths: vec![PathBuf::from(".")],
+            format: TableFormat::Md,
+            top: 0,
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+        };
+        let mut buf = Vec::new();
+        let _ = write_module_report_to(&mut buf, &report, &default_global(), &args);
+    }
+
+    #[test]
+    fn fuzz_module_tsv_no_panic(report in arb_module_report_unicode()) {
+        let args = ModuleArgs {
+            paths: vec![PathBuf::from(".")],
+            format: TableFormat::Tsv,
+            top: 0,
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+        };
+        let mut buf = Vec::new();
+        let _ = write_module_report_to(&mut buf, &report, &default_global(), &args);
+    }
+
+    #[test]
+    fn fuzz_module_json_no_panic(report in arb_module_report_unicode()) {
+        let args = ModuleArgs {
+            paths: vec![PathBuf::from(".")],
+            format: TableFormat::Json,
+            top: 0,
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::Separate,
+        };
+        let mut buf = Vec::new();
+        let _ = write_module_report_to(&mut buf, &report, &default_global(), &args);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. TSV with tabs/newlines in language names
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_tsv_with_tab_newline_names(
+        name in "[a-z\t\n\r]{1,30}",
+        code in 0usize..5_000,
+    ) {
+        let report = LangReport {
+            rows: vec![LangRow {
+                lang: name,
+                code,
+                lines: code + 10,
+                files: 1,
+                bytes: code * 10,
+                tokens: code / 4,
+                avg_lines: code + 10,
+            }],
+            total: Totals {
+                code,
+                lines: code + 10,
+                files: 1,
+                bytes: code * 10,
+                tokens: code / 4,
+                avg_lines: code + 10,
+            },
+            with_files: false,
+            children: ChildrenMode::Collapse,
+            top: 0,
+        };
+        let args = LangArgs {
+            paths: vec![PathBuf::from(".")],
+            format: TableFormat::Tsv,
+            top: 0,
+            files: false,
+            children: ChildrenMode::Collapse,
+        };
+        let mut buf = Vec::new();
+        let _ = write_lang_report_to(&mut buf, &report, &default_global(), &args);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Export formats never panic with random Unicode
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_export_csv_no_panic(rows in prop::collection::vec(arb_file_row_unicode(), 0..8)) {
+        let data = ExportData {
+            rows,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+        };
+        let args = ExportArgs {
+            paths: vec![PathBuf::from(".")],
+            format: ExportFormat::Csv,
+            output: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+            min_code: 0,
+            max_rows: 0,
+            redact: RedactMode::None,
+            meta: false,
+            strip_prefix: None,
+        };
+        let mut buf = Vec::new();
+        let _ = write_export_csv_to(&mut buf, &data, &args);
+    }
+
+    #[test]
+    fn fuzz_export_json_no_panic(rows in prop::collection::vec(arb_file_row_unicode(), 0..8)) {
+        let data = ExportData {
+            rows,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+        };
+        let args = ExportArgs {
+            paths: vec![PathBuf::from(".")],
+            format: ExportFormat::Json,
+            output: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+            min_code: 0,
+            max_rows: 0,
+            redact: RedactMode::None,
+            meta: false,
+            strip_prefix: None,
+        };
+        let mut buf = Vec::new();
+        let _ = write_export_json_to(&mut buf, &data, &default_global(), &args);
+    }
+
+    #[test]
+    fn fuzz_export_jsonl_no_panic(rows in prop::collection::vec(arb_file_row_unicode(), 0..8)) {
+        let data = ExportData {
+            rows,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+        };
+        let args = ExportArgs {
+            paths: vec![PathBuf::from(".")],
+            format: ExportFormat::Jsonl,
+            output: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+            min_code: 0,
+            max_rows: 0,
+            redact: RedactMode::None,
+            meta: false,
+            strip_prefix: None,
+        };
+        let mut buf = Vec::new();
+        let _ = write_export_jsonl_to(&mut buf, &data, &default_global(), &args);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Diff rendering never panics with arbitrary input
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_diff_md_no_panic(
+        from in arb_unicode_string(),
+        to in arb_unicode_string(),
+        rows in prop::collection::vec(arb_diff_row(), 0..10),
+        totals in arb_diff_totals(),
+    ) {
+        let _ = render_diff_md(&from, &to, &rows, &totals);
+    }
+
+    #[test]
+    fn fuzz_diff_md_compact_no_panic(
+        from in arb_unicode_string(),
+        to in arb_unicode_string(),
+        rows in prop::collection::vec(arb_diff_row(), 0..10),
+        totals in arb_diff_totals(),
+    ) {
+        let opts = DiffRenderOptions {
+            compact: true,
+            color: DiffColorMode::Off,
+        };
+        let _ = render_diff_md_with_options(&from, &to, &rows, &totals, opts);
+    }
+
+    #[test]
+    fn fuzz_diff_md_ansi_no_panic(
+        from in arb_unicode_string(),
+        to in arb_unicode_string(),
+        rows in prop::collection::vec(arb_diff_row(), 0..10),
+        totals in arb_diff_totals(),
+    ) {
+        let opts = DiffRenderOptions {
+            compact: false,
+            color: DiffColorMode::Ansi,
+        };
+        let _ = render_diff_md_with_options(&from, &to, &rows, &totals, opts);
+    }
+
+    #[test]
+    fn fuzz_compute_diff_rows_no_panic(
+        from in arb_lang_report_unicode(),
+        to in arb_lang_report_unicode(),
+    ) {
+        let rows = compute_diff_rows(&from, &to);
+        let _ = compute_diff_totals(&rows);
+    }
+}

--- a/crates/tokmd-gate/tests/fuzz_w73.rs
+++ b/crates/tokmd-gate/tests/fuzz_w73.rs
@@ -1,0 +1,386 @@
+//! Fuzz-like property tests for tokmd-gate.
+//!
+//! These tests exercise policy evaluation, JSON pointer resolution, and rule
+//! matching with large random input spaces to ensure no panics occur.
+
+use proptest::prelude::*;
+use serde_json::{Value, json};
+use tokmd_gate::{
+    PolicyConfig, PolicyRule, RatchetConfig, RatchetRule, RuleLevel, RuleOperator, evaluate_policy,
+    evaluate_ratchet_policy, resolve_pointer,
+};
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_json_value_shallow() -> impl Strategy<Value = Value> {
+    prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(|b| json!(b)),
+        any::<i64>().prop_map(|n| json!(n)),
+        any::<f64>()
+            .prop_filter("finite", |f| f.is_finite())
+            .prop_map(|n| json!(n)),
+        ".*".prop_map(|s| json!(s)),
+    ]
+}
+
+fn arb_json_value_nested() -> impl Strategy<Value = Value> {
+    arb_json_value_shallow().prop_recursive(4, 64, 8, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..8).prop_map(Value::Array),
+            prop::collection::btree_map("[a-zA-Z_]{1,8}", inner, 0..8)
+                .prop_map(|m| Value::Object(m.into_iter().collect())),
+        ]
+    })
+}
+
+fn arb_pointer_segment() -> impl Strategy<Value = String> {
+    prop_oneof![
+        "[a-zA-Z_]{1,10}",
+        "0|[1-9][0-9]{0,3}",
+        "~0|~1",
+        ".*".prop_map(|s: String| s.chars().take(10).collect()),
+    ]
+}
+
+fn arb_json_pointer() -> impl Strategy<Value = String> {
+    prop::collection::vec(arb_pointer_segment(), 0..6)
+        .prop_map(|segments| {
+            if segments.is_empty() {
+                String::new()
+            } else {
+                format!("/{}", segments.join("/"))
+            }
+        })
+}
+
+fn arb_operator() -> impl Strategy<Value = RuleOperator> {
+    prop_oneof![
+        Just(RuleOperator::Gt),
+        Just(RuleOperator::Gte),
+        Just(RuleOperator::Lt),
+        Just(RuleOperator::Lte),
+        Just(RuleOperator::Eq),
+        Just(RuleOperator::Ne),
+        Just(RuleOperator::In),
+        Just(RuleOperator::Contains),
+        Just(RuleOperator::Exists),
+    ]
+}
+
+fn arb_level() -> impl Strategy<Value = RuleLevel> {
+    prop_oneof![Just(RuleLevel::Error), Just(RuleLevel::Warn)]
+}
+
+fn arb_policy_rule() -> impl Strategy<Value = PolicyRule> {
+    (
+        "[a-z_]{1,15}",
+        arb_json_pointer(),
+        arb_operator(),
+        arb_json_value_shallow(),
+        arb_level(),
+        any::<bool>(),
+    )
+        .prop_map(|(name, pointer, op, value, level, negate)| PolicyRule {
+            name,
+            pointer,
+            op,
+            value: Some(value),
+            values: None,
+            negate,
+            level,
+            message: None,
+        })
+}
+
+fn arb_policy_config() -> impl Strategy<Value = PolicyConfig> {
+    (
+        prop::collection::vec(arb_policy_rule(), 0..8),
+        any::<bool>(),
+        any::<bool>(),
+    )
+        .prop_map(|(rules, fail_fast, allow_missing)| PolicyConfig {
+            rules,
+            fail_fast,
+            allow_missing,
+        })
+}
+
+fn arb_ratchet_rule() -> impl Strategy<Value = RatchetRule> {
+    (
+        arb_json_pointer(),
+        prop::option::of(0.0f64..1000.0),
+        prop::option::of(any::<f64>().prop_filter("finite", |f| f.is_finite())),
+        arb_level(),
+    )
+        .prop_map(|(pointer, max_increase_pct, max_value, level)| RatchetRule {
+            pointer,
+            max_increase_pct,
+            max_value,
+            level,
+            description: None,
+        })
+}
+
+fn arb_ratchet_config() -> impl Strategy<Value = RatchetConfig> {
+    (
+        prop::collection::vec(arb_ratchet_rule(), 0..6),
+        any::<bool>(),
+        any::<bool>(),
+        any::<bool>(),
+    )
+        .prop_map(
+            |(rules, fail_fast, allow_missing_baseline, allow_missing_current)| RatchetConfig {
+                rules,
+                fail_fast,
+                allow_missing_baseline,
+                allow_missing_current,
+            },
+        )
+}
+
+// ---------------------------------------------------------------------------
+// 1. JSON pointer resolution never panics
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn fuzz_resolve_pointer_no_panic(
+        doc in arb_json_value_nested(),
+        pointer in arb_json_pointer(),
+    ) {
+        let _ = resolve_pointer(&doc, &pointer);
+    }
+
+    #[test]
+    fn fuzz_resolve_pointer_arbitrary_string(
+        doc in arb_json_value_nested(),
+        pointer in ".*",
+    ) {
+        let _ = resolve_pointer(&doc, &pointer);
+    }
+
+    #[test]
+    fn fuzz_resolve_pointer_empty_always_returns_root(doc in arb_json_value_nested()) {
+        let result = resolve_pointer(&doc, "");
+        prop_assert_eq!(result, Some(&doc));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Policy evaluation never panics
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_evaluate_policy_no_panic(
+        receipt in arb_json_value_nested(),
+        policy in arb_policy_config(),
+    ) {
+        let _ = evaluate_policy(&receipt, &policy);
+    }
+
+    #[test]
+    fn fuzz_evaluate_policy_result_consistent(
+        receipt in arb_json_value_nested(),
+        policy in arb_policy_config(),
+    ) {
+        let result = evaluate_policy(&receipt, &policy);
+        // errors + warnings must equal total rule results
+        let error_count = result.rule_results.iter().filter(|r| !r.passed && r.level == RuleLevel::Error).count();
+        let warn_count = result.rule_results.iter().filter(|r| !r.passed && r.level == RuleLevel::Warn).count();
+        prop_assert_eq!(result.errors, error_count);
+        prop_assert_eq!(result.warnings, warn_count);
+    }
+
+    #[test]
+    fn fuzz_evaluate_empty_policy_always_passes(receipt in arb_json_value_nested()) {
+        let policy = PolicyConfig::default();
+        let result = evaluate_policy(&receipt, &policy);
+        prop_assert!(result.passed);
+        prop_assert_eq!(result.errors, 0);
+        prop_assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn fuzz_evaluate_policy_warn_never_fails(receipt in arb_json_value_nested()) {
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "warn_rule".into(),
+                pointer: "/nonexistent".into(),
+                op: RuleOperator::Exists,
+                value: None,
+                values: None,
+                negate: false,
+                level: RuleLevel::Warn,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: true,
+        };
+        let result = evaluate_policy(&receipt, &policy);
+        // Warn-level rules never cause overall failure
+        prop_assert!(result.passed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Ratchet evaluation never panics
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_ratchet_no_panic(
+        baseline in arb_json_value_nested(),
+        current in arb_json_value_nested(),
+        config in arb_ratchet_config(),
+    ) {
+        let _ = evaluate_ratchet_policy(&config, &baseline, &current);
+    }
+
+    #[test]
+    fn fuzz_ratchet_identical_inputs(
+        doc in arb_json_value_nested(),
+        config in arb_ratchet_config(),
+    ) {
+        let result = evaluate_ratchet_policy(&config, &doc, &doc);
+        // Same baseline and current should never regress on percentage increase
+        // (unless max_value is exceeded, which is structural)
+        let _ = result;
+    }
+
+    #[test]
+    fn fuzz_ratchet_empty_config_passes(
+        baseline in arb_json_value_nested(),
+        current in arb_json_value_nested(),
+    ) {
+        let config = RatchetConfig {
+            rules: vec![],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        };
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        prop_assert!(result.passed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Rule matching with random numbers
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn fuzz_numeric_rule_no_panic(
+        actual in any::<i64>(),
+        threshold in any::<i64>(),
+        op in arb_operator(),
+        level in arb_level(),
+    ) {
+        let receipt = json!({"value": actual});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "numeric_fuzz".into(),
+                pointer: "/value".into(),
+                op,
+                value: Some(json!(threshold)),
+                values: None,
+                negate: false,
+                level,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+        let _ = evaluate_policy(&receipt, &policy);
+    }
+
+    #[test]
+    fn fuzz_negated_rule_no_panic(
+        actual in any::<i64>(),
+        threshold in any::<i64>(),
+        op in arb_operator(),
+    ) {
+        let receipt = json!({"v": actual});
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "negated_fuzz".into(),
+                pointer: "/v".into(),
+                op,
+                value: Some(json!(threshold)),
+                values: None,
+                negate: true,
+                level: RuleLevel::Error,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+        let _ = evaluate_policy(&receipt, &policy);
+    }
+
+    #[test]
+    fn fuzz_in_operator_no_panic(
+        actual in any::<i64>(),
+        candidates in prop::collection::vec(any::<i64>(), 0..10),
+    ) {
+        let receipt = json!({"v": actual});
+        let values: Vec<Value> = candidates.into_iter().map(|c| json!(c)).collect();
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "in_fuzz".into(),
+                pointer: "/v".into(),
+                op: RuleOperator::In,
+                value: None,
+                values: Some(values),
+                negate: false,
+                level: RuleLevel::Error,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: false,
+        };
+        let _ = evaluate_policy(&receipt, &policy);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Deeply nested JSON never causes stack overflow
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_deeply_nested_receipt(depth in 1usize..50) {
+        let mut doc = json!(42);
+        for i in 0..depth {
+            doc = json!({ format!("k{}", i): doc });
+        }
+        let policy = PolicyConfig {
+            rules: vec![PolicyRule {
+                name: "deep".into(),
+                pointer: "/k0".into(),
+                op: RuleOperator::Exists,
+                value: None,
+                values: None,
+                negate: false,
+                level: RuleLevel::Error,
+                message: None,
+            }],
+            fail_fast: false,
+            allow_missing: true,
+        };
+        let _ = evaluate_policy(&doc, &policy);
+    }
+}

--- a/crates/tokmd-redact/tests/fuzz_w73.rs
+++ b/crates/tokmd-redact/tests/fuzz_w73.rs
@@ -1,0 +1,171 @@
+//! Fuzz-like property tests for tokmd-redact.
+//!
+//! These tests exercise hashing and redaction functions with large random
+//! input spaces to ensure no panics and that structural invariants hold.
+
+use proptest::prelude::*;
+use tokmd_redact::{redact_path, short_hash};
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_arbitrary_bytes_as_str() -> impl Strategy<Value = String> {
+    prop::string::string_regex(".{0,200}").unwrap()
+}
+
+fn arb_path_like() -> impl Strategy<Value = String> {
+    prop::collection::vec("[^\0]{0,30}", 1..=8).prop_map(|parts| parts.join("/"))
+}
+
+fn arb_path_with_mixed_seps() -> impl Strategy<Value = String> {
+    prop::collection::vec("[a-zA-Z0-9_.\\-]{1,15}", 1..=6).prop_map(|parts| {
+        parts
+            .iter()
+            .enumerate()
+            .map(|(i, p)| {
+                if i == 0 {
+                    p.clone()
+                } else if i % 2 == 0 {
+                    format!("/{}", p)
+                } else {
+                    format!("\\{}", p)
+                }
+            })
+            .collect::<String>()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// 1. short_hash never panics on any input
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn fuzz_short_hash_never_panics(input in arb_arbitrary_bytes_as_str()) {
+        let _ = short_hash(&input);
+    }
+
+    #[test]
+    fn fuzz_short_hash_never_panics_pathlike(input in arb_path_like()) {
+        let _ = short_hash(&input);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Hash output is always exactly 16 hex characters
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn fuzz_short_hash_length_always_16(input in arb_arbitrary_bytes_as_str()) {
+        let hash = short_hash(&input);
+        prop_assert_eq!(hash.len(), 16, "Expected 16 chars, got {} for input {:?}", hash.len(), input);
+    }
+
+    #[test]
+    fn fuzz_short_hash_all_hex(input in arb_arbitrary_bytes_as_str()) {
+        let hash = short_hash(&input);
+        prop_assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "Hash contains non-hex chars: {:?}",
+            hash
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. redact_path never panics on any input
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn fuzz_redact_path_never_panics(input in arb_arbitrary_bytes_as_str()) {
+        let _ = redact_path(&input);
+    }
+
+    #[test]
+    fn fuzz_redact_path_never_panics_pathlike(input in arb_path_like()) {
+        let _ = redact_path(&input);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Redacted path length invariants
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn fuzz_redact_path_min_length_16(input in arb_arbitrary_bytes_as_str()) {
+        let redacted = redact_path(&input);
+        prop_assert!(
+            redacted.len() >= 16,
+            "Redacted path too short: {} (len={}) for input {:?}",
+            redacted,
+            redacted.len(),
+            input
+        );
+    }
+
+    #[test]
+    fn fuzz_redact_path_preserves_extension(
+        stem in "[a-zA-Z0-9_]{1,30}",
+        ext in "[a-zA-Z]{1,8}",
+    ) {
+        let path = format!("{}.{}", stem, ext);
+        let redacted = redact_path(&path);
+        prop_assert!(
+            redacted.ends_with(&format!(".{}", ext)),
+            "Expected extension .{} in {:?} for path {:?}",
+            ext,
+            redacted,
+            path
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Determinism: same input always produces same output
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_short_hash_deterministic(input in arb_arbitrary_bytes_as_str()) {
+        prop_assert_eq!(short_hash(&input), short_hash(&input));
+    }
+
+    #[test]
+    fn fuzz_redact_path_deterministic(input in arb_arbitrary_bytes_as_str()) {
+        prop_assert_eq!(redact_path(&input), redact_path(&input));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Cross-platform normalization: backslash == forward slash
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn fuzz_separator_normalization(path in arb_path_with_mixed_seps()) {
+        let canonical = path.replace('\\', "/");
+        prop_assert_eq!(
+            short_hash(&path),
+            short_hash(&canonical),
+            "Hash differs for {:?} vs {:?}",
+            path,
+            canonical
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add fuzz-like property tests using proptest with large input spaces (256-512 cases) across three crates to simulate libfuzzer-style coverage on stable Rust.

### New test files

| File | Tests | Focus |
|------|-------|-------|
| \crates/tokmd-format/tests/fuzz_w73.rs\ | 14 | Random Unicode in Markdown/TSV/JSON rendering, diff rendering, export formats |
| \crates/tokmd-gate/tests/fuzz_w73.rs\ | 14 | JSON pointer with random paths, policy evaluation with arbitrary JSON, ratchet with nested structures, numeric rule matching |
| \crates/tokmd-redact/tests/fuzz_w73.rs\ | 11 | Hashing with arbitrary strings, hex output validation, length invariants, extension preservation, separator normalization |

### Primary invariant
No panics regardless of input content or structure.

### Key patterns
- \proptest\ with 256-512 cases per test (vs typical 16-32)
- Recursive JSON value generation for deeply nested structures
- Arbitrary Unicode strings for format rendering
- Full \i64\ range for numeric rule matching
- Mixed path separators for cross-platform normalization