### PR TITLE
fix(release): include vendored home patch in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ WORKDIR /build
 
 # Copy workspace manifest and all crate manifests first for better layer caching
 COPY Cargo.toml Cargo.lock ./
+COPY vendor/ vendor/
 COPY crates/ crates/
 COPY fuzz/ fuzz/
 COPY xtask/ xtask/
+COPY vendor/ vendor/
 
 # Build the release binary
 RUN cargo build --release --bin tokmd --locked


### PR DESCRIPTION
## Summary
- copy the vendored `home` patch into the Docker builder context
- keep the change scoped to the release image build path only

## Validation
- `git diff --check`
- copied the Dockerfile input set into a fresh temp directory and ran `cargo metadata --locked --format-version 1`
- from that same copied context ran `cargo check -p tokmd --locked --quiet`

This fixes the red `Build and Push Docker Image` release job, which currently fails because `[patch.crates-io] home = { path = "vendor/home-0.5.12" }` resolves inside the container but `vendor/` was never copied into `/build`.
