### PR TITLE
deps: remove unused anyhow dependency from tokmd-model 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/run-deps-tokmd-model.json
+++ b/.jules/deps/envelopes/run-deps-tokmd-model.json
@@ -1,0 +1,10 @@
+{
+  "id": "run-deps-tokmd-model",
+  "status": "completed",
+  "target": "tokmd-model",
+  "action": "remove unused dependency anyhow",
+  "receipts": [
+    "cargo machete output identifying unused anyhow in tokmd-model",
+    "cargo test -p tokmd-model completed successfully after removal"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -10,5 +10,17 @@
       "cargo machete output identifying unused tokmd-analysis-types in tokmd-gate",
       "cargo test -p tokmd-gate completed successfully after removal"
     ]
+  },
+  {
+    "id": "run-deps-tokmd-model",
+    "date": "2026-03-12T11:55:41Z",
+    "persona": "Auditor",
+    "lane": "scout",
+    "target": "tokmd-model",
+    "action": "remove unused dependency anyhow",
+    "receipts": [
+      "cargo machete output identifying unused anyhow in tokmd-model",
+      "cargo test -p tokmd-model completed successfully after removal"
+    ]
   }
 ]

--- a/.jules/deps/runs/2026-03-12.md
+++ b/.jules/deps/runs/2026-03-12.md
@@ -1,0 +1,7 @@
+# Dependency Hygiene Run 2026-03-12
+
+- **Persona**: Auditor
+- **Target**: `tokmd-model` crate
+- **Action**: Removed unused `anyhow` dependency
+- **Rationale**: The dependency was listed in `Cargo.toml` but not used anywhere in the source code or tests, reducing compile surface and dependency closure slightly.
+- **Verification**: `cargo test -p tokmd-model` passed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,6 @@ dependencies = [
 name = "tokmd-model"
 version = "1.7.3"
 dependencies = [
- "anyhow",
  "insta",
  "proptest",
  "serde",

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-model"
 
 [dependencies]
-anyhow = "1.0.101"
 serde = { version = "1.0.228", features = ["derive"] }
 tokei = { version = "14.0.0", default-features = false }
 tokmd-module-key.workspace = true


### PR DESCRIPTION
Removed unused `anyhow` dependency from the `tokmd-model` crate as discovered by `cargo machete` scout lane analysis. 
This reduces the dependency closure and compile surface for the core module.
Updated `.jules` ledger, envelope, and run receipts as per Auditor persona instructions.

---
*PR created automatically by Jules for task [12045845470615867916](https://jules.google.com/task/12045845470615867916) started by @EffortlessSteven*