### PR TITLE
docs: add README.md doctest coverage for tokmd-types 📚 Librarian

### DIFF
--- a/crates/tokmd-types/src/lib.rs
+++ b/crates/tokmd-types/src/lib.rs
@@ -1409,3 +1409,7 @@ mod tests {
         assert_eq!(back, r);
     }
 }
+
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub mod readme_doctests {}


### PR DESCRIPTION
Follows the "Librarian" scheduled scout task to add README.md doctest coverage to one crate (`tokmd-types`) to prevent example code drift, along with recording the scheduled task metrics into `.jules/docs/` logs, envelopes, and ledgers in adherence to project policies.

## Receipts

```
running 13 tests
test crates/tokmd-types/src/lib.rs - CONTEXT_SCHEMA_VERSION (line 649) ... ok
test crates/tokmd-types/src/../README.md - readme_doctests (line 40) ... ok
test crates/tokmd-types/src/lib.rs - CONTEXT_BUNDLE_SCHEMA_VERSION (line 642) ... ok
test crates/tokmd-types/src/lib.rs - DiffRow (line 446) ... ok
test crates/tokmd-types/src/lib.rs - DiffTotals (line 483) ... ok
test crates/tokmd-types/src/lib.rs - FileRow (line 163) ... ok
test crates/tokmd-types/src/lib.rs - LangRow (line 77) ... ok
test crates/tokmd-types/src/lib.rs - HANDOFF_SCHEMA_VERSION (line 635) ... ok
test crates/tokmd-types/src/lib.rs - SCHEMA_VERSION (line 41) ... ok
test crates/tokmd-types/src/lib.rs - TokenAudit::from_output (line 747) ... ok
test crates/tokmd-types/src/lib.rs - ModuleRow (line 116) ... ok
test crates/tokmd-types/src/lib.rs - TokenEstimationMeta::from_bytes (line 695) ... ok
test crates/tokmd-types/src/lib.rs - Totals (line 50) ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

---
*PR created automatically by Jules for task [2603536465770277045](https://jules.google.com/task/2603536465770277045) started by @EffortlessSteven*