### PR TITLE
compat: fix no-default-features build for tokmd-python 🧷 Compat

### DIFF
--- a/crates/tokmd-python/Cargo.toml
+++ b/crates/tokmd-python/Cargo.toml
@@ -17,12 +17,16 @@ name = "tokmd"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.24", features = ["abi3-py39"] }
 serde_json = "1.0.149"
 tokmd-core = { workspace = true, features = ["analysis", "cockpit"] }
 tokmd-ffi-envelope.workspace = true
 tokmd-types.workspace = true
 tokmd-analysis-types.workspace = true
+
+[features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
 
 [build-dependencies]
 pyo3-build-config = "0.24"


### PR DESCRIPTION
## Rationale

When running `cargo test --no-default-features -p tokmd-python`, the build fails due to missing linker symbols like `PyList_New` and `PyExc_Exception`. This is a documented behavior when using PyO3's `extension-module` feature for `cdylib` Python bindings, as it drops the link logic to `libpython`, expecting the interpreter to provide these symbols at load time.

However, standard Cargo test binaries *do* need to link to Python.

## The Fix

To ensure `tokmd-python` complies with workspace `--no-default-features` matrix tests, this PR extracts the PyO3 `extension-module` dependency feature into an optional Cargo feature `extension-module`. It is enabled in the `default` feature set to ensure standard `cargo build` and `maturin develop` still emit functional cdylibs, while allowing test suites to omit it cleanly.

## Artifacts & State Changes
Run Envelope: `06554180-2e65-4682-b212-b670b466729d`
Run Ledger Appended: `.jules/compat/ledger.json`
Run Doc Added: `.jules/compat/runs/2025-03-10.md`

## Receipts

### Build and Test without default features:

```bash
$ cargo build --no-default-features --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.20s

$ cargo test --no-default-features -p tokmd-python
running 26 tests
...
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.45s
```

---
*PR created automatically by Jules for task [14840446127717678775](https://jules.google.com/task/14840446127717678775) started by @EffortlessSteven*