### PR TITLE
docs: make tokmd-core README example compile under latest API

### DIFF
--- a/crates/tokmd-core/README.md
+++ b/crates/tokmd-core/README.md
@@ -18,27 +18,20 @@ tokmd-types = "1.4"
 
 ```rust,no_run
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-use tokmd_core::scan_workflow;
-use tokmd_core::config::GlobalArgs;
-use tokmd_core::types::{ChildrenMode, LangArgs, RedactMode, TableFormat};
-use std::path::PathBuf;
+use tokmd_core::lang_workflow;
+use tokmd_core::settings::{ScanSettings, LangSettings};
 
 // Configure scan
-let global = GlobalArgs::default();
-let lang = LangArgs {
-    paths: vec![PathBuf::from(".")],
-    format: TableFormat::Json,
+let scan = ScanSettings::current_dir();
+let lang = LangSettings {
     top: 10,
-    files: false,
-    children: ChildrenMode::Collapse,
+    files: true,
+    ..Default::default()
 };
 
-// Run pipeline (without redaction)
-let receipt = scan_workflow(&global, &lang, None)?;
-println!("Scanned {} languages", receipt.report.rows.len());
-
-// Run pipeline (with path redaction)
-let redacted = scan_workflow(&global, &lang, Some(RedactMode::Paths))?;
+// Run pipeline
+let receipt = lang_workflow(&scan, &lang)?;
+assert!(receipt.report.rows.len() > 0);
 # Ok(())
 # }
 ```
@@ -46,10 +39,9 @@ let redacted = scan_workflow(&global, &lang, Some(RedactMode::Paths))?;
 ## Main Function
 
 ```rust,ignore
-pub fn scan_workflow(
-    global: &GlobalArgs,
-    lang: &LangArgs,
-    redact: Option<RedactMode>,
+pub fn lang_workflow(
+    scan: &ScanSettings,
+    lang: &LangSettings,
 ) -> Result<LangReceipt>
 ```
 


### PR DESCRIPTION
Narrow follow-up for #681: docs update only. Replaces broader docs drift PR with minimal scope.