### PR TITLE
deps: remove unused serde dependency 🧾 Auditor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,7 +3334,6 @@ dependencies = [
  "insta",
  "midly",
  "proptest",
- "serde",
  "serde_json",
  "tokmd-analysis",
  "tokmd-analysis-html",

--- a/crates/tokmd-analysis-format/Cargo.toml
+++ b/crates/tokmd-analysis-format/Cargo.toml
@@ -18,7 +18,6 @@ fun = ["dep:tokmd-fun"]
 
 [dependencies]
 anyhow = "1.0.101"
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokmd-analysis-html.workspace = true
 tokmd-analysis-types.workspace = true


### PR DESCRIPTION
## Summary

Removed unused dependency `serde` from `tokmd-analysis-format` to improve dependency hygiene and reduce compile surface.

### Receipts

- Identified as unused by `cargo machete`:
  ```text
  cargo-machete found the following unused dependencies in this directory:
  ...
  tokmd-analysis-format -- ./crates/tokmd-analysis-format/Cargo.toml:
      serde
  ```
- Checked and tested: `cargo check -p tokmd-analysis-format` and `cargo test -p tokmd-analysis-format` both pass.
- Workspace tests and clippy passed: `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo test --workspace --exclude tokmd-python --exclude tokmd-node` complete without introducing regressions.
- Envelopes, runs, and ledger successfully updated inside `.jules/deps`.

---
*PR created automatically by Jules for task [9035352700529864497](https://jules.google.com/task/9035352700529864497) started by @EffortlessSteven*