### PR TITLE
docs: clarify versioned tokmd-wasm release artifact path

### DIFF
--- a/crates/tokmd-wasm/README.md
+++ b/crates/tokmd-wasm/README.md
@@ -29,7 +29,16 @@ Inputs are ordered `{ path, text | base64 }` rows.
 
 ## Distribution
 
-The browser runner consumes a release tarball named `tokmd-wasm-<tag>.tar.gz` and extracts it into `web/runner/vendor/tokmd-wasm/`.
+`tokmd-wasm` is intended to be consumed from a stable, versioned artifact in CI and releases, not from a mutable local directory.
+
+The current release path is:
+
+- GitHub release asset: `tokmd-wasm-<tag>.tar.gz` such as `tokmd-wasm-v1.9.0.tar.gz`
+- Extract contents into `web/runner/vendor/tokmd-wasm/`
+
+The runner expects the `web/runner/vendor/tokmd-wasm` layout with `tokmd_wasm.js` and `tokmd_wasm_bg.wasm` present, plus the `wasm-pack` companion files.
+
+Use `schemaVersion()` only for core receipt families. Browser callers that consume `runAnalyze()` should read `analysisSchemaVersion()` instead.
 
 ## Go deeper
 

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -28,6 +28,22 @@ npm --prefix web/runner test
 The browser bundle loads `web/runner/vendor/tokmd-wasm` and expects the wasm
 package layout produced by the build script.
 
+## Distribution artifact
+
+For repeatable deployments, consume a versioned release artifact from GitHub and extract it into:
+
+```text
+web/runner/vendor/tokmd-wasm/
+```
+
+The release asset is named:
+
+```text
+tokmd-wasm-<tag>.tar.gz
+```
+
+`v1.9.0` becomes `tokmd-wasm-v1.9.0.tar.gz`. Extracting this archive into `vendor/tokmd-wasm` gives the exact layout expected by `web/runner/worker.js` without rebuilding from source.
+
 ## Go deeper
 
 Tutorial: [Root README](../../README.md)


### PR DESCRIPTION
## Summary
- document the versioned 	okmd-wasm-<tag>.tar.gz release artifact in the crate and browser runner READMEs
- explain the expected web/runner/vendor/tokmd-wasm/ extraction layout
- point browser consumers at nalysisSchemaVersion() for analyze workflows

## Validation
- cargo test -p xtask readme_ -- --nocapture
- cargo xtask docs --check
- git diff --check origin/main..HEAD