### PR TITLE
ci: move macos nix out of main workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,33 +172,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v21
 
       - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
+        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Check flake
         run: nix flake check --no-build --accept-flake-config
-
-      - name: Build package
-        run: nix build
-
-  nix-macos:
-    name: Nix Build (macOS)
-    if: github.event_name == 'push'
-    runs-on: macos-latest
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - name: Check flake
-        run: nix flake check
 
       - name: Build package
         run: nix build

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -1,0 +1,29 @@
+name: Nix Build (macOS)
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  nix-macos:
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+
+      - name: Setup Nix cache
+        continue-on-error: true
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      - name: Check flake
+        run: nix flake check --accept-flake-config
+
+      - name: Build package
+        run: nix build


### PR DESCRIPTION
## Summary
- keep Linux Nix in the main CI workflow
- move macOS Nix into its own workflow for slower validation
- pin DeterminateSystems actions and make Nix cache setup best-effort

## Why
The fast path is already gated by Linux Nix. macOS Nix is push-only noise in the same workflow and is currently the long-running flaky leg on main.