### PR TITLE
docs: clarify tokmd CLI help message 🎨 Palette

### DIFF
--- a/crates/tokmd-config/src/lib.rs
+++ b/crates/tokmd-config/src/lib.rs
@@ -29,7 +29,11 @@ pub use tokmd_types::{
     TableFormat,
 };
 
-/// `tokmd` — a small, cross-platform, chat-friendly wrapper around `tokei`.
+/// tokmd — code awareness for AI contexts
+///
+/// A small, chat-friendly wrapper around tokei for extracting, summarizing, and shaping code telemetry.
+/// Run `tokmd` in any directory to get a high-level summary of the code.
+/// Use `tokmd [COMMAND] --help` for detailed help.
 ///
 /// Default mode (no subcommand) prints a language summary.
 #[derive(Parser, Debug)]

--- a/crates/tokmd/tests/snapshots/cli_snapshot_golden__help.snap
+++ b/crates/tokmd/tests/snapshots/cli_snapshot_golden__help.snap
@@ -3,7 +3,7 @@ source: crates/tokmd/tests/cli_snapshot_golden.rs
 assertion_line: 219
 expression: normalize(&stdout)
 ---
-`tokmd` — a small, cross-platform, chat-friendly wrapper around `tokei`
+tokmd — code awareness for AI contexts
 
 Usage: tokmd [OPTIONS] [PATH]... [COMMAND]
 


### PR DESCRIPTION
## 💡 Summary 
Updated the CLI description printed by `tokmd --help` to be more descriptive and clear about its purpose as a tool for extracting and shaping code telemetry for AI contexts. Updated the corresponding `.snap` snapshot test to ensure tests pass.
 
## 🎯 Why (user/dev pain) 
The previous help string (`tokmd — a small, cross-platform, chat-friendly wrapper around tokei.`) was overly brief and did not clearly articulate the value proposition of the tool to new users or agents.
 
## 🔎 Evidence (before/after) 
- `crates/tokmd-config/src/lib.rs`
- Before: `tokmd — a small, cross-platform, chat-friendly wrapper around tokei.`
- After: `tokmd — code awareness for AI contexts\n\nA small, chat-friendly wrapper around tokei for extracting, summarizing, and shaping code telemetry.\nRun \`tokmd\` in any directory to get a high-level summary of the code.\nUse \`tokmd [COMMAND] --help\` for detailed help.`
 
## 🧭 Options considered 
### Option A (recommended) 
- Expand the CLI description string in `tokmd-config` and update the snapshot test.
- Fits this repo by directly improving the DX for end users interacting with the CLI.
- Trade-offs: Minor documentation change; requires updating golden test.
 
### Option B 
- Leave the text as-is.
- When to choose it: If brevity is strictly favored over context.
- Trade-offs: Continued friction for new users trying to understand the tool's core utility.
 
## ✅ Decision 
Option A. It is a quick win for developer experience and aligns with the Palette persona's core goal of improving DX/UX.
 
## 🧱 Changes made (SRP) 
- `crates/tokmd-config/src/lib.rs`: Updated `Cli` docstring.
- `crates/tokmd/tests/snapshots/cli_snapshot_golden__help.snap`: Updated snapshot to match the new output.
 
## 🧪 Verification receipts 
Commands:
- `cargo build --verbose`
- `cargo test -p tokmd --test cli_snapshot_golden`
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`

Results:
- PASS `cargo test -p tokmd cli_snapshot_golden`
- PASS `cargo clippy -- -D warnings`
- PASS `cargo build --verbose`
 
## 🧭 Telemetry 
- Change shape: Shallow string replacement.
- Blast radius: Output of `tokmd --help` only.
- Risk class: Low risk. Purely cosmetic text change and snapshot test update.
- Rollback: Revert the PR.
- Merge-confidence gates: `build`, `test`, `fmt`, `clippy`.
 
## 🗂️ .jules updates 
- Initialized missing `.jules/policy/scheduled_tasks.json`, `.jules/runbooks/PR_GLASS_COCKPIT.md`, `.jules/runbooks/FRICTION_ITEM.md`, and `.jules/palette/README.md`.
- Created `.jules/palette/envelopes/9efab092-aa4b-4f8b-ad27-edf0c81a9ebf.json`.
- Created `.jules/palette/runs/2026-03-24.md`.
- Appended run summary to `.jules/palette/ledger.json`.
 
## 📝 Notes (freeform) 
None.
 
## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [18143562410065813207](https://jules.google.com/task/18143562410065813207) started by @EffortlessSteven*