### PR TITLE
compat: fix no-default-features build for tokmd tests 🧷 Compat

### DIFF
--- a/.jules/compat/envelopes/c334b849-39bc-4437-bfd5-7ec9e732765e.json
+++ b/.jules/compat/envelopes/c334b849-39bc-4437-bfd5-7ec9e732765e.json
@@ -1,0 +1,16 @@
+{
+  "run_id": "c334b849-39bc-4437-bfd5-7ec9e732765e",
+  "timestamp": "2026-03-17T09:40:38Z",
+  "persona": "Compat",
+  "target": "tokmd",
+  "action": "fix_no_default_features_warning",
+  "files_modified": [
+    "crates/tokmd/tests/deep_run_cockpit_w52.rs"
+  ],
+  "receipts": [
+    {
+      "command": "cargo test --workspace --no-default-features --exclude tokmd-python --exclude tokmd-node",
+      "result": "Tests pass and the dead_code warning is eliminated."
+    }
+  ]
+}

--- a/.jules/compat/ledger.json
+++ b/.jules/compat/ledger.json
@@ -1,0 +1,7 @@
+[
+  {
+    "run_id": "c334b849-39bc-4437-bfd5-7ec9e732765e",
+    "timestamp": "2026-03-17T09:40:38Z",
+    "description": "Fix dead_code warning in tokmd tests during no-default-features build"
+  }
+]

--- a/crates/tokmd/tests/deep_run_cockpit_w52.rs
+++ b/crates/tokmd/tests/deep_run_cockpit_w52.rs
@@ -256,6 +256,7 @@ fn run_receipt_generated_at_ms_is_present() {
 
 /// Helper: create a minimal git repo with two branches for cockpit tests.
 /// Returns the tempdir (caller must keep it alive).
+#[cfg(feature = "git")]
 fn setup_cockpit_repo() -> Option<tempfile::TempDir> {
     if !common::git_available() {
         return None;


### PR DESCRIPTION
**Lane:** Scout Discovery
**Action:** Fix `no-default-features` build for `tokmd` tests 🧷 Compat

### Description
The `setup_cockpit_repo()` test helper in `crates/tokmd/tests/deep_run_cockpit_w52.rs` was throwing a `dead_code` warning during `--no-default-features` workspace test runs because it is only invoked by tests gated behind `#[cfg(feature = "git")]`.

This PR applies the matching `#[cfg(feature = "git")]` attribute to the helper function to suppress the warning and ensure cleaner matrix builds.

### Receipts

```bash
cargo test --workspace --no-default-features --exclude tokmd-python --exclude tokmd-node
```
*(Tests pass and the dead_code warning is eliminated.)*

### Ledger Update
Run appended to `.jules/compat/ledger.json` and envelope created at `.jules/compat/envelopes/c334b849-39bc-4437-bfd5-7ec9e732765e.json`.

---
*PR created automatically by Jules for task [17296547605498440079](https://jules.google.com/task/17296547605498440079) started by @EffortlessSteven*