### PR TITLE
feat(core): add analyze workflow for in-memory inputs

### DIFF
--- a/crates/tokmd-core/README.md
+++ b/crates/tokmd-core/README.md
@@ -77,7 +77,7 @@ assert!(receipt.effort.is_some());
 - `analyze_workflow_from_inputs(inputs, scan_opts, analyze) -> AnalysisReceipt` with `analysis` feature
 - `cockpit_workflow(settings) -> CockpitReceipt` with `cockpit` feature
 
-All workflows use pure settings types from `tokmd_core::settings`, so they stay free of clap-specific argument structures. For ordered virtual inputs, build `tokmd_core::InMemoryFile` values and use the `*_workflow_from_inputs` variants instead of filesystem paths.
+All workflows use pure settings types from `tokmd_core::settings`, so they stay free of clap-specific argument structures. For ordered virtual inputs, build `tokmd_core::InMemoryFile` values and use the `*_workflow_from_inputs` variants instead of filesystem paths. Those in-memory workflows ignore ambient `tokei.toml` / `.tokeirc` discovery and clamp scan config loading to `none` so the same input set produces the same receipt regardless of host cwd.
 
 ## FFI JSON API
 

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -118,14 +118,15 @@ pub fn lang_workflow_from_inputs(
     scan_opts: &ScanOptions,
     lang: &LangSettings,
 ) -> Result<LangReceipt> {
-    let scan = tokmd_scan::scan_in_memory(inputs, scan_opts)?;
+    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
+    let scan = tokmd_scan::scan_in_memory(inputs, &scan_opts)?;
     let rows = collect_materialized_rows(&scan, &[], 1, ChildIncludeMode::Separate);
     let report =
         tokmd_model::create_lang_report_from_rows(&rows, lang.top, lang.files, lang.children);
 
     Ok(build_lang_receipt(
         scan.logical_paths(),
-        scan_opts,
+        &scan_opts,
         lang,
         report,
     ))
@@ -166,7 +167,8 @@ pub fn module_workflow_from_inputs(
     scan_opts: &ScanOptions,
     module: &ModuleSettings,
 ) -> Result<ModuleReceipt> {
-    let scan = tokmd_scan::scan_in_memory(inputs, scan_opts)?;
+    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
+    let scan = tokmd_scan::scan_in_memory(inputs, &scan_opts)?;
     let rows = collect_materialized_rows(
         &scan,
         &module.module_roots,
@@ -183,7 +185,7 @@ pub fn module_workflow_from_inputs(
 
     Ok(build_module_receipt(
         scan.logical_paths(),
-        scan_opts,
+        &scan_opts,
         module,
         report,
     ))
@@ -227,12 +229,13 @@ pub fn export_workflow_from_inputs(
     scan_opts: &ScanOptions,
     export: &ExportSettings,
 ) -> Result<ExportReceipt> {
-    let scan = tokmd_scan::scan_in_memory(inputs, scan_opts)?;
+    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
+    let scan = tokmd_scan::scan_in_memory(inputs, &scan_opts)?;
     let data = collect_materialized_export_data(&scan, export);
 
     Ok(build_export_receipt(
         scan.logical_paths(),
-        scan_opts,
+        &scan_opts,
         export,
         data,
     ))
@@ -292,7 +295,8 @@ pub fn analyze_workflow_from_inputs(
     analyze: &settings::AnalyzeSettings,
 ) -> Result<tokmd_analysis_types::AnalysisReceipt> {
     let export = ExportSettings::default();
-    let scan = tokmd_scan::scan_in_memory(inputs, scan_opts)?;
+    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
+    let scan = tokmd_scan::scan_in_memory(inputs, &scan_opts)?;
     let data = collect_materialized_export_data(&scan, &export);
     let logical_inputs: Vec<String> = scan
         .logical_paths()
@@ -300,7 +304,7 @@ pub fn analyze_workflow_from_inputs(
         .map(|path| tokmd_model::normalize_path(path, None))
         .collect();
     let root = scan.strip_prefix().to_path_buf();
-    let export_receipt = build_export_receipt(scan.logical_paths(), scan_opts, &export, data);
+    let export_receipt = build_export_receipt(scan.logical_paths(), &scan_opts, &export, data);
 
     analyze_with_export_receipt(export_receipt, logical_inputs, root, analyze)
 }
@@ -506,6 +510,13 @@ pub fn scan_workflow(
 /// Convert ScanSettings to ScanOptions for lower-tier crates.
 fn settings_to_scan_options(scan: &ScanSettings) -> ScanOptions {
     scan.options.clone()
+}
+
+fn deterministic_in_memory_scan_options(scan_opts: &ScanOptions) -> ScanOptions {
+    let mut effective = scan_opts.clone();
+    // In-memory workflows should not depend on host cwd tokei config discovery.
+    effective.config = tokmd_types::ConfigMode::None;
+    effective
 }
 
 fn collect_materialized_rows(

--- a/crates/tokmd-core/tests/in_memory_w80.rs
+++ b/crates/tokmd-core/tests/in_memory_w80.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
+use std::env;
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 
 use tempfile::TempDir;
 use tokmd_core::{
@@ -23,6 +26,34 @@ fn scan_options() -> ScanOptions {
         no_ignore_vcs: false,
         treat_doc_strings_as_comments: false,
     }
+}
+
+fn auto_scan_options() -> ScanOptions {
+    ScanOptions {
+        config: ConfigMode::Auto,
+        ..scan_options()
+    }
+}
+
+static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+struct RestoreCurrentDir(PathBuf);
+
+impl Drop for RestoreCurrentDir {
+    fn drop(&mut self) {
+        let _ = env::set_current_dir(&self.0);
+    }
+}
+
+fn with_current_dir<T>(path: &Path, f: impl FnOnce() -> T) -> T {
+    let _lock = CWD_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("cwd lock");
+    let original = env::current_dir().expect("current dir");
+    env::set_current_dir(path).expect("set current dir");
+    let _restore = RestoreCurrentDir(original);
+    f()
 }
 
 fn write_file(root: &Path, rel: &str, contents: &str) {
@@ -75,6 +106,19 @@ fn lang_workflow_from_inputs_matches_path_workflow_report() -> Result<()> {
         actual.scan.paths,
         vec!["crates/app/src/lib.rs", "src/main.rs", "tests/basic.py"]
     );
+
+    Ok(())
+}
+
+#[test]
+fn lang_workflow_from_inputs_clamps_scan_config_to_none() -> Result<()> {
+    let receipt = lang_workflow_from_inputs(
+        &fixture_inputs(),
+        &auto_scan_options(),
+        &LangSettings::default(),
+    )?;
+
+    assert_eq!(receipt.scan.config, ConfigMode::None);
 
     Ok(())
 }
@@ -186,9 +230,15 @@ fn analyze_workflow_from_inputs_uses_logical_inputs_and_populates_estimate_recei
 
     assert_eq!(actual_derived.totals.files, 3);
     assert_eq!(actual_derived.totals.code, 3);
+    assert_eq!(actual_derived.totals.comments, 1);
+    assert_eq!(actual_derived.totals.blanks, 0);
+    assert_eq!(actual_derived.totals.lines, 4);
     assert!(actual_derived.totals.bytes > 0);
     assert!(actual_derived.totals.tokens > 0);
     assert_eq!(effort.size_basis.total_lines, actual_derived.totals.code);
+    assert_eq!(effort.size_basis.authored_lines, 3);
+    assert_eq!(effort.size_basis.generated_lines, 0);
+    assert_eq!(effort.size_basis.vendored_lines, 0);
     assert!(effort.results.effort_pm_p50 > 0.0);
     assert_eq!(effort.model.to_string(), "cocomo81-basic");
     assert_eq!(
@@ -213,6 +263,78 @@ fn analyze_workflow_from_inputs_uses_logical_inputs_and_populates_estimate_recei
             .iter()
             .all(|path| !path.contains("\\temp\\"))
     );
+
+    Ok(())
+}
+
+#[cfg(feature = "analysis")]
+#[test]
+fn analyze_workflow_from_inputs_ignores_ambient_tokei_config_files() -> Result<()> {
+    let analyze = AnalyzeSettings {
+        preset: "estimate".to_string(),
+        ..Default::default()
+    };
+    let inputs = vec![
+        InMemoryFile::new(".hidden/secret.py", "print('hidden')\n"),
+        InMemoryFile::new("src/main.rs", "fn main() {}\n"),
+    ];
+    let hostile_dir = TempDir::new()?;
+    write_file(hostile_dir.path(), "tokei.toml", "hidden = true\n");
+
+    let expected = analyze_workflow_from_inputs(&inputs, &scan_options(), &analyze)?;
+    let actual = with_current_dir(hostile_dir.path(), || {
+        analyze_workflow_from_inputs(&inputs, &auto_scan_options(), &analyze)
+    })?;
+    let expected_derived = expected
+        .derived
+        .as_ref()
+        .expect("estimate should populate derived metrics");
+    let actual_derived = actual
+        .derived
+        .as_ref()
+        .expect("estimate should populate derived metrics");
+    let expected_effort = expected
+        .effort
+        .as_ref()
+        .expect("estimate should produce effort");
+    let actual_effort = actual
+        .effort
+        .as_ref()
+        .expect("estimate should produce effort");
+
+    assert_eq!(actual_derived.totals.files, 1);
+    assert_eq!(actual_derived.totals.code, 1);
+    assert_eq!(
+        actual_derived.totals.comments,
+        expected_derived.totals.comments
+    );
+    assert_eq!(actual_derived.totals.blanks, expected_derived.totals.blanks);
+    assert_eq!(actual_derived.totals.lines, expected_derived.totals.lines);
+    assert_eq!(actual_effort.size_basis.total_lines, 1);
+    assert_eq!(actual_effort.size_basis.authored_lines, 1);
+    assert_eq!(actual_effort.size_basis.generated_lines, 0);
+    assert_eq!(actual_effort.size_basis.vendored_lines, 0);
+    assert_eq!(
+        actual_effort.size_basis.total_lines,
+        expected_effort.size_basis.total_lines
+    );
+    assert_eq!(
+        actual_effort.size_basis.authored_lines,
+        expected_effort.size_basis.authored_lines
+    );
+    assert_eq!(
+        actual_effort.size_basis.generated_lines,
+        expected_effort.size_basis.generated_lines
+    );
+    assert_eq!(
+        actual_effort.size_basis.vendored_lines,
+        expected_effort.size_basis.vendored_lines
+    );
+    assert_eq!(
+        actual.source.inputs,
+        vec![".hidden/secret.py".to_string(), "src/main.rs".to_string()]
+    );
+    assert!(actual.source.inputs.iter().all(|path| !path.contains('\\')));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `tokmd_core::analyze_workflow_from_inputs` on top of the new in-memory scan/export path
- keep logical input paths normalized in `AnalysisSource.inputs` while preserving a readable materialized root for file-based enrichers
- clamp all `*_workflow_from_inputs` scan config handling to `ConfigMode::None` so ordered in-memory inputs are deterministic and do not depend on ambient `tokei.toml` / `.tokeirc` discovery
- add focused coverage for the `estimate` and `health` presets, plus a hostile-cwd regression test for ambient scan config leaks

## Verification
- cargo fmt-check
- cargo test -q -p tokmd-core --features analysis --test in_memory_w80
- cargo test -q -p tokmd-core --features analysis
- cargo clippy -q -p tokmd-core --tests --features analysis -- -D warnings
