### PR TITLE
fix(ci): gate tokmd-core test helpers behind analysis feature

### DIFF
--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -699,14 +699,20 @@ pub fn version() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "analysis")]
     use crate::settings::AnalyzeSettings;
+    #[cfg(feature = "analysis")]
     use std::fs;
+    #[cfg(feature = "analysis")]
     use std::path::{Path, PathBuf};
+    #[cfg(feature = "analysis")]
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    #[cfg(feature = "analysis")]
     #[derive(Debug)]
     struct TempDirGuard(PathBuf);
 
+    #[cfg(feature = "analysis")]
     impl Drop for TempDirGuard {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.0);
@@ -788,6 +794,7 @@ mod tests {
         assert!(err.to_string().contains("only 'cocomo81-basic'"));
     }
 
+    #[cfg(feature = "analysis")]
     fn mk_temp_dir(prefix: &str) -> PathBuf {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -798,6 +805,7 @@ mod tests {
         root
     }
 
+    #[cfg(feature = "analysis")]
     fn write_file(path: &Path, contents: &str) {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).unwrap();


### PR DESCRIPTION
## Summary
- Gates `TempDirGuard`, `mk_temp_dir`, `write_file`, and related imports in `tokmd-core` tests behind `#[cfg(feature = "analysis")]`
- These helpers are only used by analysis-feature tests and cause dead-code warnings without the feature enabled

## Test plan
- [x] `cargo test -p tokmd-core --verbose` passes
- [x] Cherry-picked from `release/v1.8.0` (`19e1cb27`)