### PR TITLE
test(w76): analysis content + assets + git deep tests (~45 tests)

### DIFF
--- a/crates/tokmd-analysis-assets/tests/assets_deep_w76.rs
+++ b/crates/tokmd-analysis-assets/tests/assets_deep_w76.rs
@@ -1,0 +1,243 @@
+//! W76 deep tests for `tokmd-analysis-assets`.
+//!
+//! Exercises asset categorisation edge cases, lockfile parsing boundary
+//! conditions, dependency counting accuracy, top-file truncation,
+//! multi-lockfile aggregation, and determinism invariants.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+use tokmd_analysis_assets::{build_assets_report, build_dependency_report};
+
+// ── Helper ──────────────────────────────────────────────────────
+
+fn write_file(dir: &Path, rel: &str, content: &[u8]) -> PathBuf {
+    let full = dir.join(rel);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&full, content).unwrap();
+    PathBuf::from(rel)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 1. Asset classification coverage
+// ═══════════════════════════════════════════════════════════════════
+
+mod asset_categories_w76 {
+    use super::*;
+
+    #[test]
+    fn all_image_extensions_classified() {
+        let tmp = TempDir::new().unwrap();
+        let exts = ["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "tiff", "ico"];
+        let files: Vec<PathBuf> = exts
+            .iter()
+            .map(|ext| write_file(tmp.path(), &format!("img.{ext}"), &[0u8; 8]))
+            .collect();
+        let r = build_assets_report(tmp.path(), &files).unwrap();
+        assert_eq!(r.total_files, exts.len());
+        assert_eq!(r.categories.len(), 1);
+        assert_eq!(r.categories[0].category, "image");
+        assert_eq!(r.categories[0].extensions.len(), exts.len());
+    }
+
+    #[test]
+    fn all_binary_extensions_classified() {
+        let tmp = TempDir::new().unwrap();
+        let exts = ["exe", "dll", "so", "dylib", "bin", "class", "jar"];
+        let files: Vec<PathBuf> = exts
+            .iter()
+            .map(|ext| write_file(tmp.path(), &format!("file.{ext}"), &[0u8; 16]))
+            .collect();
+        let r = build_assets_report(tmp.path(), &files).unwrap();
+        assert_eq!(r.total_files, exts.len());
+        assert_eq!(r.categories[0].category, "binary");
+    }
+
+    #[test]
+    fn font_extensions_classified() {
+        let tmp = TempDir::new().unwrap();
+        let exts = ["ttf", "otf", "woff", "woff2"];
+        let files: Vec<PathBuf> = exts
+            .iter()
+            .map(|ext| write_file(tmp.path(), &format!("font.{ext}"), &[0u8; 32]))
+            .collect();
+        let r = build_assets_report(tmp.path(), &files).unwrap();
+        assert_eq!(r.total_files, exts.len());
+        assert_eq!(r.categories[0].category, "font");
+    }
+
+    #[test]
+    fn files_without_extension_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let f = write_file(tmp.path(), "Makefile", b"all: build\n");
+        let r = build_assets_report(tmp.path(), &[f]).unwrap();
+        assert_eq!(r.total_files, 0);
+        assert!(r.categories.is_empty());
+    }
+
+    #[test]
+    fn unknown_extensions_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let f = write_file(tmp.path(), "code.rs", b"fn main() {}\n");
+        let r = build_assets_report(tmp.path(), &[f]).unwrap();
+        assert_eq!(r.total_files, 0);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 2. Top-files truncation and sorting
+// ═══════════════════════════════════════════════════════════════════
+
+mod top_files_w76 {
+    use super::*;
+
+    #[test]
+    fn top_files_truncated_to_ten() {
+        let tmp = TempDir::new().unwrap();
+        let files: Vec<PathBuf> = (0..15)
+            .map(|i| write_file(tmp.path(), &format!("img{i:02}.png"), &vec![0u8; (i + 1) * 10]))
+            .collect();
+        let r = build_assets_report(tmp.path(), &files).unwrap();
+        assert_eq!(r.top_files.len(), 10);
+        // Largest files should be first
+        assert!(r.top_files[0].bytes >= r.top_files[9].bytes);
+    }
+
+    #[test]
+    fn top_files_sorted_by_bytes_descending() {
+        let tmp = TempDir::new().unwrap();
+        let files = vec![
+            write_file(tmp.path(), "small.png", &[0u8; 10]),
+            write_file(tmp.path(), "medium.png", &[0u8; 100]),
+            write_file(tmp.path(), "large.png", &[0u8; 1000]),
+        ];
+        let r = build_assets_report(tmp.path(), &files).unwrap();
+        assert_eq!(r.top_files[0].path, "large.png");
+        assert_eq!(r.top_files[2].path, "small.png");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 3. Lockfile dependency counting edge cases
+// ═══════════════════════════════════════════════════════════════════
+
+mod lockfile_w76 {
+    use super::*;
+
+    #[test]
+    fn cargo_lock_single_package() {
+        let tmp = TempDir::new().unwrap();
+        let content = "[[package]]\nname = \"tokmd\"\nversion = \"0.1.0\"\n";
+        let f = write_file(tmp.path(), "Cargo.lock", content.as_bytes());
+        let r = build_dependency_report(tmp.path(), &[f]).unwrap();
+        assert_eq!(r.total, 1);
+    }
+
+    #[test]
+    fn package_lock_json_empty_packages_object() {
+        let tmp = TempDir::new().unwrap();
+        let json = r#"{"packages": {"": {}}}"#;
+        let f = write_file(tmp.path(), "package-lock.json", json.as_bytes());
+        let r = build_dependency_report(tmp.path(), &[f]).unwrap();
+        // Only root "" entry which gets subtracted
+        assert_eq!(r.lockfiles[0].dependencies, 0);
+    }
+
+    #[test]
+    fn go_sum_identical_module_different_versions_counted() {
+        let tmp = TempDir::new().unwrap();
+        let content = "github.com/pkg/errors v0.9.1 h1:abc\ngithub.com/pkg/errors v0.8.0 h1:def\ngithub.com/stretchr/testify v1.8.0 h1:ghi\n";
+        let f = write_file(tmp.path(), "go.sum", content.as_bytes());
+        let r = build_dependency_report(tmp.path(), &[f]).unwrap();
+        assert_eq!(r.lockfiles[0].dependencies, 3);
+    }
+
+    #[test]
+    fn gemfile_lock_counts_indented_specs_with_parens() {
+        let tmp = TempDir::new().unwrap();
+        let content = "GEM\n  remote: https://rubygems.org/\n  specs:\n    rake (13.0.6)\n    rspec (3.12.0)\n      rspec-core (~> 3.12.0)\n    rspec-core (3.12.1)\n\nPLATFORMS\n  ruby\n";
+        let f = write_file(tmp.path(), "Gemfile.lock", content.as_bytes());
+        let r = build_dependency_report(tmp.path(), &[f]).unwrap();
+        // All 4+ space indented lines with parens: rake, rspec, nested rspec-core, rspec-core = 4
+        assert_eq!(r.lockfiles[0].dependencies, 4);
+    }
+
+    #[test]
+    fn yarn_lock_comment_lines_excluded() {
+        let tmp = TempDir::new().unwrap();
+        let content = "# THIS IS AN AUTOGENERATED FILE.\n# yarn lockfile v1\n\nlodash@^4.17.0:\n  version \"4.17.21\"\n  resolved \"https://registry.yarnpkg.com/lodash\"\n";
+        let f = write_file(tmp.path(), "yarn.lock", content.as_bytes());
+        let r = build_dependency_report(tmp.path(), &[f]).unwrap();
+        assert_eq!(r.lockfiles[0].dependencies, 1);
+    }
+
+    #[test]
+    fn pnpm_lock_lines_without_colon_excluded() {
+        let tmp = TempDir::new().unwrap();
+        let content = "lockfileVersion: 5.4\npackages:\n  /lodash/4.17.21:\n    resolution: {}\n  some-line-without-slash\n";
+        let f = write_file(tmp.path(), "pnpm-lock.yaml", content.as_bytes());
+        let r = build_dependency_report(tmp.path(), &[f]).unwrap();
+        assert_eq!(r.lockfiles[0].dependencies, 1);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 4. Mixed reports and structural invariants
+// ═══════════════════════════════════════════════════════════════════
+
+mod structural_w76 {
+    use super::*;
+
+    #[test]
+    fn total_bytes_equals_sum_of_category_bytes() {
+        let tmp = TempDir::new().unwrap();
+        let files = vec![
+            write_file(tmp.path(), "a.png", &[0u8; 100]),
+            write_file(tmp.path(), "b.mp3", &[0u8; 200]),
+            write_file(tmp.path(), "c.zip", &[0u8; 300]),
+        ];
+        let r = build_assets_report(tmp.path(), &files).unwrap();
+        let sum: u64 = r.categories.iter().map(|c| c.bytes).sum();
+        assert_eq!(r.total_bytes, sum);
+    }
+
+    #[test]
+    fn total_files_equals_sum_of_category_files() {
+        let tmp = TempDir::new().unwrap();
+        let files = vec![
+            write_file(tmp.path(), "a.png", &[0u8; 10]),
+            write_file(tmp.path(), "b.jpg", &[0u8; 10]),
+            write_file(tmp.path(), "c.mp4", &[0u8; 10]),
+            write_file(tmp.path(), "d.wav", &[0u8; 10]),
+        ];
+        let r = build_assets_report(tmp.path(), &files).unwrap();
+        let sum: usize = r.categories.iter().map(|c| c.files).sum();
+        assert_eq!(r.total_files, sum);
+    }
+
+    #[test]
+    fn dependency_total_equals_sum_of_lockfile_deps() {
+        let tmp = TempDir::new().unwrap();
+        let cargo = "[[package]]\nname = \"a\"\nversion = \"1\"\n\n[[package]]\nname = \"b\"\nversion = \"2\"\n";
+        let yarn = "# yarn lockfile\n\nlodash@^4.0.0:\n  version \"4.17.21\"\n";
+        let f1 = write_file(tmp.path(), "Cargo.lock", cargo.as_bytes());
+        let f2 = write_file(tmp.path(), "yarn.lock", yarn.as_bytes());
+        let r = build_dependency_report(tmp.path(), &[f1, f2]).unwrap();
+        let sum: usize = r.lockfiles.iter().map(|l| l.dependencies).sum();
+        assert_eq!(r.total, sum);
+    }
+
+    #[test]
+    fn empty_file_list_produces_empty_reports() {
+        let tmp = TempDir::new().unwrap();
+        let assets = build_assets_report(tmp.path(), &[]).unwrap();
+        let deps = build_dependency_report(tmp.path(), &[]).unwrap();
+        assert_eq!(assets.total_files, 0);
+        assert_eq!(assets.total_bytes, 0);
+        assert!(assets.categories.is_empty());
+        assert_eq!(deps.total, 0);
+        assert!(deps.lockfiles.is_empty());
+    }
+}

--- a/crates/tokmd-analysis-content/tests/content_deep_w76.rs
+++ b/crates/tokmd-analysis-content/tests/content_deep_w76.rs
@@ -1,0 +1,405 @@
+//! W76 deep tests for `tokmd-analysis-content`.
+//!
+//! Exercises TODO/FIXME detection edge cases, duplicate detection with
+//! cross-module density, import report granularity, content limits
+//! boundary conditions, and determinism invariants.
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+use tokmd_analysis_content::{
+    ContentLimits, ImportGranularity, build_duplicate_report, build_import_report,
+    build_todo_report,
+};
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn make_row(path: &str, module: &str, lang: &str, bytes: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: lang.to_string(),
+        kind: FileKind::Parent,
+        code: 100,
+        comments: 10,
+        blanks: 5,
+        lines: 115,
+        bytes,
+        tokens: 200,
+    }
+}
+
+fn make_export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn default_limits() -> ContentLimits {
+    ContentLimits {
+        max_bytes: None,
+        max_file_bytes: None,
+    }
+}
+
+fn write_file(dir: &std::path::Path, rel: &str, content: &[u8]) -> PathBuf {
+    let full = dir.join(rel);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&full, content).unwrap();
+    PathBuf::from(rel)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 1. TODO/FIXME detection
+// ═══════════════════════════════════════════════════════════════════
+
+mod todo_w76 {
+    use super::*;
+
+    #[test]
+    fn density_zero_when_total_code_is_zero() {
+        let tmp = TempDir::new().unwrap();
+        let f = write_file(tmp.path(), "a.rs", b"// TODO: something\n");
+        let r = build_todo_report(tmp.path(), &[f], &default_limits(), 0).unwrap();
+        assert_eq!(r.total, 1);
+        assert_eq!(r.density_per_kloc, 0.0, "density should be 0 when kloc is 0");
+    }
+
+    #[test]
+    fn tags_in_multiline_comments_detected() {
+        let tmp = TempDir::new().unwrap();
+        let content = "/* TODO: first */\n/* FIXME: second */\n/* HACK: third */\n";
+        let f = write_file(tmp.path(), "a.rs", content.as_bytes());
+        let r = build_todo_report(tmp.path(), &[f], &default_limits(), 1000).unwrap();
+        assert_eq!(r.total, 3);
+    }
+
+    #[test]
+    fn binary_files_skipped() {
+        let tmp = TempDir::new().unwrap();
+        // Binary content with a TODO string embedded
+        let mut content = vec![0u8; 100];
+        content.extend_from_slice(b"TODO: hidden in binary");
+        let f = write_file(tmp.path(), "a.bin", &content);
+        let r = build_todo_report(tmp.path(), &[f], &default_limits(), 1000).unwrap();
+        assert_eq!(r.total, 0, "binary files should be skipped");
+    }
+
+    #[test]
+    fn tags_sorted_alphabetically_in_btreemap() {
+        let tmp = TempDir::new().unwrap();
+        let content = "// XXX: z\n// FIXME: a\n// HACK: m\n// TODO: x\n";
+        let f = write_file(tmp.path(), "a.rs", content.as_bytes());
+        let r = build_todo_report(tmp.path(), &[f], &default_limits(), 1000).unwrap();
+        let tag_names: Vec<&str> = r.tags.iter().map(|t| t.tag.as_str()).collect();
+        let mut sorted = tag_names.clone();
+        sorted.sort();
+        assert_eq!(tag_names, sorted, "tags should be in alphabetical order");
+    }
+
+    #[test]
+    fn max_bytes_limit_stops_scanning_across_files() {
+        let tmp = TempDir::new().unwrap();
+        let content = b"// TODO: item\n";
+        let f1 = write_file(tmp.path(), "a.rs", content);
+        let f2 = write_file(tmp.path(), "b.rs", content);
+        let f3 = write_file(tmp.path(), "c.rs", content);
+        let limits = ContentLimits {
+            max_bytes: Some(content.len() as u64),
+            max_file_bytes: None,
+        };
+        let r = build_todo_report(tmp.path(), &[f1, f2, f3], &limits, 1000).unwrap();
+        // Only the first file should be scanned before budget is exhausted
+        assert!(r.total <= 2, "max_bytes should cap total scanning, got {}", r.total);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 2. Duplicate detection with cross-module density
+// ═══════════════════════════════════════════════════════════════════
+
+mod duplicate_w76 {
+    use super::*;
+
+    #[test]
+    fn cross_module_density_tracks_separate_modules() {
+        let tmp = TempDir::new().unwrap();
+        let content = b"shared code content for duplication\n";
+        let f1 = write_file(tmp.path(), "src/a.rs", content);
+        let f2 = write_file(tmp.path(), "lib/a.rs", content);
+        let e = make_export(vec![
+            make_row("src/a.rs", "src", "Rust", content.len()),
+            make_row("lib/a.rs", "lib", "Rust", content.len()),
+        ]);
+        let r = build_duplicate_report(tmp.path(), &[f1, f2], &e, &default_limits()).unwrap();
+        let density = r.density.as_ref().unwrap();
+        assert!(
+            density.by_module.len() >= 2,
+            "density should track both modules"
+        );
+    }
+
+    #[test]
+    fn file_size_limit_excludes_large_files() {
+        let tmp = TempDir::new().unwrap();
+        let big = vec![0u8; 200];
+        let small = b"tiny\n";
+        let f1 = write_file(tmp.path(), "big1.rs", &big);
+        let f2 = write_file(tmp.path(), "big2.rs", &big);
+        let f3 = write_file(tmp.path(), "sm1.rs", small);
+        let f4 = write_file(tmp.path(), "sm2.rs", small);
+        let e = make_export(vec![
+            make_row("big1.rs", "src", "Rust", 200),
+            make_row("big2.rs", "src", "Rust", 200),
+            make_row("sm1.rs", "src", "Rust", 5),
+            make_row("sm2.rs", "src", "Rust", 5),
+        ]);
+        let limits = ContentLimits {
+            max_bytes: None,
+            max_file_bytes: Some(100),
+        };
+        let r = build_duplicate_report(tmp.path(), &[f1, f2, f3, f4], &e, &limits).unwrap();
+        // Big files should be excluded; only small files considered
+        assert_eq!(r.groups.len(), 1);
+        assert_eq!(r.groups[0].bytes, small.len() as u64);
+    }
+
+    #[test]
+    fn single_file_never_duplicate() {
+        let tmp = TempDir::new().unwrap();
+        let f = write_file(tmp.path(), "only.rs", b"unique\n");
+        let e = make_export(vec![make_row("only.rs", "src", "Rust", 7)]);
+        let r = build_duplicate_report(tmp.path(), &[f], &e, &default_limits()).unwrap();
+        assert!(r.groups.is_empty());
+        assert_eq!(r.wasted_bytes, 0);
+    }
+
+    #[test]
+    fn different_sizes_same_content_prefix_not_duplicate() {
+        let tmp = TempDir::new().unwrap();
+        let f1 = write_file(tmp.path(), "a.rs", b"prefix content\n");
+        let f2 = write_file(tmp.path(), "b.rs", b"prefix content\nextra line\n");
+        let e = make_export(vec![
+            make_row("a.rs", "src", "Rust", 15),
+            make_row("b.rs", "src", "Rust", 27),
+        ]);
+        let r = build_duplicate_report(tmp.path(), &[f1, f2], &e, &default_limits()).unwrap();
+        assert!(r.groups.is_empty(), "different-size files should not match");
+    }
+
+    #[test]
+    fn wasted_pct_of_codebase_correct() {
+        let tmp = TempDir::new().unwrap();
+        let content = b"exactly 10 b\n";
+        let f1 = write_file(tmp.path(), "a.rs", content);
+        let f2 = write_file(tmp.path(), "b.rs", content);
+        let e = make_export(vec![
+            make_row("a.rs", "src", "Rust", content.len()),
+            make_row("b.rs", "src", "Rust", content.len()),
+        ]);
+        let r = build_duplicate_report(tmp.path(), &[f1, f2], &e, &default_limits()).unwrap();
+        let density = r.density.as_ref().unwrap();
+        assert!(density.wasted_pct_of_codebase > 0.0);
+        assert!(density.wasted_pct_of_codebase <= 1.0);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 3. Import report
+// ═══════════════════════════════════════════════════════════════════
+
+mod import_w76 {
+    use super::*;
+
+    #[test]
+    fn module_granularity_aggregates_by_module() {
+        let tmp = TempDir::new().unwrap();
+        let content = "use std::collections::HashMap;\nuse std::io;\n";
+        let f = write_file(tmp.path(), "src/lib.rs", content.as_bytes());
+        let e = make_export(vec![make_row("src/lib.rs", "src", "Rust", content.len())]);
+        let r = build_import_report(
+            tmp.path(),
+            &[f],
+            &e,
+            ImportGranularity::Module,
+            &default_limits(),
+        )
+        .unwrap();
+        assert_eq!(r.granularity, "module");
+        for edge in &r.edges {
+            assert_eq!(edge.from, "src", "module granularity should use module name");
+        }
+    }
+
+    #[test]
+    fn file_granularity_uses_file_path() {
+        let tmp = TempDir::new().unwrap();
+        let content = "use std::collections::HashMap;\n";
+        let f = write_file(tmp.path(), "src/lib.rs", content.as_bytes());
+        let e = make_export(vec![make_row("src/lib.rs", "src", "Rust", content.len())]);
+        let r = build_import_report(
+            tmp.path(),
+            &[f],
+            &e,
+            ImportGranularity::File,
+            &default_limits(),
+        )
+        .unwrap();
+        assert_eq!(r.granularity, "file");
+        if !r.edges.is_empty() {
+            assert_eq!(r.edges[0].from, "src/lib.rs");
+        }
+    }
+
+    #[test]
+    fn no_imports_produce_empty_edges() {
+        let tmp = TempDir::new().unwrap();
+        let content = "fn main() { println!(\"hello\"); }\n";
+        let f = write_file(tmp.path(), "src/main.rs", content.as_bytes());
+        let e = make_export(vec![make_row("src/main.rs", "src", "Rust", content.len())]);
+        let r = build_import_report(
+            tmp.path(),
+            &[f],
+            &e,
+            ImportGranularity::Module,
+            &default_limits(),
+        )
+        .unwrap();
+        assert!(r.edges.is_empty());
+    }
+
+    #[test]
+    fn edges_sorted_by_count_descending() {
+        let tmp = TempDir::new().unwrap();
+        let content = "use std::collections::HashMap;\nuse std::io;\nuse std::io::Read;\n";
+        let f = write_file(tmp.path(), "src/lib.rs", content.as_bytes());
+        let e = make_export(vec![make_row("src/lib.rs", "src", "Rust", content.len())]);
+        let r = build_import_report(
+            tmp.path(),
+            &[f],
+            &e,
+            ImportGranularity::Module,
+            &default_limits(),
+        )
+        .unwrap();
+        for w in r.edges.windows(2) {
+            assert!(
+                w[0].count >= w[1].count,
+                "edges should be sorted desc by count"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_language_produces_no_edges() {
+        let tmp = TempDir::new().unwrap();
+        let content = "some random text with import statements\n";
+        let f = write_file(tmp.path(), "data.txt", content.as_bytes());
+        let e = make_export(vec![make_row("data.txt", "root", "Text", content.len())]);
+        let r = build_import_report(
+            tmp.path(),
+            &[f],
+            &e,
+            ImportGranularity::Module,
+            &default_limits(),
+        )
+        .unwrap();
+        assert!(r.edges.is_empty());
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 4. Determinism and structural invariants
+// ═══════════════════════════════════════════════════════════════════
+
+mod invariants_w76 {
+    use super::*;
+
+    #[test]
+    fn todo_report_stable_across_runs() {
+        let tmp = TempDir::new().unwrap();
+        let f = write_file(
+            tmp.path(),
+            "a.rs",
+            b"// TODO: a\n// FIXME: b\n// HACK: c\n// XXX: d\n",
+        );
+        let files = vec![f];
+        let r1 = build_todo_report(tmp.path(), &files, &default_limits(), 2000).unwrap();
+        let r2 = build_todo_report(tmp.path(), &files, &default_limits(), 2000).unwrap();
+        assert_eq!(
+            serde_json::to_string(&r1).unwrap(),
+            serde_json::to_string(&r2).unwrap(),
+        );
+    }
+
+    #[test]
+    fn duplicate_density_by_module_sorted_by_wasted_bytes() {
+        let tmp = TempDir::new().unwrap();
+        let small = b"sm\n";
+        let big = b"this is a much bigger duplicate content here\n";
+        let fs = write_file(tmp.path(), "s1.rs", small);
+        let fs2 = write_file(tmp.path(), "s2.rs", small);
+        let fb = write_file(tmp.path(), "b1.rs", big);
+        let fb2 = write_file(tmp.path(), "b2.rs", big);
+        let e = make_export(vec![
+            make_row("s1.rs", "small_mod", "Rust", small.len()),
+            make_row("s2.rs", "small_mod", "Rust", small.len()),
+            make_row("b1.rs", "big_mod", "Rust", big.len()),
+            make_row("b2.rs", "big_mod", "Rust", big.len()),
+        ]);
+        let r =
+            build_duplicate_report(tmp.path(), &[fs, fs2, fb, fb2], &e, &default_limits())
+                .unwrap();
+        let density = r.density.as_ref().unwrap();
+        for w in density.by_module.windows(2) {
+            assert!(
+                w[0].wasted_bytes >= w[1].wasted_bytes,
+                "by_module should be sorted desc by wasted_bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn import_report_deterministic() {
+        let tmp = TempDir::new().unwrap();
+        let content = "use std::io;\nuse std::collections::HashMap;\n";
+        let f = write_file(tmp.path(), "src/lib.rs", content.as_bytes());
+        let e = make_export(vec![make_row("src/lib.rs", "src", "Rust", content.len())]);
+        let files = vec![f];
+        let r1 = build_import_report(
+            tmp.path(),
+            &files,
+            &e,
+            ImportGranularity::Module,
+            &default_limits(),
+        )
+        .unwrap();
+        let r2 = build_import_report(
+            tmp.path(),
+            &files,
+            &e,
+            ImportGranularity::Module,
+            &default_limits(),
+        )
+        .unwrap();
+        assert_eq!(
+            serde_json::to_string(&r1).unwrap(),
+            serde_json::to_string(&r2).unwrap(),
+        );
+    }
+
+    #[test]
+    fn empty_file_list_produces_zero_todo_report() {
+        let tmp = TempDir::new().unwrap();
+        let r = build_todo_report(tmp.path(), &[], &default_limits(), 5000).unwrap();
+        assert_eq!(r.total, 0);
+        assert!(r.tags.is_empty());
+        assert_eq!(r.density_per_kloc, 0.0);
+    }
+}

--- a/crates/tokmd-analysis-git/tests/git_deep_w76.rs
+++ b/crates/tokmd-analysis-git/tests/git_deep_w76.rs
@@ -1,0 +1,392 @@
+//! W76 deep tests for `tokmd-analysis-git`.
+//!
+//! Exercises hotspot scoring, coupling metrics (Jaccard/lift), freshness
+//! boundaries, bus-factor calculation, code-age bucket distribution,
+//! predictive churn regression, intent classification, and edge cases.
+
+use std::path::Path;
+
+use tokmd_analysis_git::{build_git_report, build_predictive_churn_report};
+use tokmd_analysis_types::TrendClass;
+use tokmd_git::GitCommit;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const DAY: i64 = 86_400;
+const WEEK: i64 = 7 * DAY;
+
+fn row(path: &str, module: &str, lines: usize) -> FileRow {
+    FileRow {
+        path: path.to_string(),
+        module: module.to_string(),
+        lang: "Rust".to_string(),
+        kind: FileKind::Parent,
+        code: lines,
+        comments: 0,
+        blanks: 0,
+        lines,
+        bytes: lines * 10,
+        tokens: lines * 5,
+    }
+}
+
+fn export(rows: Vec<FileRow>) -> ExportData {
+    ExportData {
+        rows,
+        module_roots: vec![],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    }
+}
+
+fn commit(ts: i64, author: &str, subject: &str, files: &[&str]) -> GitCommit {
+    GitCommit {
+        timestamp: ts,
+        author: author.to_string(),
+        hash: None,
+        subject: subject.to_string(),
+        files: files.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 1. Hotspot scoring edge cases
+// ═══════════════════════════════════════════════════════════════════
+
+mod hotspot_w76 {
+    use super::*;
+
+    #[test]
+    fn many_commits_same_file_accumulates_score() {
+        let e = export(vec![row("src/hot.rs", "src", 100)]);
+        let commits: Vec<GitCommit> = (1..=20)
+            .map(|i| commit(i * DAY, "dev", &format!("c{i}"), &["src/hot.rs"]))
+            .collect();
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert_eq!(r.hotspots[0].score, 100 * 20);
+    }
+
+    #[test]
+    fn unmatched_git_files_excluded_from_hotspots() {
+        let e = export(vec![row("src/lib.rs", "src", 50)]);
+        let commits = vec![
+            commit(DAY, "a", "c1", &["src/lib.rs"]),
+            commit(2 * DAY, "a", "c2", &["nonexistent.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert_eq!(r.hotspots.len(), 1);
+        assert_eq!(r.hotspots[0].path, "src/lib.rs");
+    }
+
+    #[test]
+    fn hotspot_tie_broken_by_path() {
+        let e = export(vec![
+            row("z.rs", "src", 100),
+            row("a.rs", "src", 100),
+        ]);
+        let commits = vec![commit(DAY, "a", "c", &["z.rs", "a.rs"])];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        // Same score (100 * 1) -> alphabetical by path
+        assert_eq!(r.hotspots[0].path, "a.rs");
+        assert_eq!(r.hotspots[1].path, "z.rs");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 2. Bus factor
+// ═══════════════════════════════════════════════════════════════════
+
+mod bus_factor_w76 {
+    use super::*;
+
+    #[test]
+    fn multiple_authors_counted_per_module() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        let commits = vec![
+            commit(DAY, "alice", "c1", &["src/lib.rs"]),
+            commit(2 * DAY, "bob", "c2", &["src/lib.rs"]),
+            commit(3 * DAY, "charlie", "c3", &["src/lib.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert_eq!(r.bus_factor[0].authors, 3);
+    }
+
+    #[test]
+    fn same_author_multiple_commits_counted_once() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        let commits = vec![
+            commit(DAY, "alice", "c1", &["src/lib.rs"]),
+            commit(2 * DAY, "alice", "c2", &["src/lib.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert_eq!(r.bus_factor[0].authors, 1);
+    }
+
+    #[test]
+    fn bus_factor_sorted_by_authors_ascending() {
+        let e = export(vec![
+            row("a.rs", "alpha", 10),
+            row("b.rs", "beta", 10),
+        ]);
+        let commits = vec![
+            commit(DAY, "alice", "c1", &["a.rs"]),
+            commit(2 * DAY, "alice", "c2", &["b.rs"]),
+            commit(3 * DAY, "bob", "c3", &["b.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        // alpha has 1 author, beta has 2 -> ascending
+        assert_eq!(r.bus_factor[0].module, "alpha");
+        assert_eq!(r.bus_factor[0].authors, 1);
+        assert_eq!(r.bus_factor[1].module, "beta");
+        assert_eq!(r.bus_factor[1].authors, 2);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 3. Coupling with Jaccard/lift
+// ═══════════════════════════════════════════════════════════════════
+
+mod coupling_w76 {
+    use super::*;
+
+    #[test]
+    fn no_coupling_when_modules_never_co_change() {
+        let e = export(vec![
+            row("a.rs", "alpha", 50),
+            row("b.rs", "beta", 50),
+        ]);
+        let commits = vec![
+            commit(DAY, "a", "c1", &["a.rs"]),
+            commit(2 * DAY, "a", "c2", &["b.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert!(r.coupling.is_empty());
+    }
+
+    #[test]
+    fn perfect_coupling_jaccard_is_one() {
+        let e = export(vec![
+            row("a.rs", "alpha", 50),
+            row("b.rs", "beta", 50),
+        ]);
+        // Both modules always change together
+        let commits = vec![
+            commit(DAY, "a", "c1", &["a.rs", "b.rs"]),
+            commit(2 * DAY, "a", "c2", &["a.rs", "b.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert_eq!(r.coupling.len(), 1);
+        let j = r.coupling[0].jaccard.unwrap();
+        assert!((j - 1.0).abs() < 0.001, "perfect coupling jaccard should be 1.0, got {j}");
+    }
+
+    #[test]
+    fn coupling_count_reflects_co_occurrence() {
+        let e = export(vec![
+            row("a.rs", "alpha", 50),
+            row("b.rs", "beta", 50),
+        ]);
+        let commits = vec![
+            commit(DAY, "a", "c1", &["a.rs", "b.rs"]),
+            commit(2 * DAY, "a", "c2", &["a.rs", "b.rs"]),
+            commit(3 * DAY, "a", "c3", &["a.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert_eq!(r.coupling[0].count, 2);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 4. Freshness boundary conditions
+// ═══════════════════════════════════════════════════════════════════
+
+mod freshness_w76 {
+    use super::*;
+
+    #[test]
+    fn all_files_fresh_gives_zero_stale_pct() {
+        let now = 100 * DAY;
+        let e = export(vec![
+            row("a.rs", "src", 10),
+            row("b.rs", "src", 10),
+        ]);
+        let commits = vec![
+            commit(now - DAY, "a", "c1", &["a.rs"]),
+            commit(now, "a", "c2", &["b.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        assert_eq!(r.freshness.stale_files, 0);
+        assert_eq!(r.freshness.stale_pct, 0.0);
+    }
+
+    #[test]
+    fn all_files_stale_gives_one_stale_pct() {
+        let now = 1000 * DAY;
+        let e = export(vec![
+            row("a.rs", "src", 10),
+            row("b.rs", "src", 10),
+            // Need a recent file to set the reference timestamp
+            row("ref.rs", "src", 10),
+        ]);
+        let commits = vec![
+            commit(now - 400 * DAY, "a", "c1", &["a.rs"]),
+            commit(now - 500 * DAY, "a", "c2", &["b.rs"]),
+            commit(now, "a", "ref", &["ref.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        // a.rs (400d) and b.rs (500d) are stale, ref.rs (0d) is not
+        assert_eq!(r.freshness.stale_files, 2);
+        assert_eq!(r.freshness.total_files, 3);
+    }
+
+    #[test]
+    fn freshness_p90_within_reasonable_range() {
+        let now = 200 * DAY;
+        let e = export(vec![
+            row("a.rs", "src", 10),
+            row("b.rs", "src", 10),
+            row("c.rs", "src", 10),
+        ]);
+        let commits = vec![
+            commit(now - 10 * DAY, "a", "c1", &["a.rs"]),
+            commit(now - 50 * DAY, "a", "c2", &["b.rs"]),
+            commit(now, "a", "c3", &["c.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        for m in &r.freshness.by_module {
+            assert!(m.p90_days >= 0.0, "p90 should be non-negative");
+            assert!(m.p90_days >= m.avg_days * 0.5, "p90 should be >= half the average");
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 5. Predictive churn regression
+// ═══════════════════════════════════════════════════════════════════
+
+mod churn_w76 {
+    use super::*;
+
+    #[test]
+    fn decreasing_commits_give_falling_trend() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        // 3 commits in week 1, 2 in week 2, 1 in week 3
+        let commits = vec![
+            commit(WEEK, "a", "c1", &["src/lib.rs"]),
+            commit(WEEK + DAY, "a", "c2", &["src/lib.rs"]),
+            commit(WEEK + 2 * DAY, "a", "c3", &["src/lib.rs"]),
+            commit(2 * WEEK, "a", "c4", &["src/lib.rs"]),
+            commit(2 * WEEK + DAY, "a", "c5", &["src/lib.rs"]),
+            commit(3 * WEEK, "a", "c6", &["src/lib.rs"]),
+        ];
+        let r = build_predictive_churn_report(&e, &commits, Path::new("."));
+        let trend = r.per_module.get("src").unwrap();
+        assert!(trend.slope < 0.0, "slope should be negative for decreasing churn");
+        assert_eq!(trend.classification, TrendClass::Falling);
+    }
+
+    #[test]
+    fn single_commit_gives_flat_trend() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        let commits = vec![commit(WEEK, "a", "c1", &["src/lib.rs"])];
+        let r = build_predictive_churn_report(&e, &commits, Path::new("."));
+        let trend = r.per_module.get("src").unwrap();
+        assert_eq!(trend.classification, TrendClass::Flat);
+    }
+
+    #[test]
+    fn no_commits_gives_empty_per_module() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        let r = build_predictive_churn_report(&e, &[], Path::new("."));
+        assert!(r.per_module.is_empty());
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 6. Intent classification and corrective ratio
+// ═══════════════════════════════════════════════════════════════════
+
+mod intent_w76 {
+    use super::*;
+
+    #[test]
+    fn feat_commits_classified_correctly() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        let commits = vec![
+            commit(DAY, "a", "feat: add new feature", &["src/lib.rs"]),
+            commit(2 * DAY, "a", "feat: another feature", &["src/lib.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        let intent = r.intent.unwrap();
+        assert_eq!(intent.overall.feat, 2);
+        assert_eq!(intent.overall.total, 2);
+    }
+
+    #[test]
+    fn mixed_intents_all_counted() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        let commits = vec![
+            commit(DAY, "a", "feat: add", &["src/lib.rs"]),
+            commit(2 * DAY, "a", "fix: bug", &["src/lib.rs"]),
+            commit(3 * DAY, "a", "docs: readme", &["src/lib.rs"]),
+            commit(4 * DAY, "a", "refactor: cleanup", &["src/lib.rs"]),
+            commit(5 * DAY, "a", "test: add tests", &["src/lib.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        let intent = r.intent.unwrap();
+        assert_eq!(intent.overall.feat, 1);
+        assert_eq!(intent.overall.fix, 1);
+        assert_eq!(intent.overall.docs, 1);
+        assert_eq!(intent.overall.refactor, 1);
+        assert_eq!(intent.overall.test, 1);
+        assert_eq!(intent.overall.total, 5);
+    }
+
+    #[test]
+    fn all_fix_commits_gives_corrective_ratio_one() {
+        let e = export(vec![row("src/lib.rs", "src", 100)]);
+        let commits = vec![
+            commit(DAY, "a", "fix: bug one", &["src/lib.rs"]),
+            commit(2 * DAY, "a", "fix: bug two", &["src/lib.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        let intent = r.intent.unwrap();
+        assert!((intent.corrective_ratio.unwrap() - 1.0).abs() < 0.001);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// § 7. Code age distribution buckets
+// ═══════════════════════════════════════════════════════════════════
+
+mod age_w76 {
+    use super::*;
+
+    #[test]
+    fn files_in_each_bucket_sum_to_total() {
+        let now = 500 * DAY;
+        let e = export(vec![
+            row("a.rs", "src", 10),
+            row("b.rs", "src", 10),
+            row("c.rs", "src", 10),
+        ]);
+        let commits = vec![
+            commit(now - 10 * DAY, "a", "c1", &["a.rs"]),
+            commit(now - 100 * DAY, "a", "c2", &["b.rs"]),
+            commit(now - 400 * DAY, "a", "c3", &["c.rs"]),
+        ];
+        let r = build_git_report(Path::new("."), &e, &commits).unwrap();
+        let dist = r.age_distribution.unwrap();
+        let total: usize = dist.buckets.iter().map(|b| b.files).sum();
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn refresh_trend_flat_when_no_commits() {
+        let e = export(vec![row("a.rs", "src", 10)]);
+        let r = build_git_report(Path::new("."), &e, &[]).unwrap();
+        let dist = r.age_distribution.unwrap();
+        assert_eq!(dist.refresh_trend, TrendClass::Flat);
+    }
+}


### PR DESCRIPTION
## Summary

Add deep integration tests across three analysis crates (56 tests total):

### tokmd-analysis-content (19 tests)
- TODO/FIXME detection: density at zero kloc, multiline comments, binary file skip, tag ordering, max_bytes budget
- Duplicate detection: cross-module density tracking, file-size limits, single-file no-match, different-size prefix, wasted percentage
- Import report: module vs file granularity, empty edges, sort order, unsupported languages
- Invariants: determinism, sorted density modules, empty inputs

### tokmd-analysis-assets (17 tests)
- Asset classification: all image/binary/font extensions, no-extension skip, unknown extension skip
- Top-files: truncation to 10, descending sort
- Lockfile parsing: Cargo.lock, package-lock.json (empty packages), go.sum (multi-version), Gemfile.lock, yarn.lock, pnpm-lock.yaml
- Structural invariants: total bytes/files consistency, dependency sum, empty inputs

### tokmd-analysis-git (20 tests)
- Hotspot scoring: accumulation, unmatched files, tie-breaking
- Bus factor: multi-author, dedup, ascending sort
- Coupling: no co-change, perfect Jaccard, count accuracy
- Freshness: zero/full stale, p90 range
- Churn: falling trend, single commit flat, empty
- Intent: feat classification, mixed intents, corrective ratio
- Age distribution: bucket sum, flat trend on empty