### PR TITLE
deps: remove unused console, indicatif, and serde from xtask 🧾 Auditor

### DIFF
--- a/.jules/deps/envelopes/9ce74cba-4438-4a7d-8cf1-502e69ab10b5.json
+++ b/.jules/deps/envelopes/9ce74cba-4438-4a7d-8cf1-502e69ab10b5.json
@@ -1,0 +1,14 @@
+{
+  "run_id": "9ce74cba-4438-4a7d-8cf1-502e69ab10b5",
+  "date": "2026-03-23T11:56:39Z",
+  "persona": "Auditor",
+  "lane": "scout",
+  "target": "xtask",
+  "action": "remove unused dependencies console, indicatif, and serde",
+  "receipts": [
+    "cargo machete output identifying unused dependencies in xtask",
+    "cargo check -p xtask completed successfully",
+    "cargo clippy -p xtask -- -D warnings completed successfully",
+    "cargo fmt --manifest-path xtask/Cargo.toml -- --check completed successfully"
+  ]
+}

--- a/.jules/deps/ledger.json
+++ b/.jules/deps/ledger.json
@@ -49,5 +49,19 @@
       "cargo clippy -p tokmd-node -p tokmd-python -- -D warnings",
       "cargo fmt -- --check"
     ]
+  },
+  {
+    "run_id": "9ce74cba-4438-4a7d-8cf1-502e69ab10b5",
+    "date": "2026-03-23T11:56:39Z",
+    "persona": "Auditor",
+    "lane": "scout",
+    "target": "xtask",
+    "action": "remove unused dependencies console, indicatif, and serde",
+    "receipts": [
+      "cargo machete output identifying unused dependencies in xtask",
+      "cargo check -p xtask completed successfully",
+      "cargo clippy -p xtask -- -D warnings completed successfully",
+      "cargo fmt --manifest-path xtask/Cargo.toml -- --check completed successfully"
+    ]
   }
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4957,11 +4957,8 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
- "console 0.16.3",
- "indicatif",
  "petgraph",
  "semver",
- "serde",
  "serde_json",
  "toml 1.0.7+spec-1.1.0",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 [dependencies]
 anyhow = "1.0.101"
 clap = { version = "4.6.0", features = ["derive"] }
-indicatif = "0.18.3"
-console = "0.16.3"
-serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.0.6"
 cargo_metadata = "0.23.1"
 petgraph = "0.8.3"


### PR DESCRIPTION
## 💡 Summary
Removed the unused dependencies `console`, `indicatif`, and `serde` from the `xtask` workspace crate. 

## 🎯 Why / Threat model
Dependency hygiene reduces the workspace's total dependency tree, speeding up builds and reducing the surface area for potential security vulnerabilities. `cargo-machete` identified these crates as completely unused in `xtask` source code.

## 🔎 Finding (evidence)
- `cargo machete` flagged `console`, `indicatif`, and `serde` as unused in `xtask/Cargo.toml`.
- Searching `xtask/src` for `console`, `indicatif`, and `serde` returned no usages (except `serde_json` which is in `[dev-dependencies]`).

## 🧭 Options considered
### Option A (recommended)
- Remove the unused dependencies from `xtask/Cargo.toml`.
- Why it fits this repo: Keeps the workspace lean and follows the Auditor persona's dependency hygiene mandate.
- Trade-offs: Trivial structural change. Zero impact on runtime velocity.

### Option B
- Ignore them or configure `cargo-machete` to ignore them.
- When to choose it instead: If the dependencies were used in a way the tool missed (e.g., via a macro or undocumented feature).
- Trade-offs: Retains unnecessary bloat in the lockfile and compilation step.

## ✅ Decision
Option A. The dependencies are definitively unused.

## 🧱 Changes made (SRP)
- `xtask/Cargo.toml`: Removed `console`, `indicatif`, and `serde` from `[dependencies]`.

## 🧪 Verification receipts
- `cargo machete output identifying unused dependencies in xtask`
- `cargo check -p xtask completed successfully`
- `cargo clippy -p xtask -- -D warnings completed successfully`
- `cargo fmt --manifest-path xtask/Cargo.toml -- --check completed successfully`

## 🧭 Telemetry
- Change shape: Dependency removal
- Blast radius (API / IO / config / schema / concurrency): None. Restricted entirely to internal workspace task tooling (`xtask`).
- Risk class: Minimal.
- Rollback: Revert the PR to restore dependencies.
- Merge-confidence gates: `cargo check`, `cargo clippy`, `cargo fmt`, `cargo test`

## 🗂️ .jules updates
- Appended the execution receipts and decision summary to `.jules/deps/ledger.json`.
- Captured the run context in `.jules/deps/envelopes/9ce74cba-4438-4a7d-8cf1-502e69ab10b5.json`.

---
*PR created automatically by Jules for task [17979549332267983087](https://jules.google.com/task/17979549332267983087) started by @EffortlessSteven*