### PR TITLE
Split Nix PR gate from full validation and narrow package dep builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: "22 3 * * *"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -218,10 +220,10 @@ jobs:
         env:
           CI: true
 
-  nix:
-    name: Nix Build
+  nix-pr:
+    name: Nix PR Package Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 60
     permissions:
       contents: read
     env:
@@ -243,7 +245,38 @@ jobs:
         run: nix flake check --no-build --accept-flake-config
 
       - name: Build package
-        run: nix build -L
+        run: nix build -L .#tokmd
+
+  nix-full:
+    name: Nix Full Validation
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+
+      - name: Setup Nix cache
+        continue-on-error: true
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+          use-gha-cache: enabled
+
+      - name: Check flake
+        run: nix flake check --accept-flake-config
+
+      - name: Build default package
+        run: nix build -L .#tokmd
+
+      - name: Build alias package
+        run: nix build -L .#tokmd-with-alias
 
   mutation:
     name: Mutation Testing (Required)
@@ -340,7 +373,7 @@ jobs:
       - publish-plan
       - version-consistency
       - docs-check
-      - nix
+      - nix-pr
       - mutation
       - feature-boundaries
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -106,17 +106,25 @@
             strictDeps = true;
           };
 
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          tokmdDeps = craneLib.buildDepsOnly (commonArgs // {
+            cargoExtraArgs = "--locked -p tokmd";
+            doCheck = false;
+          });
 
           tokmd = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p tokmd";
+            cargoArtifacts = tokmdDeps;
+            cargoExtraArgs = "--locked -p tokmd";
+            doCheck = false;
+          });
+
+          tokmdAliasDeps = craneLib.buildDepsOnly (commonArgs // {
+            cargoExtraArgs = "--locked -p tokmd --features alias-tok";
             doCheck = false;
           });
 
           tokmdWithAlias = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p tokmd --features alias-tok";
+            cargoArtifacts = tokmdAliasDeps;
+            cargoExtraArgs = "--locked -p tokmd --features alias-tok";
             doCheck = false;
           });
         in


### PR DESCRIPTION
### Motivation
- Keep Nix as a required PR gate while preventing a single broad Nix derivation from dominating PR latency. 
- Make the PR lane a tight package-validation lane and move broader Nix assurance to a separate, less-frequent lane for `main`/nightly/releases. 

### Description
- Refactored `flake.nix` so each package gets a package-scoped `buildDepsOnly` derivation (`tokmdDeps`, `tokmdAliasDeps`) and wired each package to its matching dep artifact with aligned `cargoExtraArgs` and `doCheck = false` to avoid one oversized shared dep build. 
- Reworked CI in `.github/workflows/ci.yml` to rename the required job to `nix-pr` and make it a narrow package-only build that runs `nix flake check --no-build --accept-flake-config` and `nix build -L .#tokmd` with a `60m` timeout. 
- Added a `nix-full` job that runs on schedule and push to `main`/`release/**` to perform full flake checks and build both `.#tokmd` and `.#tokmd-with-alias` with a longer timeout. 
- Adjusted workflow triggers (added `release/**` pushes and a nightly `schedule`) and updated the `ci-required` aggregation to depend on `nix-pr` instead of the old monolithic Nix job. 

### Testing
- Ran `git diff --check`, which completed with no reported whitespace/patch errors. 
- Attempted `nix flake check --no-build --accept-flake-config` locally but it could not run in this environment because `nix` is not installed (`/bin/bash: nix: command not found`). 
- All changes are limited to `flake.nix` and `.github/workflows/ci.yml` and will be validated by CI where the new `nix-pr` and `nix-full` jobs will execute full Nix checks and builds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65b3b4c908333be4c9521d486c89d)