### PR TITLE
Split Nix PR gate from full validation and scope package dep builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**", "v1.9.0-rc" ]
   pull_request:
     branches: [ "main" ]
 
@@ -218,10 +218,10 @@ jobs:
         env:
           CI: true
 
-  nix:
-    name: Nix Build
+  nix-pr:
+    name: Nix PR Package Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 60
     permissions:
       contents: read
     env:
@@ -243,7 +243,38 @@ jobs:
         run: nix flake check --no-build --accept-flake-config
 
       - name: Build package
-        run: nix build -L
+        run: nix build -L .#tokmd
+
+  nix-full:
+    name: Nix Full Validation
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+
+      - name: Setup Nix cache
+        continue-on-error: true
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+          use-gha-cache: enabled
+
+      - name: Check flake
+        run: nix flake check --accept-flake-config
+
+      - name: Build tokmd package
+        run: nix build -L .#tokmd
+
+      - name: Build tokmd-with-alias package
+        run: nix build -L .#tokmd-with-alias
 
   mutation:
     name: Mutation Testing (Required)
@@ -340,7 +371,7 @@ jobs:
       - publish-plan
       - version-consistency
       - docs-check
-      - nix
+      - nix-pr
       - mutation
       - feature-boundaries
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -106,17 +106,25 @@
             strictDeps = true;
           };
 
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          tokmdDeps = craneLib.buildDepsOnly (commonArgs // {
+            cargoExtraArgs = "--locked -p tokmd";
+            doCheck = false;
+          });
 
           tokmd = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p tokmd";
+            cargoArtifacts = tokmdDeps;
+            cargoExtraArgs = "--locked -p tokmd";
+            doCheck = false;
+          });
+
+          tokmdAliasDeps = craneLib.buildDepsOnly (commonArgs // {
+            cargoExtraArgs = "--locked -p tokmd --features alias-tok";
             doCheck = false;
           });
 
           tokmdWithAlias = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p tokmd --features alias-tok";
+            cargoArtifacts = tokmdAliasDeps;
+            cargoExtraArgs = "--locked -p tokmd --features alias-tok";
             doCheck = false;
           });
         in


### PR DESCRIPTION
### Motivation
- Keep Nix as a required PR gate while making that gate narrowly focused on the release package to avoid long unnecessary rebuilds. 
- Reduce spurious cache invalidation caused by a single broad `buildDepsOnly` derivation shared across package shapes. 
- Provide a separate broader Nix validation lane for `main`/release branches so full surface checks and alternate package shapes run at a lower cadence.

### Description
- Refactored `flake.nix` to replace the single shared `buildDepsOnly` artifact with package-scoped dep derivations `tokmdDeps` and `tokmdAliasDeps`, and wired package builds to consume the matching dep artifact. 
- Reworked CI in `.github/workflows/ci.yml` by renaming the prior `nix` job to `nix-pr` and narrowing it to run `nix flake check --no-build --accept-flake-config` and `nix build -L .#tokmd` with a reduced timeout. 
- Added a push-only `nix-full` job that runs full `nix flake check` and builds both `.#tokmd` and `.#tokmd-with-alias`, and expanded push coverage to `release/**` and `v1.9.0-rc`. 
- Updated the required aggregate `ci-required` job to depend on `nix-pr` instead of the old broader `nix` job so PR-required status tracks the tighter package gate. 

### Testing
- Attempted to run `nix --version` and `nix flake check --no-build --accept-flake-config` in the local execution environment, but the commands failed because `nix` is not installed (`nix: command not found`). 
- No Rust workspace tests or CI runs were executed in this environment; CI behavior will be validated when the updated workflow runs on GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65b3b4c908333be4c9521d486c89d)