### PR TITLE
⚡ perf: eliminate path string clone in context pack spine loop

### DIFF
--- a/crates/tokmd/src/context_pack.rs
+++ b/crates/tokmd/src/context_pack.rs
@@ -521,7 +521,7 @@ pub fn select_files_with_options(
 
     let mut spine_files: Vec<ContextFileRow> = Vec::new();
     let mut spine_used = 0;
-    let mut spine_paths: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut spine_paths: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
 
     let mut spine_candidates: Vec<&FileRow> = parents
         .iter()
@@ -533,7 +533,7 @@ pub fn select_files_with_options(
     for row in spine_candidates {
         if spine_used + row.tokens <= spine_budget {
             spine_used += row.tokens;
-            spine_paths.insert(row.path.clone());
+            spine_paths.insert(row.path.as_str());
             spine_files.push(to_context_row_with_reason(
                 row,
                 effective_metric,
@@ -547,7 +547,7 @@ pub fn select_files_with_options(
     let remaining_budget = budget.saturating_sub(spine_used);
     let non_spine_rows: Vec<FileRow> = pack_rows
         .iter()
-        .filter(|r| !spine_paths.contains(&r.path))
+        .filter(|r| !spine_paths.contains(&r.path.as_str()))
         .cloned()
         .collect();
 


### PR DESCRIPTION
This PR removes one avoidable allocation in the context-pack spine path reservation flow by switching `spine_paths` from `BTreeSet<String>` to `BTreeSet<&str>`.

The branch keeps the same dedup semantics: the borrowed path slices come from `FileRow.path` owned by the candidate rows, and those rows stay alive and immutable for the entire reserve/filter pass. No public API changes are involved.

Verified with:
- `cargo test -p tokmd test_select_files_with_options_spine_reservation --lib`
- `cargo test -p tokmd test_select_files_with_options_rank_reason --lib`
- `cargo test -p tokmd test_pack_spread_no_duplicates --lib`
