### PR TITLE
devex: centralize shared agent repo guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 
+Canonical shared repo guidance is mirrored in `agents/shared/repo.md`.
+This file remains a Codex-facing entrypoint because some tooling ingests `AGENTS.md` directly.
+
 This file provides guidance to Claude Code when working with code in this repository.
 
 ## Project Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,18 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with code in this repository.
+Canonical repo guidance lives in `agents/shared/repo.md`.
 
-## Project Overview
+This file is the Claude adapter wrapper for runtime-specific notes.
 
-**tokmd** is a Rust CLI tool and library that wraps the `tokei` library to generate "inventory receipts" and derived analytics of code repositories. It produces human-readable summaries (Markdown/TSV) and machine-friendly datasets (JSON/JSONL/CSV) for AI-native workflows, LLM context generation, and code analysis pipelines.
+## Claude Runtime Surface
 
-## Build and Test Commands
+- Settings: `.claude/settings.json`
+- Post-edit hook: `.claude/hooks/format-rust.sh`
+- Checked-in adapter notes: `.claude/README.md`
 
-```bash
-cargo build                          # Debug build
-cargo build --release                # Release build with LTO
-cargo test --verbose                 # Run all tests
-cargo fmt                            # Format code
-cargo clippy -- -D warnings          # Lint with strict warnings
-cargo install --path crates/tokmd    # Local install
-```
+## Claude-Oriented Workflow
 
-## Developer Workflow
+Preferred commands for repo work:
 
 | Command | Purpose |
 |---------|---------|
@@ -26,249 +21,13 @@ cargo install --path crates/tokmd    # Local install
 | `cargo xtask gate --check` | Full quality gate (read-only) |
 | `cargo xtask gate` | Quality gate with auto-fix fmt step |
 
-### Git Hooks Setup
+Optional git hooks:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-- **pre-commit**: `cargo xtask lint-fix` + restage + typos
-- **pre-push**: `cargo xtask gate --check`
+- `pre-commit`: `cargo xtask lint-fix` + restage + typos
+- `pre-push`: `cargo xtask gate --check`
 
-### Agent Rule
-
-Always run `cargo xtask lint-fix` before considering a code-editing task complete. This ensures fmt and clippy issues are resolved before the user sees the result.
-
-## Architecture
-
-The codebase follows a tiered microcrate architecture: **types → scan → model → format → analysis → CLI**
-
-### Crate Hierarchy
-
-| Tier | Crate | Purpose |
-|------|-------|---------|
-| 0 | `tokmd-types` | Core data structures, no dependencies |
-| 0 | `tokmd-analysis-types` | Analysis receipt types |
-| 0 | `tokmd-settings` | Clap-free settings types (`ScanOptions`, etc.) |
-| 0 | `tokmd-envelope` | Cross-fleet `SensorReport` contract |
-| 0 | `tokmd-substrate` | Shared repo context (`RepoSubstrate`) |
-| 1 | `tokmd-scan` | tokei wrapper for code scanning |
-| 1 | `tokmd-model` | Aggregation logic (lang, module, file rows) |
-| 1 | `tokmd-tokeignore` | `.tokeignore` template generation |
-| 1 | `tokmd-redact` | BLAKE3-based path redaction utilities |
-| 1 | `tokmd-context-policy` | Context/handoff selection policy helpers (smart excludes, classifications, inclusion policy) |
-| 1 | `tokmd-scan-args` | Deterministic `ScanArgs` metadata construction + redaction wiring |
-| 1 | `tokmd-sensor` | `EffortlessSensor` trait + substrate builder |
-| 2 | `tokmd-format` | Output rendering (Markdown, TSV, JSON) |
-| 2 | `tokmd-walk` | File system traversal for assets |
-| 2 | `tokmd-content` | File content scanning (entropy, imports) |
-| 2 | `tokmd-git` | Git history analysis |
-| 2 | `tokmd-badge` | SVG badge rendering helpers |
-| 2 | `tokmd-progress` | Progress spinner and progress-bar abstractions |
-| 3 | `tokmd-analysis` | Analysis orchestration and enrichers |
-| 3 | `tokmd-analysis-api-surface` | API surface analysis |
-| 3 | `tokmd-analysis-archetype` | Archetype inference adapter |
-| 3 | `tokmd-analysis-assets` | Asset and dependency reports |
-| 3 | `tokmd-analysis-complexity` | Cyclomatic/cognitive complexity |
-| 3 | `tokmd-analysis-content` | Content scanning adapters (TODO, dup, imports) |
-| 3 | `tokmd-analysis-derived` | Core derived metrics (density, COCOMO) |
-| 3 | `tokmd-analysis-entropy` | High-entropy file detection |
-| 3 | `tokmd-analysis-fingerprint` | Corporate fingerprint adapter |
-| 3 | `tokmd-analysis-format` | Analysis output rendering |
-| 3 | `tokmd-analysis-git` | Git history analysis adapters |
-| 3 | `tokmd-analysis-grid` | Preset/feature matrix metadata |
-| 3 | `tokmd-analysis-halstead` | Halstead metrics |
-| 3 | `tokmd-analysis-license` | License radar scanning |
-| 3 | `tokmd-analysis-near-dup` | Near-duplicate detection |
-| 3 | `tokmd-analysis-topics` | Topic-cloud extraction adapter |
-| 3 | `tokmd-analysis-util` | Shared analysis utilities |
-| 3 | `tokmd-fun` | Novelty outputs (eco-label, etc.) |
-| 3 | `tokmd-gate` | Policy evaluation with JSON pointer rules |
-| 4 | `tokmd-config` | Configuration loading (`tokmd.toml`) |
-| 4 | `tokmd-tool-schema` | AI tool-schema generation from clap command trees |
-| 4 | `tokmd-core` | Library facade with FFI layer |
-| 5 | `tokmd` | CLI binary |
-| 5 | `tokmd-python` | PyO3 bindings for PyPI |
-| 5 | `tokmd-node` | napi-rs bindings for npm |
-
-### CLI Commands
-
-- `tokmd` / `tokmd lang` — Language summary
-- `tokmd module` — Module breakdown by directory
-- `tokmd export` — File-level inventory (JSONL/CSV/CycloneDX)
-- `tokmd run` — Full scan with artifact output
-- `tokmd analyze` — Derived metrics and enrichments
-- `tokmd badge` — SVG badge generation
-- `tokmd diff` — Compare two runs or receipts
-- `tokmd cockpit` — PR metrics for code review with evidence gates
-- `tokmd sensor` — Conforming sensor producing sensor.report.v1 envelope
-- `tokmd gate` — Policy-based quality gates with JSON pointer rules
-- `tokmd tools` — Generate LLM tool definitions (OpenAI, Anthropic, JSON Schema)
-- `tokmd context` — Pack files into LLM context window within token budget
-- `tokmd baseline` — Capture complexity baseline for trend tracking
-- `tokmd handoff` — Bundle codebase for LLM handoff with intelligence presets
-- `tokmd init` — Generate `.tokeignore` template
-- `tokmd check-ignore` — Explain why files are being ignored
-- `tokmd completions` — Generate shell completions
-
-### Library API (tokmd-core)
-
-The `tokmd-core` crate provides a clap-free library facade for embedding:
-
-**Workflow Functions** (Rust):
-- `lang_workflow(scan, lang) -> LangReceipt`
-- `module_workflow(scan, module) -> ModuleReceipt`
-- `export_workflow(scan, export) -> ExportReceipt`
-- `diff_workflow(settings) -> DiffReceipt`
-
-**FFI Layer** (`ffi::run_json`):
-- Single JSON entrypoint: `run_json(mode, args_json) -> String`
-- Modes: `lang`, `module`, `export`, `analyze`, `diff`, `version`
-- Response envelope: `{"ok": bool, "data": {...}, "error": {...}}`
-
-**Python Bindings** (tokmd-python):
-- `tokmd.lang()`, `tokmd.module()`, `tokmd.export()`, `tokmd.analyze()`, `tokmd.diff()`
-- Returns native Python dicts
-- Releases GIL during long scans
-
-**Node.js Bindings** (tokmd-node):
-- All functions return Promises (async)
-- Uses `tokio::task::spawn_blocking()` for non-blocking event loop
-
-### Analysis Presets
-
-| Preset | Includes |
-|--------|----------|
-| `receipt` | Core derived metrics (density, distribution, COCOMO) |
-| `health` | + TODO density, complexity, Halstead metrics |
-| `risk` | + Git hotspots, coupling, freshness, complexity, Halstead metrics |
-| `supply` | + Assets, dependency lockfiles |
-| `architecture` | + Import graph |
-| `topics` | Semantic topic clouds |
-| `security` | License radar, entropy profiling |
-| `identity` | Archetype detection, corporate fingerprint |
-| `git` | Predictive churn, advanced git metrics |
-| `deep` | Everything (except fun) |
-| `fun` | Eco-label, novelty outputs |
-
-## Critical Patterns
-
-### Deterministic Output
-- Uses `BTreeMap` instead of `HashMap` everywhere for stable key ordering
-- Sorting: descending by code lines, then by name
-- Essential for golden snapshot tests and reproducible receipts
-
-### Path Normalization
-- All paths normalized to forward slashes (`/`) regardless of OS
-- Always use `normalize_path()` before output
-- Module keys computed from normalized paths
-
-### Children/Embedded Language Handling
-- `ChildrenMode::Collapse`: Merge embedded languages into parent totals
-- `ChildrenMode::Separate`: Show as "(embedded)" rows
-- Applies consistently across all commands
-
-### Receipt Schema
-- JSON outputs include envelope metadata with `schema_version`
-- Increment schema_version when modifying JSON output structure
-- Update `docs/schema.json` (formal JSON Schema) when structures change
-- **Schema versions are separate for each receipt family**:
-  - Core receipts (`lang`, `module`, `export`, `diff`, `run`): `SCHEMA_VERSION = 2` (in `tokmd-types`)
-  - Analysis receipts: `ANALYSIS_SCHEMA_VERSION = 9` (in `tokmd-analysis-types`)
-  - Cockpit receipts: `COCKPIT_SCHEMA_VERSION = 3` (in `tokmd-types`)
-  - Handoff manifests: `HANDOFF_SCHEMA_VERSION = 5` (in `tokmd-types`)
-  - Context receipts: `CONTEXT_SCHEMA_VERSION = 4` (in `tokmd-types`)
-  - Context bundles: `CONTEXT_BUNDLE_SCHEMA_VERSION = 2` (in `tokmd-types`)
-
-### Feature Flags
-- `git`: Git history analysis (uses shell `git log`)
-- `content`: File content scanning (entropy, tags, hashing)
-- `walk`: Filesystem traversal for assets
-- `halstead`: Halstead metrics computation (requires `content` + `walk`)
-
-### Git Diff Syntax (Two-dot vs Three-dot)
-When invoking `git diff` or `git log` with range syntax:
-
-| Syntax | Meaning | Use Case |
-|--------|---------|----------|
-| `A..B` | Commits reachable from B but not A | Comparing tags/releases (`cockpit`, `diff` commands) |
-| `A...B` | Symmetric difference from merge-base | CI workflows comparing PR branches |
-
-**Rule**: Use `..` (two dots) in cockpit/diff commands comparing releases or tags. Use `...` (three dots) only in CI workflows where you want changes since branch divergence.
-
-## Testing
-
-- **Integration tests**: `crates/tokmd/tests/` using `assert_cmd` + `predicates`
-- **Golden snapshots**: Using `insta` crate (timestamps normalized)
-- **Crate-level tests**: Each crate has its own `tests/` directory
-- **Unit tests**: In-module tests
-- **Property-based tests**: Using `proptest` across 14 crates for invariant verification
-- **Fuzz targets**: 9 targets using `libfuzzer` (see `fuzz/` directory) with seed corpus and dictionaries
-- **Mutation testing**: Using `cargo-mutants` for test quality verification (configured in `.cargo/mutants.toml`)
-
-Run a single test:
-```bash
-cargo test test_name --verbose
-```
-
-Update snapshots:
-```bash
-cargo insta review
-```
-
-Run property tests:
-```bash
-cargo test -p tokmd-redact properties
-```
-
-Run mutation testing:
-```bash
-cargo mutants --file crates/tokmd-redact/src/lib.rs
-```
-
-Run fuzz targets:
-```bash
-cargo +nightly fuzz run fuzz_entropy --features content
-cargo +nightly fuzz list  # List all targets
-```
-
-## Key Dependencies
-
-| Crate | Purpose |
-|-------|---------|
-| `tokei` | Core LOC counting |
-| `clap` (derive) | CLI parsing |
-| `serde`/`serde_json` | JSON serialization |
-| `blake3` | Fast hashing for redaction and integrity |
-| `anyhow` | Error handling |
-| `ignore` | File walking with gitignore support |
-| `pyo3` | Python bindings (tokmd-python) |
-| `napi-rs` | Node.js bindings (tokmd-node) |
-
-## Documentation
-
-### Architecture & Design
-- `docs/architecture.md`: Crate hierarchy, data flow, dependency rules
-- `docs/design.md`: Design principles, system context, data model
-- `docs/requirements.md`: Requirements, interfaces, quality bar
-- `docs/implementation-plan.md`: Phased roadmap for future work
-
-### User Guides
-- `docs/tutorial.md`: Getting started guide
-- `docs/recipes.md`: Real-world usage examples
-- `docs/reference-cli.md`: CLI flag reference
-- `docs/troubleshooting.md`: Common issues and solutions
-
-### Technical Reference
-- `docs/SCHEMA.md`: Receipt format documentation
-- `docs/schema.json`: Formal JSON Schema Draft 7 definition
-- `docs/testing.md`: Testing strategy and frameworks
-
-### Product & Philosophy
-- `docs/PRODUCT.md`: Product contract and invariants
-- `docs/explanation.md`: Philosophy and design principles
-
-### Project
-- `ROADMAP.md`: Current status and future plans
-- `CHANGELOG.md`: Version history
-- `CONTRIBUTING.md`: Development setup, testing, and publishing guide
+Use `agents/shared/repo.md` for project overview, architecture, CLI surface, invariants, testing notes, and reference docs.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,72 +1,23 @@
-# Gemini Context: tokmd
+# GEMINI.md
 
-## Project Overview
+Canonical repo guidance lives in `agents/shared/repo.md`.
 
-**tokmd** is a code intelligence tool for humans, machines, and LLMs. It analyzes codebases to produce deterministic "receipts" (schema-compliant JSON/Markdown artifacts) and derived insights (metrics, risk analysis, context packing). It is built on top of `tokei`.
+This file is the Gemini and Jules adapter wrapper for runtime-specific notes.
 
-**Key Value Proposition:**
-*   **Deterministic Receipts:** Stable output for CI/CD and diffing.
-*   **LLM Ready:** Token estimation and context window packing.
-*   **Git Analysis:** Hotspots, freshness, and coupling metrics.
-*   **Multi-language Support:** Native CLI, plus Python and Node.js bindings.
+## Gemini-Oriented Workflow
 
-## Architecture
+Common shortcuts:
 
-The project follows a **tiered microcrate architecture** to ensure strict separation of concerns and dependency rules.
+| Task | Command |
+|------|---------|
+| Build | `cargo build` |
+| Test workspace | `cargo test --workspace` |
+| Lint | `just lint` |
+| Format | `just fmt` |
+| Publish plan | `just publish-plan` |
 
-*   **Tier 0 (Contracts):** `tokmd-types`, `tokmd-analysis-types`, `tokmd-envelope`, `tokmd-substrate`. Pure data structures, no heavy dependencies.
-*   **Tier 1 (Core):** `tokmd-scan` (tokei wrapper), `tokmd-model` (aggregation), `tokmd-redact` (hashing).
-*   **Tier 2 (Adapters):** `tokmd-format` (rendering), `tokmd-walk` (fs), `tokmd-content` (scanning), `tokmd-git`.
-*   **Tier 3 (Orchestration):** `tokmd-analysis` (enrichers), `tokmd-analysis-format`, `tokmd-gate`.
-*   **Tier 4 (Facade):** `tokmd-config`, `tokmd-core` (library facade + FFI).
-*   **Tier 5 (Products):** `tokmd` (CLI binary), `tokmd-python`, `tokmd-node`.
+## Adapter Notes
 
-**Dependency Rule:** Lower tiers must **never** depend on higher tiers.
-
-## Build & Development
-
-The project uses `cargo` and `just` for task management.
-
-### Key Commands
-
-| Task | Command | Description |
-| :--- | :--- | :--- |
-| **Build** | `cargo build` | Build all crates. |
-| **Test (Unit)** | `cargo test` | Run unit tests. |
-| **Test (All)** | `cargo test --workspace` | Run all tests in workspace. |
-| **Lint** | `just lint` | `cargo clippy --all-features -- -D warnings` |
-| **Format** | `just fmt` | `cargo fmt` |
-| **Publish Plan** | `just publish-plan` | Dry-run publish sequence. |
-
-### Testing Strategy
-
-1.  **Determinism is King:** Outputs must be byte-stable. Use `insta` for snapshot testing.
-    *   **CRITICAL:** Line endings must be LF-normalized.
-    *   If output logic changes, verify diffs carefully before running `cargo insta review`.
-2.  **Property Testing:** `proptest` used for invariant checking (hashing, normalization).
-3.  **Fuzzing:** `libfuzzer` targets in `fuzz/` for parsing and security-critical paths.
-4.  **Mutation Testing:** `cargo-mutants` runs on CI to ensure test coverage quality.
-
-## Coding Conventions
-
-*   **Style:** Standard Rust (rustfmt).
-*   **Linting:** Strict clippy (`-D warnings`).
-*   **Schema Versioning:**
-    *   Core receipts: `SCHEMA_VERSION`
-    *   Analysis receipts: `ANALYSIS_SCHEMA_VERSION`
-    *   **Rule:** Increment version on breaking changes (renaming fields, changing types).
-*   **Path Normalization:** Always normalize paths to use forward slashes (`/`), even on Windows.
-*   **Context Awareness:** When adding features, consider "Is this deterministic?" and "Does this belong in a specific tier?"
-
-## Subsystem: Sensors
-
-`tokmd` supports a multi-sensor pipeline via `tokmd-sensor` and `tokmd-envelope`.
-*   **Substrate:** `RepoSubstrate` is built once (scan) and shared.
-*   **Report:** Sensors emit `SensorReport` (standardized envelope).
-
-## Reference Files
-
-*   `Cargo.toml`: Workspace configuration.
-*   `Justfile`: Task runner shortcuts.
-*   `docs/architecture.md`: Detailed architectural guidelines.
-*   `docs/SCHEMA.md`: Output data shapes.
+- Keep deterministic outputs intact.
+- Preserve tier boundaries between contracts, adapters, orchestration, and product crates.
+- Use `agents/shared/repo.md` for project overview, architecture, invariants, testing notes, and reference docs.

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -1,0 +1,154 @@
+# Shared Agent Repo Guide
+
+This file is the canonical shared repo context for checked-in agent adapters in this repository.
+
+## Project Overview
+
+**tokmd** is a Rust CLI tool and library that generates deterministic inventory receipts and derived analytics for code repositories. It produces human-readable summaries and machine-friendly artifacts for AI-native workflows, LLM context generation, code analysis, and review pipelines.
+
+## Developer Workflow
+
+Common commands:
+
+```bash
+cargo build
+cargo build --release
+cargo test --workspace
+cargo fmt
+cargo clippy --all-features -- -D warnings
+cargo xtask lint-fix
+cargo xtask gate --check
+just lint
+just fmt
+just publish-plan
+```
+
+Optional git hooks:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## Architecture
+
+The codebase follows a tiered microcrate architecture:
+
+`types -> scan -> model -> format -> analysis -> CLI`
+
+Tier summary:
+
+| Tier | Purpose | Example crates |
+|------|---------|----------------|
+| 0 | Contracts and settings | `tokmd-types`, `tokmd-analysis-types`, `tokmd-settings`, `tokmd-envelope`, `tokmd-substrate` |
+| 1 | Core scan and aggregation | `tokmd-scan`, `tokmd-model`, `tokmd-redact`, `tokmd-context-policy`, `tokmd-scan-args`, `tokmd-sensor` |
+| 2 | Adapters and rendering | `tokmd-format`, `tokmd-walk`, `tokmd-content`, `tokmd-git`, `tokmd-badge`, `tokmd-progress` |
+| 3 | Analysis orchestration | `tokmd-analysis`, `tokmd-analysis-format`, `tokmd-analysis-*`, `tokmd-fun`, `tokmd-gate` |
+| 4 | Facade and config | `tokmd-config`, `tokmd-tool-schema`, `tokmd-core` |
+| 5 | End-user products | `tokmd`, `tokmd-python`, `tokmd-node` |
+
+Dependency rule:
+
+- Lower tiers must never depend on higher tiers.
+
+## CLI Surface
+
+- `tokmd` / `tokmd lang` - language summary
+- `tokmd module` - module breakdown
+- `tokmd export` - file-level inventory
+- `tokmd run` - full scan with artifacts
+- `tokmd analyze` - derived metrics and enrichments
+- `tokmd badge` - SVG badge generation
+- `tokmd diff` - compare runs or receipts
+- `tokmd cockpit` - PR metrics and evidence gates
+- `tokmd sensor` - sensor envelope output
+- `tokmd gate` - policy evaluation
+- `tokmd tools` - LLM tool definitions
+- `tokmd context` - context packing under token budget
+- `tokmd baseline` - baseline capture
+- `tokmd handoff` - LLM handoff bundle generation
+- `tokmd init` - generate `.tokeignore`
+- `tokmd check-ignore` - explain ignore decisions
+- `tokmd completions` - shell completions
+
+## Critical Invariants
+
+### Deterministic output
+
+- Use `BTreeMap` instead of `HashMap` for stable ordering.
+- Sort descending by code lines, then by name.
+- Keep output byte-stable for snapshot and receipt diffs.
+
+### Path normalization
+
+- Normalize output paths to forward slashes (`/`) on every platform.
+- Normalize before emitting output or computing module keys.
+
+### Children and embedded languages
+
+- `ChildrenMode::Collapse` merges embedded languages into parent totals.
+- `ChildrenMode::Separate` emits explicit embedded rows.
+- Apply this consistently across commands and receipt surfaces.
+
+### Schema versioning
+
+- Bump the relevant schema version when JSON structure changes.
+- Update formal schema docs when structure changes.
+- Receipt families currently version independently:
+  - core receipts: `SCHEMA_VERSION = 2`
+  - analysis receipts: `ANALYSIS_SCHEMA_VERSION = 9`
+  - cockpit receipts: `COCKPIT_SCHEMA_VERSION = 3`
+  - handoff manifests: `HANDOFF_SCHEMA_VERSION = 5`
+  - context receipts: `CONTEXT_SCHEMA_VERSION = 4`
+  - context bundles: `CONTEXT_BUNDLE_SCHEMA_VERSION = 2`
+
+### Feature flags
+
+- `git` enables git-history analysis.
+- `content` enables file-content scanning.
+- `walk` enables filesystem traversal helpers.
+- `halstead` requires `content` plus `walk`.
+
+### Git range syntax
+
+| Syntax | Meaning | Use case |
+|--------|---------|----------|
+| `A..B` | commits reachable from `B` but not `A` | comparing tags or releases |
+| `A...B` | symmetric difference from merge-base | CI workflows comparing branch divergence |
+
+Rule:
+
+- Use `..` in cockpit and diff flows comparing releases or tags.
+- Use `...` only in CI workflows that want branch-divergence changes.
+
+## Testing Notes
+
+- Integration tests live under `crates/tokmd/tests/`.
+- Golden snapshots use `insta`.
+- Property testing uses `proptest`.
+- Fuzz targets live in `fuzz/`.
+- Mutation testing is configured in `.cargo/mutants.toml`.
+
+Common targeted commands:
+
+```bash
+cargo test test_name --verbose
+cargo test -p tokmd-redact properties
+cargo mutants --file crates/tokmd-redact/src/lib.rs
+cargo +nightly fuzz list
+```
+
+## Reference Docs
+
+- `docs/architecture.md`
+- `docs/design.md`
+- `docs/requirements.md`
+- `docs/implementation-plan.md`
+- `docs/reference-cli.md`
+- `docs/SCHEMA.md`
+- `docs/schema.json`
+- `docs/testing.md`
+- `docs/PRODUCT.md`
+- `docs/explanation.md`
+- `ROADMAP.md`
+- `CHANGELOG.md`
+- `CONTRIBUTING.md`


### PR DESCRIPTION
## Summary
- add a canonical shared repo guide under gents/shared/repo.md
- slim CLAUDE.md and GEMINI.md down to adapter-specific wrapper notes
- keep AGENTS.md as the Codex entrypoint, but point it at the shared guide

## Why
- reduce drift between agent-specific docs
- make .claude and .jules adapters sit on top of one shared repo contract
- keep this cleanup slice narrow and non-release-focused