### PR TITLE
devex: keep jules history tracked

### DIFF
--- a/.jules/deps/envelopes/4be9e67a-585e-420e-a72e-2f33ee592216.json
+++ b/.jules/deps/envelopes/4be9e67a-585e-420e-a72e-2f33ee592216.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "4be9e67a-585e-420e-a72e-2f33ee592216",
+  "date": "2026-03-06T12:59:53Z",
+  "persona": "Auditor",
+  "lane": "scout",
+  "target": "tokmd-gate",
+  "action": "remove unused dependency tokmd-analysis-types",
+  "receipts": [
+    "cargo machete output identifying unused tokmd-analysis-types in tokmd-gate",
+    "cargo test -p tokmd-gate completed successfully after removal"
+  ]
+}

--- a/.jules/deps/envelopes/6e1b6f31-fc3d-468f-91eb-24db4170e6a7.json
+++ b/.jules/deps/envelopes/6e1b6f31-fc3d-468f-91eb-24db4170e6a7.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "6e1b6f31-fc3d-468f-91eb-24db4170e6a7",
+  "date": "2026-03-06T13:00:20Z",
+  "persona": "Auditor",
+  "lane": "scout",
+  "target": "tokmd-gate",
+  "action": "remove unused dependency tokmd-analysis-types",
+  "receipts": [
+    "cargo machete output identifying unused tokmd-analysis-types in tokmd-gate",
+    "cargo test -p tokmd-gate completed successfully after removal"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -1,0 +1,14 @@
+[
+  {
+    "run_id": "6e1b6f31-fc3d-468f-91eb-24db4170e6a7",
+    "date": "2026-03-06T13:00:20Z",
+    "persona": "Auditor",
+    "lane": "scout",
+    "target": "tokmd-gate",
+    "action": "remove unused dependency tokmd-analysis-types",
+    "receipts": [
+      "cargo machete output identifying unused tokmd-analysis-types in tokmd-gate",
+      "cargo test -p tokmd-gate completed successfully after removal"
+    ]
+  }
+]

--- a/.jules/deps/runs/2026-03-06.md
+++ b/.jules/deps/runs/2026-03-06.md
@@ -1,0 +1,14 @@
+# Auditor Run: 2026-03-06
+**Run ID:** 6e1b6f31-fc3d-468f-91eb-24db4170e6a7
+**Target:** tokmd-gate
+
+## Objective
+Remove unused dependency `tokmd-analysis-types` to improve dependency hygiene and reduce compile surface.
+
+## Steps
+1. Discovered unused dependency via `cargo machete`.
+2. Removed `tokmd-analysis-types` from `crates/tokmd-gate/Cargo.toml`.
+3. Validated changes with `cargo test -p tokmd-gate` and `cargo check -p tokmd-gate`.
+
+## Result
+Successful removal. Tests pass.

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -11,7 +11,7 @@
 ## NEXT (short horizon)
 
 - **Main CI boringness**: confirm the cleaned workflow shape stays green on normal pushes.
-- **Automation spillover cleanup**: remove tracked `.jules` artifacts and keep them out of the repo.
+- **Jules history**: keep curated `.jules/` history in the repo so agent work can accumulate context without broadening unrelated diffs.
 - **Low-blast-radius devex**: continue small workflow, docs, and compat fixes that reduce false red and review noise.
 - **Release discipline**: keep release work paused until `main` is boring again.
 


### PR DESCRIPTION
## Summary
- restore the tracked .jules/deps/* history files removed in the last cleanup wave
- update docs/NOW.md so it reflects that curated .jules/ history is intentional

## Why
.jules/deps is small Jules run history, not accidental spillover. This keeps that history while leaving the broader ignore behavior untouched for now.