### PR TITLE
fix: preserve vendored home patch in nix dummy source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,16 +90,21 @@
           || (baseName == ".gitignore");
       };
 
-      # Package dependency builds only need Cargo metadata plus the small
-      # non-Cargo inputs that affect vendored path overrides.
-      mkPackageDummySrc = craneLib: src: craneLib.mkDummySrc {
-        inherit src;
-        extraDummyScript = ''
+      # Package dependency builds only need workspace dummy crates plus the
+      # real vendored `home` patch source used by Cargo's path override.
+      mkPackageDummySrc = pkgs: craneLib: src:
+        let
+          dummyBase = craneLib.mkDummySrc { inherit src; };
+        in
+        pkgs.runCommand "tokmd-package-dummy-src" { } ''
+          mkdir -p "$out"
+          cp -R ${dummyBase}/. "$out"
+          chmod -R u+w "$out"
           mkdir -p "$out/.cargo" "$out/vendor"
           install -Dm644 ${./.cargo/config.toml} "$out/.cargo/config.toml"
+          rm -rf "$out/vendor/home-0.5.12"
           cp -R ${./vendor/home-0.5.12} "$out/vendor/home-0.5.12"
         '';
-      };
     in
     {
       packages = forAllSystems (system:
@@ -107,7 +112,7 @@
           pkgs = mkPkgs system;
           craneLib = mkCraneLib system;
           src = mkBuildSrc craneLib;
-          dummySrc = mkPackageDummySrc craneLib src;
+          dummySrc = mkPackageDummySrc pkgs craneLib src;
 
           commonArgs = {
             pname = "tokmd";


### PR DESCRIPTION
## Summary
- build the package dummy source from `mkDummySrc`, then overlay the real vendored `home` patch source on top so Cargo path overrides still see the full crate API during `buildDepsOnly`

## Context
`#829` fixed the `Check flake` half of the Nix regression by restoring the broad `checks.*` lane to the real filtered check source. `main` is still failing the required `Nix PR Package Gate` during `Build package`, though, because the narrowed package dummy source is still dummyfying the vendored `home` patch under `vendor/home-0.5.12`.

That breaks the patched `home` crate API seen by `etcetera`, which shows up in CI as:

`error[E0425]: cannot find function 'home_dir' in crate 'home'`

This patch keeps the package-level narrowing from `#826`, but overlays the real vendored `home` source back onto the generated dummy tree so Cargo path overrides resolve against the real crate.

## Validation
- `git diff --check`

## Notes
- `nix` is not installed in this Windows environment, so the actual package-build repair still has to be proven by CI.