### PR TITLE
deps: remove unused tokmd-git dependency 🧾 Auditor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokmd-envelope",
- "tokmd-git",
  "tokmd-model",
  "tokmd-scan",
  "tokmd-settings",

--- a/crates/tokmd-sensor/Cargo.toml
+++ b/crates/tokmd-sensor/Cargo.toml
@@ -13,7 +13,6 @@ documentation = "https://docs.rs/tokmd-sensor"
 
 [features]
 default = []
-git = ["dep:tokmd-git"]
 
 [dependencies]
 anyhow = "1.0.101"
@@ -24,7 +23,6 @@ tokmd-settings.workspace = true
 tokmd-scan.workspace = true
 tokmd-model.workspace = true
 tokmd-types.workspace = true
-tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = "1.10.0"


### PR DESCRIPTION
# PR GLASS COCKPIT

## Problem
`tokmd-sensor` includes an unused optional dependency `tokmd-git`, which adds unnecessary compile surface and dependency footprint to the crate.

## Solution
Removed `tokmd-git` dependency and the `git` feature from `crates/tokmd-sensor/Cargo.toml`.

## Context & Constraints
* Persona: `Auditor`
* Tracked via append-only `.jules/deps/ledger.json` and a specific run envelope.

## Verification
- `cargo machete` confirmed it is unused.
- `cargo xtask gate` passed cleanly locally.

## Receipts
- Successfully ran `cargo check -p tokmd-sensor` and `cargo test -p tokmd-sensor`
- Successfully evaluated CI pre-commit checks locally via `cargo xtask gate`

---
*PR created automatically by Jules for task [5190550026601504059](https://jules.google.com/task/5190550026601504059) started by @EffortlessSteven*