### PR TITLE
compat: fix no-default-features build for tokmd-analysis 🧷 Compat

### DIFF
--- a/.jules/compat/envelopes/37650a63-683c-4dda-9ed6-9c5f825929ae.json
+++ b/.jules/compat/envelopes/37650a63-683c-4dda-9ed6-9c5f825929ae.json
@@ -1,0 +1,6 @@
+{
+  "id": "37650a63-683c-4dda-9ed6-9c5f825929ae",
+  "status": "PASS",
+  "friction_ids": [],
+  "receipts": []
+}

--- a/.jules/compat/ledger.json
+++ b/.jules/compat/ledger.json
@@ -12,5 +12,10 @@
   {
     "run_id": "13bf324d-a8ad-4e74-9d27-673789e16269",
     "status": "PASS"
+  },
+  {
+    "run_id": "37650a63-683c-4dda-9ed6-9c5f825929ae",
+    "status": "PASS",
+    "friction_ids": []
   }
 ]

--- a/.jules/compat/runs/2024-05-24.md
+++ b/.jules/compat/runs/2024-05-24.md
@@ -1,0 +1,6 @@
+# Run 2024-05-24
+
+- **Target**: tokmd-analysis conditional warnings
+- **Issue**: `ROOTLESS_FILE_ANALYSIS_WARNING` was throwing dead code warnings when compiled with `--no-default-features --features git` because it was defined for `any(walk, content, git)` but only used under `walk` and `content`.
+- **Fix**: Adjusted `#[cfg]` attributes so `ROOTLESS_FILE_ANALYSIS_WARNING` is only defined for `any(walk, content)` and `ROOTLESS_GIT_ANALYSIS_WARNING` is defined for `git`.
+- **Verification**: `cargo check -p tokmd --no-default-features --features git` now compiles without dead code warnings. `cargo xtask gate --check` passes all steps.

--- a/crates/tokmd-analysis/src/analysis.rs
+++ b/crates/tokmd-analysis/src/analysis.rs
@@ -93,10 +93,10 @@ fn preset_plan(preset: AnalysisPreset) -> PresetPlan {
     preset_plan_for(preset)
 }
 
-#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
+#[cfg(any(feature = "walk", feature = "content"))]
 const ROOTLESS_FILE_ANALYSIS_WARNING: &str =
     "in-memory analysis has no host root; skipping file-backed enrichers";
-#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
+#[cfg(feature = "git")]
 const ROOTLESS_GIT_ANALYSIS_WARNING: &str =
     "in-memory analysis has no host root; skipping git-backed enrichers";
 


### PR DESCRIPTION
## Description
Fixed unused constants warning in `tokmd-analysis` causing compilation
issues when running `cargo check --no-default-features --features git`.

**Root Cause**:
`ROOTLESS_FILE_ANALYSIS_WARNING` and `ROOTLESS_GIT_ANALYSIS_WARNING` were both defined under `#[cfg(any(feature = "walk", feature = "content", feature = "git"))]`. However, the file warning was only used under `walk`/`content` contexts and the git warning only under `git` contexts. When compiling with only `feature = "git"` and NO `walk`/`content` features, the file warning became unused (dead code). Because `tokmd-analysis` effectively `#[deny(warnings)]`, this broke the `no-default-features` matrix pipeline.

**Resolution**:
Adjusted `#[cfg]` attribute scopes to reflect actual usage for both constants. 

## Receipts
```
$ cargo check -p tokmd --no-default-features --features git
    Checking tokmd-analysis v1.8.1 (/app/crates/tokmd-analysis)
    Checking tokmd v1.8.1 (/app/crates/tokmd)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.49s

$ cargo xtask gate --check
[1/4] fmt
   ✅ Step 1 (fmt) passed
[2/4] check (warm graph)
   ✅ Step 2 (check (warm graph)) passed
[3/4] clippy
   ✅ Step 3 (clippy) passed
[4/4] test (compile-only)
   ✅ Step 4 (test (compile-only)) passed

gate result: 4/4 steps passed
```

## Matrix verification
- `--no-default-features`
- `--all-features`

---
*PR created automatically by Jules for task [14419431153768749308](https://jules.google.com/task/14419431153768749308) started by @EffortlessSteven*