### PR TITLE
docs: unify formatting commands on repo-native aliases

### DIFF
--- a/.github/agents/ci-fix-forward.agent.md
+++ b/.github/agents/ci-fix-forward.agent.md
@@ -23,7 +23,7 @@ Workflow
 
 2) Reproduce minimally
 - Prefer the narrowest local reproduction:
-  - fmt: cargo fmt --all -- --check
+  - fmt: cargo fmt-check
   - clippy: cargo clippy -- -D warnings (or workspace if CI uses it)
   - tests: cargo test -p <crate> --verbose
   - docs: cargo xtask docs --check

--- a/Justfile
+++ b/Justfile
@@ -47,11 +47,11 @@ lint:
 
 # Format code
 fmt:
-    cargo fmt
+    cargo fmt-fix
 
 # Check formatting without modifying
 fmt-check:
-    cargo fmt -- --check
+    cargo fmt-check
 
 # Run all checks (fmt, lint, test)
 check: fmt-check lint test

--- a/_fix_branch.ps1
+++ b/_fix_branch.ps1
@@ -20,10 +20,10 @@ Set-Location $PSScriptRoot
 $branch = git rev-parse --abbrev-ref HEAD 2>&1
 Write-Host "Branch: $branch"
 
-# Run cargo fmt
-Write-Host "Running cargo fmt..."
-cargo fmt 2>&1
-Write-Host "Cargo fmt exit: $LASTEXITCODE"
+# Run cargo fmt-fix
+Write-Host "Running cargo fmt-fix..."
+cargo fmt-fix 2>&1
+Write-Host "Cargo fmt-fix exit: $LASTEXITCODE"
 
 # Add changes
 Write-Host "Running git add..."
@@ -37,7 +37,7 @@ Write-Host "Changed files: $diff"
 
 if ($diff) {
     Write-Host "Committing..."
-    git -c core.fsmonitor=false commit --no-verify -m "style: cargo fmt" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" 2>&1
+    git -c core.fsmonitor=false commit --no-verify -m "style: cargo fmt-fix" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" 2>&1
     Write-Host "Commit exit: $LASTEXITCODE"
     
     Write-Host "Pushing..."

--- a/_fix_branch4.py
+++ b/_fix_branch4.py
@@ -48,10 +48,10 @@ if rc != 0:
     log("FAILED to clone")
     sys.exit(1)
 
-# Run cargo fmt
-rc, _ = run("cargo fmt", cwd=CLONE_DIR, timeout=300)
+# Run cargo fmt-fix
+rc, _ = run("cargo fmt-fix", cwd=CLONE_DIR, timeout=300)
 if rc != 0:
-    log("FAILED cargo fmt")
+    log("FAILED cargo fmt-fix")
     sys.exit(1)
 
 # Check and fix typos

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -14,7 +14,8 @@ Common commands:
 cargo build
 cargo build --release
 cargo test --workspace
-cargo fmt
+cargo fmt-fix
+cargo fmt-check
 cargo clippy --all-features -- -D warnings
 cargo xtask lint-fix
 cargo xtask gate --check

--- a/run_checks.ps1
+++ b/run_checks.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 Set-Location 'C:\Code\Rust\tokmd-analysis-tests2'
 
-Write-Host "=== Running cargo fmt ===" -ForegroundColor Green
-cargo fmt
+Write-Host "=== Running cargo fmt-fix ===" -ForegroundColor Green
+cargo fmt-fix
 $fmtExitCode = $LASTEXITCODE
 
 Write-Host "`n=== Running cargo clippy ===" -ForegroundColor Green
@@ -10,7 +10,7 @@ cargo clippy -p tokmd-analysis-halstead -p tokmd-analysis-license -p tokmd-analy
 $clippyExitCode = $LASTEXITCODE
 
 Write-Host "`n=== Summary ===" -ForegroundColor Green
-Write-Host "cargo fmt exit code: $fmtExitCode"
+Write-Host "cargo fmt-fix exit code: $fmtExitCode"
 Write-Host "cargo clippy exit code: $clippyExitCode"
 
 if ($fmtExitCode -eq 0 -and $clippyExitCode -eq 0) {


### PR DESCRIPTION
### Motivation

- The repo already provides Windows-safe formatter aliases (`cargo fmt-fix` / `cargo fmt-check`) to avoid large argv issues with `cargo fmt`, and some checked-in guidance and scripts still referenced raw `cargo fmt` which reintroduces the problem.  
- This change standardizes the repository command surface so developers and automated agents are directed to the canonical, workspace-safe formatter entry points.  
- Aligning docs and helper scripts reduces future accidental use of `cargo fmt` from workspace roots on Windows and other environments that may hit command-line limits.

### Description

- Updated `Justfile` so `fmt` runs `cargo fmt-fix` and `fmt-check` runs `cargo fmt-check` to match the repo-native aliases.  
- Updated `.github/agents/ci-fix-forward.agent.md` to recommend `cargo fmt-check` as the minimal local reproduction for formatting failures.  
- Updated `agents/shared/repo.md` to prefer `cargo fmt-fix` and `cargo fmt-check` in the common commands list.  
- Updated legacy helper scripts (`run_checks.ps1`, `_fix_branch4.py`, `_fix_branch.ps1`) to call `cargo fmt-fix` and to align related log and commit messaging.

### Testing

- Ran `cargo fmt-check` locally which exercised the repo-native formatting path and completed successfully.  
- Verified changes were staged and committed (`git commit`) and the working tree reflects the updated docs and scripts without further failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64b71115883338e88941832bbff32)