### PR TITLE
deps: remove unused proptest and serde from tokmd-analysis-effort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,8 +3284,6 @@ name = "tokmd-analysis-effort"
 version = "1.8.0-rc.1"
 dependencies = [
  "anyhow",
- "proptest",
- "serde",
  "tempfile",
  "tokmd-analysis-types",
  "tokmd-analysis-util",

--- a/crates/tokmd-analysis-effort/Cargo.toml
+++ b/crates/tokmd-analysis-effort/Cargo.toml
@@ -17,12 +17,10 @@ git = ["dep:tokmd-git"]
 
 [dependencies]
 anyhow = "1.0.101"
-serde = { version = "1.0.228", features = ["derive"] }
 tokmd-analysis-types.workspace = true
 tokmd-types.workspace = true
 tokmd-analysis-util.workspace = true
 tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
-proptest = "1.10.0"
 tempfile = "3.25.0"


### PR DESCRIPTION
Narrow follow-up for #681: dependency cleanup limited to tokmd-analysis-effort.