### PR TITLE
ci: canary Nix actions on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,10 @@ jobs:
     name: Nix Build
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    permissions:
+      contents: read
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 
@@ -190,6 +194,9 @@ jobs:
       - name: Setup Nix cache
         continue-on-error: true
         uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+          use-gha-cache: enabled
 
       - name: Check flake
         run: nix flake check --no-build --accept-flake-config


### PR DESCRIPTION
## Summary
- opt the Nix job into GitHub's Node 24 canary path
- disable the FlakeHub-specific path on the current Determinate actions
- keep the GitHub Actions cache path explicit so the job behavior stays stable

## Why
The last green CI run was clean except for two Nix-job annotations:
- FlakeHub auth/registration noise
- Node 20 deprecation warnings on the Determinate actions

This PR moves the job as far forward as the current upstream action line allows without changing the rest of the workflow shape.
