### PR TITLE
fix: harden env shebangs and runner wasm boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         run: wasm-pack test --node crates/tokmd-wasm --features analysis
       - name: Build browser runner wasm bundle
         run: npm --prefix web/runner run build:wasm
-      - name: Browser runner protocol smoke
+      - name: Browser runner protocol and wasm boot smoke
         run: npm --prefix web/runner test
       - name: Browser runner syntax check
         run: npm --prefix web/runner run check

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -104,11 +104,74 @@ fn language_from_in_memory_shebang(bytes: &[u8]) -> Option<LanguageType> {
 
     let mut words = first_line.split_whitespace();
     if words.next() == Some("#!/usr/bin/env") {
-        let interpreter = words.find(|word| !word.starts_with('-') && !word.contains('='))?;
+        let interpreter = env_interpreter_token(words)?;
         return language_from_env_interpreter(interpreter);
     }
 
     None
+}
+
+fn env_interpreter_token<'a>(words: impl Iterator<Item = &'a str>) -> Option<&'a str> {
+    let mut skip_next = false;
+
+    for word in words {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+
+        if word.is_empty() {
+            continue;
+        }
+
+        if looks_like_env_assignment(word) {
+            continue;
+        }
+
+        match word {
+            "-S" | "--split-string" | "-i" | "--ignore-environment" => continue,
+            "-u" | "--unset" | "-C" | "--chdir" | "-P" | "--default-path" | "-a" | "--argv0"
+            | "--default-signal" | "--ignore-signal" | "--block-signal" => {
+                skip_next = true;
+                continue;
+            }
+            _ if word.starts_with("--unset=")
+                || word.starts_with("--chdir=")
+                || word.starts_with("--default-path=")
+                || word.starts_with("--argv0=")
+                || word.starts_with("--default-signal=")
+                || word.starts_with("--ignore-signal=")
+                || word.starts_with("--block-signal=") =>
+            {
+                continue;
+            }
+            _ if word.starts_with('-') => continue,
+            _ => return Some(word),
+        }
+    }
+
+    None
+}
+
+fn looks_like_env_assignment(word: &str) -> bool {
+    let Some((name, _)) = word.split_once('=') else {
+        return false;
+    };
+
+    if name.is_empty() {
+        return false;
+    }
+
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
 fn language_from_env_interpreter(interpreter: &str) -> Option<LanguageType> {

--- a/crates/tokmd-model/tests/in_memory_rows_w82.rs
+++ b/crates/tokmd-model/tests/in_memory_rows_w82.rs
@@ -108,3 +108,47 @@ fn collect_in_memory_file_rows_supports_env_split_string_shebangs() {
     assert_eq!(actual.len(), 1);
     assert_eq!(actual[0].lang, LanguageType::Python.name());
 }
+
+#[test]
+fn collect_in_memory_file_rows_supports_env_assignment_prefixes() {
+    let inputs = vec![InMemoryRowInput::new(
+        Path::new("script"),
+        b"#!/usr/bin/env VAR=1 python3\nprint('ok')\n",
+    )];
+    let actual = collect_in_memory_file_rows(
+        &inputs,
+        &[],
+        1,
+        ChildIncludeMode::Separate,
+        &Config::default(),
+    );
+
+    assert_eq!(actual.len(), 1);
+    assert_eq!(actual[0].lang, LanguageType::Python.name());
+}
+
+#[test]
+fn collect_in_memory_file_rows_supports_env_flags_with_values() {
+    let inputs = vec![
+        InMemoryRowInput::new(
+            Path::new("script"),
+            b"#!/usr/bin/env -u PYTHONPATH python3\nprint('ok')\n",
+        ),
+        InMemoryRowInput::new(
+            Path::new("shell-script"),
+            b"#!/usr/bin/env -i bash\necho ok\n",
+        ),
+    ];
+    let actual = collect_in_memory_file_rows(
+        &inputs,
+        &[],
+        1,
+        ChildIncludeMode::Separate,
+        &Config::default(),
+    );
+
+    assert_eq!(actual.len(), 2);
+    let langs: Vec<&str> = actual.iter().map(|row| row.lang.as_str()).collect();
+    assert!(langs.contains(&LanguageType::Python.name()));
+    assert!(langs.contains(&LanguageType::Bash.name()));
+}

--- a/web/runner/worker.js
+++ b/web/runner/worker.js
@@ -4,6 +4,7 @@ import { handleRunnerMessage } from "./runtime.js";
 let emitMessage;
 let subscribe;
 let nodeWorkerData = null;
+let isNodeWorker = false;
 
 if (
     typeof globalThis.postMessage === "function" &&
@@ -17,6 +18,7 @@ if (
     };
 } else {
     const { parentPort, workerData } = await import("node:worker_threads");
+    isNodeWorker = true;
     nodeWorkerData = workerData;
 
     emitMessage = (message) => parentPort.postMessage(message);
@@ -74,8 +76,13 @@ async function loadTokmdRunner() {
 
     const moduleUrl = new URL("./vendor/tokmd-wasm/tokmd_wasm.js", import.meta.url);
     const wasmModule = await import(moduleUrl.href);
-
-    await wasmModule.default();
+    if (isNodeWorker) {
+        const { readFile } = await import("node:fs/promises");
+        const wasmUrl = new URL("./vendor/tokmd-wasm/tokmd_wasm_bg.wasm", import.meta.url);
+        await wasmModule.default({ module_or_path: await readFile(wasmUrl) });
+    } else {
+        await wasmModule.default();
+    }
 
     return {
         runLang(args) {

--- a/web/runner/worker.test.mjs
+++ b/web/runner/worker.test.mjs
@@ -1,8 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import { Worker } from "node:worker_threads";
 
 import { MESSAGE_TYPES } from "./messages.js";
+
+const HAS_REAL_WASM_BUNDLE =
+    existsSync(new URL("./vendor/tokmd-wasm/tokmd_wasm.js", import.meta.url)) &&
+    existsSync(new URL("./vendor/tokmd-wasm/tokmd_wasm_bg.wasm", import.meta.url));
 
 function onceMessage(worker) {
     return new Promise((resolve, reject) => {
@@ -74,3 +79,45 @@ test("worker forwards run messages through the runtime", async () => {
         await worker.terminate();
     }
 });
+
+test(
+    "worker boots the real tokmd-wasm bundle when it has been built",
+    async (t) => {
+        if (!HAS_REAL_WASM_BUNDLE) {
+            t.skip("built tokmd-wasm bundle not present");
+        }
+
+        const worker = new Worker(new URL("./worker.js", import.meta.url), {
+            type: "module",
+        });
+
+        try {
+            const ready = await onceMessage(worker);
+
+            assert.equal(ready.type, MESSAGE_TYPES.READY);
+            assert.equal(ready.capabilities.wasm, true);
+            assert.notEqual(ready.engine.version, "stub");
+            assert.ok(ready.engine.schemaVersion > 0);
+
+            worker.postMessage({
+                type: "run",
+                requestId: "run-real-lang",
+                mode: "lang",
+                args: {
+                    inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+                    files: true,
+                },
+            });
+
+            const result = await onceMessage(worker);
+
+            assert.equal(result.type, MESSAGE_TYPES.RESULT);
+            assert.equal(result.requestId, "run-real-lang");
+            assert.equal(result.data.mode, "lang");
+            assert.equal(result.data.total.files, 1);
+            assert.equal(result.data.scan.paths[0], "src/lib.rs");
+        } finally {
+            await worker.terminate();
+        }
+    }
+);


### PR DESCRIPTION
## Summary
- harden in-memory `/usr/bin/env` shebang parsing for env assignments and flag/value pairs before interpreter detection
- add regression coverage for env assignment prefixes and env flags with values in the pure in-memory path
- make the browser-runner worker boot the generated wasm bundle in Node by passing wasm bytes explicitly
- add a real non-stub worker smoke that exercises the built `web/runner/vendor/tokmd-wasm` path in CI
- clarify the CI step name so it reflects real wasm boot coverage, not just stub protocol coverage

## Verification
- cargo test -q -p tokmd-model --test in_memory_rows_w82
- cargo clippy -q -p tokmd-model --tests -- -D warnings
- npm --prefix web/runner run build:wasm
- npm --prefix web/runner test
- npm --prefix web/runner run check
- cargo fmt-check