### PR TITLE
docs: fix tokmd-walk README example to compile under doctests 📚 Librarian

### DIFF
--- a/crates/tokmd-walk/README.md
+++ b/crates/tokmd-walk/README.md
@@ -16,6 +16,7 @@ tokmd-walk = "1.3"
 ## Usage
 
 ```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use tokmd_walk::{list_files, license_candidates, file_size};
 use std::path::Path;
 
@@ -29,18 +30,20 @@ println!("Metadata files: {:?}", candidates.metadata_files);
 
 // Get file size
 let size = file_size(Path::new("."), Path::new("src/lib.rs"))?;
+# Ok(())
+# }
 ```
 
 ## Key Functions
 
 ### File Listing
-```rust
+```rust,ignore
 pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
 ```
 Lists files respecting gitignore. Tries `git ls-files` first, falls back to the `ignore` crate.
 
 ### License Detection
-```rust
+```rust,ignore
 pub fn license_candidates(files: &[PathBuf]) -> LicenseCandidates
 ```
 Identifies common license files:
@@ -48,7 +51,7 @@ Identifies common license files:
 - Metadata: `Cargo.toml`, `package.json`, `pyproject.toml`
 
 ### File Size
-```rust
+```rust,ignore
 pub fn file_size(root: &Path, relative: &Path) -> Result<u64>
 ```
 

--- a/crates/tokmd-walk/src/lib.rs
+++ b/crates/tokmd-walk/src/lib.rs
@@ -264,3 +264,8 @@ mod tests {
         assert!(files.len() <= 3);
     }
 }
+
+#[cfg(doctest)]
+pub mod readme_doctests {
+    #![doc = include_str!("../README.md")]
+}


### PR DESCRIPTION
This PR fixes the examples in `crates/tokmd-walk/README.md` to properly compile via doctests, addressing example drift.

### Details
- Wrapped the primary `Usage` example code block in a hidden `fn main() -> Result<(), Box<dyn std::error::Error>>` block to handle the `?` operator.
- Tagged the function signature code blocks (`File Listing`, `License Detection`, `File Size`) with ````rust,ignore` as they are just signatures, not runnable code.
- Added `#![cfg(doctest)] pub mod readme_doctests { ... }` block to `crates/tokmd-walk/src/lib.rs` to wire up the doctest via `cargo test -p tokmd-walk --doc`.

### Receipts

```bash
$ cargo test -p tokmd-walk --doc

running 4 tests
test crates/tokmd-walk/src/../README.md - readme_doctests (line 40) ... ignored
test crates/tokmd-walk/src/../README.md - readme_doctests (line 46) ... ignored
test crates/tokmd-walk/src/../README.md - readme_doctests (line 54) ... ignored
test crates/tokmd-walk/src/../README.md - readme_doctests (line 18) ... ok

test result: ok. 1 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.01s

all doctests ran in 1.94s; merged doctests compilation took 1.92s
```

---
*PR created automatically by Jules for task [10534903819657535242](https://jules.google.com/task/10534903819657535242) started by @EffortlessSteven*