### PR TITLE
docs: add contributor-facing architecture overview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,122 +1,85 @@
-# Architecture: AI-Native Crate Design
+# Architecture Overview
 
-## Why 45 Crates?
+`tokmd` uses a tiered microcrate workspace. That is deliberate.
 
-This repository uses fine-grained crate decomposition optimized for AI agent development, not human developer convenience.
+The project ships a CLI, library facade, Python/Node bindings, and a browser
+WASM surface over the same deterministic receipt model. Small crates keep those
+surfaces composable, reduce blast radius, and make it easier to isolate optional
+host-backed capabilities from pure data and analysis logic.
 
-### Design Rationale
+The exact crate count changes over time. The important constraint is not "how
+many crates", but whether each crate has a clear boundary and fits the tier
+rules below.
 
-**Unix Philosophy for AI Agents**
-- Each crate has one focused responsibility (SRP enforced at crate boundary)
-- Agents can reason about narrow scope → clearer tool selection
-- Independent versioning enables precise dependency tracking
+## Tier Model
 
-**Agent Workflow Optimization**
-- Smaller context windows per crate (fits easily in agent working memory)
-- Clear scope boundaries → agents know exactly which crate to use
-- Composable tools → agents chain focused crates rather than navigating monolithic APIs
-- Independent reasoning → "I need complexity metrics" → `tokmd-analysis-complexity`
+The canonical detailed inventory lives in [docs/architecture.md](docs/architecture.md).
+At a high level:
 
-**Tradeoffs Acknowledged**
-- ✅ Benefit: Agent clarity, focused scope, composable tooling
-- ⚠️ Cost: Cargo workspace overhead, dependency duplication in Cargo.toml files
-- ⚠️ Cost: Human developers see "crate proliferation" as friction
+- Tier 0: pure contracts and shared DTOs such as `tokmd-types`,
+  `tokmd-analysis-types`, `tokmd-settings`, `tokmd-envelope`, and
+  `tokmd-io-port`
+- Tier 1: core processing such as scanning, modeling, math, path/module-key
+  derivation, redaction, and settings-to-scan translation
+- Tier 2: adapters such as formatting, file walking, content scanning, git, and
+  badge/progress helpers
+- Tier 3: orchestration crates such as `tokmd-analysis`, its focused enrichers,
+  `tokmd-cockpit`, and `tokmd-gate`
+- Tier 4: facades such as `tokmd-config`, `tokmd-core`, `tokmd-ffi-envelope`,
+  and `tokmd-tool-schema`
+- Tier 5: products such as the CLI and language/browser bindings
 
-This is intentional: we optimize for agentic development workflows, not traditional human-only development.
+## Why This Shape Exists
 
-## Crate Discovery Patterns for Agents
+- Deterministic receipts are the product boundary, so low-level contracts stay
+  small and reusable.
+- Optional capabilities like git, content scanning, filesystem walking, and UI
+  helpers are easier to keep honest when they sit behind explicit crate and
+  feature boundaries.
+- The same core workflows need to serve CLI, FFI, and browser/WASM callers
+  without pulling clap or host-only assumptions into lower tiers.
+- Smaller crates are easier to test, fuzz, mutation-check, and evolve without
+  dragging unrelated surfaces along.
 
-### How Agents Select Crates
+This structure helps both human contributors and automated tooling. It is not a
+claim that every tiny distinction deserves a new crate forever.
 
-1. **By metric type**: `tokmd-analysis-*` crates are named by metric (complexity, entropy, halstead, fingerprint)
-2. **By function**: `tokmd-scan` for scanning, `tokmd-walk` for traversal, `tokmd-path` for normalization
-3. **By output**: `tokmd-receipts` for evidence generation, `tokmd-report` for formatting
+## Architecture Rules
 
-### Crate Categories
+- Contracts stay clap-free and as pure as possible.
+- Lower tiers do not depend on higher tiers.
+- Optional host-backed behavior is feature-gated and capability-honest.
+- Ordered inputs, normalized paths, and stable sorting take priority over local
+  convenience because determinism is part of the user contract.
+- Browser/WASM paths only expose modes that can stay rootless and honest about
+  missing host or git capabilities.
 
-**Analysis Crates** (tokmd-analysis-*):
-- Each implements one metric algorithm
-- Independent versioning (can update halstead without touching entropy)
-- Agents select by metric name
+## When To Add A Crate
 
-**Infrastructure Crates** (tokmd-scan, tokmd-walk, tokmd-path):
-- Filesystem operations
-- Shared utilities
-- Lower-level building blocks
+Add a crate when the boundary is real:
 
-**Governance Crates** (tokmd-gate, tokmd-policy, tokmd-receipts):
-- Policy enforcement
-- Evidence generation
-- CI/CD integration
+- the code has a reusable contract that other tiers or products can consume
+- the dependency set is meaningfully different or optional
+- the feature can be tested and versioned with a focused surface
+- the split improves dependency direction or keeps a lower tier pure
 
-## Crate Boundary Rules
+## When To Keep Code In An Existing Crate
 
-### What Belongs in a New Crate
+Do not create a new crate just because code is long.
 
-✅ Algorithm implementation (one metric, one crate)
-✅ Independent lifecycle (versioned separately)
-✅ Reusable across contexts (not template-specific)
-✅ Clear input/output contract
+Keep code in an existing crate when:
 
-### What Stays in Existing Crates
+- it is only a variation of an existing workflow or preset
+- it always changes in lockstep with its parent crate
+- it is formatter or glue code that does not create a new public boundary
+- the split would add naming and workspace overhead without clarifying ownership
 
-❌ Variations of same algorithm (use feature flags)
-❌ Always-versioned-together code (use modules)
-❌ Template-specific logic (stays in rust-as-spec)
+## Where To Go Deeper
 
-## Agentic Development Workflow
-
-### Typical Agent Session
-
-1. Agent receives task: "Add cyclomatic complexity tracking"
-2. Agent searches for existing complexity crate: `tokmd-analysis-complexity`
-3. Agent examines crate API (small, focused)
-4. Agent implements changes with clear scope
-5. Agent runs tests for that crate only (fast feedback)
-
-### Vs Monolithic Alternative
-
-In a monolithic `tokmd-analysis` crate:
-- Agent must navigate 10x more code
-- Scope unclear (where does complexity logic end?)
-- Tests slower (entire crate must rebuild)
-- Harder to reason about changes
-
-## For Human Contributors
-
-If you're a human developer reading this and thinking "this seems like over-engineering":
-
-**You're right — for human-only development, it would be.**
-
-This architecture is designed for a future where AI agents are primary code authors, and humans are reviewers/orchestrators. The crate boundaries serve agent reasoning, not human IDE navigation.
-
-### Working With This Structure
-
-1. **Don't consolidate crates** for "simplicity" — this breaks agentic workflows
-2. **Do add new crates** for genuinely independent functionality
-3. **Use modules within crates** for sub-structure (not new crates for everything)
-4. **Question boundaries** if crates always version together (may be false granularity)
-
-## Questions & Answers
-
-**Q: Why not use modules instead of crates?**
-
-A: Crates provide compilation boundaries, independent versioning, and clear API surfaces. Modules are invisible to agents as tool selection units.
-
-**Q: Don't agents just read the whole codebase?**
-
-A: No — context windows are limited, and focused crates reduce token usage. Agents work more effectively with narrow scope.
-
-**Q: Will this work for human developers?**
-
-A: Yes, but with friction. Import paths are longer, Cargo.toml has more entries. This is an intentional tradeoff.
-
-**Q: How do I know if something needs a new crate?**
-
-A: Ask: "Does this have independent versioning lifecycle?" and "Would an agent want to use this without the rest?" If yes → new crate.
-
-## Related Documentation
-
-- CONTRIBUTING.md: Development workflow
-- crates/*/README.md: Individual crate documentation
-- docs/agentic-development.md: Agent workflow guides
+- [docs/architecture.md](docs/architecture.md): detailed crate inventory and
+  dependency rules
+- [docs/design.md](docs/design.md): design principles and system context
+- [docs/implementation-plan.md](docs/implementation-plan.md): forward-looking
+  work and sequencing
+- [CONTRIBUTING.md](CONTRIBUTING.md): local workflow, testing, and contribution
+  guidance


### PR DESCRIPTION
## Summary
- add a top-level ARCHITECTURE.md as a short contributor-facing overview
- explain the tiered microcrate model without duplicating the full canonical inventory
- point readers to docs/architecture.md, docs/design.md, and docs/implementation-plan.md for the detailed source of truth

## Notes
- this version removes the earlier stale crate-count and nonexistent-crate claims
- the document now focuses on architecture rules and crate-boundary reasoning rather than a frozen workspace snapshot

## Verification
- cargo run -q -p xtask -- docs --check
- typos ARCHITECTURE.md
- npx -y markdownlint-cli2 ARCHITECTURE.md