### PR TITLE
test(w76): io-port + progress deep tests (~25 tests)

### DIFF
--- a/crates/tokmd-io-port/tests/io_port_deep_w76.rs
+++ b/crates/tokmd-io-port/tests/io_port_deep_w76.rs
@@ -1,0 +1,172 @@
+//! Deep tests for tokmd-io-port (W76).
+//!
+//! ~15 tests covering: ReadFs trait contract for HostFs and MemFs,
+//! file enumeration via MemFs, error display messages, binary vs text
+//! round-trips, directory inference from nested paths, and isolation.
+
+use std::path::{Path, PathBuf};
+
+use tokmd_io_port::{HostFs, MemFs, ReadFs};
+
+// ===========================================================================
+// 1. MemFs - text file round-trip
+// ===========================================================================
+
+#[test]
+fn w76_memfs_add_file_read_to_string() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("hello.txt"), "hello world");
+    assert_eq!(fs.read_to_string(Path::new("hello.txt")).unwrap(), "hello world");
+}
+
+#[test]
+fn w76_memfs_empty_file_reads_empty_string() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("empty.txt"), "");
+    assert_eq!(fs.read_to_string(Path::new("empty.txt")).unwrap(), "");
+}
+
+// ===========================================================================
+// 2. MemFs - binary file round-trip
+// ===========================================================================
+
+#[test]
+fn w76_memfs_add_bytes_read_bytes() {
+    let mut fs = MemFs::new();
+    let data: Vec<u8> = (0..=255).collect();
+    fs.add_bytes(PathBuf::from("all_bytes.bin"), data.clone());
+    assert_eq!(fs.read_bytes(Path::new("all_bytes.bin")).unwrap(), data);
+}
+
+#[test]
+fn w76_memfs_read_bytes_on_text_file() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("text.txt"), "abc");
+    assert_eq!(fs.read_bytes(Path::new("text.txt")).unwrap(), b"abc".to_vec());
+}
+
+// ===========================================================================
+// 3. MemFs - error paths
+// ===========================================================================
+
+#[test]
+fn w76_memfs_read_string_not_found_includes_path() {
+    let fs = MemFs::new();
+    let err = fs.read_to_string(Path::new("missing/file.rs")).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("not found"), "error: {msg}");
+    assert!(msg.contains("missing"), "error should mention path: {msg}");
+}
+
+#[test]
+fn w76_memfs_read_bytes_not_found_error() {
+    let fs = MemFs::new();
+    let err = fs.read_bytes(Path::new("gone.bin")).unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn w76_memfs_invalid_utf8_error_includes_path() {
+    let mut fs = MemFs::new();
+    fs.add_bytes(PathBuf::from("data/bad.txt"), vec![0x80, 0x81, 0x82]);
+    let err = fs.read_to_string(Path::new("data/bad.txt")).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("invalid UTF-8"), "error: {msg}");
+    assert!(msg.contains("bad.txt"), "error should mention path: {msg}");
+}
+
+// ===========================================================================
+// 4. MemFs - directory inference and file enumeration
+// ===========================================================================
+
+#[test]
+fn w76_memfs_deep_nested_directory_inference() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("a/b/c/d/e.rs"), "fn e() {}");
+    assert!(fs.is_dir(Path::new("a")));
+    assert!(fs.is_dir(Path::new("a/b")));
+    assert!(fs.is_dir(Path::new("a/b/c")));
+    assert!(fs.is_dir(Path::new("a/b/c/d")));
+    assert!(!fs.is_dir(Path::new("a/b/c/d/e.rs")));
+    assert!(fs.is_file(Path::new("a/b/c/d/e.rs")));
+}
+
+#[test]
+fn w76_memfs_multiple_files_same_directory() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("src/lib.rs"), "pub mod a;");
+    fs.add_file(PathBuf::from("src/a.rs"), "pub fn a() {}");
+    fs.add_file(PathBuf::from("src/b.rs"), "pub fn b() {}");
+    assert!(fs.is_dir(Path::new("src")));
+    assert!(fs.is_file(Path::new("src/lib.rs")));
+    assert!(fs.is_file(Path::new("src/a.rs")));
+    assert!(fs.is_file(Path::new("src/b.rs")));
+    assert!(!fs.is_file(Path::new("src/c.rs")));
+}
+
+#[test]
+fn w76_memfs_exists_covers_both_files_and_dirs() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("pkg/mod.rs"), "");
+    assert!(fs.exists(Path::new("pkg/mod.rs")));
+    assert!(fs.exists(Path::new("pkg")));
+    assert!(!fs.exists(Path::new("other")));
+}
+
+// ===========================================================================
+// 5. MemFs - overwrite and isolation
+// ===========================================================================
+
+#[test]
+fn w76_memfs_overwrite_replaces_content() {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("cfg.toml"), "[old]");
+    fs.add_file(PathBuf::from("cfg.toml"), "[new]");
+    assert_eq!(fs.read_to_string(Path::new("cfg.toml")).unwrap(), "[new]");
+}
+
+#[test]
+fn w76_memfs_instances_are_isolated() {
+    let mut a = MemFs::new();
+    let b = MemFs::new();
+    a.add_file(PathBuf::from("only_in_a.txt"), "data");
+    assert!(a.exists(Path::new("only_in_a.txt")));
+    assert!(!b.exists(Path::new("only_in_a.txt")));
+}
+
+// ===========================================================================
+// 6. HostFs - real filesystem via tempfile
+// ===========================================================================
+
+#[test]
+fn w76_hostfs_read_write_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("greeting.txt");
+    std::fs::write(&file, "good morning").unwrap();
+
+    let fs = HostFs;
+    assert_eq!(fs.read_to_string(&file).unwrap(), "good morning");
+    assert_eq!(fs.read_bytes(&file).unwrap(), b"good morning".to_vec());
+    assert!(fs.exists(&file));
+    assert!(fs.is_file(&file));
+    assert!(!fs.is_dir(&file));
+    assert!(fs.is_dir(dir.path()));
+}
+
+#[test]
+fn w76_hostfs_missing_file_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does_not_exist.txt");
+    assert!(HostFs.read_to_string(&missing).is_err());
+    assert!(HostFs.read_bytes(&missing).is_err());
+    assert!(!HostFs.exists(&missing));
+}
+
+#[test]
+fn w76_hostfs_binary_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("data.bin");
+    let bytes: Vec<u8> = (0..=127).collect();
+    std::fs::write(&file, &bytes).unwrap();
+    assert_eq!(HostFs.read_bytes(&file).unwrap(), bytes);
+}

--- a/crates/tokmd-progress/tests/progress_deep_w76.rs
+++ b/crates/tokmd-progress/tests/progress_deep_w76.rs
@@ -1,0 +1,130 @@
+//! Deep tests for tokmd-progress (W76).
+//!
+//! ~10 tests covering: Progress spinner creation (disabled/enabled-in-CI),
+//! message variants, lifecycle (finish/drop), ProgressBarWithEta creation
+//! edge cases, bar operations, and full quiet-mode lifecycle.
+//!
+//! All tests run with `enabled=false` (no-op mode) so they are deterministic
+//! and safe in CI (no TTY required).
+
+use tokmd_progress::{Progress, ProgressBarWithEta};
+
+// ===========================================================================
+// 1. Progress spinner - creation
+// ===========================================================================
+
+#[test]
+fn w76_progress_disabled_creates_without_panic() {
+    let _p = Progress::new(false);
+}
+
+#[test]
+fn w76_progress_enabled_in_ci_creates_without_panic() {
+    // In non-TTY CI, enabled=true still works (noop internally).
+    let _p = Progress::new(true);
+}
+
+// ===========================================================================
+// 2. Progress spinner - message variants
+// ===========================================================================
+
+#[test]
+fn w76_progress_set_message_borrowed_owned_empty() {
+    let p = Progress::new(false);
+    p.set_message("literal &str");
+    p.set_message(String::from("owned String"));
+    p.set_message("");
+}
+
+#[test]
+fn w76_progress_set_message_unicode_and_long() {
+    let p = Progress::new(false);
+    p.set_message("analysing...");
+    p.set_message("a".repeat(100_000));
+}
+
+// ===========================================================================
+// 3. Progress spinner - lifecycle (finish, double-finish, drop)
+// ===========================================================================
+
+#[test]
+fn w76_progress_finish_and_clear_no_panic() {
+    let p = Progress::new(false);
+    p.set_message("working");
+    p.finish_and_clear();
+}
+
+#[test]
+fn w76_progress_double_finish_is_safe() {
+    let p = Progress::new(false);
+    p.finish_and_clear();
+    p.finish_and_clear();
+}
+
+#[test]
+fn w76_progress_drop_does_not_panic() {
+    {
+        let p = Progress::new(false);
+        p.set_message("about to drop");
+    }
+    // implicit drop - no panic
+}
+
+// ===========================================================================
+// 4. ProgressBarWithEta - creation edge cases
+// ===========================================================================
+
+#[test]
+fn w76_bar_zero_total_is_valid() {
+    let b = ProgressBarWithEta::new(false, 0, "nothing");
+    b.inc();
+    b.finish_and_clear();
+}
+
+#[test]
+fn w76_bar_max_total_is_valid() {
+    let b = ProgressBarWithEta::new(false, u64::MAX, "enormous");
+    b.inc();
+    b.finish_and_clear();
+}
+
+// ===========================================================================
+// 5. ProgressBarWithEta - operations after finish
+// ===========================================================================
+
+#[test]
+fn w76_bar_full_operation_sequence() {
+    let b = ProgressBarWithEta::new(false, 50, "scan");
+    b.inc();
+    b.inc_by(5);
+    b.set_position(20);
+    b.set_length(100);
+    b.set_message("halfway");
+    b.finish_with_message("complete");
+    // Operations after finish must not panic.
+    b.inc();
+    b.set_position(0);
+    b.set_message("post-finish");
+    b.finish_and_clear();
+}
+
+// ===========================================================================
+// 6. Full quiet-mode lifecycle (spinner + bar together)
+// ===========================================================================
+
+#[test]
+fn w76_quiet_full_lifecycle_spinner_and_bar() {
+    // Spinner
+    let p = Progress::new(false);
+    for i in 0..100 {
+        p.set_message(format!("step {i}"));
+    }
+    p.finish_and_clear();
+
+    // Bar
+    let b = ProgressBarWithEta::new(false, 500, "batch");
+    for _ in 0..500 {
+        b.inc();
+    }
+    b.finish_with_message("done");
+}


### PR DESCRIPTION
## Summary

Add deep integration test suites for \	okmd-io-port\ and \	okmd-progress\ crates.

### io_port_deep_w76 (15 tests)
- MemFs text/binary file round-trips
- Error messages: not-found includes path, invalid UTF-8 includes path
- Directory inference from nested file paths
- Multiple files in same directory
- Overwrite semantics (last-write-wins)
- Instance isolation (two MemFs share nothing)
- HostFs real-filesystem read/write/exists via tempfile
- HostFs missing file error handling
- HostFs binary round-trip

### progress_deep_w76 (11 tests)
- Progress spinner creation (disabled + enabled-in-CI)
- Message variants: borrowed \&str\, owned \String\, empty, unicode, long (100k chars)
- Lifecycle: finish-and-clear, double-finish, implicit drop
- ProgressBarWithEta edge cases: zero total, u64::MAX total
- Full operation sequence (inc/inc_by/set_position/set_length/set_message/finish)
- Operations after finish do not panic
- Quiet-mode full lifecycle (spinner + bar together)

All tests pass in CI (no TTY required).