### PR TITLE
docs: make README example compile under latest API 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/7eaab69b-8746-4670-8fce-29cfe85f7f45.json
+++ b/.jules/docs/envelopes/7eaab69b-8746-4670-8fce-29cfe85f7f45.json
@@ -1,0 +1,13 @@
+{
+  "id": "7eaab69b-8746-4670-8fce-29cfe85f7f45",
+  "commands": [
+    {
+      "command": "cargo test --workspace --doc",
+      "status": "success"
+    },
+    {
+      "command": "cargo test --workspace --exclude tokmd-python --exclude tokmd-node",
+      "status": "success"
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -1,0 +1,1 @@
+[{"id": "7eaab69b-8746-4670-8fce-29cfe85f7f45", "date": "2026-03-09", "type": "docs_update", "description": "Updated crates/tokmd-core/README.md to use the new lang_workflow API"}]

--- a/.jules/docs/runs/2026-03-09.md
+++ b/.jules/docs/runs/2026-03-09.md
@@ -1,0 +1,7 @@
+# Run: 7eaab69b-8746-4670-8fce-29cfe85f7f45
+Date: 2026-03-09
+Type: docs_update
+Description: Updated crates/tokmd-core/README.md to use the new lang_workflow API instead of the deprecated scan_workflow API.
+Changes:
+- Modified crates/tokmd-core/README.md to use lang_workflow, ScanSettings, and LangSettings.
+- Verified with cargo test --workspace --doc and standard workspace tests.

--- a/crates/tokmd-core/README.md
+++ b/crates/tokmd-core/README.md
@@ -18,27 +18,27 @@ tokmd-types = "1.4"
 
 ```rust,no_run
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-use tokmd_core::scan_workflow;
-use tokmd_core::config::GlobalArgs;
-use tokmd_core::types::{ChildrenMode, LangArgs, RedactMode, TableFormat};
-use std::path::PathBuf;
+use tokmd_core::lang_workflow;
+use tokmd_core::settings::{ScanSettings, LangSettings};
+use tokmd_core::types::{ChildrenMode, RedactMode};
 
 // Configure scan
-let global = GlobalArgs::default();
-let lang = LangArgs {
-    paths: vec![PathBuf::from(".")],
-    format: TableFormat::Json,
+let scan = ScanSettings::current_dir();
+let lang = LangSettings {
     top: 10,
     files: false,
     children: ChildrenMode::Collapse,
+    ..Default::default()
 };
 
 // Run pipeline (without redaction)
-let receipt = scan_workflow(&global, &lang, None)?;
+let receipt = lang_workflow(&scan, &lang)?;
 println!("Scanned {} languages", receipt.report.rows.len());
 
 // Run pipeline (with path redaction)
-let redacted = scan_workflow(&global, &lang, Some(RedactMode::Paths))?;
+let mut redacted_lang = lang.clone();
+redacted_lang.redact = Some(RedactMode::Paths);
+let redacted = lang_workflow(&scan, &redacted_lang)?;
 # Ok(())
 # }
 ```
@@ -46,10 +46,9 @@ let redacted = scan_workflow(&global, &lang, Some(RedactMode::Paths))?;
 ## Main Function
 
 ```rust,ignore
-pub fn scan_workflow(
-    global: &GlobalArgs,
-    lang: &LangArgs,
-    redact: Option<RedactMode>,
+pub fn lang_workflow(
+    scan: &ScanSettings,
+    lang: &LangSettings,
 ) -> Result<LangReceipt>
 ```
 


### PR DESCRIPTION
This PR addresses API drift in the `crates/tokmd-core/README.md` file.

The `tokmd-core` API has been modernized to use `lang_workflow` alongside `ScanSettings` and `LangSettings` structures. The previous code example in the README was utilizing the deprecated `scan_workflow` function, along with older structs like `GlobalArgs` and `LangArgs` from `tokmd-config`, which resulted in inaccurate usage documentation.

I have updated the README's code snippets to correctly reflect the current API structure, including correctly instantiating `ScanSettings::current_dir()` and utilizing `lang_workflow`. The updated snippets were tested with `cargo test --workspace --doc` to ensure they compile and type-check without errors under the latest API.

**Run Details:**
* Persona: Librarian 📚
* Target: crates/tokmd-core/README.md (Docs drift fix)
* Receipts: Logged in `.jules/docs/envelopes/7eaab69b-8746-4670-8fce-29cfe85f7f45.json` and `.jules/docs/ledger.json`

**Checklist:**
- [x] Verified code snippets via `cargo test --workspace --doc`
- [x] Confirmed SRP constraints (single coherent documentation update)
- [x] Added `git add -f` for `.jules/` artifact staging
- [x] Logged run envelope and updated append-only ledger

---
*PR created automatically by Jules for task [15037647543725448281](https://jules.google.com/task/15037647543725448281) started by @EffortlessSteven*