### PR TITLE
test(w74): insta snapshot golden tests (~35 tests)

### DIFF
--- a/crates/tokmd-analysis-format/tests/snapshot_w74.rs
+++ b/crates/tokmd-analysis-format/tests/snapshot_w74.rs
@@ -1,0 +1,487 @@
+//! Golden snapshot tests for analysis format rendering (W74).
+//!
+//! Comprehensive insta snapshot coverage for Markdown, JSON, XML, SVG,
+//! Mermaid, Tree, JSON-LD, and HTML analysis output formats.
+
+use std::collections::BTreeMap;
+
+use tokmd_analysis_format::{render, RenderedOutput};
+use tokmd_analysis_types::*;
+use tokmd_types::{AnalysisFormat, ScanStatus, ToolInfo};
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+fn minimal_receipt() -> AnalysisReceipt {
+    AnalysisReceipt {
+        schema_version: ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: 0,
+        tool: ToolInfo {
+            name: "tokmd".into(),
+            version: "0.0.0-test".into(),
+        },
+        mode: "analyze".into(),
+        status: ScanStatus::Complete,
+        warnings: vec![],
+        source: AnalysisSource {
+            inputs: vec![".".into()],
+            export_path: None,
+            base_receipt_path: None,
+            export_schema_version: None,
+            export_generated_at_ms: None,
+            base_signature: None,
+            module_roots: vec![],
+            module_depth: 1,
+            children: "collapse".into(),
+        },
+        args: AnalysisArgsMeta {
+            preset: "receipt".into(),
+            format: "json".into(),
+            window_tokens: None,
+            git: None,
+            max_files: None,
+            max_bytes: None,
+            max_file_bytes: None,
+            max_commits: None,
+            max_commit_files: None,
+            import_granularity: "module".into(),
+        },
+        archetype: None,
+        topics: None,
+        entropy: None,
+        predictive_churn: None,
+        corporate_fingerprint: None,
+        license: None,
+        derived: None,
+        assets: None,
+        deps: None,
+        git: None,
+        imports: None,
+        dup: None,
+        complexity: None,
+        api_surface: None,
+        fun: None,
+    }
+}
+
+fn sample_derived() -> DerivedReport {
+    DerivedReport {
+        totals: DerivedTotals {
+            files: 12,
+            code: 2400,
+            comments: 310,
+            blanks: 160,
+            lines: 2870,
+            bytes: 72_000,
+            tokens: 19_200,
+        },
+        doc_density: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 310,
+                denominator: 2710,
+                ratio: 0.1143,
+            },
+            by_lang: vec![
+                RatioRow {
+                    key: "Rust".into(),
+                    numerator: 250,
+                    denominator: 2100,
+                    ratio: 0.1190,
+                },
+                RatioRow {
+                    key: "TOML".into(),
+                    numerator: 60,
+                    denominator: 610,
+                    ratio: 0.0983,
+                },
+            ],
+            by_module: vec![],
+        },
+        whitespace: RatioReport {
+            total: RatioRow {
+                key: "total".into(),
+                numerator: 160,
+                denominator: 2870,
+                ratio: 0.0557,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        verbosity: RateReport {
+            total: RateRow {
+                key: "total".into(),
+                numerator: 72_000,
+                denominator: 2870,
+                rate: 25.08,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        max_file: MaxFileReport {
+            overall: FileStatRow {
+                path: "src/core.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 520,
+                comments: 75,
+                blanks: 40,
+                lines: 635,
+                bytes: 15_600,
+                tokens: 4_160,
+                doc_pct: Some(0.126),
+                bytes_per_line: Some(24.56),
+                depth: 1,
+            },
+            by_lang: vec![],
+            by_module: vec![],
+        },
+        lang_purity: LangPurityReport { rows: vec![] },
+        nesting: NestingReport {
+            max: 6,
+            avg: 2.8,
+            by_module: vec![],
+        },
+        test_density: TestDensityReport {
+            test_lines: 350,
+            prod_lines: 2050,
+            test_files: 4,
+            prod_files: 8,
+            ratio: 0.1707,
+        },
+        boilerplate: BoilerplateReport {
+            infra_lines: 120,
+            logic_lines: 2750,
+            ratio: 0.0436,
+            infra_langs: vec!["TOML".into(), "YAML".into()],
+        },
+        polyglot: PolyglotReport {
+            lang_count: 3,
+            entropy: 0.78,
+            dominant_lang: "Rust".into(),
+            dominant_lines: 2100,
+            dominant_pct: 0.73,
+        },
+        distribution: DistributionReport {
+            count: 12,
+            min: 45,
+            max: 635,
+            mean: 239.16,
+            median: 195.0,
+            p90: 520.0,
+            p99: 635.0,
+            gini: 0.32,
+        },
+        histogram: vec![
+            HistogramBucket {
+                label: "Small".into(),
+                min: 0,
+                max: Some(100),
+                files: 5,
+                pct: 0.4167,
+            },
+            HistogramBucket {
+                label: "Medium".into(),
+                min: 101,
+                max: Some(500),
+                files: 5,
+                pct: 0.4167,
+            },
+            HistogramBucket {
+                label: "Large".into(),
+                min: 501,
+                max: None,
+                files: 2,
+                pct: 0.1667,
+            },
+        ],
+        top: TopOffenders {
+            largest_lines: vec![FileStatRow {
+                path: "src/core.rs".into(),
+                module: "src".into(),
+                lang: "Rust".into(),
+                code: 520,
+                comments: 75,
+                blanks: 40,
+                lines: 635,
+                bytes: 15_600,
+                tokens: 4_160,
+                doc_pct: Some(0.126),
+                bytes_per_line: Some(24.56),
+                depth: 1,
+            }],
+            largest_tokens: vec![],
+            largest_bytes: vec![],
+            least_documented: vec![],
+            most_dense: vec![],
+        },
+        tree: None,
+        reading_time: ReadingTimeReport {
+            minutes: 143.5,
+            lines_per_minute: 20,
+            basis_lines: 2870,
+        },
+        context_window: Some(ContextWindowReport {
+            window_tokens: 128_000,
+            total_tokens: 19_200,
+            pct: 15.0,
+            fits: true,
+        }),
+        cocomo: Some(CocomoReport {
+            mode: "organic".into(),
+            kloc: 2.4,
+            effort_pm: 6.87,
+            duration_months: 4.56,
+            staff: 1.5,
+            a: 2.4,
+            b: 1.05,
+            c: 2.5,
+            d: 0.38,
+        }),
+        todo: Some(TodoReport {
+            total: 8,
+            density_per_kloc: 3.33,
+            tags: vec![
+                TodoTagRow {
+                    tag: "TODO".into(),
+                    count: 5,
+                },
+                TodoTagRow {
+                    tag: "FIXME".into(),
+                    count: 3,
+                },
+            ],
+        }),
+        integrity: IntegrityReport {
+            algo: "blake3".into(),
+            hash: "a".repeat(64),
+            entries: 12,
+        },
+    }
+}
+
+fn text(output: RenderedOutput) -> String {
+    match output {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text output"),
+    }
+}
+
+fn redact_timestamp(html: &str) -> String {
+    let mut result = html.to_string();
+    while let Some(pos) = result.find(" UTC") {
+        if pos >= 19 {
+            let candidate = &result[pos - 19..pos + 4];
+            if candidate.len() == 23
+                && candidate.as_bytes()[4] == b'-'
+                && candidate.as_bytes()[7] == b'-'
+                && candidate.as_bytes()[10] == b' '
+            {
+                result.replace_range(pos - 19..pos + 4, "[TIMESTAMP]");
+                continue;
+            }
+        }
+        break;
+    }
+    result
+}
+
+// ===========================================================================
+// Markdown snapshots (5 tests)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_md_minimal() {
+    let receipt = minimal_receipt();
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w74_analysis_md_minimal", out);
+}
+
+#[test]
+fn w74_analysis_md_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w74_analysis_md_with_derived", out);
+}
+
+#[test]
+fn w74_analysis_md_with_warnings() {
+    let mut receipt = minimal_receipt();
+    receipt.warnings = vec!["truncated at max_files".into(), "git history unavailable".into()];
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w74_analysis_md_with_warnings", out);
+}
+
+#[test]
+fn w74_analysis_md_archetype_and_topics() {
+    let mut receipt = minimal_receipt();
+    receipt.archetype = Some(Archetype {
+        kind: "web-app".into(),
+        evidence: vec!["package.json".into(), "src/index.tsx".into()],
+    });
+    receipt.topics = Some(TopicClouds {
+        per_module: BTreeMap::new(),
+        overall: vec![
+            TopicTerm {
+                term: "frontend".into(),
+                score: 0.91,
+                tf: 15,
+                df: 4,
+            },
+            TopicTerm {
+                term: "rendering".into(),
+                score: 0.68,
+                tf: 9,
+                df: 3,
+            },
+        ],
+    });
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w74_analysis_md_archetype_topics", out);
+}
+
+#[test]
+fn w74_analysis_md_derived_no_cocomo() {
+    let mut receipt = minimal_receipt();
+    let mut d = sample_derived();
+    d.cocomo = None;
+    d.context_window = None;
+    d.todo = None;
+    receipt.derived = Some(d);
+    let out = text(render(&receipt, AnalysisFormat::Md).unwrap());
+    insta::assert_snapshot!("w74_analysis_md_derived_no_cocomo", out);
+}
+
+// ===========================================================================
+// JSON snapshots (3 tests)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_json_minimal() {
+    let receipt = minimal_receipt();
+    let out = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("w74_analysis_json_minimal", out);
+}
+
+#[test]
+fn w74_analysis_json_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("w74_analysis_json_with_derived", out);
+}
+
+#[test]
+fn w74_analysis_json_eco_label() {
+    let mut receipt = minimal_receipt();
+    receipt.fun = Some(FunReport {
+        eco_label: Some(EcoLabel {
+            score: 92.0,
+            label: "A+".into(),
+            bytes: 150_000,
+            notes: "Size-based eco label (0.14 MB)".into(),
+        }),
+    });
+    let out = text(render(&receipt, AnalysisFormat::Json).unwrap());
+    insta::assert_snapshot!("w74_analysis_json_eco_label", out);
+}
+
+// ===========================================================================
+// XML snapshot (1 test)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_xml_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Xml).unwrap());
+    insta::assert_snapshot!("w74_analysis_xml_with_derived", out);
+}
+
+// ===========================================================================
+// SVG snapshot (1 test)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_svg_with_context_window() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Svg).unwrap());
+    insta::assert_snapshot!("w74_analysis_svg_with_context_window", out);
+}
+
+// ===========================================================================
+// Mermaid snapshot (1 test)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_mermaid_with_imports() {
+    let mut receipt = minimal_receipt();
+    receipt.imports = Some(ImportReport {
+        granularity: "module".into(),
+        edges: vec![
+            ImportEdge {
+                from: "core".into(),
+                to: "types".into(),
+                count: 8,
+            },
+            ImportEdge {
+                from: "api".into(),
+                to: "core".into(),
+                count: 4,
+            },
+            ImportEdge {
+                from: "api".into(),
+                to: "types".into(),
+                count: 2,
+            },
+        ],
+    });
+    let out = text(render(&receipt, AnalysisFormat::Mermaid).unwrap());
+    insta::assert_snapshot!("w74_analysis_mermaid_with_imports", out);
+}
+
+// ===========================================================================
+// Tree snapshot (1 test)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_tree_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Tree).unwrap());
+    insta::assert_snapshot!("w74_analysis_tree_with_derived", out);
+}
+
+// ===========================================================================
+// JSON-LD snapshot (1 test)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_jsonld_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = text(render(&receipt, AnalysisFormat::Jsonld).unwrap());
+    insta::assert_snapshot!("w74_analysis_jsonld_with_derived", out);
+}
+
+// ===========================================================================
+// HTML snapshots (2 tests)
+// ===========================================================================
+
+#[test]
+fn w74_analysis_html_with_derived() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let out = redact_timestamp(&text(render(&receipt, AnalysisFormat::Html).unwrap()));
+    insta::assert_snapshot!("w74_analysis_html_with_derived", out);
+}
+
+#[test]
+fn w74_analysis_html_minimal() {
+    let receipt = minimal_receipt();
+    let out = redact_timestamp(&text(render(&receipt, AnalysisFormat::Html).unwrap()));
+    insta::assert_snapshot!("w74_analysis_html_minimal", out);
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_html_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_html_minimal.snap
@@ -1,0 +1,401 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tokmd Analysis Report</title>
+    <style>
+        :root {
+            --bg-primary: #1a1a2e;
+            --bg-secondary: #16213e;
+            --bg-card: #0f3460;
+            --text-primary: #e6e6e6;
+            --text-secondary: #a0a0a0;
+            --accent: #4c9aff;
+            --accent-hover: #357abd;
+            --success: #4caf50;
+            --warning: #ff9800;
+            --danger: #f44336;
+            --border: #2a2a4a;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
+        header {
+            text-align: center;
+            padding: 40px 20px;
+            background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card));
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 30px;
+        }
+        header h1 { font-size: 2.5rem; margin-bottom: 10px; }
+        header .timestamp { color: var(--text-secondary); font-size: 0.9rem; }
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .metric-card {
+            background: var(--bg-card);
+            border-radius: 12px;
+            padding: 20px;
+            text-align: center;
+            border: 1px solid var(--border);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .metric-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 20px rgba(76, 154, 255, 0.2);
+        }
+        .metric-card .value {
+            font-size: 2rem;
+            font-weight: bold;
+            color: var(--accent);
+            display: block;
+        }
+        .metric-card .label {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .section {
+            background: var(--bg-secondary);
+            border-radius: 12px;
+            padding: 24px;
+            margin-bottom: 24px;
+            border: 1px solid var(--border);
+        }
+        .section h2 {
+            font-size: 1.3rem;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--accent);
+            display: inline-block;
+        }
+        #treemap {
+            width: 100%;
+            height: 400px;
+            background: var(--bg-primary);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        .treemap-cell {
+            position: absolute;
+            overflow: hidden;
+            border: 1px solid var(--bg-primary);
+            transition: opacity 0.2s;
+            cursor: pointer;
+        }
+        .treemap-cell:hover { opacity: 0.85; }
+        .treemap-label {
+            padding: 4px 6px;
+            font-size: 11px;
+            color: white;
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .search-box {
+            width: 100%;
+            padding: 12px 16px;
+            font-size: 1rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text-primary);
+            margin-bottom: 16px;
+        }
+        .search-box:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(76, 154, 255, 0.2);
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+        th, td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        th {
+            background: var(--bg-card);
+            color: var(--accent);
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+        }
+        th:hover { background: var(--accent); color: white; }
+        tr:hover { background: rgba(76, 154, 255, 0.1); }
+        .num { text-align: right; font-family: 'SF Mono', Monaco, monospace; }
+        .path { font-family: 'SF Mono', Monaco, monospace; font-size: 0.85rem; }
+        .lang-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+        .hidden { display: none; }
+        footer {
+            text-align: center;
+            padding: 30px;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+        }
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>tokmd Analysis Report</h1>
+        <div class="timestamp">Generated: [TIMESTAMP]</div>
+    </header>
+
+    <div class="container">
+        <div class="metrics-grid">
+            
+        </div>
+
+        <div class="section">
+            <h2>Code Distribution</h2>
+            <div id="treemap"></div>
+        </div>
+
+        <div class="section">
+            <h2>Files</h2>
+            <input type="text" class="search-box" id="search" placeholder="Filter by path, module, or language...">
+            <table id="files-table">
+                <thead>
+                    <tr>
+                        <th data-sort="path">Path</th>
+                        <th data-sort="module">Module</th>
+                        <th data-sort="lang">Lang</th>
+                        <th data-sort="lines" class="num">Lines</th>
+                        <th data-sort="code" class="num">Code</th>
+                        <th data-sort="tokens" class="num">Tokens</th>
+                        <th data-sort="bytes" class="num">Bytes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <footer>
+        Generated by <a href="https://github.com/EffortlessMetrics/tokmd">tokmd</a>
+    </footer>
+
+    <script>
+    const REPORT_DATA = {"files":[]};
+
+    // Language colors
+    const LANG_COLORS = {
+        'Rust': '#dea584',
+        'JavaScript': '#f1e05a',
+        'TypeScript': '#3178c6',
+        'Python': '#3572A5',
+        'Go': '#00ADD8',
+        'Java': '#b07219',
+        'C': '#555555',
+        'C++': '#f34b7d',
+        'C#': '#178600',
+        'Ruby': '#701516',
+        'PHP': '#4F5D95',
+        'Swift': '#F05138',
+        'Kotlin': '#A97BFF',
+        'Scala': '#c22d40',
+        'HTML': '#e34c26',
+        'CSS': '#563d7c',
+        'SCSS': '#c6538c',
+        'JSON': '#292929',
+        'YAML': '#cb171e',
+        'TOML': '#9c4221',
+        'Markdown': '#083fa1',
+        'Shell': '#89e051',
+        'SQL': '#e38c00',
+    };
+
+    function getLangColor(lang) {
+        return LANG_COLORS[lang] || '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+    }
+
+    // Treemap implementation (squarify algorithm)
+    function squarify(data, x, y, width, height) {
+        if (data.length === 0 || width <= 0 || height <= 0) return [];
+
+        const total = data.reduce((sum, d) => sum + d.value, 0);
+        if (total === 0) return [];
+
+        const rects = [];
+        let remaining = [...data];
+        let cx = x, cy = y, cw = width, ch = height;
+
+        while (remaining.length > 0) {
+            const vertical = ch > cw;
+            const side = vertical ? ch : cw;
+            const scale = (cw * ch) / total;
+
+            let row = [];
+            let rowArea = 0;
+            let worst = Infinity;
+
+            for (const item of remaining) {
+                const testRow = [...row, item];
+                const testArea = rowArea + item.value * scale;
+                const testWorst = getWorst(testRow, testArea, side, scale);
+
+                if (testWorst <= worst) {
+                    row = testRow;
+                    rowArea = testArea;
+                    worst = testWorst;
+                } else {
+                    break;
+                }
+            }
+
+            // Layout row
+            const rowSide = rowArea / side;
+            let offset = 0;
+
+            for (const item of row) {
+                const itemSize = (item.value * scale) / rowSide;
+                if (vertical) {
+                    rects.push({ ...item, x: cx, y: cy + offset, w: rowSide, h: itemSize });
+                } else {
+                    rects.push({ ...item, x: cx + offset, y: cy, w: itemSize, h: rowSide });
+                }
+                offset += itemSize;
+            }
+
+            // Update remaining area
+            if (vertical) {
+                cx += rowSide;
+                cw -= rowSide;
+            } else {
+                cy += rowSide;
+                ch -= rowSide;
+            }
+
+            remaining = remaining.slice(row.length);
+        }
+
+        return rects;
+    }
+
+    function getWorst(row, area, side, scale) {
+        if (row.length === 0) return Infinity;
+        const s2 = side * side;
+        let min = Infinity, max = 0;
+        for (const item of row) {
+            const v = item.value * scale;
+            min = Math.min(min, v);
+            max = Math.max(max, v);
+        }
+        return Math.max((s2 * max) / (area * area), (area * area) / (s2 * min));
+    }
+
+    function renderTreemap() {
+        const container = document.getElementById('treemap');
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
+        container.innerHTML = '';
+        container.style.position = 'relative';
+
+        // Aggregate by module
+        const moduleData = {};
+        for (const file of REPORT_DATA.files || []) {
+            const mod = file.module || '(root)';
+            if (!moduleData[mod]) moduleData[mod] = { name: mod, value: 0, lang: file.lang };
+            moduleData[mod].value += file.code || file.lines || 1;
+        }
+
+        const data = Object.values(moduleData).sort((a, b) => b.value - a.value).slice(0, 50);
+        const rects = squarify(data, 0, 0, width, height);
+
+        for (const rect of rects) {
+            const div = document.createElement('div');
+            div.className = 'treemap-cell';
+            div.style.left = rect.x + 'px';
+            div.style.top = rect.y + 'px';
+            div.style.width = rect.w + 'px';
+            div.style.height = rect.h + 'px';
+            div.style.background = getLangColor(rect.lang);
+
+            const label = document.createElement('div');
+            label.className = 'treemap-label';
+            label.textContent = rect.name + ' (' + rect.value.toLocaleString() + ')';
+            div.appendChild(label);
+
+            div.title = rect.name + ': ' + rect.value.toLocaleString() + ' lines';
+            container.appendChild(div);
+        }
+    }
+
+    // Table filtering
+    document.getElementById('search').addEventListener('input', function(e) {
+        const filter = e.target.value.toLowerCase();
+        const rows = document.querySelectorAll('#files-table tbody tr');
+        rows.forEach(row => {
+            const text = row.textContent.toLowerCase();
+            row.classList.toggle('hidden', filter && !text.includes(filter));
+        });
+    });
+
+    // Table sorting
+    let sortCol = null, sortAsc = true;
+    document.querySelectorAll('#files-table th').forEach(th => {
+        th.addEventListener('click', function() {
+            const col = this.dataset.sort;
+            if (sortCol === col) sortAsc = !sortAsc;
+            else { sortCol = col; sortAsc = true; }
+
+            const tbody = document.querySelector('#files-table tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+
+            rows.sort((a, b) => {
+                const aVal = a.querySelector(`[data-${col}]`)?.dataset[col] || a.cells[getColIndex(col)].textContent;
+                const bVal = b.querySelector(`[data-${col}]`)?.dataset[col] || b.cells[getColIndex(col)].textContent;
+                const aNum = parseFloat(aVal.replace(/,/g, ''));
+                const bNum = parseFloat(bVal.replace(/,/g, ''));
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return sortAsc ? aNum - bNum : bNum - aNum;
+                }
+                return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+            });
+
+            rows.forEach(row => tbody.appendChild(row));
+        });
+    });
+
+    function getColIndex(col) {
+        const map = { path: 0, module: 1, lang: 2, lines: 3, code: 4, tokens: 5, bytes: 6 };
+        return map[col] || 0;
+    }
+
+    // Initialize
+    window.addEventListener('load', renderTreemap);
+    window.addEventListener('resize', renderTreemap);
+    </script>
+</body>
+</html>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_html_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_html_with_derived.snap
@@ -1,0 +1,401 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tokmd Analysis Report</title>
+    <style>
+        :root {
+            --bg-primary: #1a1a2e;
+            --bg-secondary: #16213e;
+            --bg-card: #0f3460;
+            --text-primary: #e6e6e6;
+            --text-secondary: #a0a0a0;
+            --accent: #4c9aff;
+            --accent-hover: #357abd;
+            --success: #4caf50;
+            --warning: #ff9800;
+            --danger: #f44336;
+            --border: #2a2a4a;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+        .container { max-width: 1400px; margin: 0 auto; padding: 20px; }
+        header {
+            text-align: center;
+            padding: 40px 20px;
+            background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card));
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 30px;
+        }
+        header h1 { font-size: 2.5rem; margin-bottom: 10px; }
+        header .timestamp { color: var(--text-secondary); font-size: 0.9rem; }
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .metric-card {
+            background: var(--bg-card);
+            border-radius: 12px;
+            padding: 20px;
+            text-align: center;
+            border: 1px solid var(--border);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .metric-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 20px rgba(76, 154, 255, 0.2);
+        }
+        .metric-card .value {
+            font-size: 2rem;
+            font-weight: bold;
+            color: var(--accent);
+            display: block;
+        }
+        .metric-card .label {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .section {
+            background: var(--bg-secondary);
+            border-radius: 12px;
+            padding: 24px;
+            margin-bottom: 24px;
+            border: 1px solid var(--border);
+        }
+        .section h2 {
+            font-size: 1.3rem;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--accent);
+            display: inline-block;
+        }
+        #treemap {
+            width: 100%;
+            height: 400px;
+            background: var(--bg-primary);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        .treemap-cell {
+            position: absolute;
+            overflow: hidden;
+            border: 1px solid var(--bg-primary);
+            transition: opacity 0.2s;
+            cursor: pointer;
+        }
+        .treemap-cell:hover { opacity: 0.85; }
+        .treemap-label {
+            padding: 4px 6px;
+            font-size: 11px;
+            color: white;
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .search-box {
+            width: 100%;
+            padding: 12px 16px;
+            font-size: 1rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text-primary);
+            margin-bottom: 16px;
+        }
+        .search-box:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(76, 154, 255, 0.2);
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+        th, td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        th {
+            background: var(--bg-card);
+            color: var(--accent);
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+        }
+        th:hover { background: var(--accent); color: white; }
+        tr:hover { background: rgba(76, 154, 255, 0.1); }
+        .num { text-align: right; font-family: 'SF Mono', Monaco, monospace; }
+        .path { font-family: 'SF Mono', Monaco, monospace; font-size: 0.85rem; }
+        .lang-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+        .hidden { display: none; }
+        footer {
+            text-align: center;
+            padding: 30px;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+        }
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>tokmd Analysis Report</h1>
+        <div class="timestamp">Generated: [TIMESTAMP]</div>
+    </header>
+
+    <div class="container">
+        <div class="metrics-grid">
+            <div class="metric-card"><span class="value">12</span><span class="label">Files</span></div><div class="metric-card"><span class="value">2.9K</span><span class="label">Lines</span></div><div class="metric-card"><span class="value">2.4K</span><span class="label">Code</span></div><div class="metric-card"><span class="value">19.2K</span><span class="label">Tokens</span></div><div class="metric-card"><span class="value">11.4%</span><span class="label">Doc%</span></div><div class="metric-card"><span class="value">1500.0%</span><span class="label">Context Fit</span></div>
+        </div>
+
+        <div class="section">
+            <h2>Code Distribution</h2>
+            <div id="treemap"></div>
+        </div>
+
+        <div class="section">
+            <h2>Files</h2>
+            <input type="text" class="search-box" id="search" placeholder="Filter by path, module, or language...">
+            <table id="files-table">
+                <thead>
+                    <tr>
+                        <th data-sort="path">Path</th>
+                        <th data-sort="module">Module</th>
+                        <th data-sort="lang">Lang</th>
+                        <th data-sort="lines" class="num">Lines</th>
+                        <th data-sort="code" class="num">Code</th>
+                        <th data-sort="tokens" class="num">Tokens</th>
+                        <th data-sort="bytes" class="num">Bytes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td class="path" data-path="src/core.rs">src/core.rs</td><td data-module="src">src</td><td data-lang="Rust"><span class="lang-badge">Rust</span></td><td class="num" data-lines="635">635</td><td class="num" data-code="520">520</td><td class="num" data-tokens="4160">4.2K</td><td class="num" data-bytes="15600">15.6K</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <footer>
+        Generated by <a href="https://github.com/EffortlessMetrics/tokmd">tokmd</a>
+    </footer>
+
+    <script>
+    const REPORT_DATA = {"files":[{"code":520,"lang":"Rust","lines":635,"module":"src","path":"src/core.rs","tokens":4160}]};
+
+    // Language colors
+    const LANG_COLORS = {
+        'Rust': '#dea584',
+        'JavaScript': '#f1e05a',
+        'TypeScript': '#3178c6',
+        'Python': '#3572A5',
+        'Go': '#00ADD8',
+        'Java': '#b07219',
+        'C': '#555555',
+        'C++': '#f34b7d',
+        'C#': '#178600',
+        'Ruby': '#701516',
+        'PHP': '#4F5D95',
+        'Swift': '#F05138',
+        'Kotlin': '#A97BFF',
+        'Scala': '#c22d40',
+        'HTML': '#e34c26',
+        'CSS': '#563d7c',
+        'SCSS': '#c6538c',
+        'JSON': '#292929',
+        'YAML': '#cb171e',
+        'TOML': '#9c4221',
+        'Markdown': '#083fa1',
+        'Shell': '#89e051',
+        'SQL': '#e38c00',
+    };
+
+    function getLangColor(lang) {
+        return LANG_COLORS[lang] || '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+    }
+
+    // Treemap implementation (squarify algorithm)
+    function squarify(data, x, y, width, height) {
+        if (data.length === 0 || width <= 0 || height <= 0) return [];
+
+        const total = data.reduce((sum, d) => sum + d.value, 0);
+        if (total === 0) return [];
+
+        const rects = [];
+        let remaining = [...data];
+        let cx = x, cy = y, cw = width, ch = height;
+
+        while (remaining.length > 0) {
+            const vertical = ch > cw;
+            const side = vertical ? ch : cw;
+            const scale = (cw * ch) / total;
+
+            let row = [];
+            let rowArea = 0;
+            let worst = Infinity;
+
+            for (const item of remaining) {
+                const testRow = [...row, item];
+                const testArea = rowArea + item.value * scale;
+                const testWorst = getWorst(testRow, testArea, side, scale);
+
+                if (testWorst <= worst) {
+                    row = testRow;
+                    rowArea = testArea;
+                    worst = testWorst;
+                } else {
+                    break;
+                }
+            }
+
+            // Layout row
+            const rowSide = rowArea / side;
+            let offset = 0;
+
+            for (const item of row) {
+                const itemSize = (item.value * scale) / rowSide;
+                if (vertical) {
+                    rects.push({ ...item, x: cx, y: cy + offset, w: rowSide, h: itemSize });
+                } else {
+                    rects.push({ ...item, x: cx + offset, y: cy, w: itemSize, h: rowSide });
+                }
+                offset += itemSize;
+            }
+
+            // Update remaining area
+            if (vertical) {
+                cx += rowSide;
+                cw -= rowSide;
+            } else {
+                cy += rowSide;
+                ch -= rowSide;
+            }
+
+            remaining = remaining.slice(row.length);
+        }
+
+        return rects;
+    }
+
+    function getWorst(row, area, side, scale) {
+        if (row.length === 0) return Infinity;
+        const s2 = side * side;
+        let min = Infinity, max = 0;
+        for (const item of row) {
+            const v = item.value * scale;
+            min = Math.min(min, v);
+            max = Math.max(max, v);
+        }
+        return Math.max((s2 * max) / (area * area), (area * area) / (s2 * min));
+    }
+
+    function renderTreemap() {
+        const container = document.getElementById('treemap');
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
+        container.innerHTML = '';
+        container.style.position = 'relative';
+
+        // Aggregate by module
+        const moduleData = {};
+        for (const file of REPORT_DATA.files || []) {
+            const mod = file.module || '(root)';
+            if (!moduleData[mod]) moduleData[mod] = { name: mod, value: 0, lang: file.lang };
+            moduleData[mod].value += file.code || file.lines || 1;
+        }
+
+        const data = Object.values(moduleData).sort((a, b) => b.value - a.value).slice(0, 50);
+        const rects = squarify(data, 0, 0, width, height);
+
+        for (const rect of rects) {
+            const div = document.createElement('div');
+            div.className = 'treemap-cell';
+            div.style.left = rect.x + 'px';
+            div.style.top = rect.y + 'px';
+            div.style.width = rect.w + 'px';
+            div.style.height = rect.h + 'px';
+            div.style.background = getLangColor(rect.lang);
+
+            const label = document.createElement('div');
+            label.className = 'treemap-label';
+            label.textContent = rect.name + ' (' + rect.value.toLocaleString() + ')';
+            div.appendChild(label);
+
+            div.title = rect.name + ': ' + rect.value.toLocaleString() + ' lines';
+            container.appendChild(div);
+        }
+    }
+
+    // Table filtering
+    document.getElementById('search').addEventListener('input', function(e) {
+        const filter = e.target.value.toLowerCase();
+        const rows = document.querySelectorAll('#files-table tbody tr');
+        rows.forEach(row => {
+            const text = row.textContent.toLowerCase();
+            row.classList.toggle('hidden', filter && !text.includes(filter));
+        });
+    });
+
+    // Table sorting
+    let sortCol = null, sortAsc = true;
+    document.querySelectorAll('#files-table th').forEach(th => {
+        th.addEventListener('click', function() {
+            const col = this.dataset.sort;
+            if (sortCol === col) sortAsc = !sortAsc;
+            else { sortCol = col; sortAsc = true; }
+
+            const tbody = document.querySelector('#files-table tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+
+            rows.sort((a, b) => {
+                const aVal = a.querySelector(`[data-${col}]`)?.dataset[col] || a.cells[getColIndex(col)].textContent;
+                const bVal = b.querySelector(`[data-${col}]`)?.dataset[col] || b.cells[getColIndex(col)].textContent;
+                const aNum = parseFloat(aVal.replace(/,/g, ''));
+                const bNum = parseFloat(bVal.replace(/,/g, ''));
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return sortAsc ? aNum - bNum : bNum - aNum;
+                }
+                return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+            });
+
+            rows.forEach(row => tbody.appendChild(row));
+        });
+    });
+
+    function getColIndex(col) {
+        const map = { path: 0, module: 1, lang: 2, lines: 3, code: 4, tokens: 5, bytes: 6 };
+        return map[col] || 0;
+    }
+
+    // Initialize
+    window.addEventListener('load', renderTreemap);
+    window.addEventListener('resize', renderTreemap);
+    </script>
+</body>
+</html>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_json_eco_label.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_json_eco_label.snap
@@ -1,0 +1,62 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "json",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": null,
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": {
+    "eco_label": {
+      "score": 92.0,
+      "label": "A+",
+      "bytes": 150000,
+      "notes": "Size-based eco label (0.14 MB)"
+    }
+  }
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_json_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_json_minimal.snap
@@ -1,0 +1,55 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "json",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": null,
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": null
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_json_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_json_with_derived.snap
@@ -1,0 +1,254 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+{
+  "schema_version": 8,
+  "generated_at_ms": 0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "mode": "analyze",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature": null,
+    "module_roots": [],
+    "module_depth": 1,
+    "children": "collapse"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "json",
+    "window_tokens": null,
+    "git": null,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": {
+    "totals": {
+      "files": 12,
+      "code": 2400,
+      "comments": 310,
+      "blanks": 160,
+      "lines": 2870,
+      "bytes": 72000,
+      "tokens": 19200
+    },
+    "doc_density": {
+      "total": {
+        "key": "total",
+        "numerator": 310,
+        "denominator": 2710,
+        "ratio": 0.1143
+      },
+      "by_lang": [
+        {
+          "key": "Rust",
+          "numerator": 250,
+          "denominator": 2100,
+          "ratio": 0.119
+        },
+        {
+          "key": "TOML",
+          "numerator": 60,
+          "denominator": 610,
+          "ratio": 0.0983
+        }
+      ],
+      "by_module": []
+    },
+    "whitespace": {
+      "total": {
+        "key": "total",
+        "numerator": 160,
+        "denominator": 2870,
+        "ratio": 0.0557
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "verbosity": {
+      "total": {
+        "key": "total",
+        "numerator": 72000,
+        "denominator": 2870,
+        "rate": 25.08
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "max_file": {
+      "overall": {
+        "path": "src/core.rs",
+        "module": "src",
+        "lang": "Rust",
+        "code": 520,
+        "comments": 75,
+        "blanks": 40,
+        "lines": 635,
+        "bytes": 15600,
+        "tokens": 4160,
+        "doc_pct": 0.126,
+        "bytes_per_line": 24.56,
+        "depth": 1
+      },
+      "by_lang": [],
+      "by_module": []
+    },
+    "lang_purity": {
+      "rows": []
+    },
+    "nesting": {
+      "max": 6,
+      "avg": 2.8,
+      "by_module": []
+    },
+    "test_density": {
+      "test_lines": 350,
+      "prod_lines": 2050,
+      "test_files": 4,
+      "prod_files": 8,
+      "ratio": 0.1707
+    },
+    "boilerplate": {
+      "infra_lines": 120,
+      "logic_lines": 2750,
+      "ratio": 0.0436,
+      "infra_langs": [
+        "TOML",
+        "YAML"
+      ]
+    },
+    "polyglot": {
+      "lang_count": 3,
+      "entropy": 0.78,
+      "dominant_lang": "Rust",
+      "dominant_lines": 2100,
+      "dominant_pct": 0.73
+    },
+    "distribution": {
+      "count": 12,
+      "min": 45,
+      "max": 635,
+      "mean": 239.16,
+      "median": 195.0,
+      "p90": 520.0,
+      "p99": 635.0,
+      "gini": 0.32
+    },
+    "histogram": [
+      {
+        "label": "Small",
+        "min": 0,
+        "max": 100,
+        "files": 5,
+        "pct": 0.4167
+      },
+      {
+        "label": "Medium",
+        "min": 101,
+        "max": 500,
+        "files": 5,
+        "pct": 0.4167
+      },
+      {
+        "label": "Large",
+        "min": 501,
+        "max": null,
+        "files": 2,
+        "pct": 0.1667
+      }
+    ],
+    "top": {
+      "largest_lines": [
+        {
+          "path": "src/core.rs",
+          "module": "src",
+          "lang": "Rust",
+          "code": 520,
+          "comments": 75,
+          "blanks": 40,
+          "lines": 635,
+          "bytes": 15600,
+          "tokens": 4160,
+          "doc_pct": 0.126,
+          "bytes_per_line": 24.56,
+          "depth": 1
+        }
+      ],
+      "largest_tokens": [],
+      "largest_bytes": [],
+      "least_documented": [],
+      "most_dense": []
+    },
+    "tree": null,
+    "reading_time": {
+      "minutes": 143.5,
+      "lines_per_minute": 20,
+      "basis_lines": 2870
+    },
+    "context_window": {
+      "window_tokens": 128000,
+      "total_tokens": 19200,
+      "pct": 15.0,
+      "fits": true
+    },
+    "cocomo": {
+      "mode": "organic",
+      "kloc": 2.4,
+      "effort_pm": 6.87,
+      "duration_months": 4.56,
+      "staff": 1.5,
+      "a": 2.4,
+      "b": 1.05,
+      "c": 2.5,
+      "d": 0.38
+    },
+    "todo": {
+      "total": 8,
+      "density_per_kloc": 3.33,
+      "tags": [
+        {
+          "tag": "TODO",
+          "count": 5
+        },
+        {
+          "tag": "FIXME",
+          "count": 3
+        }
+      ]
+    },
+    "integrity": {
+      "algo": "blake3",
+      "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "entries": 12
+    }
+  },
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": null,
+  "complexity": null,
+  "api_surface": null,
+  "fun": null
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_jsonld_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_jsonld_with_derived.snap
@@ -1,0 +1,18 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "codeLines": 2400,
+  "commentCount": 310,
+  "fileSize": 72000,
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "http://schema.org/ReadAction",
+    "userInteractionCount": 19200
+  },
+  "lineCount": 2870,
+  "name": "."
+}

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_archetype_topics.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_archetype_topics.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Archetype
+
+- Kind: `web-app`
+- Evidence: `package.json`, `src/index.tsx`
+
+## Topics
+
+- Overall: `frontend, rendering`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_derived_no_cocomo.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_derived_no_cocomo.snap
@@ -1,0 +1,116 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Totals
+
+|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|
+|---:|---:|---:|---:|---:|---:|---:|
+|12|2400|310|160|2870|72000|19200|
+
+## Ratios
+
+|Metric|Value|
+|---|---:|
+|Doc density|11.4%|
+|Whitespace ratio|5.6%|
+|Bytes per line|25.08|
+
+### Doc density by language
+
+|Lang|Doc%|Comments|Code|
+|---|---:|---:|---:|
+|Rust|11.9%|250|1850|
+|TOML|9.8%|60|550|
+
+### Whitespace ratio by language
+
+|Lang|Blank%|Blanks|Code+Comments|
+|---|---:|---:|---:|
+
+### Verbosity by language
+
+|Lang|Bytes/Line|Bytes|Lines|
+|---|---:|---:|---:|
+
+## Distribution
+
+|Count|Min|Max|Mean|Median|P90|P99|Gini|
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|12|45|635|239.16|195.00|520.00|635.00|0.3200|
+
+## File size histogram
+
+|Bucket|Min|Max|Files|Pct|
+|---|---:|---:|---:|---:|
+|Small|0|100|5|41.7%|
+|Medium|101|500|5|41.7%|
+|Large|501|∞|2|16.7%|
+
+## Top offenders
+
+### Largest files by lines
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|src/core.rs|Rust|635|520|15600|4160|12.6%|24.56|
+
+### Largest files by tokens
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Largest files by bytes
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Least documented (min LOC)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Most dense (bytes/line)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+## Structure
+
+- Max depth: `6`
+- Avg depth: `2.80`
+
+## Test density
+
+- Test lines: `350`
+- Prod lines: `2050`
+- Test ratio: `17.1%`
+
+## Boilerplate ratio
+
+- Infra lines: `120`
+- Logic lines: `2750`
+- Infra ratio: `4.4%`
+
+## Polyglot
+
+- Languages: `3`
+- Dominant: `Rust` (73.0%)
+- Entropy: `0.7800`
+
+## Reading time
+
+- Minutes: `143.50` (20 lines/min)
+
+## Integrity
+
+- Hash: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` (`blake3`)
+- Entries: `12`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_minimal.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_minimal.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_with_derived.snap
@@ -1,0 +1,141 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Totals
+
+|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|
+|---:|---:|---:|---:|---:|---:|---:|
+|12|2400|310|160|2870|72000|19200|
+
+## Ratios
+
+|Metric|Value|
+|---|---:|
+|Doc density|11.4%|
+|Whitespace ratio|5.6%|
+|Bytes per line|25.08|
+
+### Doc density by language
+
+|Lang|Doc%|Comments|Code|
+|---|---:|---:|---:|
+|Rust|11.9%|250|1850|
+|TOML|9.8%|60|550|
+
+### Whitespace ratio by language
+
+|Lang|Blank%|Blanks|Code+Comments|
+|---|---:|---:|---:|
+
+### Verbosity by language
+
+|Lang|Bytes/Line|Bytes|Lines|
+|---|---:|---:|---:|
+
+## Distribution
+
+|Count|Min|Max|Mean|Median|P90|P99|Gini|
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|12|45|635|239.16|195.00|520.00|635.00|0.3200|
+
+## File size histogram
+
+|Bucket|Min|Max|Files|Pct|
+|---|---:|---:|---:|---:|
+|Small|0|100|5|41.7%|
+|Medium|101|500|5|41.7%|
+|Large|501|∞|2|16.7%|
+
+## Top offenders
+
+### Largest files by lines
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|src/core.rs|Rust|635|520|15600|4160|12.6%|24.56|
+
+### Largest files by tokens
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Largest files by bytes
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Least documented (min LOC)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Most dense (bytes/line)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+## Structure
+
+- Max depth: `6`
+- Avg depth: `2.80`
+
+## Test density
+
+- Test lines: `350`
+- Prod lines: `2050`
+- Test ratio: `17.1%`
+
+## TODOs
+
+- Total: `8`
+- Density (per KLOC): `3.33`
+
+|Tag|Count|
+|---|---:|
+|TODO|5|
+|FIXME|3|
+
+## Boilerplate ratio
+
+- Infra lines: `120`
+- Logic lines: `2750`
+- Infra ratio: `4.4%`
+
+## Polyglot
+
+- Languages: `3`
+- Dominant: `Rust` (73.0%)
+- Entropy: `0.7800`
+
+## Reading time
+
+- Minutes: `143.50` (20 lines/min)
+
+## Context window
+
+- Window tokens: `128000`
+- Total tokens: `19200`
+- Utilization: `1500.0%`
+- Fits: `true`
+
+## COCOMO estimate
+
+- Mode: `organic`
+- KLOC: `2.4000`
+- Effort (PM): `6.87`
+- Duration (months): `4.56`
+- Staff: `1.50`
+
+## Integrity
+
+- Hash: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` (`blake3`)
+- Entries: `12`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_with_warnings.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_md_with_warnings.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_mermaid_with_imports.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_mermaid_with_imports.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+graph TD
+  core -->|8| types
+  api -->|4| core
+  api -->|2| types

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_svg_with_context_window.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_svg_with_context_window.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="32" role="img"><rect width="80" height="32" fill="#555"/><rect x="80" width="160" height="32" fill="#4c9aff"/><text x="40" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">context</text><text x="160" y="20" fill="#fff" font-family="Verdana" font-size="12" text-anchor="middle">1500.0%</text></svg>

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_tree_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_tree_with_derived.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+(tree unavailable)

--- a/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_xml_with_derived.snap
+++ b/crates/tokmd-analysis-format/tests/snapshots/snapshot_w74__w74_analysis_xml_with_derived.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tokmd-analysis-format/tests/snapshot_w74.rs
+expression: out
+---
+<analysis><totals files="12" code="2400" comments="310" blanks="160" lines="2870" bytes="72000" tokens="19200"/></analysis>

--- a/crates/tokmd-format/tests/snapshot_w74.rs
+++ b/crates/tokmd-format/tests/snapshot_w74.rs
@@ -1,0 +1,507 @@
+//! Golden snapshot tests for output formats (W74).
+//!
+//! Comprehensive insta snapshot coverage for Markdown, TSV, JSON, CSV, and JSONL
+//! renderings across lang, module, and export commands.
+
+use std::path::PathBuf;
+
+use tokmd_format::{
+    write_export_csv_to, write_export_jsonl_to, write_export_json_to,
+    write_export_cyclonedx_with_options, write_lang_report_to, write_module_report_to,
+};
+use tokmd_settings::{ChildIncludeMode, ChildrenMode, ScanOptions};
+use tokmd_types::{
+    ExportArgs, ExportData, ExportFormat, FileKind, FileRow, LangArgs, LangReport, LangRow,
+    ModuleArgs, ModuleReport, ModuleRow, RedactMode, TableFormat, Totals,
+};
+
+// ===========================================================================
+// Fixtures
+// ===========================================================================
+
+fn three_lang_report(with_files: bool) -> LangReport {
+    LangReport {
+        rows: vec![
+            LangRow {
+                lang: "Rust".into(),
+                code: 5200,
+                lines: 6800,
+                files: 40,
+                bytes: 182_000,
+                tokens: 46_000,
+                avg_lines: 170,
+            },
+            LangRow {
+                lang: "TypeScript".into(),
+                code: 3100,
+                lines: 4000,
+                files: 25,
+                bytes: 93_000,
+                tokens: 28_000,
+                avg_lines: 160,
+            },
+            LangRow {
+                lang: "TOML".into(),
+                code: 400,
+                lines: 520,
+                files: 8,
+                bytes: 12_000,
+                tokens: 3_200,
+                avg_lines: 65,
+            },
+        ],
+        total: Totals {
+            code: 8700,
+            lines: 11320,
+            files: 73,
+            bytes: 287_000,
+            tokens: 77_200,
+            avg_lines: 155,
+        },
+        with_files,
+        children: ChildrenMode::Collapse,
+        top: 0,
+    }
+}
+
+fn single_lang_report() -> LangReport {
+    LangReport {
+        rows: vec![LangRow {
+            lang: "Python".into(),
+            code: 920,
+            lines: 1180,
+            files: 7,
+            bytes: 27_600,
+            tokens: 9_200,
+            avg_lines: 168,
+        }],
+        total: Totals {
+            code: 920,
+            lines: 1180,
+            files: 7,
+            bytes: 27_600,
+            tokens: 9_200,
+            avg_lines: 168,
+        },
+        with_files: true,
+        children: ChildrenMode::Collapse,
+        top: 0,
+    }
+}
+
+fn empty_lang_report() -> LangReport {
+    LangReport {
+        rows: vec![],
+        total: Totals {
+            code: 0,
+            lines: 0,
+            files: 0,
+            bytes: 0,
+            tokens: 0,
+            avg_lines: 0,
+        },
+        with_files: false,
+        children: ChildrenMode::Collapse,
+        top: 0,
+    }
+}
+
+fn embedded_lang_report() -> LangReport {
+    LangReport {
+        rows: vec![
+            LangRow {
+                lang: "HTML".into(),
+                code: 420,
+                lines: 540,
+                files: 5,
+                bytes: 12_600,
+                tokens: 4_200,
+                avg_lines: 108,
+            },
+            LangRow {
+                lang: "JavaScript (embedded)".into(),
+                code: 210,
+                lines: 260,
+                files: 5,
+                bytes: 6_300,
+                tokens: 2_100,
+                avg_lines: 52,
+            },
+            LangRow {
+                lang: "CSS (embedded)".into(),
+                code: 130,
+                lines: 160,
+                files: 4,
+                bytes: 3_900,
+                tokens: 1_300,
+                avg_lines: 40,
+            },
+        ],
+        total: Totals {
+            code: 760,
+            lines: 960,
+            files: 14,
+            bytes: 22_800,
+            tokens: 7_600,
+            avg_lines: 68,
+        },
+        with_files: true,
+        children: ChildrenMode::Separate,
+        top: 0,
+    }
+}
+
+fn three_module_report() -> ModuleReport {
+    ModuleReport {
+        rows: vec![
+            ModuleRow {
+                module: "crates/core".into(),
+                code: 3200,
+                lines: 4100,
+                files: 16,
+                bytes: 96_000,
+                tokens: 25_600,
+                avg_lines: 256,
+            },
+            ModuleRow {
+                module: "crates/api".into(),
+                code: 1800,
+                lines: 2250,
+                files: 10,
+                bytes: 54_000,
+                tokens: 14_400,
+                avg_lines: 225,
+            },
+            ModuleRow {
+                module: "tests".into(),
+                code: 1100,
+                lines: 1350,
+                files: 6,
+                bytes: 33_000,
+                tokens: 8_800,
+                avg_lines: 225,
+            },
+        ],
+        total: Totals {
+            code: 6100,
+            lines: 7700,
+            files: 32,
+            bytes: 183_000,
+            tokens: 48_800,
+            avg_lines: 240,
+        },
+        module_roots: vec!["crates".into()],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+        top: 0,
+    }
+}
+
+fn sample_file_rows() -> Vec<FileRow> {
+    vec![
+        FileRow {
+            path: "src/main.rs".into(),
+            module: "src".into(),
+            lang: "Rust".into(),
+            kind: FileKind::Parent,
+            code: 280,
+            comments: 40,
+            blanks: 30,
+            lines: 350,
+            bytes: 8_400,
+            tokens: 2_800,
+        },
+        FileRow {
+            path: "src/lib.rs".into(),
+            module: "src".into(),
+            lang: "Rust".into(),
+            kind: FileKind::Parent,
+            code: 450,
+            comments: 65,
+            blanks: 45,
+            lines: 560,
+            bytes: 13_500,
+            tokens: 4_500,
+        },
+        FileRow {
+            path: "tests/smoke.rs".into(),
+            module: "tests".into(),
+            lang: "Rust".into(),
+            kind: FileKind::Parent,
+            code: 95,
+            comments: 12,
+            blanks: 15,
+            lines: 122,
+            bytes: 2_850,
+            tokens: 950,
+        },
+    ]
+}
+
+fn sample_export_data() -> ExportData {
+    ExportData {
+        rows: sample_file_rows(),
+        module_roots: vec!["src".into()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+// ===========================================================================
+// Args helpers
+// ===========================================================================
+
+fn default_scan() -> ScanOptions {
+    ScanOptions::default()
+}
+
+fn lang_args(format: TableFormat) -> LangArgs {
+    LangArgs {
+        paths: vec![PathBuf::from(".")],
+        format,
+        top: 0,
+        files: true,
+        children: ChildrenMode::Collapse,
+    }
+}
+
+fn module_args(format: TableFormat) -> ModuleArgs {
+    ModuleArgs {
+        paths: vec![PathBuf::from(".")],
+        format,
+        top: 0,
+        module_roots: vec![],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn export_args(format: ExportFormat) -> ExportArgs {
+    ExportArgs {
+        paths: vec![PathBuf::from(".")],
+        format,
+        output: None,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+        min_code: 0,
+        max_rows: 0,
+        redact: RedactMode::None,
+        meta: false,
+        strip_prefix: None,
+    }
+}
+
+// ===========================================================================
+// Render helpers
+// ===========================================================================
+
+fn render_lang(report: &LangReport, format: TableFormat) -> String {
+    let mut buf = Vec::new();
+    write_lang_report_to(&mut buf, report, &default_scan(), &lang_args(format)).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn render_module(report: &ModuleReport, format: TableFormat) -> String {
+    let mut buf = Vec::new();
+    write_module_report_to(&mut buf, report, &default_scan(), &module_args(format)).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn render_export_csv(data: &ExportData) -> String {
+    let mut buf = Vec::new();
+    write_export_csv_to(&mut buf, data, &export_args(ExportFormat::Csv)).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn render_export_jsonl(data: &ExportData) -> String {
+    let mut buf = Vec::new();
+    write_export_jsonl_to(
+        &mut buf,
+        data,
+        &default_scan(),
+        &export_args(ExportFormat::Jsonl),
+    )
+    .unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn render_export_json(data: &ExportData) -> String {
+    let mut buf = Vec::new();
+    write_export_json_to(
+        &mut buf,
+        data,
+        &default_scan(),
+        &export_args(ExportFormat::Json),
+    )
+    .unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn normalize_json(raw: &str) -> String {
+    let mut v: serde_json::Value = serde_json::from_str(raw).unwrap();
+    if let Some(obj) = v.as_object_mut() {
+        obj.insert("generated_at_ms".into(), serde_json::json!(0));
+        obj.insert(
+            "tool".into(),
+            serde_json::json!({"name": "tokmd", "version": "0.0.0-test"}),
+        );
+        obj.remove("scan");
+    }
+    serde_json::to_string_pretty(&v).unwrap()
+}
+
+// ===========================================================================
+// Lang – Markdown (6 tests)
+// ===========================================================================
+
+#[test]
+fn w74_lang_md_three_langs_with_files() {
+    let out = render_lang(&three_lang_report(true), TableFormat::Md);
+    insta::assert_snapshot!("w74_lang_md_three_langs_with_files", out);
+}
+
+#[test]
+fn w74_lang_md_three_langs_without_files() {
+    let out = render_lang(&three_lang_report(false), TableFormat::Md);
+    insta::assert_snapshot!("w74_lang_md_three_langs_without_files", out);
+}
+
+#[test]
+fn w74_lang_md_single_lang() {
+    let out = render_lang(&single_lang_report(), TableFormat::Md);
+    insta::assert_snapshot!("w74_lang_md_single_lang", out);
+}
+
+#[test]
+fn w74_lang_md_empty() {
+    let out = render_lang(&empty_lang_report(), TableFormat::Md);
+    insta::assert_snapshot!("w74_lang_md_empty", out);
+}
+
+#[test]
+fn w74_lang_md_embedded_separate() {
+    let out = render_lang(&embedded_lang_report(), TableFormat::Md);
+    insta::assert_snapshot!("w74_lang_md_embedded_separate", out);
+}
+
+#[test]
+fn w74_lang_md_empty_with_files() {
+    let mut report = empty_lang_report();
+    report.with_files = true;
+    let out = render_lang(&report, TableFormat::Md);
+    insta::assert_snapshot!("w74_lang_md_empty_with_files", out);
+}
+
+// ===========================================================================
+// Lang – TSV (4 tests)
+// ===========================================================================
+
+#[test]
+fn w74_lang_tsv_three_langs() {
+    let out = render_lang(&three_lang_report(true), TableFormat::Tsv);
+    insta::assert_snapshot!("w74_lang_tsv_three_langs", out);
+}
+
+#[test]
+fn w74_lang_tsv_without_files() {
+    let out = render_lang(&three_lang_report(false), TableFormat::Tsv);
+    insta::assert_snapshot!("w74_lang_tsv_without_files", out);
+}
+
+#[test]
+fn w74_lang_tsv_single_lang() {
+    let out = render_lang(&single_lang_report(), TableFormat::Tsv);
+    insta::assert_snapshot!("w74_lang_tsv_single_lang", out);
+}
+
+#[test]
+fn w74_lang_tsv_empty() {
+    let out = render_lang(&empty_lang_report(), TableFormat::Tsv);
+    insta::assert_snapshot!("w74_lang_tsv_empty", out);
+}
+
+// ===========================================================================
+// Lang – JSON (3 tests)
+// ===========================================================================
+
+#[test]
+fn w74_lang_json_three_langs() {
+    let out = render_lang(&three_lang_report(true), TableFormat::Json);
+    insta::assert_snapshot!("w74_lang_json_three_langs", normalize_json(&out));
+}
+
+#[test]
+fn w74_lang_json_single_lang() {
+    let out = render_lang(&single_lang_report(), TableFormat::Json);
+    insta::assert_snapshot!("w74_lang_json_single_lang", normalize_json(&out));
+}
+
+#[test]
+fn w74_lang_json_empty() {
+    let out = render_lang(&empty_lang_report(), TableFormat::Json);
+    insta::assert_snapshot!("w74_lang_json_empty", normalize_json(&out));
+}
+
+// ===========================================================================
+// Module – Markdown / TSV / JSON (3 tests)
+// ===========================================================================
+
+#[test]
+fn w74_module_md_three_modules() {
+    let out = render_module(&three_module_report(), TableFormat::Md);
+    insta::assert_snapshot!("w74_module_md_three_modules", out);
+}
+
+#[test]
+fn w74_module_tsv_three_modules() {
+    let out = render_module(&three_module_report(), TableFormat::Tsv);
+    insta::assert_snapshot!("w74_module_tsv_three_modules", out);
+}
+
+#[test]
+fn w74_module_json_three_modules() {
+    let out = render_module(&three_module_report(), TableFormat::Json);
+    insta::assert_snapshot!("w74_module_json_three_modules", normalize_json(&out));
+}
+
+// ===========================================================================
+// Export – CSV / JSONL / JSON / CycloneDX (4 tests)
+// ===========================================================================
+
+#[test]
+fn w74_export_csv() {
+    let out = render_export_csv(&sample_export_data());
+    insta::assert_snapshot!("w74_export_csv", out);
+}
+
+#[test]
+fn w74_export_jsonl() {
+    let out = render_export_jsonl(&sample_export_data());
+    insta::assert_snapshot!("w74_export_jsonl", out);
+}
+
+#[test]
+fn w74_export_json() {
+    let raw = render_export_json(&sample_export_data());
+    insta::assert_snapshot!("w74_export_json", normalize_json(&raw));
+}
+
+#[test]
+fn w74_export_cyclonedx() {
+    let mut buf = Vec::new();
+    write_export_cyclonedx_with_options(
+        &mut buf,
+        &sample_export_data(),
+        RedactMode::None,
+        Some("urn:uuid:00000000-0000-0000-0000-000000000000".into()),
+        Some("2024-01-01T00:00:00Z".into()),
+    )
+    .unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    let pretty: serde_json::Value = serde_json::from_str(&out).unwrap();
+    insta::assert_snapshot!(
+        "w74_export_cyclonedx",
+        serde_json::to_string_pretty(&pretty).unwrap()
+    );
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_csv.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_csv.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+path,module,lang,kind,code,comments,blanks,lines,bytes,tokens
+src/main.rs,src,Rust,parent,280,40,30,350,8400,2800
+src/lib.rs,src,Rust,parent,450,65,45,560,13500,4500
+tests/smoke.rs,tests,Rust,parent,95,12,15,122,2850,950

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -1,0 +1,127 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: "serde_json::to_string_pretty(&pretty).unwrap()"
+---
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "group": "src",
+      "name": "src/main.rs",
+      "properties": [
+        {
+          "name": "tokmd:lang",
+          "value": "Rust"
+        },
+        {
+          "name": "tokmd:code",
+          "value": "280"
+        },
+        {
+          "name": "tokmd:comments",
+          "value": "40"
+        },
+        {
+          "name": "tokmd:blanks",
+          "value": "30"
+        },
+        {
+          "name": "tokmd:lines",
+          "value": "350"
+        },
+        {
+          "name": "tokmd:bytes",
+          "value": "8400"
+        },
+        {
+          "name": "tokmd:tokens",
+          "value": "2800"
+        }
+      ],
+      "type": "file"
+    },
+    {
+      "group": "src",
+      "name": "src/lib.rs",
+      "properties": [
+        {
+          "name": "tokmd:lang",
+          "value": "Rust"
+        },
+        {
+          "name": "tokmd:code",
+          "value": "450"
+        },
+        {
+          "name": "tokmd:comments",
+          "value": "65"
+        },
+        {
+          "name": "tokmd:blanks",
+          "value": "45"
+        },
+        {
+          "name": "tokmd:lines",
+          "value": "560"
+        },
+        {
+          "name": "tokmd:bytes",
+          "value": "13500"
+        },
+        {
+          "name": "tokmd:tokens",
+          "value": "4500"
+        }
+      ],
+      "type": "file"
+    },
+    {
+      "group": "tests",
+      "name": "tests/smoke.rs",
+      "properties": [
+        {
+          "name": "tokmd:lang",
+          "value": "Rust"
+        },
+        {
+          "name": "tokmd:code",
+          "value": "95"
+        },
+        {
+          "name": "tokmd:comments",
+          "value": "12"
+        },
+        {
+          "name": "tokmd:blanks",
+          "value": "15"
+        },
+        {
+          "name": "tokmd:lines",
+          "value": "122"
+        },
+        {
+          "name": "tokmd:bytes",
+          "value": "2850"
+        },
+        {
+          "name": "tokmd:tokens",
+          "value": "950"
+        }
+      ],
+      "type": "file"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2024-01-01T00:00:00Z",
+    "tools": [
+      {
+        "name": "tokmd",
+        "vendor": "tokmd",
+        "version": "1.7.2"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:00000000-0000-0000-0000-000000000000",
+  "specVersion": "1.6",
+  "version": 1
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_json.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_json.snap
@@ -1,0 +1,42 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: normalize_json(&raw)
+---
+[
+  {
+    "blanks": 30,
+    "bytes": 8400,
+    "code": 280,
+    "comments": 40,
+    "kind": "parent",
+    "lang": "Rust",
+    "lines": 350,
+    "module": "src",
+    "path": "src/main.rs",
+    "tokens": 2800
+  },
+  {
+    "blanks": 45,
+    "bytes": 13500,
+    "code": 450,
+    "comments": 65,
+    "kind": "parent",
+    "lang": "Rust",
+    "lines": 560,
+    "module": "src",
+    "path": "src/lib.rs",
+    "tokens": 4500
+  },
+  {
+    "blanks": 15,
+    "bytes": 2850,
+    "code": 95,
+    "comments": 12,
+    "kind": "parent",
+    "lang": "Rust",
+    "lines": 122,
+    "module": "tests",
+    "path": "tests/smoke.rs",
+    "tokens": 950
+  }
+]

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_jsonl.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_jsonl.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+{"type":"row","path":"src/main.rs","module":"src","lang":"Rust","kind":"parent","code":280,"comments":40,"blanks":30,"lines":350,"bytes":8400,"tokens":2800}
+{"type":"row","path":"src/lib.rs","module":"src","lang":"Rust","kind":"parent","code":450,"comments":65,"blanks":45,"lines":560,"bytes":13500,"tokens":4500}
+{"type":"row","path":"tests/smoke.rs","module":"tests","lang":"Rust","kind":"parent","code":95,"comments":12,"blanks":15,"lines":122,"bytes":2850,"tokens":950}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_json_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_json_empty.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": false
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 0,
+    "bytes": 0,
+    "code": 0,
+    "files": 0,
+    "lines": 0,
+    "tokens": 0
+  },
+  "warnings": [],
+  "with_files": false
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_json_single_lang.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_json_single_lang.snap
@@ -1,0 +1,43 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": true
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [
+    {
+      "avg_lines": 168,
+      "bytes": 27600,
+      "code": 920,
+      "files": 7,
+      "lang": "Python",
+      "lines": 1180,
+      "tokens": 9200
+    }
+  ],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 168,
+    "bytes": 27600,
+    "code": 920,
+    "files": 7,
+    "lines": 1180,
+    "tokens": 9200
+  },
+  "warnings": [],
+  "with_files": true
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_json_three_langs.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_json_three_langs.snap
@@ -1,0 +1,61 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "collapse",
+    "format": "json",
+    "top": 0,
+    "with_files": true
+  },
+  "children": "collapse",
+  "generated_at_ms": 0,
+  "mode": "lang",
+  "rows": [
+    {
+      "avg_lines": 170,
+      "bytes": 182000,
+      "code": 5200,
+      "files": 40,
+      "lang": "Rust",
+      "lines": 6800,
+      "tokens": 46000
+    },
+    {
+      "avg_lines": 160,
+      "bytes": 93000,
+      "code": 3100,
+      "files": 25,
+      "lang": "TypeScript",
+      "lines": 4000,
+      "tokens": 28000
+    },
+    {
+      "avg_lines": 65,
+      "bytes": 12000,
+      "code": 400,
+      "files": 8,
+      "lang": "TOML",
+      "lines": 520,
+      "tokens": 3200
+    }
+  ],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 155,
+    "bytes": 287000,
+    "code": 8700,
+    "files": 73,
+    "lines": 11320,
+    "tokens": 77200
+  },
+  "warnings": [],
+  "with_files": true
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_embedded_separate.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_embedded_separate.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|HTML|420|540|5|12600|4200|108|
+|JavaScript (embedded)|210|260|5|6300|2100|52|
+|CSS (embedded)|130|160|4|3900|1300|40|
+|**Total**|760|960|14|22800|7600|68|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_empty.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+|Lang|Code|Lines|Bytes|Tokens|
+|---|---:|---:|---:|---:|
+|**Total**|0|0|0|0|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_empty_with_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_empty_with_files.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|**Total**|0|0|0|0|0|0|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_single_lang.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_single_lang.snap
@@ -1,0 +1,8 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|Python|920|1180|7|27600|9200|168|
+|**Total**|920|1180|7|27600|9200|168|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_three_langs_with_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_three_langs_with_files.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+|Lang|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|Rust|5200|6800|40|182000|46000|170|
+|TypeScript|3100|4000|25|93000|28000|160|
+|TOML|400|520|8|12000|3200|65|
+|**Total**|8700|11320|73|287000|77200|155|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_three_langs_without_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_md_three_langs_without_files.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+|Lang|Code|Lines|Bytes|Tokens|
+|---|---:|---:|---:|---:|
+|Rust|5200|6800|182000|46000|
+|TypeScript|3100|4000|93000|28000|
+|TOML|400|520|12000|3200|
+|**Total**|8700|11320|287000|77200|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_empty.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_empty.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+Lang	Code	Lines	Bytes	Tokens
+Total	0	0	0	0

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_single_lang.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_single_lang.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+Lang	Code	Lines	Files	Bytes	Tokens	Avg
+Python	920	1180	7	27600	9200	168
+Total	920	1180	7	27600	9200	168

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_three_langs.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_three_langs.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+Lang	Code	Lines	Files	Bytes	Tokens	Avg
+Rust	5200	6800	40	182000	46000	170
+TypeScript	3100	4000	25	93000	28000	160
+TOML	400	520	8	12000	3200	65
+Total	8700	11320	73	287000	77200	155

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_without_files.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_lang_tsv_without_files.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+Lang	Code	Lines	Bytes	Tokens
+Rust	5200	6800	182000	46000
+TypeScript	3100	4000	93000	28000
+TOML	400	520	12000	3200
+Total	8700	11320	287000	77200

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_module_json_three_modules.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_module_json_three_modules.snap
@@ -1,0 +1,67 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: normalize_json(&out)
+---
+{
+  "args": {
+    "children": "separate",
+    "format": "json",
+    "module_depth": 2,
+    "module_roots": [
+      "crates"
+    ],
+    "top": 0
+  },
+  "children": "separate",
+  "generated_at_ms": 0,
+  "mode": "module",
+  "module_depth": 2,
+  "module_roots": [
+    "crates"
+  ],
+  "rows": [
+    {
+      "avg_lines": 256,
+      "bytes": 96000,
+      "code": 3200,
+      "files": 16,
+      "lines": 4100,
+      "module": "crates/core",
+      "tokens": 25600
+    },
+    {
+      "avg_lines": 225,
+      "bytes": 54000,
+      "code": 1800,
+      "files": 10,
+      "lines": 2250,
+      "module": "crates/api",
+      "tokens": 14400
+    },
+    {
+      "avg_lines": 225,
+      "bytes": 33000,
+      "code": 1100,
+      "files": 6,
+      "lines": 1350,
+      "module": "tests",
+      "tokens": 8800
+    }
+  ],
+  "schema_version": 2,
+  "status": "complete",
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0-test"
+  },
+  "top": 0,
+  "total": {
+    "avg_lines": 240,
+    "bytes": 183000,
+    "code": 6100,
+    "files": 32,
+    "lines": 7700,
+    "tokens": 48800
+  },
+  "warnings": []
+}

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_module_md_three_modules.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_module_md_three_modules.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+|Module|Code|Lines|Files|Bytes|Tokens|Avg|
+|---|---:|---:|---:|---:|---:|---:|
+|crates/core|3200|4100|16|96000|25600|256|
+|crates/api|1800|2250|10|54000|14400|225|
+|tests|1100|1350|6|33000|8800|225|
+|**Total**|6100|7700|32|183000|48800|240|

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_module_tsv_three_modules.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_module_tsv_three_modules.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tokmd-format/tests/snapshot_w74.rs
+expression: out
+---
+Module	Code	Lines	Files	Bytes	Tokens	Avg
+crates/core	3200	4100	16	96000	25600	256
+crates/api	1800	2250	10	54000	14400	225
+tests	1100	1350	6	33000	8800	225
+Total	6100	7700	32	183000	48800	240


### PR DESCRIPTION
## Summary

Add comprehensive insta snapshot golden tests for key output formats across two crates.

### tokmd-format (20 tests)
- **Markdown**: 3-language with/without files columns, single language, empty input, embedded languages (children mode separate), empty with files
- **TSV**: 3-language with/without files, single language, empty
- **JSON**: 3-language, single language, empty (with timestamp/tool normalization)
- **Module**: Markdown, TSV, JSON for 3-module report
- **Export**: CSV, JSONL, JSON, CycloneDX (with deterministic serial number + timestamp)

### tokmd-analysis-format (15 tests)
- **Markdown**: minimal, with derived metrics, with warnings, archetype+topics, derived without COCOMO
- **JSON**: minimal, with derived, eco-label
- **XML**: with derived metrics
- **SVG**: with context window
- **Mermaid**: import graph
- **Tree**: with derived
- **JSON-LD**: with derived
- **HTML**: with derived (timestamp redacted), minimal (timestamp redacted)

### Verification
- All 35 tests pass: \cargo test -p tokmd-format --test snapshot_w74\ (20 passed) and \cargo test -p tokmd-analysis-format --test snapshot_w74\ (15 passed)
- Snapshots accepted and committed in \snapshots/\ directories