### PR TITLE
fix: align main with 1.9.0 release truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-03-27
+
+### Added
+
+- Browser/WASM product surface for `tokmd` via the new `tokmd-wasm` crate and `web/runner` browser runner
+- In-browser `lang`, `module`, `export`, and rootless `analyze` support for ordered in-memory inputs
+- Public GitHub repo ingestion in the browser through tree + contents APIs with explicit progress, caching, and partial-load reporting
+
+### Changed
+
+- Browser runner deployments now consume a versioned `tokmd-wasm-<tag>.tar.gz` release artifact unpacked into `web/runner/vendor/tokmd-wasm`
+- Release prep and publish metadata are aligned on `1.9.0` across Cargo and Node package surfaces
+
+### Fixed
+
+- Hardened browser runner boot and wasm export guardrails so unsupported bundles fail explicitly instead of degrading silently
+- Locked the post-`#807` release-prep lane to a single re-anchored proof chain from current `origin/main`
+
 ## [1.8.1] - 2026-03-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-api-surface"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-archetype"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-assets"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-complexity"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-content"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-derived"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-effort"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-entropy"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-explain"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-fingerprint"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-format"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-fun"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-git"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3370,14 +3370,14 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-grid"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "tokmd-analysis-halstead"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-html"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-imports"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-license"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-maintainability"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-near-dup"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-topics"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-util"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "tokmd-analysis-types",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-badge"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-config"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "clap",
  "proptest",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-content"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-context-git"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "tempfile",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-context-policy"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "tokmd-path",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-exclude"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "tokmd-path",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-export-tree"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "tokmd-types",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-ffi-envelope"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "csv",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-fun"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "tempfile",
@@ -3693,14 +3693,14 @@ dependencies = [
 
 [[package]]
 name = "tokmd-math"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "tokmd-model"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3714,14 +3714,14 @@ dependencies = [
 
 [[package]]
 name = "tokmd-module-key"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "tokmd-node"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -3736,14 +3736,14 @@ dependencies = [
 
 [[package]]
 name = "tokmd-path"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "tokmd-progress"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "indicatif",
  "proptest",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-redact"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan-args"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-substrate"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-tokeignore"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-tool-schema"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "clap",
  "insta",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-walk"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -4949,7 +4949,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xtask"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.8.1"
+version = "1.9.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -135,63 +135,63 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.8.1" }
-tokmd-badge = { path = "crates/tokmd-badge", version = "1.8.1" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.8.1" }
-tokmd-analysis-imports = { path = "crates/tokmd-analysis-imports", version = "1.8.1" }
-tokmd-analysis-explain = { path = "crates/tokmd-analysis-explain", version = "1.8.1" }
-tokmd-analysis-html = { path = "crates/tokmd-analysis-html", version = "1.8.1" }
-tokmd-analysis-format = { path = "crates/tokmd-analysis-format", version = "1.8.1" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.8.1" }
-tokmd-analysis-api-surface = { path = "crates/tokmd-analysis-api-surface", version = "1.8.1" }
-tokmd-analysis-complexity = { path = "crates/tokmd-analysis-complexity", version = "1.8.1" }
-tokmd-analysis-entropy = { path = "crates/tokmd-analysis-entropy", version = "1.8.1" }
-tokmd-analysis-license = { path = "crates/tokmd-analysis-license", version = "1.8.1" }
-tokmd-analysis-halstead = { path = "crates/tokmd-analysis-halstead", version = "1.8.1" }
-tokmd-analysis-maintainability = { path = "crates/tokmd-analysis-maintainability", version = "1.8.1" }
-tokmd-analysis-assets = { path = "crates/tokmd-analysis-assets", version = "1.8.1" }
-tokmd-analysis-near-dup = { path = "crates/tokmd-analysis-near-dup", version = "1.8.1" }
-tokmd-analysis-content = { path = "crates/tokmd-analysis-content", version = "1.8.1" }
-tokmd-config = { path = "crates/tokmd-config", version = "1.8.1" }
-tokmd-content = { path = "crates/tokmd-content", version = "1.8.1" }
-tokmd-context-git = { path = "crates/tokmd-context-git", version = "1.8.1" }
-tokmd-context-policy = { path = "crates/tokmd-context-policy", version = "1.8.1" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.8.1" }
-tokmd-export-tree = { path = "crates/tokmd-export-tree", version = "1.8.1" }
-tokmd-ffi-envelope = { path = "crates/tokmd-ffi-envelope", version = "1.8.1" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.8.1" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.8.1" }
-tokmd-fun = { path = "crates/tokmd-fun", version = "1.8.1" }
-tokmd-analysis-derived = { path = "crates/tokmd-analysis-derived", version = "1.8.1" }
-tokmd-analysis-git = { path = "crates/tokmd-analysis-git", version = "1.8.1" }
-tokmd-analysis-util = { path = "crates/tokmd-analysis-util", version = "1.8.1" }
-tokmd-analysis-fun = { path = "crates/tokmd-analysis-fun", version = "1.8.1" }
-tokmd-analysis-grid = { path = "crates/tokmd-analysis-grid", version = "1.8.1" }
-tokmd-analysis-archetype = { path = "crates/tokmd-analysis-archetype", version = "1.8.1" }
-tokmd-analysis-topics = { path = "crates/tokmd-analysis-topics", version = "1.8.1" }
-tokmd-analysis-fingerprint = { path = "crates/tokmd-analysis-fingerprint", version = "1.8.1" }
-tokmd-analysis-effort = { path = "crates/tokmd-analysis-effort", version = "1.8.1" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.8.1" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.8.1" }
-tokmd-module-key = { path = "crates/tokmd-module-key", version = "1.8.1" }
-tokmd-math = { path = "crates/tokmd-math", version = "1.8.1" }
-tokmd-exclude = { path = "crates/tokmd-exclude", version = "1.8.1" }
-tokmd-path = { path = "crates/tokmd-path", version = "1.8.1" }
-tokmd-progress = { path = "crates/tokmd-progress", version = "1.8.1" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.8.1" }
-tokmd-redact = { path = "crates/tokmd-redact", version = "1.8.1" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.8.1" }
-tokmd-scan-args = { path = "crates/tokmd-scan-args", version = "1.8.1" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.8.1" }
-tokmd-substrate = { path = "crates/tokmd-substrate", version = "1.8.1" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.8.1" }
-tokmd-tokeignore = { path = "crates/tokmd-tokeignore", version = "1.8.1" }
-tokmd-tool-schema = { path = "crates/tokmd-tool-schema", version = "1.8.1" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.8.1" }
-tokmd-walk = { path = "crates/tokmd-walk", version = "1.8.1" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.8.1" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.8.1" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.8.1" }
+tokmd = { path = "crates/tokmd", version = "1.9.0" }
+tokmd-badge = { path = "crates/tokmd-badge", version = "1.9.0" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.9.0" }
+tokmd-analysis-imports = { path = "crates/tokmd-analysis-imports", version = "1.9.0" }
+tokmd-analysis-explain = { path = "crates/tokmd-analysis-explain", version = "1.9.0" }
+tokmd-analysis-html = { path = "crates/tokmd-analysis-html", version = "1.9.0" }
+tokmd-analysis-format = { path = "crates/tokmd-analysis-format", version = "1.9.0" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.9.0" }
+tokmd-analysis-api-surface = { path = "crates/tokmd-analysis-api-surface", version = "1.9.0" }
+tokmd-analysis-complexity = { path = "crates/tokmd-analysis-complexity", version = "1.9.0" }
+tokmd-analysis-entropy = { path = "crates/tokmd-analysis-entropy", version = "1.9.0" }
+tokmd-analysis-license = { path = "crates/tokmd-analysis-license", version = "1.9.0" }
+tokmd-analysis-halstead = { path = "crates/tokmd-analysis-halstead", version = "1.9.0" }
+tokmd-analysis-maintainability = { path = "crates/tokmd-analysis-maintainability", version = "1.9.0" }
+tokmd-analysis-assets = { path = "crates/tokmd-analysis-assets", version = "1.9.0" }
+tokmd-analysis-near-dup = { path = "crates/tokmd-analysis-near-dup", version = "1.9.0" }
+tokmd-analysis-content = { path = "crates/tokmd-analysis-content", version = "1.9.0" }
+tokmd-config = { path = "crates/tokmd-config", version = "1.9.0" }
+tokmd-content = { path = "crates/tokmd-content", version = "1.9.0" }
+tokmd-context-git = { path = "crates/tokmd-context-git", version = "1.9.0" }
+tokmd-context-policy = { path = "crates/tokmd-context-policy", version = "1.9.0" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.9.0" }
+tokmd-export-tree = { path = "crates/tokmd-export-tree", version = "1.9.0" }
+tokmd-ffi-envelope = { path = "crates/tokmd-ffi-envelope", version = "1.9.0" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.9.0" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.9.0" }
+tokmd-fun = { path = "crates/tokmd-fun", version = "1.9.0" }
+tokmd-analysis-derived = { path = "crates/tokmd-analysis-derived", version = "1.9.0" }
+tokmd-analysis-git = { path = "crates/tokmd-analysis-git", version = "1.9.0" }
+tokmd-analysis-util = { path = "crates/tokmd-analysis-util", version = "1.9.0" }
+tokmd-analysis-fun = { path = "crates/tokmd-analysis-fun", version = "1.9.0" }
+tokmd-analysis-grid = { path = "crates/tokmd-analysis-grid", version = "1.9.0" }
+tokmd-analysis-archetype = { path = "crates/tokmd-analysis-archetype", version = "1.9.0" }
+tokmd-analysis-topics = { path = "crates/tokmd-analysis-topics", version = "1.9.0" }
+tokmd-analysis-fingerprint = { path = "crates/tokmd-analysis-fingerprint", version = "1.9.0" }
+tokmd-analysis-effort = { path = "crates/tokmd-analysis-effort", version = "1.9.0" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.9.0" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.9.0" }
+tokmd-module-key = { path = "crates/tokmd-module-key", version = "1.9.0" }
+tokmd-math = { path = "crates/tokmd-math", version = "1.9.0" }
+tokmd-exclude = { path = "crates/tokmd-exclude", version = "1.9.0" }
+tokmd-path = { path = "crates/tokmd-path", version = "1.9.0" }
+tokmd-progress = { path = "crates/tokmd-progress", version = "1.9.0" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.9.0" }
+tokmd-redact = { path = "crates/tokmd-redact", version = "1.9.0" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.9.0" }
+tokmd-scan-args = { path = "crates/tokmd-scan-args", version = "1.9.0" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.9.0" }
+tokmd-substrate = { path = "crates/tokmd-substrate", version = "1.9.0" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.9.0" }
+tokmd-tokeignore = { path = "crates/tokmd-tokeignore", version = "1.9.0" }
+tokmd-tool-schema = { path = "crates/tokmd-tool-schema", version = "1.9.0" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.9.0" }
+tokmd-walk = { path = "crates/tokmd-walk", version = "1.9.0" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.9.0" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.9.0" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.9.0" }
 
 # External crates - centralized for consistent versioning
 blake3 = "1.8.3"

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.8.1",
-    "@tokmd/core-darwin-x64": "1.8.1",
-    "@tokmd/core-linux-arm64-gnu": "1.8.1",
-    "@tokmd/core-linux-x64-gnu": "1.8.1",
-    "@tokmd/core-win32-x64-msvc": "1.8.1"
+    "@tokmd/core-darwin-arm64": "1.9.0",
+    "@tokmd/core-darwin-x64": "1.9.0",
+    "@tokmd/core-linux-arm64-gnu": "1.9.0",
+    "@tokmd/core-linux-x64-gnu": "1.9.0",
+    "@tokmd/core-win32-x64-msvc": "1.9.0"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.0.0-alpha.66"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.8.1",
-    "@tokmd/core-darwin-x64": "1.8.1",
-    "@tokmd/core-darwin-arm64": "1.8.1",
-    "@tokmd/core-linux-x64-gnu": "1.8.1",
-    "@tokmd/core-linux-x64-musl": "1.8.1",
-    "@tokmd/core-linux-arm64-gnu": "1.8.1",
-    "@tokmd/core-linux-arm64-musl": "1.8.1",
-    "@tokmd/core-win32-arm64-msvc": "1.8.1"
+    "@tokmd/core-win32-x64-msvc": "1.9.0",
+    "@tokmd/core-darwin-x64": "1.9.0",
+    "@tokmd/core-darwin-arm64": "1.9.0",
+    "@tokmd/core-linux-x64-gnu": "1.9.0",
+    "@tokmd/core-linux-x64-musl": "1.9.0",
+    "@tokmd/core-linux-arm64-gnu": "1.9.0",
+    "@tokmd/core-linux-arm64-musl": "1.9.0",
+    "@tokmd/core-win32-arm64-msvc": "1.9.0"
   }
 }

--- a/xtask/src/tasks/bump.rs
+++ b/xtask/src/tasks/bump.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
+use serde_json::Value as JsonValue;
 
 use crate::cli::BumpArgs;
 
@@ -62,6 +63,11 @@ const SCHEMA_LOCATIONS: &[SchemaVersionLocation] = &[
     },
 ];
 
+const NODE_PACKAGE_MANIFESTS: &[&str] = &[
+    "crates/tokmd-node/package.json",
+    "crates/tokmd-node/npm/package.json",
+];
+
 /// Run the version bump task.
 pub fn run(args: BumpArgs) -> Result<()> {
     // Validate version format
@@ -99,6 +105,12 @@ pub fn run(args: BumpArgs) -> Result<()> {
     // 2. Update [workspace.dependencies] internal crate versions
     let (final_content, dep_changes) = update_workspace_dependencies(&new_content, &args.version)?;
     changes.extend(dep_changes);
+
+    // 3. Update Node package manifest versions and internal @tokmd/* dependency versions.
+    let node_manifest_updates = plan_node_manifest_updates(&workspace_root, &args.version)?;
+    for update in &node_manifest_updates {
+        changes.extend(update.changes.iter().cloned());
+    }
 
     // Print planned changes
     println!("Planned changes:");
@@ -139,6 +151,13 @@ pub fn run(args: BumpArgs) -> Result<()> {
     fs::write(&cargo_toml_path, &final_content).context("Failed to write root Cargo.toml")?;
     println!("\nWrote: {}", cargo_toml_path.display());
 
+    for update in &node_manifest_updates {
+        let manifest_path = workspace_root.join(&update.path);
+        fs::write(&manifest_path, &update.updated_content)
+            .with_context(|| format!("Failed to write {}", update.path))?;
+        println!("Wrote: {}", manifest_path.display());
+    }
+
     // Apply schema version updates if specified
     if let Some(schema_bumps) = &args.schema {
         for bump in schema_bumps {
@@ -152,7 +171,7 @@ pub fn run(args: BumpArgs) -> Result<()> {
     println!("Version bumped: {} -> {}", current_version, args.version);
     println!(
         "Files modified: {}",
-        1 + args.schema.as_ref().map(|s| s.len()).unwrap_or(0)
+        1 + node_manifest_updates.len() + args.schema.as_ref().map(|s| s.len()).unwrap_or(0)
     );
 
     println!("\nNext steps:");
@@ -165,6 +184,13 @@ pub fn run(args: BumpArgs) -> Result<()> {
     println!("  4. Publish: cargo xtask publish --plan");
 
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct NodeManifestUpdate {
+    path: String,
+    updated_content: String,
+    changes: Vec<String>,
 }
 
 /// Find the workspace root by looking for Cargo.toml with [workspace].
@@ -345,6 +371,155 @@ fn replace_version_in_dep_line(line: &str, old_version: &str, new_version: &str)
     line.replace(&pattern, &replacement)
 }
 
+fn plan_node_manifest_updates(
+    workspace_root: &Path,
+    new_version: &str,
+) -> Result<Vec<NodeManifestUpdate>> {
+    let mut updates = Vec::new();
+
+    for path in NODE_PACKAGE_MANIFESTS {
+        let manifest_path = workspace_root.join(path);
+        let content =
+            fs::read_to_string(&manifest_path).with_context(|| format!("Failed to read {path}"))?;
+        let (updated_content, changes) = update_node_manifest_versions(&content, path, new_version)
+            .with_context(|| format!("Failed to update {path}"))?;
+
+        if !changes.is_empty() {
+            updates.push(NodeManifestUpdate {
+                path: path.to_string(),
+                updated_content,
+                changes,
+            });
+        }
+    }
+
+    Ok(updates)
+}
+
+fn update_node_manifest_versions(
+    content: &str,
+    path: &str,
+    new_version: &str,
+) -> Result<(String, Vec<String>)> {
+    let mut result = String::with_capacity(content.len());
+    let mut changes = Vec::new();
+    let mut root_version_updated = false;
+    let mut current_section: Option<&str> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if let Some(section) = current_section {
+            if trimmed.starts_with('}') {
+                current_section = None;
+                result.push_str(line);
+                result.push('\n');
+                continue;
+            }
+
+            if trimmed.starts_with("\"@tokmd/") {
+                let dependency_name = extract_json_key(trimmed)
+                    .with_context(|| format!("Missing dependency name in {path}: {trimmed}"))?;
+                let old_version = extract_json_string_value(trimmed)
+                    .with_context(|| format!("Missing dependency version in {path}: {trimmed}"))?;
+
+                if old_version != new_version {
+                    changes.push(format!(
+                        "{path}: {section}.{dependency_name} = \"{old_version}\" -> \"{new_version}\""
+                    ));
+                    result.push_str(&replace_json_string_value(line, new_version)?);
+                    result.push('\n');
+                    continue;
+                }
+            }
+
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        if !root_version_updated && trimmed.starts_with("\"version\":") {
+            let old_version = extract_json_string_value(trimmed)
+                .with_context(|| format!("Missing top-level version in {path}: {trimmed}"))?;
+
+            if old_version != new_version {
+                changes.push(format!(
+                    "{path}: version = \"{old_version}\" -> \"{new_version}\""
+                ));
+                result.push_str(&replace_json_string_value(line, new_version)?);
+                result.push('\n');
+                root_version_updated = true;
+                continue;
+            }
+
+            root_version_updated = true;
+        }
+
+        if matches!(
+            trimmed,
+            "\"dependencies\": {" | "\"optionalDependencies\": {" | "\"peerDependencies\": {"
+        ) {
+            current_section = Some(extract_json_key(trimmed).with_context(|| {
+                format!("Missing dependency section name in {path}: {trimmed}")
+            })?);
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    if !content.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    if !root_version_updated {
+        bail!("Failed to find top-level version in {path}");
+    }
+
+    let _: JsonValue = serde_json::from_str(&result)
+        .with_context(|| format!("Updated {path} is not valid JSON"))?;
+
+    Ok((result, changes))
+}
+
+fn extract_json_key(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    let remainder = trimmed.strip_prefix('"')?;
+    let key_end = remainder.find('"')?;
+    Some(&remainder[..key_end])
+}
+
+fn extract_json_string_value(line: &str) -> Option<String> {
+    let colon_index = line.find(':')?;
+    let value_part = &line[colon_index + 1..];
+    let quote_start = value_part.find('"')? + 1;
+    let remainder = &value_part[quote_start..];
+    let quote_end = remainder.find('"')?;
+    Some(remainder[..quote_end].to_string())
+}
+
+fn replace_json_string_value(line: &str, new_value: &str) -> Result<String> {
+    let colon_index = line
+        .find(':')
+        .with_context(|| format!("Expected ':' in JSON line: {line}"))?;
+    let value_start = line[colon_index + 1..]
+        .find('"')
+        .with_context(|| format!("Expected opening quote in JSON line: {line}"))?
+        + colon_index
+        + 2;
+    let value_end = line[value_start..]
+        .find('"')
+        .with_context(|| format!("Expected closing quote in JSON line: {line}"))?
+        + value_start;
+
+    Ok(format!(
+        "{}{}{}",
+        &line[..value_start],
+        new_value,
+        &line[value_end..]
+    ))
+}
+
 /// Parse a schema bump argument like "SCHEMA_VERSION=3" or "ANALYSIS_SCHEMA_VERSION=5".
 fn parse_schema_bump(bump: &str) -> Result<(String, u32)> {
     let parts: Vec<&str> = bump.split('=').collect();
@@ -514,5 +689,35 @@ edition = "2021"
     fn test_parse_schema_bump_invalid() {
         assert!(parse_schema_bump("SCHEMA_VERSION").is_err());
         assert!(parse_schema_bump("SCHEMA_VERSION=abc").is_err());
+    }
+
+    #[test]
+    fn updates_node_manifest_versions_in_place() {
+        let content = r#"{
+  "name": "@tokmd/core",
+  "version": "1.8.1",
+  "optionalDependencies": {
+    "@tokmd/core-win32-x64-msvc": "1.8.1",
+    "@tokmd/core-linux-x64-gnu": "1.8.1",
+    "chalk": "^5.0.0"
+  }
+}"#;
+
+        let (updated, changes) =
+            update_node_manifest_versions(content, "crates/tokmd-node/package.json", "1.9.0")
+                .expect("node manifest should update");
+
+        assert!(updated.contains("\"version\": \"1.9.0\""));
+        assert!(updated.contains("\"@tokmd/core-win32-x64-msvc\": \"1.9.0\""));
+        assert!(updated.contains("\"@tokmd/core-linux-x64-gnu\": \"1.9.0\""));
+        assert!(updated.contains("\"chalk\": \"^5.0.0\""));
+        assert_eq!(changes.len(), 3);
+    }
+
+    #[test]
+    fn replace_json_string_value_preserves_json_line_shape() {
+        let line = r#"    "@tokmd/core-linux-x64-gnu": "1.8.1","#;
+        let updated = replace_json_string_value(line, "1.9.0").expect("value should replace");
+        assert_eq!(updated, r#"    "@tokmd/core-linux-x64-gnu": "1.9.0","#);
     }
 }

--- a/xtask/src/tasks/version_consistency.rs
+++ b/xtask/src/tasks/version_consistency.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashSet},
     fs,
-    path::Path,
+    path::{Path, PathBuf},
     process::Command,
 };
 
@@ -18,15 +18,16 @@ const NODE_PACKAGE_MANIFESTS: &[&str] = &[
 ];
 
 pub fn run(_args: VersionConsistencyArgs) -> Result<()> {
-    let workspace_version = load_workspace_version()?;
+    let workspace_root = find_workspace_root()?;
+    let workspace_version = load_workspace_version(&workspace_root)?;
 
     println!("Checking version consistency against workspace version {workspace_version}\n");
 
-    let metadata = load_workspace_metadata()?;
+    let metadata = load_workspace_metadata(&workspace_root)?;
     check_cargo_versions(&metadata, &workspace_version)?;
-    check_workspace_dependency_versions(&workspace_version)?;
-    check_node_manifest_versions(&workspace_version)?;
-    check_case_insensitive_path_collisions()?;
+    check_workspace_dependency_versions(&workspace_root, &workspace_version)?;
+    check_node_manifest_versions(&workspace_root, &workspace_version)?;
+    check_case_insensitive_path_collisions(&workspace_root)?;
 
     println!("Version consistency checks passed.");
     Ok(())
@@ -64,8 +65,8 @@ fn check_cargo_versions(metadata: &Metadata, expected: &str) -> Result<()> {
     Ok(())
 }
 
-fn check_workspace_dependency_versions(expected: &str) -> Result<()> {
-    let manifest = read_toml("Cargo.toml")?;
+fn check_workspace_dependency_versions(workspace_root: &Path, expected: &str) -> Result<()> {
+    let manifest = read_toml(&workspace_root.join("Cargo.toml"))?;
     let workspace = manifest
         .get("workspace")
         .and_then(TomlValue::as_table)
@@ -107,11 +108,12 @@ fn check_workspace_dependency_versions(expected: &str) -> Result<()> {
     Ok(())
 }
 
-fn check_node_manifest_versions(expected: &str) -> Result<()> {
+fn check_node_manifest_versions(workspace_root: &Path, expected: &str) -> Result<()> {
     let mut mismatches = Vec::new();
 
     for path in NODE_PACKAGE_MANIFESTS {
-        let manifest = read_package_manifest(path).with_context(|| format!("Reading {path}"))?;
+        let manifest = read_package_manifest(workspace_root, path)
+            .with_context(|| format!("Reading {path}"))?;
         let actual = manifest_package_version(&manifest, path)?;
         if actual != expected {
             mismatches.push(format!("{path} ({actual})"));
@@ -134,8 +136,8 @@ fn check_node_manifest_versions(expected: &str) -> Result<()> {
     Ok(())
 }
 
-fn check_case_insensitive_path_collisions() -> Result<()> {
-    let tracked_paths = read_tracked_paths()?;
+fn check_case_insensitive_path_collisions(workspace_root: &Path) -> Result<()> {
+    let tracked_paths = read_tracked_paths(workspace_root)?;
     let collisions = detect_case_insensitive_collisions(tracked_paths);
 
     if !collisions.is_empty() {
@@ -155,8 +157,25 @@ fn check_case_insensitive_path_collisions() -> Result<()> {
     Ok(())
 }
 
-fn load_workspace_version() -> Result<String> {
-    let manifest = read_toml("Cargo.toml")?;
+fn find_workspace_root() -> Result<PathBuf> {
+    let mut dir = std::env::current_dir()?;
+    loop {
+        let cargo_toml = dir.join("Cargo.toml");
+        if cargo_toml.exists() {
+            let content = fs::read_to_string(&cargo_toml)
+                .with_context(|| format!("Failed to read {}", cargo_toml.display()))?;
+            if content.contains("[workspace]") {
+                return Ok(dir);
+            }
+        }
+        if !dir.pop() {
+            bail!("Could not find workspace root (Cargo.toml with [workspace])");
+        }
+    }
+}
+
+fn load_workspace_version(workspace_root: &Path) -> Result<String> {
+    let manifest = read_toml(&workspace_root.join("Cargo.toml"))?;
     let workspace = manifest
         .get("workspace")
         .and_then(TomlValue::as_table)
@@ -174,16 +193,18 @@ fn load_workspace_version() -> Result<String> {
     Ok(version)
 }
 
-fn load_workspace_metadata() -> Result<Metadata> {
+fn load_workspace_metadata(workspace_root: &Path) -> Result<Metadata> {
     MetadataCommand::new()
+        .manifest_path(workspace_root.join("Cargo.toml"))
         .no_deps()
         .exec()
         .context("Failed to load cargo metadata")
 }
 
-fn read_tracked_paths() -> Result<Vec<String>> {
+fn read_tracked_paths(workspace_root: &Path) -> Result<Vec<String>> {
     let output = Command::new("git")
         .args(["ls-files", "-z"])
+        .current_dir(workspace_root)
         .output()
         .context("Failed to run `git ls-files -z`")?;
 
@@ -221,13 +242,14 @@ fn detect_case_insensitive_collisions(paths: Vec<String>) -> Vec<Vec<String>> {
         .collect()
 }
 
-fn read_package_manifest(path: &str) -> Result<JsonValue> {
-    let package_path = Path::new(path);
+fn read_package_manifest(workspace_root: &Path, path: &str) -> Result<JsonValue> {
+    let package_path = workspace_root.join(path);
     if !package_path.exists() {
         bail!("Missing package manifest: {path}");
     }
 
-    let raw = fs::read_to_string(package_path).with_context(|| format!("Failed to read {path}"))?;
+    let raw =
+        fs::read_to_string(&package_path).with_context(|| format!("Failed to read {path}"))?;
     serde_json::from_str(&raw).with_context(|| format!("Failed to parse JSON in {path}"))
 }
 
@@ -271,9 +293,10 @@ fn find_internal_node_dependency_mismatches(
     mismatches
 }
 
-fn read_toml(path: &str) -> Result<TomlValue> {
-    let raw = fs::read_to_string(path).with_context(|| format!("Failed to read {path}"))?;
-    toml::from_str(&raw).with_context(|| format!("Failed to parse TOML in {path}"))
+fn read_toml(path: &Path) -> Result<TomlValue> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("Failed to parse TOML in {}", path.display()))
 }
 
 #[cfg(test)]
@@ -282,13 +305,16 @@ mod tests {
 
     #[test]
     fn test_parse_workspace_version() {
-        let version = load_workspace_version().expect("workspace version should parse");
+        let workspace_root = find_workspace_root().expect("workspace root should parse");
+        let version =
+            load_workspace_version(&workspace_root).expect("workspace version should parse");
         assert!(!version.is_empty());
     }
 
     #[test]
     fn test_read_package_manifest_errors() {
-        assert!(read_package_manifest("no-such-file.json").is_err());
+        let workspace_root = find_workspace_root().expect("workspace root should parse");
+        assert!(read_package_manifest(&workspace_root, "no-such-file.json").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- sync the proven 1.9.0 release metadata from the frozen RC onto main
- update xtask bump so future version bumps keep the Node manifests aligned
- fix xtask version-consistency to resolve the workspace root before reading release metadata

## Validation
- cargo fmt-check
- cargo test -p xtask bump -- --nocapture
- cargo test -p xtask version_consistency -- --nocapture
- cargo xtask version-consistency
- cargo xtask publish --plan --verbose