### PR TITLE
fix: restore main quality gate

### DIFF
--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -5,7 +5,7 @@ pub mod docs;
 pub mod gate;
 pub mod lint_fix;
 pub mod publish;
-pub mod version_consistency;
 pub mod sccache;
 pub mod trim_target;
+pub mod version_consistency;
 pub mod workspace;

--- a/xtask/src/tasks/version_consistency.rs
+++ b/xtask/src/tasks/version_consistency.rs
@@ -82,10 +82,7 @@ fn check_workspace_dependency_versions(expected: &str) -> Result<()> {
                 continue;
             }
 
-            let Some(dep_version) = dep_table
-                .get("version")
-                .and_then(TomlValue::as_str)
-            else {
+            let Some(dep_version) = dep_table.get("version").and_then(TomlValue::as_str) else {
                 continue;
             };
 
@@ -103,7 +100,10 @@ fn check_workspace_dependency_versions(expected: &str) -> Result<()> {
         );
     }
 
-    println!("  ✓ Cargo workspace dependency versions match {}.", expected);
+    println!(
+        "  ✓ Cargo workspace dependency versions match {}.",
+        expected
+    );
     Ok(())
 }
 
@@ -192,13 +192,13 @@ fn read_tracked_paths() -> Result<Vec<String>> {
         bail!("`git ls-files -z` failed: {}", stderr.trim());
     }
 
-    Ok(output
+    output
         .stdout
         .split(|byte| *byte == 0)
         .filter(|entry| !entry.is_empty())
         .map(|entry| String::from_utf8(entry.to_vec()))
         .collect::<std::result::Result<Vec<_>, _>>()
-        .context("`git ls-files -z` produced non-UTF-8 output")?)
+        .context("`git ls-files -z` produced non-UTF-8 output")
 }
 
 fn detect_case_insensitive_collisions(paths: Vec<String>) -> Vec<Vec<String>> {
@@ -331,8 +331,11 @@ mod tests {
             }
         });
 
-        let mismatches =
-            find_internal_node_dependency_mismatches("crates/tokmd-node/package.json", &manifest, "1.9.0");
+        let mismatches = find_internal_node_dependency_mismatches(
+            "crates/tokmd-node/package.json",
+            &manifest,
+            "1.9.0",
+        );
 
         assert_eq!(
             mismatches,


### PR DESCRIPTION
## Summary
- fix the clippy failure in xtask version consistency by removing the needless Ok(...)? wrapper
- apply the rustfmt-required layout changes in xtask task modules and tests
- verify the repo quality gate passes again on a clean worktree

## Validation
- cargo fmt-check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo xtask gate --check
- cargo xtask version-consistency