### PR TITLE
fix: replace test unwraps with explicit expects in bindings and core 🛡️ Sentinel

### DIFF
--- a/.jules/security/envelopes/84d96f8b-dde7-4bdd-8d74-58fbf4191afe.json
+++ b/.jules/security/envelopes/84d96f8b-dde7-4bdd-8d74-58fbf4191afe.json
@@ -1,0 +1,25 @@
+{
+  "run_id": "84d96f8b-dde7-4bdd-8d74-58fbf4191afe",
+  "timestamp_utc": "2026-03-26T12:22:07Z",
+  "lane": "scout",
+  "target": "Burn down test unwraps in language bindings (tokmd-node, tokmd-python) and tokmd-core",
+  "commands": [],
+  "results": [
+    {
+      "cmd": "cargo build --verbose",
+      "status": "PASS"
+    },
+    {
+      "cmd": "cargo test --verbose",
+      "status": "PASS"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "status": "PASS"
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "status": "PASS"
+    }
+  ]
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -65,5 +65,19 @@
     ],
     "status": "PASS",
     "friction_ids": []
+  },
+  {
+    "date": "2026-03-26T12:29:57Z",
+    "lane": "scout",
+    "target": "Burn down test unwraps in language bindings (tokmd-node, tokmd-python) and tokmd-core",
+    "pr_link": "PENDING",
+    "gates": [
+      "build",
+      "test",
+      "fmt",
+      "clippy"
+    ],
+    "status": "PASS",
+    "friction_ids": []
   }
 ]

--- a/.jules/security/notes/20260326T1230MZ--test-unwraps.md
+++ b/.jules/security/notes/20260326T1230MZ--test-unwraps.md
@@ -1,0 +1,15 @@
+# Descriptive unwraps in tests
+
+## Context
+When maintaining tests, test failures due to `.unwrap()` calls provide little context to exactly what invariant or assertion failed, often just showing a `called Result::unwrap() on an Err value` trace.
+
+## Pattern
+Avoid raw `.unwrap()` in test suites, including test helper setups. Instead, use `.expect("...")` with descriptive text detailing what operation was taking place and what result was expected, so developers can quickly identify the source of the issue.
+
+## Prevention Guidance
+- If a test expects to safely unwrap a JSON string, avoid `.unwrap()`. Prefer `serde_json::from_str(&data).expect("parse json");`.
+- When using bindings where item extraction from dictionaries is common (like PyO3), provide explicit extraction paths: `dict.get_item("key").expect("get key")`.
+
+## Links
+- [tokmd-node test suites](crates/tokmd-node/src/lib.rs)
+- [tokmd-python test suites](crates/tokmd-python/src/lib.rs)

--- a/.jules/security/runs/2026-03-26.md
+++ b/.jules/security/runs/2026-03-26.md
@@ -1,0 +1,26 @@
+# Sentinel Run - 2026-03-26
+
+**Lane**: Scout
+**Target**: Burn down test `.unwrap()` and `.expect()` calls in `tokmd-node`, `tokmd-python`, and `tokmd-core` tests.
+
+## Findings
+During a scout sweep, several `.unwrap()` and generic `.expect()` calls were found in test code within the `tokmd-node`, `tokmd-python`, and `tokmd-core` crates. Panics in tests can mask true error origins and reduce DX.
+
+## Options Considered
+### Option A (recommended)
+Replace `.unwrap()` with descriptive `.expect("...")` statements in tests.
+- What it is: Replace raw `.unwrap()` with `.expect()` describing what was expected.
+- Why it fits: Aligns with the Sentinel goal to burn down unwraps and improve test failure clarity without refactoring test signatures to return `Result`, which can be noisy for simple extractions.
+- Trade-offs: Structure / Velocity / Governance: Low structural impact, high velocity improvement for debugging test failures.
+
+### Option B
+Refactor tests to return `anyhow::Result<()>` and use the `?` operator.
+- What it is: Change test function signatures and bubble up errors.
+- When to choose: When tests have complex setup phases where multiple fallible operations occur.
+- Trade-offs: Higher structural change, but native error propagation.
+
+## Decision
+**Option A**. Replacing `.unwrap()` with descriptive `.expect()` statements in tests is the simplest, most effective way to improve DX and eliminate raw unwraps in the target test files.
+
+## Links
+- PR: PENDING

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -43,7 +43,7 @@
 //! use tokmd_core::ffi::run_json;
 //!
 //! let result = run_json("lang", r#"{"paths": ["."], "top": 10}"#);
-//! let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+//! let parsed: serde_json::Value = serde_json::from_str(&result).expect("parse json");
 //! assert_eq!(parsed["ok"], true);
 //! ```
 
@@ -1149,9 +1149,9 @@ mod tests {
     #[cfg(feature = "analysis")]
     fn write_file(path: &Path, contents: &str) {
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).unwrap();
+            fs::create_dir_all(parent).expect("create parent dirs");
         }
-        fs::write(path, contents).unwrap();
+        fs::write(path, contents).expect("write file contents");
     }
 
     #[cfg(feature = "analysis")]

--- a/crates/tokmd-node/src/lib.rs
+++ b/crates/tokmd-node/src/lib.rs
@@ -513,7 +513,7 @@ mod tests {
     #[test]
     fn core_run_json_unknown_mode_returns_error() {
         let result = tokmd_core::ffi::run_json("bogus", "{}");
-        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&result).expect("parse json");
         assert_eq!(v["ok"], false);
         assert_eq!(v["error"]["code"].as_str(), Some("unknown_mode"));
     }

--- a/crates/tokmd-python/src/lib.rs
+++ b/crates/tokmd-python/src/lib.rs
@@ -548,8 +548,8 @@ mod tests {
     fn extract_envelope_returns_data_when_ok() {
         with_py(|py| {
             let dict = PyDict::new(py);
-            dict.set_item("ok", true).unwrap();
-            dict.set_item("data", "ok").unwrap();
+            dict.set_item("ok", true).expect("set item");
+            dict.set_item("data", "ok").expect("set item");
             let obj = extract_envelope(py, dict.as_any()).expect("extract data");
             let value: String = obj.extract(py).expect("extract string");
             assert_eq!(value, "ok");
@@ -560,10 +560,10 @@ mod tests {
     fn extract_envelope_returns_envelope_when_data_missing() {
         with_py(|py| {
             let dict = PyDict::new(py);
-            dict.set_item("ok", true).unwrap();
+            dict.set_item("ok", true).expect("set item");
             let obj = extract_envelope(py, dict.as_any()).expect("extract envelope");
             let out = obj.downcast_bound::<PyDict>(py).expect("dict");
-            assert!(out.get_item("data").unwrap().is_none());
+            assert!(out.get_item("data").expect("get item").is_none());
         });
     }
 
@@ -571,7 +571,7 @@ mod tests {
     fn extract_envelope_returns_unknown_error_when_error_missing() {
         with_py(|py| {
             let dict = PyDict::new(py);
-            dict.set_item("ok", false).unwrap();
+            dict.set_item("ok", false).expect("set item");
             let err = extract_envelope(py, dict.as_any()).unwrap_err();
             assert!(err.to_string().contains("Unknown error"));
         });
@@ -581,8 +581,8 @@ mod tests {
     fn extract_envelope_returns_unknown_error_when_error_not_dict() {
         with_py(|py| {
             let dict = PyDict::new(py);
-            dict.set_item("ok", false).unwrap();
-            dict.set_item("error", "boom").unwrap();
+            dict.set_item("ok", false).expect("set item");
+            dict.set_item("error", "boom").expect("set item");
             let err = extract_envelope(py, dict.as_any()).unwrap_err();
             assert!(err.to_string().contains("Unknown error"));
         });
@@ -593,9 +593,9 @@ mod tests {
         with_py(|py| {
             let dict = PyDict::new(py);
             let err_dict = PyDict::new(py);
-            dict.set_item("ok", false).unwrap();
-            err_dict.set_item("message", "boom").unwrap();
-            dict.set_item("error", err_dict).unwrap();
+            dict.set_item("ok", false).expect("set item");
+            err_dict.set_item("message", "boom").expect("set item");
+            dict.set_item("error", err_dict).expect("set item");
             let err = extract_envelope(py, dict.as_any()).unwrap_err();
             assert!(err.to_string().contains("unknown"));
         });
@@ -606,9 +606,9 @@ mod tests {
         with_py(|py| {
             let dict = PyDict::new(py);
             let err_dict = PyDict::new(py);
-            dict.set_item("ok", false).unwrap();
-            err_dict.set_item("code", "E").unwrap();
-            dict.set_item("error", err_dict).unwrap();
+            dict.set_item("ok", false).expect("set item");
+            err_dict.set_item("code", "E").expect("set item");
+            dict.set_item("error", err_dict).expect("set item");
             let err = extract_envelope(py, dict.as_any()).unwrap_err();
             assert!(err.to_string().contains("Unknown error"));
         });
@@ -627,11 +627,16 @@ mod tests {
     fn build_args_sets_defaults_and_options() {
         with_py(|py| {
             let args = build_args(py, None, 0, None, false);
-            let paths: Vec<String> = args.get_item("paths").unwrap().unwrap().extract().unwrap();
+            let paths: Vec<String> = args
+                .get_item("paths")
+                .expect("get paths")
+                .expect("some paths")
+                .extract()
+                .expect("extract item");
             assert_eq!(paths, vec!["."]);
-            assert!(args.get_item("top").unwrap().is_none());
-            assert!(args.get_item("excluded").unwrap().is_none());
-            assert!(args.get_item("hidden").unwrap().is_none());
+            assert!(args.get_item("top").expect("get item").is_none());
+            assert!(args.get_item("excluded").expect("get item").is_none());
+            assert!(args.get_item("hidden").expect("get item").is_none());
 
             let args = build_args(
                 py,
@@ -640,13 +645,18 @@ mod tests {
                 Some(vec!["target".to_string()]),
                 true,
             );
-            let top: i64 = args.get_item("top").unwrap().unwrap().extract().unwrap();
+            let top: i64 = args
+                .get_item("top")
+                .expect("get top")
+                .expect("some top")
+                .extract()
+                .expect("extract item");
             assert_eq!(top, 3);
-            assert!(args.get_item("excluded").unwrap().is_some());
-            assert!(args.get_item("hidden").unwrap().is_some());
+            assert!(args.get_item("excluded").expect("get item").is_some());
+            assert!(args.get_item("hidden").expect("get item").is_some());
 
             let args = build_args(py, Some(vec!["src".to_string()]), 0, Some(vec![]), false);
-            assert!(args.get_item("excluded").unwrap().is_none());
+            assert!(args.get_item("excluded").expect("get item").is_none());
         });
     }
 
@@ -728,10 +738,10 @@ mod tests {
             assert_eq!(
                 lang_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "lang"
             );
 
@@ -753,10 +763,10 @@ mod tests {
             assert_eq!(
                 module_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "module"
             );
 
@@ -780,10 +790,10 @@ mod tests {
             assert_eq!(
                 export_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "export"
             );
         });
@@ -810,10 +820,10 @@ mod tests {
             assert_eq!(
                 lang_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "lang"
             );
 
@@ -835,10 +845,10 @@ mod tests {
             assert_eq!(
                 module_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "module"
             );
 
@@ -862,10 +872,10 @@ mod tests {
             assert_eq!(
                 export_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "export"
             );
 
@@ -888,10 +898,10 @@ mod tests {
             assert_eq!(
                 analysis_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "analysis"
             );
         });
@@ -921,10 +931,10 @@ mod tests {
             assert_eq!(
                 analysis_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "analysis"
             );
         });
@@ -943,10 +953,10 @@ mod tests {
             assert_eq!(
                 diff_dict
                     .get_item("mode")
-                    .unwrap()
-                    .unwrap()
+                    .expect("get item")
+                    .expect("some")
                     .extract::<String>()
-                    .unwrap(),
+                    .expect("extract item"),
                 "diff"
             );
         });
@@ -991,7 +1001,7 @@ mod tests {
     #[test]
     fn core_run_json_unknown_mode_returns_error() {
         let result = tokmd_core::ffi::run_json("bogus", "{}");
-        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&result).expect("parse json");
         assert_eq!(v["ok"], false);
         assert_eq!(v["error"]["code"].as_str(), Some("unknown_mode"));
     }
@@ -1000,7 +1010,7 @@ mod tests {
     fn extract_data_json_valid_success_envelope() {
         let envelope = r#"{"ok":true,"data":{"mode":"lang"}}"#;
         let data = extract_data_json(envelope).expect("should extract data");
-        let v: serde_json::Value = serde_json::from_str(&data).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&data).expect("parse json");
         assert_eq!(v["mode"].as_str(), Some("lang"));
     }
 

--- a/crates/tokmd-sensor/src/substrate_builder.rs
+++ b/crates/tokmd-sensor/src/substrate_builder.rs
@@ -111,7 +111,7 @@ mod tests {
             2,
             None,
         )
-        .unwrap();
+        .expect("build substrate");
 
         assert!(!substrate.files.is_empty());
         assert!(substrate.lang_summary.contains_key("Rust"));
@@ -132,8 +132,8 @@ mod tests {
             insertions: 5,
             deletions: 2,
         };
-        let substrate =
-            build_substrate(manifest_dir, &ScanOptions::default(), &[], 2, Some(diff)).unwrap();
+        let substrate = build_substrate(manifest_dir, &ScanOptions::default(), &[], 2, Some(diff))
+            .expect("build substrate with diff");
 
         assert!(substrate.diff_range.is_some());
         let diff_files: Vec<&str> = substrate


### PR DESCRIPTION
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Replaced raw `.unwrap()` calls with `.expect("...")` containing descriptive messages inside test suites for `tokmd-core`, `tokmd-node`, `tokmd-python`, and `tokmd-sensor`. This improves DX by providing clear failure contexts when tests abort.

## 🎯 Why / Threat model
Panics in tests can mask true error origins and reduce developer velocity. Burning down generic `unwrap` calls provides clear explanations of expected invariants and ensures developers immediately know why a test aborted.

## 🔎 Finding (evidence)
Minimal proof:
- `crates/tokmd-core/src/lib.rs` (e.g. `unwrap()` on directory creations)
- `crates/tokmd-python/src/lib.rs` (e.g. `unwrap()` on PyDict insertions and extractions)
- `crates/tokmd-node/src/lib.rs` (e.g. `unwrap()` parsing json envelopes)
- `crates/tokmd-sensor/src/substrate_builder.rs` (e.g. `unwrap()` on substrate builds)

## 🧭 Options considered
### Option A (recommended)
- Replace `.unwrap()` with descriptive `.expect("...")` statements in tests.
- Why it fits this repo: Aligns with the Sentinel goal to burn down unwraps and improve test failure clarity without refactoring test signatures to return `Result`, which can be noisy for simple extractions.
- Trade-offs: Low structural impact, high velocity improvement for debugging test failures.

### Option B
- Refactor tests to return `anyhow::Result<()>` and use the `?` operator.
- When to choose it instead: When tests have complex setup phases where multiple fallible operations occur.
- Trade-offs: Higher structural change, but native error propagation.

## ✅ Decision
Option A was chosen as it efficiently improves DX without requiring massive structural test rewrites, maintaining the fast execution and clarity of tests while eliminating generic panics.

## 🧱 Changes made (SRP)
- Modified `crates/tokmd-core/src/lib.rs` tests.
- Modified `crates/tokmd-node/src/lib.rs` tests.
- Modified `crates/tokmd-python/src/lib.rs` tests.
- Modified `crates/tokmd-sensor/src/substrate_builder.rs` tests.

## 🧪 Verification receipts
```json
[
  {
    "cmd": "cargo build --verbose",
    "status": "PASS"
  },
  {
    "cmd": "cargo test --verbose",
    "status": "PASS"
  },
  {
    "cmd": "cargo fmt -- --check",
    "status": "PASS"
  },
  {
    "cmd": "cargo clippy -- -D warnings",
    "status": "PASS"
  }
]
```

## 🧭 Telemetry
- Change shape: Moderate, highly repetitive test refactoring.
- Blast radius (API / IO / config / schema / concurrency): Negligible, strictly constrained to test modules.
- Risk class + why: Low risk. No production logic changes.
- Rollback: Revert commit.
- Merge-confidence gates (what ran): `cargo fmt`, `cargo clippy`, `cargo test -p tokmd-core -p tokmd-node -p tokmd-python -p tokmd-sensor`, `cargo test -p tokmd-python --no-default-features`.

## 🗂️ .jules updates
- Updated `.jules/security/ledger.json` with the new run log.
- Added a note on test unwraps inside `.jules/security/notes/YYYYMMDDTHHMMZ--test-unwraps.md`.
- Created envelope payload to capture execution steps.
- Created run summary markdown.

## 📝 Notes (freeform)
Replaced many Python PyDict `unwrap()` calls that cascaded in chains using Python scripts for safer multi-line Regex substitutions.

## 🔜 Follow-ups
None immediately necessary for these specific crates.

---
*PR created automatically by Jules for task [14098680558794517569](https://jules.google.com/task/14098680558794517569) started by @EffortlessSteven*