### PR TITLE
test: replace unwrap_or_default in json assertions to prevent silent failures 🎨 Palette

### DIFF
--- a/.jules/palette/README.md
+++ b/.jules/palette/README.md
@@ -1,0 +1,9 @@
+# Palette Persona
+
+Palette focuses on developer experience (UX/DX) in tokmd.
+Areas of focus:
+- Error messages and diagnostics
+- CLI help/usage
+- README/examples correctness
+- Public API docs and ergonomics
+- Predictable output and sharp edges in docs/tests

--- a/.jules/palette/envelopes/20260326T125631Z.json
+++ b/.jules/palette/envelopes/20260326T125631Z.json
@@ -1,0 +1,18 @@
+{
+  "run_id": "20260326T125631Z",
+  "timestamp_utc": "2026-03-26T12:56:31Z",
+  "lane": "scout",
+  "target": "Refactor unwrap_or_default in json assertions to prevent silent test failures",
+  "commands": [
+    "cargo build --verbose",
+    "CI=true cargo test --verbose",
+    "cargo fmt -- --check",
+    "cargo clippy -- -D warnings"
+  ],
+  "results": [
+    {"cmd": "cargo build --verbose", "status": "PASS", "lines": "Finished `dev` profile"},
+    {"cmd": "CI=true cargo test --verbose", "status": "PASS", "lines": "test result: ok."},
+    {"cmd": "cargo fmt -- --check", "status": "PASS", "lines": ""},
+    {"cmd": "cargo clippy -- -D warnings", "status": "PASS", "lines": "Finished `dev` profile"}
+  ]
+}

--- a/.jules/palette/ledger.json
+++ b/.jules/palette/ledger.json
@@ -12,6 +12,19 @@
         "clippy"
       ],
       "friction_ids": []
+    },
+    {
+      "date": "2026-03-26T12:56:31Z",
+      "lane": "scout",
+      "target": "Refactor unwrap_or_default in json assertions to prevent silent test failures",
+      "pr_link": "test: replace unwrap_or_default in json assertions to prevent silent failures 🎨 Palette",
+      "gates": [
+        "build",
+        "test",
+        "fmt",
+        "clippy"
+      ],
+      "friction_ids": []
     }
   ]
 }

--- a/.jules/palette/runs/2026-03-26.md
+++ b/.jules/palette/runs/2026-03-26.md
@@ -1,0 +1,26 @@
+# Palette Run: 2026-03-26
+
+## What I read
+Checked `.github/workflows/` and `.jules/policy/scheduled_tasks.json`.
+Baseline gates: `cargo build --verbose`, `CI=true cargo test --verbose`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`.
+
+## Selected lane
+Scout
+
+## Target
+Refactor `unwrap_or_default()` in JSON test assertions to `.expect("message")` across multiple test files. Using `unwrap_or_default()` when checking string properties like `path` or `module` or `lang` obscures test failures (if the JSON structure changes and the property is missing or not a string, the test continues with an empty string, which might spuriously pass validations like `!path.contains('\\')` and hide the schema breakage).
+
+Instead of swallowing missing fields with defaults, tests should fail fast and explicitly if the output format has drifted. This improves the DX by providing a clear trace when developers break output shapes.
+
+## Findings
+Updated test files:
+- `crates/tokmd/tests/regression_suite_w52.rs`
+- `crates/tokmd/tests/bdd_lang_scenarios_w50.rs`
+- `crates/tokmd/tests/bdd_export_scenarios_w50.rs`
+- `crates/tokmd/tests/regression_prevention_w55.rs`
+
+## Receipts
+- `cargo build --verbose`: PASS
+- `CI=true cargo test --verbose`: PASS
+- `cargo fmt -- --check`: PASS
+- `cargo clippy -- -D warnings`: PASS

--- a/crates/tokmd/tests/bdd_export_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_export_scenarios_w50.rs
@@ -159,7 +159,7 @@ fn given_project_when_export_redact_paths_then_no_real_paths() {
 
     let known_filenames = ["main.rs", "script.js", "large.rs", "README.md", "mixed.md"];
     for row in rows {
-        let path = row["path"].as_str().unwrap_or_default();
+        let path = row["path"].as_str().expect("path should be a string");
         for name in &known_filenames {
             assert!(
                 !path.contains(name),

--- a/crates/tokmd/tests/bdd_lang_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_lang_scenarios_w50.rs
@@ -142,7 +142,7 @@ fn given_project_with_embedded_code_when_children_collapse_then_mode_recorded() 
     // And: no row should have "(embedded)" in the lang name
     let rows = json["rows"].as_array().expect("rows should be array");
     for row in rows {
-        let lang = row["lang"].as_str().unwrap_or_default();
+        let lang = row["lang"].as_str().expect("lang should be a string");
         assert!(
             !lang.contains("(embedded)"),
             "collapse mode should not have (embedded) rows, found: {lang}"

--- a/crates/tokmd/tests/regression_prevention_w55.rs
+++ b/crates/tokmd/tests/regression_prevention_w55.rs
@@ -506,7 +506,7 @@ fn no_backslash_in_any_json_path() {
     let json = run_json(&["export", "--format", "json"]);
     let rows = json["rows"].as_array().unwrap();
     for row in rows {
-        let path = row["path"].as_str().unwrap_or_default();
+        let path = row["path"].as_str().expect("path should be a string");
         assert!(!path.contains('\\'), "backslash in export path: {path}");
     }
 }
@@ -516,7 +516,7 @@ fn module_keys_never_start_with_slash() {
     let json = run_json(&["module", "--format", "json"]);
     let rows = json["rows"].as_array().unwrap();
     for row in rows {
-        let module = row["module"].as_str().unwrap_or_default();
+        let module = row["module"].as_str().expect("module should be a string");
         assert!(!module.starts_with('/'), "module starts with /: {module}");
     }
 }

--- a/crates/tokmd/tests/regression_suite_w52.rs
+++ b/crates/tokmd/tests/regression_suite_w52.rs
@@ -244,7 +244,7 @@ fn no_backslash_paths_in_json_output() {
     let json = run_json(&["export", "--format", "json"]);
     let rows = json["rows"].as_array().expect("rows is not an array");
     for row in rows {
-        let path = row["path"].as_str().unwrap_or_default();
+        let path = row["path"].as_str().expect("path should be a string");
         assert!(
             !path.contains('\\'),
             "backslash found in export path: {path}"
@@ -257,7 +257,7 @@ fn module_keys_never_start_with_slash() {
     let json = run_json(&["module", "--format", "json"]);
     let rows = json["rows"].as_array().expect("rows is not an array");
     for row in rows {
-        let module = row["module"].as_str().unwrap_or_default();
+        let module = row["module"].as_str().expect("module should be a string");
         assert!(
             !module.starts_with('/'),
             "module key starts with /: {module}"
@@ -270,7 +270,7 @@ fn export_paths_are_relative() {
     let json = run_json(&["export", "--format", "json"]);
     let rows = json["rows"].as_array().expect("rows is not an array");
     for row in rows {
-        let path = row["path"].as_str().unwrap_or_default();
+        let path = row["path"].as_str().expect("path should be a string");
         assert!(
             !path.starts_with('/'),
             "export path is absolute (starts with /): {path}"


### PR DESCRIPTION
# PR Glass Cockpit 
 
Make review boring. Make truth cheap. 
 
## 💡 Summary 
Replaced `unwrap_or_default()` with explicit `.expect("...")` calls in JSON test assertions across multiple test suites.
 
## 🎯 Why (user/dev pain) 
Using `unwrap_or_default()` when extracting string properties from JSON output obscures test failures. If the JSON structure changes and a property (like `path` or `module`) is missing or not a string, the test continues with an empty string, which might spuriously pass validations (like `!path.contains('\\')`) and silently hide the schema breakage. This improves Developer Experience by ensuring tests fail fast and explicitly with clear tracing if the output format drifts.
 
## 🔎 Evidence (before/after) 
- File paths: 
  - `crates/tokmd/tests/bdd_export_scenarios_w50.rs`
  - `crates/tokmd/tests/bdd_lang_scenarios_w50.rs`
  - `crates/tokmd/tests/regression_suite_w52.rs`
  - `crates/tokmd/tests/regression_prevention_w55.rs`
- Behavior: Previously, a missing `path` key would default to `""` and quietly pass string formatting checks. Now, tests immediately panic with `"path should be a string"` pointing to the exact broken row.
 
## 🧭 Options considered 
### Option A (recommended) 
- What it is: Replace `.unwrap_or_default()` with `.expect("<field> should be a string")`
- Why it fits this repo: Follows the rule to burn down obscuring unwrap patterns in favor of descriptive panic contexts. Tests are meant to assert correctness strictly.
- Trade-offs: Strict parsing means tests break immediately if optional fields are missing. This forces explicit schema contracts.
 
### Option B 
- What it is: Use `.as_str().unwrap()` 
- When to choose it instead: If the context of the panic is perfectly obvious.
- Trade-offs: Loses the descriptive context string, making test failure analysis slightly slower.
 
## ✅ Decision 
Option A. Enforcing explicit, clear error messages in test failures accelerates debugging and prevents silent regressions.
 
## 🧱 Changes made (SRP) 
- Replaced `unwrap_or_default()` in string field assertions with `.expect(...)` in:
  - `crates/tokmd/tests/bdd_export_scenarios_w50.rs`
  - `crates/tokmd/tests/bdd_lang_scenarios_w50.rs`
  - `crates/tokmd/tests/regression_suite_w52.rs`
  - `crates/tokmd/tests/regression_prevention_w55.rs`
 
## 🧪 Verification receipts 
- `cargo build --verbose`: PASS
- `CI=true cargo test --verbose`: PASS
- `cargo fmt -- --check`: PASS
- `cargo clippy -- -D warnings`: PASS
 
## 🧭 Telemetry 
- Change shape: Test refactoring (Search and replace)
- Blast radius: Tests only. No API, IO, or Schema changes.
- Risk class: Low
- Rollback: Revert commit
- Merge-confidence gates: `build`, `test`, `fmt`, `clippy`
 
## 🗂️ .jules updates 
- Appended new run index entry to `.jules/palette/ledger.json`.
- Logged the task in `.jules/palette/runs/2026-03-26.md`.
- Wrote full execution receipts in `.jules/palette/envelopes/20260326T125631Z.json`.
 
## 📝 Notes (freeform) 
None.
 
## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [14775119627140177253](https://jules.google.com/task/14775119627140177253) started by @EffortlessSteven*