### PR TITLE
docs: make README example compile under latest API 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/1772963867.json
+++ b/.jules/docs/envelopes/1772963867.json
@@ -1,0 +1,4 @@
+{
+  "lane": "B",
+  "reason": "Found outdated API usage in crates/tokmd-core/README.md examples. `scan_workflow` and `GlobalArgs`/`LangArgs` are deprecated in favor of `lang_workflow` and settings types."
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -1,0 +1,8 @@
+[
+  {
+    "run_id": "run-1772963981",
+    "timestamp": 1772963981,
+    "description": "Updated tokmd-core README API examples to match current lang_workflow and settings structs.",
+    "target": "crates/tokmd-core/README.md"
+  }
+]

--- a/.jules/docs/runs/2026-03-08.md
+++ b/.jules/docs/runs/2026-03-08.md
@@ -1,0 +1,4 @@
+# Librarian Run Log
+Target: `crates/tokmd-core/README.md`
+Strategy: Update outdated examples to match the newly adopted API (`lang_workflow`, `ScanSettings`, `LangSettings`).
+Verification: ran `cargo test -p tokmd-core --doc` successfully.

--- a/crates/tokmd-core/README.md
+++ b/crates/tokmd-core/README.md
@@ -18,27 +18,19 @@ tokmd-types = "1.4"
 
 ```rust,no_run
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-use tokmd_core::scan_workflow;
-use tokmd_core::config::GlobalArgs;
-use tokmd_core::types::{ChildrenMode, LangArgs, RedactMode, TableFormat};
-use std::path::PathBuf;
+use tokmd_core::{lang_workflow, settings::{ScanSettings, LangSettings}};
 
 // Configure scan
-let global = GlobalArgs::default();
-let lang = LangArgs {
-    paths: vec![PathBuf::from(".")],
-    format: TableFormat::Json,
+let scan = ScanSettings::current_dir();
+let lang = LangSettings {
     top: 10,
     files: false,
-    children: ChildrenMode::Collapse,
+    ..Default::default()
 };
 
-// Run pipeline (without redaction)
-let receipt = scan_workflow(&global, &lang, None)?;
+// Run pipeline
+let receipt = lang_workflow(&scan, &lang)?;
 println!("Scanned {} languages", receipt.report.rows.len());
-
-// Run pipeline (with path redaction)
-let redacted = scan_workflow(&global, &lang, Some(RedactMode::Paths))?;
 # Ok(())
 # }
 ```

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,25 +1,19 @@
-## Summary
+# PR Glass Cockpit
 
-Add 116 targeted mutation-killing tests across four critical crates to improve mutation testing scores and protect against subtle behavioral regressions.
+## Type
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Maintenance
+- [x] Documentation / Examples
 
-### Crates Covered
+## Description
+Updated the `tokmd-core` README example to properly compile under the latest API which favors `lang_workflow` and `ScanSettings`/`LangSettings` over the old clap-based arg structs.
 
-| Crate | Tests | Key Mutation Targets |
-|-------|-------|---------------------|
-| **tokmd-redact** | 20 | Hash truncation boundary (16 vs 15/17), separator normalization, extension preservation, privacy guarantees |
-| **tokmd-gate** | 48 | Comparison operator boundaries (> vs >=, < vs <=), negate logic, from_results counting, fail_fast conjunctions, ratchet percentage arithmetic, missing value handling |
-| **tokmd-model** | 20 | avg() division-by-zero guard, rounding arithmetic, normalize_path separator handling, module_key depth logic |
-| **tokmd-types** | 28 | Schema version constant pinning (all 5 constants), TokenEstimationMeta ceil-vs-floor arithmetic, TokenAudit saturating_sub, default trait impls, serde roundtrips |
-
-### Mutation Patterns Targeted
-
-- **Boundary conditions**: Exact values where `>` vs `>=` (or `<` vs `<=`) produce different results
-- **Arithmetic mutations**: `+` to `-`, `*` to `/`, `ceil` to `floor`
-- **Boolean logic**: `&&` to `||`, `!` removal, `true`/`false` flips
-- **Guard removal**: `if x == 0 { return 0 }` deletion
-- **Constant mutations**: Schema version ±1 changes
-- **Method removal**: `replace()`, `strip_prefix()`, `saturating_sub()` deletions
-
-### Testing
-
-All 116 tests pass. No existing tests affected. Clippy clean.
+## Verification Receipts
+```
+$ cargo test -p tokmd-core --doc
+running 6 tests
+test crates/tokmd-core/src/../README.md - readme_doctests (line 19) - compile ... ok
+...
+test result: ok. 4 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.12s
+```


### PR DESCRIPTION
# PR Glass Cockpit

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Maintenance
- [x] Documentation / Examples

## Description
Updated the `tokmd-core` README example to properly compile under the latest API which favors `lang_workflow` and `ScanSettings`/`LangSettings` over the old clap-based arg structs.

## Verification Receipts
```
$ cargo test -p tokmd-core --doc
running 6 tests
test crates/tokmd-core/src/../README.md - readme_doctests (line 19) - compile ... ok
...
test result: ok. 4 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.12s
```

---
*PR created automatically by Jules for task [5419710818793980664](https://jules.google.com/task/5419710818793980664) started by @EffortlessSteven*