### PR TITLE
docs: sync ANALYSIS_SCHEMA_VERSION in tokmd-analysis-types README to 9 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/20260320T093403Z.json
+++ b/.jules/docs/envelopes/20260320T093403Z.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "20260320T093403Z",
+  "status": "started",
+  "receipts": [
+    {
+      "command": "cargo build --verbose",
+      "result": "passed"
+    },
+    {
+      "command": "CI=true cargo test --verbose",
+      "result": "passed"
+    },
+    {
+      "command": "cargo fmt -- --check",
+      "result": "passed"
+    },
+    {
+      "command": "cargo clippy -- -D warnings",
+      "result": "passed"
+    }
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -1,0 +1,8 @@
+[
+  {
+    "run_id": "20260320T093403Z",
+    "date": "2026-03-20",
+    "status": "completed",
+    "target": "crates/tokmd-analysis-types/README.md"
+  }
+]

--- a/.jules/docs/runs/2026-03-20.md
+++ b/.jules/docs/runs/2026-03-20.md
@@ -1,0 +1,2 @@
+# Run 20260320T093403Z
+Updated ANALYSIS_SCHEMA_VERSION in crates/tokmd-analysis-types/README.md to match src/lib.rs (9).

--- a/crates/tokmd-analysis-types/README.md
+++ b/crates/tokmd-analysis-types/README.md
@@ -48,13 +48,15 @@ pub struct AnalysisReceipt {
 ## Schema Version
 
 ```rust
-pub const ANALYSIS_SCHEMA_VERSION: u32 = 8;
+pub const ANALYSIS_SCHEMA_VERSION: u32 = 9;
 ```
 
 v4 added cognitive complexity, nesting depth, and function-level details.
 v5 added Halstead metrics, maintainability index, complexity histogram, technical debt ratio, duplication density, and code age distribution.
 v6 added API surface enricher.
 v7 added coupling normalization (Jaccard/Lift), commit intent classification, and near-duplicate detection.
+v8 added near-dup clusters, selection metadata, max_pairs guardrail, runtime stats.
+v9 added effort estimation report.
 
 ## Design Principles
 


### PR DESCRIPTION
## 💡 Summary
Synchronize the `ANALYSIS_SCHEMA_VERSION` in `crates/tokmd-analysis-types/README.md` to 9 and add the missing changelog lines for v8 and v9.

## 🎯 Why / Threat model
The README serves as a primary reference for API consumers and integration tests. Providing an outdated schema version creates friction for users developing downstream tools who rely on the documented envelope version.

## 🔎 Finding (evidence)
- `crates/tokmd-analysis-types/README.md` showed `ANALYSIS_SCHEMA_VERSION: u32 = 8;`.
- `crates/tokmd-analysis-types/src/lib.rs` and `CLAUDE.md` accurately declared `9`.

## 🧭 Options considered
### Option A (recommended)
- Update the README to match the actual API version and history.
- **Why it fits**: Directly addresses the API documentation drift.
- **Trade-offs**: None, it is a straightforward fix.

### Option B
- Ignore the drift and rely on users reading `src/lib.rs` or `CLAUDE.md`.
- **Trade-offs**: Introduces confusion and friction for developers relying on the README.

## ✅ Decision
Option A was chosen. I updated the `ANALYSIS_SCHEMA_VERSION` to 9 in the README and added the missing v8 and v9 changelog entries to align with the source code.

## 🧱 Changes made (SRP)
- `crates/tokmd-analysis-types/README.md`: Updated `ANALYSIS_SCHEMA_VERSION` to 9 and added missing v8/v9 descriptions.

## 🧪 Verification receipts
- `cargo build --verbose`
- `CI=true cargo test --verbose`
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`

All checks ran and passed without introducing new errors.

## 🧭 Telemetry
- **Change shape**: Documentation fix
- **Blast radius**: Only modifies a README, no runtime impact
- **Risk class**: Trivial
- **Rollback**: Trivial Git revert
- **Merge-confidence gates**: `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`

## 🗂️ .jules updates
Created run envelope, logged run in `runs/2026-03-20.md`, and appended entry to `ledger.json`.

---
*PR created automatically by Jules for task [2893546833635075671](https://jules.google.com/task/2893546833635075671) started by @EffortlessSteven*