### PR TITLE
test(w77): FFI + core facade + diff command deep tests (~50 tests)

### DIFF
--- a/crates/tokmd-core/tests/ffi_deep_w77.rs
+++ b/crates/tokmd-core/tests/ffi_deep_w77.rs
@@ -25,8 +25,11 @@ use tokmd_core::ffi::run_json;
 /// Create a temp dir with a simple Rust file for scanning.
 fn scaffold() -> TempDir {
     let tmp = TempDir::new().expect("create temp dir");
-    fs::write(tmp.path().join("main.rs"), "fn main() {\n    println!(\"hi\");\n}\n")
-        .expect("write main.rs");
+    fs::write(
+        tmp.path().join("main.rs"),
+        "fn main() {\n    println!(\"hi\");\n}\n",
+    )
+    .expect("write main.rs");
     tmp
 }
 
@@ -66,7 +69,9 @@ fn version_mode_returns_success() {
 #[test]
 fn version_mode_contains_version_string() {
     let v = assert_ok(&run_json("version", "{}"));
-    let ver = v["data"]["version"].as_str().expect("version must be string");
+    let ver = v["data"]["version"]
+        .as_str()
+        .expect("version must be string");
     assert!(!ver.is_empty(), "version must not be empty");
 }
 
@@ -225,7 +230,10 @@ fn ffi_response_is_valid_json_on_every_mode() {
     for mode in &["version", "lang", "module", "export", "nonexistent"] {
         let result = run_json(mode, &args);
         let parsed: Result<Value, _> = serde_json::from_str(&result);
-        assert!(parsed.is_ok(), "mode '{mode}' must return valid JSON, got: {result}");
+        assert!(
+            parsed.is_ok(),
+            "mode '{mode}' must return valid JSON, got: {result}"
+        );
     }
 }
 

--- a/crates/tokmd-ffi-envelope/tests/envelope_w77.rs
+++ b/crates/tokmd-ffi-envelope/tests/envelope_w77.rs
@@ -56,7 +56,10 @@ fn error_envelope_missing_ok_treated_as_false() {
 #[test]
 fn format_error_message_with_full_error() {
     let err_obj = json!({"code": "bad_input", "message": "path missing"});
-    assert_eq!(format_error_message(Some(&err_obj)), "[bad_input] path missing");
+    assert_eq!(
+        format_error_message(Some(&err_obj)),
+        "[bad_input] path missing"
+    );
 }
 
 #[test]
@@ -66,7 +69,10 @@ fn format_error_message_with_none() {
 
 #[test]
 fn format_error_message_with_non_object() {
-    assert_eq!(format_error_message(Some(&json!("string_err"))), "Unknown error");
+    assert_eq!(
+        format_error_message(Some(&json!("string_err"))),
+        "Unknown error"
+    );
 }
 
 // ============================================================================

--- a/crates/tokmd/tests/diff_deep_w77.rs
+++ b/crates/tokmd/tests/diff_deep_w77.rs
@@ -271,7 +271,10 @@ fn diff_removed_language_appears_with_negative_delta() {
     let json: Value = serde_json::from_slice(&output.stdout).unwrap();
 
     let rows = json["diff_rows"].as_array().unwrap();
-    let shell_row = rows.iter().find(|r| r["lang"] == "Shell").expect("Shell row");
+    let shell_row = rows
+        .iter()
+        .find(|r| r["lang"] == "Shell")
+        .expect("Shell row");
     assert_eq!(shell_row["new_code"], 0);
     assert_eq!(shell_row["delta_code"], -30);
     assert_eq!(shell_row["delta_files"], -2);
@@ -734,17 +737,19 @@ fn diff_only_from_no_to_fails() {
         &lang_receipt(&[("Rust", 10, 12, 1, 500, 25)]),
     );
 
-    tokmd()
-        .args(["diff", "--from"])
-        .arg(&a)
-        .assert()
-        .failure();
+    tokmd().args(["diff", "--from"]).arg(&a).assert().failure();
 }
 
 #[test]
 fn diff_nonexistent_file_fails() {
     tokmd()
-        .args(["diff", "--from", "/nonexistent/path.json", "--to", "/also/missing.json"])
+        .args([
+            "diff",
+            "--from",
+            "/nonexistent/path.json",
+            "--to",
+            "/also/missing.json",
+        ])
         .assert()
         .failure();
 }


### PR DESCRIPTION
## Summary

Add deep integration tests for the FFI `run_json` entrypoint (`tokmd-core`) and the `tokmd-ffi-envelope` crate.

### `crates/tokmd-core/tests/ffi_deep_w77.rs` (21 tests)

- `run_json("version", "{}")` returns success with version + schema_version
- `run_json("lang", json)` returns success with mode, rows
- `run_json("module", json)` returns success with mode
- `run_json("export", json)` returns success with mode
- `run_json("invalid_mode", "{}")` returns error with `unknown_mode` code
- `run_json("lang", "not json")` returns error with `invalid_json` code
- Envelope always has `ok` field (success and error)
- Error envelope has `error` object, success has `data` object
- FFI response is valid UTF-8
- FFI response is valid JSON for every mode
- Empty args string returns error

### `crates/tokmd-ffi-envelope/tests/envelope_w77.rs` (11 tests)

- Envelope construction roundtrip (success + error)
- Invalid JSON rejection
- Error extraction (upstream errors, missing ok field)
- `format_error_message` edge cases (full, None, non-object)
- JSON serialization of extracted data
- Non-object envelope rejection

All tests use `tempfile` for scan targets.