### PR TITLE
test: replace unwrap and expect calls in commands tests 🛡️ Sentinel

### DIFF
--- a/.jules/policy/scheduled_tasks.json
+++ b/.jules/policy/scheduled_tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "selection_strategy": "random",
+  "default_gates": [
+    "build",
+    "test",
+    "fmt",
+    "clippy"
+  ],
+  "prefer_full_suite_when_touching": [
+    "src/",
+    "tests/",
+    "crates/",
+    ".github/workflows/"
+  ],
+  "notes_write_threshold": "only_when_reusable_pattern_discovered"
+}

--- a/.jules/runbooks/FRICTION_ITEM.md
+++ b/.jules/runbooks/FRICTION_ITEM.md
@@ -1,0 +1,13 @@
+# Title
+
+## Pain
+...
+
+## Evidence
+...
+
+## Done-when
+...
+
+## Tags
+...

--- a/.jules/runbooks/PR_GLASS_COCKPIT.md
+++ b/.jules/runbooks/PR_GLASS_COCKPIT.md
@@ -1,0 +1,53 @@
+---
+# PR Glass Cockpit
+
+Make review boring. Make truth cheap.
+
+## 💡 Summary
+1–4 sentences. What changed.
+
+## 🎯 Why / Threat model
+High level impact. No exploit steps.
+
+## 🔎 Finding (evidence)
+Minimal proof:
+- file path(s)
+- observed behavior
+- test/command demonstrating it
+
+## 🧭 Options considered
+### Option A (recommended)
+- What it is
+- Why it fits this repo
+- Trade-offs: Structure / Velocity / Governance
+
+### Option B
+- What it is
+- When to choose it instead
+- Trade-offs
+
+## ✅ Decision
+State the decision and why.
+
+## 🧱 Changes made (SRP)
+Bullets with file paths.
+
+## 🧪 Verification receipts
+Copy from the run envelope. Commands + results.
+
+## 🧭 Telemetry
+- Change shape
+- Blast radius (API / IO / config / schema / concurrency)
+- Risk class + why
+- Rollback
+- Merge-confidence gates (what ran)
+
+## 🗂️ .jules updates
+What changed in .jules and why.
+
+## 📝 Notes (freeform)
+Optional. Extra context for future runs or reviewers.
+
+## 🔜 Follow-ups
+If anything remains, create friction items and link them.
+---

--- a/.jules/security/README.md
+++ b/.jules/security/README.md
@@ -1,0 +1,1 @@
+# Sentinel Checks in tokmd

--- a/.jules/security/envelopes/20260306T132241Z.json
+++ b/.jules/security/envelopes/20260306T132241Z.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "20260306T132241Z",
+  "timestamp_utc": "2026-03-06T13:22:41.621050+00:00",
+  "lane": "scout",
+  "target": "unwrap/expect burn-down in crates/tokmd/src/commands/",
+  "commands": [
+    {
+      "cmd": "rg -n '\\bunsafe\\b' .",
+      "status": "0",
+      "result": "Found 33 unsafe lines. Top files: crates/tokmd-analysis-complexity/src/lib.rs (8), crates/tokmd-content/src/complexity.rs (5), crates/tokmd-analysis-api-surface/src/lib.rs (5)."
+    },
+    {
+      "cmd": "cargo build --verbose",
+      "status": "0",
+      "result": "PASS"
+    },
+    {
+      "cmd": "CI=true cargo test --verbose",
+      "status": "0",
+      "result": "PASS (Verified tests in tokmd)"
+    },
+    {
+      "cmd": "cargo fmt",
+      "status": "0",
+      "result": "PASS"
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "status": "0",
+      "result": "PASS"
+    }
+  ],
+  "results": []
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -1,0 +1,17 @@
+[
+  {
+    "timestamp": "2026-03-06T13:48:53.755184+00:00",
+    "lane": "scout",
+    "target": "unwrap/expect burn-down in crates/tokmd/src/commands/",
+    "pr_link": "PENDING",
+    "gates_run": [
+      "rg -n '\\bunsafe\\b' .",
+      "cargo build --verbose",
+      "CI=true cargo test --verbose",
+      "cargo fmt",
+      "cargo clippy -- -D warnings"
+    ],
+    "gates_status": "PASS",
+    "friction_ids_created": []
+  }
+]

--- a/.jules/security/runs/2026-03-06.md
+++ b/.jules/security/runs/2026-03-06.md
@@ -1,0 +1,21 @@
+# Run 2026-03-06
+Links: [Envelope](../envelopes/20260306T132241Z.json)
+Lane: scout
+Target: unwrap/expect burn-down in crates/tokmd/src/commands/
+
+## Findings
+
+## Options considered
+### Option A
+- Replace `unwrap` and `expect` with proper error handling or Result returns where applicable in `crates/tokmd/src/commands/`.
+- If in tests, replace with `?` by returning `Result<(), Box<dyn std::error::Error>>`.
+- Why it fits: Matches Sentinel's goal of "unwrap/expect/panic candidates everywhere" burn-down and improves code quality/stability.
+- Trade-offs: Increases lines of code slightly due to test signatures changing or explicit mapping.
+
+### Option B
+- Focus on just one specific command like `sensor.rs`.
+- Why it fits: Very tight scope.
+- Trade-offs: Less impact per run.
+
+## Decision
+Choosing Option A because the blast radius is small enough (15 occurrences in `crates/tokmd/src/commands/`), and modifying all tests within these specific modules provides a meaningful and bounded SRP improvement.

--- a/crates/tokmd/src/commands/baseline.rs
+++ b/crates/tokmd/src/commands/baseline.rs
@@ -227,6 +227,6 @@ mod tests {
         let sha = capture_git_commit(&PathBuf::from("/"));
         // Root should not be a git repo (in most cases)
         // Note: This might fail in some edge cases where / is somehow a git repo
-        assert!(sha.is_none() || sha.unwrap().len() == 40);
+        assert!(sha.is_none() || sha.is_some_and(|s| s.len() == 40));
     }
 }

--- a/crates/tokmd/src/commands/check_ignore.rs
+++ b/crates/tokmd/src/commands/check_ignore.rs
@@ -346,27 +346,28 @@ mod tests {
     }
 
     #[test]
-    fn check_tokeignore_matches_parent_dir() {
-        let dir = tempdir().unwrap();
+    fn check_tokeignore_matches_parent_dir() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
         let src_dir = dir.path().join("src");
-        std::fs::create_dir_all(&src_dir).unwrap();
-        std::fs::write(dir.path().join(".tokeignore"), "*.rs\n").unwrap();
+        std::fs::create_dir_all(&src_dir)?;
+        std::fs::write(dir.path().join(".tokeignore"), "*.rs\n")?;
 
         let file_path = src_dir.join("main.rs");
-        std::fs::write(&file_path, "fn main() {}\n").unwrap();
+        std::fs::write(&file_path, "fn main() {}\n")?;
 
         let reason = check_tokeignore(&file_path, file_path.to_string_lossy().as_ref());
         assert!(matches!(
             reason,
             Some(IgnoreReason::Tokeignore { pattern }) if pattern == "*.rs"
         ));
+        Ok(())
     }
 
     #[test]
-    fn check_path_reports_not_found() {
-        let dir = tempdir().unwrap();
+    fn check_path_reports_not_found() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
         let missing = dir.path().join("missing.rs");
-        let result = check_path(&missing, &GlobalArgs::default(), false).unwrap();
+        let result = check_path(&missing, &GlobalArgs::default(), false)?;
         assert!(!result.ignored);
         assert!(
             result
@@ -374,23 +375,25 @@ mod tests {
                 .iter()
                 .any(|r| matches!(r, IgnoreReason::NotFound))
         );
+        Ok(())
     }
 
     #[test]
-    fn check_path_honors_exclude_flag() {
-        let dir = tempdir().unwrap();
+    fn check_path_honors_exclude_flag() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
         let file_path = dir.path().join("skip.rs");
-        std::fs::write(&file_path, "fn skip() {}\n").unwrap();
+        std::fs::write(&file_path, "fn skip() {}\n")?;
 
         let mut global = GlobalArgs::default();
         global.excluded.push("*.rs".to_string());
 
-        let result = check_path(&file_path, &global, false).unwrap();
+        let result = check_path(&file_path, &global, false)?;
         assert!(result.ignored);
         assert!(
             result.reasons.iter().any(|r| {
                 matches!(r, IgnoreReason::ExcludeFlag { pattern } if pattern == "*.rs")
             })
         );
+        Ok(())
     }
 }

--- a/crates/tokmd/src/commands/sensor.rs
+++ b/crates/tokmd/src/commands/sensor.rs
@@ -465,7 +465,7 @@ mod tests {
     };
 
     #[test]
-    fn render_sensor_md_includes_findings_and_gates() {
+    fn render_sensor_md_includes_findings_and_gates() -> Result<(), Box<dyn std::error::Error>> {
         let mut report = SensorReport::new(
             ToolMeta::tokmd("1.0.0", "sensor"),
             "2024-01-01T00:00:00Z".to_string(),
@@ -488,7 +488,7 @@ mod tests {
             vec![GateItem::new("mutation", Verdict::Warn).with_source("computed")],
         );
         report = report.with_data(serde_json::json!({
-            "gates": serde_json::to_value(gates).unwrap(),
+            "gates": serde_json::to_value(gates)?,
         }));
 
         let md = render_sensor_md(&report);
@@ -497,6 +497,7 @@ mod tests {
         assert!(md.contains("risk.hotspot"));
         assert!(md.contains("### Gates (warn)"));
         assert!(md.contains("mutation"));
+        Ok(())
     }
 
     #[cfg(feature = "git")]
@@ -622,7 +623,7 @@ mod tests {
 
     #[cfg(feature = "git")]
     #[test]
-    fn map_gates_includes_optional_items_and_reasons() {
+    fn map_gates_includes_optional_items_and_reasons() -> Result<(), Box<dyn std::error::Error>> {
         let mut evidence = base_evidence();
         evidence.diff_coverage = Some(DiffCoverageGate {
             meta: sample_meta(GateStatus::Fail),
@@ -682,7 +683,7 @@ mod tests {
             .items
             .iter()
             .find(|g| g.id == "diff_coverage")
-            .expect("diff gate");
+            .ok_or("diff gate missing")?;
         assert_eq!(diff_gate.threshold, Some(0.8));
         assert_eq!(diff_gate.actual, Some(0.5));
 
@@ -690,16 +691,18 @@ mod tests {
             .items
             .iter()
             .find(|g| g.id == "contracts")
-            .expect("contracts gate");
+            .ok_or("contracts gate missing")?;
         assert_eq!(
             contracts_gate.reason.as_deref(),
             Some("2 sub-gate(s) failed")
         );
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn emit_risk_findings_emits_hotspots_and_bus_factor() {
+    fn emit_risk_findings_emits_hotspots_and_bus_factor() -> Result<(), Box<dyn std::error::Error>>
+    {
         let mut report = SensorReport::new(
             ToolMeta::tokmd("1.0.0", "sensor"),
             "2024-01-01T00:00:00Z".to_string(),
@@ -720,15 +723,16 @@ mod tests {
             .findings
             .iter()
             .find(|f| f.code == findings::risk::HOTSPOT)
-            .expect("hotspot finding");
+            .ok_or("hotspot finding missing")?;
         assert!(hotspot.location.is_some());
 
         let bus_factor = report
             .findings
             .iter()
             .find(|f| f.code == findings::risk::BUS_FACTOR)
-            .expect("bus factor finding");
+            .ok_or("bus factor finding missing")?;
         assert!(bus_factor.location.is_some());
+        Ok(())
     }
 
     #[cfg(feature = "git")]


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Replaced several instances of `unwrap()` and `expect()` in test functions within `crates/tokmd/src/commands/` (`check_ignore.rs`, `sensor.rs`, `baseline.rs`). These were changed to safely bubble up errors via `Result<(), Box<dyn std::error::Error>>` or safe assertions, burning down tech debt.

## 🎯 Why / Threat model
Panicking macros like `unwrap` and `expect` represent a fragility risk, particularly if they leak out of test code or obscure actual runtime errors in CI. Eliminating them enhances code quality, reliability, and satisfies the Sentinel goal of a complete `unwrap/expect/panic` burn-down.

## 🔎 Finding (evidence)
Minimal proof:
- file path: `crates/tokmd/src/commands/check_ignore.rs`, `crates/tokmd/src/commands/sensor.rs`, `crates/tokmd/src/commands/baseline.rs`
- observed behavior: 15 occurrences of `unwrap` and `expect` were found in these tests.
- test/command demonstrating it: `rg -n "\bunwrap\(|\bexpect\(" crates/tokmd/src/commands/`

## 🧭 Options considered
### Option A (recommended)
- What it is: Replace `unwrap` and `expect` with proper error handling or Result returns in `crates/tokmd/src/commands/` tests.
- Why it fits this repo: Matches Sentinel's goal of "unwrap/expect/panic candidates everywhere" burn-down.
- Trade-offs: Increases lines of code slightly due to test signatures changing or explicit mapping.

### Option B
- What it is: Focus on just one specific command like `sensor.rs`.
- When to choose it instead: If blast radius constraints were significantly tighter.
- Trade-offs: Less impact per run.

## ✅ Decision
Chose Option A because the blast radius is small enough (15 occurrences), and modifying all tests within these specific modules provides a meaningful and bounded SRP improvement.

## 🧱 Changes made (SRP)
- `crates/tokmd/src/commands/baseline.rs`
- `crates/tokmd/src/commands/check_ignore.rs`
- `crates/tokmd/src/commands/sensor.rs`
- `.jules/policy/scheduled_tasks.json`
- `.jules/runbooks/PR_GLASS_COCKPIT.md`
- `.jules/runbooks/FRICTION_ITEM.md`
- `.jules/security/README.md`
- `.jules/security/ledger.json`
- `.jules/security/runs/2026-03-06.md`
- `.jules/security/envelopes/20260306T132241Z.json`

## 🧪 Verification receipts
```json
[
  {
    "cmd": "rg -n '\\bunsafe\\b' .",
    "status": "0",
    "result": "Found 33 unsafe lines. Top files: crates/tokmd-analysis-complexity/src/lib.rs (8), crates/tokmd-content/src/complexity.rs (5), crates/tokmd-analysis-api-surface/src/lib.rs (5)."
  },
  {
    "cmd": "cargo build --verbose",
    "status": "0",
    "result": "PASS"
  },
  {
    "cmd": "cargo fmt",
    "status": "0",
    "result": "PASS"
  },
  {
    "cmd": "cargo clippy -- -D warnings",
    "status": "0",
    "result": "PASS"
  },
  {
    "cmd": "CI=true cargo test --verbose",
    "status": "0",
    "result": "PASS (Verified tests in tokmd)"
  }
]
```

## 🧭 Telemetry
- Change shape: Test refactor, adding Result returns and safe unwrap checks.
- Blast radius: Only affects tests in `commands/` module (No API / IO / config / schema / concurrency changes).
- Risk class: Low
- Rollback: Safe to revert if needed.
- Merge-confidence gates: `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`.

## 🗂️ .jules updates
Created the required folder structure and policy files for scheduled runs, initialized the security ledger and run log, and stored the run envelope with receipts.

## 📝 Notes (freeform)
N/A

## 🔜 Follow-ups
None for this specific target.
---

---
*PR created automatically by Jules for task [7963971525791393418](https://jules.google.com/task/7963971525791393418) started by @EffortlessSteven*