### PR TITLE
compat: fix no-default-features build for tokmd-cockpit 🧷 Compat

### DIFF
--- a/.jules/compat/envelopes/7df7dfc4-fa15-41eb-809b-835a445c8722.json
+++ b/.jules/compat/envelopes/7df7dfc4-fa15-41eb-809b-835a445c8722.json
@@ -1,0 +1,23 @@
+{
+  "run_id": "7df7dfc4-fa15-41eb-809b-835a445c8722",
+  "timestamp": "2026-03-22T09:33:27Z",
+  "description": "Fix dead_code warning on compute_risk_owned in tokmd-cockpit during no-default-features build",
+  "receipts": [
+    {
+      "command": "cargo check -p tokmd-cockpit --no-default-features",
+      "output": "    Checking tokmd-cockpit v1.8.1 (/app/crates/tokmd-cockpit)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.70s"
+    },
+    {
+      "command": "cargo clippy -p tokmd-cockpit --no-default-features -- -D warnings",
+      "output": "    Checking tokmd-cockpit v1.8.1 (/app/crates/tokmd-cockpit)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.90s"
+    },
+    {
+      "command": "cargo test -p tokmd-cockpit --no-default-features",
+      "output": "test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s"
+    },
+    {
+      "command": "cargo test -p tokmd-cockpit --all-features",
+      "output": "test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s"
+    }
+  ]
+}

--- a/.jules/compat/ledger.json
+++ b/.jules/compat/ledger.json
@@ -3,5 +3,10 @@
     "run_id": "c334b849-39bc-4437-bfd5-7ec9e732765e",
     "timestamp": "2026-03-17T09:40:38Z",
     "description": "Fix dead_code warning in tokmd tests during no-default-features build"
+  },
+  {
+    "run_id": "7df7dfc4-fa15-41eb-809b-835a445c8722",
+    "timestamp": "2026-03-22T09:33:27Z",
+    "description": "Fix dead_code warning on compute_risk_owned in tokmd-cockpit during no-default-features build"
   }
 ]

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -2082,6 +2082,7 @@ pub fn compute_risk(file_stats: &[FileStat], contracts: &Contracts, health: &Cod
 }
 
 /// Internal fast path used by cockpit assembly when it already owns the stats.
+#[cfg(feature = "git")]
 fn compute_risk_owned(
     file_stats: Vec<FileStat>,
     contracts: &Contracts,


### PR DESCRIPTION
## 💡 Summary
Added `#[cfg(feature = "git")]` feature gate to `compute_risk_owned` in `crates/tokmd-cockpit/src/lib.rs` to fix a `dead_code` warning that occurred during `--no-default-features` builds.

## 🎯 Why / Threat model
When `tokmd-cockpit` was built without the `git` feature, `compute_cockpit` (which is gated by `git` feature) was excluded. This left the helper function `compute_risk_owned` unused, causing a `dead_code` warning. Ensuring clean `--no-default-features` builds prevents CI noise and maintains matrix compatibility.

## 🔎 Finding (evidence)
Observed in `cargo clippy --no-default-features -p tokmd-cockpit -- -D warnings`:
```
error: function `compute_risk_owned` is never used
    --> crates/tokmd-cockpit/src/lib.rs:2085:4
     |
2085 | fn compute_risk_owned(
     |    ^^^^^^^^^^^^^^^^^^
     |
     = note: `-D dead-code` implied by `-D warnings`
     = help: to override `-D warnings` add `#[expect(dead_code)]` or `#[allow(dead_code)]`

error: could not compile `tokmd-cockpit` (lib) due to 1 previous error
```

## 🧭 Options considered
### Option A (recommended)
- What it is: Add `#[cfg(feature = "git")]` to `compute_risk_owned`.
- Why it fits this repo: Cleanest way to solve dead code warning conditionally.
- Trade-offs: Structure / Velocity / Governance: Zero risk of regression.

### Option B
- What it is: Allow dead code for the function.
- When to choose it instead: If the function might be consumed by non-git paths in the future.
- Trade-offs: Degrades code quality by masking true dead code.

## ✅ Decision
Option A chosen and implemented as it directly solves the matrix incompatibility cleanly.

## 🧱 Changes made (SRP)
- `crates/tokmd-cockpit/src/lib.rs`: added `#[cfg(feature = "git")]` to `compute_risk_owned`.

## 🧪 Verification receipts
```json
{
  "run_id": "7df7dfc4-fa15-41eb-809b-835a445c8722",
  "timestamp": "2026-03-22T09:33:27Z",
  "description": "Fix dead_code warning on compute_risk_owned in tokmd-cockpit during no-default-features build",
  "receipts": [
    {
      "command": "cargo check -p tokmd-cockpit --no-default-features",
      "output": "    Checking tokmd-cockpit v1.8.1 (/app/crates/tokmd-cockpit)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.70s"
    },
    {
      "command": "cargo clippy -p tokmd-cockpit --no-default-features -- -D warnings",
      "output": "    Checking tokmd-cockpit v1.8.1 (/app/crates/tokmd-cockpit)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.90s"
    },
    {
      "command": "cargo test -p tokmd-cockpit --no-default-features",
      "output": "test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s"
    },
    {
      "command": "cargo test -p tokmd-cockpit --all-features",
      "output": "test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s"
    }
  ]
}
```

## 🧭 Telemetry
- Change shape: Minor refactor
- Blast radius (API / IO / config / schema / concurrency): None.
- Risk class + why: Low, pure feature gate.
- Rollback: Safe to revert.
- Merge-confidence gates (what ran): Cargo check, clippy and tests against the target crate.

## 🗂️ .jules updates
- Appended run envelope at `.jules/compat/envelopes/7df7dfc4-fa15-41eb-809b-835a445c8722.json`
- Added entry to `.jules/compat/ledger.json`

## 📝 Notes (freeform)

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [16282204140581017982](https://jules.google.com/task/16282204140581017982) started by @EffortlessSteven*