### PR TITLE
docs: add doctests for deep and fun analysis presets 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/docs-preset-tests.json
+++ b/.jules/docs/envelopes/docs-preset-tests.json
@@ -1,0 +1,7 @@
+{
+  "id": "docs-preset-tests",
+  "status": "PASS",
+  "receipts": [
+    "cargo test -p tokmd --test docs\n\nrunning 13 tests\ntest recipe_ci_workflow_snippet ... ok\ntest recipe_default_map ... ok\ntest recipe_export_map_jsonl ... ok\ntest recipe_export_full_json ... ok\ntest recipe_generate_baseline ... ok\ntest recipe_badge_generation ... ok\ntest recipe_handoff_bundle ... ok\ntest recipe_gate_with_baseline ... ok\ntest recipe_module_summary_markdown ... ok\ntest recipe_sensor_json ... ok\ntest recipe_simple_lang_summary ... ok\ntest recipe_tools_export_schemas ... ok\ntest recipe_analyze_presets ... ok\n\ntest result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s"
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -31,5 +31,13 @@
   {
     "run_id": "0ff363bd-f129-45fb-a4b4-e5437f5b7a41",
     "status": "PASS"
+  },
+  {
+    "run_id": "docs-preset-tests",
+    "timestamp": "2026-03-27T00:00:00Z",
+    "lane": "docs",
+    "action": "add_doctests",
+    "target": "crates/tokmd/tests/docs.rs",
+    "description": "Added doctests for deep and fun analysis presets in crates/tokmd/tests/docs.rs to prevent documentation drift from docs/recipes.md"
   }
 ]

--- a/crates/tokmd/tests/docs.rs
+++ b/crates/tokmd/tests/docs.rs
@@ -77,6 +77,31 @@ fn recipe_analyze_presets() {
         .arg("md")
         .assert()
         .success();
+
+    // "tokmd analyze --preset deep --format json --output-dir analysis/"
+    let tmp = tempfile::tempdir().unwrap();
+    let analysis_dir = tmp.path().join("analysis");
+    tokmd()
+        .arg("analyze")
+        .arg("--preset")
+        .arg("deep")
+        .arg("--format")
+        .arg("json")
+        .arg("--output-dir")
+        .arg(&analysis_dir)
+        .assert()
+        .success();
+    assert!(analysis_dir.exists());
+
+    // "tokmd analyze --preset fun --format json"
+    tokmd()
+        .arg("analyze")
+        .arg("--preset")
+        .arg("fun")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success();
 }
 
 #[test]


### PR DESCRIPTION
## 💡 Summary
Added doctests for the `deep` and `fun` analysis presets in `crates/tokmd/tests/docs.rs` to ensure the CLI recipes provided in the documentation continue to compile and work as expected.

## 🎯 Why (perf bottleneck)
The `docs/recipes.md` file documented the usage of `tokmd analyze --preset deep` and `tokmd analyze --preset fun`, but these commands lacked corresponding doc tests in `crates/tokmd/tests/docs.rs`, meaning they could silently drift or fail if the CLI structure changed. 

## 📊 Proof (before/after)
No performance metrics affected. This is a pure test coverage/documentation hygiene fix.

## 🧭 Options considered
### Option A (recommended)
- Add the missing `assert_cmd` blocks to `recipe_analyze_presets` in `tests/docs.rs`.
- Why it fits this repo: This fits perfectly with the repo's established pattern for tracking "Docs as tests".

### Option B
- Modify the existing preset tests to iterate over all possible presets.
- When to choose it instead: If the goal was exhaustiveness over documentation accuracy.
- Trade-offs: That would test the engine, but not necessarily ensure the exact commands in the README/tutorial/recipes remain valid.

## ✅ Decision
Option A was chosen. Adding targeted integration tests mirroring the documentation ensures the documentation remains accurate over time.

## 🧱 Changes made (SRP)
- `crates/tokmd/tests/docs.rs`: Added `tokmd analyze --preset deep` and `tokmd analyze --preset fun` invocations to `recipe_analyze_presets`.
- `.jules/docs/ledger.json`: Appended the action.
- `.jules/docs/envelopes/docs-preset-tests.json`: Created receipt envelope.

## 🧪 Verification receipts
```
running 13 tests
test recipe_ci_workflow_snippet ... ok
test recipe_default_map ... ok
test recipe_export_map_jsonl ... ok
test recipe_export_full_json ... ok
test recipe_generate_baseline ... ok
test recipe_badge_generation ... ok
test recipe_handoff_bundle ... ok
test recipe_gate_with_baseline ... ok
test recipe_module_summary_markdown ... ok
test recipe_sensor_json ... ok
test recipe_simple_lang_summary ... ok
test recipe_tools_export_schemas ... ok
test recipe_analyze_presets ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s
```

## 🧭 Telemetry
- Change shape: Minor test additions
- Blast radius: `crates/tokmd/tests/docs.rs` and `.jules/` state only. Zero impact on production binaries or library functionality.
- Risk class: Negligible
- Rollback: `git revert`
- Merge-confidence gates: `cargo test -p tokmd --test docs`

## 🗂️ .jules updates
- Appended to `.jules/docs/ledger.json`
- Wrote `.jules/docs/envelopes/docs-preset-tests.json`

## 📝 Notes (freeform)
None.

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [7976731847454659164](https://jules.google.com/task/7976731847454659164) started by @EffortlessSteven*