### PR TITLE
test: lock deterministic ordering for blocks 🧪 Gatekeeper

### DIFF
--- a/crates/tokmd/tests/sensor_integration.rs
+++ b/crates/tokmd/tests/sensor_integration.rs
@@ -90,7 +90,7 @@ fn sensor_json_outputs_artifacts_and_data() {
         .get("artifacts")
         .and_then(|v| v.as_array())
         .expect("artifacts array");
-    let ids: std::collections::HashSet<_> = artifacts
+    let ids: std::collections::BTreeSet<_> = artifacts
         .iter()
         .filter_map(|a| a.get("id").and_then(|id| id.as_str()))
         .collect();


### PR DESCRIPTION
Replaces `HashSet` with `BTreeSet` in `crates/tokmd/tests/sensor_integration.rs` to fix determinism issues during test artifact validations.

The Gatekeeper task successfully:
- Selected `crates/tokmd/tests/sensor_integration.rs` as a scout-discovered Lane B improvement for determinism and flake reduction.
- Applied the stable sorting constraint.
- Validated via `cargo test -p tokmd --test sensor_integration`.
- Tracked run outcomes via receipts in the append-only `.jules/quality` tracker.

## Run context
**Persona**: Gatekeeper
**Lane**: Lane B (scout discovery)

---
*PR created automatically by Jules for task [15318921725158746059](https://jules.google.com/task/15318921725158746059) started by @EffortlessSteven*