### PR TITLE
docs: rework README surfaces around user workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tokmd
 
-> **Deterministic code receipts, analysis, and review artifacts for humans, CI, and LLM workflows.**
+> Deterministic repo receipts, analysis, and review artifacts for humans, CI, and LLM workflows.
 
 [![Crates.io](https://img.shields.io/crates/v/tokmd)](https://crates.io/crates/tokmd)
 [![GitHub Release](https://img.shields.io/github/v/release/EffortlessMetrics/tokmd?display_name=tag)](https://github.com/EffortlessMetrics/tokmd/releases)
@@ -9,309 +9,165 @@
 [![License](https://img.shields.io/crates/l/tokmd)](https://crates.io/crates/tokmd)
 [![Downloads](https://img.shields.io/crates/d/tokmd)](https://crates.io/crates/tokmd)
 
-`tokmd` turns a source tree into deterministic receipts you can diff, analyze, pack for LLMs, and gate in CI. It starts with [`tokei`](https://github.com/XAMPPRocky/tokei) counting, then adds stable artifact generation, derived analysis, review surfaces, and automation-friendly outputs that hold up across runs and operating systems.
+`tokmd` turns a source tree into stable receipts you can diff, analyze, archive, gate, and pack for downstream automation. It starts with code inventory, then keeps going: saved artifacts, derived metrics, PR review surfaces, policy checks, sensor outputs, and browser-safe context bundles.
 
-## Choose a Lane
+## The Problem
+
+Raw LOC counts are easy to produce and hard to reuse.
+
+- Terminal output is awkward to diff and archive.
+- CI needs artifacts and gates, not screenshots of a table.
+- LLM workflows need bounded, deterministic context instead of pasted summaries.
+- Review workflows need stable before/after surfaces, not one-off shell output.
+
+`tokmd` exists to turn repository shape into repeatable, machine-friendly truth.
+
+## What `tokmd` Gives You
+
+- Deterministic receipts for `lang`, `module`, `export`, `run`, `diff`, and `analyze`.
+- Review surfaces such as `cockpit`, `gate`, `baseline`, and `sensor`.
+- Saved artifacts in Markdown, JSON, JSONL, CSV, CycloneDX, HTML, SVG, Mermaid, and tree formats.
+- LLM-oriented workflows through `context`, `handoff`, redaction, token budgeting, and tool-schema generation.
+- Multiple product surfaces: CLI, Rust facade, Python bindings, Node bindings, and a browser/WASM slice.
+
+## Start Here
+
+Install:
+
+```bash
+cargo install tokmd --locked
+# or
+nix run github:EffortlessMetrics/tokmd -- --version
+```
+
+Run the common paths:
+
+```bash
+# Summarize the current repo
+tokmd --format md --top 8
+
+# Save a deterministic run directory for CI or later diffing
+tokmd run --analysis receipt --output-dir .runs/current
+
+# Compare two states
+tokmd diff main HEAD
+
+# Generate a risk-oriented analysis view
+tokmd analyze --preset risk --format md
+
+# Pack code for an LLM budget
+tokmd context --budget 128k --mode bundle --output context.txt
+```
+
+## Choose a Path
 
 | If you need to... | Start with... | Typical output |
 | :---------------- | :------------ | :------------- |
 | summarize a repo or PR | `tokmd`, `diff`, `cockpit` | Markdown summary, diff tables, review plan |
 | save deterministic artifacts | `run`, `export` | JSON/JSONL/CSV/CycloneDX receipts |
 | analyze code health or risk | `analyze` | Markdown, JSON, HTML, SVG, Mermaid |
-| estimate effort | `analyze --preset estimate` | effort report with optional base/head delta |
-| pack code for an LLM | `context`, `handoff` | bundle text, JSON receipts, handoff directory |
-| automate policy or multi-sensor CI | `gate`, `baseline`, `sensor` | ratchet checks, `sensor.report.v1`, policy results |
-
-## What You Get
-
-- **Deterministic receipts**: Markdown, JSON, JSONL, CSV, CycloneDX, HTML, tree, and more.
-- **Derived analysis**: doc density, test density, hotspots, coupling, freshness, and effort estimation.
-- **Review workflows**: `diff`, `cockpit`, `gate`, `baseline`, and `sensor.report.v1` output.
-- **LLM workflows**: `context` packing, `handoff` bundles, token estimates, redaction, and smart excludes.
-- **Browser/WASM workflows**: `tokmd-wasm` plus `web/runner` for local browser `lang`, `module`, `export`, and `analyze` (`receipt`, `estimate`) on ordered in-memory inputs.
-- **Cross-platform behavior**: Windows/Linux/macOS-friendly outputs, release automation, and repo-native CI usage.
-
-## Why Deterministic Matters
-
-- **Readable diffs**: stable ordering and normalized paths keep repo summaries comparable across runs.
-- **CI-friendly artifacts**: saved receipts can be diffed, gated, archived, and reused instead of scraped from ad-hoc terminal output.
-- **LLM-friendly context**: structured exports and bounded bundles are easier to feed into agents than pasted tables.
-- **One scan, many surfaces**: summaries, badges, review plans, and policy results come from the same underlying receipt graph.
-
-## Quickstart
-
-```bash
-# Install quickly
-nix run github:EffortlessMetrics/tokmd -- --version
-# or
-cargo install tokmd --locked
-
-# 1. High-signal repo summary for a PR or issue
-tokmd --format md --top 8 > summary.md
-
-# 2. Save full receipts for later diffing
-tokmd run --analysis receipt --output-dir .runs/current
-
-# 3. Pack code for an LLM within a budget
-tokmd context --budget 128k --mode bundle --output context.txt
-
-# 4. Estimate effort between two refs
-tokmd analyze --preset estimate --effort-base-ref main --effort-head-ref HEAD --format md
-
-# 5. Generate a review-friendly risk report
-tokmd analyze --preset risk --format md
-
-# 6. Emit a generated badge
-tokmd badge --metric hotspot --preset risk --output hotspot.svg
-
-# 7. Diff two states deterministically
-tokmd diff main HEAD
-```
+| estimate effort between refs | `analyze --preset estimate` | effort report with optional base/head delta |
+| gate policy in CI | `gate`, `baseline`, `sensor` | policy verdicts, ratchets, `sensor.report.v1` |
+| pack context for an LLM | `context`, `handoff` | bounded bundle text, JSON receipts, handoff directory |
 
 ## What It Looks Like
 
-These are checked-in example SVG badges generated by `tokmd badge` from this repository:
+These are live GitHub Actions badges from this repository:
 
-![Example Lines Badge](docs/assets/readme-badge-lines.svg)
-![Example Hotspot Badge](docs/assets/readme-badge-hotspot.svg)
+[![CI](https://github.com/EffortlessMetrics/tokmd/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/tokmd/actions/workflows/ci.yml)
+[![Release Workflow](https://github.com/EffortlessMetrics/tokmd/actions/workflows/release.yml/badge.svg)](https://github.com/EffortlessMetrics/tokmd/actions/workflows/release.yml)
 
-The source SVGs live under `docs/assets/` as checked-in documentation assets. They are real generated badge files, not screenshots and not remote badge-service URLs.
-
-Example summary output:
+Example summary output from this repository:
 
 ```md
 |Lang|Code|Lines|Bytes|Tokens|
 |---|---:|---:|---:|---:|
-|Rust|373655|466093|15200310|3799662|
-|JSON|5395|5395|283670|70912|
-|Markdown|2977|16757|540759|135143|
-|TOML|1867|2284|68871|17197|
-|Other|2216|2973|86971|21730|
-|**Total**|386110|493502|16180581|4044644|
+|Rust|377263|470341|15334354|3833170|
+|JSON|5405|5405|284012|70997|
+|Markdown|3067|17273|567919|141930|
+|JavaScript|1979|2233|64463|16111|
+|TOML|1947|2387|71514|17855|
+|Other|1978|2758|78806|19691|
+|**Total**|391639|500397|16401068|4099754|
 ```
-
-## Common Paths
-
-### PR and Review Summaries
-
-```bash
-tokmd --format md --top 10
-tokmd diff main HEAD
-tokmd cockpit
-```
-
-Use this path when you want a stable repo-shape summary, a before/after diff, and a review-plan surface instead of raw `tokei` output.
-
-### Saved Runs and Diffs
-
-```bash
-tokmd run --analysis receipt --output-dir .runs/base
-tokmd run --analysis receipt --output-dir .runs/current
-tokmd diff .runs/base .runs/current
-```
-
-Use this path when you want durable receipts on disk for later comparison, release prep, or CI artifact retention.
-
-### LLM Context and Handoff
-
-```bash
-tokmd context --budget 128k --mode bundle --output context.txt
-tokmd context --budget 200k --strategy spread --mode json
-tokmd handoff --preset risk --budget 128k --out-dir .handoff
-```
-
-Use `context` when you just need selected files inside a token budget. Use `handoff` when you want a fuller bundle with manifest, inventory, and intelligence artifacts.
-
-### Analysis and Effort
-
-```bash
-tokmd analyze --preset receipt --format md
-tokmd analyze --preset risk --format md
-tokmd analyze --preset estimate --effort-base-ref main --effort-head-ref HEAD --format md
-```
-
-`estimate` is the effort-focused preset, built around the `tokmd-analysis-effort` engine and diff-aware effort deltas.
-
-### Policy and Sensor Integration
-
-```bash
-tokmd gate --policy policy.toml --preset health .
-tokmd sensor --base main --head HEAD --output artifacts/tokmd/report.json
-```
-
-These are the automation-facing paths for CI pipelines, sensor fleets, and ratchet-style guardrails.
-
-## Command Surface
-
-| Command              | Purpose |
-| :------------------- | :------ |
-| `tokmd lang`         | Language summary for a repo or path set. |
-| `tokmd module`       | Group stats by module roots such as `crates/` or `packages/`. |
-| `tokmd export`       | File-level dataset for downstream pipelines (`jsonl`, `csv`, `cyclonedx`). |
-| `tokmd run`          | Save a full receipt set to a run directory, optionally with analysis. |
-| `tokmd analyze`      | Derived metrics and enrichments in formats including `md`, `json`, `html`, `svg`, and `mermaid`. |
-| `tokmd badge`        | Render SVG badges for `lines`, `tokens`, `bytes`, `doc`, `blank`, or `hotspot`. |
-| `tokmd diff`         | Compare two runs, receipts, or refs deterministically. |
-| `tokmd context`      | Pack code into an LLM context window inside a token budget. |
-| `tokmd handoff`      | Build an LLM handoff bundle with manifest, code bundle, and intelligence files. |
-| `tokmd cockpit`      | PR-review metrics with risk, evidence gates, and review-plan output. |
-| `tokmd gate`         | Evaluate TOML policy rules and optional ratchet baselines. |
-| `tokmd baseline`     | Capture a complexity baseline for later ratchet comparisons. |
-| `tokmd sensor`       | Emit a conforming `sensor.report.v1` envelope for multi-sensor pipelines. |
-| `tokmd tools`        | Generate tool definitions for OpenAI, Anthropic, and JSON Schema consumers. |
-| `tokmd init`         | Generate a `.tokeignore` template. |
-| `tokmd check-ignore` | Explain why a path is being ignored. |
-| `tokmd completions`  | Generate shell completions. |
-
-## Analysis Presets
-
-`tokmd analyze` ships focused preset bundles:
-
-| Preset         | What You Get |
-| :------------- | :----------- |
-| `receipt`      | Totals, density, distribution, COCOMO, context-window fit |
-| `estimate`     | Effort-focused view with effort model selection and base/head delta support |
-| `health`       | `receipt` + TODO/FIXME density, complexity, Halstead |
-| `risk`         | `health` + hotspots, coupling, freshness, git-derived risk signals |
-| `supply`       | Assets and dependency-lockfile inventory |
-| `architecture` | Import/dependency graph analysis |
-| `topics`       | Semantic topic clouds |
-| `security`     | License and high-entropy scanning |
-| `identity`     | Archetype detection and corporate fingerprinting |
-| `git`          | Predictive churn and advanced git metrics |
-| `deep`         | Everything except `fun` |
-| `fun`          | Novelty outputs such as eco-labels |
 
 ## Generated Badges
 
-The badge row at the very top of this README is release/project metadata from external services. The example badges shown above and the badges produced by `tokmd badge` are repo-local SVG files generated from your code data:
+The badges above are GitHub-hosted workflow badges. `tokmd badge` produces repo-local SVG badges from your own code data:
 
 ```bash
-# Lines-of-code badge
 tokmd badge --metric lines --output badge-lines.svg
-
-# Risk-oriented hotspot badge
 tokmd badge --metric hotspot --preset risk --output badge-hotspot.svg
 ```
 
-Embed the generated SVG in your own README:
+Embed them in your own README:
 
 ```markdown
 ![Lines of Code](badge-lines.svg)
 ![Hotspot](badge-hotspot.svg)
 ```
 
-## Why `tokmd` over `tokei`?
+## Command Surface
 
-| Feature                 | `tokei`                 | `tokmd` |
-| :---------------------- | :---------------------- | :------ |
-| Core value              | Fast counting           | Counting + analysis + workflow artifacts |
-| Output                  | Terminal tables         | Receipts, badges, HTML, diagrams, bundles |
-| Stability               | CLI-oriented output     | Schema-versioned, deterministic receipts |
-| Diff/review surface     | Minimal                 | `diff`, `cockpit`, `gate`, `sensor` |
-| LLM workflow support    | None                    | Context packing, handoff bundles, token estimates |
-| Git/risk analysis       | None                    | Hotspots, freshness, coupling, churn |
-| Effort estimation       | None                    | `estimate` preset with effort deltas |
+| Command | Purpose |
+| :------ | :------ |
+| `tokmd` | Language summary for a repo or path set |
+| `tokmd module` | Group stats by module roots such as `crates/` or `packages/` |
+| `tokmd export` | File-level dataset for downstream pipelines |
+| `tokmd run` | Save a full receipt set to a run directory |
+| `tokmd analyze` | Derived metrics and enrichments |
+| `tokmd badge` | Render SVG badges from receipt metrics |
+| `tokmd diff` | Compare two runs, receipts, or refs deterministically |
+| `tokmd context` | Pack code into an LLM context window |
+| `tokmd handoff` | Build an LLM handoff bundle |
+| `tokmd cockpit` | PR-review metrics with risk and evidence gates |
+| `tokmd gate` | Evaluate TOML policy rules and ratchets |
+| `tokmd baseline` | Capture a baseline for later ratchet comparisons |
+| `tokmd sensor` | Emit a `sensor.report.v1` envelope |
+| `tokmd tools` | Generate tool definitions for OpenAI, Anthropic, and JSON Schema consumers |
+| `tokmd init` | Generate a `.tokeignore` template |
+| `tokmd check-ignore` | Explain why a path is being ignored |
+| `tokmd completions` | Generate shell completions |
+
+## Browser And WASM
+
+`tokmd-wasm` and `web/runner` expose a narrower browser-safe slice of the product.
+
+- Supported today: `lang`, `module`, `export`, and browser-safe `analyze` presets on ordered in-memory inputs.
+- Public repo ingestion uses GitHub tree and contents APIs, not zipball-first fetches.
+- Git-history enrichers and full native filesystem flows remain native-first.
 
 ## What `tokmd` Is Not
 
-`tokmd` is deliberately not trying to be every code-quality tool:
+- It is not a formatter, linter, or build system.
+- It is not a developer-scoring tool.
+- It is not a vulnerability database or SAST replacement.
+- It does not ask you to trust prose where a receipt can be emitted instead.
 
-- It does not format or lint code.
-- It does not replace vulnerability scanners or advisory databases.
-- It does not try to score developers or turn LOC into performance theater.
-- It does not require you to trust prose when a receipt can be emitted instead.
+## Go Deeper
 
-## Configuration
+### Tutorial
 
-Persist settings in `tokmd.toml` in a project root or home directory:
+- [Tutorial](docs/tutorial.md) for first-run setup and basic workflows
 
-```toml
-[view.llm]
-format = "jsonl"
-redact = "paths"
-min_code = 10
-max_rows = 500
+### How-To
 
-[export]
-format = "jsonl"
-```
+- [Recipes](docs/recipes.md) for practical usage patterns
+- [Troubleshooting](docs/troubleshooting.md) for common problems and fixes
+- [Contributing](CONTRIBUTING.md) for local development and release work
 
-Use profiles with `--profile`:
+### Reference
 
-```bash
-tokmd export --profile llm > context.jsonl
-```
+- [CLI Reference](docs/reference-cli.md) for flags, formats, and config
+- [Schema](docs/SCHEMA.md) for receipt contracts
+- [tokmd responsibilities](tokmd-role.md) for the wider sensor/receipt stack
 
-See the [CLI Reference](docs/reference-cli.md#configuration-file) for the full configuration model.
+### Explanation
 
-## Library and Bindings
-
-`tokmd` is not only a CLI:
-
-- **`tokmd-core`** is the clap-free facade for embedding workflows in Rust or via FFI.
-- **Python bindings** live in `crates/tokmd-python`.
-- **Node bindings** live in `crates/tokmd-node`.
-- **`tokmd-wasm`** exposes browser/worker bindings for `lang`, `module`, `export`, and browser-safe `analyze` (`receipt`, `estimate`).
-- **`web/runner`** is the static browser shell that boots the real wasm bundle in a worker and can load public GitHub repos through the tree+contents APIs.
-- **Tool-schema output** is available through `tokmd tools` for agent/tool consumers.
-
-## Browser/WASM Status
-
-Browser support is real now, but intentionally narrower than the full native CLI surface.
-
-- Supported today: `lang`, `module`, `export`, and `analyze` with `receipt` or `estimate` on ordered in-memory `{ path, text }` inputs.
-- Public repo acquisition uses the browser-safe GitHub tree and contents APIs, with deterministic ordering and browser-side size/file limits.
-- Unsupported today: zipball fetch as the primary browser path, git-history enrichers, broader filesystem-backed analyze presets, and real cancel/progress flows.
-
-See [crates/tokmd-wasm/README.md](crates/tokmd-wasm/README.md) and [web/runner/README.md](web/runner/README.md) for the current browser contract.
-
-## Installation
-
-### Nix
-
-```bash
-nix run github:EffortlessMetrics/tokmd -- --version
-nix profile install github:EffortlessMetrics/tokmd
-nix build
-```
-
-### crates.io
-
-```bash
-cargo install tokmd --locked
-```
-
-### GitHub Action
-
-```yaml
-- uses: EffortlessMetrics/tokmd@v1
-  with:
-    paths: "."
-```
-
-### Additional Channels
-
-Package-manager channels outside crates.io and Nix can drift independently. This README only documents the install paths verified in this repo and release flow; if you publish or restore Homebrew, Scoop, WinGet, or AUR support later, add them back with a verification pass.
-
-### Language Bindings (Build from Source)
-
-Native FFI bindings are available from source today:
-
-- **Python**: `cd crates/tokmd-python && maturin develop`
-- **Node.js**: `cd crates/tokmd-node && npm run build`
-
-## Documentation
-
-- [Tutorial](docs/tutorial.md) — getting started
-- [Recipes](docs/recipes.md) — real-world usage patterns
-- [CLI Reference](docs/reference-cli.md) — flags and formats
-- [Schema](docs/SCHEMA.md) — receipt contracts
-- [Troubleshooting](docs/troubleshooting.md) — common issues and fixes
-- [Philosophy](docs/explanation.md) — design stance
-- [tokmd responsibilities](tokmd-role.md) — where tokmd sits in the wider sensor/receipt stack
-- [Contributing](CONTRIBUTING.md) — development and publishing workflow
-- [Roadmap](ROADMAP.md) — current milestone and future direction
+- [Philosophy](docs/explanation.md) for the design stance
+- [Architecture](docs/architecture.md) for the crate graph and boundaries
+- [Design](docs/design.md) for system concepts and invariants
+- [Roadmap](ROADMAP.md) for the active horizon
 
 ## License
 

--- a/contracts/sensor.report.v1/README.md
+++ b/contracts/sensor.report.v1/README.md
@@ -1,116 +1,32 @@
 # sensor.report.v1
 
-Standardized sensor report format for multi-sensor CI integration.
+Stable JSON contract for multi-sensor PR reports.
 
-## Overview
+## Problem
 
-The `sensor.report.v1` protocol defines a JSON envelope format that allows code quality sensors to integrate with external orchestrators ("directors") that aggregate reports from multiple sensors into a unified PR view.
+Use this contract when several sensors need one envelope, one verdict order,
+and one place to carry evidence without coupling the director to any one tool.
 
-## Design Principles
+## What it gives you
 
-1. **Stable top-level, rich underneath**: Minimal stable envelope; tool-specific richness in `data`
-2. **Verdict-first**: Quick pass/fail/warn determination without parsing tool-specific data
-3. **Findings are portable**: Common finding structure for cross-tool aggregation
-4. **Self-describing**: Schema version and tool metadata enable forward compatibility
-5. **No Green By Omission**: Capabilities block distinguishes "all passed" from "nothing ran"
+- required top-level fields: `schema`, `tool`, `generated_at`, `verdict`, `summary`, `findings`
+- optional `artifacts`, `capabilities`, and opaque `data`
+- verdict precedence: `fail > pending > warn > pass > skip`
+- findings keyed by `check_id` and `code`
+- explicit capabilities so "nothing ran" stays different from "all passed"
 
-## Top-Level Fields
+## Quick use / integration notes
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `schema` | string | Yes | Always `"sensor.report.v1"` |
-| `tool` | object | Yes | Tool identification (name, version, mode) |
-| `generated_at` | string | Yes | ISO 8601 timestamp |
-| `verdict` | string | Yes | Overall result: `pass`, `fail`, `warn`, `skip`, `pending` |
-| `summary` | string | Yes | Human-readable one-line summary |
-| `findings` | array | Yes | List of findings (may be empty) |
-| `artifacts` | array | No | Related artifact paths |
-| `capabilities` | object | No | Capability availability status |
-| `data` | object | No | Tool-specific payload (opaque to director) |
+`schema.json` is the contract. `examples/pass.json` and `examples/fail.json`
+show the intended shape.
 
-## Verdict Aggregation
+`tokmd cockpit --sensor-mode --artifacts-dir ...` emits this envelope in the
+current tokmd flow.
 
-Directors aggregate verdicts using this precedence (highest first):
-1. `fail` - Hard failure (evidence gate failed, policy violation)
-2. `pending` - Awaiting external data (CI artifacts, etc.)
-3. `warn` - Soft warnings present, review recommended
-4. `pass` - All checks passed, no significant findings
-5. `skip` - Sensor skipped (missing inputs, not applicable)
+## Go deeper
 
-## Findings
-
-Findings use a `(check_id, code)` tuple for identity. Combined with `tool.name`, this forms the triple `(tool, check_id, code)` used for routing and policy.
-
-Example: `("tokmd", "risk", "hotspot")` identifies a hotspot finding from tokmd.
-
-### Severity Levels
-
-| Severity | Description |
-|----------|-------------|
-| `error` | Blocks merge (hard gate failure) |
-| `warn` | Review recommended |
-| `info` | Informational, no action required |
-
-## Capabilities (No Green By Omission)
-
-The `capabilities` field explicitly reports which checks were available, unavailable, or skipped. This enables directors to distinguish between:
-- "All checks passed" (capabilities available, verdict pass)
-- "Nothing ran" (capabilities unavailable/skipped)
-
-```json
-{
-  "capabilities": {
-    "mutation": { "status": "available" },
-    "coverage": { "status": "unavailable", "reason": "no coverage artifact" },
-    "semver": { "status": "skipped", "reason": "no API files changed" }
-  }
-}
-```
-
-## Example Usage
-
-### Producing a Report (tokmd)
-
-```bash
-# Run tokmd cockpit in sensor mode
-tokmd cockpit --sensor-mode --artifacts-dir artifacts/tokmd
-
-# Output: artifacts/tokmd/report.json (sensor.report.v1 envelope)
-# Output: artifacts/tokmd/comment.md (PR comment markdown)
-```
-
-### Consuming a Report (director)
-
-```javascript
-const report = JSON.parse(fs.readFileSync('artifacts/tokmd/report.json'));
-
-// Quick verdict check
-if (report.verdict === 'fail') {
-  console.log('Sensor failed:', report.summary);
-}
-
-// Aggregate findings across sensors
-for (const finding of report.findings) {
-  const id = `${report.tool.name}.${finding.check_id}.${finding.code}`;
-  console.log(`${id}: ${finding.title}`);
-}
-
-// Check capabilities for "No Green By Omission"
-for (const [name, cap] of Object.entries(report.capabilities || {})) {
-  if (cap.status === 'unavailable') {
-    console.warn(`Capability ${name} unavailable: ${cap.reason}`);
-  }
-}
-```
-
-## Files in This Contract
-
-- `schema.json` - JSON Schema Draft 7 definition
-- `examples/pass.json` - Example passing envelope
-- `examples/fail.json` - Example failing envelope
-
-## Versioning
-
-The schema identifier `sensor.report.v1` is immutable. Breaking changes require a new version (`sensor.report.v2`).
-
-Non-breaking additions (new optional fields) are allowed within the same version.
+Tutorial: [Root README](../../README.md)
+How-to: `tokmd cockpit --sensor-mode --artifacts-dir ...`
+Reference: [schema.json](schema.json)
+Reference: [pass.json](examples/pass.json) and [fail.json](examples/fail.json)
+Explanation: [tokmd-envelope](../../crates/tokmd-envelope/README.md)

--- a/crates/tokmd-analysis-api-surface/README.md
+++ b/crates/tokmd-analysis-api-surface/README.md
@@ -1,8 +1,22 @@
 # tokmd-analysis-api-surface
 
-API surface analysis helpers for tokmd analysis receipts. This crate focuses on
-extracting and summarizing public symbols per language.
+API-surface and doc-coverage analysis for supported source languages.
 
-## API
+## Problem
+You need symbol-level API metrics without building a bespoke parser pipeline.
 
-- `build_api_surface_report` — compute an `ApiSurfaceReport` for a repository.
+## What it gives you
+- `build_api_surface_report`
+- `ApiSurfaceReport`, `ApiExportItem`, `LangApiSurface`, `ModuleApiRow`
+- Public/internal symbol counts and documented-public coverage
+
+## Integration notes
+- No feature flags.
+- Supports Rust, JavaScript, TypeScript, Python, Go, and Java.
+- Consumes normalized export data plus source files and `AnalysisLimits`.
+
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-archetype/README.md
+++ b/crates/tokmd-analysis-archetype/README.md
@@ -1,20 +1,22 @@
 # tokmd-analysis-archetype
 
-Tiered microcrate for archetype inference used by analysis receipts.
+Infers a coarse repository archetype from export metadata.
 
-## What it does
+## Problem
+You need a quick repository-shape signal without adding a separate classification layer.
 
-- Detects repository archetypes from normalized `ExportData` paths.
-- Returns optional `Archetype` values for analysis consumers.
+## What it gives you
+- `detect_archetype`
+- `Archetype`
+- Heuristics for Rust workspaces, Next.js apps, containerized services, IaC projects, Python packages, and Node packages
 
-## API
+## Integration notes
+- No feature flags.
+- Works from normalized export metadata, not file content.
+- Designed to feed the `archetype` analysis preset.
 
-- `detect_archetype(export: &ExportData) -> Option<Archetype>`
-
-## Contract
-
-- `Cargo` + `crates/*` + workspace directories => `Rust workspace`
-- `Cargo.toml` + `next.config.*` + `package.json` => `Next.js app`
-- `Dockerfile` + Kubernetes manifests => `Containerized service`
-- Terraform inputs => `Infrastructure as code`
-- `pyproject.toml` => `Python package`
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-assets/README.md
+++ b/crates/tokmd-analysis-assets/README.md
@@ -1,3 +1,22 @@
 # tokmd-analysis-assets
 
-Microcrate for analysis enrichments that summarize file assets and dependency lockfiles.
+Asset inventory and lockfile summaries for analysis receipts.
+
+## Problem
+You need file-asset and dependency counts without teaching the orchestrator how to walk the tree.
+
+## What it gives you
+- `build_assets_report`
+- `build_dependency_report`
+- `AssetReport`, `DependencyReport`, `LockfileReport`
+
+## Integration notes
+- No feature flags.
+- Reads file sizes from the walk root and lockfiles from detected package roots.
+- Truncates the top asset rows for stable receipts.
+
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-complexity/README.md
+++ b/crates/tokmd-analysis-complexity/README.md
@@ -1,8 +1,22 @@
 # tokmd-analysis-complexity
 
-Complexity analysis helpers for tokmd analysis receipts. This crate estimates
-function metrics, complexity risk, and technical debt ratios.
+Complexity scoring and histogram generation for analysis receipts.
 
-## API
+## Problem
+You need per-file complexity and technical-debt signals without folding parsing logic into the receipt model.
 
-- `build_complexity_report` — compute a `ComplexityReport` for a repository.
+## What it gives you
+- `build_complexity_report`
+- `generate_complexity_histogram`
+- `ComplexityReport`, `FileComplexity`, `ComplexityHistogram`
+
+## Integration notes
+- No feature flags.
+- Uses `AnalysisLimits` to cap bytes and file counts.
+- Can attach per-function details when requested; relies on `tokmd-content` and maintainability helpers.
+
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-content/README.md
+++ b/crates/tokmd-analysis-content/README.md
@@ -1,13 +1,23 @@
 # tokmd-analysis-content
 
-Content-oriented analysis primitives for `tokmd-analysis`.
+Content-driven helpers for TODO, duplication, and import analysis.
 
-This crate provides shared analysis implementations for:
+## Problem
+You need text-level signals without coupling callers to the full analysis orchestrator.
 
-- TODO/TODO-like tag counting
-- Duplicate file detection (exact hash match)
-- Import graph extraction (delegates language parsing to `tokmd-analysis-imports`)
+## What it gives you
+- `build_todo_report`
+- `build_duplicate_report`
+- `build_import_report`
+- `ImportGranularity`, `ContentLimits`
 
-It is intentionally small and single-purpose so it can be composed by
-`tokmd-analysis` and any other consumers that want these reports without
-bringing in the full analysis orchestration layer.
+## Integration notes
+- No feature flags.
+- Shared by `tokmd-analysis` for TODO, duplicate, and import reporting.
+- Uses language-aware import parsing and content hashing helpers.
+
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-derived/README.md
+++ b/crates/tokmd-analysis-derived/README.md
@@ -1,14 +1,22 @@
 # tokmd-analysis-derived
 
-Derived metrics builder for `tokmd-analysis`.
+Derived metrics and tree output for analysis receipts.
 
-It computes deterministic aggregate analytics from `ExportData`, including:
+## Problem
+You need receipt-level rollups without pushing aggregation logic into the CLI or formatter.
 
-- totals and rates
-- doc/test/whitespace ratios
-- file distributions and histogram outputs
-- complexity proxy signals like top files, gini/polynomial style indicators
-- optional context-window fit and tree rendering (via `tokmd-export-tree`)
+## What it gives you
+- `derive_report`
+- `build_tree`
+- `DerivedReport`, `DerivedTotals`, `ReadingTimeReport`
 
-This is consumed by `tokmd-analysis` and can be used by other adapters
-without pulling optional analysis feature dependencies.
+## Integration notes
+- No feature flags.
+- Consumes export data plus optional `window_tokens`.
+- Produces totals, distributions, reading-time, COCOMO, TODO, and integrity data.
+
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-effort/README.md
+++ b/crates/tokmd-analysis-effort/README.md
@@ -1,19 +1,23 @@
 # tokmd-analysis-effort
 
-Deterministic effort-estimation support for `tokmd` analysis receipts.
+Effort estimation scaffolding and outputs for analysis receipts.
 
-This crate builds `tokmd_analysis_types::EffortEstimateReport` values from
-repository inventory data plus optional analysis enrichers. The model is
-receipt-driven and local-only: it uses repository files and already-computed
-analysis reports, and it does not call external services.
+## Problem
+You need an effort model that stays receipt-driven instead of pulling in a separate estimation service.
 
-The effort pipeline is intentionally layered:
+## What it gives you
+- `build_effort_report`
+- `build_size_basis`, `build_drivers`, `build_delta`
+- `apply_monte_carlo`, `apply_uncertainty`
+- `EffortRequest`, `EffortModelKind`, `EffortLayer`, `DeltaInput`
 
-- build an authored-vs-total size basis
-- run a deterministic baseline model over authored KLOC
-- widen or narrow the estimate using observed repository signals
-- explain the result with drivers and confidence reasons
-- optionally attach a base/head delta estimate
+## Integration notes
+- No default features.
+- Optional `git` support adds commit-history context for effort layers and delta estimates.
+- The output contract lives in `tokmd-analysis-types` as `EffortEstimateReport`.
 
-Primary consumers are `tokmd-analysis` and downstream renderers that need a
-stable effort semantics layer.
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-entropy/README.md
+++ b/crates/tokmd-analysis-entropy/README.md
@@ -1,8 +1,21 @@
 # tokmd-analysis-entropy
 
-Entropy profiling helpers for tokmd analysis receipts. This crate samples file
-content to identify potential secrets or suspicious blobs.
+Entropy profiling for suspicious or packed-looking files.
 
-## API
+## Problem
+You need a lightweight entropy signal without turning every file into a full content scan.
 
-- `build_entropy_report` — compute an `EntropyReport` for a repository.
+## What it gives you
+- `build_entropy_report`
+- `EntropyReport`, `EntropyFinding`, `EntropyClass`
+
+## Integration notes
+- No feature flags.
+- Samples file heads and tails with `AnalysisLimits`.
+- Designed to surface high-entropy outliers for the `security` preset.
+
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-explain/README.md
+++ b/crates/tokmd-analysis-explain/README.md
@@ -1,14 +1,33 @@
 # tokmd-analysis-explain
 
-Single-responsibility microcrate for analysis metric/finding explanation lookup.
+Metric and finding explanation catalog for tokmd analysis receipts.
 
-## What it does
+## Problem
 
-- Normalizes user-provided metric keys and aliases.
-- Resolves a key to a concise explanation string.
-- Emits a deterministic catalog of available explanation keys.
+You need stable human-readable explanations for metric keys and findings
+without pulling in the full analysis orchestrator.
 
-## API
+## What it gives you
 
-- `lookup(key: &str) -> Option<String>`
-- `catalog() -> String`
+- `lookup`
+- `catalog`
+
+## Integration notes
+
+- Normalizes metric keys and supports alias lookup.
+- Returns a deterministic catalog order for stable docs and tests.
+- Keeps the explanation surface separate from receipt generation.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+- [Schema](../../docs/SCHEMA.md)
+- [Schema JSON](../../docs/schema.json)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Design](../../docs/design.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-fingerprint/README.md
+++ b/crates/tokmd-analysis-fingerprint/README.md
@@ -1,29 +1,22 @@
 # tokmd-analysis-fingerprint
 
-This microcrate computes corporate fingerprint enrichment from commit metadata.
-It belongs to the `tokmd-analysis` family as a small, stable adapter crate so the
-fingerprint logic can evolve without forcing broader analysis changes.
+Corporate fingerprint enrichment from git history.
 
-## Overview
+## Problem
+You need an org-signal summary from commit history without coupling to the full analysis orchestrator.
 
-`tokmd-analysis-fingerprint` exposes a single API:
+## What it gives you
+- `build_corporate_fingerprint`
+- `CorporateFingerprint`
+- Domain-level commit concentration signals
 
-- `build_corporate_fingerprint(commits: &[tokmd_git::GitCommit]) -> CorporateFingerprint`
+## Integration notes
+- No feature flags.
+- Depends on `tokmd-git` commit metadata.
+- Designed for the `identity` analysis preset.
 
-## Usage
-
-```rust
-use tokmd_analysis_fingerprint::build_corporate_fingerprint;
-use tokmd_git::GitCommit;
-
-let commits = vec![GitCommit {
-    timestamp: 0,
-    author: "alice@acme.com".to_string(),
-    hash: None,
-    subject: String::new(),
-    files: vec!["src/main.rs".to_string()],
-}];
-
-let fingerprint = build_corporate_fingerprint(&commits);
-assert!(!fingerprint.domains.is_empty());
-```
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-format/README.md
+++ b/crates/tokmd-analysis-format/README.md
@@ -1,86 +1,22 @@
 # tokmd-analysis-format
 
-Formatting and rendering for tokmd analysis receipts.
+Formatting and rendering for analysis receipts.
 
-## Overview
+## Problem
+You need receipt output in several formats without mixing rendering logic into the data model.
 
-This is a **Tier 3** crate that renders analysis results in multiple formats. It transforms `AnalysisReceipt` structures into human-readable or machine-processable outputs.
+## What it gives you
+- `render`
+- `RenderedOutput`
+- Markdown, JSON, JSON-LD, XML, SVG, Mermaid, OBJ, MIDI, tree, and HTML output paths
 
-The HTML output path is delegated to `tokmd-analysis-html` to keep rendering concerns single-purpose.
+## Integration notes
+- HTML rendering is delegated to `tokmd-analysis-html`.
+- The optional `fun` feature enables novelty output via `tokmd-fun`.
+- Rendering preserves whatever the receipt already contains.
 
-## Installation
-
-```toml
-[dependencies]
-tokmd-analysis-format = "1.3"
-
-# Enable fun outputs (OBJ, MIDI)
-[dependencies.tokmd-analysis-format]
-version = "1.3"
-features = ["fun"]
-```
-
-## Usage
-
-```rust
-use tokmd_analysis_format::{render, RenderedOutput};
-use tokmd_types::AnalysisFormat;
-
-let output = render(&receipt, AnalysisFormat::Md)?;
-
-match output {
-    RenderedOutput::Text(s) => println!("{}", s),
-    RenderedOutput::Binary(b) => std::fs::write("output.midi", b)?,
-}
-```
-
-## Supported Formats
-
-| Format | Output | Description |
-|--------|--------|-------------|
-| `Md` | Text | Markdown with tables and sections |
-| `Json` | Text | Pretty-printed JSON |
-| `Jsonld` | Text | JSON-LD with semantic markup |
-| `Xml` | Text | XML serialization |
-| `Svg` | Text | SVG visualization |
-| `Mermaid` | Text | Mermaid diagram syntax |
-| `Obj` | Text | 3D code city (OBJ format) |
-| `Midi` | Binary | Audio representation |
-| `Tree` | Text | Directory tree visualization |
-| `Html` | Text | Self-contained HTML report |
-
-## Markdown Output
-
-Sections rendered when data is present:
-- Archetype with evidence
-- Topics with TF scores
-- Entropy suspects table
-- License findings table
-- Churn trends table
-- Corporate domains table
-- Git metrics (hotspots, bus factor, freshness)
-- COCOMO estimates
-- Distribution statistics
-- Top offenders
-
-Tables limited to top 10 items by default.
-
-## Feature Flags
-
-```toml
-[features]
-fun = ["tokmd-fun"]  # Enable OBJ, MIDI outputs
-```
-
-## Output Types
-
-```rust
-pub enum RenderedOutput {
-    Text(String),    // Most formats
-    Binary(Vec<u8>), // MIDI
-}
-```
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Reference CLI](../../docs/reference-cli.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-fun/README.md
+++ b/crates/tokmd-analysis-fun/README.md
@@ -1,18 +1,31 @@
 # tokmd-analysis-fun
 
-Microcrate for novelty/enrichment computations used by `tokmd-analysis`.
+Novelty enrichments for tokmd analysis receipts.
 
-## Current Responsibility
+## Problem
 
-- Compute the `FunReport` eco-label in `build_fun_report`.
+You want optional novelty signals, such as eco-labels, without tying them to
+the core analysis orchestrator.
 
-## API
+## What it gives you
 
-```rust
-pub fn build_fun_report(derived: &DerivedReport) -> FunReport;
-```
+- `build_fun_report`
+- `EcoLabel` output on the analysis receipt
 
-## Notes
+## Integration notes
 
-- Keeps novelty logic in a separate crate behind the `fun` feature in `tokmd-analysis`.
-- This crate has no formatting/rendering dependencies.
+- Consumes a `DerivedReport` and emits `FunReport`.
+- Currently centers on the size-based eco-label path used by `AnalysisPreset::Fun`.
+- Keeps novelty output isolated so it can evolve independently.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+- [Analysis types](../tokmd-analysis-types/README.md)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-git/README.md
+++ b/crates/tokmd-analysis-git/README.md
@@ -1,11 +1,31 @@
 # tokmd-analysis-git
 
-Git-focused enrichment for `tokmd-analysis`.
+Git-history enrichments for tokmd analysis presets.
 
-Includes:
+## Problem
 
-- Hotspot/coupling/freshness/git activity reports
-- Predictive churn trend analysis
+You need churn, freshness, and coupling signals from git history without
+mixing them into the core scan or format layers.
 
-The crate is dependency-free with respect to `tokmd-analysis` internals so it can evolve
-independently while keeping orchestration in `tokmd-analysis`.
+## What it gives you
+
+- `build_git_report`
+- `build_predictive_churn_report`
+
+## Integration notes
+
+- Consumes git-derived inputs and produces analysis-side enrichment reports.
+- Keeps history-based heuristics separate from the receipt model and renderer.
+- Deterministic ordering is preserved through the shared analysis types.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+- [Churn implementation](src/churn.rs)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-grid/README.md
+++ b/crates/tokmd-analysis-grid/README.md
@@ -1,20 +1,23 @@
 # tokmd-analysis-grid
 
-This microcrate owns the analysis preset matrix and feature-gate warning
-catalog used by `tokmd-analysis`.
+Preset and feature-gate metadata for analysis orchestration.
 
-## Purpose
+## Problem
+You need one source of truth for preset composition and feature warnings.
 
-- Keep preset-to-component mapping centralized.
-- Keep disabled-feature warning messages consistent.
-- Make the BDD-style feature matrix explicit and easy to audit.
-- Keep feature-gated behavior interoperable across crates.
+## What it gives you
+- `PresetKind`, `PRESET_KINDS`
+- `PresetPlan`, `PRESET_GRID`
+- `preset_plan_for`, `preset_plan_for_name`
+- `DisabledFeature`
 
-## API
+## Integration notes
+- Pure data and serialization, with deterministic ordering at the type boundary.
+- Central source of preset plans and disabled-feature warnings.
+- `halstead` depends on `content` and `walk`; the other preset features are independent gates.
 
-- `PresetKind` - preset identifiers.
-- `PresetPlan` - enabled analysis components for one preset.
-- `preset_plan_for` - retrieve plan by `PresetKind`.
-- `preset_plan_for_name` - retrieve plan by preset name.
-- `PRESET_GRID` - canonical BDD-style matrix table.
-- `DisabledFeature::warning()` - stable disabled-gate messages.
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Schema](../../docs/SCHEMA.md), [Schema JSON](../../docs/schema.json)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-halstead/README.md
+++ b/crates/tokmd-analysis-halstead/README.md
@@ -1,8 +1,35 @@
 # tokmd-analysis-halstead
 
-Halstead analysis helpers for tokmd analysis receipts. This crate computes
-Halstead operator/operand statistics by language.
+Halstead metric helpers for tokmd analysis receipts.
 
-## API
+## Problem
 
-- `build_halstead_report` — compute `HalsteadMetrics` for a repository.
+You need Halstead metrics from source text without pulling the full analysis
+pipeline into your caller.
+
+## What it gives you
+
+- `is_halstead_lang`
+- `operators_for_lang`
+- `FileTokenCounts`
+- `tokenize_for_halstead`
+- `build_halstead_report`
+
+## Integration notes
+
+- Supports a curated language set only.
+- Reads text through `tokmd-content` and caps file sizes through analysis
+  limits.
+- Produces deterministic aggregate metrics for the shared analysis receipts.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+- [tokmd-content](../tokmd-content/README.md)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-html/README.md
+++ b/crates/tokmd-analysis-html/README.md
@@ -1,13 +1,34 @@
 # tokmd-analysis-html
 
-Single-responsibility microcrate for rendering `AnalysisReceipt` values as a self-contained HTML report.
+HTML rendering for tokmd analysis receipts.
 
-## What it does
+## Problem
 
-- Produces a static HTML report from analysis receipts.
-- Renders metric cards, top-file table rows, and embedded treemap JSON payload.
-- Applies HTML and JSON escaping for browser-safe output.
+You need a self-contained HTML report without mixing rendering concerns into
+the analysis data model.
 
-## API
+## What it gives you
 
-- `render(receipt: &AnalysisReceipt) -> String`
+- `render`
+
+## Integration notes
+
+- Renders a complete `AnalysisReceipt` into a single HTML document.
+- Escapes embedded HTML and JSON so the output is browser-safe.
+- Uses the bundled template in `src/templates/report.html`.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+- [Template](src/templates/report.html)
+
+### How-to
+
+- [Recipes](../../docs/recipes.md)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-imports/README.md
+++ b/crates/tokmd-analysis-imports/README.md
@@ -1,16 +1,31 @@
 # tokmd-analysis-imports
 
-Single-responsibility microcrate for language-aware import extraction used by
-`tokmd-analysis-content`.
+Language-aware import parsing and target normalization for tokmd analysis.
 
-## What it does
+## Problem
 
-- Detects whether a language is supported for import extraction.
-- Extracts import targets from Rust, JavaScript/TypeScript, Python, and Go.
-- Normalizes import targets into deterministic dependency roots.
+You need import extraction and normalization without dragging in filesystem or
+receipt orchestration.
 
-## API
+## What it gives you
 
-- `supports_language(lang: &str) -> bool`
-- `parse_imports(lang: &str, lines: &[impl AsRef<str>]) -> Vec<String>`
-- `normalize_import_target(target: &str) -> String`
+- `supports_language`
+- `parse_imports`
+- `normalize_import_target`
+
+## Integration notes
+
+- Supports Rust, JavaScript, TypeScript, Python, and Go.
+- Relative targets collapse to `local`.
+- Keeps the parser logic small and deterministic for higher-tier enrichers.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-license/README.md
+++ b/crates/tokmd-analysis-license/README.md
@@ -1,8 +1,32 @@
 # tokmd-analysis-license
 
-License discovery helpers for tokmd analysis receipts. This crate inspects
-metadata and license texts to infer SPDX identifiers.
+License discovery for tokmd analysis receipts.
 
-## API
+## Problem
 
-- `build_license_report` — compute a `LicenseReport` for a repository.
+You need license signals from metadata and text without coupling that logic to
+the main analysis orchestrator.
+
+## What it gives you
+
+- `build_license_report`
+
+## Integration notes
+
+- Checks package metadata first, then falls back to license-file and text
+  scanning.
+- Produces a sorted list of findings plus an effective SPDX guess.
+- Uses deterministic ranking so ties remain stable.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+- [tokmd-walk](../tokmd-walk/README.md)
+- [tokmd-content](../tokmd-content/README.md)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-maintainability/README.md
+++ b/crates/tokmd-analysis-maintainability/README.md
@@ -1,15 +1,32 @@
 # tokmd-analysis-maintainability
 
-This microcrate owns maintainability-index scoring rules and Halstead-based
-maintainability updates for `tokmd` analysis receipts.
+Maintainability scoring helpers for tokmd analysis receipts.
 
-## Purpose
+## Problem
 
-- Keep SEI maintainability math in one place.
-- Keep letter-grade thresholds stable (`A` / `B` / `C`).
-- Keep Halstead-to-maintainability integration behavior deterministic.
+You want maintainability metrics derived from complexity and size without
+re-implementing the scoring math in the caller.
 
-## API
+## What it gives you
 
-- `compute_maintainability_index` - compute simplified or full SEI MI.
-- `attach_halstead_metrics` - attach Halstead metrics and refresh MI when valid.
+- `compute_maintainability_index`
+- `attach_halstead_metrics`
+
+## Integration notes
+
+- Uses the simplified or full SEI-style formula depending on Halstead volume.
+- Recomputes the index only when the existing complexity report already has a
+  maintainability slot and Halstead volume is positive.
+- Keeps the Halstead merge logic local to the analysis layer.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+- [tokmd-analysis-halstead](../tokmd-analysis-halstead/README.md)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-near-dup/README.md
+++ b/crates/tokmd-analysis-near-dup/README.md
@@ -1,3 +1,30 @@
 # tokmd-analysis-near-dup
 
-Microcrate that computes near-duplicate file pairs for tokmd analysis receipts.
+Near-duplicate detection for tokmd analysis receipts.
+
+## Problem
+
+You need a deterministic way to identify duplicate or near-duplicate files
+without embedding that logic in the orchestrator.
+
+## What it gives you
+
+- `NearDupLimits`
+- `build_near_dup_report`
+
+## Integration notes
+
+- Uses Winnowing fingerprints with deterministic sorting and clustering.
+- Supports `Global`, `Module`, and `Lang` scopes.
+- Accepts threshold, truncation, and exclude-pattern controls for large repos.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-topics/README.md
+++ b/crates/tokmd-analysis-topics/README.md
@@ -1,13 +1,29 @@
 # tokmd-analysis-topics
 
-Tiered microcrate for topic-cloud enrichment used by analysis receipts.
+Topic-cloud enrichment for analysis receipts.
 
-## What it does
+## Problem
 
-- Tokenizes file paths into lightweight terms.
-- Computes weighted TF-like per-module topic scores.
-- Emits module-level and overall top-k topic lists.
+You want path-based topic signals without coupling the score-building logic to
+the main analysis orchestrator.
 
-## API
+## What it gives you
 
-- `build_topic_clouds(export: &ExportData) -> TopicClouds`
+- `build_topic_clouds`
+
+## Integration notes
+
+- Builds per-module and overall topic clouds from `ExportData`.
+- Uses token weights, stopwords, and deterministic TF-IDF-style scoring.
+- Keeps topic enrichment isolated so preset orchestration stays small.
+
+## Go deeper
+
+### Reference
+
+- [Source](src/lib.rs)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Philosophy](../../docs/explanation.md)

--- a/crates/tokmd-analysis-types/README.md
+++ b/crates/tokmd-analysis-types/README.md
@@ -1,69 +1,22 @@
 # tokmd-analysis-types
 
-Analysis receipt contracts for tokmd.
+Analysis receipt contracts and shared report types.
 
-## Overview
+## Problem
+You need a stable analysis schema without pulling in orchestration or rendering code.
 
-This is a **Tier 0** crate defining pure data structures for analysis receipts. It contains no I/O or business logic - only type definitions and serialization.
+## What it gives you
+- `ANALYSIS_SCHEMA_VERSION`
+- `AnalysisReceipt`, `AnalysisSource`, `AnalysisArgsMeta`
+- Shared report and finding structs used by the analysis presets
 
-## Installation
+## Integration notes
+- Pure data and serialization, with deterministic ordering at the type boundary.
+- `ANALYSIS_SCHEMA_VERSION = 9`.
+- Includes the optional sections used by the analysis preset matrix.
 
-```toml
-[dependencies]
-tokmd-analysis-types = "1.3"
-```
-
-## Key Types
-
-### Core Receipt
-```rust
-pub struct AnalysisReceipt {
-    pub schema_version: u32,
-    pub archetype: Option<Archetype>,
-    pub topics: Option<TopicClouds>,
-    pub entropy: Option<EntropyReport>,
-    pub derived: Option<DerivedReport>,
-    pub git: Option<GitReport>,
-    // ... and more optional sections
-}
-```
-
-### Analysis Result Types
-
-| Type | Purpose |
-|------|---------|
-| `Archetype` | Project kind detection (CLI, library, web app) |
-| `TopicClouds` | Semantic topic extraction with TF-IDF scores |
-| `EntropyReport` | High-entropy file detection |
-| `PredictiveChurnReport` | Git-based change trend prediction |
-| `CorporateFingerprint` | Author domain statistics |
-| `LicenseReport` | SPDX license detection |
-| `DerivedReport` | Core metrics (density, distribution, COCOMO) |
-| `AssetReport` | Non-code file categorization |
-| `GitReport` | Hotspots, bus factor, freshness, coupling |
-| `ImportReport` | Module dependency graph |
-| `DuplicateReport` | Content duplication detection |
-| `FunReport` | Eco-label and novelty outputs |
-
-## Schema Version
-
-```rust
-pub const ANALYSIS_SCHEMA_VERSION: u32 = 9;
-```
-
-v4 added cognitive complexity, nesting depth, and function-level details.
-v5 added Halstead metrics, maintainability index, complexity histogram, technical debt ratio, duplication density, and code age distribution.
-v6 added API surface enricher.
-v7 added coupling normalization (Jaccard/Lift), commit intent classification, and near-duplicate detection.
-v8 added near-dup clusters, selection metadata, max_pairs guardrail, runtime stats.
-v9 added effort estimation report.
-
-## Design Principles
-
-- All analysis sections are `Option<T>` to support preset-based inclusion
-- Uses `BTreeMap` for deterministic key ordering
-- No I/O operations - pure data definitions
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Schema](../../docs/SCHEMA.md), [Schema JSON](../../docs/schema.json)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis-util/README.md
+++ b/crates/tokmd-analysis-util/README.md
@@ -1,14 +1,24 @@
 # tokmd-analysis-util
 
-A tiny microcrate for shared, deterministic analysis helpers used across analysis enrichers.
+Shared normalization, limits, and math helpers for analysis code.
 
-## API
+## Problem
+You need deterministic helpers without dragging in orchestration or receipt-specific logic.
 
+## What it gives you
 - `AnalysisLimits`
-- `normalize_path`
-- `normalize_root`
-- path and language heuristics for derived/content metrics
-- compatibility re-exports for numeric helpers from `tokmd-math`
+- `normalize_path`, `normalize_root`
+- `path_depth`, `is_test_path`, `is_infra_lang`
+- `now_ms`, `empty_file_row`
+- `gini_coefficient`, `percentile`, `round_f64`, `safe_ratio`
 
-This crate is intentionally small and stable so the higher-level analysis crates
-can evolve independently.
+## Integration notes
+- No feature flags.
+- Pure helper crate with deterministic path and ratio utilities.
+- Re-exports math helpers from `tokmd-math`.
+
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [Root README](../../README.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-analysis/README.md
+++ b/crates/tokmd-analysis/README.md
@@ -1,145 +1,23 @@
 # tokmd-analysis
 
-Analysis logic and enrichers for tokmd receipts.
+Orchestrates analysis presets and enrichers for tokmd receipts.
 
-## Overview
+## Problem
+You need one analysis entrypoint that can assemble receipt enrichments without wiring every leaf crate yourself.
 
-This is a **Tier 3** orchestration crate that computes derived metrics and optional enrichments from code inventories. It coordinates multiple analysis modules based on preset configuration.
+## What it gives you
+- `analyze`
+- `AnalysisContext`, `AnalysisRequest`, `AnalysisPreset`
+- `ImportGranularity`
+- Re-exports of `AnalysisLimits`, `NearDupScope`, and `normalize_root`
 
-## Installation
+## Integration notes
+- Default features: `fun`, `topics`, `archetype`, `effort`.
+- Optional features: `git`, `walk`, `content`, `halstead`, `effort`, `fun`, `topics`, `archetype`.
+- Use this crate when you want preset-driven orchestration; use the leaf crates directly when you only need one report.
 
-```toml
-[dependencies]
-tokmd-analysis = "1.4"
-
-# Enable optional features
-[dependencies.tokmd-analysis]
-version = "1.4"
-features = ["git", "walk", "content", "fun", "topics", "archetype"]
-```
-
-## Usage
-
-```rust,no_run
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-use std::path::PathBuf;
-use tokmd_analysis::{
-    analyze, AnalysisContext, AnalysisLimits, AnalysisPreset, AnalysisRequest,
-    ImportGranularity, NearDupScope,
-};
-use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisSource};
-use tokmd_types::{ChildIncludeMode, ExportData};
-
-let context = AnalysisContext {
-    export: ExportData {
-        rows: vec![],
-        module_roots: vec![],
-        module_depth: 1,
-        children: ChildIncludeMode::Separate,
-    },
-    root: PathBuf::from("."),
-    source: AnalysisSource {
-        inputs: vec![".".into()],
-        export_path: None,
-        base_receipt_path: None,
-        export_schema_version: None,
-        export_generated_at_ms: None,
-        base_signature: None,
-        module_roots: vec![],
-        module_depth: 1,
-        children: "separate".into(),
-    },
-};
-
-let request = AnalysisRequest {
-    preset: AnalysisPreset::Risk,
-    args: AnalysisArgsMeta {
-        preset: "risk".into(),
-        format: "json".into(),
-        window_tokens: None,
-        git: None,
-        max_files: None,
-        max_bytes: None,
-        max_commits: None,
-        max_commit_files: None,
-        max_file_bytes: None,
-        import_granularity: "module".into(),
-    },
-    limits: AnalysisLimits::default(),
-    #[cfg(feature = "effort")]
-    effort: None,
-    window_tokens: None,
-    git: None,
-    import_granularity: ImportGranularity::Module,
-    detail_functions: false,
-    near_dup: false,
-    near_dup_threshold: 0.8,
-    near_dup_max_files: 500,
-    near_dup_scope: NearDupScope::Module,
-    near_dup_max_pairs: None,
-    near_dup_exclude: vec![],
-};
-
-let receipt = analyze(context, request)?;
-# Ok(())
-# }
-```
-
-## Analysis Presets
-
-| Preset | Includes |
-|--------|----------|
-| `Receipt` | Core derived metrics (density, distribution, COCOMO) |
-| `Health` | + TODO density |
-| `Risk` | + Git hotspots, coupling, freshness |
-| `Supply` | + Assets, dependency lockfiles |
-| `Architecture` | + Import graph |
-| `Topics` | Semantic topic clouds (TF-IDF) |
-| `Security` | License radar, entropy profiling |
-| `Identity` | Archetype detection, corporate fingerprint |
-| `Git` | Predictive churn, advanced git metrics |
-| `Deep` | Everything (except fun) |
-| `Fun` | Eco-label, novelty outputs |
-
-## Analysis Modules
-
-| Module | Feature | Purpose |
-|--------|---------|---------|
-| `archetype` | archetype | Project kind detection |
-| `derived` | - | Core metrics |
-| `topics` | topics | Semantic keyword extraction |
-| `entropy` | content+walk | High-entropy file detection |
-| `license` | content+walk | License radar scanning |
-| `fingerprint` | git | Corporate domain analysis |
-| `churn` | git | Git-based change prediction |
-| `assets` | walk | Asset categorization |
-| `git` | git | Hotspots, bus factor, freshness |
-| `content` | content | TODOs, duplicates, imports |
-
-## Feature Flags
-
-```toml
-[features]
-git = ["tokmd-git"]       # Git history analysis
-walk = ["tokmd-walk"]     # Asset discovery
-content = ["tokmd-analysis-content", "tokmd-analysis-complexity", "tokmd-analysis-entropy"]  # Content-derived enrichers
-topics = ["tokmd-analysis-topics"] # Topic-cloud extraction
-archetype = ["tokmd-analysis-archetype"] # Archetype detection
-fun = ["tokmd-analysis-fun"]  # Fun/novelty report enrichers
-```
-
-## Key Types
-
-```rust
-pub struct AnalysisLimits {
-    pub max_files: Option<usize>,
-    pub max_bytes: Option<u64>,
-    pub max_commits: Option<usize>,
-    pub max_commit_files: Option<usize>,
-    pub max_file_bytes: Option<u64>,
-}
-```
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [Tutorial](../../docs/tutorial.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md), [CLI reference](../../docs/reference-cli.md)
+- Explanation: [Explanation](../../docs/explanation.md)

--- a/crates/tokmd-badge/README.md
+++ b/crates/tokmd-badge/README.md
@@ -1,6 +1,31 @@
 # tokmd-badge
 
-SVG badge rendering helpers for `tokmd`.
+Build compact SVG badges for tokmd metrics.
 
-This crate is intentionally small and clap-free so badge generation can be reused
-without pulling in CLI argument dependencies.
+## Problem
+
+Use this crate when you need a deterministic badge renderer without pulling in
+the CLI or the rest of the formatting pipeline.
+
+## What it gives you
+
+- `badge_svg(label, value) -> String`
+- XML escaping for badge text
+- compact two-segment SVG output sized from the label and value text
+
+## Quick use / integration notes
+
+```toml
+[dependencies]
+tokmd-badge = { workspace = true }
+```
+
+Feed it a label and value, then embed the returned SVG in a README or docs
+page.
+
+## Go deeper
+
+Tutorial: [Root README](../../README.md)
+How-to: [Generated badges](../../README.md#generated-badges)
+Reference: [Source](src/lib.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-cockpit/README.md
+++ b/crates/tokmd-cockpit/README.md
@@ -1,7 +1,35 @@
 # tokmd-cockpit
 
-Cockpit PR metrics computation and rendering for `tokmd`.
+Compute PR metrics, evidence gates, and review plans from git diffs.
 
-This crate provides the core logic for computing change surface analysis,
-code composition breakdown, health metrics, risk assessment, and evidence gates
-used by the `tokmd cockpit` CLI command.
+## Problem
+
+Review needs a compact evidence trail, not just changed files.
+
+## What it gives you
+
+- `compute_cockpit` for git-backed PR receipts
+- `load_and_compute_trend` for baseline comparisons
+- `compute_composition`, `compute_code_health`, `compute_risk`, `generate_review_plan`
+- `render_json`, `render_markdown`, `render_comment_md`, `write_artifacts`
+
+## Quick use / integration notes
+
+The default `git` feature lets the crate walk `base..head`, hash file sets, and populate evidence gates before rendering.
+
+Without `git`, the pure render helpers stay available for prebuilt cockpit receipts.
+
+## Go deeper
+
+### How-to
+
+- `../../docs/reference-cli.md`
+
+### Reference
+
+- `src/lib.rs`
+- `src/render.rs`
+
+### Explanation
+
+- `../../docs/explanation.md`

--- a/crates/tokmd-config/README.md
+++ b/crates/tokmd-config/README.md
@@ -1,94 +1,42 @@
 # tokmd-config
 
-Configuration schemas and CLI argument parsing for tokmd.
+Define tokmd CLI arguments and config files in one schema.
 
-## Overview
+## Problem
 
-This is a **Tier 3** crate defining CLI arguments (via Clap) and configuration file structures (via Serde). It couples configuration schemas with CLI parsing.
+The CLI, config file, and tool-schema generation need to agree on the same option surface.
 
-## Installation
+## What it gives you
+
+- `Cli`, `Commands`, and `GlobalArgs`
+- command-specific args such as `CliLangArgs`, `CliAnalyzeArgs`, `CliGateArgs`, `CockpitArgs`, `HandoffArgs`, and `SensorArgs`
+- config models: `UserConfig` and `Profile`
+- re-exports from `tokmd-types` plus `ToolSchemaFormat`
+
+## Quick use / integration notes
+
+`Cli::parse()` reads the clap surface. `UserConfig` and `Profile` model `tokmd.toml`.
 
 ```toml
-[dependencies]
-tokmd-config = "1.3"
+[profiles.ci]
+top = 10
+format = "json"
 ```
 
-## Usage
+## Go deeper
 
-```rust
-use clap::Parser;
-use tokmd_config::Cli;
+### Tutorial
 
-let cli = Cli::parse();
-println!("Verbose: {}", cli.global.verbose);
-```
+- `../../docs/tutorial.md`
 
-## Main Structures
+### How-to
 
-### CLI Parser
-```rust
-pub struct Cli {
-    pub global: GlobalArgs,
-    pub lang: CliLangArgs,
-    pub command: Option<Commands>,
-    pub profile: Option<String>,
-}
-```
+- `../../docs/reference-cli.md`
 
-### Global Arguments
-```rust
-pub struct GlobalArgs {
-    pub excluded: Vec<String>,
-    pub config: ConfigMode,
-    pub hidden: bool,
-    pub no_ignore: bool,
-    pub no_ignore_parent: bool,
-    pub no_ignore_dot: bool,
-    pub no_ignore_vcs: bool,
-    pub treat_doc_strings_as_comments: bool,
-    pub verbose: u8,
-    pub no_progress: bool,
-}
-```
+### Reference
 
-## Commands
+- `src/lib.rs`
 
-| Command | Description |
-|---------|-------------|
-| `Lang` | Language summary (default) |
-| `Module` | Module breakdown |
-| `Export` | File-level inventory |
-| `Analyze` | Derived metrics |
-| `Badge` | SVG badge generation |
-| `Init` | Generate .tokeignore |
-| `Completions` | Shell completions |
-| `Run` | Full scan with artifacts |
-| `Diff` | Compare receipts |
-| `Context` | LLM context packing |
-| `CheckIgnore` | Explain ignored files |
+### Explanation
 
-## Key Enums
-
-| Enum | Values |
-|------|--------|
-| `ConfigMode` | Auto, None |
-| `TableFormat` | Md, Tsv, Json |
-| `ExportFormat` | Csv, Jsonl, Json, Cyclonedx |
-| `AnalysisFormat` | Md, Json, Jsonld, Xml, Svg, Mermaid, Obj, Midi, Tree, Html |
-| `RedactMode` | None, Paths, All |
-| `ChildrenMode` | Collapse, Separate |
-| `AnalysisPreset` | Receipt, Health, Risk, Supply, Architecture, Topics, Security, Identity, Git, Deep, Fun |
-
-## Configuration File
-
-Supports `tokmd.toml` with sections for scan, module, export, analyze, context, and badge settings. Named profiles allow saving common option combinations.
-
-## Re-exports
-
-Common types from `tokmd-types` are re-exported for convenience:
-- `ChildIncludeMode`, `ChildrenMode`, `ConfigMode`
-- `ExportFormat`, `RedactMode`, `TableFormat`
-
-## License
-
-MIT OR Apache-2.0
+- `../../docs/explanation.md`

--- a/crates/tokmd-content/README.md
+++ b/crates/tokmd-content/README.md
@@ -1,75 +1,36 @@
 # tokmd-content
 
-Content scanning helpers for tokmd analysis.
+Read, hash, and score file content for tokmd analysis.
 
-## Overview
+## Problem
 
-This is a **Tier 2** utility crate for file content inspection. It provides functions for reading file contents, detecting text files, computing hashes, counting tags, and calculating entropy.
+Use this crate when path listings are not enough and you need bounded content
+sampling for tags, entropy, hashes, or function-level complexity.
 
-## Installation
+## What it gives you
+
+- `read_head`, `read_head_tail`, `read_lines`, `read_text_capped`
+- `is_text_like`, `hash_bytes`, `hash_file`
+- `count_tags`, `entropy_bits_per_byte`
+- `complexity::analyze_functions`
+- `complexity::estimate_cyclomatic_complexity`
+- `complexity::estimate_cognitive_complexity`
+- `complexity::analyze_nesting_depth`
+
+## Quick use / integration notes
 
 ```toml
 [dependencies]
-tokmd-content = "1.3"
+tokmd-content = { workspace = true }
 ```
 
-## Usage
+Use the head/tail readers for bounded sampling, then feed the bytes into
+entropy or tag checks.
 
-```rust
-use tokmd_content::{read_head, hash_file, count_tags, entropy_bits_per_byte, is_text_like};
-use std::path::Path;
+## Go deeper
 
-// Read first 4KB of file
-let bytes = read_head(Path::new("src/lib.rs"), 4096)?;
-
-// Check if content is text
-if is_text_like(&bytes) {
-    // Count TODO/FIXME tags
-    let text = String::from_utf8_lossy(&bytes);
-    let tags = count_tags(&text, &["TODO", "FIXME", "HACK"]);
-}
-
-// Calculate entropy (for secret detection)
-let entropy = entropy_bits_per_byte(&bytes);
-
-// Hash file for duplicate detection
-let hash = hash_file(Path::new("src/lib.rs"), 1_000_000)?;
-```
-
-## Key Functions
-
-### Reading
-- `read_head()` - Read first N bytes
-- `read_head_tail()` - Read balanced head + tail
-- `read_lines()` - Read lines with limits
-- `read_text_capped()` - Read as text with byte limit
-
-### Detection
-- `is_text_like()` - Check for null bytes and valid UTF-8
-
-### Hashing
-- `hash_bytes()` - BLAKE3 hash of bytes
-- `hash_file()` - Hash file content (capped)
-
-### Analysis
-- `count_tags()` - Case-insensitive tag counting
-- `entropy_bits_per_byte()` - Shannon entropy calculation
-
-## Entropy Interpretation
-
-| Range | Interpretation |
-|-------|----------------|
-| 0.0 | Empty or uniform |
-| < 4.0 | Low (plain text) |
-| 4.0-6.0 | Medium (source code) |
-| 6.0-7.5 | High (compressed/encrypted) |
-| > 7.5 | Suspicious (secrets, random) |
-
-## Dependencies
-
-- `blake3` - Fast cryptographic hashing
-- `anyhow` - Error handling
-
-## License
-
-MIT OR Apache-2.0
+Tutorial: [Root README](../../README.md)
+How-to: [Recipes](../../docs/recipes.md)
+Reference: [Source](src/lib.rs)
+Reference: [Complexity module](src/complexity.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-context-git/README.md
+++ b/crates/tokmd-context-git/README.md
@@ -1,10 +1,32 @@
 # tokmd-context-git
 
-Git-derived scoring primitives for context ranking workflows.
+Rank files for context selection using git churn signals.
 
-This crate provides:
+## Problem
 
-- `GitScores`: per-file hotspot and commit-count maps
-- `compute_git_scores()`: history-backed score computation with graceful fallback when git support is disabled
+Use this crate when you want a small, deterministic way to rank files by
+hotspot and commit-count pressure for context or handoff bundles.
 
-It is used by the `tokmd` context and handoff commands.
+## What it gives you
+
+- `GitScores` with `hotspots` and `commit_counts`
+- `compute_git_scores` behind the `git` feature
+- `None` fallback when git support is disabled or unavailable
+- shared path normalization via `tokmd-path`
+
+## Quick use / integration notes
+
+```toml
+[dependencies]
+tokmd-context-git = { workspace = true }
+```
+
+Enable the `git` feature when you want churn-backed ranking; leave it off for
+lightweight builds.
+
+## Go deeper
+
+Tutorial: [Root README](../../README.md)
+How-to: [Recipes](../../docs/recipes.md)
+Reference: [Source](src/lib.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-context-policy/README.md
+++ b/crates/tokmd-context-policy/README.md
@@ -1,15 +1,24 @@
 # tokmd-context-policy
 
-Single-responsibility microcrate for deterministic context/handoff policy rules.
+Deterministic file-selection policy for context and handoff workflows.
 
-## API
+## Problem
+Context packing needs stable inclusion rules for spine files, generated files, and file-size caps.
 
-- `smart_exclude_reason(path)` - classify lockfiles/minified files/sourcemaps for
-  payload exclusion.
-- `is_spine_file(path)` - match must-include project spine files.
-- `classify_file(path, tokens, lines, dense_threshold)` - deterministic file hygiene
-  classification.
-- `compute_file_cap(budget, max_file_pct, max_file_tokens)` - per-file token cap
-  calculation.
-- `assign_policy(tokens, file_cap, classifications)` - decide `InclusionPolicy`
-  plus reason text.
+## What it gives you
+- `smart_exclude_reason(path)`
+- `is_spine_file(path)`
+- `classify_file(path, tokens, lines, dense_threshold)`
+- `compute_file_cap(budget, max_file_pct, max_file_tokens)`
+- `assign_policy(tokens, file_cap, classifications)`
+
+## API / usage notes
+- Use this crate when deciding what to include in a context or handoff bundle.
+- The rules are deterministic and text-based, not heuristic prose.
+- `src/lib.rs` is the canonical list of lockfiles, generated files, and spine patterns.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-core/README.md
+++ b/crates/tokmd-core/README.md
@@ -1,137 +1,48 @@
 # tokmd-core
 
-Clap-free library facade for embedding `tokmd` workflows in Rust or through FFI-friendly JSON calls.
+Primary library facade for embedding tokmd workflows.
 
-## Overview
+## Problem
 
-This is the **Tier 4** crate that exposes the binding-friendly workflow layer. Use it when you want deterministic receipts without depending on the CLI crate or on lower-tier scan/model internals directly.
+You want tokmd receipts from Rust or FFI without depending on clap or the CLI binary.
 
-## Installation
+## What it gives you
 
-For core receipt workflows only:
+- Settings-based workflows: `lang_workflow`, `module_workflow`, `export_workflow`, `diff_workflow`, `analyze_workflow`, `cockpit_workflow`
+- Ordered in-memory variants: `*_workflow_from_inputs`
+- Shared JSON entrypoint: `ffi::run_json`
+- Convenience re-exports: `config`, `types`, `InMemoryFile`
+
+## Quick use / integration notes
+
+Add only the features you need:
 
 ```toml
 [dependencies]
-tokmd-core = "1.8"
+tokmd-core = { version = "1", features = ["analysis", "cockpit"] }
 ```
 
-If you also want analysis or cockpit workflows, enable the corresponding features:
+`run_json` supports these modes: `lang`, `module`, `export`, `analyze`, `diff`, `cockpit`, and `version`.
 
-```toml
-[dependencies]
-tokmd-core = { version = "1.8", features = ["analysis", "cockpit"] }
-```
+For browser-safe in-memory inputs, pass ordered `scan.inputs` rows with `{ path, text | base64 }`.
 
-## Rust Workflow Example
+## Go deeper
 
-```rust,no_run
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-use tokmd_core::settings::{LangSettings, ScanSettings};
-use tokmd_core::lang_workflow;
+### Tutorial
 
-let scan = ScanSettings::current_dir();
-let lang = LangSettings {
-    top: 10,
-    files: true,
-    ..Default::default()
-};
+- `../../docs/tutorial.md`
 
-let receipt = lang_workflow(&scan, &lang)?;
-assert!(!receipt.report.rows.is_empty());
-# Ok(())
-# }
-```
+### How-to
 
-With the `analysis` feature enabled, the same facade can drive the effort-aware analysis path:
+- `../../docs/recipes.md`
 
-```rust,no_run
-# #[cfg(feature = "analysis")]
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-use tokmd_core::settings::{AnalyzeSettings, ScanSettings};
-use tokmd_core::analyze_workflow;
+### Reference
 
-let scan = ScanSettings::current_dir();
-let analyze = AnalyzeSettings {
-    preset: "estimate".to_string(),
-    ..Default::default()
-};
+- `src/lib.rs`
+- `src/ffi.rs`
+- `../../docs/SCHEMA.md`
 
-let receipt = analyze_workflow(&scan, &analyze)?;
-assert!(receipt.effort.is_some());
-# Ok(())
-# }
-# #[cfg(not(feature = "analysis"))]
-# fn main() {}
-```
+### Explanation
 
-## Main Workflows
-
-- `lang_workflow(scan, lang) -> LangReceipt`
-- `lang_workflow_from_inputs(inputs, scan_opts, lang) -> LangReceipt`
-- `module_workflow(scan, module) -> ModuleReceipt`
-- `module_workflow_from_inputs(inputs, scan_opts, module) -> ModuleReceipt`
-- `export_workflow(scan, export) -> ExportReceipt`
-- `export_workflow_from_inputs(inputs, scan_opts, export) -> ExportReceipt`
-- `diff_workflow(settings) -> DiffReceipt`
-- `analyze_workflow(scan, analyze) -> AnalysisReceipt` with `analysis` feature
-- `analyze_workflow_from_inputs(inputs, scan_opts, analyze) -> AnalysisReceipt` with `analysis` feature
-- `cockpit_workflow(settings) -> CockpitReceipt` with `cockpit` feature
-
-All workflows use pure settings types from `tokmd_core::settings`, so they stay free of clap-specific argument structures. For ordered virtual inputs, build `tokmd_core::InMemoryFile` values and use the `*_workflow_from_inputs` variants instead of filesystem paths. Those in-memory workflows ignore ambient `tokei.toml` / `.tokeirc` discovery and clamp scan config loading to `none` so the same input set produces the same receipt regardless of host cwd.
-
-## FFI JSON API
-
-`tokmd-core` also exposes a single JSON entrypoint for bindings:
-
-```rust,no_run
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-use tokmd_core::ffi::run_json;
-
-let envelope = run_json("lang", r#"{"paths":["."],"top":5}"#);
-let parsed: serde_json::Value = serde_json::from_str(&envelope)?;
-
-assert_eq!(parsed["ok"], true);
-assert_eq!(parsed["data"]["mode"], "lang");
-# Ok(())
-# }
-```
-
-Supported `run_json` modes are `lang`, `module`, `export`, `analyze`, `diff`, `cockpit`, and `version`.
-
-Response shape:
-
-- Success: `{"ok": true, "data": {...}}`
-- Error: `{"ok": false, "error": {"code": "...", "message": "..."}}`
-
-For ordered virtual inputs, pass `scan.inputs` instead of `paths`. Bindings may also send top-level `inputs` for backwards-compatible flat request shapes. Each entry supplies a logical `path` plus exactly one of `text` or `base64`:
-
-```json
-{
-  "scan": {
-    "inputs": [
-      { "path": "src/lib.rs", "text": "pub fn alpha() {}\n" },
-      { "path": "tests/basic.py", "base64": "cHJpbnQoJ29rJykK" }
-    ]
-  }
-}
-```
-
-## Re-exports
-
-For convenience, the crate re-exports:
-
-```rust,no_run
-pub use tokmd_config as config;
-pub use tokmd_types as types;
-```
-
-## When to Use
-
-- Embedding `tokmd` in another Rust tool
-- Reusing the receipt workflows without the CLI
-- Driving the JSON envelope API from Python, Node, or another FFI layer
-- Accessing `estimate` analysis or cockpit workflows from Rust with explicit feature flags
-
-## License
-
-MIT OR Apache-2.0
+- `../../docs/architecture.md`
+- `../../docs/design.md`

--- a/crates/tokmd-envelope/README.md
+++ b/crates/tokmd-envelope/README.md
@@ -1,5 +1,22 @@
 # tokmd-envelope
 
-Cross-fleet contract types for multi-sensor integration. Defines the `SensorReport` envelope, `Finding`, `Verdict`, and gate types used by all sensors.
+Cross-fleet `SensorReport` contracts for multi-sensor integration.
 
-See the [root README](../../README.md) for full documentation.
+## Problem
+Sensors and policy checks need one shared envelope for verdicts, findings, artifacts, and gate output.
+
+## What it gives you
+- `SensorReport`, `ToolMeta`, and `Verdict`
+- `Finding`, `FindingSeverity`, and `FindingLocation`
+- `GateResults`, `GateItem`, `Artifact`, and capability status types
+
+## API / usage notes
+- This crate is the shared JSON contract for sensors, gate, and cockpit-style consumers.
+- Keep the envelope shape stable and version it deliberately.
+- `src/lib.rs` is the canonical field reference.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [tokmd-sensor](../tokmd-sensor/README.md)
+- Reference: [Schema](../../docs/SCHEMA.md)
+- Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-exclude/README.md
+++ b/crates/tokmd-exclude/README.md
@@ -1,12 +1,22 @@
 # tokmd-exclude
 
-Single-responsibility microcrate for deterministic exclude-pattern handling.
+Deterministic exclude-pattern normalization and matching.
 
-## API
+## Problem
+Exclude lists drift quickly when paths are compared in different forms or are added more than once.
 
-- `normalize_exclude_pattern(root, path)` - normalize path separators, strip `./`,
-  and make absolute paths root-relative when possible.
-- `has_exclude_pattern(existing, pattern)` - membership check with normalized
-  matching (slash and `./` insensitive).
-- `add_exclude_pattern(existing, pattern)` - push only when the normalized pattern
-  is non-empty and not already present.
+## What it gives you
+- `normalize_exclude_pattern(root, path)`
+- `has_exclude_pattern(existing, pattern)`
+- `add_exclude_pattern(existing, pattern)`
+
+## API / usage notes
+- Normalize patterns before storing or comparing them.
+- The helpers keep slash handling and `./` prefixes consistent across platforms.
+- Use `src/lib.rs` for the full matching behavior.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Troubleshooting](../../docs/troubleshooting.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-export-tree/README.md
+++ b/crates/tokmd-export-tree/README.md
@@ -1,11 +1,33 @@
 # tokmd-export-tree
 
-Single-responsibility microcrate for deterministic tree rendering from
-`tokmd_types::ExportData`.
+Render deterministic trees from `tokmd_types::ExportData`.
 
-It provides two renderers:
+## Problem
 
-- `render_analysis_tree`: full tree with file leaves and `(lines, tokens)` payloads
-- `render_handoff_tree`: directory-only tree with `(files, lines, tokens)` payloads and depth limit
+Use this crate when nested path summaries need stable trees instead of ad hoc
+recursion or order drift.
 
-Both outputs are stable across input order for reproducible receipts and tests.
+## What it gives you
+
+- `render_analysis_tree(export)`
+- `render_handoff_tree(export, max_depth)`
+- lexicographically ordered siblings via `BTreeMap`
+- analysis trees with file leaves
+- handoff trees with directory-only nodes and depth limiting
+
+## Quick use / integration notes
+
+```toml
+[dependencies]
+tokmd-export-tree = { workspace = true }
+```
+
+Pass in `ExportData` and render the tree variant that matches your report or
+bundle.
+
+## Go deeper
+
+Tutorial: [Root README](../../README.md)
+How-to: [Recipes](../../docs/recipes.md)
+Reference: [Source](src/lib.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-ffi-envelope/README.md
+++ b/crates/tokmd-ffi-envelope/README.md
@@ -1,22 +1,26 @@
 # tokmd-ffi-envelope
 
-Single-responsibility microcrate for parsing and extracting data from tokmd FFI JSON envelopes.
+Stable JSON envelope parsing for tokmd bindings.
 
-## Purpose
+## Problem
+FFI callers need one deterministic way to unwrap `tokmd_core::ffi::run_json` responses and normalize errors.
 
-- Parse JSON envelopes returned by `tokmd_core::ffi::run_json`.
-- Extract the success payload (`data`) deterministically.
-- Normalize upstream error formatting for bindings (`[code] message`).
+## What it gives you
+- `EnvelopeExtractError`
+- `parse_envelope`
+- `format_error_message`
+- `extract_data`
+- `extract_data_from_json`
+- `extract_data_json`
 
-## Envelope Contract
+## API / usage notes
+- Success envelopes return the `data` payload when present.
+- Success envelopes without `data` return the original envelope unchanged.
+- Upstream failures normalize to the `[code] message` shape used by bindings.
+- `src/lib.rs` is the exact contract for parsing and extraction behavior.
 
-- Success: `{"ok": true, "data": ...}`
-- Error: `{"ok": false, "error": {"code": "...", "message": "..."}}`
-- Success without `data`: returns the whole envelope unchanged.
-
-## API
-
-- `parse_envelope(&str) -> Result<Value, EnvelopeExtractError>`
-- `extract_data(Value) -> Result<Value, EnvelopeExtractError>`
-- `extract_data_from_json(&str) -> Result<Value, EnvelopeExtractError>`
-- `extract_data_json(&str) -> Result<String, EnvelopeExtractError>`
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [tokmd-core](../tokmd-core/README.md)
+- Reference: [src/lib.rs](src/lib.rs)
+- Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-format/README.md
+++ b/crates/tokmd-format/README.md
@@ -1,107 +1,35 @@
 # tokmd-format
 
-Output formatting and serialization for tokmd.
+Render tokmd receipts into stable text and machine formats.
 
-## Overview
+## Problem
 
-This is a **Tier 2** crate that renders tokmd receipts to various formats: Markdown, TSV, JSON, JSONL, CSV, and CycloneDX SBOM.
+Use this crate when scan results need to become Markdown tables, JSON receipts,
+CSV or JSONL exports, CycloneDX SBOMs, or diff output without duplicating
+formatting logic.
 
-## Installation
+## What it gives you
+
+- `print_lang_report` / `write_lang_report_to`
+- `print_module_report` / `write_module_report_to`
+- `write_export`, `write_export_csv_to`, `write_export_jsonl_to`, `write_export_json_to`, `write_export_cyclonedx_to`
+- `compute_diff_rows`, `compute_diff_totals`, `render_diff_md`, `create_diff_receipt`
+- `scan_args`, `normalize_scan_input`, `redact_path`, `short_hash`
+
+## Quick use / integration notes
 
 ```toml
 [dependencies]
-tokmd-format = "1.3"
+tokmd-format = { workspace = true }
 ```
 
-## Usage
+Call the `print_*` or `write_*` helpers from your own integration layer when
+you need a specific output format.
 
-```rust
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-use std::path::PathBuf;
-use tokmd_format::{print_lang_report, scan_args, normalize_scan_input};
-use tokmd_settings::ScanOptions;
-use tokmd_types::{ChildrenMode, LangArgs, LangReport, RedactMode, TableFormat, Totals};
+## Go deeper
 
-// Create dummy data
-let report = LangReport {
-    with_files: true,
-    top: 10,
-    children: ChildrenMode::Separate,
-    total: Totals {
-        code: 0,
-        lines: 0,
-        files: 0,
-        bytes: 0,
-        tokens: 0,
-        avg_lines: 0,
-    },
-    rows: vec![],
-};
-let global_args = ScanOptions::default();
-let lang_args = LangArgs {
-    paths: vec![PathBuf::from(".")],
-    format: TableFormat::Md,
-    top: 10,
-    files: true,
-    children: ChildrenMode::Separate,
-};
-
-// Print language report to stdout
-print_lang_report(&report, &global_args, &lang_args)?;
-
-// Build ScanArgs with optional redaction
-let paths = vec![PathBuf::from("src")];
-let args = scan_args(&paths, &global_args, Some(RedactMode::Paths));
-
-// Normalize path for cross-platform consistency
-let normalized = normalize_scan_input(std::path::Path::new("src/lib.rs"));
-assert_eq!(normalized, "src/lib.rs");
-# Ok(())
-# }
-```
-
-## Supported Formats
-
-### Table Formats
-- **Markdown** - Pipes with right-aligned numeric columns
-- **TSV** - Tab-separated with header row
-- **JSON** - Receipt with envelope metadata
-
-### Export Formats
-- **CSV** - Standard comma-separated
-- **JSONL** - Lines with type discriminator
-- **JSON** - Full receipt array
-- **CycloneDX 1.6** - SBOM with tokmd-specific properties
-
-## Key Functions
-
-### Console Output
-- `print_lang_report()` - Language summary
-- `print_module_report()` - Module breakdown
-
-### File Writing
-- `write_export()` - Write export data
-- `write_lang_json_to_file()` - Language receipt
-- `write_module_json_to_file()` - Module receipt
-- `write_export_jsonl_to_file()` - Export receipt
-
-### ScanArgs Construction
-- `scan_args()` - Re-export from `tokmd-scan-args` for compatibility
-
-## Redaction Modes
-
-| Mode | Behavior |
-|------|----------|
-| `None` | Paths shown as-is |
-| `Paths` | Hash paths, preserve extensions |
-| `All` | Hash paths and excluded patterns |
-
-## Re-exports
-
-```rust,no_run
-pub use tokmd_redact::{redact_path, short_hash};
-```
-
-## License
-
-MIT OR Apache-2.0
+Tutorial: [Root README](../../README.md)
+How-to: [Recipes](../../docs/recipes.md)
+Reference: [CLI Reference](../../docs/reference-cli.md)
+Explanation: [Architecture](../../docs/architecture.md)
+Reference: [Source](src/lib.rs)

--- a/crates/tokmd-fun/README.md
+++ b/crates/tokmd-fun/README.md
@@ -1,102 +1,32 @@
 # tokmd-fun
 
-Fun renderers for tokmd analysis.
+Generate novelty outputs from tokmd metrics.
 
-## Overview
+## Problem
 
-This is a **Tier 3** novelty crate providing creative visualizations of code metrics. It generates 3D code city models and audio representations of codebases.
+Use this crate when you want a derived artifact for demos, visualizations, or
+experimentation without changing the core receipt model.
 
-## Installation
+## What it gives you
+
+- `render_obj` with `ObjBuilding`
+- `render_midi` with `MidiNote`
+- Wavefront OBJ output for code-city style models
+- Type 1 MIDI output with configurable tempo
+
+## Quick use / integration notes
 
 ```toml
 [dependencies]
-tokmd-fun = "1.3"
+tokmd-fun = { workspace = true }
 ```
 
-## Usage
+Feed metrics into the renderers, then write the returned OBJ or MIDI bytes to
+disk.
 
-### OBJ Code City
+## Go deeper
 
-```rust
-use tokmd_fun::{render_obj, ObjBuilding};
-
-let buildings = vec![
-    ObjBuilding {
-        name: "src_main".to_string(),
-        x: 0.0, y: 0.0,
-        w: 1.0, d: 1.0,
-        h: 100.0,  // Height = lines of code
-    },
-];
-
-let obj_content = render_obj(&buildings);
-std::fs::write("city.obj", obj_content)?;
-```
-
-### MIDI Sonification
-
-```rust
-use tokmd_fun::{render_midi, MidiNote};
-
-let notes = vec![
-    MidiNote {
-        key: 60,       // Middle C
-        velocity: 80,
-        start: 0,
-        duration: 480,
-        channel: 0,
-    },
-];
-
-let midi_bytes = render_midi(&notes, 120)?;  // 120 BPM
-std::fs::write("code.midi", midi_bytes)?;
-```
-
-## Types
-
-### ObjBuilding
-```rust
-pub struct ObjBuilding {
-    pub name: String,  // Object name (sanitized)
-    pub x: f32,        // X position
-    pub y: f32,        // Y position
-    pub w: f32,        // Width
-    pub d: f32,        // Depth
-    pub h: f32,        // Height (maps to code lines)
-}
-```
-
-### MidiNote
-```rust
-pub struct MidiNote {
-    pub key: u8,       // MIDI note (0-127)
-    pub velocity: u8,  // Volume (0-127)
-    pub start: u32,    // Start tick
-    pub duration: u32, // Duration in ticks
-    pub channel: u8,   // MIDI channel (0-15)
-}
-```
-
-## OBJ Format
-
-Generates standard Wavefront OBJ with:
-- Named objects for each building
-- 8 vertices per cube
-- 6 faces per building
-- Sanitized names (alphanumeric + underscore)
-
-## MIDI Format
-
-Generates Type 1 MIDI files:
-- 480 ticks per quarter note
-- Configurable tempo
-- Supports all 16 MIDI channels
-
-## Dependencies
-
-- `midly` - MIDI file generation
-- `anyhow` - Error handling
-
-## License
-
-MIT OR Apache-2.0
+Tutorial: [Root README](../../README.md)
+How-to: [Recipes](../../docs/recipes.md)
+Reference: [Source](src/lib.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-gate/README.md
+++ b/crates/tokmd-gate/README.md
@@ -1,52 +1,41 @@
 # tokmd-gate
 
-Policy evaluation engine for tokmd analysis receipts. Enables CI gating based on code metrics.
+Evaluate JSON Pointer policies against tokmd receipts.
 
-## Usage
+## Problem
 
-```rust
-use tokmd_gate::{PolicyConfig, evaluate_policy};
-use serde_json::Value;
+CI needs explicit pass/fail rules over structured receipts, not ad hoc scripts.
 
-let receipt: Value = serde_json::from_str(receipt_json)?;
-let policy = PolicyConfig::from_file("policy.toml")?;
-let result = evaluate_policy(&receipt, &policy)?;
+## What it gives you
 
-if !result.passed {
-    eprintln!("Policy check failed: {} errors, {} warnings", result.errors, result.warnings);
-}
-```
+- `PolicyConfig`, `PolicyRule`, `RuleOperator`, `RuleLevel`
+- `evaluate_policy` for receipt checks
+- `evaluate_ratchet_policy` for trend gates
+- `resolve_pointer` for JSON Pointer lookup
 
-## Policy File Format
+## Quick use / integration notes
 
 ```toml
-fail_fast = false
-
 [[rules]]
 name = "max_tokens"
 pointer = "/derived/totals/tokens"
 op = "<="
 value = 500000
 level = "error"
-message = "Codebase exceeds token budget"
-
-[[rules]]
-name = "min_doc_density"
-pointer = "/derived/doc_density/total/ratio"
-op = ">="
-value = 0.1
-level = "warn"
-message = "Documentation below 10%"
 ```
 
-## Supported Operators
+Supported operators: `>`, `>=`, `<`, `<=`, `==`, `!=`, `in`, `contains`, and `exists`.
 
-- `>`, `>=`, `<`, `<=`: Numeric comparisons
-- `==`, `!=`: Equality checks
-- `in`: Value is in a list
-- `contains`: String/array contains value
-- `exists`: JSON pointer exists
+## Go deeper
 
-## License
+### How-to
 
-MIT OR Apache-2.0
+- `../../docs/reference-cli.md`
+
+### Reference
+
+- `src/lib.rs`
+
+### Explanation
+
+- `../../docs/explanation.md`

--- a/crates/tokmd-git/README.md
+++ b/crates/tokmd-git/README.md
@@ -1,77 +1,34 @@
 # tokmd-git
 
-Streaming git log adapter for tokmd analysis.
+Git history and diff helpers for tokmd.
 
-## Overview
+## Problem
 
-This is a **Tier 2** crate for git history collection. It provides a streaming interface to collect commit information without loading entire history into memory.
+Use this crate when you need commit history, touched files, or stable range
+handling without pulling in libgit2.
 
-## Installation
+## What it gives you
+
+- `git_available` and `repo_root`
+- `collect_history`
+- `get_added_lines`
+- `rev_exists` and `resolve_base_ref`
+- `GitRangeMode` with `TwoDot` and `ThreeDot`
+- `classify_intent`
+
+## Quick use / integration notes
 
 ```toml
 [dependencies]
-tokmd-git = "1.3"
+tokmd-git = { workspace = true }
 ```
 
-## Usage
+This crate shells out to `git`, streams log output, and keeps range handling
+deterministic.
 
-```rust
-use tokmd_git::{git_available, repo_root, collect_history};
-use std::path::Path;
+## Go deeper
 
-// Check git availability
-if git_available() {
-    // Find repository root
-    if let Some(root) = repo_root(Path::new(".")) {
-        // Collect history with limits
-        let commits = collect_history(&root, Some(500), Some(50))?;
-
-        for commit in commits {
-            println!("{}: {} files by {}",
-                commit.timestamp,
-                commit.files.len(),
-                commit.author
-            );
-        }
-    }
-}
-```
-
-## Key Functions
-
-### Detection
-```rust
-pub fn git_available() -> bool
-pub fn repo_root(path: &Path) -> Option<PathBuf>
-```
-
-### History Collection
-```rust
-pub fn collect_history(
-    repo_root: &Path,
-    max_commits: Option<usize>,
-    max_commit_files: Option<usize>,
-) -> Result<Vec<GitCommit>>
-
-pub struct GitCommit {
-    pub timestamp: i64,      // Unix timestamp
-    pub author: String,      // Email address
-    pub files: Vec<String>,  // Affected file paths
-}
-```
-
-## Implementation Details
-
-- Uses `git log --name-only --pretty=format:%ct|%ae`
-- Parses output line by line (streaming)
-- Respects `max_commits` and `max_commit_files` limits
-- Returns error if git command fails
-- Returns empty vec if not a git repository
-
-## Why Shell Out?
-
-This crate uses the git CLI rather than libgit2 for simplicity and to avoid native dependency complexity. The streaming approach keeps memory usage low for large repositories.
-
-## License
-
-MIT OR Apache-2.0
+Tutorial: [Root README](../../README.md)
+How-to: [Recipes](../../docs/recipes.md)
+Reference: [Source](src/lib.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-io-port/README.md
+++ b/crates/tokmd-io-port/README.md
@@ -1,18 +1,23 @@
 # tokmd-io-port
 
-I/O port traits for host-abstracted file access.
+Read-only file access ports for tokmd.
 
-Provides `ReadFs` – a trait that abstracts read-only filesystem operations so
-that `tokmd-scan` (and other crates) can work against in-memory data when
-compiled for WASM targets.
+## Problem
+Scan and model code should work against disk and in-memory inputs, including WASM, without changing call sites.
 
-## Implementations
+## What it gives you
+- `ReadFs`
+- `HostFs`
+- `MemFs`
+- `MemFsError`
 
-| Struct   | Purpose                            |
-|----------|------------------------------------|
-| `HostFs` | Delegates to `std::fs` (default)   |
-| `MemFs`  | In-memory store for tests and WASM |
+## API / usage notes
+- Use `HostFs` for production filesystem access.
+- Use `MemFs` in tests and browser/WASM code.
+- This crate stays read-only by design.
 
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [tokmd-scan](../tokmd-scan/README.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-math/README.md
+++ b/crates/tokmd-math/README.md
@@ -1,16 +1,23 @@
 # tokmd-math
 
-Single-responsibility microcrate for deterministic numeric helpers used across tokmd analysis crates.
+Deterministic numeric helpers for tokmd analysis crates.
 
-## API
+## Problem
+Analysis metrics should round, divide, and rank the same way every time.
 
-- `round_f64(value, decimals)` - deterministic decimal rounding helper
-- `safe_ratio(numer, denom)` - zero-safe ratio helper (4 decimal places)
-- `percentile(sorted, pct)` - percentile lookup over sorted integer values
-- `gini_coefficient(sorted)` - inequality coefficient for sorted integer values
+## What it gives you
+- `round_f64(value, decimals)`
+- `safe_ratio(numer, denom)`
+- `percentile(sorted, pct)`
+- `gini_coefficient(sorted)`
 
-## Guarantees
+## API / usage notes
+- Use these helpers for presentation and report math, not for ad hoc business rules.
+- They are designed for stable outputs on identical inputs.
+- See `src/lib.rs` for the exact rounding and percentile behavior.
 
-- deterministic for identical inputs
-- no allocation for core operations
-- no unsafe code
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-model/README.md
+++ b/crates/tokmd-model/README.md
@@ -2,79 +2,25 @@
 
 Deterministic aggregation and receipt modeling for tokmd.
 
-## Overview
+## Problem
+Raw scan results are not stable enough yet for output, diffing, or receipt generation.
 
-This is a **Tier 1** crate containing the core business logic for transforming raw tokei scan results into tokmd receipts. It handles aggregation, sorting, path normalization, and filtering.
+## What it gives you
+- `collect_file_rows`
+- `create_lang_report`
+- `create_module_report`
+- `create_export_data`
+- `unique_parent_file_count`
+- `normalize_path`
+- `module_key`
 
-## Installation
+## API / usage notes
+- This crate owns aggregation, sorting, filtering, and path normalization.
+- It turns `tokei::Languages` plus optional in-memory inputs into tokmd receipts.
+- `src/lib.rs` shows the exact report-building helpers and invariants.
 
-```toml
-[dependencies]
-tokmd-model = "1.3"
-```
-
-## Usage
-
-```rust
-use tokmd_model::{create_lang_report, create_module_report, collect_file_rows};
-use tokmd_types::ChildrenMode;
-
-// Create language summary
-let report = create_lang_report(&languages, 10, false, ChildrenMode::Collapse);
-
-// Create module breakdown
-let module_report = create_module_report(
-    &languages,
-    &["crates".to_string()],
-    2,
-    ChildIncludeMode::Separate,
-    0
-);
-
-// Collect file-level rows
-let rows = collect_file_rows(
-    &languages,
-    &["src".to_string()],
-    1,
-    ChildIncludeMode::Separate,
-    None
-);
-```
-
-## Key Functions
-
-### Report Creation
-- `create_lang_report()` - Aggregate by language
-- `create_module_report()` - Aggregate by directory structure
-- `create_export_data()` - File-level inventory with filtering
-- `collect_file_rows()` - Raw file row collection
-
-### Path Utilities
-- `normalize_path()` - Cross-platform path normalization
-- `module_key()` - Compute module key from path
-
-## Key Patterns
-
-### Token Estimation
-```rust
-const CHARS_PER_TOKEN: usize = 4;
-```
-Simple heuristic: `tokens = bytes / 4`
-
-### Deterministic Sorting
-All outputs sorted by:
-1. Code lines (descending)
-2. Name (ascending)
-
-### Children Mode
-- `Collapse` - Merge embedded languages into parent
-- `Separate` - Show as distinct rows
-
-### Path Normalization
-- Forward slashes on all platforms
-- Strip leading `./` and `/`
-- Optional prefix stripping
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [src/lib.rs](src/lib.rs)
+- Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-module-key/README.md
+++ b/crates/tokmd-module-key/README.md
@@ -1,14 +1,21 @@
 # tokmd-module-key
 
-Single-responsibility microcrate for deterministic module-key derivation from paths.
+Deterministic module-key derivation for tokmd paths.
 
-## What it does
+## Problem
+Module grouping has to stay stable across path separators, prefixes, and repository layouts.
 
-- Normalizes path separators for module grouping (`\` -> `/`).
-- Handles common relative path prefixes (`./`).
-- Derives stable module keys from a path, module roots, and depth.
-
-## API
-
+## What it gives you
 - `module_key(path: &str, module_roots: &[String], module_depth: usize) -> String`
 - `module_key_from_normalized(path: &str, module_roots: &[String], module_depth: usize) -> String`
+
+## API / usage notes
+- Use this crate after path normalization.
+- It keeps module grouping deterministic by combining path shape, roots, and depth.
+- `src/lib.rs` documents the exact matching rules.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-node/README.md
+++ b/crates/tokmd-node/README.md
@@ -1,107 +1,41 @@
 # @tokmd/core
 
-Node.js bindings for [tokmd](https://github.com/EffortlessMetrics/tokmd): deterministic repo receipts, analysis, cockpit metrics, and diff workflows from JavaScript.
+Async Node.js bindings for tokmd.
 
-## Installation
+## Problem
 
-```bash
-npm install @tokmd/core
-# or
-yarn add @tokmd/core
-# or
-pnpm add @tokmd/core
-```
+Use tokmd from JavaScript without blocking the event loop or hand-parsing JSON envelopes.
 
-## Quick Start
+## What it gives you
+
+- Promise-based helpers: `lang`, `module`, `export`, `analyze`, `cockpit`, and `diff`
+- Low-level access: `run` and `runJson`
+- Sync metadata helpers: `version` and `schemaVersion`
+- Async Rust bridge built on `napi-rs` and `spawn_blocking`
+
+## Quick use / integration notes
 
 ```javascript
 import { lang, analyze, diff } from '@tokmd/core';
 
-// Language summary
-const langReceipt = await lang({ paths: ['src'], top: 5 });
-for (const row of langReceipt.report.rows) {
-  console.log(`${row.lang}: ${row.code} lines`);
-}
-
-// Effort-focused analysis (1.8.0 preset)
-const analysisReceipt = await analyze({
-  paths: ['.'],
-  preset: 'estimate',
-  effort_base_ref: 'main',
-  effort_head_ref: 'HEAD',
-});
-
-if (analysisReceipt.effort) {
-  console.log(`P50 effort: ${analysisReceipt.effort.results.effort_pm_p50}`);
-}
-
-// Compare two saved receipts or run directories
-const diffReceipt = await diff('.runs/base/lang.json', '.runs/current/lang.json');
-console.log(diffReceipt.mode);
+const summary = await lang({ paths: ['src'], top: 5 });
+const analysis = await analyze({ paths: ['.'], preset: 'estimate' });
+const delta = await diff('.runs/base/lang.json', '.runs/current/lang.json');
 ```
 
-## API Surface
+The published npm package is `@tokmd/core`. Exact TypeScript shapes live in `index.d.ts`.
 
-High-level Promise-based helpers:
+## Go deeper
 
-- `lang(options?)`
-- `module(options?)`
-- `export(options?)`
-- `analyze(options?)`
-- `cockpit(options?)`
-- `diff(fromPath, toPath)`
+### Tutorial
 
-Low-level helpers:
+- `../../docs/tutorial.md`
 
-- `run(mode, args)`
-- `runJson(mode, argsJson)`
-- `version()`
-- `schemaVersion()`
+### How-to
 
-These wrappers sit on top of `tokmd-core` and use `spawn_blocking` internally so long-running scans do not block the Node event loop.
+- `../../docs/reference-cli.md`
 
-## Low-Level Modes
+### Reference
 
-`run()` and `runJson()` target the shared JSON/FFI workflow boundary. Supported modes are:
-
-- `lang`
-- `module`
-- `export`
-- `analyze`
-- `cockpit`
-- `diff`
-- `version`
-
-The JSON envelope is stable:
-
-- success: `{"ok": true, "data": {...}}`
-- error: `{"ok": false, "error": {...}}`
-
-## Notes
-
-- Current analysis presets include `estimate`, `risk`, `deep`, and `fun`.
-- `estimate` is the effort-focused preset added in `1.8.0`.
-- For exact TypeScript shapes, use the bundled declarations in [`index.d.ts`](./index.d.ts).
-
-## Platform Support
-
-Prebuilt binaries are available for:
-
-- macOS (`x64`, `arm64`)
-- Linux (`x64`, `arm64`)
-- Windows (`x64`)
-
-## Development
-
-Building from source requires Rust and napi-rs:
-
-```bash
-cd crates/tokmd-node
-npm install
-npm run build
-npm test
-```
-
-## License
-
-MIT OR Apache-2.0
+- `index.d.ts`
+- `src/lib.rs`

--- a/crates/tokmd-path/README.md
+++ b/crates/tokmd-path/README.md
@@ -1,8 +1,21 @@
 # tokmd-path
 
-Single-responsibility microcrate for path normalization used across tokmd crates.
+Path normalization helpers for tokmd.
 
-## API
+## Problem
+Cross-platform receipts only stay deterministic if paths normalize the same way on Windows, macOS, and Linux.
 
+## What it gives you
 - `normalize_slashes(path: &str) -> String`
 - `normalize_rel_path(path: &str) -> String`
+
+## API / usage notes
+- Normalize before you derive module keys, compare excludes, or emit output.
+- The helpers collapse backslashes and clean relative prefixes without changing the rest of the path.
+- `src/lib.rs` has the edge cases and tests.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-progress/README.md
+++ b/crates/tokmd-progress/README.md
@@ -1,9 +1,32 @@
 # tokmd-progress
 
-Progress spinner and progress-bar helpers used by `tokmd`.
+Optional terminal progress helpers for long tokmd runs.
 
-## Features
+## Problem
 
-- `ui`: enables interactive terminal rendering via `indicatif`
+Use this crate when you want a spinner or ETA bar in interactive terminals,
+but nothing in CI, non-TTYs, or user sessions that disable progress.
 
-Without `ui`, all progress APIs are no-op stubs.
+## What it gives you
+
+- `Progress`
+- `ProgressBarWithEta`
+- `ui` feature gate for `indicatif`
+- `NO_COLOR` and `TOKMD_NO_PROGRESS` opt-outs
+- no-op fallbacks when `ui` is disabled
+
+## Quick use / integration notes
+
+```toml
+[dependencies]
+tokmd-progress = { workspace = true, features = ["ui"] }
+```
+
+Without `ui`, the API stays callable but renders nothing.
+
+## Go deeper
+
+Tutorial: [Root README](../../README.md)
+How-to: [Troubleshooting](../../docs/troubleshooting.md)
+Reference: [Source](src/lib.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-python/README.md
+++ b/crates/tokmd-python/README.md
@@ -1,89 +1,41 @@
 # tokmd
 
-Python bindings for [tokmd](https://github.com/EffortlessMetrics/tokmd): deterministic repo receipts, analysis, cockpit metrics, and diff workflows from Python.
+Python bindings for tokmd.
 
-## Installation
+## Problem
 
-```bash
-pip install tokmd
-```
+Use tokmd from Python without rebuilding the Rust workflow layer yourself.
 
-## Quick Start
+## What it gives you
+
+- High-level helpers: `lang`, `module`, `export`, `analyze`, `cockpit`, and `diff`
+- Low-level access: `run`, `run_json`, `version`, and `schema_version`
+- Python dict results extracted from the shared JSON envelope
+
+## Quick use / integration notes
 
 ```python
 import tokmd
 
-# Language summary
-result = tokmd.lang(paths=["src"], top=5)
-for row in result["report"]["rows"]:
-    print(f"{row['lang']}: {row['code']} lines")
-
-# Effort-focused analysis (1.8.0 preset)
-result = tokmd.analyze(
-    paths=["."],
-    preset="estimate",
-    effort_base_ref="main",
-    effort_head_ref="HEAD",
-)
-
-if result.get("effort"):
-    print(result["effort"]["results"]["effort_pm_p50"])
+receipt = tokmd.lang(paths=["src"], top=5)
+analysis = tokmd.analyze(paths=["."], preset="estimate")
 ```
 
-## High-Level Functions
+`run_json` is the low-level boundary. The higher-level helpers return Python dicts.
 
-The binding exposes Python-native wrappers for:
+Long scans release the GIL while Rust is doing the work.
 
-- `lang(...)`
-- `module(...)`
-- `export(...)`
-- `analyze(...)`
-- `cockpit(...)`
-- `diff(from_path, to_path)`
+## Go deeper
 
-These return Python dictionaries extracted from the shared JSON envelope.
+### Tutorial
 
-## Low-Level API
+- `../../docs/tutorial.md`
 
-Use these when you want direct access to the FFI boundary:
+### How-to
 
-- `run_json(mode, args_json)`
-- `run(mode, args)`
-- `version()`
-- `schema_version()`
+- `../../docs/reference-cli.md`
 
-Supported low-level modes are:
+### Reference
 
-- `lang`
-- `module`
-- `export`
-- `analyze`
-- `cockpit`
-- `diff`
-- `version`
-
-The response envelope is stable:
-
-- success: `{"ok": true, "data": {...}}`
-- error: `{"ok": false, "error": {...}}`
-
-## Notes
-
-- Current analysis presets include `estimate`, `risk`, `deep`, and `fun`.
-- The binding forwards current effort options such as `effort_base_ref`, `effort_head_ref`, `effort_layer`, `effort_monte_carlo`, `effort_mc_iterations`, and `effort_mc_seed`.
-- Long-running scans release the GIL while the Rust core is doing the work.
-
-## Development
-
-Building from source requires Rust and maturin:
-
-```bash
-pip install maturin
-cd crates/tokmd-python
-maturin develop
-pytest tests/
-```
-
-## License
-
-MIT OR Apache-2.0
+- `src/lib.rs`
+- `pyproject.toml`

--- a/crates/tokmd-redact/README.md
+++ b/crates/tokmd-redact/README.md
@@ -1,64 +1,22 @@
 # tokmd-redact
 
-Redaction utilities for privacy-safe tokmd output.
+Privacy-safe redaction helpers for tokmd output.
 
-## Overview
+## Problem
+Receipts need to preserve structure without leaking path details or other sensitive strings.
 
-This is a **Tier 0.5** utility crate providing BLAKE3-based hashing functions for redacting sensitive information in receipts while preserving useful structure.
+## What it gives you
+- `short_hash`
+- `redact_path`
 
-## Installation
+## API / usage notes
+- Use `short_hash` when you need a stable identifier.
+- Use `redact_path` when you want to hide path contents but keep file-type hints.
+- Path separators are normalized before hashing so Windows and Unix produce the same result.
+- `src/lib.rs` is the canonical source for the redaction rules.
 
-```toml
-[dependencies]
-tokmd-redact = "1.3"
-```
-
-## Usage
-
-```rust
-use tokmd_redact::{short_hash, redact_path};
-
-// Hash any string to 16 characters
-let hash = short_hash("my-secret-path");
-assert_eq!(hash.len(), 16);
-
-// Redact path while preserving extension
-let redacted = redact_path("src/secrets/config.json");
-assert!(redacted.ends_with(".json"));
-// Result: "a1b2c3d4e5f6g7h8.json"
-```
-
-## Functions
-
-### `short_hash(s: &str) -> String`
-Returns a 16-character BLAKE3 hex hash of the input string.
-
-### `redact_path(path: &str) -> String`
-Returns a hashed path with the file extension preserved.
-
-## Cross-Platform Consistency
-
-Both functions normalize path separators (`\` to `/`) before hashing, ensuring identical hashes across Windows and Unix:
-
-```rust
-assert_eq!(short_hash("src\\lib"), short_hash("src/lib"));
-assert_eq!(redact_path("src\\main.rs"), redact_path("src/main.rs"));
-```
-
-## Use Cases
-
-- Share receipts without exposing internal paths
-- Privacy-safe LLM context generation
-- Anonymize repository structure in reports
-
-## Redaction Modes (in tokmd-format)
-
-| Mode | Behavior |
-|------|----------|
-| `None` | Paths shown as-is |
-| `Paths` | Hash file paths, preserve extension |
-| `All` | Hash paths and excluded patterns |
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Troubleshooting](../../docs/troubleshooting.md)
+- Reference: [src/lib.rs](src/lib.rs)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-scan-args/README.md
+++ b/crates/tokmd-scan-args/README.md
@@ -1,14 +1,21 @@
 # tokmd-scan-args
 
-Single-responsibility helpers for building deterministic `ScanArgs` receipts.
+Deterministic scan-argument shaping for tokmd receipts.
 
-## Purpose
+## Problem
+Scan inputs, excludes, and redaction choices need to be serialized the same way everywhere.
 
-- Normalize scan input paths for cross-platform stability.
-- Apply optional scan-path and exclusion redaction.
-- Keep scan argument shaping out of formatting crates.
-
-## API
-
+## What it gives you
 - `normalize_scan_input(&Path) -> String`
 - `scan_args(&[PathBuf], &ScanOptions, Option<RedactMode>) -> ScanArgs`
+
+## API / usage notes
+- Use this crate when you need a stable `ScanArgs` snapshot for receipts or FFI.
+- It keeps path normalization and redaction policy out of formatting crates.
+- `src/lib.rs` documents the full conversion path.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [CLI Reference](../../docs/reference-cli.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-scan/README.md
+++ b/crates/tokmd-scan/README.md
@@ -1,58 +1,26 @@
 # tokmd-scan
 
-Source code scanning adapter for tokmd.
+Tokei-backed scan adapter for tokmd.
 
-## Overview
+## Problem
+Raw scanning and config translation should live behind one boundary instead of leaking into model or formatting code.
 
-This is a **Tier 1** crate that wraps the [tokei](https://github.com/XAMPPRocky/tokei) library, isolating this dependency to a single location. It handles configuration mapping and scan execution.
+## What it gives you
+- `scan`
+- `scan_in_memory`
+- `config_from_scan_options`
+- `normalize_in_memory_paths`
+- `InMemoryFile`
+- `MaterializedScan`
 
-## Installation
+## API / usage notes
+- `scan` wraps `tokei` and returns a `Languages` map for host paths.
+- `scan_in_memory` writes logical inputs into a temporary root and keeps the logical paths alive for downstream model code.
+- `config_from_scan_options` maps `ScanOptions` into `tokei::Config`.
+- `src/lib.rs` and its tests are the canonical reference for path validation and ignore handling.
 
-```toml
-[dependencies]
-tokmd-scan = "1.3"
-```
-
-## Usage
-
-```rust
-use tokmd_scan::scan;
-use tokmd_config::GlobalArgs;
-use std::path::PathBuf;
-
-let args = GlobalArgs::default();
-let paths = vec![PathBuf::from(".")];
-
-let languages = scan(&paths, &args)?;
-// Returns tokei::Languages with code statistics
-```
-
-## Configuration Mapping
-
-Maps `GlobalArgs` fields to tokei configuration:
-
-| Arg | Effect |
-|-----|--------|
-| `hidden` | Include hidden files/directories |
-| `no_ignore` | Skip all ignore files |
-| `no_ignore_dot` | Skip .ignore files |
-| `no_ignore_parent` | Skip parent ignore files |
-| `no_ignore_vcs` | Skip .gitignore |
-| `treat_doc_strings_as_comments` | Count doc strings as comments |
-| `config` | Config file loading strategy |
-
-## Error Handling
-
-- Returns error for non-existent paths (as of v1.3.0)
-- Propagates tokei configuration errors
-- Empty `Languages` for valid but empty directories
-
-## Dependencies
-
-- `tokei` - Core line counting
-- `tokmd-config` - GlobalArgs definition
-- `tokmd-types` - ConfigMode enum
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Troubleshooting](../../docs/troubleshooting.md)
+- Reference: [src/lib.rs](src/lib.rs)
+- Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-sensor/README.md
+++ b/crates/tokmd-sensor/README.md
@@ -1,5 +1,21 @@
 # tokmd-sensor
 
-Sensor integration layer for tokmd. Provides substrate building and sensor orchestration for multi-sensor cockpit systems.
+Sensor contract and substrate builder for tokmd.
 
-See the [root README](../../README.md) for full documentation.
+## Problem
+Sensors should share one scan-and-diff substrate instead of each re-running the expensive parts.
+
+## What it gives you
+- The `EffortlessSensor` trait.
+- `substrate_builder::build_substrate(...) -> Result<RepoSubstrate>`.
+
+## API / usage notes
+- Implement `EffortlessSensor` for a sensor that consumes `RepoSubstrate` and returns `SensorReport`.
+- `build_substrate` runs the scan once, normalizes diff membership, and builds the shared substrate.
+- Keep sensor implementations in their own crates; this crate is the contract layer.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [tokmd-envelope](../tokmd-envelope/README.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-settings/README.md
+++ b/crates/tokmd-settings/README.md
@@ -1,65 +1,24 @@
 # tokmd-settings
 
-**Tier 0 (Pure Settings)** -- Clap-free configuration types for tokmd.
+Clap-free settings and TOML config for tokmd workflows.
 
-Provides scan and workflow settings plus TOML config parsing types so lower-tier
-crates can consume configuration without pulling in `clap`. This is the boundary
-between the CLI layer and the library internals.
+## Problem
+Lower-tier crates need one config shape without depending on Clap or the CLI layer.
 
-## Public API
+## What it gives you
+- Scan inputs: `ScanOptions`, `ScanSettings`
+- Workflow settings: `LangSettings`, `ModuleSettings`, `ExportSettings`, `AnalyzeSettings`, `CockpitSettings`, `DiffSettings`
+- TOML config types: `TomlConfig`, `ScanConfig`, `ModuleConfig`, `ExportConfig`, `AnalyzeConfig`, `ContextConfig`, `BadgeConfig`, `GateConfig`, `ViewProfile`
+- Convenience re-exports: `ChildIncludeMode`, `ChildrenMode`, `ConfigMode`, `ExportFormat`, `RedactMode`
 
-### Workflow Settings
+## API / usage notes
+- `ScanOptions` mirrors the scan-relevant CLI flags without the Clap dependency.
+- `ScanSettings::current_dir()` and `ScanSettings::for_paths(...)` cover the common library entry points.
+- `TomlConfig::from_file(...)` is the only I/O convenience; the rest of the crate is pure data and serde.
+- `src/lib.rs` is the canonical source for defaults, flattening, and TOML shapes.
 
-| Type              | Purpose                                          |
-| :---------------- | :----------------------------------------------- |
-| `ScanOptions`     | Excludes, ignore flags, hidden-file toggle       |
-| `ScanSettings`    | Paths + `ScanOptions` (flattened for serde)      |
-| `LangSettings`    | Top-N, files flag, children mode, redact mode    |
-| `ModuleSettings`  | Module roots, depth, children mode, redact mode  |
-| `ExportSettings`  | Format, min-code, max-rows, redact, meta, strip  |
-| `AnalyzeSettings` | Preset, window, git, max-files/bytes/commits     |
-| `DiffSettings`    | From/to references                               |
-
-### TOML Config Types
-
-| Type              | Purpose                                          |
-| :---------------- | :----------------------------------------------- |
-| `TomlConfig`      | Root `tokmd.toml` structure                      |
-| `ScanConfig`      | `[scan]` section                                 |
-| `ModuleConfig`    | `[module]` section                               |
-| `ExportConfig`    | `[export]` section                               |
-| `AnalyzeConfig`   | `[analyze]` section                              |
-| `ContextConfig`   | `[context]` section                              |
-| `BadgeConfig`     | `[badge]` section                                |
-| `GateConfig`      | `[gate]` section (rules, ratchet, baseline)      |
-| `ViewProfile`     | `[view.<name>]` named profiles                   |
-
-### Re-exports
-
-Types re-exported from `tokmd-types` for convenience:
-
-- `ChildIncludeMode`
-- `ChildrenMode`
-- `ConfigMode`
-- `ExportFormat`
-- `RedactMode`
-
-## Usage
-
-```rust
-use tokmd_settings::{ScanSettings, LangSettings};
-
-// Library consumer: scan the current directory with defaults
-let scan = ScanSettings::current_dir();
-let lang = LangSettings::default();
-```
-
-## Design Rules
-
-- **No `clap` dependency** -- lower-tier crates (scan, format, model) depend on
-  this instead of `tokmd-config`.
-- **Pure data + serde** -- all types derive `Serialize` and `Deserialize`.
-- **No I/O** -- `TomlConfig::from_file` is the only I/O convenience; everything
-  else is pure data.
-
-See the [root README](../../README.md) for full documentation.
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Configuration file reference](../../docs/reference-cli.md#configuration-file)
+- Reference: [src/lib.rs](src/lib.rs)
+- Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-substrate/README.md
+++ b/crates/tokmd-substrate/README.md
@@ -1,5 +1,21 @@
 # tokmd-substrate
 
-Data substrate types for sensor computation. Provides file-level metrics, diff ranges, and language summaries used as input to sensor report generation.
+Shared repo-substrate types for sensor computation.
 
-See the [root README](../../README.md) for full documentation.
+## Problem
+Sensors should work from one shared snapshot instead of re-running scan and diff logic.
+
+## What it gives you
+- `RepoSubstrate`, `SubstrateFile`, and `LangSummary`
+- `DiffRange` for carrying changed-file context into sensors
+
+## API / usage notes
+- `tokmd-sensor::substrate_builder::build_substrate` produces this data.
+- Files carry normalized paths, language, module, metrics, and diff membership.
+- `src/lib.rs` is the authoritative field reference.
+
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [tokmd-sensor](../tokmd-sensor/README.md)
+- Reference: [Architecture](../../docs/architecture.md)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-tokeignore/README.md
+++ b/crates/tokmd-tokeignore/README.md
@@ -1,62 +1,22 @@
 # tokmd-tokeignore
 
-Template generation for `.tokeignore` files.
+`.tokeignore` template generation for tokmd.
 
-## Overview
+## Problem
+Scans stay noisy when build outputs and vendored blobs are not excluded in a predictable way.
 
-This is a **Tier 1** utility crate for generating `.tokeignore` templates. It provides language-specific and monorepo-aware patterns for excluding build artifacts and vendored code from tokmd scans.
+## What it gives you
+- Template generation for `Default`, `Rust`, `Node`, `Mono`, `Python`, `Go`, and `Cpp` profiles
+- `init_tokeignore(&InitArgs) -> Result<Option<PathBuf>>`
+- Print, overwrite, and directory-validation behavior for creating a `.tokeignore`
 
-## Installation
+## API / usage notes
+- Use `--print` to preview a template and `--force` to overwrite an existing file.
+- The templates are profile-based and tuned for common build artifacts and vendored code.
+- `src/lib.rs` contains the exact template text and profile mapping.
 
-```toml
-[dependencies]
-tokmd-tokeignore = "1.3"
-```
-
-## Usage
-
-```rust
-use tokmd_tokeignore::init_tokeignore;
-use tokmd_config::{InitArgs, InitProfile};
-use std::path::PathBuf;
-
-let args = InitArgs {
-    dir: PathBuf::from("."),
-    template: InitProfile::Rust,
-    force: false,
-    print: false,
-    non_interactive: true,
-};
-
-init_tokeignore(&args)?;
-```
-
-## Available Profiles
-
-| Profile | Patterns |
-|---------|----------|
-| `Default` | All common build artifacts |
-| `Rust` | `target/`, `*.rs.bk`, coverage |
-| `Node` | `node_modules/`, `dist/`, `build/` |
-| `Mono` | Conservative monorepo defaults |
-| `Python` | `__pycache__/`, `.venv/`, `.tox/` |
-| `Go` | `vendor/`, `bin/` |
-| `Cpp` | `build/`, `cmake-build-*/` |
-
-## CLI Options
-
-- `--template <PROFILE>` - Select template profile
-- `--print` - Print template to stdout
-- `--force` - Overwrite existing file
-- `--dir <PATH>` - Target directory
-
-## Behavior
-
-1. Validates target directory exists
-2. Checks for existing `.tokeignore` (fails without `--force`)
-3. Generates template based on profile
-4. Writes to file or stdout
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [CLI Reference](../../docs/reference-cli.md)
+- Reference: [src/lib.rs](src/lib.rs)
+- Explanation: [Troubleshooting](../../docs/troubleshooting.md)

--- a/crates/tokmd-tool-schema/README.md
+++ b/crates/tokmd-tool-schema/README.md
@@ -1,14 +1,33 @@
 # tokmd-tool-schema
 
-Single-responsibility microcrate for generating AI tool schemas from a clap command tree.
+Generate AI tool schemas from clap command trees.
 
-## What it does
+## Problem
 
-- Builds a deterministic command/argument schema model from `clap::Command`.
-- Renders the model as OpenAI, Anthropic, JSON Schema, or raw clap JSON.
-- Provides a shared `ToolSchemaFormat` enum for CLI argument wiring.
+AI agents need stable tool definitions from the same CLI tree humans use.
 
-## API
+## What it gives you
 
-- `build_tool_schema(cmd: &clap::Command) -> ToolSchemaOutput`
-- `render_output(schema: &ToolSchemaOutput, format: ToolSchemaFormat, pretty: bool) -> anyhow::Result<String>`
+- `build_tool_schema(&Command) -> ToolSchemaOutput`
+- `render_output(..., ToolSchemaFormat, pretty) -> Result<String>`
+- `ToolSchemaFormat::{Openai, Anthropic, Jsonschema, Clap}`
+
+## Quick use / integration notes
+
+`build_tool_schema` walks the root command and subcommands, skips generated `help` and `version` args, and captures defaults plus enum values.
+
+`render_output` can serialize the same schema as `openai`, `anthropic`, `jsonschema`, or raw `clap`.
+
+## Go deeper
+
+### How-to
+
+- `../../docs/reference-cli.md`
+
+### Reference
+
+- `src/lib.rs`
+
+### Explanation
+
+- `../../docs/explanation.md`

--- a/crates/tokmd-types/README.md
+++ b/crates/tokmd-types/README.md
@@ -1,57 +1,23 @@
 # tokmd-types
 
-Core data structures and contracts for tokmd.
+Core receipt and schema contracts for tokmd.
 
-## Overview
+## Problem
+Receipts, rows, and enums need one stable serde contract without pulling in CLI or scan logic.
 
-This is a **Tier 0** crate containing pure data types with no business logic dependencies. It defines the receipt schemas, row types, and enums used throughout the tokmd ecosystem.
+## What it gives you
+- Core rows and totals: `Totals`, `LangRow`, `ModuleRow`, `FileRow`
+- Receipt wrappers: `LangReceipt`, `ModuleReceipt`, `ExportReceipt`, `ContextReceipt`, `DiffReceipt`, `RunReceipt`
+- Shared enums and helpers: `TableFormat`, `ExportFormat`, `ConfigMode`, `ChildrenMode`, `ChildIncludeMode`, `RedactMode`, `AnalysisFormat`, `FileKind`, `ScanStatus`
+- Contract markers: `SCHEMA_VERSION`, `HANDOFF_SCHEMA_VERSION`, `CONTEXT_SCHEMA_VERSION`, `CONTEXT_BUNDLE_SCHEMA_VERSION`
 
-## Installation
+## API / usage notes
+- Use this crate for serde-compatible receipt payloads and report rows.
+- Enable the `clap` feature only if you need derive support for the exported enums.
+- `src/lib.rs` is the source of truth for field names, schema versions, and wrapper shapes.
 
-```toml
-[dependencies]
-tokmd-types = "1.3"
-```
-
-## Key Types
-
-### Receipt Types
-- `LangReceipt` - Language summary with envelope metadata
-- `ModuleReceipt` - Module summary with envelope metadata
-- `ExportReceipt` - File-level export with envelope metadata
-- `ContextReceipt` - LLM context packing result
-- `DiffReceipt` - Comparison between two receipts
-
-### Data Types
-- `LangRow` / `LangReport` - Language-level statistics
-- `ModuleRow` / `ModuleReport` - Module/directory breakdowns
-- `FileRow` / `ExportData` - File-level inventory
-- `Totals` - Aggregate statistics (files, lines, code, bytes, tokens)
-
-### Enums
-- `TableFormat` - Output format (Md, Tsv, Json)
-- `ExportFormat` - Export format (Csv, Jsonl, Json, Cyclonedx)
-- `RedactMode` - Redaction level (None, Paths, All)
-- `ChildrenMode` - Embedded language handling (Collapse, Separate)
-- `ConfigMode` - Config file strategy (Auto, None)
-
-## Schema Versioning
-
-```rust
-pub const SCHEMA_VERSION: u32 = 2;
-```
-
-All JSON receipts include a `schema_version` field. Breaking changes increment this version.
-
-## Stability Policy
-
-- **JSON consumers**: Stable. New fields have sensible defaults.
-- **Rust library consumers**: Semi-stable. Use `..Default::default()` patterns for forward compatibility.
-
-## Features
-
-- `clap` - Enable clap derive macros for enums (optional)
-
-## License
-
-MIT OR Apache-2.0
+## Go deeper
+- Tutorial: [tokmd README](../../README.md)
+- How-to: [Recipes](../../docs/recipes.md)
+- Reference: [SCHEMA](../../docs/SCHEMA.md) and [schema.json](../../docs/schema.json)
+- Explanation: [Design](../../docs/design.md)

--- a/crates/tokmd-walk/README.md
+++ b/crates/tokmd-walk/README.md
@@ -1,71 +1,33 @@
 # tokmd-walk
 
-File listing and asset discovery utilities for tokmd.
+Deterministic filesystem traversal and asset discovery for tokmd.
 
-## Overview
+## Problem
 
-This is a **Tier 2** utility crate for filesystem traversal with gitignore support. It provides efficient file listing and license candidate detection.
+Use this crate when you need repo file listing, license candidate detection, or
+file sizes without reimplementing gitignore-aware walking.
 
-## Installation
+## What it gives you
+
+- `list_files` and `list_files_from_memfs`
+- `license_candidates`
+- `file_size` and `file_size_from_memfs`
+- deterministic alphabetical ordering
+- `git ls-files` first, `ignore` fallback second
+
+## Quick use / integration notes
 
 ```toml
 [dependencies]
-tokmd-walk = "1.3"
+tokmd-walk = { workspace = true }
 ```
 
-## Usage
+Use it for repo-local file discovery in analysis code, tests, or WASM-backed
+virtual filesystems.
 
-```rust
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-use tokmd_walk::{list_files, license_candidates, file_size};
-use std::path::Path;
+## Go deeper
 
-// List all files respecting gitignore
-let files = list_files(Path::new("."), Some(1000))?;
-
-// Find license-related files
-let candidates = license_candidates(&files);
-println!("License files: {:?}", candidates.license_files);
-println!("Metadata files: {:?}", candidates.metadata_files);
-
-// Get file size
-let size = file_size(Path::new("."), Path::new("src/lib.rs"))?;
-# Ok(())
-# }
-```
-
-## Key Functions
-
-### File Listing
-```rust,ignore
-pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
-```
-Lists files respecting gitignore. Tries `git ls-files` first, falls back to the `ignore` crate.
-
-### License Detection
-```rust,ignore
-pub fn license_candidates(files: &[PathBuf]) -> LicenseCandidates
-```
-Identifies common license files:
-- License files: `LICENSE*`, `COPYING*`, `NOTICE*`
-- Metadata: `Cargo.toml`, `package.json`, `pyproject.toml`
-
-### File Size
-```rust,ignore
-pub fn file_size(root: &Path, relative: &Path) -> Result<u64>
-```
-
-## Behavior
-
-1. Try `git ls-files` for accurate repo file listing
-2. Fall back to `ignore` crate with gitignore support
-3. Sort files alphabetically for deterministic output
-
-## Dependencies
-
-- `ignore` - Gitignore-aware file walking
-- `anyhow` - Error handling
-
-## License
-
-MIT OR Apache-2.0
+Tutorial: [Root README](../../README.md)
+How-to: [Recipes](../../docs/recipes.md)
+Reference: [Source](src/lib.rs)
+Explanation: [Architecture](../../docs/architecture.md)

--- a/crates/tokmd-wasm/README.md
+++ b/crates/tokmd-wasm/README.md
@@ -1,43 +1,18 @@
 # tokmd-wasm
 
-`tokmd-wasm` is the browser-friendly product surface for `tokmd`.
+Browser and worker bindings for tokmd in-memory workflows.
 
-It exposes thin `wasm-bindgen` bindings over `tokmd-core`'s JSON API so browser
-and worker callers can run `lang`, `module`, `export`, and `analyze` against
-ordered in-memory inputs without going through the CLI.
+## Problem
 
-The current browser acquisition story lives one layer up in `web/runner`, which
-materializes public GitHub repos through the tree and contents APIs before
-dispatching those ordered in-memory inputs into `tokmd-wasm`.
+Run tokmd in the browser without depending on a filesystem-backed scan path.
 
-Analyze entrypoints are intentionally narrower today: only
-`preset: "receipt"` and `preset: "estimate"` are browser-safe in the wasm
-wrapper. Richer analyze presets still depend on the filesystem-backed scan
-path and return an error from `tokmd-wasm` until the remaining in-memory
-analysis seams land. This applies consistently to `runJson("analyze", ...)`,
-`run("analyze", ...)`, and `runAnalyze()`. These rootless analyze modes can
-still report partial results with warnings when host-backed file or git
-enrichers are unavailable in browser mode. Omitting `preset` defaults to
-`receipt`, matching `tokmd-core`.
+## What it gives you
 
-## Exports
+- `version`, `schemaVersion`, and `analysisSchemaVersion`
+- `runJson`, `run`, `runLang`, `runModule`, `runExport`, and `runAnalyze`
+- a thin `wasm-bindgen` wrapper over `tokmd-core`
 
-- `version()`
-- `schemaVersion()` for core receipts (`lang`, `module`, `export`)
-- `analysisSchemaVersion()` when the `analysis` feature is enabled
-- `runJson(mode, argsJson)`
-- `run(mode, args)`
-- `runLang(args)`
-- `runModule(args)`
-- `runExport(args)`
-- `runAnalyze(args)` when the `analysis` feature is enabled
-  Analyze currently supports only `receipt` and `estimate` across `runJson`,
-  `run`, and `runAnalyze`. If omitted, `preset` defaults to `receipt`.
-
-## Input shape
-
-The wrapper reuses the `tokmd-core::ffi::run_json` contract. In-memory inputs
-use the same JSON shape that the Node and Python bindings already accept:
+## Quick use / integration notes
 
 ```json
 {
@@ -48,22 +23,28 @@ use the same JSON shape that the Node and Python bindings already accept:
 }
 ```
 
-`runJson()` returns the raw response envelope as a JSON string. `run()` and the
-fixed-mode helpers unwrap that envelope and return the `data` payload as a
-plain JavaScript object, throwing on upstream errors.
+Inputs are ordered `{ path, text | base64 }` rows.
 
-## Distribution artifact
+`lang`, `module`, `export`, and `analyze` are the supported browser workflows today. `analyze` currently accepts only `preset: "receipt"` or `preset: "estimate"`, and `analysisSchemaVersion()` is only exported when the `analysis` feature is enabled.
 
-`tokmd-wasm` is intended to be consumed from a stable, versioned artifact in
-CI and releases, not from a mutable local directory.
+## Distribution
 
-The current release path is:
+The browser runner consumes a release tarball named `tokmd-wasm-<tag>.tar.gz` and extracts it into `web/runner/vendor/tokmd-wasm/`.
 
-- GitHub release asset: `tokmd-wasm-<tag>.tar.gz` (for example `tokmd-wasm-v1.9.0.tar.gz`)
-- Extract contents into `web/runner/vendor/tokmd-wasm/`
+## Go deeper
 
-The runner expects the `web/runner/vendor/tokmd-wasm` layout with `tokmd_wasm.js`
-and `tokmd_wasm_bg.wasm` present (plus wasm-pack generated companion files).
+### Tutorial
 
-Use `schemaVersion()` only for core receipt families. Browser callers that
-consume `runAnalyze()` should read `analysisSchemaVersion()` instead.
+- `../../web/runner/README.md`
+
+### How-to
+
+- `../../web/runner/README.md`
+
+### Reference
+
+- `src/lib.rs`
+
+### Explanation
+
+- `../../docs/architecture.md`

--- a/crates/tokmd/README.md
+++ b/crates/tokmd/README.md
@@ -1,96 +1,63 @@
 # tokmd
 
-CLI binary for `tokmd`: deterministic code receipts, derived analysis, and review artifacts for humans, CI, and LLM workflows.
+CLI product surface for deterministic repo receipts and analysis.
 
-## Overview
+## Problem
 
-This is the **Tier 5** entry point that wires together the lower-tier crates into the end-user CLI. It turns a source tree into stable receipts you can summarize, diff, analyze, gate, and pack into bounded LLM context.
+You need the full `tokmd` workflow from the terminal: summaries, saved receipts, analysis presets, diffs, policy gates, and LLM-oriented packing, without composing lower-tier crates by hand.
 
-## Installation
+## What it gives you
+
+- The `tokmd` CLI binary
+- Commands such as `lang`, `module`, `export`, `run`, `analyze`, `badge`, `diff`, `context`, `handoff`, `cockpit`, `gate`, `baseline`, `sensor`, and `tools`
+- Default feature set for git, walk, content, UI, novelty, topics, and archetype flows
+- The `tok` alias binary when `alias-tok` is enabled
+
+## Quick use / integration notes
+
+Install it:
 
 ```bash
-# From crates.io
 cargo install tokmd --locked
-
-# From source
-cargo install --path crates/tokmd
-
-# With Nix
-nix profile install github:EffortlessMetrics/tokmd
 ```
 
-## Quick Start
+Run the common paths:
 
 ```bash
-# Language summary
 tokmd --format md --top 8
-
-# Pack code into an LLM-ready bundle
-tokmd context --budget 128k --mode bundle --output context.txt
-
-# Save deterministic artifacts for later comparison
 tokmd run --analysis receipt --output-dir .runs/current
-
-# Risk-oriented analysis
 tokmd analyze --preset risk --format md
-
-# Effort estimate between refs
-tokmd analyze --preset estimate --effort-base-ref main --effort-head-ref HEAD --format md
-
-# Generate a badge
-tokmd badge --metric hotspot --preset risk --output hotspot.svg
+tokmd diff main HEAD
+tokmd context --budget 128k --mode bundle --output context.txt
 ```
 
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| `tokmd` / `tokmd lang` | Language summary for a repo or path set |
-| `tokmd module` | Module breakdown by directory roots |
-| `tokmd export` | File-level inventory (`jsonl`, `json`, `csv`, `cyclonedx`) |
-| `tokmd run` | Save receipts to a run directory, optionally with `--analysis <preset>` |
-| `tokmd analyze` | Derived metrics and enrichments, including the `estimate` preset |
-| `tokmd badge` | SVG badge generation |
-| `tokmd diff` | Compare two runs, receipts, or refs |
-| `tokmd cockpit` | PR metrics with evidence gates and review plan output |
-| `tokmd baseline` | Capture a complexity baseline for ratchet comparisons |
-| `tokmd handoff` | Build an LLM handoff bundle |
-| `tokmd sensor` | Emit a `sensor.report.v1` envelope |
-| `tokmd gate` | Evaluate policy and ratchet rules |
-| `tokmd tools` | Generate tool definitions for OpenAI, Anthropic, and JSON Schema consumers |
-| `tokmd context` | Pack files into an LLM context window under a token budget |
-| `tokmd init` | Generate a `.tokeignore` template |
-| `tokmd check-ignore` | Explain why files are ignored |
-| `tokmd completions` | Generate shell completions |
-
-## Feature Flags
+Feature flags:
 
 ```toml
-[features]
-default = ["git", "walk", "content", "ui", "fun", "topics", "archetype"]
-alias-tok = []   # Enable the `tok` binary alias
-git = []         # Git history analysis and PR-oriented commands
-walk = []        # Filesystem traversal helpers
-content = []     # Content scanning (entropy, imports, etc.)
-ui = []          # Interactive prompts and progress UI
-fun = []         # Novelty outputs
-topics = []      # Semantic topic analysis
-archetype = []   # Project archetype detection
+[dependencies]
+tokmd = { workspace = true, features = ["git", "content"] }
 ```
 
-## Notes
+Use `tokmd-core` instead when you need the same workflows embedded in Rust or FFI without the CLI layer.
 
-- `tokmd run` now uses `--analysis <preset>` when you want saved analysis artifacts.
-- `tokmd context` uses `--mode <list|bundle|json>` for output mode and `--output <path>` for file output.
-- `tokmd analyze --preset estimate` is the effort-focused lane introduced in `1.8.0`.
+## Go deeper
 
-## Documentation
+### Tutorial
 
+- [Root README](../../README.md)
 - [Tutorial](../../docs/tutorial.md)
-- [CLI Reference](../../docs/reference-cli.md)
+
+### How-to
+
 - [Recipes](../../docs/recipes.md)
 - [Troubleshooting](../../docs/troubleshooting.md)
 
-## License
+### Reference
 
-MIT OR Apache-2.0
+- [CLI Reference](../../docs/reference-cli.md)
+- [Schema](../../docs/SCHEMA.md)
+
+### Explanation
+
+- [Architecture](../../docs/architecture.md)
+- [Design](../../docs/design.md)

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -1,101 +1,36 @@
 # Browser Runner
 
-`web/runner` is the browser-facing `tokmd` slice for the current `1.9.0` lane.
+Browser-facing tokmd entrypoint for the web and WASM lane.
 
-It now boots `tokmd-wasm` inside a dedicated worker and runs the in-memory
-`lang`, `module`, `export`, and rootless `analyze` (`receipt` / `estimate`)
-paths locally in the browser. Public GitHub repo acquisition now uses the
-browser-safe GitHub tree and contents APIs to materialize ordered in-memory
-inputs before dispatching into the worker. Zipball fetch remains out of the
-current browser contract. Repo-load progress and cancel now exist in the main
-thread loader, but worker run cancel still remains intentionally unavailable.
+## Problem
 
-## Files
+Use this project when you want `tokmd` inside a browser worker, backed by
+`tokmd-wasm`, without widening the browser contract to the full native CLI.
 
-- `index.html`: static browser shell
-- `main.js`: main-thread wiring, sample requests, and log surface
-- `worker.js`: dedicated Worker entrypoint
-- `runtime.js`: request validation plus mode dispatch into the wasm runner
-- `messages.js`: protocol constants and helpers
-- `*.test.mjs`: Node smoke tests for protocol and runtime behavior
-- `package.json`: repeatable local scripts for building the browser wasm bundle
+## What it gives you
 
-## Protocol
+- a static browser shell in `index.html`
+- main-thread wiring in `main.js`
+- a dedicated worker in `worker.js`
+- runtime validation and protocol handling in `runtime.js`
+- public GitHub repo ingestion through browser-safe tree + contents APIs
+- `lang`, `module`, `export`, and `analyze` with `receipt` or `estimate`
+- `cancel` reserved in the protocol but not wired yet
+- live result panes with downloadable JSON artifacts
 
-Worker -> main:
-
-- `ready`
-- `result`
-- `error`
-
-Main -> worker:
-
-- `run`
-- `cancel`
-
-Current behavior:
-
-- `ready` advertises supported modes plus `receipt` / `estimate` analyze presets
-  and reports the loaded `tokmd-wasm` engine version
-- `run` currently requires ordered in-memory `inputs` rows with `{ path, text }`
-- the page can fetch a public GitHub `owner/repo@ref`, filter browser-unsafe
-  files, and materialize `inputs` rows directly into the request editor
-- public repo fetches default to unauthenticated browser GitHub API calls, but
-  the page also accepts an optional token for higher limits or private access
-- repo ingestion surfaces memory-cache hits, partial-load reasons, tree
-  truncation, and primary/secondary rate-limit failures explicitly
-- analyze presets beyond `receipt` / `estimate` are intentionally rejected in
-  browser mode instead of degrading silently
-- `run` validates the request shape and executes the corresponding `tokmd-wasm`
-  entrypoint
-- repo-load cancel uses `AbortController`; worker `cancel` is still reserved in
-  the protocol and returns `cancel_unavailable`
-- the page renders the capability block explicitly instead of leaving it as raw
-  worker noise
-- the latest successful result is shown in a dedicated artifact pane and can be
-  downloaded as JSON from the browser
-
-## Build The Browser Bundle
+## Quick use / integration notes
 
 ```bash
 npm --prefix web/runner run build:wasm
-```
-
-## Distribution artifact
-
-For repeatable deployments, consume a versioned release artifact from GitHub
-and extract it into:
-
-```text
-web/runner/vendor/tokmd-wasm/
-```
-
-The release asset is named:
-
-```text
-tokmd-wasm-<tag>.tar.gz
-```
-
-(`v1.9.0` becomes `tokmd-wasm-v1.9.0.tar.gz`).
-Extracting this archive into `vendor/tokmd-wasm` gives the exact layout expected by
-`web/runner/worker.js` without rebuilding from source.
-
-## Local Smoke Test
-
-```bash
 npm --prefix web/runner test
 ```
 
-## Local Preview
+The browser bundle loads `web/runner/vendor/tokmd-wasm` and expects the wasm
+package layout produced by the build script.
 
-Build the browser bundle, then serve the repo root with any static file server
-and open `/web/runner/`.
+## Go deeper
 
-Examples:
-
-```bash
-npm --prefix web/runner run build:wasm
-python -m http.server 8080
-# or
-npx serve .
-```
+Tutorial: [Root README](../../README.md)
+How-to: [package.json](package.json)
+Reference: [worker.js](worker.js) and [runtime.js](runtime.js)
+Explanation: [main.js](main.js)


### PR DESCRIPTION
## Summary
- rewrite the root README around the user problem, fast-start flows, and Diataxis-style deeper links
- rework every crate README plus the browser runner and sensor contract docs to the same concise problem-first shape
- remove stale version-specific wording and normalize quick-use snippets across the docs surface

## Verification
- git diff --check
- cargo test -p xtask readme_ -- --nocapture
- cargo test -p xtask docs_ -- --nocapture
- cargo xtask docs --check