### PR TITLE
fix: resolve case-colliding pr body path

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,42 +1,46 @@
 ## 💡 Summary
-Added a doctest to `pub fn scan` in `crates/tokmd-scan/src/lib.rs` to demonstrate typical library usage of setting up mock source files, applying `ScanOptions`, and checking the resulting code count metrics.
+Added usage examples as Rust doctests for the four main workflow APIs in `tokmd-core`. This helps library consumers understand how to embed the `lang`, `module`, `export`, `diff`, and `analyze` engines directly.
 
 ## 🎯 Why / Threat model
-Improves library usability for downstream developers by documenting the usage pattern of the core scanning function inline, ensuring the documentation does not silently drift since it runs during `cargo test`.
+The core library facade lacked executable documentation for its highest-traffic methods. Writing them as doctests ensures they can never silently drift out of sync with the actual API surface.
 
 ## 🔎 Finding (evidence)
-* `crates/tokmd-scan/src/lib.rs` lacked a doctest on its core `pub fn scan` method.
+- `crates/tokmd-core/src/lib.rs` lacked `/// ```rust` blocks for its public `*_workflow` functions.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- Add a doctest explicitly constructing mock `ScanOptions` and demonstrating the scan.
-- Why it fits this repo: This repository values doctests as a truth mechanism to prevent documentation drift.
-- Trade-offs: Increases CI runtime slightly but adds strong verification guarantees.
+- Add standard `#[test]` unit tests that happen to be readable.
+- This is fine, but doesn't show up in `rustdoc` or IDE hover cards.
 
 ### Option B
-- Document the behavior implicitly using `README.md` examples.
-- When to choose it instead: If the setup logic involves non-trivial mock environment generation that makes the doctest noisy.
-- Trade-offs: Documentation examples get stale, reducing trust in the API reference over time.
+- Write inline `/// ```rust` doctests on the public functions.
+- Why it fits: The `tokmd-core` crate is a library intended for embedding, and users will look directly at the Rustdoc for these functions.
+- Trade-offs: Doctests run sequentially by default, but these are small and fast.
 
 ## ✅ Decision
-Option A was selected to enforce truth and trust via a verified doctest directly on the function signature.
+Option B. We want the examples visible directly on the trait/function definitions.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd-scan/src/lib.rs`: Added a doctest demonstrating `scan` functionality.
+- Added doctests to `module_workflow` in `crates/tokmd-core/src/lib.rs`.
+- Added doctests to `export_workflow` in `crates/tokmd-core/src/lib.rs`.
+- Added doctests to `diff_workflow` in `crates/tokmd-core/src/lib.rs`.
+- Added doctests to `analyze_workflow` in `crates/tokmd-core/src/lib.rs`.
 
 ## 🧪 Verification receipts
-```json
-[
-  "running 1 test\ntest crates/tokmd-scan/src/lib.rs - scan (line 80) ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n\nall doctests ran in 2.66s; merged doctests compilation took 2.55s\n    Compiling tokmd-scan v1.8.1 (/app/crates/tokmd-scan)\n    Finished `test` profile [unoptimized + debuginfo] target(s) in 3.42s\n   Doc-tests tokmd_scan\n"
-]
+```
+cargo test -p tokmd-core --doc --all-features
 ```
 
 ## 🧭 Telemetry
-- Change shape: Documentation addition
-- Blast radius: Isolated to documentation rendering and testing; no changes to production code logic.
-- Risk class: Negligible
-- Rollback: Revert commit
-- Merge-confidence gates: `cargo fmt -- --check`, `cargo test -p tokmd-scan`
+- Change shape: Documentation additions.
+- Blast radius: Rustdoc and `cargo test --doc` execution.
+- Risk class: Very low. Only comments were touched.
+- Rollback: Revert the PR.
+- Merge-confidence gates: `cargo build`, `cargo fmt`, `cargo clippy`, `cargo test -p tokmd-core`.
 
 ## 🗂️ .jules updates
-Created run envelope `.jules/docs/envelopes/20260322T093657Z.json` and appended the run context to `.jules/docs/ledger.json`.
+- Wrote run envelope to `.jules/docs/envelopes/`.
+- Appended run ID to `.jules/docs/ledger.json`.
+
+## 📝 Notes (freeform)
+All doctests are self-contained and use the `current_dir()` defaults to avoid needing test fixtures.


### PR DESCRIPTION
## Summary
- remove the uppercase PR_BODY.md path
- keep the lowercase pr_body.md path
- eliminate a case-insensitive filesystem collision that creates Windows worktree noise

## Why
- this is a pure repo-hygiene fix
- it removes a Windows landmine before other cleanup branches stack on top of it

## Validation
- verified the cleanup branch contains only the path collision fix relative to main