### PR TITLE
perf: reduce string allocations in lang report generation ⚡ Bolt

### DIFF
--- a/.jules/bolt/envelopes/cc7116df-c51d-4482-8f10-396b45b56bc7.json
+++ b/.jules/bolt/envelopes/cc7116df-c51d-4482-8f10-396b45b56bc7.json
@@ -1,0 +1,14 @@
+{
+  "run_id": "cc7116df-c51d-4482-8f10-396b45b56bc7",
+  "timestamp_utc": "2026-03-27T12:45:39Z",
+  "lane": "scout",
+  "target": "crates/tokmd-model/src/lib.rs: reduce String allocations in create_lang_report_from_rows",
+  "proof_method": "structural",
+  "commands": ["cargo build --verbose", "CI=true cargo test -p tokmd -p tokmd-model --verbose", "cargo fmt -- --check", "cargo clippy -- -D warnings"],
+  "results": [
+    {"cmd": "cargo build --verbose", "status": "PASS", "summary": "Successfully compiled tokmd-model"},
+    {"cmd": "CI=true cargo test -p tokmd -p tokmd-model --verbose", "status": "PASS", "summary": "All tests passed for tokmd and tokmd-model"},
+    {"cmd": "cargo fmt -- --check", "status": "PASS", "summary": "Code format is correct"},
+    {"cmd": "cargo clippy -- -D warnings", "status": "PASS", "summary": "No clippy warnings"}
+  ]
+}

--- a/.jules/bolt/ledger.json
+++ b/.jules/bolt/ledger.json
@@ -35,5 +35,20 @@
       "clippy"
     ],
     "friction_ids": []
+  },
+  {
+    "date": "2026-03-27T12:43:40Z",
+    "run_id": "1",
+    "lane": "scout",
+    "target": "crates/tokmd-model/src/lib.rs",
+    "proof_method": "structural",
+    "pr_link": null,
+    "gates": [
+      "build",
+      "test(tokmd, tokmd-model)",
+      "fmt",
+      "clippy"
+    ],
+    "friction_ids": []
   }
 ]

--- a/.jules/bolt/runs/2026-03-27.md
+++ b/.jules/bolt/runs/2026-03-27.md
@@ -1,0 +1,16 @@
+# Bolt Run Log 2026-03-27
+
+**Read:** Checked CI definitions and docs.
+**Lane:** scout
+**Target:** `crates/tokmd-model/src/lib.rs` - `create_lang_report_from_rows` function
+**Proof Method:** structural
+**Options:**
+- **Option A (recommended):** Use `std::borrow::Cow<'_, str>` as the key for `by_lang` `BTreeMap`. This allows borrowing `row.lang` for normal parent rows, avoiding allocations, while allowing `format!` strings for embedded language rows via `Cow::Owned`.
+- **Option B:** Leave as `String` but deduplicate formatting via a separate pass. Requires more boilerplate and a `HashMap` or extra clones before insertion.
+- **Decision:** Selected Option A for simplicity and maximum performance, correctly capturing both borrowed values and necessary formatted Strings in the same tree map.
+
+## Receipts
+- `cargo build --verbose` (PASS)
+- `CI=true cargo test -p tokmd -p tokmd-model --verbose` (PASS)
+- `cargo fmt -- --check` (PASS)
+- `cargo clippy -- -D warnings` (PASS)

--- a/.jules/policy/scheduled_tasks.json
+++ b/.jules/policy/scheduled_tasks.json
@@ -1,6 +1,1 @@
-{
-  "version": 1,
-  "selection_strategy": "random",
-  "default_gates": ["build", "test", "fmt", "clippy"],
-  "notes_write_threshold": "only_when_reusable_pattern_discovered"
-}
+{"version": 1,"selection_strategy": "random","default_gates": ["build", "test", "fmt", "clippy"],"notes_write_threshold": "only_when_reusable_pattern_discovered"}

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -340,13 +340,13 @@ pub fn create_lang_report_from_rows(
         entry.1 += row.lines;
     }
 
-    let mut by_lang: BTreeMap<String, (LangAgg, BTreeSet<&str>)> = BTreeMap::new();
+    let mut by_lang: BTreeMap<Cow<'_, str>, (LangAgg, BTreeSet<&str>)> = BTreeMap::new();
 
     for row in file_rows {
         match (children, row.kind) {
             (ChildrenMode::Collapse, FileKind::Parent) => {
                 let entry = by_lang
-                    .entry(row.lang.clone())
+                    .entry(Cow::Borrowed(row.lang.as_str()))
                     .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                 entry.0.code += row.code;
                 entry.0.lines += row.lines;
@@ -357,7 +357,7 @@ pub fn create_lang_report_from_rows(
             (ChildrenMode::Collapse, FileKind::Child) => {
                 if !parent_lang_by_path.contains_key(row.path.as_str()) {
                     let entry = by_lang
-                        .entry(row.lang.clone())
+                        .entry(Cow::Borrowed(row.lang.as_str()))
                         .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                     entry.0.code += row.code;
                     entry.0.lines += row.lines;
@@ -371,7 +371,7 @@ pub fn create_lang_report_from_rows(
                     .unwrap_or((0, 0));
 
                 let entry = by_lang
-                    .entry(row.lang.clone())
+                    .entry(Cow::Borrowed(row.lang.as_str()))
                     .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                 entry.0.code += row.code.saturating_sub(child_code);
                 entry.0.lines += row.lines.saturating_sub(child_lines);
@@ -381,7 +381,7 @@ pub fn create_lang_report_from_rows(
             }
             (ChildrenMode::Separate, FileKind::Child) => {
                 let entry = by_lang
-                    .entry(format!("{} (embedded)", row.lang))
+                    .entry(Cow::Owned(format!("{} (embedded)", row.lang)))
                     .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                 entry.0.code += row.code;
                 entry.0.lines += row.lines;
@@ -397,7 +397,7 @@ pub fn create_lang_report_from_rows(
         }
         let files = files_set.len();
         rows.push(LangRow {
-            lang: lang.to_string(),
+            lang: lang.into_owned(),
             code: agg.code,
             lines: agg.lines,
             files,


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Replaced string allocations with `std::borrow::Cow<'_, str>` inside `create_lang_report_from_rows` in `tokmd-model`.

## 🎯 Why (perf bottleneck)
The `BTreeMap` key aggregation in `create_lang_report_from_rows` previously `.clone()`d the `String` for every file processed to build up the map. This causes unneeded allocation pressure on the hot path of report aggregation. 

## 📊 Proof (before/after)
- structural proof: The `BTreeMap` type was changed to use `Cow<'_, str>` as the key. We can now use `Cow::Borrowed(row.lang.as_str())` for all standard parent languages, completely eliminating allocations for those rows. We only allocate for `Cow::Owned(format!("{} (embedded)", row.lang))` for the subset of rows that actually require dynamic naming.

## 🧭 Options considered
### Option A (recommended)
- What it is: Swap map key to `Cow<'_, str>` and borrow directly from `row.lang`.
- Why it fits this repo: Requires no new traits, no complex wrapper structs, and gracefully handles both standard referenced strings and formatted embedded strings.
- Trade-offs: Minor ergonomic cost (`into_owned()` on export).

### Option B
- What it is: Extract the formatted string generation to a separate pass or construct it locally inside a `HashMap` before moving to `BTreeMap` for sorting. 
- When to choose it instead: If borrowing from `row.lang` was impossible due to lifetimes.
- Trade-offs: More boilerplate and intermediate variables.

## ✅ Decision
Option A was chosen for its optimal simplicity and direct structural proof of eliminated clones.

## 🧱 Changes made (SRP)
- `crates/tokmd-model/src/lib.rs`

## 🧪 Verification receipts
- `cargo build --verbose` (PASS)
- `CI=true cargo test -p tokmd -p tokmd-model --verbose` (PASS)
- `cargo fmt -- --check` (PASS)
- `cargo clippy -- -D warnings` (PASS)

## 🧭 Telemetry
- Change shape: Internal structure change.
- Blast radius: Low, isolated to report string allocations.
- Risk class: Low, backed by deterministic tests.

## 🗂️ .jules updates
Created run envelope, ledger entry, and `2026-03-27.md` log for `scout` path.
---

---
*PR created automatically by Jules for task [12265107731157871855](https://jules.google.com/task/12265107731157871855) started by @EffortlessSteven*