### PR TITLE
perf: remove allocation on file aggregation loop ⚡ Bolt

### DIFF
--- a/.jules/bolt/envelopes/1620be1e-3e7a-411f-82a8-d86c7282ced1.json
+++ b/.jules/bolt/envelopes/1620be1e-3e7a-411f-82a8-d86c7282ced1.json
@@ -1,0 +1,47 @@
+{
+  "run_id": "1620be1e-3e7a-411f-82a8-d86c7282ced1",
+  "timestamp_utc": "2026-03-28T12:44:12Z",
+  "lane": "scout",
+  "target": "crates/tokmd-model/src/lib.rs - lang_workflow",
+  "proof_method": "structural proof (eliminates String::clone() over file_rows)",
+  "commands": [
+    {
+      "cmd": "cargo check",
+      "status": "PASS"
+    },
+    {
+      "cmd": "cargo test -p tokmd-model",
+      "status": "PASS"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "status": "PASS"
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "status": "PASS"
+    }
+  ],
+  "results": [
+    {
+      "cmd": "cargo check",
+      "status": "PASS",
+      "output": "    Checking tokmd v1.9.0 (/app/crates/tokmd)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.51s"
+    },
+    {
+      "cmd": "cargo test -p tokmd-model",
+      "status": "PASS",
+      "output": "test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n\nall doctests ran in 0.62s; merged doctests compilation took 0.60s"
+    },
+    {
+      "cmd": "cargo fmt -- --check",
+      "status": "PASS",
+      "output": ""
+    },
+    {
+      "cmd": "cargo clippy -- -D warnings",
+      "status": "PASS",
+      "output": "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s"
+    }
+  ]
+}

--- a/.jules/bolt/ledger.json
+++ b/.jules/bolt/ledger.json
@@ -35,5 +35,33 @@
       "clippy"
     ],
     "friction_ids": []
+  },
+  {
+    "date": "2026-03-28T12:36:26Z",
+    "lane": "scout",
+    "target": "crates/tokmd-model/src/lib.rs lang_workflow",
+    "proof_method": "structural",
+    "pr_link": "pending",
+    "gates": [
+      "build",
+      "test",
+      "fmt",
+      "clippy"
+    ],
+    "friction_ids": []
+  },
+  {
+    "date": "2026-03-28T12:44:46Z",
+    "lane": "scout",
+    "target": "crates/tokmd-model/src/lib.rs lang_workflow",
+    "proof_method": "structural proof (eliminates String::clone() over file_rows)",
+    "pr_link": "pending",
+    "gates": [
+      "check",
+      "test",
+      "fmt",
+      "clippy"
+    ],
+    "friction_ids": []
   }
 ]

--- a/.jules/bolt/runs/2026-03-28.md
+++ b/.jules/bolt/runs/2026-03-28.md
@@ -1,0 +1,27 @@
+# Bolt Run Log: 2026-03-28
+
+## Initialization
+- Loaded repo guidance (README.md, CI workflows)
+- Discovered baseline gates
+
+## Selection
+- Lane: scout
+- Target: `crates/tokmd-model/src/lib.rs` - `lang_workflow`
+- Proof Method: Structural proof (eliminates `String::clone()` in hot loop over all file rows)
+
+## Options Considered
+### Option A
+- Change `by_lang` map key from `String` to `Cow<'_, str>`.
+- Why it fits this repo: Avoids allocating a `String` per parent file row while retaining the ability to allocate owned strings for formatting "(embedded)" language names for children.
+
+### Option B
+- Split the map into two separate loops (one for parents mapping to `&str`, another for children mapping to `String`), then merge at the end.
+- Trade-offs: Increases structural complexity and makes the aggregation logic less cohesive.
+
+## Decision
+- Option A: It provides the most straightforward performance win with minimal cognitive overhead.
+
+## Receipts
+- tests pass (cargo test -p tokmd-model)
+- compilation succeeds with `Cow`
+- No regressions in sorting determinism

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,3 @@
+perf: remove allocation on file aggregation loop ⚡ Bolt
+
+This change replaces `String` keys with `Cow<'_, str>` in the `BTreeMap` used for language aggregation (`lang_workflow` in `tokmd-model`). This eliminates a `row.lang.clone()` call for every file row being processed while keeping the ability to format `" (embedded)"` child row keys efficiently as owned Cows.

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -340,13 +340,13 @@ pub fn create_lang_report_from_rows(
         entry.1 += row.lines;
     }
 
-    let mut by_lang: BTreeMap<String, (LangAgg, BTreeSet<&str>)> = BTreeMap::new();
+    let mut by_lang: BTreeMap<Cow<'_, str>, (LangAgg, BTreeSet<&str>)> = BTreeMap::new();
 
     for row in file_rows {
         match (children, row.kind) {
             (ChildrenMode::Collapse, FileKind::Parent) => {
                 let entry = by_lang
-                    .entry(row.lang.clone())
+                    .entry(Cow::Borrowed(row.lang.as_str()))
                     .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                 entry.0.code += row.code;
                 entry.0.lines += row.lines;
@@ -357,7 +357,7 @@ pub fn create_lang_report_from_rows(
             (ChildrenMode::Collapse, FileKind::Child) => {
                 if !parent_lang_by_path.contains_key(row.path.as_str()) {
                     let entry = by_lang
-                        .entry(row.lang.clone())
+                        .entry(Cow::Borrowed(row.lang.as_str()))
                         .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                     entry.0.code += row.code;
                     entry.0.lines += row.lines;
@@ -371,7 +371,7 @@ pub fn create_lang_report_from_rows(
                     .unwrap_or((0, 0));
 
                 let entry = by_lang
-                    .entry(row.lang.clone())
+                    .entry(Cow::Borrowed(row.lang.as_str()))
                     .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                 entry.0.code += row.code.saturating_sub(child_code);
                 entry.0.lines += row.lines.saturating_sub(child_lines);
@@ -381,7 +381,7 @@ pub fn create_lang_report_from_rows(
             }
             (ChildrenMode::Separate, FileKind::Child) => {
                 let entry = by_lang
-                    .entry(format!("{} (embedded)", row.lang))
+                    .entry(Cow::Owned(format!("{} (embedded)", row.lang)))
                     .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                 entry.0.code += row.code;
                 entry.0.lines += row.lines;


### PR DESCRIPTION
## 💡 Summary 
Removed `String` clone allocations in the `lang_workflow` map logic over all file rows. Replaced the `BTreeMap` key with `Cow<'_, str>`.

## 🎯 Why (perf bottleneck) 
A hot loop iterating over all file paths to aggregate language metrics allocated `.clone()` for every `lang` string merely to be inserted as a map key. This caused massive unnecessary string allocation overhead proportional to the file count.

## 📊 Proof (before/after) 
Structural proof: Work eliminated. The previous `BTreeMap<String, ...>` instantiated an owned String for every file row being processed. By switching to `BTreeMap<Cow<'_, str>, ...>`, we avoid creating a string for all standard files, utilizing `Cow::Borrowed` with `row.lang.as_str()`. We retain the capacity for dynamic allocation `Cow::Owned` only for embedded child entries, reducing net string allocation footprint cleanly. 

## 🧭 Options considered 
### Option A (recommended) 
- Change `by_lang` map key from `String` to `Cow<'_, str>`.
- Why it fits this repo: Avoids allocating a `String` per parent file row while retaining the ability to allocate owned strings for formatting "(embedded)" language names for children.

### Option B 
- Split the map into two separate loops (one for parents mapping to `&str`, another for children mapping to `String`), then merge at the end.
- Trade-offs: Increases structural complexity and makes the aggregation logic less cohesive.

## ✅ Decision 
Option A: It provides the most straightforward performance win with minimal cognitive overhead. 

## 🧱 Changes made (SRP) 
- `crates/tokmd-model/src/lib.rs`
- `.jules/bolt/ledger.json`, `.jules/bolt/runs/2026-03-28.md`, `.jules/bolt/envelopes/...`

## 🧪 Verification receipts 
```json
    {
      "cmd": "cargo test -p tokmd-model",
      "status": "PASS",
      "output": "test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n\nall doctests ran in 0.62s; merged doctests compilation took 0.60s"
    },
    {
      "cmd": "cargo fmt -- --check",
      "status": "PASS",
      "output": ""
    },
    {
      "cmd": "cargo clippy -- -D warnings",
      "status": "PASS",
      "output": "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s"
    }
```

## 🧭 Telemetry 
- Change shape: Internal structure refactor
- Blast radius (API / IO / format stability / concurrency): Minimal. Only affects the internal map used for aggregation within `lang_workflow`. No API changes. Determinism guarantees unmodified. 
- Risk class + why: Very low. 
- Rollback: Direct git revert
- Merge-confidence gates (what ran): fmt, clippy, build, test.

## 🗂️ .jules updates 
- Append to `ledger.json`
- Add PR run file to `runs/`
- Envelope data written and verified via receipts.

## 📝 Notes (freeform) 
A previous commit already included the `std::borrow::Cow` import so `replace_with_git_merge_diff` only changed the struct instantiation. Test binaries were cleared prior to the commit. 

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [6934639574282092816](https://jules.google.com/task/6934639574282092816) started by @EffortlessSteven*