### PR TITLE
test(w74): analysis enricher unit tests (~50 tests)

### DIFF
--- a/crates/tokmd-analysis-complexity/tests/complexity_w74.rs
+++ b/crates/tokmd-analysis-complexity/tests/complexity_w74.rs
@@ -1,0 +1,159 @@
+//! W74 – Unit tests for tokmd-analysis-complexity enricher.
+
+use tokmd_analysis_complexity::generate_complexity_histogram;
+use tokmd_analysis_types::{ComplexityRisk, FileComplexity};
+
+// ---------------------------------------------------------------------------
+// Helper: build a FileComplexity with sensible defaults
+// ---------------------------------------------------------------------------
+fn fc(path: &str, cyclomatic: usize) -> FileComplexity {
+    FileComplexity {
+        path: path.to_string(),
+        module: "mod".to_string(),
+        function_count: 1,
+        max_function_length: 10,
+        cyclomatic_complexity: cyclomatic,
+        cognitive_complexity: None,
+        max_nesting: None,
+        risk_level: ComplexityRisk::Low,
+        functions: None,
+    }
+}
+
+// ── generate_complexity_histogram ──────────────────────────────────────────
+
+#[test]
+fn histogram_empty_input() {
+    let hist = generate_complexity_histogram(&[], 5);
+    assert_eq!(hist.total, 0);
+    assert!(hist.counts.iter().all(|&c| c == 0));
+}
+
+#[test]
+fn histogram_single_file_low_complexity() {
+    let files = vec![fc("a.rs", 2)];
+    let hist = generate_complexity_histogram(&files, 5);
+    assert_eq!(hist.total, 1);
+    // Bucket 0 (0-4) should have 1
+    assert_eq!(hist.counts[0], 1);
+    assert_eq!(hist.counts[1..].iter().sum::<u32>(), 0);
+}
+
+#[test]
+fn histogram_multiple_buckets() {
+    let files = vec![
+        fc("a.rs", 3),  // bucket 0 (0-4)
+        fc("b.rs", 7),  // bucket 1 (5-9)
+        fc("c.rs", 12), // bucket 2 (10-14)
+        fc("d.rs", 18), // bucket 3 (15-19)
+        fc("e.rs", 22), // bucket 4 (20-24)
+        fc("f.rs", 28), // bucket 5 (25-29)
+        fc("g.rs", 35), // bucket 6 (30+)
+    ];
+    let hist = generate_complexity_histogram(&files, 5);
+    assert_eq!(hist.total, 7);
+    for &count in &hist.counts {
+        assert_eq!(count, 1);
+    }
+}
+
+#[test]
+fn histogram_high_complexity_clamped_to_last_bucket() {
+    let files = vec![fc("x.rs", 999)];
+    let hist = generate_complexity_histogram(&files, 5);
+    assert_eq!(hist.total, 1);
+    // Should land in the last bucket (30+)
+    assert_eq!(*hist.counts.last().unwrap(), 1);
+}
+
+#[test]
+fn histogram_bucket_labels_are_multiples_of_bucket_size() {
+    let hist = generate_complexity_histogram(&[], 5);
+    assert_eq!(hist.buckets, vec![0, 5, 10, 15, 20, 25, 30]);
+}
+
+#[test]
+fn histogram_with_bucket_size_ten() {
+    let files = vec![fc("a.rs", 15)];
+    let hist = generate_complexity_histogram(&files, 10);
+    // bucket index = 15/10 = 1
+    assert_eq!(hist.counts[1], 1);
+    assert_eq!(hist.total, 1);
+}
+
+#[test]
+fn histogram_all_files_in_same_bucket() {
+    let files: Vec<FileComplexity> = (0..5).map(|i| fc(&format!("{i}.rs"), 2)).collect();
+    let hist = generate_complexity_histogram(&files, 5);
+    assert_eq!(hist.counts[0], 5);
+    assert_eq!(hist.total, 5);
+}
+
+// ── FileComplexity defaults / risk levels ─────────────────────────────────
+
+#[test]
+fn file_complexity_default_optional_fields() {
+    let f = fc("a.rs", 1);
+    assert!(f.cognitive_complexity.is_none());
+    assert!(f.max_nesting.is_none());
+    assert!(f.functions.is_none());
+}
+
+#[test]
+fn risk_enum_variants_exist() {
+    // Ensure all four risk levels are representable
+    let levels = [
+        ComplexityRisk::Low,
+        ComplexityRisk::Moderate,
+        ComplexityRisk::High,
+        ComplexityRisk::Critical,
+    ];
+    assert_eq!(levels.len(), 4);
+}
+
+#[test]
+fn histogram_deterministic_across_calls() {
+    let files = vec![fc("a.rs", 5), fc("b.rs", 15), fc("c.rs", 25)];
+    let h1 = generate_complexity_histogram(&files, 5);
+    let h2 = generate_complexity_histogram(&files, 5);
+    assert_eq!(h1.counts, h2.counts);
+    assert_eq!(h1.buckets, h2.buckets);
+}
+
+#[test]
+fn histogram_boundary_value_at_bucket_edge() {
+    // Value exactly at bucket boundary
+    let files = vec![fc("a.rs", 5)];
+    let hist = generate_complexity_histogram(&files, 5);
+    // 5 / 5 = 1 → bucket 1
+    assert_eq!(hist.counts[1], 1);
+}
+
+#[test]
+fn histogram_zero_complexity_in_first_bucket() {
+    let files = vec![fc("a.rs", 0)];
+    let hist = generate_complexity_histogram(&files, 5);
+    assert_eq!(hist.counts[0], 1);
+}
+
+#[test]
+fn histogram_counts_sum_equals_total() {
+    let files = vec![fc("a.rs", 3), fc("b.rs", 8), fc("c.rs", 50)];
+    let hist = generate_complexity_histogram(&files, 5);
+    let sum: u32 = hist.counts.iter().sum();
+    assert_eq!(sum, hist.total);
+}
+
+#[test]
+fn histogram_seven_buckets() {
+    let hist = generate_complexity_histogram(&[], 5);
+    assert_eq!(hist.buckets.len(), 7);
+    assert_eq!(hist.counts.len(), 7);
+}
+
+#[test]
+fn file_complexity_path_preserved() {
+    let f = fc("src/deep/nested/file.rs", 10);
+    assert_eq!(f.path, "src/deep/nested/file.rs");
+    assert_eq!(f.module, "mod");
+}

--- a/crates/tokmd-analysis-halstead/tests/halstead_w74.rs
+++ b/crates/tokmd-analysis-halstead/tests/halstead_w74.rs
@@ -1,0 +1,188 @@
+//! W74 – Unit tests for tokmd-analysis-halstead enricher.
+
+use tokmd_analysis_halstead::{
+    is_halstead_lang, operators_for_lang, round_f64, tokenize_for_halstead,
+};
+
+// ── is_halstead_lang ──────────────────────────────────────────────────────
+
+#[test]
+fn supported_languages() {
+    for lang in &[
+        "rust",
+        "javascript",
+        "typescript",
+        "python",
+        "go",
+        "c",
+        "c++",
+        "java",
+        "c#",
+        "php",
+        "ruby",
+    ] {
+        assert!(is_halstead_lang(lang), "expected {lang} to be supported");
+    }
+}
+
+#[test]
+fn unsupported_languages() {
+    assert!(!is_halstead_lang("markdown"));
+    assert!(!is_halstead_lang("json"));
+    assert!(!is_halstead_lang("toml"));
+    assert!(!is_halstead_lang("yaml"));
+}
+
+#[test]
+fn case_insensitive_lang_check() {
+    assert!(is_halstead_lang("Rust"));
+    assert!(is_halstead_lang("PYTHON"));
+    assert!(is_halstead_lang("JavaScript"));
+}
+
+// ── operators_for_lang ────────────────────────────────────────────────────
+
+#[test]
+fn rust_operators_non_empty() {
+    let ops = operators_for_lang("rust");
+    assert!(!ops.is_empty());
+    assert!(ops.contains(&"fn"));
+    assert!(ops.contains(&"if"));
+    assert!(ops.contains(&"match"));
+}
+
+#[test]
+fn unknown_lang_has_no_operators() {
+    let ops = operators_for_lang("brainfuck");
+    assert!(ops.is_empty());
+}
+
+#[test]
+fn python_operators_include_def() {
+    let ops = operators_for_lang("python");
+    assert!(ops.contains(&"def"));
+    assert!(ops.contains(&"class"));
+    assert!(ops.contains(&"lambda"));
+}
+
+// ── tokenize_for_halstead ─────────────────────────────────────────────────
+
+#[test]
+fn tokenize_empty_input() {
+    let counts = tokenize_for_halstead("", "rust");
+    assert_eq!(counts.total_operators, 0);
+    assert_eq!(counts.total_operands, 0);
+    assert!(counts.operators.is_empty());
+    assert!(counts.operands.is_empty());
+}
+
+#[test]
+fn tokenize_comment_only() {
+    let code = "// this is a comment\n// another comment\n";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert_eq!(counts.total_operators, 0);
+    assert_eq!(counts.total_operands, 0);
+}
+
+#[test]
+fn tokenize_simple_rust_function() {
+    let code = "fn add(a: i32, b: i32) -> i32 { a + b }";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert!(counts.total_operators > 0, "should have operators");
+    assert!(counts.total_operands > 0, "should have operands");
+    assert!(counts.operators.contains_key("fn"));
+}
+
+#[test]
+fn tokenize_python_function() {
+    let code = "def add(a, b):\n    return a + b\n";
+    let counts = tokenize_for_halstead(code, "python");
+    assert!(counts.operators.contains_key("def"));
+    assert!(counts.operators.contains_key("return"));
+    assert!(counts.operators.contains_key("+"));
+}
+
+#[test]
+fn tokenize_string_literals_counted_as_operand() {
+    let code = r#"let msg = "hello world";"#;
+    let counts = tokenize_for_halstead(code, "rust");
+    assert!(counts.operands.contains("<string>"));
+}
+
+#[test]
+fn tokenize_multiple_operators_counted() {
+    let code = "if x > 0 && y < 10 || z == 5 { }";
+    let counts = tokenize_for_halstead(code, "rust");
+    assert!(counts.operators.contains_key("if"));
+    assert!(counts.operators.contains_key("&&"));
+    assert!(counts.operators.contains_key("||"));
+    assert!(counts.operators.contains_key("=="));
+}
+
+// ── Halstead formula verification ─────────────────────────────────────────
+
+#[test]
+fn vocabulary_is_distinct_operators_plus_operands() {
+    let code = "fn add(a: i32, b: i32) -> i32 { a + b }";
+    let counts = tokenize_for_halstead(code, "rust");
+    let n1 = counts.operators.len();
+    let n2 = counts.operands.len();
+    let vocab = n1 + n2;
+    assert!(vocab > 0);
+    assert_eq!(vocab, n1 + n2);
+}
+
+#[test]
+fn length_is_total_operators_plus_operands() {
+    let code = "let x = 1; let y = 2;";
+    let counts = tokenize_for_halstead(code, "rust");
+    let length = counts.total_operators + counts.total_operands;
+    assert!(length > 0);
+}
+
+#[test]
+fn volume_formula_correctness() {
+    // Manual computation: vocab=5, length=10 → volume = 10 * log2(5) ≈ 23.22
+    let vocab = 5usize;
+    let length = 10usize;
+    let volume = length as f64 * (vocab as f64).log2();
+    assert!((volume - 23.22).abs() < 0.1);
+}
+
+#[test]
+fn difficulty_formula_correctness() {
+    // n1=2, n2=3, N2=6 → difficulty = (2/2) * (6/3) = 2.0
+    let n1 = 2usize;
+    let n2 = 3usize;
+    let total_opds = 6usize;
+    let difficulty = (n1 as f64 / 2.0) * (total_opds as f64 / n2 as f64);
+    assert!((difficulty - 2.0).abs() < 0.001);
+}
+
+#[test]
+fn effort_is_difficulty_times_volume() {
+    let difficulty = 2.0f64;
+    let volume = 23.22f64;
+    let effort = difficulty * volume;
+    assert!((effort - 46.44).abs() < 0.01);
+}
+
+// ── round_f64 ─────────────────────────────────────────────────────────────
+
+#[test]
+fn round_f64_two_decimals() {
+    assert_eq!(round_f64(3.14159, 2), 3.14);
+    assert_eq!(round_f64(2.005, 2), 2.01); // banker's rounding edge
+    assert_eq!(round_f64(0.0, 2), 0.0);
+}
+
+#[test]
+fn round_f64_zero_decimals() {
+    assert_eq!(round_f64(3.7, 0), 4.0);
+    assert_eq!(round_f64(3.2, 0), 3.0);
+}
+
+#[test]
+fn round_f64_four_decimals() {
+    assert_eq!(round_f64(1.23456789, 4), 1.2346);
+}

--- a/crates/tokmd-analysis-near-dup/tests/neardup_w74.rs
+++ b/crates/tokmd-analysis-near-dup/tests/neardup_w74.rs
@@ -1,0 +1,191 @@
+//! W74 – Unit tests for tokmd-analysis-near-dup enricher.
+
+use std::path::Path;
+
+use tokmd_analysis_near_dup::{build_near_dup_report, NearDupLimits};
+use tokmd_analysis_types::NearDupScope;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal ExportData with given file paths
+// ---------------------------------------------------------------------------
+fn make_export(files: &[(&str, &str, usize)]) -> ExportData {
+    let rows = files
+        .iter()
+        .map(|(path, lang, bytes)| FileRow {
+            path: path.to_string(),
+            module: "root".to_string(),
+            lang: lang.to_string(),
+            kind: FileKind::Parent,
+            code: 50,
+            comments: 5,
+            blanks: 5,
+            lines: 60,
+            bytes: *bytes,
+            tokens: 200,
+        })
+        .collect();
+    ExportData {
+        rows,
+        module_roots: vec!["root".to_string()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ── Empty / trivial inputs ────────────────────────────────────────────────
+
+#[test]
+fn empty_export_yields_no_pairs() {
+    let export = make_export(&[]);
+    let limits = NearDupLimits::default();
+    let report = build_near_dup_report(
+        Path::new("."),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits,
+        &[],
+    )
+    .unwrap();
+    assert!(report.pairs.is_empty());
+    assert_eq!(report.files_analyzed, 0);
+}
+
+#[test]
+fn single_file_yields_no_pairs() {
+    let export = make_export(&[("src/main.rs", "Rust", 100)]);
+    let limits = NearDupLimits::default();
+    let report = build_near_dup_report(
+        Path::new("."),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits,
+        &[],
+    )
+    .unwrap();
+    assert!(report.pairs.is_empty());
+}
+
+// ── Report structure ──────────────────────────────────────────────────────
+
+#[test]
+fn report_params_reflect_inputs() {
+    let export = make_export(&[]);
+    let limits = NearDupLimits {
+        max_bytes: Some(1_000_000),
+        max_file_bytes: Some(512_000),
+    };
+    let report = build_near_dup_report(
+        Path::new("."),
+        &export,
+        NearDupScope::Module,
+        0.75,
+        50,
+        Some(10),
+        &limits,
+        &[],
+    )
+    .unwrap();
+    assert_eq!(report.params.threshold, 0.75);
+    assert_eq!(report.params.max_files, 50);
+    assert_eq!(report.params.max_pairs, Some(10));
+    assert_eq!(report.params.scope, NearDupScope::Module);
+}
+
+#[test]
+fn report_not_truncated_when_under_limit() {
+    let export = make_export(&[]);
+    let limits = NearDupLimits::default();
+    let report = build_near_dup_report(
+        Path::new("."),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        Some(50),
+        &limits,
+        &[],
+    )
+    .unwrap();
+    assert!(!report.truncated);
+}
+
+// ── Scope variants ────────────────────────────────────────────────────────
+
+#[test]
+fn scope_global_is_default_variant() {
+    // Just ensure the enum variant is usable
+    let scope = NearDupScope::Global;
+    assert_eq!(scope, NearDupScope::Global);
+}
+
+#[test]
+fn scope_module_variant_exists() {
+    let scope = NearDupScope::Module;
+    assert_eq!(scope, NearDupScope::Module);
+}
+
+#[test]
+fn scope_lang_variant_exists() {
+    let scope = NearDupScope::Lang;
+    assert_eq!(scope, NearDupScope::Lang);
+}
+
+// ── Limits ────────────────────────────────────────────────────────────────
+
+#[test]
+fn default_limits_are_none() {
+    let limits = NearDupLimits::default();
+    assert!(limits.max_bytes.is_none());
+    assert!(limits.max_file_bytes.is_none());
+}
+
+#[test]
+fn files_exceeding_max_file_bytes_are_excluded() {
+    // File with 1MB bytes should be excluded when limit is 512KB
+    let export = make_export(&[("big.rs", "Rust", 1_000_000)]);
+    let limits = NearDupLimits {
+        max_bytes: None,
+        max_file_bytes: Some(512_000),
+    };
+    let report = build_near_dup_report(
+        Path::new("."),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits,
+        &[],
+    )
+    .unwrap();
+    // The file exceeds the per-file limit so should not be analyzed
+    assert_eq!(report.files_analyzed, 0);
+}
+
+#[test]
+fn exclude_patterns_filter_files() {
+    let export = make_export(&[
+        ("src/main.rs", "Rust", 100),
+        ("tests/test_main.rs", "Rust", 100),
+    ]);
+    let limits = NearDupLimits::default();
+    let report = build_near_dup_report(
+        Path::new("."),
+        &export,
+        NearDupScope::Global,
+        0.5,
+        100,
+        None,
+        &limits,
+        &["tests/**".to_string()],
+    )
+    .unwrap();
+    assert_eq!(report.excluded_by_pattern, Some(1));
+}

--- a/crates/tokmd-analysis-topics/tests/topics_w74.rs
+++ b/crates/tokmd-analysis-topics/tests/topics_w74.rs
@@ -1,0 +1,175 @@
+//! W74 – Unit tests for tokmd-analysis-topics enricher.
+
+use tokmd_analysis_topics::build_topic_clouds;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ---------------------------------------------------------------------------
+// Helper: build an ExportData from (path, module, lang, tokens) tuples
+// ---------------------------------------------------------------------------
+fn make_export(files: &[(&str, &str, &str, usize)]) -> ExportData {
+    let rows = files
+        .iter()
+        .map(|(path, module, lang, tokens)| FileRow {
+            path: path.to_string(),
+            module: module.to_string(),
+            lang: lang.to_string(),
+            kind: FileKind::Parent,
+            code: 50,
+            comments: 5,
+            blanks: 5,
+            lines: 60,
+            bytes: 500,
+            tokens: *tokens,
+        })
+        .collect();
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ── Empty input ───────────────────────────────────────────────────────────
+
+#[test]
+fn empty_export_yields_empty_topics() {
+    let export = make_export(&[]);
+    let clouds = build_topic_clouds(&export);
+    assert!(clouds.overall.is_empty());
+    assert!(clouds.per_module.is_empty());
+}
+
+// ── Basic topic extraction ────────────────────────────────────────────────
+
+#[test]
+fn topics_from_path_tokens() {
+    let export = make_export(&[
+        ("crates/auth/login.rs", "crates/auth", "Rust", 100),
+        ("crates/auth/token.rs", "crates/auth", "Rust", 100),
+    ]);
+    let clouds = build_topic_clouds(&export);
+    let auth = clouds.per_module.get("crates/auth").unwrap();
+    let terms: Vec<&str> = auth.iter().map(|t| t.term.as_str()).collect();
+    assert!(terms.contains(&"login"), "expected 'login' in {terms:?}");
+    assert!(terms.contains(&"token"), "expected 'token' in {terms:?}");
+}
+
+#[test]
+fn overall_topics_are_populated() {
+    let export = make_export(&[
+        ("crates/auth/login.rs", "crates/auth", "Rust", 100),
+        ("crates/payments/stripe.rs", "crates/payments", "Rust", 100),
+    ]);
+    let clouds = build_topic_clouds(&export);
+    assert!(!clouds.overall.is_empty());
+}
+
+// ── Stopword filtering ───────────────────────────────────────────────────
+
+#[test]
+fn file_extensions_are_stopwords() {
+    // "rs" should be filtered out as a stopword
+    let export = make_export(&[
+        ("crates/auth/login.rs", "crates/auth", "Rust", 100),
+    ]);
+    let clouds = build_topic_clouds(&export);
+    let all_terms: Vec<&str> = clouds
+        .overall
+        .iter()
+        .map(|t| t.term.as_str())
+        .collect();
+    assert!(!all_terms.contains(&"rs"), "'rs' should be a stopword");
+}
+
+#[test]
+fn common_dirs_are_stopwords() {
+    // "src", "lib", "test" should be filtered
+    let export = make_export(&[
+        ("src/lib/utils/helpers.rs", "src/lib", "Rust", 100),
+    ]);
+    let clouds = build_topic_clouds(&export);
+    let all_terms: Vec<&str> = clouds
+        .overall
+        .iter()
+        .map(|t| t.term.as_str())
+        .collect();
+    assert!(!all_terms.contains(&"src"), "'src' should be a stopword");
+    assert!(!all_terms.contains(&"lib"), "'lib' should be a stopword");
+}
+
+// ── Per-module isolation ──────────────────────────────────────────────────
+
+#[test]
+fn topics_are_grouped_by_module() {
+    let export = make_export(&[
+        ("crates/auth/login.rs", "crates/auth", "Rust", 100),
+        ("crates/payments/invoice.rs", "crates/payments", "Rust", 100),
+    ]);
+    let clouds = build_topic_clouds(&export);
+    assert!(clouds.per_module.contains_key("crates/auth"));
+    assert!(clouds.per_module.contains_key("crates/payments"));
+}
+
+#[test]
+fn module_topics_contain_relevant_terms() {
+    let export = make_export(&[
+        ("crates/payments/stripe_api.rs", "crates/payments", "Rust", 100),
+        ("crates/payments/refund.rs", "crates/payments", "Rust", 100),
+    ]);
+    let clouds = build_topic_clouds(&export);
+    let payments = clouds.per_module.get("crates/payments").unwrap();
+    let terms: Vec<&str> = payments.iter().map(|t| t.term.as_str()).collect();
+    assert!(terms.contains(&"stripe"), "expected 'stripe' in {terms:?}");
+    assert!(terms.contains(&"refund"), "expected 'refund' in {terms:?}");
+}
+
+// ── Determinism ───────────────────────────────────────────────────────────
+
+#[test]
+fn topic_clouds_are_deterministic() {
+    let export = make_export(&[
+        ("crates/auth/login.rs", "crates/auth", "Rust", 100),
+        ("crates/auth/token.rs", "crates/auth", "Rust", 100),
+        ("crates/payments/stripe.rs", "crates/payments", "Rust", 100),
+    ]);
+    let c1 = build_topic_clouds(&export);
+    let c2 = build_topic_clouds(&export);
+    assert_eq!(c1.overall.len(), c2.overall.len());
+    for (a, b) in c1.overall.iter().zip(c2.overall.iter()) {
+        assert_eq!(a.term, b.term);
+        assert_eq!(a.tf, b.tf);
+        assert_eq!(a.df, b.df);
+    }
+}
+
+// ── TopicTerm fields ──────────────────────────────────────────────────────
+
+#[test]
+fn topic_terms_have_positive_scores() {
+    let export = make_export(&[
+        ("crates/auth/login.rs", "crates/auth", "Rust", 100),
+    ]);
+    let clouds = build_topic_clouds(&export);
+    for term in &clouds.overall {
+        assert!(term.score > 0.0, "score should be positive: {:?}", term);
+        assert!(term.tf > 0, "tf should be > 0");
+    }
+}
+
+#[test]
+fn top_k_limits_per_module_terms() {
+    // Even with many files, per-module topics should be limited to top-K (8)
+    let files: Vec<(&str, &str, &str, usize)> = (0..20)
+        .map(|i| {
+            // Leak strings to get &str with 'static lifetime
+            let path: &'static str = Box::leak(format!("mod/file_{i}.rs").into_boxed_str());
+            (path, "mod", "Rust", 100usize)
+        })
+        .collect();
+    let export = make_export(&files);
+    let clouds = build_topic_clouds(&export);
+    if let Some(topics) = clouds.per_module.get("mod") {
+        assert!(topics.len() <= 8, "should be capped at top-K=8");
+    }
+}


### PR DESCRIPTION
## Summary

Add unit tests for four analysis enricher crates covering ~55 tests total.

### Test files

| Crate | File | Tests |
|-------|------|-------|
| tokmd-analysis-complexity | \complexity_w74.rs\ | 15 |
| tokmd-analysis-halstead | \halstead_w74.rs\ | 20 |
| tokmd-analysis-near-dup | \
eardup_w74.rs\ | 10 |
| tokmd-analysis-topics | \	opics_w74.rs\ | 10 |

### Coverage areas

- **Complexity**: histogram generation, bucket boundaries, determinism, risk enum variants
- **Halstead**: language support, operator tables, tokenization, formula verification, rounding
- **Near-dup**: empty/single inputs, report structure, scope variants, limits, exclusion patterns
- **Topics**: topic extraction, stopwords, per-module grouping, determinism, top-K capping

All tests pass locally.