### PR TITLE
docs: restore schema version sync in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,4 +30,14 @@ git config core.hooksPath .githooks
 - `pre-commit`: `cargo xtask lint-fix` + restage + typos
 - `pre-push`: `cargo xtask gate --check`
 
+## Schema Version Sync
+
+These lines are kept explicit here because `tokmd-types` tests verify that `CLAUDE.md` stays aligned with the exported schema constants:
+
+- `SCHEMA_VERSION = 2`
+- `COCKPIT_SCHEMA_VERSION = 3`
+- `HANDOFF_SCHEMA_VERSION = 5`
+- `CONTEXT_SCHEMA_VERSION = 4`
+- `CONTEXT_BUNDLE_SCHEMA_VERSION = 2`
+
 Use `agents/shared/repo.md` for project overview, architecture, CLI surface, invariants, testing notes, and reference docs.


### PR DESCRIPTION
## Summary
- restore the explicit schema version lines that 	okmd-types tests still require in CLAUDE.md
- keep the slimmer wrapper structure from the shared-guidance cleanup
- avoid reopening any other agent-doc changes

## Why
- main failed in schema_doc_sync after the wrapper cleanup removed these lines
- this is the smallest honest fix for the current red head