### PR TITLE
deps: remove unused anyhow dependency from tokmd-model 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/ff8eec83-e154-48f8-b601-5a9fad17bea0.json
+++ b/.jules/deps/envelopes/ff8eec83-e154-48f8-b601-5a9fad17bea0.json
@@ -1,0 +1,15 @@
+{
+  "run_id": "ff8eec83-e154-48f8-b601-5a9fad17bea0",
+  "persona": "Auditor",
+  "lane": "B",
+  "target": "crates/tokmd-model/Cargo.toml",
+  "action": "remove_unused_dependency",
+  "dependency": "anyhow",
+  "status": "success",
+  "receipts": [
+    "cargo machete --with-metadata",
+    "cargo test -p tokmd-model",
+    "cargo check --workspace"
+  ],
+  "timestamp": "2024-03-09T12:00:00Z"
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -10,5 +10,15 @@
       "cargo machete output identifying unused tokmd-analysis-types in tokmd-gate",
       "cargo test -p tokmd-gate completed successfully after removal"
     ]
+  },
+  {
+    "run_id": "ff8eec83-e154-48f8-b601-5a9fad17bea0",
+    "date": "2024-03-09",
+    "action": "Removed unused anyhow dependency from tokmd-model",
+    "receipts": [
+      "cargo machete --with-metadata",
+      "cargo test -p tokmd-model",
+      "cargo check --workspace"
+    ]
   }
 ]

--- a/.jules/deps/runs/2024-03-09.md
+++ b/.jules/deps/runs/2024-03-09.md
@@ -1,0 +1,19 @@
+# Run ff8eec83-e154-48f8-b601-5a9fad17bea0
+
+**Date:** 2024-03-09
+**Persona:** Auditor
+**Lane:** B (Scout discovery)
+
+## Findings
+Identified unused dependency `anyhow` in `crates/tokmd-model/Cargo.toml` using `cargo machete --with-metadata`.
+
+## Actions Taken
+- Removed `anyhow = "1.0.101"` from `crates/tokmd-model/Cargo.toml`.
+- Ran `cargo test -p tokmd-model` and `cargo check --workspace` to ensure no regressions were introduced. Both passed successfully.
+- Created run envelope `.jules/deps/envelopes/ff8eec83-e154-48f8-b601-5a9fad17bea0.json`.
+- Appended execution receipt to `.jules/deps/ledger.json`.
+
+## Receipts
+- `cargo machete --with-metadata`
+- `cargo test -p tokmd-model`
+- `cargo check --workspace`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,6 @@ dependencies = [
 name = "tokmd-model"
 version = "1.7.3"
 dependencies = [
- "anyhow",
  "insta",
  "proptest",
  "serde",

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-model"
 
 [dependencies]
-anyhow = "1.0.101"
+
 serde = { version = "1.0.228", features = ["derive"] }
 tokei = { version = "14.0.0", default-features = false }
 tokmd-module-key.workspace = true


### PR DESCRIPTION
## Objective
Maximize SRP-quality improvement by removing the unused `anyhow` dependency from the `tokmd-model` crate.

## Implementation Option Chosen
- Option A: Removing unused `anyhow` dependency identified by `cargo machete` as it represents a safe reduction in dependency surface.

## Rationale
Removing unused dependencies directly improves dependency hygiene, speeds up CI builds by avoiding unnecessary fetches/compilations, and adheres to the SRP by focusing on one concrete improvement.

## Receipts
- `cargo machete --with-metadata` confirmed `anyhow` was unused in `crates/tokmd-model`.
- `cargo test -p tokmd-model` passed with 0 test failures.
- `cargo check --workspace` passed successfully.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ran without throwing errors directly attributable to this change.

---
*PR created automatically by Jules for task [3767278621170806540](https://jules.google.com/task/3767278621170806540) started by @EffortlessSteven*