### PR TITLE
Split Nix CI into PR package gate and full validation; narrow flake dep artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: "25 7 * * *"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -218,10 +220,10 @@ jobs:
         env:
           CI: true
 
-  nix:
-    name: Nix Build
+  nix-pr:
+    name: Nix PR Package Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 60
     permissions:
       contents: read
     env:
@@ -243,7 +245,38 @@ jobs:
         run: nix flake check --no-build --accept-flake-config
 
       - name: Build package
-        run: nix build -L
+        run: nix build -L .#tokmd
+
+  nix-full:
+    name: Nix Full Validation
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+
+      - name: Setup Nix cache
+        continue-on-error: true
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+          use-gha-cache: enabled
+
+      - name: Run full flake checks
+        run: nix flake check --accept-flake-config
+
+      - name: Build tokmd package
+        run: nix build -L .#tokmd
+
+      - name: Build tokmd alias package
+        run: nix build -L .#tokmd-with-alias
 
   mutation:
     name: Mutation Testing (Required)
@@ -340,7 +373,7 @@ jobs:
       - publish-plan
       - version-consistency
       - docs-check
-      - nix
+      - nix-pr
       - mutation
       - feature-boundaries
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -106,17 +106,25 @@
             strictDeps = true;
           };
 
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          tokmdArtifacts = craneLib.buildDepsOnly (commonArgs // {
+            cargoExtraArgs = "--locked -p tokmd";
+            doCheck = false;
+          });
+
+          tokmdAliasArtifacts = craneLib.buildDepsOnly (commonArgs // {
+            cargoExtraArgs = "--locked -p tokmd --features alias-tok";
+            doCheck = false;
+          });
 
           tokmd = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p tokmd";
+            cargoArtifacts = tokmdArtifacts;
+            cargoExtraArgs = "--locked -p tokmd";
             doCheck = false;
           });
 
           tokmdWithAlias = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p tokmd --features alias-tok";
+            cargoArtifacts = tokmdAliasArtifacts;
+            cargoExtraArgs = "--locked -p tokmd --features alias-tok";
             doCheck = false;
           });
         in


### PR DESCRIPTION
### Motivation
- Reduce PR wall-clock time while keeping Nix as a required gate by separating quick package validation from broader Nix assurance.
- Avoid a single oversized `buildDepsOnly` derivation that invalidates too often and forces expensive dependency builds for every PR.
- Make the flake artifact scope deterministic and match the package being validated so CI cache hits are more predictable.

### Description
- Updated `flake.nix` to replace the single shared `buildDepsOnly` artifact with package-scoped artifacts: `tokmdArtifacts` (for `-p tokmd`) and `tokmdAliasArtifacts` (for `-p tokmd --features alias-tok`), and passed those into the corresponding `buildPackage` calls with matching `--locked` `cargoExtraArgs` and `doCheck = false`.
- Modified `.github/workflows/ci.yml` to introduce two Nix lanes: a required PR lane `nix-pr` (shorter timeout, runs `nix flake check --no-build` and `nix build -L .#tokmd`) and a non-required `nix-full` lane (runs on `push`/`schedule`, does full `nix flake check` and builds both `.#tokmd` and `.#tokmd-with-alias`), and added a scheduled trigger so the broader validation runs regularly.
- Wired `ci-required` to depend on the new `nix-pr` job instead of the prior full Nix job and reduced required-lane scope to package validation.

### Testing
- Ran a local diff verification with `git diff -- .github/workflows/ci.yml flake.nix` to confirm the intended changes were applied, which succeeded.
- Attempted `nix --version` in the environment but `nix` is not installed here, so no local Nix builds or `nix flake` executions were performed.
- Changes were committed successfully (`git commit`) and will be validated by CI when the pipeline runs on GitHub.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65b3b4c908333be4c9521d486c89d)