### PR TITLE
ci: split full Nix validation out of required CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  schedule:
-    - cron: "23 4 * * *"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -246,37 +244,6 @@ jobs:
 
       - name: Build package
         run: nix build -L .#tokmd
-
-  nix-full:
-    name: Nix Full Validation
-    if: github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    permissions:
-      contents: read
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v21
-
-      - name: Setup Nix cache
-        continue-on-error: true
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-        with:
-          use-flakehub: false
-          use-gha-cache: enabled
-
-      - name: Check flake (full)
-        run: nix flake check --accept-flake-config
-
-      - name: Build default package
-        run: nix build -L .#tokmd
-
-      - name: Build alias package
-        run: nix build -L .#tokmd-with-alias
 
   mutation:
     name: Mutation Testing (Required)

--- a/.github/workflows/nix-full.yml
+++ b/.github/workflows/nix-full.yml
@@ -1,0 +1,47 @@
+name: Nix Full Validation
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [ "main" ]
+  schedule:
+    - cron: "23 4 * * *"
+
+concurrency:
+  group: nix-full-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  nix-full:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+
+      - name: Setup Nix cache
+        continue-on-error: true
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+          use-gha-cache: enabled
+
+      - name: Check flake (full)
+        run: nix flake check --accept-flake-config
+
+      - name: Build default package
+        run: nix build -L .#tokmd
+
+      - name: Build alias package
+        run: nix build -L .#tokmd-with-alias


### PR DESCRIPTION
## Summary
- remove the long-running 
ix-full lane from the main CI workflow so CI can conclude when the required jobs finish
- add a separate Nix Full Validation workflow that runs after successful CI on main, and on the nightly schedule
- keep the required 
ix-pr gate in CI unchanged for pull requests and main

## Why
The current main run stays in_progress even after CI (Required) passes because the non-required full Nix lane is embedded in the same workflow. This PR moves that work onto its own workflow so CI goes green promptly while full Nix validation still runs off the critical path.

## Validation
- git diff --check
- inspected the live main run and confirmed the only remaining in-progress job is Nix Full Validation

## Notes
- No local Nix execution was possible in this Windows environment because 
ix is not installed here.
- The agent launcher is not exposed in this session, so I used dedicated worktrees and parallel inspection instead of delegated subagents.