### PR TITLE
compat: fix docs_schema_w72 test drift 🧷 Compat

### DIFF
--- a/.jules/compat/envelopes/13bf324d-a8ad-4e74-9d27-673789e16269.json
+++ b/.jules/compat/envelopes/13bf324d-a8ad-4e74-9d27-673789e16269.json
@@ -1,0 +1,1 @@
+{"status": "PASS", "friction_ids": []}

--- a/.jules/compat/ledger.json
+++ b/.jules/compat/ledger.json
@@ -8,5 +8,9 @@
     "run_id": "7df7dfc4-fa15-41eb-809b-835a445c8722",
     "timestamp": "2026-03-22T09:33:27Z",
     "description": "Fix dead_code warning on compute_risk_owned in tokmd-cockpit during no-default-features build"
+  },
+  {
+    "run_id": "13bf324d-a8ad-4e74-9d27-673789e16269",
+    "status": "PASS"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ These are the automation-facing paths for CI pipelines, sensor fleets, and ratch
 
 | Command              | Purpose |
 | :------------------- | :------ |
-| `tokmd` / `lang`     | Language summary for a repo or path set. |
+| `tokmd lang`         | Language summary for a repo or path set. |
 | `tokmd module`       | Group stats by module roots such as `crates/` or `packages/`. |
 | `tokmd export`       | File-level dataset for downstream pipelines (`jsonl`, `csv`, `cyclonedx`). |
 | `tokmd run`          | Save a full receipt set to a run directory, optionally with analysis. |

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -2,7 +2,7 @@
 
 This document details the command-line interface for `tokmd`.
 
-## Top-Level `tokmd` Arguments
+## Global Arguments
 
 These arguments apply when you invoke `tokmd` directly without an explicit subcommand. They describe the root language-summary surface, not a universal flag set shared by every subcommand.
 


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Fix failing `docs_schema_w72` schema and documentation consistency tests in `xtask` due to drift in command documentation mappings for the root `tokmd` language command.

## 🎯 Why / Threat model
Prevents CI failures during schema and documentation validation, ensuring the docs match the CLI exactly and tests can run cleanly on all permutations.

## 🔎 Finding (evidence)
- `cargo test -p xtask --test docs_schema_w72` was failing with:
  - `README.md lists tokmd / lang but docs/reference-cli.md has no section for it`
  - `docs/reference-cli.md must have a Global Arguments section`

## 🧭 Options considered
### Option A (recommended)
- Update `README.md` to use exactly `tokmd lang` and update `docs/reference-cli.md`'s top-level heading to `## Global Arguments` to align exactly with the strict parsers in `xtask`.
- Why it fits this repo: Follows the established validation structure in the codebase without breaking the CLI documentation generators.
- Trade-offs: Structure / Velocity / Governance - Very fast and low impact.

### Option B
- Rewrite `xtask` regex string parsers to support `"tokmd / lang"` or alias headings.
- When to choose it instead: If the documentation format had a specific, immutable reason to remain out-of-band of validation.
- Trade-offs: Increases complexity of the test framework unnecessarily for a simple docs drift fix.

## ✅ Decision
Option A was chosen to normalize the documentation to standard formats enforced by `xtask` checks.

## 🧱 Changes made (SRP)
- `README.md`: `| tokmd / lang |` -> `| tokmd lang |`
- `docs/reference-cli.md`: `## Top-Level tokmd Arguments` -> `## Global Arguments`

## 🧪 Verification receipts
- `cargo check --no-default-features`: Success
- `cargo check --all-features`: Success
- `cargo test -p xtask --test docs_schema_w72`: Success

## 🧭 Telemetry
- Change shape: Documentation syntax and heading updates
- Blast radius (API / IO / config / schema / concurrency): None (documentation and test-fixing only)
- Risk class + why: Low (No functional logic changed)
- Rollback: `git revert`
- Merge-confidence gates (what ran): `cargo check --no-default-features`, `cargo check --all-features`, `CI=true cargo test --workspace`, `cargo build`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`

## 🗂️ .jules updates
- Updated `.jules/compat/ledger.json` and generated envelope in `.jules/compat/envelopes/`.

## 📝 Notes (freeform)
N/A

## 🔜 Follow-ups
N/A
---

---
*PR created automatically by Jules for task [15665953818097310677](https://jules.google.com/task/15665953818097310677) started by @EffortlessSteven*