### PR TITLE
docs: reset browser and wasm status after 1.9.0 slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - **Derived analysis**: doc density, test density, hotspots, coupling, freshness, and effort estimation.
 - **Review workflows**: `diff`, `cockpit`, `gate`, `baseline`, and `sensor.report.v1` output.
 - **LLM workflows**: `context` packing, `handoff` bundles, token estimates, redaction, and smart excludes.
+- **Browser/WASM workflows**: `tokmd-wasm` plus `web/runner` for local browser `lang`, `module`, `export`, and `analyze` (`receipt`, `estimate`) on ordered in-memory inputs.
 - **Cross-platform behavior**: Windows/Linux/macOS-friendly outputs, release automation, and repo-native CI usage.
 
 ## Why Deterministic Matters
@@ -251,7 +252,19 @@ See the [CLI Reference](docs/reference-cli.md#configuration-file) for the full c
 - **`tokmd-core`** is the clap-free facade for embedding workflows in Rust or via FFI.
 - **Python bindings** live in `crates/tokmd-python`.
 - **Node bindings** live in `crates/tokmd-node`.
+- **`tokmd-wasm`** exposes browser/worker bindings for `lang`, `module`, `export`, and browser-safe `analyze` (`receipt`, `estimate`).
+- **`web/runner`** is the static browser shell that boots the real wasm bundle in a worker and can load public GitHub repos through the tree+contents APIs.
 - **Tool-schema output** is available through `tokmd tools` for agent/tool consumers.
+
+## Browser/WASM Status
+
+Browser support is real now, but intentionally narrower than the full native CLI surface.
+
+- Supported today: `lang`, `module`, `export`, and `analyze` with `receipt` or `estimate` on ordered in-memory `{ path, text }` inputs.
+- Public repo acquisition uses the browser-safe GitHub tree and contents APIs, with deterministic ordering and browser-side size/file limits.
+- Unsupported today: zipball fetch as the primary browser path, git-history enrichers, broader filesystem-backed analyze presets, and real cancel/progress flows.
+
+See [crates/tokmd-wasm/README.md](crates/tokmd-wasm/README.md) and [web/runner/README.md](web/runner/README.md) for the current browser contract.
 
 ## Installation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ This document outlines the evolution of `tokmd` and the path forward.
 | **v1.7.2** | ✅ Complete | Near-dup enricher extraction, commit intent classification, and CI fixes. |
 | **v1.7.x** | ✅ Complete | Deep test expansion across the workspace, sensor determinism, and the first `tokmd-io-port` seam. |
 | **v1.8.0** | ✅ Complete | Effort estimation, estimate preset/reporting, `tokmd-io-port` seam work, and release/devex hardening. |
-| **v1.9.0** | 🔭 Planned  | Finish WASM-ready core + browser runner: in-memory scan, wasm CI, zipball ingestion |
+| **v1.9.0** | 🚧 In progress | Browser/WASM productization: parity-covered wasm entrypoints, browser runner MVP, and public repo ingestion via tree+contents |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
 | **v3.0.0** | 🔭 Long-term | Tree-sitter AST integration (requires significant R&D).      |
 | **v4.0.0** | 🔭 Long-term | Adze AST integration.      |
@@ -476,27 +476,37 @@ UX work is explicitly **incremental and non-breaking**:
 
 - The full in-memory scan path and wasm CI parity work did not fully land in `1.8.0`; that continuation is now the next milestone instead of implicit spillover.
 
-## Planned: v1.9.0 — Finish WASM-Ready Core + Browser Runner
+## In Progress: v1.9.0 — Browser/WASM Productization
 
-**Goal:** Complete the in-memory/WASM execution path and provide a browser-first runner that can generate deterministic receipts locally from a fetched repo archive.
+**Goal:** Finish the browser/WASM product surface around the already-landed in-memory execution path and make the supported browser workflow explicit, repeatable, and capability-honest.
 
-### Work items
+### What has landed so far
 
-- Wire `tokmd-io-port` through scan and walk paths so scans can run entirely from a host-provided in-memory substrate.
-- Add an in-memory scan pipeline that accepts ordered `(path, bytes)` inputs and preserves deterministic output.
-- Keep CLI/Clap separation hard so lower-tier library crates stay free of OS-bound argument types.
-- Add a `wasm`/`web` feature profile and CI builds for `wasm32-unknown-unknown`, plus conformance tests against native output.
-- `tokmd-wasm` crate: expose JS-friendly APIs (via `wasm-bindgen`) for `run_lang`, `run_module`, `run_export`, and `run_analyze`.
-- Browser runner (static app): minimal web UI (repo URL + ref + Run), Web Worker execution, progress updates, cancel, and artifact download.
-- Zipball ingestion: fetch `https://api.github.com/repos/{owner}/{repo}/zipball/{ref}`, unzip in-browser, filter files, and feed `(path, bytes)` to wasm.
-- Caching & guardrails: IndexedDB cache keyed by `(repo,ref,options)`, ETag support, and hard limits for archive size, file count, and bytes read.
-- Capability reporting: outputs include a capabilities section describing what ran and what was unavailable (for example, git-history metrics).
-- Packaging & distribution: publish the WASM bundle as a pinned artifact (GitHub release / npm) for the web app to consume.
+- [x] `tokmd-io-port`, in-memory scan/model/core workflow seams, and lower-tier clap-free boundaries now keep browser/WASM execution honest.
+- [x] `tokmd-wasm` exposes browser-friendly entrypoints for `lang`, `module`, `export`, and browser-safe `analyze`.
+- [x] Native-vs-wasm parity coverage now exists for `lang`, `module`, `export`, `analyze receipt`, and `analyze estimate`.
+- [x] `web/runner` now boots the real `tokmd-wasm` bundle in a dedicated worker, reports capabilities, renders the latest successful result, and supports JSON download.
+- [x] Public GitHub repo acquisition now uses the browser-safe GitHub tree and contents APIs to materialize deterministic ordered inputs locally in the page.
+
+### Supported browser-safe surface today
+
+- Browser/WASM modes: `lang`, `module`, `export`
+- Browser/WASM analyze presets: `receipt`, `estimate`
+- Public repo acquisition strategy: GitHub tree + contents API, not zipball fetch
+- Capability reporting is explicit about unavailable host-backed enrichers and reserved protocol features
+
+### Remaining for v1.9.0
+
+- Package and publish the `tokmd-wasm` bundle through one pinned, documented distribution path.
+- Finish the docs truth pass so README and architecture docs match the shipped browser/WASM surface.
+- Add browser guardrails and UX hardening such as caching, progress, authenticated fetch options, and better rate-limit handling.
+- Expand browser-safe analysis only where the preset can stay rootless and capability-honest.
 
 ### Non-goals for v1.9
 
-- No git-history churn/hotspot metrics in browser mode (offer backend escape hatch later).
-- No mutation testing or heavy tooling in-browser.
+- No browser-side git-history churn/hotspot metrics; keep those as explicit capability misses or backend follow-ups.
+- No browser zipball ingestion as the primary supported path for `v1.9.0`; tree+contents is the supported browser acquisition strategy.
+- No mutation testing or other heavy tooling in-browser.
 
 ## Future Horizons
 

--- a/crates/tokmd-wasm/README.md
+++ b/crates/tokmd-wasm/README.md
@@ -6,6 +6,10 @@ It exposes thin `wasm-bindgen` bindings over `tokmd-core`'s JSON API so browser
 and worker callers can run `lang`, `module`, `export`, and `analyze` against
 ordered in-memory inputs without going through the CLI.
 
+The current browser acquisition story lives one layer up in `web/runner`, which
+materializes public GitHub repos through the tree and contents APIs before
+dispatching those ordered in-memory inputs into `tokmd-wasm`.
+
 Analyze entrypoints are intentionally narrower today: only
 `preset: "receipt"` and `preset: "estimate"` are browser-safe in the wasm
 wrapper. Richer analyze presets still depend on the filesystem-backed scan

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,30 +264,34 @@ among many (cargo-deny, cargo-audit, etc.) in a CI/CD fleet.
 3. **Clap-free settings**: Lower-tier crates use `ScanOptions` from `tokmd-settings`, not `GlobalArgs`
 4. **Finding identity**: `(check_id, code)` tuples enable category-based routing for buildfix automation
 
-## WASM & Browser Runner (post-1.8.0 horizon)
+## WASM & Browser Runner (v1.9.0 in progress)
 
-### Foundation Landed in v1.8.0
+### Landed foundation and product surface
 
-`1.8.0` did not finish the full browser/WASM milestone, but it did land the core seam work needed to keep that path real:
+The browser/WASM lane is no longer just seam work:
 
-- `tokmd-io-port` introduces host-abstracted file access with `HostFs`, `ReadFs`, and `MemFs`.
-- Feature-stability tests keep lower tiers honest around clap-free and WASM-friendly boundaries.
-- The release/devex hardening work keeps CI and release automation boring enough that a future wasm lane can be added without compounding operator noise.
+- `tokmd-io-port` plus the in-memory scan/model/core workflow paths keep lower tiers host-abstracted and deterministic on ordered in-memory inputs.
+- `tokmd-wasm` now exposes the browser-facing `lang`, `module`, `export`, and browser-safe `analyze` entrypoints.
+- CI includes wasm compile/tests plus native-vs-wasm parity coverage for the browser-safe modes.
+- `web/runner` now boots the real wasm bundle in a dedicated worker, renders capabilities, shows the latest successful result, and supports JSON download.
+- Public browser repo loading now uses the GitHub tree and contents APIs to materialize ordered `{ path, text }` inputs locally.
 
-### Next: v1.9.0 — Finish WASM-Ready Core + Browser Runner
+### Supported browser-safe contract today
 
-Goal: Complete the in-memory/WASM execution path and expose it through a browser-first runner that produces deterministic receipts locally.
+- Modes: `lang`, `module`, `export`
+- Analyze presets: `receipt`, `estimate`
+- Input contract: ordered in-memory rows, not filesystem paths
+- Acquisition strategy: GitHub tree + contents API, not zipball fetch
 
-Work items:
-- Wire `tokmd-io-port` through scan and walk paths so scans can run against a host-provided in-memory substrate instead of only filesystem `PathBuf`s.
-- Add an in-memory scan pipeline that accepts `(path, bytes)` inputs and preserves deterministic ordering and capability reporting.
-- Keep CLI/Clap separation strict so the library surface stays free of OS-bound argument types.
-- Add a `wasm`/`web` feature profile and CI builds for `wasm32-unknown-unknown`, plus parity tests against the native engine.
-- Harden the new `tokmd-wasm` crate so its JS-friendly APIs for `lang`, `module`, `export`, and `analyze` are ready for browser packaging.
-- Build a minimal browser runner that fetches a GitHub zipball, unpacks in a Worker, runs tokmd locally, and supports progress/cancel/download flows.
-- Add caching and guardrails: IndexedDB cache keyed by `(repo,ref,options)`, ETag support, and hard limits for archive size, file count, and bytes read.
-- Publish the WASM bundle as a pinned artifact (GitHub Release / npm) for the web app to consume.
+Host-backed enrichers remain explicit capability misses in browser mode. Git-history signals such as hotspots and churn are intentionally unavailable there today.
 
-Notes: Git-history enrichers (hotspots/churn) are not available in browser WASM mode and must be reported as unavailable in capability reporting.
+### Remaining v1.9.0 work
 
-Non-goals for v1.9.0: no in-browser git churn/hotspot metrics or heavy tooling; provide a backend escape hatch for very large repos or git-based analysis.
+- Publish the `tokmd-wasm` bundle through one pinned distribution path for the runner to consume repeatably.
+- Add browser guardrails such as caching, authenticated fetch options, and better rate-limit/progress handling.
+- Broaden browser analysis only where the preset can stay rootless and capability-honest.
+
+### Non-goals for v1.9.0
+
+- No browser-side git-history churn/hotspot metrics or other heavy host tooling.
+- No browser zipball ingestion as the primary supported path while tree+contents is the stable browser-safe acquisition strategy.

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -1,13 +1,14 @@
 # Browser Runner
 
-`web/runner` is the first browser-facing slice for `tokmd` `1.9.0`.
+`web/runner` is the browser-facing `tokmd` slice for the current `1.9.0` lane.
 
 It now boots `tokmd-wasm` inside a dedicated worker and runs the in-memory
 `lang`, `module`, `export`, and rootless `analyze` (`receipt` / `estimate`)
 paths locally in the browser. Public GitHub repo acquisition now uses the
 browser-safe GitHub tree and contents APIs to materialize ordered in-memory
-inputs before dispatching into the worker. Zipball fetch, progress, and cancel
-still come later, but the worker contract and wasm bootstrap are live now.
+inputs before dispatching into the worker. Zipball fetch remains out of the
+current browser contract, and progress/cancel are still later work, but the
+worker contract and wasm bootstrap are live now.
 
 ## Files
 
@@ -41,6 +42,8 @@ Current behavior:
   files, and materialize `inputs` rows directly into the request editor
 - public repo fetches use unauthenticated browser GitHub API calls, so they are
   subject to GitHub rate limits for anonymous requests
+- analyze presets beyond `receipt` / `estimate` are intentionally rejected in
+  browser mode instead of degrading silently
 - `run` validates the request shape and executes the corresponding `tokmd-wasm`
   entrypoint
 - `cancel` is reserved in the protocol but returns `cancel_unavailable` for now


### PR DESCRIPTION
## Summary
- reset the public browser/WASM story after the landed #769-#771 slices
- move 1.9.0 from planned zipball wording to in-progress browser/WASM productization
- document the supported browser-safe surface: lang, module, xport, and nalyze with eceipt / stimate
- make GitHub tree + contents the official browser acquisition path in the public docs instead of zipball fetch

## Verification
- cargo run -q -p xtask -- docs --check
- cargo test -q -p tokmd --test docs_sync_w72
- typos README.md ROADMAP.md docs/architecture.md crates/tokmd-wasm/README.md web/runner/README.md
