### PR TITLE
fix: restore real check source for nix flake checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,9 +151,9 @@
           src = mkCheckSrc craneLib pkgs;
           checkArgs = {
             inherit src;
-            # Keep checks aligned with the package build when vendored path
-            # patches are in use.
-            dummySrc = mkPackageDummySrc craneLib src;
+            # Keep the broad check lane on the real filtered source. The
+            # package-only dummy source is only for the release package builds.
+            dummySrc = src;
             strictDeps = true;
           };
           clippyCargoArtifacts = craneLib.buildDepsOnly (checkArgs // {


### PR DESCRIPTION
## Summary
- restore the Nix package builds to use the real filtered source instead of the package dummy source
- keep the trusted-lane workflow cleanup from `#827` separate from the flake recovery

## Context
`main` is currently failing `Nix PR Package Gate` in CI run `23681687665`, and the recovery PR `#829` showed the concrete package-build failure more clearly:

- `etcetera 0.8.0` fails during the `tokmd-deps` package build
- the Cargo patching is already correct
- the vendored `home` crate itself is not broken
- the remaining bad interaction is Crane's package dummy source shape

The safest fix is to restore the package build path to `dummySrc = src`, which is the last known-good behavior before `#826` narrowed the package source tree.

## Validation
- `git diff --check`
- CI required: `Nix PR Package Gate`

## Notes
- `nix` is not installed in this Windows environment, so the flake/package build path still needs GitHub CI to verify the fix.