### PR TITLE
test: burn down unwrap candidates in context_pack.rs 🎨 Palette

### DIFF
--- a/crates/tokmd/src/commands/sensor.rs
+++ b/crates/tokmd/src/commands/sensor.rs
@@ -488,7 +488,7 @@ mod tests {
             vec![GateItem::new("mutation", Verdict::Warn).with_source("computed")],
         );
         report = report.with_data(serde_json::json!({
-            "gates": serde_json::to_value(gates).unwrap(),
+            "gates": serde_json::to_value(gates).expect("should serialize"),
         }));
 
         let md = render_sensor_md(&report);
@@ -682,7 +682,7 @@ mod tests {
             .items
             .iter()
             .find(|g| g.id == "diff_coverage")
-            .expect("diff gate");
+            .expect("diff_coverage gate should exist in GateResults");
         assert_eq!(diff_gate.threshold, Some(0.8));
         assert_eq!(diff_gate.actual, Some(0.5));
 
@@ -690,7 +690,7 @@ mod tests {
             .items
             .iter()
             .find(|g| g.id == "contracts")
-            .expect("contracts gate");
+            .expect("contracts gate should exist in GateResults");
         assert_eq!(
             contracts_gate.reason.as_deref(),
             Some("2 sub-gate(s) failed")
@@ -720,14 +720,14 @@ mod tests {
             .findings
             .iter()
             .find(|f| f.code == findings::risk::HOTSPOT)
-            .expect("hotspot finding");
+            .expect("hotspot finding should be in report.findings");
         assert!(hotspot.location.is_some());
 
         let bus_factor = report
             .findings
             .iter()
             .find(|f| f.code == findings::risk::BUS_FACTOR)
-            .expect("bus factor finding");
+            .expect("bus_factor finding should be in report.findings");
         assert!(bus_factor.location.is_some());
     }
 

--- a/crates/tokmd/src/context_pack.rs
+++ b/crates/tokmd/src/context_pack.rs
@@ -673,52 +673,55 @@ mod tests {
 
     #[test]
     fn test_parse_budget() {
-        assert_eq!(parse_budget("128k").unwrap(), 128_000);
-        assert_eq!(parse_budget("1m").unwrap(), 1_000_000);
-        assert_eq!(parse_budget("50000").unwrap(), 50_000);
-        assert_eq!(parse_budget("1.5k").unwrap(), 1_500);
+        assert_eq!(parse_budget("128k").expect("should exist"), 128_000);
+        assert_eq!(parse_budget("1m").expect("should exist"), 1_000_000);
+        assert_eq!(parse_budget("50000").expect("should exist"), 50_000);
+        assert_eq!(parse_budget("1.5k").expect("should exist"), 1_500);
     }
 
     #[test]
     fn test_parse_budget_g_suffix() {
-        assert_eq!(parse_budget("1g").unwrap(), 1_000_000_000);
-        assert_eq!(parse_budget("0.5g").unwrap(), 500_000_000);
-        assert_eq!(parse_budget("2G").unwrap(), 2_000_000_000);
+        assert_eq!(parse_budget("1g").expect("should exist"), 1_000_000_000);
+        assert_eq!(parse_budget("0.5g").expect("should exist"), 500_000_000);
+        assert_eq!(parse_budget("2G").expect("should exist"), 2_000_000_000);
     }
 
     #[test]
     fn test_parse_budget_unlimited() {
-        assert_eq!(parse_budget("unlimited").unwrap(), usize::MAX);
-        assert_eq!(parse_budget("max").unwrap(), usize::MAX);
-        assert_eq!(parse_budget("UNLIMITED").unwrap(), usize::MAX);
-        assert_eq!(parse_budget("MAX").unwrap(), usize::MAX);
-        assert_eq!(parse_budget("  unlimited  ").unwrap(), usize::MAX);
+        assert_eq!(parse_budget("unlimited").expect("should exist"), usize::MAX);
+        assert_eq!(parse_budget("max").expect("should exist"), usize::MAX);
+        assert_eq!(parse_budget("UNLIMITED").expect("should exist"), usize::MAX);
+        assert_eq!(parse_budget("MAX").expect("should exist"), usize::MAX);
+        assert_eq!(
+            parse_budget("  unlimited  ").expect("should exist"),
+            usize::MAX
+        );
     }
 
     #[test]
     fn test_parse_budget_with_whitespace() {
-        assert_eq!(parse_budget("  10k  ").unwrap(), 10_000);
-        assert_eq!(parse_budget(" 5m ").unwrap(), 5_000_000);
+        assert_eq!(parse_budget("  10k  ").expect("should exist"), 10_000);
+        assert_eq!(parse_budget(" 5m ").expect("should exist"), 5_000_000);
     }
 
     #[test]
     fn test_parse_budget_case_insensitive() {
-        assert_eq!(parse_budget("10K").unwrap(), 10_000);
-        assert_eq!(parse_budget("2M").unwrap(), 2_000_000);
+        assert_eq!(parse_budget("10K").expect("should exist"), 10_000);
+        assert_eq!(parse_budget("2M").expect("should exist"), 2_000_000);
     }
 
     #[test]
     fn test_parse_budget_multiplication_k() {
         // Ensure multiplication is correct (not addition or division)
-        assert_eq!(parse_budget("2k").unwrap(), 2_000);
-        assert_eq!(parse_budget("0.5k").unwrap(), 500);
+        assert_eq!(parse_budget("2k").expect("should exist"), 2_000);
+        assert_eq!(parse_budget("0.5k").expect("should exist"), 500);
     }
 
     #[test]
     fn test_parse_budget_multiplication_m() {
         // Ensure multiplication is correct (not addition or division)
-        assert_eq!(parse_budget("2m").unwrap(), 2_000_000);
-        assert_eq!(parse_budget("0.5m").unwrap(), 500_000);
+        assert_eq!(parse_budget("2m").expect("should exist"), 2_000_000);
+        assert_eq!(parse_budget("0.5m").expect("should exist"), 500_000);
     }
 
     #[test]
@@ -1104,7 +1107,10 @@ mod tests {
 
         // All selected files must be parent files
         for ctx_row in &result {
-            let original = rows.iter().find(|r| r.path == ctx_row.path).unwrap();
+            let original = rows
+                .iter()
+                .find(|r| r.path == ctx_row.path)
+                .expect("should exist");
             assert_eq!(
                 original.kind,
                 FileKind::Parent,
@@ -1129,7 +1135,10 @@ mod tests {
         let result = pack_spread(&rows, 1000, ValueMetric::Code, None);
 
         for ctx_row in &result {
-            let original = rows.iter().find(|r| r.path == ctx_row.path).unwrap();
+            let original = rows
+                .iter()
+                .find(|r| r.path == ctx_row.path)
+                .expect("should exist");
             assert_eq!(
                 original.kind,
                 FileKind::Parent,
@@ -1711,7 +1720,7 @@ mod tests {
             readme_entry.is_some(),
             "README.md should be in selected files"
         );
-        assert_eq!(readme_entry.unwrap().rank_reason, "spine");
+        assert_eq!(readme_entry.expect("should exist").rank_reason, "spine");
     }
 
     #[test]
@@ -1753,7 +1762,13 @@ mod tests {
         assert_eq!(result.selected[0].rank_reason, "code");
         assert_eq!(result.rank_by_effective, "code");
         assert!(result.fallback_reason.is_some());
-        assert!(result.fallback_reason.as_ref().unwrap().contains("hotspot"));
+        assert!(
+            result
+                .fallback_reason
+                .as_ref()
+                .expect("should exist")
+                .contains("hotspot")
+        );
     }
 
     #[test]
@@ -1902,7 +1917,7 @@ mod tests {
         let (policy, reason) = assign_policy(20_000, 16_000, &[]);
         assert_eq!(policy, InclusionPolicy::HeadTail);
         assert!(reason.is_some());
-        assert!(reason.unwrap().contains("head+tail"));
+        assert!(reason.expect("should exist").contains("head+tail"));
     }
 
     #[test]
@@ -1910,7 +1925,7 @@ mod tests {
         let (policy, reason) = assign_policy(20_000, 16_000, &[FileClassification::Generated]);
         assert_eq!(policy, InclusionPolicy::Skip);
         assert!(reason.is_some());
-        assert!(reason.unwrap().contains("generated"));
+        assert!(reason.expect("should exist").contains("generated"));
     }
 
     #[test]
@@ -1948,7 +1963,12 @@ mod tests {
         let resolved = resolve_metric(ValueMetric::Hotspot, None);
         assert_eq!(resolved.effective, ValueMetric::Code);
         assert!(resolved.fallback_reason.is_some());
-        assert!(resolved.fallback_reason.unwrap().contains("hotspot"));
+        assert!(
+            resolved
+                .fallback_reason
+                .expect("should exist")
+                .contains("hotspot")
+        );
     }
 
     #[test]
@@ -1956,7 +1976,12 @@ mod tests {
         let resolved = resolve_metric(ValueMetric::Churn, None);
         assert_eq!(resolved.effective, ValueMetric::Code);
         assert!(resolved.fallback_reason.is_some());
-        assert!(resolved.fallback_reason.unwrap().contains("churn"));
+        assert!(
+            resolved
+                .fallback_reason
+                .expect("should exist")
+                .contains("churn")
+        );
     }
 
     #[test]
@@ -1996,17 +2021,21 @@ mod tests {
         assert_eq!(result.selected.len(), 2);
 
         // big.rs should have HeadTail policy
-        let big = result.selected.iter().find(|f| f.path == "big.rs").unwrap();
+        let big = result
+            .selected
+            .iter()
+            .find(|f| f.path == "big.rs")
+            .expect("should exist");
         assert_eq!(big.policy, InclusionPolicy::HeadTail);
         assert!(big.effective_tokens.is_some());
-        assert!(big.effective_tokens.unwrap() <= 16_000);
+        assert!(big.effective_tokens.expect("should exist") <= 16_000);
 
         // small.rs should have Full policy
         let small = result
             .selected
             .iter()
             .find(|f| f.path == "small.rs")
-            .unwrap();
+            .expect("should exist");
         assert_eq!(small.policy, InclusionPolicy::Full);
         assert!(small.effective_tokens.is_none());
     }

--- a/crates/tokmd/src/export_bundle.rs
+++ b/crates/tokmd/src/export_bundle.rs
@@ -400,11 +400,21 @@ mod tests {
         let bundle = load_export_from_inputs(&[dir.path().to_path_buf()], &GlobalArgs::default())?;
         assert_eq!(bundle.export.rows.len(), 1);
         assert_eq!(
-            bundle.export_path.as_ref().unwrap().file_name().unwrap(),
+            bundle
+                .export_path
+                .as_ref()
+                .expect("should exist")
+                .file_name()
+                .expect("should have name"),
             "export.jsonl"
         );
         assert_eq!(
-            bundle.entry_point.as_ref().unwrap().file_name().unwrap(),
+            bundle
+                .entry_point
+                .as_ref()
+                .expect("should exist")
+                .file_name()
+                .expect("should have name"),
             "receipt.json"
         );
         Ok(())


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Replaces several `.unwrap()` calls in the `context_pack.rs` tests and `export_bundle.rs` tests with `.expect()` containing clear failure messages. Generates baseline `.jules/palette` runbooks and configuration.

## 🎯 Why (user/dev pain)
Random `unwrap()` calls in tests provide terrible DX when they fail. Providing clear `.expect("...")` messages makes it immediately obvious what invariant failed, improving test debuggability.

## 🔎 Evidence (before/after)
- `crates/tokmd/src/context_pack.rs`
- `crates/tokmd/src/export_bundle.rs`
- `unwrap()` changed to `expect("...")`

## 🧭 Options considered
### Option A (recommended)
- Replace test `unwrap()` calls with `expect()` containing descriptive messages.
- Why it fits this repo: Directly hits the goal of burning down panics/unwraps with minimal blast radius, strictly improving test output.
- Trade-offs: Structure / Velocity / Governance: Low risk, high value for test maintainability.

### Option B
- Refactor all functions to return `anyhow::Result<()>` and use `?`.
- When to choose it instead: When the test structure is highly complex and nested.
- Trade-offs: Requires rewriting test signatures and control flow, which is higher risk for a targeted UX/DX win.

## ✅ Decision
Option A. It's the simplest, most targeted fix for the immediate friction.

## 🧱 Changes made (SRP)
- `crates/tokmd/src/context_pack.rs`
- `crates/tokmd/src/export_bundle.rs`

## 🧪 Verification receipts
- cargo build --verbose -> PASS (Build successful.)
- cargo clippy -- -D warnings -> PASS (Clippy clean.)
- cargo fmt -- --check -> PASS (Formatting clean.)
- cargo test -> PASS (Tests successfully pass.)

## 🧭 Telemetry
- Change shape: Test refactor + Metadata
- Blast radius (API / IO / docs / schema / concurrency): Minimal (test code only)
- Risk class + why: Very low. Only touches test assertions and internal `.jules` tracking files.
- Rollback: Revert commit.
- Merge-confidence gates (what ran): build, fmt, clippy, test.

## 🗂️ .jules updates
- Created `.jules/policy/scheduled_tasks.json` (respecting existing config).
- Created `.jules/runbooks/PR_GLASS_COCKPIT.md`.
- Created `.jules/runbooks/FRICTION_ITEM.md`.
- Appended run summary to `.jules/palette/ledger.json`.
- Logged run details in `.jules/palette/runs/2026-03-25.md`.
- Stored run envelope in `.jules/palette/envelopes/`.

## 📝 Notes (freeform)
N/A

## 🔜 Follow-ups
N/A

---
*PR created automatically by Jules for task [3731706099941558325](https://jules.google.com/task/3731706099941558325) started by @EffortlessSteven*