### PR TITLE
ci: finish cache-first nix rollout

### DIFF
--- a/.github/workflows/nix-full.yml
+++ b/.github/workflows/nix-full.yml
@@ -2,6 +2,9 @@ name: Nix Full Validation
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "v*"
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -25,6 +28,8 @@ jobs:
       id-token: write
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      # Set the repository variable `NIX_USE_FLAKEHUB_CACHE=true` once the
+      # trusted FlakeHub Cache path is provisioned for this repo.
       USE_FLAKEHUB_CACHE: ${{ vars.NIX_USE_FLAKEHUB_CACHE }}
     steps:
       - uses: actions/checkout@v6
@@ -43,7 +48,7 @@ jobs:
         id: flakehub-cache
         if: env.USE_FLAKEHUB_CACHE == 'true'
         continue-on-error: true
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
 
       - name: Setup Nix cache
         if: env.USE_FLAKEHUB_CACHE != 'true' || steps.flakehub-cache.outcome != 'success'

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -20,6 +20,8 @@ jobs:
       contents: read
       id-token: write
     env:
+      # Set the repository variable `NIX_USE_FLAKEHUB_CACHE=true` once the
+      # trusted FlakeHub Cache path is provisioned for this repo.
       USE_FLAKEHUB_CACHE: ${{ vars.NIX_USE_FLAKEHUB_CACHE }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
@@ -37,7 +39,7 @@ jobs:
         id: flakehub-cache
         if: env.USE_FLAKEHUB_CACHE == 'true'
         continue-on-error: true
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
 
       - name: Setup Nix cache
         if: env.USE_FLAKEHUB_CACHE != 'true' || steps.flakehub-cache.outcome != 'success'


### PR DESCRIPTION
## Summary
- pin the trusted-lane FlakeHub cache action to `@v3` in the standalone Nix workflows
- let `nix-full` run on version tags as well as green `main` and manual triggers

## Context
`#826` already landed the base cache-first rollout: trusted-lane FlakeHub gating in the standalone Nix workflows plus the package dummy-source cleanup. This PR keeps the required PR Nix gate unchanged and finishes the remaining trusted-lane workflow cleanup.

## Validation
- `cargo test -p tokmd --test docs_sync_w72 -- --nocapture`
- `cargo test -p xtask docs_ -- --nocapture`
- `cargo fmt-check`
- `git diff --check`

## Notes
- `nix` and `actionlint` are not installed in this Windows environment, so workflow execution still needs CI to exercise the Nix paths directly.