### PR TITLE
build: update rustls-webpki to 0.103.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,9 +2564,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- refresh Cargo.lock to pick up ustls-webpki 0.103.10
- clear RUSTSEC-2026-0049 from the workspace advisory lane
- keep the fix isolated from the in-memory 1.9.0 feature PRs

## Verification
- cargo deny check advisories
- cargo test -q -p tokmd --test schema_validation
- cargo test -q -p tokmd --test schema_doc_sync
- cargo fmt-check