### PR TITLE
ci: separate nix full concurrency by trigger

### DIFF
--- a/.github/workflows/nix-full.yml
+++ b/.github/workflows/nix-full.yml
@@ -10,7 +10,9 @@ on:
     - cron: "23 4 * * *"
 
 concurrency:
-  group: nix-full-${{ github.event.workflow_run.head_sha || github.sha }}
+  # Keep workflow_run validation and nightly schedule runs from canceling each
+  # other when they target the same main-branch commit.
+  group: nix-full-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- stop workflow_run and nightly schedule Nix validation runs from sharing the same concurrency bucket
- keep cancellation within each trigger class, but prevent a scheduled run on the same main SHA from canceling post-merge validation

## Validation
- git diff --check