### PR TITLE
test(w74): sensor + envelope integration tests (~40 tests)

### DIFF
--- a/crates/tokmd-config/tests/error_edge_w73.rs
+++ b/crates/tokmd-config/tests/error_edge_w73.rs
@@ -51,16 +51,12 @@ fn parse_toml_with_duplicate_keys_returns_error() {
 fn parse_toml_with_unknown_top_level_section_succeeds() {
     // serde(default) + no deny_unknown_fields means unknown sections are ignored
     let config = TomlConfig::parse("[unknown_section]\nfoo = 42");
-    // This should either succeed (fields ignored) or fail — document actual behavior
-    // Since TomlConfig uses serde(default) without deny_unknown_fields, unknown
-    // top-level keys should cause an error because the struct doesn't have that field
-    // unless serde flatten is used. Let's verify the actual behavior:
+    // Document actual behavior: either ignored or error
     if let Ok(c) = config {
         // If it succeeds, all known fields should be at defaults
         assert_eq!(c.scan.hidden, None);
         assert_eq!(c.module.depth, None);
     }
-    // Either outcome documents the behavior — the test passes regardless
 }
 
 #[test]
@@ -78,10 +74,8 @@ fn parse_toml_with_extra_nested_table_in_known_section() {
     // serde(default) without deny_unknown_fields: unknown nested tables may be
     // silently ignored. Document actual behavior:
     if let Ok(c) = result {
-        // All known fields should be at defaults
         assert_eq!(c.scan.hidden, None);
     }
-    // Either outcome is acceptable — test documents the behavior
 }
 
 // =============================================================================

--- a/crates/tokmd-content/tests/error_edge_w73.rs
+++ b/crates/tokmd-content/tests/error_edge_w73.rs
@@ -126,14 +126,16 @@ fn read_lines_with_very_long_line_respects_byte_limit() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("long_line.txt");
     let mut f = File::create(&path).unwrap();
-    // Write a single 10,000-character line
     let long_line = "x".repeat(10_000);
     writeln!(f, "{}", long_line).unwrap();
     writeln!(f, "short").unwrap();
 
-    // Byte limit should kick in after the first line
     let lines = read_lines(&path, 100, 5000).unwrap();
-    assert_eq!(lines.len(), 1, "byte limit should stop after first long line");
+    assert_eq!(
+        lines.len(),
+        1,
+        "byte limit should stop after first long line"
+    );
     assert_eq!(lines[0].len(), 10_000);
 }
 
@@ -181,7 +183,6 @@ fn entropy_empty_input_returns_zero() {
 
 #[test]
 fn entropy_single_byte_returns_zero() {
-    // Only one byte value present — zero entropy
     assert_eq!(entropy_bits_per_byte(&[42]), 0.0);
 }
 
@@ -189,12 +190,14 @@ fn entropy_single_byte_returns_zero() {
 fn entropy_all_same_bytes_returns_zero() {
     let data = vec![0xAB; 10_000];
     let e = entropy_bits_per_byte(&data);
-    assert!(e.abs() < 1e-6, "uniform bytes should have ~0 entropy, got {e}");
+    assert!(
+        e.abs() < 1e-6,
+        "uniform bytes should have ~0 entropy, got {e}"
+    );
 }
 
 #[test]
 fn entropy_maximum_for_uniform_256_values() {
-    // All 256 byte values equally represented -> 8 bits per byte
     let data: Vec<u8> = (0..=255).cycle().take(256 * 100).collect();
     let e = entropy_bits_per_byte(&data);
     assert!(

--- a/crates/tokmd-envelope/tests/envelope_integration_w74.rs
+++ b/crates/tokmd-envelope/tests/envelope_integration_w74.rs
@@ -1,0 +1,263 @@
+//! W74 – Envelope integration tests.
+//!
+//! Tests full envelope construction, serialization/deserialization roundtrip,
+//! schema version, timestamp format, and findings.
+
+use std::collections::BTreeMap;
+
+use tokmd_envelope::{
+    Artifact, CapabilityState, CapabilityStatus, Finding, FindingLocation, FindingSeverity,
+    GateItem, GateResults, SensorReport, ToolMeta, Verdict, SENSOR_REPORT_SCHEMA, findings,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn minimal_report() -> SensorReport {
+    SensorReport::new(
+        ToolMeta::tokmd("2.0.0", "cockpit"),
+        "2025-06-01T08:30:00Z".to_string(),
+        Verdict::Pass,
+        "All clear".to_string(),
+    )
+}
+
+fn rich_report() -> SensorReport {
+    let mut caps = BTreeMap::new();
+    caps.insert("scan".to_string(), CapabilityStatus::available());
+    caps.insert(
+        "git".to_string(),
+        CapabilityStatus::unavailable("git binary not found"),
+    );
+    caps.insert(
+        "coverage".to_string(),
+        CapabilityStatus::skipped("no test files changed"),
+    );
+
+    let mut report = SensorReport::new(
+        ToolMeta::new("my-sensor", "3.1.0", "analyze"),
+        "2025-07-04T14:00:00Z".to_string(),
+        Verdict::Warn,
+        "Risk hotspots detected".to_string(),
+    )
+    .with_capabilities(caps)
+    .with_artifacts(vec![
+        Artifact::receipt("out/receipt.json").with_mime("application/json"),
+        Artifact::badge("out/badge.svg"),
+    ])
+    .with_data(serde_json::json!({
+        "lines_scanned": 42000,
+        "hotspot_count": 3,
+    }));
+
+    report.add_finding(
+        Finding::new(
+            findings::risk::CHECK_ID,
+            findings::risk::HOTSPOT,
+            FindingSeverity::Warn,
+            "High-churn file",
+            "src/lib.rs modified 37 times in 30 days",
+        )
+        .with_location(FindingLocation::path_line("src/lib.rs", 1))
+        .with_fingerprint("my-sensor"),
+    );
+
+    report.add_finding(
+        Finding::new(
+            findings::contract::CHECK_ID,
+            findings::contract::SCHEMA_CHANGED,
+            FindingSeverity::Info,
+            "Schema bumped",
+            "schema_version changed from 7 to 8",
+        )
+        .with_evidence(serde_json::json!({ "old": 7, "new": 8 }))
+        .with_docs_url("https://example.com/schema"),
+    );
+
+    report
+}
+
+// ---------------------------------------------------------------------------
+// 1. Schema version
+// ---------------------------------------------------------------------------
+
+#[test]
+fn schema_is_sensor_report_v1() {
+    let r = minimal_report();
+    assert_eq!(r.schema, "sensor.report.v1");
+    assert_eq!(r.schema, SENSOR_REPORT_SCHEMA);
+}
+
+#[test]
+fn schema_present_in_serialized_json() {
+    let r = minimal_report();
+    let json = serde_json::to_string(&r).unwrap();
+    assert!(json.contains(r#""schema":"sensor.report.v1""#));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Timestamp format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generated_at_is_iso8601() {
+    let r = minimal_report();
+    assert!(r.generated_at.contains('T'));
+    assert!(r.generated_at.ends_with('Z'));
+}
+
+#[test]
+fn generated_at_preserved_through_roundtrip() {
+    let r = rich_report();
+    let json = serde_json::to_string(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.generated_at, "2025-07-04T14:00:00Z");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Full roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn minimal_report_roundtrip() {
+    let r = minimal_report();
+    let json = serde_json::to_string_pretty(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(back.schema, r.schema);
+    assert_eq!(back.verdict, Verdict::Pass);
+    assert_eq!(back.tool.name, "tokmd");
+    assert_eq!(back.tool.version, "2.0.0");
+    assert_eq!(back.tool.mode, "cockpit");
+    assert_eq!(back.summary, "All clear");
+    assert!(back.findings.is_empty());
+    assert!(back.artifacts.is_none());
+    assert!(back.capabilities.is_none());
+    assert!(back.data.is_none());
+}
+
+#[test]
+fn rich_report_roundtrip() {
+    let r = rich_report();
+    let json = serde_json::to_string(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+
+    // Verdict
+    assert_eq!(back.verdict, Verdict::Warn);
+
+    // Tool meta
+    assert_eq!(back.tool.name, "my-sensor");
+    assert_eq!(back.tool.version, "3.1.0");
+    assert_eq!(back.tool.mode, "analyze");
+
+    // Capabilities
+    let caps = back.capabilities.as_ref().unwrap();
+    assert_eq!(caps.len(), 3);
+    assert_eq!(caps["scan"].status, CapabilityState::Available);
+    assert_eq!(caps["git"].status, CapabilityState::Unavailable);
+    assert_eq!(caps["coverage"].status, CapabilityState::Skipped);
+
+    // Artifacts
+    let arts = back.artifacts.as_ref().unwrap();
+    assert_eq!(arts.len(), 2);
+    assert_eq!(arts[0].artifact_type, "receipt");
+    assert_eq!(arts[1].artifact_type, "badge");
+
+    // Data payload
+    let data = back.data.as_ref().unwrap();
+    assert_eq!(data["lines_scanned"], 42000);
+
+    // Findings
+    assert_eq!(back.findings.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Findings
+// ---------------------------------------------------------------------------
+
+#[test]
+fn findings_check_id_and_code_preserved() {
+    let r = rich_report();
+    let json = serde_json::to_string(&r).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(back.findings[0].check_id, "risk");
+    assert_eq!(back.findings[0].code, "hotspot");
+    assert_eq!(back.findings[1].check_id, "contract");
+    assert_eq!(back.findings[1].code, "schema_changed");
+}
+
+#[test]
+fn finding_fingerprint_is_deterministic() {
+    let f1 = Finding::new("risk", "hotspot", FindingSeverity::Warn, "A", "B")
+        .with_location(FindingLocation::path("src/lib.rs"));
+    let f2 = Finding::new("risk", "hotspot", FindingSeverity::Warn, "C", "D")
+        .with_location(FindingLocation::path("src/lib.rs"));
+
+    // Same (tool, check_id, code, path) → same fingerprint
+    assert_eq!(
+        f1.compute_fingerprint("tokmd"),
+        f2.compute_fingerprint("tokmd")
+    );
+    // Different tool → different fingerprint
+    assert_ne!(
+        f1.compute_fingerprint("tokmd"),
+        f1.compute_fingerprint("other-tool")
+    );
+}
+
+#[test]
+fn finding_location_variants_roundtrip() {
+    let finding = Finding::new("test", "loc", FindingSeverity::Info, "T", "M")
+        .with_location(FindingLocation::path_line_column("src/main.rs", 42, 10));
+
+    let json = serde_json::to_string(&finding).unwrap();
+    let back: Finding = serde_json::from_str(&json).unwrap();
+
+    let loc = back.location.unwrap();
+    assert_eq!(loc.path, "src/main.rs");
+    assert_eq!(loc.line, Some(42));
+    assert_eq!(loc.column, Some(10));
+}
+
+// ---------------------------------------------------------------------------
+// 5. Gates embedded in data
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gate_results_roundtrip_via_data() {
+    let gates = GateResults::new(
+        Verdict::Fail,
+        vec![
+            GateItem::new("mutation", Verdict::Fail)
+                .with_threshold(80.0, 72.0)
+                .with_reason("Below mutation threshold"),
+            GateItem::new("coverage", Verdict::Pass)
+                .with_threshold(70.0, 85.5)
+                .with_source("ci_artifact"),
+        ],
+    );
+
+    let report = SensorReport::new(
+        ToolMeta::tokmd("2.0.0", "cockpit"),
+        "2025-01-01T00:00:00Z".to_string(),
+        Verdict::Fail,
+        "Gate failed".to_string(),
+    )
+    .with_data(serde_json::json!({
+        "gates": serde_json::to_value(&gates).unwrap(),
+    }));
+
+    let json = serde_json::to_string(&report).unwrap();
+    let back: SensorReport = serde_json::from_str(&json).unwrap();
+    let data = back.data.unwrap();
+    let back_gates: GateResults = serde_json::from_value(data["gates"].clone()).unwrap();
+
+    assert_eq!(back_gates.status, Verdict::Fail);
+    assert_eq!(back_gates.items.len(), 2);
+    assert_eq!(back_gates.items[0].id, "mutation");
+    assert_eq!(back_gates.items[0].actual, Some(72.0));
+    assert_eq!(back_gates.items[1].id, "coverage");
+    assert_eq!(back_gates.items[1].source.as_deref(), Some("ci_artifact"));
+}

--- a/crates/tokmd-scan/tests/error_edge_w73.rs
+++ b/crates/tokmd-scan/tests/error_edge_w73.rs
@@ -30,7 +30,7 @@ fn default_options() -> ScanOptions {
 fn scan_nonexistent_directory_error_message_includes_path() {
     let dir = tempfile::tempdir().unwrap();
     let missing = dir.path().join("does_not_exist_w73");
-    let result = scan(&[missing.clone()], &default_options());
+    let result = scan(std::slice::from_ref(&missing), &default_options());
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -53,8 +53,7 @@ fn scan_empty_directory_returns_empty_languages() {
     let result = scan(&[dir.path().to_path_buf()], &default_options());
     assert!(result.is_ok());
     let langs = result.unwrap();
-    // Empty dir has no source files — all language entries should have 0 code
-    let total_code: usize = langs.iter().map(|(_, lang)| lang.code).sum();
+    let total_code: usize = langs.values().map(|lang| lang.code).sum();
     assert_eq!(total_code, 0, "empty dir should yield zero code lines");
 }
 
@@ -71,7 +70,7 @@ fn scan_hidden_only_dir_without_hidden_flag_returns_no_code() {
 
     let opts = default_options(); // hidden = false
     let result = scan(&[dir.path().to_path_buf()], &opts).unwrap();
-    let total_code: usize = result.iter().map(|(_, lang)| lang.code).sum();
+    let total_code: usize = result.values().map(|lang| lang.code).sum();
     assert_eq!(
         total_code, 0,
         "hidden files should not be counted without --hidden"
@@ -88,7 +87,7 @@ fn scan_hidden_only_dir_with_hidden_flag_finds_code() {
     let mut opts = default_options();
     opts.hidden = true;
     let result = scan(&[dir.path().to_path_buf()], &opts).unwrap();
-    let total_code: usize = result.iter().map(|(_, lang)| lang.code).sum();
+    let total_code: usize = result.values().map(|lang| lang.code).sum();
     assert!(
         total_code > 0,
         "hidden files should be counted with --hidden"
@@ -133,7 +132,6 @@ fn scan_with_exclude_pattern_filters_matching_files() {
         ..default_options()
     };
     let result = scan(&[dir.path().to_path_buf()], &opts).unwrap();
-    // At most one Rust file should be found (keep.rs)
     if let Some(rust) = result.get(&tokei::LanguageType::Rust) {
         assert!(
             rust.reports.len() <= 1,

--- a/crates/tokmd-sensor/tests/sensor_w74.rs
+++ b/crates/tokmd-sensor/tests/sensor_w74.rs
@@ -1,0 +1,357 @@
+//! W74 – Sensor pipeline integration tests.
+//!
+//! Tests the `EffortlessSensor` trait, substrate building, sensor report
+//! generation, capability reporting, and metadata completeness.
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use tokmd_envelope::{
+    CapabilityState, CapabilityStatus, Finding, FindingSeverity, FindingLocation,
+    SensorReport, ToolMeta, Verdict, SENSOR_REPORT_SCHEMA,
+};
+use tokmd_sensor::EffortlessSensor;
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Minimal sensor for exercising the trait contract.
+struct StubSensor {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct StubSettings {
+    code_threshold: usize,
+}
+
+impl EffortlessSensor for StubSensor {
+    type Settings = StubSettings;
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn version(&self) -> &str {
+        self.version
+    }
+
+    fn run(&self, settings: &StubSettings, substrate: &RepoSubstrate) -> Result<SensorReport> {
+        let verdict = if substrate.total_code_lines > settings.code_threshold {
+            Verdict::Warn
+        } else {
+            Verdict::Pass
+        };
+        let mut report = SensorReport::new(
+            ToolMeta::new(self.name(), self.version(), "check"),
+            "2025-01-15T12:00:00Z".to_string(),
+            verdict,
+            format!(
+                "{} code lines (threshold: {})",
+                substrate.total_code_lines, settings.code_threshold
+            ),
+        );
+        report.add_capability("scan", CapabilityStatus::available());
+        if substrate.diff_range.is_some() {
+            report.add_capability("diff", CapabilityStatus::available());
+        } else {
+            report.add_capability(
+                "diff",
+                CapabilityStatus::skipped("no diff range provided"),
+            );
+        }
+        Ok(report)
+    }
+}
+
+fn default_sensor() -> StubSensor {
+    StubSensor {
+        name: "test-sensor",
+        version: "0.1.0",
+    }
+}
+
+fn sample_substrate() -> RepoSubstrate {
+    RepoSubstrate {
+        repo_root: "/repo".to_string(),
+        files: vec![
+            SubstrateFile {
+                path: "src/lib.rs".to_string(),
+                lang: "Rust".to_string(),
+                code: 200,
+                lines: 250,
+                bytes: 6000,
+                tokens: 1500,
+                module: "src".to_string(),
+                in_diff: true,
+            },
+            SubstrateFile {
+                path: "src/main.rs".to_string(),
+                lang: "Rust".to_string(),
+                code: 80,
+                lines: 100,
+                bytes: 2400,
+                tokens: 600,
+                module: "src".to_string(),
+                in_diff: false,
+            },
+            SubstrateFile {
+                path: "tests/smoke.rs".to_string(),
+                lang: "Rust".to_string(),
+                code: 40,
+                lines: 50,
+                bytes: 1200,
+                tokens: 300,
+                module: "tests".to_string(),
+                in_diff: false,
+            },
+        ],
+        lang_summary: BTreeMap::from([(
+            "Rust".to_string(),
+            LangSummary {
+                files: 3,
+                code: 320,
+                lines: 400,
+                bytes: 9600,
+                tokens: 2400,
+            },
+        )]),
+        diff_range: Some(DiffRange {
+            base: "main".to_string(),
+            head: "HEAD".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            commit_count: 2,
+            insertions: 15,
+            deletions: 3,
+        }),
+        total_tokens: 2400,
+        total_bytes: 9600,
+        total_code_lines: 320,
+    }
+}
+
+fn empty_substrate() -> RepoSubstrate {
+    RepoSubstrate {
+        repo_root: "/empty".to_string(),
+        files: vec![],
+        lang_summary: BTreeMap::new(),
+        diff_range: None,
+        total_tokens: 0,
+        total_bytes: 0,
+        total_code_lines: 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. EffortlessSensor trait basics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sensor_name_returns_expected_value() {
+    let s = default_sensor();
+    assert_eq!(s.name(), "test-sensor");
+}
+
+#[test]
+fn sensor_version_returns_expected_value() {
+    let s = default_sensor();
+    assert_eq!(s.version(), "0.1.0");
+}
+
+#[test]
+fn sensor_run_returns_pass_below_threshold() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 500,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+#[test]
+fn sensor_run_returns_warn_above_threshold() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 100,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    assert_eq!(report.verdict, Verdict::Warn);
+}
+
+#[test]
+fn sensor_run_on_empty_substrate_passes() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 0,
+    };
+    // 0 code lines is NOT > 0, so should pass
+    let report = s.run(&settings, &empty_substrate()).unwrap();
+    assert_eq!(report.verdict, Verdict::Pass);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Report metadata completeness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn report_schema_is_sensor_report_v1() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 1000,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    assert_eq!(report.schema, SENSOR_REPORT_SCHEMA);
+    assert_eq!(report.schema, "sensor.report.v1");
+}
+
+#[test]
+fn report_tool_meta_matches_sensor() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 1000,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    assert_eq!(report.tool.name, "test-sensor");
+    assert_eq!(report.tool.version, "0.1.0");
+    assert_eq!(report.tool.mode, "check");
+}
+
+#[test]
+fn report_generated_at_is_iso8601() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 1000,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    assert!(report.generated_at.contains('T'));
+    assert!(report.generated_at.ends_with('Z'));
+}
+
+#[test]
+fn report_summary_contains_code_lines() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 1000,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    assert!(report.summary.contains("320"));
+    assert!(report.summary.contains("1000"));
+}
+
+// ---------------------------------------------------------------------------
+// 3. Capability reporting
+// ---------------------------------------------------------------------------
+
+#[test]
+fn capabilities_present_when_diff_range_exists() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 1000,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    let caps = report.capabilities.as_ref().expect("capabilities should be set");
+    assert_eq!(caps["scan"].status, CapabilityState::Available);
+    assert_eq!(caps["diff"].status, CapabilityState::Available);
+}
+
+#[test]
+fn capabilities_diff_skipped_without_diff_range() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 1000,
+    };
+    let report = s.run(&settings, &empty_substrate()).unwrap();
+    let caps = report.capabilities.as_ref().expect("capabilities should be set");
+    assert_eq!(caps["scan"].status, CapabilityState::Available);
+    assert_eq!(caps["diff"].status, CapabilityState::Skipped);
+    assert!(caps["diff"].reason.as_ref().unwrap().contains("no diff"));
+}
+
+#[test]
+fn capabilities_unavailable_variant_works() {
+    let cap = CapabilityStatus::unavailable("git not found");
+    assert_eq!(cap.status, CapabilityState::Unavailable);
+    assert_eq!(cap.reason.as_deref(), Some("git not found"));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Serde roundtrip of sensor report
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sensor_report_serde_roundtrip() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 100,
+    };
+    let report = s.run(&settings, &sample_substrate()).unwrap();
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let deser: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.schema, report.schema);
+    assert_eq!(deser.verdict, report.verdict);
+    assert_eq!(deser.tool.name, report.tool.name);
+    assert_eq!(deser.summary, report.summary);
+    let caps = deser.capabilities.as_ref().unwrap();
+    assert_eq!(caps.len(), 2);
+}
+
+#[test]
+fn sensor_report_with_findings_roundtrip() {
+    let s = default_sensor();
+    let settings = StubSettings {
+        code_threshold: 100,
+    };
+    let mut report = s.run(&settings, &sample_substrate()).unwrap();
+    report.add_finding(
+        Finding::new("risk", "hotspot", FindingSeverity::Warn, "Churn", "high churn")
+            .with_location(FindingLocation::path("src/lib.rs"))
+            .with_fingerprint("test-sensor"),
+    );
+    report.add_finding(Finding::new(
+        "contract",
+        "schema_changed",
+        FindingSeverity::Info,
+        "Schema",
+        "version bumped",
+    ));
+
+    let json = serde_json::to_string(&report).unwrap();
+    let deser: SensorReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.findings.len(), 2);
+    assert_eq!(deser.findings[0].check_id, "risk");
+    assert!(deser.findings[0].fingerprint.is_some());
+    assert!(deser.findings[1].fingerprint.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// 5. Substrate builder (integration – scans own crate)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_substrate_scans_own_crate() {
+    use tokmd_sensor::substrate_builder::build_substrate;
+    use tokmd_settings::ScanOptions;
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let substrate = build_substrate(
+        &format!("{}/src", manifest_dir),
+        &ScanOptions::default(),
+        &[],
+        2,
+        None,
+    )
+    .unwrap();
+
+    assert!(!substrate.files.is_empty(), "should find source files");
+    assert!(
+        substrate.lang_summary.contains_key("Rust"),
+        "should detect Rust"
+    );
+    assert!(substrate.total_code_lines > 0);
+    assert!(substrate.total_tokens > 0);
+    assert!(substrate.total_bytes > 0);
+    assert!(substrate.diff_range.is_none());
+}

--- a/crates/tokmd-substrate/tests/substrate_w74.rs
+++ b/crates/tokmd-substrate/tests/substrate_w74.rs
@@ -1,0 +1,302 @@
+//! W74 – Substrate integration tests.
+//!
+//! Tests `RepoSubstrate` construction, field population, serialization
+//! roundtrip, and edge cases (empty repo, multi-language, diff filtering).
+
+use std::collections::BTreeMap;
+
+use tokmd_substrate::{DiffRange, LangSummary, RepoSubstrate, SubstrateFile};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn single_lang_substrate() -> RepoSubstrate {
+    RepoSubstrate {
+        repo_root: "/project".to_string(),
+        files: vec![
+            SubstrateFile {
+                path: "src/lib.rs".to_string(),
+                lang: "Rust".to_string(),
+                code: 150,
+                lines: 200,
+                bytes: 4500,
+                tokens: 1125,
+                module: "src".to_string(),
+                in_diff: true,
+            },
+            SubstrateFile {
+                path: "src/util.rs".to_string(),
+                lang: "Rust".to_string(),
+                code: 50,
+                lines: 60,
+                bytes: 1500,
+                tokens: 375,
+                module: "src".to_string(),
+                in_diff: false,
+            },
+        ],
+        lang_summary: BTreeMap::from([(
+            "Rust".to_string(),
+            LangSummary {
+                files: 2,
+                code: 200,
+                lines: 260,
+                bytes: 6000,
+                tokens: 1500,
+            },
+        )]),
+        diff_range: Some(DiffRange {
+            base: "v1.0.0".to_string(),
+            head: "v1.1.0".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            commit_count: 5,
+            insertions: 20,
+            deletions: 8,
+        }),
+        total_tokens: 1500,
+        total_bytes: 6000,
+        total_code_lines: 200,
+    }
+}
+
+fn multi_lang_substrate() -> RepoSubstrate {
+    RepoSubstrate {
+        repo_root: "/polyglot".to_string(),
+        files: vec![
+            SubstrateFile {
+                path: "src/lib.rs".to_string(),
+                lang: "Rust".to_string(),
+                code: 100,
+                lines: 120,
+                bytes: 3000,
+                tokens: 750,
+                module: "src".to_string(),
+                in_diff: false,
+            },
+            SubstrateFile {
+                path: "src/index.ts".to_string(),
+                lang: "TypeScript".to_string(),
+                code: 80,
+                lines: 100,
+                bytes: 2400,
+                tokens: 600,
+                module: "src".to_string(),
+                in_diff: true,
+            },
+            SubstrateFile {
+                path: "scripts/build.py".to_string(),
+                lang: "Python".to_string(),
+                code: 30,
+                lines: 40,
+                bytes: 900,
+                tokens: 225,
+                module: "scripts".to_string(),
+                in_diff: false,
+            },
+        ],
+        lang_summary: BTreeMap::from([
+            (
+                "Python".to_string(),
+                LangSummary {
+                    files: 1,
+                    code: 30,
+                    lines: 40,
+                    bytes: 900,
+                    tokens: 225,
+                },
+            ),
+            (
+                "Rust".to_string(),
+                LangSummary {
+                    files: 1,
+                    code: 100,
+                    lines: 120,
+                    bytes: 3000,
+                    tokens: 750,
+                },
+            ),
+            (
+                "TypeScript".to_string(),
+                LangSummary {
+                    files: 1,
+                    code: 80,
+                    lines: 100,
+                    bytes: 2400,
+                    tokens: 600,
+                },
+            ),
+        ]),
+        diff_range: None,
+        total_tokens: 1575,
+        total_bytes: 6300,
+        total_code_lines: 210,
+    }
+}
+
+fn empty_substrate() -> RepoSubstrate {
+    RepoSubstrate {
+        repo_root: "/empty".to_string(),
+        files: vec![],
+        lang_summary: BTreeMap::new(),
+        diff_range: None,
+        total_tokens: 0,
+        total_bytes: 0,
+        total_code_lines: 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Construction and field population
+// ---------------------------------------------------------------------------
+
+#[test]
+fn substrate_repo_root_stored() {
+    let sub = single_lang_substrate();
+    assert_eq!(sub.repo_root, "/project");
+}
+
+#[test]
+fn substrate_file_count_matches() {
+    let sub = single_lang_substrate();
+    assert_eq!(sub.files.len(), 2);
+}
+
+#[test]
+fn substrate_totals_are_consistent() {
+    let sub = single_lang_substrate();
+    let sum_code: usize = sub.files.iter().map(|f| f.code).sum();
+    let sum_tokens: usize = sub.files.iter().map(|f| f.tokens).sum();
+    let sum_bytes: usize = sub.files.iter().map(|f| f.bytes).sum();
+    assert_eq!(sub.total_code_lines, sum_code);
+    assert_eq!(sub.total_tokens, sum_tokens);
+    assert_eq!(sub.total_bytes, sum_bytes);
+}
+
+#[test]
+fn substrate_lang_summary_aggregates_correctly() {
+    let sub = single_lang_substrate();
+    let rust = &sub.lang_summary["Rust"];
+    assert_eq!(rust.files, 2);
+    assert_eq!(rust.code, 200);
+    assert_eq!(rust.lines, 260);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Diff filtering
+// ---------------------------------------------------------------------------
+
+#[test]
+fn diff_files_returns_only_changed() {
+    let sub = single_lang_substrate();
+    let diff: Vec<_> = sub.diff_files().collect();
+    assert_eq!(diff.len(), 1);
+    assert_eq!(diff[0].path, "src/lib.rs");
+}
+
+#[test]
+fn diff_files_empty_when_no_changes() {
+    let sub = empty_substrate();
+    let diff: Vec<_> = sub.diff_files().collect();
+    assert!(diff.is_empty());
+}
+
+#[test]
+fn diff_range_fields_populated() {
+    let sub = single_lang_substrate();
+    let dr = sub.diff_range.as_ref().unwrap();
+    assert_eq!(dr.base, "v1.0.0");
+    assert_eq!(dr.head, "v1.1.0");
+    assert_eq!(dr.commit_count, 5);
+    assert_eq!(dr.insertions, 20);
+    assert_eq!(dr.deletions, 8);
+    assert_eq!(dr.changed_files.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Multi-language substrates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multi_lang_summary_keys_sorted() {
+    let sub = multi_lang_substrate();
+    let keys: Vec<_> = sub.lang_summary.keys().cloned().collect();
+    assert_eq!(keys, vec!["Python", "Rust", "TypeScript"]);
+}
+
+#[test]
+fn files_for_lang_filters_correctly() {
+    let sub = multi_lang_substrate();
+    let ts: Vec<_> = sub.files_for_lang("TypeScript").collect();
+    assert_eq!(ts.len(), 1);
+    assert_eq!(ts[0].path, "src/index.ts");
+
+    let go: Vec<_> = sub.files_for_lang("Go").collect();
+    assert!(go.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 4. Empty substrate edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_substrate_has_zero_totals() {
+    let sub = empty_substrate();
+    assert_eq!(sub.total_code_lines, 0);
+    assert_eq!(sub.total_tokens, 0);
+    assert_eq!(sub.total_bytes, 0);
+    assert!(sub.files.is_empty());
+    assert!(sub.lang_summary.is_empty());
+}
+
+#[test]
+fn empty_substrate_diff_range_is_none() {
+    let sub = empty_substrate();
+    assert!(sub.diff_range.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// 5. Serialization roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn serde_roundtrip_single_lang() {
+    let sub = single_lang_substrate();
+    let json = serde_json::to_string(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.files.len(), sub.files.len());
+    assert_eq!(back.total_code_lines, sub.total_code_lines);
+    assert_eq!(back.repo_root, sub.repo_root);
+    assert!(back.diff_range.is_some());
+}
+
+#[test]
+fn serde_roundtrip_multi_lang() {
+    let sub = multi_lang_substrate();
+    let json = serde_json::to_string_pretty(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.lang_summary.len(), 3);
+    assert_eq!(back.files.len(), 3);
+    assert!(back.diff_range.is_none());
+}
+
+#[test]
+fn serde_roundtrip_empty() {
+    let sub = empty_substrate();
+    let json = serde_json::to_string(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    assert!(back.files.is_empty());
+    assert_eq!(back.total_code_lines, 0);
+    // diff_range should be omitted from JSON (skip_serializing_if)
+    assert!(!json.contains("diff_range"));
+}
+
+#[test]
+fn substrate_file_in_diff_preserved_through_serde() {
+    let sub = single_lang_substrate();
+    let json = serde_json::to_string(&sub).unwrap();
+    let back: RepoSubstrate = serde_json::from_str(&json).unwrap();
+    let in_diff_count = back.files.iter().filter(|f| f.in_diff).count();
+    assert_eq!(in_diff_count, 1);
+    assert!(back.files.iter().find(|f| f.in_diff).unwrap().path == "src/lib.rs");
+}


### PR DESCRIPTION
## Summary

Adds integration tests across the sensor pipeline (40 tests total):

### tokmd-sensor (15 tests)
- EffortlessSensor trait implementation (name, version, run)
- Substrate builder (scans own crate)
- Sensor report generation with pass/warn verdicts
- Capability reporting (available/skipped/unavailable)
- Report metadata completeness (schema, tool meta, timestamp, summary)
- Serde roundtrip with and without findings

### tokmd-substrate (15 tests)
- RepoSubstrate construction and field population
- Totals consistency (code lines, tokens, bytes)
- Lang summary aggregation
- Diff file filtering
- Multi-language substrates with BTreeMap ordering
- Empty substrate edge cases
- Serde roundtrip (single-lang, multi-lang, empty)

### tokmd-envelope (10 tests)
- Schema version verification (sensor.report.v1)
- ISO 8601 timestamp format
- Minimal and rich report roundtrip
- Finding check_id/code preservation
- Fingerprint determinism
- Finding location variants roundtrip
- Gate results embedded in data payload