### PR TITLE
deps: remove unused anyhow dependency 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/1.json
+++ b/.jules/deps/envelopes/1.json
@@ -1,0 +1,16 @@
+{
+  "run_id": "1",
+  "timestamp": "2026-03-07T12:39:05Z",
+  "lane": "scout discovery",
+  "action": "remove unused anyhow from tokmd-model",
+  "receipts": [
+    {
+      "command": "cargo check -p tokmd-model",
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test -p tokmd-model",
+      "exit_code": 0
+    }
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -10,5 +10,18 @@
       "cargo machete output identifying unused tokmd-analysis-types in tokmd-gate",
       "cargo test -p tokmd-gate completed successfully after removal"
     ]
+  },
+  {
+    "run_id": "1",
+    "date": "2026-03-07T12:43:15Z",
+    "persona": "Auditor",
+    "lane": "scout",
+    "target": "tokmd-model",
+    "action": "remove unused dependency anyhow",
+    "receipts": [
+      "cargo machete output identifying unused anyhow in tokmd-model",
+      "cargo check -p tokmd-model completed successfully after removal",
+      "cargo test -p tokmd-model completed successfully after removal"
+    ]
   }
 ]

--- a/.jules/deps/runs/2026-03-07.md
+++ b/.jules/deps/runs/2026-03-07.md
@@ -1,0 +1,6 @@
+# Auditor Run: 2026-03-07
+
+- **Goal**: Maximize SRP-quality improvement per reviewer minute.
+- **Action**: Removed `anyhow` dependency from `tokmd-model` crate as it was unused.
+- **Lane**: Scout discovery
+- **Outcome**: Tests pass, compilation succeeds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,6 @@ dependencies = [
 name = "tokmd-model"
 version = "1.7.3"
 dependencies = [
- "anyhow",
  "insta",
  "proptest",
  "serde",

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-model"
 
 [dependencies]
-anyhow = "1.0.101"
 serde = { version = "1.0.228", features = ["derive"] }
 tokei = { version = "14.0.0", default-features = false }
 tokmd-module-key.workspace = true


### PR DESCRIPTION
## ✈️ Glass Cockpit PR

**Persona**: Auditor 🧾
**Goal**: Remove unused dependencies for hygiene and reduced build surface.
**Lane**: Scout discovery
**Target**: `tokmd-model`

### Change summary
Removed the unused `anyhow` dependency from the `tokmd-model` crate as identified by `cargo machete` and manual codebase verification. `serde` was preserved since it's used via derived macros that `cargo machete` occasionally misses.

### Validation Receipts
- [x] Verified unused via `cargo machete`
- [x] `cargo check -p tokmd-model`
- [x] `cargo test -p tokmd-model`
- [x] Documented run envelope, log, and ledger inside `.jules/deps/`
- [x] Adhered to single-responsibility bounds and strictly bounded blast radius

```text
cargo-machete found the following unused dependencies in this directory:
tokmd-model -- ./crates/tokmd-model/Cargo.toml:
	anyhow
```

---
*PR created automatically by Jules for task [3364234382016980875](https://jules.google.com/task/3364234382016980875) started by @EffortlessSteven*