### PR TITLE
docs: enable doctest compilation for tokmd-core and tokmd-analysis 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/69e2c4e2-a991-41f8-a23c-dfdb35a69d1a.json
+++ b/.jules/docs/envelopes/69e2c4e2-a991-41f8-a23c-dfdb35a69d1a.json
@@ -1,0 +1,5 @@
+{
+  "type": "doc_improvement",
+  "status": "completed",
+  "timestamp": "2026-03-18T09:51:14Z"
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "69e2c4e2-a991-41f8-a23c-dfdb35a69d1a",
+    "type": "doc_improvement",
+    "timestamp": "2026-03-18T09:51:14Z"
+  }
+]

--- a/.jules/docs/runs/2026-03-18.md
+++ b/.jules/docs/runs/2026-03-18.md
@@ -1,0 +1,15 @@
+# Librarian Run Log
+
+## Receipts
+```bash
+cargo build --verbose
+CI=true cargo test --verbose
+cargo fmt -- --check
+cargo clippy -- -D warnings
+```
+All baseline merge-confidence gates passed.
+
+## Details
+- Removed `no_run` from Rust doctests in `crates/tokmd-core/README.md` and `crates/tokmd-analysis/README.md`.
+- Verified changes with `cargo test --doc`.
+- Updated `.jules/docs/ledger.json` and `.jules/docs/envelopes/<run-id>.json`.

--- a/crates/tokmd-analysis/README.md
+++ b/crates/tokmd-analysis/README.md
@@ -20,7 +20,7 @@ features = ["git", "walk", "content", "fun", "topics", "archetype"]
 
 ## Usage
 
-```rust,no_run
+```rust
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 use std::path::PathBuf;
 use tokmd_analysis::{

--- a/crates/tokmd-core/README.md
+++ b/crates/tokmd-core/README.md
@@ -16,7 +16,7 @@ tokmd-types = "1.4"
 
 ## Usage
 
-```rust,no_run
+```rust
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 use tokmd_core::lang_workflow;
 use tokmd_core::settings::{ScanSettings, LangSettings};


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Enables doctest coverage for `crates/tokmd-core/README.md` and `crates/tokmd-analysis/README.md` by changing ````rust,no_run``` to ````rust``` so they are compiled during `cargo test --doc`.

## 🎯 Why / Threat model
Prevents documentation drift. Code blocks in the README should reflect the current API state and should compile properly; `no_run` hides compile failures until users attempt to use the snippets.

## 🔎 Finding (evidence)
- `crates/tokmd-core/README.md` and `crates/tokmd-analysis/README.md` contained ````rust,no_run``` blocks.
- `cargo test --doc` reported these blocks as "ignored" or "ok" without compiling them correctly for potential issues.

## 🧭 Options considered
### Option A (recommended)
- Change ````rust,no_run``` to ````rust``` to compile (but not run) the examples.
- Fits this repo as it uses `#[cfg(doctest)]` inclusions to verify READMEs.
- Trade-offs: Increases `cargo test --doc` compile time slightly, ensures strict API conformity.

### Option B
- Change ````rust,no_run``` to ````rust,ignore```.
- When to choose: If the examples refer to fictional namespaces or non-compilable pseudocode.
- Trade-offs: Bypasses compilation, risking docs rot.

## ✅ Decision
Option A was selected to maximize compilation coverage and prevent silent API drift in public documentation.

## 🧱 Changes made (SRP)
- `crates/tokmd-analysis/README.md`: `s/rust,no_run/rust/`
- `crates/tokmd-core/README.md`: `s/rust,no_run/rust/`

## 🧪 Verification receipts
```bash
cargo build --verbose
CI=true cargo test --verbose
cargo fmt -- --check
cargo clippy -- -D warnings
```
All baseline merge-confidence gates passed.

## 🧭 Telemetry
- Change shape: Minor documentation syntax fix
- Blast radius: CI/Testing only (doctests)
- Risk class: Low
- Rollback: Revert the commit.
- Merge-confidence gates: `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`

## 🗂️ .jules updates
- Appended a new run entry in `.jules/docs/ledger.json`
- Created a run envelope in `.jules/docs/envelopes/<run-id>.json`
- Created a run log in `.jules/docs/runs/2026-03-18.md`

## 📝 Notes (freeform)
Only modified the core and analysis crates. Other `no_run` / `ignore` blocks in other crates (e.g., `tokmd-walk`) were failing to compile on their own, so they were left as `ignore` for a future cleanup pass.
---

---
*PR created automatically by Jules for task [11143245365102980458](https://jules.google.com/task/11143245365102980458) started by @EffortlessSteven*