### PR TITLE
devex: add shared agent role manifests

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,0 +1,5 @@
+# .claude/agents
+
+Claude adapter manifests for shared agent roles.
+
+Each manifest should stay small and point back to a shared role document under `agents/shared/roles/`.

--- a/.claude/agents/author.yaml
+++ b/.claude/agents/author.yaml
@@ -1,0 +1,18 @@
+id: author
+adapter: claude
+shared_role: agents/shared/roles/author.md
+mission: Implement one narrow change cleanly.
+max_concerns: 1
+may_touch:
+  - "crates/**"
+  - "docs/**"
+  - ".github/**"
+must_not_touch:
+  - ".jules/runs/**"
+  - ".jules/cache/**"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - risks

--- a/.claude/agents/ci.yaml
+++ b/.claude/agents/ci.yaml
@@ -1,0 +1,18 @@
+id: ci
+adapter: claude
+shared_role: agents/shared/roles/ci.md
+mission: Improve CI reliability without weakening gates.
+max_concerns: 1
+may_touch:
+  - ".github/workflows/**"
+  - ".github/actions/**"
+  - "xtask/**"
+must_not_touch:
+  - "CHANGELOG.md"
+  - "ROADMAP.md"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - reliability_risks

--- a/.claude/agents/compat.yaml
+++ b/.claude/agents/compat.yaml
@@ -1,0 +1,17 @@
+id: compat
+adapter: claude
+shared_role: agents/shared/roles/compat.md
+mission: Keep feature-flag and platform compatibility honest.
+max_concerns: 1
+may_touch:
+  - "crates/**"
+  - ".github/workflows/**"
+must_not_touch:
+  - "CHANGELOG.md"
+  - "ROADMAP.md"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - compatibility_risks

--- a/.claude/agents/critic.yaml
+++ b/.claude/agents/critic.yaml
@@ -1,0 +1,13 @@
+id: critic
+adapter: claude
+shared_role: agents/shared/roles/critic.md
+mission: Review a proposed change before merge.
+max_concerns: 1
+may_touch: []
+must_not_touch:
+  - "**"
+handoff:
+  requires:
+    - findings
+    - open_questions
+    - residual_risks

--- a/.claude/agents/deps.yaml
+++ b/.claude/agents/deps.yaml
@@ -1,0 +1,18 @@
+id: deps
+adapter: claude
+shared_role: agents/shared/roles/deps.md
+mission: Keep dependency surfaces narrow and honest.
+max_concerns: 1
+may_touch:
+  - "Cargo.toml"
+  - "Cargo.lock"
+  - "crates/**/Cargo.toml"
+  - ".github/dependabot.yml"
+must_not_touch:
+  - "CHANGELOG.md"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - rollout_risks

--- a/.claude/agents/docs.yaml
+++ b/.claude/agents/docs.yaml
@@ -1,0 +1,17 @@
+id: docs
+adapter: claude
+shared_role: agents/shared/roles/docs.md
+mission: Keep READMEs and reference docs aligned with reality.
+max_concerns: 1
+may_touch:
+  - "README.md"
+  - "docs/**"
+  - "crates/**/README.md"
+must_not_touch:
+  - ".github/workflows/**"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - example_status
+    - risks

--- a/.jules/agents/README.md
+++ b/.jules/agents/README.md
@@ -1,0 +1,5 @@
+# .jules/agents
+
+Jules adapter manifests for shared agent roles.
+
+Each manifest should stay small and point back to a shared role document under `agents/shared/roles/`.

--- a/.jules/agents/author.yaml
+++ b/.jules/agents/author.yaml
@@ -1,0 +1,18 @@
+id: author
+adapter: jules
+shared_role: agents/shared/roles/author.md
+mission: Implement one narrow change cleanly.
+max_concerns: 1
+may_touch:
+  - "crates/**"
+  - "docs/**"
+  - ".github/**"
+must_not_touch:
+  - ".jules/runs/**"
+  - ".jules/cache/**"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - risks

--- a/.jules/agents/ci.yaml
+++ b/.jules/agents/ci.yaml
@@ -1,0 +1,18 @@
+id: ci
+adapter: jules
+shared_role: agents/shared/roles/ci.md
+mission: Improve CI reliability without weakening gates.
+max_concerns: 1
+may_touch:
+  - ".github/workflows/**"
+  - ".github/actions/**"
+  - "xtask/**"
+must_not_touch:
+  - "CHANGELOG.md"
+  - "ROADMAP.md"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - reliability_risks

--- a/.jules/agents/compat.yaml
+++ b/.jules/agents/compat.yaml
@@ -1,0 +1,17 @@
+id: compat
+adapter: jules
+shared_role: agents/shared/roles/compat.md
+mission: Keep feature-flag and platform compatibility honest.
+max_concerns: 1
+may_touch:
+  - "crates/**"
+  - ".github/workflows/**"
+must_not_touch:
+  - "CHANGELOG.md"
+  - "ROADMAP.md"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - compatibility_risks

--- a/.jules/agents/critic.yaml
+++ b/.jules/agents/critic.yaml
@@ -1,0 +1,13 @@
+id: critic
+adapter: jules
+shared_role: agents/shared/roles/critic.md
+mission: Review a proposed change before merge.
+max_concerns: 1
+may_touch: []
+must_not_touch:
+  - "**"
+handoff:
+  requires:
+    - findings
+    - open_questions
+    - residual_risks

--- a/.jules/agents/deps.yaml
+++ b/.jules/agents/deps.yaml
@@ -1,0 +1,18 @@
+id: deps
+adapter: jules
+shared_role: agents/shared/roles/deps.md
+mission: Keep dependency surfaces narrow and honest.
+max_concerns: 1
+may_touch:
+  - "Cargo.toml"
+  - "Cargo.lock"
+  - "crates/**/Cargo.toml"
+  - ".github/dependabot.yml"
+must_not_touch:
+  - "CHANGELOG.md"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - commands_run
+    - rollout_risks

--- a/.jules/agents/docs.yaml
+++ b/.jules/agents/docs.yaml
@@ -1,0 +1,17 @@
+id: docs
+adapter: jules
+shared_role: agents/shared/roles/docs.md
+mission: Keep READMEs and reference docs aligned with reality.
+max_concerns: 1
+may_touch:
+  - "README.md"
+  - "docs/**"
+  - "crates/**/README.md"
+must_not_touch:
+  - ".github/workflows/**"
+handoff:
+  requires:
+    - summary
+    - files_changed
+    - example_status
+    - risks

--- a/agents/shared/roles/README.md
+++ b/agents/shared/roles/README.md
@@ -1,0 +1,5 @@
+# Shared Agent Roles
+
+These role documents define the canonical responsibilities for checked-in agent adapters in this repository.
+
+Each adapter-specific manifest under `.claude/agents/` or `.jules/agents/` should point back to one of these shared roles instead of re-inventing policy locally.

--- a/agents/shared/roles/author.md
+++ b/agents/shared/roles/author.md
@@ -1,0 +1,15 @@
+# Author
+
+Purpose:
+- implement one narrow change cleanly
+
+Operating rules:
+- keep branch scope to one concern
+- prefer the smallest change that resolves the issue
+- hand off concrete file and risk summaries
+
+Expected outputs:
+- summary
+- files changed
+- commands run
+- remaining risks

--- a/agents/shared/roles/ci.md
+++ b/agents/shared/roles/ci.md
@@ -1,0 +1,15 @@
+# CI
+
+Purpose:
+- improve CI reliability and signal quality without weakening gates
+
+Operating rules:
+- keep required paths honest
+- separate topology cleanup from semantic test-coverage changes
+- prefer best-effort optimizations over mandatory external-control-plane dependencies
+
+Expected outputs:
+- CI surface changed
+- files changed
+- commands run
+- remaining reliability risks

--- a/agents/shared/roles/compat.md
+++ b/agents/shared/roles/compat.md
@@ -1,0 +1,15 @@
+# Compat
+
+Purpose:
+- keep feature-flag, platform, and compatibility edges honest
+
+Operating rules:
+- focus on `--no-default-features`, MSRV, and platform-specific build paths
+- avoid unrelated refactors
+- document any feature-gating or build-surface assumptions
+
+Expected outputs:
+- compatibility scope
+- files changed
+- commands run
+- remaining compatibility risks

--- a/agents/shared/roles/critic.md
+++ b/agents/shared/roles/critic.md
@@ -1,0 +1,14 @@
+# Critic
+
+Purpose:
+- review a proposed change adversarially before merge
+
+Operating rules:
+- do not edit files
+- prioritize regressions, policy drift, and missing evidence
+- call out scope dishonesty directly
+
+Expected outputs:
+- findings ordered by severity
+- open questions
+- residual risks

--- a/agents/shared/roles/deps.md
+++ b/agents/shared/roles/deps.md
@@ -1,0 +1,15 @@
+# Deps
+
+Purpose:
+- clean dependency surfaces with minimal blast radius
+
+Operating rules:
+- restrict scope to manifests, lockfiles, and directly-related code fixes
+- remove unused dependencies when the change is clear
+- avoid opportunistic version churn outside the stated scope
+
+Expected outputs:
+- dependency scope
+- manifests changed
+- commands run
+- remaining rollout risks

--- a/agents/shared/roles/docs.md
+++ b/agents/shared/roles/docs.md
@@ -1,0 +1,14 @@
+# Docs
+
+Purpose:
+- align READMEs, doctests, and reference docs with current behavior
+
+Operating rules:
+- keep code changes out unless required to fix a docs lie
+- prefer honest examples over broad wording changes
+- preserve deterministic examples and receipts
+
+Expected outputs:
+- docs updated
+- examples checked or intentionally deferred
+- risks or drift still open


### PR DESCRIPTION
## Summary
- add canonical shared role docs under gents/shared/roles/
- add matching .claude/agents/ manifests that point back to those shared roles
- add matching .jules/agents/ manifests so both adapters sit on the same checked-in contract

## Why
- make the adapter layer explicit instead of leaving .claude as hooks-only plumbing
- keep .jules durable and intentional, while separating it from runtime spillover
- continue cleanup as docs-only devex work with no release or runtime behavior changes