### PR TITLE
fix: eliminate panicking unwraps in determinism tests 🛡️ Sentinel

### DIFF
--- a/.jules/policy/scheduled_tasks.json
+++ b/.jules/policy/scheduled_tasks.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "selection_strategy": "random",
+  "default_gates": ["build", "test", "fmt", "clippy"],
+  "prefer_full_suite_when_touching": ["src/", "tests/", "crates/", ".github/workflows/"],
+  "notes_write_threshold": "only_when_reusable_pattern_discovered"
+}

--- a/.jules/runbooks/FRICTION_ITEM.md
+++ b/.jules/runbooks/FRICTION_ITEM.md
@@ -1,0 +1,13 @@
+# Friction Item
+
+## Pain
+Describe the friction/pain point.
+
+## Evidence
+Commands, logs, or file paths demonstrating it.
+
+## Done When
+Conditions for resolving this item.
+
+## Tags
+Comma-separated tags.

--- a/.jules/runbooks/PR_GLASS_COCKPIT.md
+++ b/.jules/runbooks/PR_GLASS_COCKPIT.md
@@ -1,0 +1,53 @@
+---
+# PR Glass Cockpit
+
+Make review boring. Make truth cheap.
+
+## 💡 Summary
+1–4 sentences. What changed.
+
+## 🎯 Why / Threat model
+High level impact. No exploit steps.
+
+## 🔎 Finding (evidence)
+Minimal proof:
+- file path(s)
+- observed behavior
+- test/command demonstrating it
+
+## 🧭 Options considered
+### Option A (recommended)
+- What it is
+- Why it fits this repo
+- Trade-offs: Structure / Velocity / Governance
+
+### Option B
+- What it is
+- When to choose it instead
+- Trade-offs
+
+## ✅ Decision
+State the decision and why.
+
+## 🧱 Changes made (SRP)
+Bullets with file paths.
+
+## 🧪 Verification receipts
+Copy from the run envelope. Commands + results.
+
+## 🧭 Telemetry
+- Change shape
+- Blast radius (API / IO / config / schema / concurrency)
+- Risk class + why
+- Rollback
+- Merge-confidence gates (what ran)
+
+## 🗂️ .jules updates
+What changed in .jules and why.
+
+## 📝 Notes (freeform)
+Optional. Extra context for future runs or reviewers.
+
+## 🔜 Follow-ups
+If anything remains, create friction items and link them.
+---

--- a/.jules/security/envelopes/9ec8ee5d-c6c4-44b7-9d6d-1fbdea23ac90.json
+++ b/.jules/security/envelopes/9ec8ee5d-c6c4-44b7-9d6d-1fbdea23ac90.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "9ec8ee5d-c6c4-44b7-9d6d-1fbdea23ac90",
+  "timestamp_utc": "2026-03-13T12:29:16Z",
+  "lane": "scout",
+  "target": "tokmd-cockpit determinism tests",
+  "commands": [
+    {
+      "cmd": "cargo fmt -p tokmd-cockpit",
+      "exit_status": 0,
+      "result": "PASS"
+    },
+    {
+      "cmd": "cargo check -p tokmd-cockpit",
+      "exit_status": 0,
+      "result": "PASS"
+    },
+    {
+      "cmd": "cargo test -p tokmd-cockpit --all-features",
+      "exit_status": 0,
+      "result": "PASS"
+    },
+    {
+      "cmd": "cargo build --verbose",
+      "exit_status": 0,
+      "result": "PASS"
+    },
+    {
+      "cmd": "cargo clippy -p tokmd-cockpit -- -D warnings",
+      "exit_status": 0,
+      "result": "PASS"
+    }
+  ],
+  "results": []
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -1,0 +1,17 @@
+[
+  {
+    "date": "2026-03-13",
+    "run_id": "9ec8ee5d-c6c4-44b7-9d6d-1fbdea23ac90",
+    "lane": "scout",
+    "target": "tokmd-cockpit determinism tests",
+    "pr_link": "pending",
+    "gates_run": [
+      "build",
+      "test",
+      "fmt",
+      "clippy"
+    ],
+    "status": "success",
+    "friction_ids_created": []
+  }
+]

--- a/.jules/security/runs/2026-03-13.md
+++ b/.jules/security/runs/2026-03-13.md
@@ -1,0 +1,20 @@
+# Security Run $(cat /tmp/run_date.txt)
+**Run ID:** $(cat /tmp/run_id.txt)
+**Lane:** Scout (Lane B)
+**Target:** tokmd-cockpit determinism tests
+
+## Findings
+- Found heavy use of `unwrap()` in `crates/tokmd-cockpit/src/determinism.rs` tests.
+- We will refactor these tests to return `Result<(), Box<dyn std::error::Error>>` and use the `?` operator.
+
+## Options considered
+### Option A (recommended)
+- Change test signatures to return `Result<(), Box<dyn std::error::Error>>` and replace `unwrap()` with `?`.
+- Trade-offs: Increases code quality and removes panics, standardizing test structure in line with the Sentinel rules.
+
+### Option B
+- Ignore tests and only focus on production code panics.
+- Trade-offs: Goes against the mandate to treat panics as candidates *everywhere* (including tests).
+
+## Decision
+Choosing Option A to maximize SRP repo-quality improvement by strictly adhering to the "no panics in tests" rule.

--- a/crates/tokmd-cockpit/src/determinism.rs
+++ b/crates/tokmd-cockpit/src/determinism.rs
@@ -150,135 +150,143 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn test_hash_files_deterministic() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_hash_files_deterministic() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
 
         let paths = vec!["a.rs", "b.rs"];
-        let h1 = hash_files_from_paths(dir.path(), &paths).unwrap();
-        let h2 = hash_files_from_paths(dir.path(), &paths).unwrap();
+        let h1 = hash_files_from_paths(dir.path(), &paths)?;
+        let h2 = hash_files_from_paths(dir.path(), &paths)?;
 
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // BLAKE3 hex digest
+        Ok(())
     }
 
     #[test]
-    fn test_hash_files_order_independent() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_hash_files_order_independent() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
 
-        let h1 = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"]).unwrap();
-        let h2 = hash_files_from_paths(dir.path(), &["b.rs", "a.rs"]).unwrap();
+        let h1 = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"])?;
+        let h2 = hash_files_from_paths(dir.path(), &["b.rs", "a.rs"])?;
 
         assert_eq!(h1, h2, "hash should be order-independent");
+        Ok(())
     }
 
     #[test]
-    fn test_hash_files_changes_on_modification() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
+    fn test_hash_files_changes_on_modification() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
 
-        let h1 = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let h1 = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
-        fs::write(dir.path().join("a.rs"), "fn main() { panic!(); }").unwrap();
+        fs::write(dir.path().join("a.rs"), "fn main() { panic!(); }")?;
 
-        let h2 = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let h2 = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
         assert_ne!(h1, h2, "hash should change when file content changes");
+        Ok(())
     }
 
     #[test]
-    fn test_hash_cargo_lock_present() {
-        let dir = tempfile::tempdir().unwrap();
+    fn test_hash_cargo_lock_present() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
         fs::write(
             dir.path().join("Cargo.lock"),
             "[[package]]\nname = \"test\"",
-        )
-        .unwrap();
+        )?;
 
-        let result = hash_cargo_lock(dir.path()).unwrap();
+        let result = hash_cargo_lock(dir.path())?;
         assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), 64);
+        assert_eq!(result.ok_or("missing lock hash")?.len(), 64);
+        Ok(())
     }
 
     #[test]
-    fn test_hash_cargo_lock_absent() {
-        let dir = tempfile::tempdir().unwrap();
+    fn test_hash_cargo_lock_absent() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
 
-        let result = hash_cargo_lock(dir.path()).unwrap();
+        let result = hash_cargo_lock(dir.path())?;
         assert!(result.is_none());
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_hash_files_from_walk_deterministic() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_hash_files_from_walk_deterministic() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
 
-        let h1 = hash_files_from_walk(dir.path(), &[]).unwrap();
-        let h2 = hash_files_from_walk(dir.path(), &[]).unwrap();
+        let h1 = hash_files_from_walk(dir.path(), &[])?;
+        let h2 = hash_files_from_walk(dir.path(), &[])?;
 
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64);
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_walk_and_paths_produce_same_hash() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_walk_and_paths_produce_same_hash() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
         // Create .git marker so ignore crate works properly
-        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::create_dir_all(dir.path().join(".git"))?;
 
-        let from_paths = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"]).unwrap();
-        let from_walk = hash_files_from_walk(dir.path(), &[]).unwrap();
+        let from_paths = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"])?;
+        let from_walk = hash_files_from_walk(dir.path(), &[])?;
 
         assert_eq!(
             from_paths, from_walk,
             "walk and explicit paths should produce same hash for same files"
         );
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_walk_excludes_specified_paths() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_walk_excludes_specified_paths() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
         // Create .git marker so ignore crate works properly
-        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::create_dir_all(dir.path().join(".git"))?;
 
         // Walk excluding b.rs should match paths-only hash of just a.rs
-        let walk_excluded = hash_files_from_walk(dir.path(), &["b.rs"]).unwrap();
-        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let walk_excluded = hash_files_from_walk(dir.path(), &["b.rs"])?;
+        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
         assert_eq!(
             walk_excluded, paths_only,
             "excluding b.rs from walk should match paths-only a.rs"
         );
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_walk_excludes_tokmd_directory() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
+    fn test_walk_excludes_tokmd_directory() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
         // Create .git marker so ignore crate works properly
-        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::create_dir_all(dir.path().join(".git"))?;
         // Create .tokmd directory with a baseline file -- should be auto-excluded
-        fs::create_dir_all(dir.path().join(".tokmd")).unwrap();
-        fs::write(dir.path().join(".tokmd/baseline.json"), "{}").unwrap();
+        fs::create_dir_all(dir.path().join(".tokmd"))?;
+        fs::write(dir.path().join(".tokmd/baseline.json"), "{}")?;
 
-        let with_tokmd = hash_files_from_walk(dir.path(), &[]).unwrap();
-        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let with_tokmd = hash_files_from_walk(dir.path(), &[])?;
+        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
         assert_eq!(
             with_tokmd, paths_only,
             ".tokmd/ directory should be auto-excluded from walk hash"
         );
+        Ok(())
     }
 }


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Refactored the tests in `crates/tokmd-cockpit/src/determinism.rs` to return `Result<(), Box<dyn std::error::Error>>` instead of using panicking `.unwrap()` calls. 

## 🎯 Why / Threat model
Panics should be treated as candidates for removal everywhere across the repository, including tests. Burning down unwraps guarantees clean teardown and prevents the runner from panicking instead of gracefully capturing error context.

## 🔎 Finding (evidence)
Minimal proof:
- file path(s): `crates/tokmd-cockpit/src/determinism.rs`
- observed behavior: Heavy reliance on `.unwrap()` in test logic.
- test/command demonstrating it: `rg -n "\bunwrap\(" crates/tokmd-cockpit/src/determinism.rs`

## 🧭 Options considered
### Option A (recommended)
- What it is: Replace panicking test assertions with `Result` returning signatures and use the `?` propagation operator.
- Why it fits this repo: Strongly adheres to the repo's full quality stance that requires treating unwrap/expect/panic as candidates everywhere.
- Trade-offs: Minor syntactic change to append `Ok(())` at the end of each test block. Velocity impact is minimal.

### Option B
- What it is: Ignore the issue and assume tests are allowed to panic.
- When to choose it instead: Never, as it goes against the explicit Sentinel persona instruction to "treat unwrap/expect/panic as candidates everywhere (including tests)."
- Trade-offs: Increases long-term maintenance cost.

## ✅ Decision
Option A was chosen to meet the high quality standards for tests and ensure they exit gracefully.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd-cockpit/src/determinism.rs`
  - Changed `test_hash_files_deterministic`
  - Changed `test_hash_files_order_independent`
  - Changed `test_hash_files_changes_on_modification`
  - Changed `test_hash_cargo_lock_present`
  - Changed `test_hash_cargo_lock_absent`
  - Changed `test_hash_files_from_walk_deterministic`
  - Changed `test_walk_and_paths_produce_same_hash`
  - Changed `test_walk_excludes_specified_paths`
  - Changed `test_walk_excludes_tokmd_directory`

## 🧪 Verification receipts
Commands run from `.jules/security/envelopes/...`:
- `cargo fmt -p tokmd-cockpit` -> PASS (0)
- `cargo check -p tokmd-cockpit` -> PASS (0)
- `cargo test -p tokmd-cockpit --all-features` -> PASS (0)
- `cargo build --verbose` -> PASS (0)
- `cargo clippy -p tokmd-cockpit -- -D warnings` -> PASS (0)

## 🧭 Telemetry
- Change shape: Hardening
- Blast radius (API / IO / config / schema / concurrency): Test only, no API changes.
- Risk class + why: Low, affects only local testing surfaces.
- Rollback: Revert the PR.
- Merge-confidence gates (what ran): fmt, clippy, check, test, build

## 🗂️ .jules updates
- Initialized `.jules/policy/scheduled_tasks.json` with default rules.
- Set up PR and Friction runbook templates in `.jules/runbooks/`.
- Populated a daily security log in `.jules/security/runs/`.
- Wrote receipt data to `.jules/security/envelopes/`.
- Appended run entry to `.jules/security/ledger.json`.

## 📝 Notes (freeform)
Scouting run revealed other subsystems using unwraps, which will be targeted in future Lane B runs.

## 🔜 Follow-ups
None for this specific file.
---

---
*PR created automatically by Jules for task [5063618699183381757](https://jules.google.com/task/5063618699183381757) started by @EffortlessSteven*