### PR TITLE
fix(ci): unblock main from Nix timeout cancellations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
   nix:
     name: Nix Build
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v6
 
@@ -282,7 +282,6 @@ jobs:
       - publish-plan
       - docs-check
       - nix
-      - nix-macos
       - mutation
       - feature-boundaries
     steps:


### PR DESCRIPTION
## Summary

- **Problem:** Both Nix CI jobs (Linux and macOS) hit the 90-minute timeout and get cancelled. The `ci-required` rollup treats `cancelled` as failure via `contains(needs.*.result, 'cancelled')`, making main red with no actual code error.
- **Fix 1:** Increase Linux Nix timeout from 90 → 150 minutes to give cache-miss builds headroom.
- **Fix 2:** Remove `nix-macos` from `ci-required` needs list. The cargo-based macOS CI already covers macOS; `nix-macos` continues to run on push as an informational job.

## Test plan

- [ ] Verify CI passes on this PR (the two changed lines are the only diff)
- [ ] Confirm `ci-required` still lists `nix` (Linux) as a required job
- [ ] Confirm `nix-macos` still runs on push, just no longer blocks `ci-required`