### PR TITLE
test(w73): error handling + edge case tests (~40 tests)

### DIFF
--- a/crates/tokmd-config/tests/error_edge_w73.rs
+++ b/crates/tokmd-config/tests/error_edge_w73.rs
@@ -51,16 +51,12 @@ fn parse_toml_with_duplicate_keys_returns_error() {
 fn parse_toml_with_unknown_top_level_section_succeeds() {
     // serde(default) + no deny_unknown_fields means unknown sections are ignored
     let config = TomlConfig::parse("[unknown_section]\nfoo = 42");
-    // This should either succeed (fields ignored) or fail — document actual behavior
-    // Since TomlConfig uses serde(default) without deny_unknown_fields, unknown
-    // top-level keys should cause an error because the struct doesn't have that field
-    // unless serde flatten is used. Let's verify the actual behavior:
+    // Document actual behavior: either ignored or error
     if let Ok(c) = config {
         // If it succeeds, all known fields should be at defaults
         assert_eq!(c.scan.hidden, None);
         assert_eq!(c.module.depth, None);
     }
-    // Either outcome documents the behavior — the test passes regardless
 }
 
 #[test]
@@ -78,10 +74,8 @@ fn parse_toml_with_extra_nested_table_in_known_section() {
     // serde(default) without deny_unknown_fields: unknown nested tables may be
     // silently ignored. Document actual behavior:
     if let Ok(c) = result {
-        // All known fields should be at defaults
         assert_eq!(c.scan.hidden, None);
     }
-    // Either outcome is acceptable — test documents the behavior
 }
 
 // =============================================================================

--- a/crates/tokmd-content/tests/error_edge_w73.rs
+++ b/crates/tokmd-content/tests/error_edge_w73.rs
@@ -126,14 +126,16 @@ fn read_lines_with_very_long_line_respects_byte_limit() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("long_line.txt");
     let mut f = File::create(&path).unwrap();
-    // Write a single 10,000-character line
     let long_line = "x".repeat(10_000);
     writeln!(f, "{}", long_line).unwrap();
     writeln!(f, "short").unwrap();
 
-    // Byte limit should kick in after the first line
     let lines = read_lines(&path, 100, 5000).unwrap();
-    assert_eq!(lines.len(), 1, "byte limit should stop after first long line");
+    assert_eq!(
+        lines.len(),
+        1,
+        "byte limit should stop after first long line"
+    );
     assert_eq!(lines[0].len(), 10_000);
 }
 
@@ -181,7 +183,6 @@ fn entropy_empty_input_returns_zero() {
 
 #[test]
 fn entropy_single_byte_returns_zero() {
-    // Only one byte value present — zero entropy
     assert_eq!(entropy_bits_per_byte(&[42]), 0.0);
 }
 
@@ -189,12 +190,14 @@ fn entropy_single_byte_returns_zero() {
 fn entropy_all_same_bytes_returns_zero() {
     let data = vec![0xAB; 10_000];
     let e = entropy_bits_per_byte(&data);
-    assert!(e.abs() < 1e-6, "uniform bytes should have ~0 entropy, got {e}");
+    assert!(
+        e.abs() < 1e-6,
+        "uniform bytes should have ~0 entropy, got {e}"
+    );
 }
 
 #[test]
 fn entropy_maximum_for_uniform_256_values() {
-    // All 256 byte values equally represented -> 8 bits per byte
     let data: Vec<u8> = (0..=255).cycle().take(256 * 100).collect();
     let e = entropy_bits_per_byte(&data);
     assert!(

--- a/crates/tokmd-scan/tests/error_edge_w73.rs
+++ b/crates/tokmd-scan/tests/error_edge_w73.rs
@@ -30,7 +30,7 @@ fn default_options() -> ScanOptions {
 fn scan_nonexistent_directory_error_message_includes_path() {
     let dir = tempfile::tempdir().unwrap();
     let missing = dir.path().join("does_not_exist_w73");
-    let result = scan(&[missing.clone()], &default_options());
+    let result = scan(std::slice::from_ref(&missing), &default_options());
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -53,8 +53,7 @@ fn scan_empty_directory_returns_empty_languages() {
     let result = scan(&[dir.path().to_path_buf()], &default_options());
     assert!(result.is_ok());
     let langs = result.unwrap();
-    // Empty dir has no source files — all language entries should have 0 code
-    let total_code: usize = langs.iter().map(|(_, lang)| lang.code).sum();
+    let total_code: usize = langs.values().map(|lang| lang.code).sum();
     assert_eq!(total_code, 0, "empty dir should yield zero code lines");
 }
 
@@ -71,7 +70,7 @@ fn scan_hidden_only_dir_without_hidden_flag_returns_no_code() {
 
     let opts = default_options(); // hidden = false
     let result = scan(&[dir.path().to_path_buf()], &opts).unwrap();
-    let total_code: usize = result.iter().map(|(_, lang)| lang.code).sum();
+    let total_code: usize = result.values().map(|lang| lang.code).sum();
     assert_eq!(
         total_code, 0,
         "hidden files should not be counted without --hidden"
@@ -88,7 +87,7 @@ fn scan_hidden_only_dir_with_hidden_flag_finds_code() {
     let mut opts = default_options();
     opts.hidden = true;
     let result = scan(&[dir.path().to_path_buf()], &opts).unwrap();
-    let total_code: usize = result.iter().map(|(_, lang)| lang.code).sum();
+    let total_code: usize = result.values().map(|lang| lang.code).sum();
     assert!(
         total_code > 0,
         "hidden files should be counted with --hidden"
@@ -133,7 +132,6 @@ fn scan_with_exclude_pattern_filters_matching_files() {
         ..default_options()
     };
     let result = scan(&[dir.path().to_path_buf()], &opts).unwrap();
-    // At most one Rust file should be found (keep.rs)
     if let Some(rust) = result.get(&tokei::LanguageType::Rust) {
         assert!(
             rust.reports.len() <= 1,


### PR DESCRIPTION
Add error handling and edge case integration tests for three crates (54 total tests).

**tokmd-config** (16 tests): invalid TOML, unknown fields, non-existent paths, empty config, explicit defaults, UserConfig edge cases.

**tokmd-scan** (9 tests): non-existent dir, empty dir, hidden-only dir, conflicting options, exclude patterns, empty paths panic, ConfigMode variations.

**tokmd-content** (29 tests): empty files, binary files, large lines, entropy boundaries, non-existent files, tag counting edges, complexity on non-code.