### PR TITLE
cleanup: make claude and jules first-class adapters

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,16 @@
+# .claude
+
+Checked-in Claude adapter surface for this repo.
+
+Tracked here:
+- runtime-specific settings and hooks
+- checked-in Claude agent manifests and command shims
+- adapter docs that explain how Claude maps onto the shared repo contract
+
+Not tracked here:
+- worktrees
+- caches
+- transcripts
+- other runtime-only state
+
+Shared repo policy should live outside this directory. `.claude/` is the Claude-specific adapter over that shared contract.

--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,18 @@ mutants.out.old/
 # Claude Code (local overrides)
 .claude/settings.local.json
 .claude/worktrees/
+.claude/cache/
+.claude/transcripts/
+.claude/runtime/
 
-# Jules agent metadata (stale run logs, envelopes)
-.jules/
+# Jules runtime state
+.jules/settings.local.json
+.jules/worktrees/
+.jules/runs/
+.jules/cache/
+.jules/transcripts/
+.jules/runtime/
+.jules/tmp/
 
 # Windows artifacts
 nul

--- a/.jules/README.md
+++ b/.jules/README.md
@@ -1,0 +1,17 @@
+# .jules
+
+Checked-in Jules adapter surface for this repo.
+
+Tracked here:
+- Jules-specific settings, hooks, agents, and command shims
+- curated Jules history that is intentionally kept in git
+- adapter docs that explain how Jules maps onto the shared repo contract
+
+Not tracked here:
+- worktrees
+- ephemeral runs
+- caches
+- transcripts
+- other runtime-only state
+
+`.jules/` is not spillover by default. The cleanup target is runtime state, not durable Jules history.

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -11,7 +11,7 @@
 ## NEXT (short horizon)
 
 - **Main CI boringness**: confirm the cleaned workflow shape stays green on normal pushes.
-- **Jules history**: keep curated `.jules/` history in the repo so agent work can accumulate context without broadening unrelated diffs.
+- **Agent boundary cleanup**: keep `.claude/` and `.jules/` as checked-in adapter surfaces; keep only runtime state out of git.
 - **Low-blast-radius devex**: continue small workflow, docs, and compat fixes that reduce false red and review noise.
 - **Release discipline**: keep release work paused until `main` is boring again.
 


### PR DESCRIPTION
## Summary
- stop blanket-ignoring .jules/ and ignore only runtime state for .claude/ and .jules/
- add .claude/README.md and .jules/README.md as checked-in adapter docs
- update docs/NOW.md so it matches the boundary policy

## Why
This is the smallest policy correction toward treating .claude/ and .jules/ as sibling checked-in adapters while keeping runtime spillover out of git.