### PR TITLE
test: centralize crypto fixtures and guard blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,7 +205,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -209,6 +215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -404,6 +419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,18 +452,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -458,6 +467,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -491,10 +506,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -534,6 +564,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.0",
+ "serdect",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +585,26 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+dependencies = [
+ "crypto-bigint",
+ "libm",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -581,6 +645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctutils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,8 +680,19 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -644,7 +728,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.16.3",
+ "console",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -662,9 +746,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -685,7 +780,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -766,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1158,6 +1253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,7 +1488,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.3",
+ "console",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1402,11 +1506,11 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "6f40e41efb5f592d3a0764f818e2f08e5e21c4f368126f74f37c81bd4af7a0c6"
 dependencies = [
- "console 0.15.11",
+ "console",
  "once_cell",
  "serde",
  "similar",
@@ -1748,7 +1852,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1931,6 +2035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,7 +2089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2047,9 +2160,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -2058,8 +2181,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -2143,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -2507,17 +2640,36 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest 0.11.2",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.0",
+ "sha2 0.11.0",
+ "signature 3.0.0-rc.10",
+ "spki 0.8.0-rc.4",
  "zeroize",
 ]
 
@@ -2537,7 +2689,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2593,7 +2745,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2756,14 +2908,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2784,8 +2957,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2851,7 +3034,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -2930,7 +3123,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3127,7 +3320,7 @@ dependencies = [
  "blake3",
  "clap",
  "clap_complete",
- "console 0.16.3",
+ "console",
  "dialoguer",
  "dirs",
  "insta",
@@ -4123,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "uselesskey"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f81a867b596e0b732e766b467bc6c48ced2512814f0c0028f826fbf9e3d20a2"
+checksum = "85cb7c9ebbc99ebeeb242466b1f5b65ce18314fa65124116ae30abf6792da86f"
 dependencies = [
  "uselesskey-core",
  "uselesskey-rsa",
@@ -4133,9 +4326,9 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6694713cbd54b58f17bfbb4ec50f4da95b74f486d2f190e8c61dd93d273d068a"
+checksum = "aa6972fd4eace29958c694b1a674484efd61e161780ba512d3187366afa3391f"
 dependencies = [
  "thiserror 2.0.18",
  "uselesskey-core-cache",
@@ -4147,9 +4340,9 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-cache"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85821e0eef60f348ea9e1c1b9afd415f21fa6bcc56b4eda7d9e95ea2e5bb9862"
+checksum = "70b7fb00acbeb3c5494f6ffe3b7a6a01202b851cc651842dc1e2f382b47a0606"
 dependencies = [
  "dashmap",
  "spin 0.10.0",
@@ -4158,9 +4351,9 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-factory"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34190df9e83014bf0b553529a4053db64bd938c760414f7466a9aea22c59aa40"
+checksum = "2bf46a46655ddc51eed1c165cd69357f6fd5af027536de050d45c8d53b248a6c"
 dependencies = [
  "rand 0.10.0",
  "uselesskey-core-cache",
@@ -4169,18 +4362,18 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-hash"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7541863ee49fb627a20bea671ce7873fed271d7304b2a2b6cdba5bd79190d123"
+checksum = "e481e13c5ae0dafd07f1f1ed0a6a91abccc64f7baf6905737a52f17928956b78"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "uselesskey-core-id"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000e7f255b4ef3ff3fed1a0507493f91db964c7b192b8d78d42444a1c43b1a8"
+checksum = "6de7ab748e8513664720a90a1f96f354ff52ae10cab703c85d55ef106944f8c2"
 dependencies = [
  "uselesskey-core-hash",
  "uselesskey-core-seed",
@@ -4188,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-keypair-material"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f22446c76948b06a03c694ac725990acd8744de861bdc374864394ef7684b4"
+checksum = "707fb74cd170ea3bdc1bca7f904db6d3b52a07ca983653d9a94f0834362c8390"
 dependencies = [
  "uselesskey-core",
  "uselesskey-core-kid",
@@ -4198,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-kid"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304ffa6cf47e823f7584637e069dbbaa676ad2ae1eea5ca499a9a8622bdf4e58"
+checksum = "9a1f14829f539079c19f56f22d29bcd253d1a38f63fd58c712bd0b4479265022"
 dependencies = [
  "base64",
  "blake3",
@@ -4208,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddae24e5515639aefec352e5ae2ddf73e62b5259ec8fd8fe25f5103613eb3ee"
+checksum = "e416a896ba31c86eb26b0f9674372594d4a59ff5d73a8e17b32adf3d0620fa61"
 dependencies = [
  "uselesskey-core-negative-der",
  "uselesskey-core-negative-pem",
@@ -4218,27 +4411,27 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative-der"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eada76b181f2b28df3d42f3c3f0fe4061c0a06ab6fc71581d0dd2ae3fdf956a"
+checksum = "5045f08ad993e0b44b866ae2063dd1fd531838a4cde554ecbb31d67c77d16313"
 dependencies = [
  "uselesskey-core-hash",
 ]
 
 [[package]]
 name = "uselesskey-core-negative-pem"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bb47de0d54f59dbb944467ff2e851f56a9fce51347c6b65cd2d1a2706e551f"
+checksum = "bc8655e538f40ed19d05dacbf873984cae15eba9cdf607a004c8566f100e228d"
 dependencies = [
  "uselesskey-core-hash",
 ]
 
 [[package]]
 name = "uselesskey-core-seed"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4eb6ca50ea6d87b7309786813f1fe9573307b251bd5a7c16b5de9974986149"
+checksum = "0d5f8a13d928d399fe950487fbac66f7b11b8a6544ff0021bc0316305dcaf68f"
 dependencies = [
  "blake3",
  "rand_chacha 0.10.0",
@@ -4247,22 +4440,25 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-sink"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d42624000e28959a601483a58e06e2a4f30198aee08a1694577fd5a76253a5a"
+checksum = "27f16a6c364acde821cba60dfc983f24794cac577d554ddb7f67b98020bce834"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "uselesskey-rsa"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cdb48a92bb116c0b49d4f142a5c82895fa1f6c8715c5a6cb2e2ecd9e2b9998"
+checksum = "d5579cadfac51dc59aea6fbb77d42dbc57991b2369418630f74fd9231d1cc743"
 dependencies = [
+ "rand_chacha 0.10.0",
  "rand_chacha 0.3.1",
+ "rand_core 0.10.0",
  "rand_core 0.6.4",
- "rsa",
+ "rsa 0.10.0-rc.17",
+ "rsa 0.9.10",
  "uselesskey-core",
  "uselesskey-core-keypair-material",
 ]
@@ -4547,7 +4743,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,10 +194,14 @@ tokmd-gate = { path = "crates/tokmd-gate", version = "1.9.0" }
 tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.9.0" }
 
 # External crates - centralized for consistent versioning
+anyhow = "1.0.102"
 blake3 = "1.8.3"
+proptest = "1.11.0"
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-insta = { version = "1.46.3", features = ["json"] }
-uselesskey = { version = "0.4.1", default-features = false, features = ["rsa"] }
+tempfile = "3.27.0"
+insta = { version = "1.47.0", features = ["json"] }
+uselesskey = { version = "0.5.1", default-features = false, features = ["rsa"] }
 
 [profile.release]
 lto = true

--- a/crates/tokmd-analysis-api-surface/Cargo.toml
+++ b/crates/tokmd-analysis-api-surface/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-api-surface"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-analysis-util.workspace = true
 tokmd-content.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1"
-tempfile = "3.27.0"
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-analysis-archetype/Cargo.toml
+++ b/crates/tokmd-analysis-archetype/Cargo.toml
@@ -16,5 +16,5 @@ tokmd-analysis-types.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 serde_json.workspace = true

--- a/crates/tokmd-analysis-assets/Cargo.toml
+++ b/crates/tokmd-analysis-assets/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-assets"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 serde_json.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-walk.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true
 

--- a/crates/tokmd-analysis-complexity/Cargo.toml
+++ b/crates/tokmd-analysis-complexity/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-complexity"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-analysis-maintainability.workspace = true
 tokmd-analysis-util.workspace = true
@@ -20,6 +20,6 @@ tokmd-content.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 serde_json.workspace = true
-tempfile = "3.27.0"
+tempfile.workspace = true

--- a/crates/tokmd-analysis-content/Cargo.toml
+++ b/crates/tokmd-analysis-content/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-content"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-analysis-imports.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-analysis-util.workspace = true
@@ -22,6 +22,6 @@ tokmd-types.workspace = true
 blake3.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 serde_json.workspace = true
-tempfile = "3.27.0"
+tempfile.workspace = true

--- a/crates/tokmd-analysis-derived/Cargo.toml
+++ b/crates/tokmd-analysis-derived/Cargo.toml
@@ -20,5 +20,5 @@ tokmd-export-tree.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 serde_json.workspace = true

--- a/crates/tokmd-analysis-effort/Cargo.toml
+++ b/crates/tokmd-analysis-effort/Cargo.toml
@@ -16,11 +16,11 @@ default = []
 git = ["dep:tokmd-git"]
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-types.workspace = true
 tokmd-analysis-util.workspace = true
 tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
-tempfile = "3.27.0"
+tempfile.workspace = true

--- a/crates/tokmd-analysis-entropy/Cargo.toml
+++ b/crates/tokmd-analysis-entropy/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-entropy"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-analysis-util.workspace = true
 tokmd-content.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1"
-tempfile = "3.27.0"
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
 uselesskey.workspace = true

--- a/crates/tokmd-analysis-explain/Cargo.toml
+++ b/crates/tokmd-analysis-explain/Cargo.toml
@@ -15,4 +15,4 @@ documentation = "https://docs.rs/tokmd-analysis-explain"
 
 [dev-dependencies]
 insta.workspace = true
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-analysis-fingerprint/Cargo.toml
+++ b/crates/tokmd-analysis-fingerprint/Cargo.toml
@@ -16,5 +16,5 @@ tokmd-analysis-types.workspace = true
 tokmd-git.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 serde_json.workspace = true

--- a/crates/tokmd-analysis-format/Cargo.toml
+++ b/crates/tokmd-analysis-format/Cargo.toml
@@ -17,8 +17,8 @@ default = []
 fun = ["dep:tokmd-fun"]
 
 [dependencies]
-anyhow = "1.0.101"
-serde_json = "1.0.149"
+anyhow.workspace = true
+serde_json.workspace = true
 tokmd-analysis-html.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-types.workspace = true
@@ -29,5 +29,5 @@ tokmd-fun = { workspace = true, optional = true }
 [dev-dependencies]
 insta = { workspace = true }
 midly = "0.5.3"
-proptest = "1.10.0"
+proptest.workspace = true
 tokmd-analysis.workspace = true

--- a/crates/tokmd-analysis-fun/Cargo.toml
+++ b/crates/tokmd-analysis-fun/Cargo.toml
@@ -16,5 +16,5 @@ tokmd-analysis-types.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest = "1.10.0"
-serde_json = "1.0.149"
+proptest.workspace = true
+serde_json.workspace = true

--- a/crates/tokmd-analysis-git/Cargo.toml
+++ b/crates/tokmd-analysis-git/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-git"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-analysis-util.workspace = true
 tokmd-math.workspace = true
@@ -20,5 +20,5 @@ tokmd-git.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 serde_json.workspace = true

--- a/crates/tokmd-analysis-grid/Cargo.toml
+++ b/crates/tokmd-analysis-grid/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-grid"
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 
 [features]
 default = []

--- a/crates/tokmd-analysis-halstead/Cargo.toml
+++ b/crates/tokmd-analysis-halstead/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-halstead"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-analysis-util.workspace = true
 tokmd-content.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1"
-tempfile = "3"
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-analysis-html/Cargo.toml
+++ b/crates/tokmd-analysis-html/Cargo.toml
@@ -13,11 +13,11 @@ documentation = "https://docs.rs/tokmd-analysis-html"
 include = ["src/", "README.md", "Cargo.toml"]
 
 [dependencies]
-serde_json = "1.0.149"
+serde_json.workspace = true
 time = { version = "0.3.47", features = ["formatting", "macros"] }
 tokmd-analysis-types.workspace = true
 
 [dev-dependencies]
 insta = "1"
-proptest = "1"
+proptest.workspace = true
 tokmd-types.workspace = true

--- a/crates/tokmd-analysis-imports/Cargo.toml
+++ b/crates/tokmd-analysis-imports/Cargo.toml
@@ -13,4 +13,4 @@ documentation = "https://docs.rs/tokmd-analysis-imports"
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-analysis-license/Cargo.toml
+++ b/crates/tokmd-analysis-license/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-license"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 serde_json.workspace = true
 tokmd-analysis-types.workspace = true
 tokmd-analysis-util.workspace = true
@@ -20,5 +20,5 @@ tokmd-content.workspace = true
 tokmd-walk.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-analysis-maintainability/Cargo.toml
+++ b/crates/tokmd-analysis-maintainability/Cargo.toml
@@ -15,5 +15,5 @@ documentation = "https://docs.rs/tokmd-analysis-maintainability"
 tokmd-analysis-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 serde_json.workspace = true

--- a/crates/tokmd-analysis-near-dup/Cargo.toml
+++ b/crates/tokmd-analysis-near-dup/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-analysis-near-dup"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 globset = "0.4.18"
 rustc-hash = "2"
 tokmd-analysis-types.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1"
-tempfile = "3.27.0"
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
 

--- a/crates/tokmd-analysis-topics/Cargo.toml
+++ b/crates/tokmd-analysis-topics/Cargo.toml
@@ -16,5 +16,5 @@ tokmd-analysis-types.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1"
+proptest.workspace = true
+serde_json.workspace = true

--- a/crates/tokmd-analysis-types/Cargo.toml
+++ b/crates/tokmd-analysis-types/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["development-tools", "data-structures"]
 documentation = "https://docs.rs/tokmd-analysis-types"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 tokmd-envelope.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 

--- a/crates/tokmd-analysis-util/Cargo.toml
+++ b/crates/tokmd-analysis-util/Cargo.toml
@@ -17,4 +17,4 @@ tokmd-math.workspace = true
 tokmd-analysis-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-analysis/Cargo.toml
+++ b/crates/tokmd-analysis/Cargo.toml
@@ -47,8 +47,8 @@ topics = ["dep:tokmd-analysis-topics", "tokmd-analysis-grid/topics"]
 archetype = ["dep:tokmd-analysis-archetype", "tokmd-analysis-grid/archetype"]
 
 [dependencies]
-anyhow = "1.0.101"
-serde_json = "1.0.149"
+anyhow.workspace = true
+serde_json.workspace = true
 
 # Core contracts
 tokmd-analysis-derived.workspace = true
@@ -77,7 +77,7 @@ tokmd-analysis-maintainability = { workspace = true, optional = true }
 tokmd-analysis-effort = { workspace = true, optional = true }
 
 [dev-dependencies]
-tempfile = "3.27.0"
-proptest = "1.10.0"
+tempfile.workspace = true
+proptest.workspace = true
 uselesskey.workspace = true
-serde = { version = "1.0.228", features = ["derive"] }
+serde.workspace = true

--- a/crates/tokmd-badge/Cargo.toml
+++ b/crates/tokmd-badge/Cargo.toml
@@ -15,4 +15,4 @@ categories = ["command-line-utilities"]
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-cockpit/Cargo.toml
+++ b/crates/tokmd-cockpit/Cargo.toml
@@ -16,11 +16,11 @@ default = ["git"]
 git = ["dep:tokmd-git"]
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 blake3.workspace = true
 ignore = "0.4.23"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 time = { version = "0.3.41", features = ["formatting"] }
 tokmd-analysis-types.workspace = true
 tokmd-envelope.workspace = true
@@ -31,6 +31,6 @@ tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest = "1.10.0"
-serde_json = "1.0.149"
-tempfile = "3.27.0"
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-config/Cargo.toml
+++ b/crates/tokmd-config/Cargo.toml
@@ -13,15 +13,15 @@ documentation = "https://docs.rs/tokmd-config"
 
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 tokmd-settings.workspace = true
 tokmd-tool-schema.workspace = true
 tokmd-types = { workspace = true, features = ["clap"] }
 
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true
 toml = "1.0"
 tokmd-settings.workspace = true

--- a/crates/tokmd-content/Cargo.toml
+++ b/crates/tokmd-content/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-content"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 blake3.workspace = true
 regex = "1.12.3"
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true
 

--- a/crates/tokmd-context-git/Cargo.toml
+++ b/crates/tokmd-context-git/Cargo.toml
@@ -21,5 +21,5 @@ tokmd-path.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-context-policy/Cargo.toml
+++ b/crates/tokmd-context-policy/Cargo.toml
@@ -16,4 +16,4 @@ tokmd-path.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-core/Cargo.toml
+++ b/crates/tokmd-core/Cargo.toml
@@ -28,10 +28,10 @@ analysis = [
 cockpit = ["dep:tokmd-cockpit", "dep:tokmd-git"]
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 base64 = "0.22.1"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 tokmd-config.workspace = true
 tokmd-format.workspace = true
 tokmd-settings.workspace = true
@@ -49,8 +49,8 @@ tokmd-cockpit = { workspace = true, optional = true }
 tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.101"
-proptest = "1.10.0"
-serde_json = "1.0.149"
-tempfile = "3"
+anyhow.workspace = true
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
 tokmd-format.workspace = true

--- a/crates/tokmd-envelope/Cargo.toml
+++ b/crates/tokmd-envelope/Cargo.toml
@@ -13,9 +13,9 @@ documentation = "https://docs.rs/tokmd-envelope"
 
 [dependencies]
 blake3 = "1.8.3"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 

--- a/crates/tokmd-exclude/Cargo.toml
+++ b/crates/tokmd-exclude/Cargo.toml
@@ -15,4 +15,4 @@ documentation = "https://docs.rs/tokmd-exclude"
 tokmd-path.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-export-tree/Cargo.toml
+++ b/crates/tokmd-export-tree/Cargo.toml
@@ -15,4 +15,4 @@ documentation = "https://docs.rs/tokmd-export-tree"
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-ffi-envelope/Cargo.toml
+++ b/crates/tokmd-ffi-envelope/Cargo.toml
@@ -15,5 +15,5 @@ documentation = "https://docs.rs/tokmd-ffi-envelope"
 serde_json.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 tokmd-core.workspace = true

--- a/crates/tokmd-format/Cargo.toml
+++ b/crates/tokmd-format/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["development-tools", "encoding"]
 documentation = "https://docs.rs/tokmd-format"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 csv = "1.4.0"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 time = { version = "0.3.47", features = ["formatting"] }
 uuid = { version = "1.22", features = ["v4", "js"] }
 tokmd-redact.workspace = true
@@ -24,7 +24,7 @@ tokmd-settings.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 insta = { workspace = true }
-serde_json = "1.0.149"
-tempfile = "3.27.0"
+serde_json.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-fun/Cargo.toml
+++ b/crates/tokmd-fun/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["development-tools", "visualization"]
 documentation = "https://docs.rs/tokmd-fun"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 midly = "0.5.3"
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest = "1.10.0"
+proptest.workspace = true
 

--- a/crates/tokmd-gate/Cargo.toml
+++ b/crates/tokmd-gate/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["policy", "ci", "gate", "analysis"]
 categories = ["development-tools"]
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 toml = "1.0.6"
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3"
+proptest.workspace = true
+tempfile.workspace = true
 

--- a/crates/tokmd-git/Cargo.toml
+++ b/crates/tokmd-git/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-git"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true
 

--- a/crates/tokmd-io-port/Cargo.toml
+++ b/crates/tokmd-io-port/Cargo.toml
@@ -14,5 +14,5 @@ documentation = "https://docs.rs/tokmd-io-port"
 [dependencies]
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3"
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-math/Cargo.toml
+++ b/crates/tokmd-math/Cargo.toml
@@ -14,4 +14,4 @@ documentation = "https://docs.rs/tokmd-math"
 [dependencies]
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-model"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde.workspace = true
 tokei = { version = "14.0.0", default-features = false }
 tokmd-module-key.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest = "1.10.0"
-serde_json = "1.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-module-key/Cargo.toml
+++ b/crates/tokmd-module-key/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-module-key"
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-node/Cargo.toml
+++ b/crates/tokmd-node/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib"]
 napi = { version = "3", features = ["async", "serde-json", "tokio_rt", "error_anyhow"] }
 napi-derive = "3"
 tokio = { version = "1", features = ["rt-multi-thread"] }
-serde_json = "1.0.149"
-serde = "1.0.228"
+serde_json.workspace = true
+serde.workspace = true
 tokmd-core = { workspace = true, features = ["analysis", "cockpit"] }
 tokmd-ffi-envelope.workspace = true
 
@@ -28,4 +28,4 @@ tokmd-ffi-envelope.workspace = true
 napi-build = "2"
 
 [dev-dependencies]
-tempfile = "3.27.0"
+tempfile.workspace = true

--- a/crates/tokmd-path/Cargo.toml
+++ b/crates/tokmd-path/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-path"
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true

--- a/crates/tokmd-progress/Cargo.toml
+++ b/crates/tokmd-progress/Cargo.toml
@@ -19,4 +19,4 @@ ui = ["dep:indicatif"]
 indicatif = { version = "0.18.4", optional = true }
 
 [dev-dependencies]
-proptest = "1"
+proptest.workspace = true

--- a/crates/tokmd-python/Cargo.toml
+++ b/crates/tokmd-python/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.24", features = ["abi3-py39"] }
-serde_json = "1.0.149"
+serde_json.workspace = true
 tokmd-core = { workspace = true, features = ["analysis", "cockpit"] }
 tokmd-ffi-envelope.workspace = true
 
@@ -30,4 +30,4 @@ extension-module = ["pyo3/extension-module"]
 pyo3-build-config = "0.24"
 
 [dev-dependencies]
-tempfile = "3.27.0"
+tempfile.workspace = true

--- a/crates/tokmd-redact/Cargo.toml
+++ b/crates/tokmd-redact/Cargo.toml
@@ -15,5 +15,5 @@ documentation = "https://docs.rs/tokmd-redact"
 blake3.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
+proptest.workspace = true
 

--- a/crates/tokmd-scan-args/Cargo.toml
+++ b/crates/tokmd-scan-args/Cargo.toml
@@ -18,5 +18,5 @@ tokmd-settings.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1.0"
+proptest.workspace = true
+serde_json.workspace = true

--- a/crates/tokmd-scan/Cargo.toml
+++ b/crates/tokmd-scan/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-scan"
 
 [dependencies]
-anyhow = "1.0.101"
-tempfile = "3.27.0"
+anyhow.workspace = true
+tempfile.workspace = true
 tokei = { version = "14.0.0", default-features = false }
 tokmd-settings.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true
 tokmd-model.workspace = true

--- a/crates/tokmd-sensor/Cargo.toml
+++ b/crates/tokmd-sensor/Cargo.toml
@@ -15,8 +15,8 @@ documentation = "https://docs.rs/tokmd-sensor"
 default = []
 
 [dependencies]
-anyhow = "1.0.101"
-serde = { version = "1.0.228", features = ["derive"] }
+anyhow.workspace = true
+serde.workspace = true
 tokmd-envelope.workspace = true
 tokmd-substrate.workspace = true
 tokmd-settings.workspace = true
@@ -25,7 +25,7 @@ tokmd-model.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1.0.149"
-tempfile = "3.27.0"
+proptest.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
 

--- a/crates/tokmd-settings/Cargo.toml
+++ b/crates/tokmd-settings/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["development-tools", "config"]
 documentation = "https://docs.rs/tokmd-settings"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 toml = "1.0"
 tokmd-types.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd-substrate/Cargo.toml
+++ b/crates/tokmd-substrate/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["development-tools", "data-structures"]
 documentation = "https://docs.rs/tokmd-substrate"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1.0.149"
+proptest.workspace = true
+serde_json.workspace = true
 

--- a/crates/tokmd-tokeignore/Cargo.toml
+++ b/crates/tokmd-tokeignore/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-tokeignore"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 tokmd-config.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true
 

--- a/crates/tokmd-tool-schema/Cargo.toml
+++ b/crates/tokmd-tool-schema/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-tool-schema"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 clap = { version = "4.6.0", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }

--- a/crates/tokmd-types/Cargo.toml
+++ b/crates/tokmd-types/Cargo.toml
@@ -15,12 +15,12 @@ documentation = "https://docs.rs/tokmd-types"
 clap = ["dep:clap"]
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde.workspace = true
 clap = { version = "4.6.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-proptest = "1.10.0"
-serde_json = "1.0.149"
+proptest.workspace = true
+serde_json.workspace = true
 insta = { workspace = true }
 tokmd-path = { workspace = true }
 tokmd-module-key = { workspace = true }

--- a/crates/tokmd-walk/Cargo.toml
+++ b/crates/tokmd-walk/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["development-tools", "filesystem"]
 documentation = "https://docs.rs/tokmd-walk"
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 ignore = "0.4.25"
 tokmd-io-port.workspace = true
 
 [dev-dependencies]
-proptest = "1.10.0"
-tempfile = "3.27.0"
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -52,7 +52,7 @@ path = "src/bin/tok.rs"
 required-features = ["alias-tok"]
 
 [dependencies]
-anyhow = "1.0.101"
+anyhow.workspace = true
 clap = { version = "4.6.0", features = ["derive"] }
 tokmd-analysis = { workspace = true }
 tokmd-analysis-explain.workspace = true
@@ -84,19 +84,19 @@ dialoguer = { version = "0.12.0", optional = true }
 console = { version = "0.16.3", optional = true }
 toml = { version = "1.0.6", optional = true }
 dirs = "6.0.0"
-serde_json = "1.0.149"
+serde_json.workspace = true
 tokmd-gate.workspace = true
-serde = { version = "1.0.228", features = ["derive"] }
+serde.workspace = true
 blake3.workspace = true
 time = { version = "0.3.47", features = ["formatting"] }
 
 [dev-dependencies]
 assert_cmd = "2.2.0"
 predicates = "3.1.4"
-tempfile = "3.27.0"
+tempfile.workspace = true
 insta = { workspace = true }
 regex = "1.12.3"
-proptest = "1.10.0"
+proptest.workspace = true
 jsonschema = { version = "0.45.0", default-features = false, features = ["resolve-http", "resolve-file", "tls-ring"] }
 toml = "1.0.6"
 tokmd-analysis-derived.workspace = true


### PR DESCRIPTION
## Summary
- centralize shared workspace dependency pins and bump the deterministic `uselesskey` fixture stack to `0.5.1`
- add an internal `tokmd-test-support` crate with one deterministic crypto fixture factory, stable labels, and shared runtime fixture helpers
- add `cargo xtask fixture-blobs-check` and run it from `cargo xtask gate` to block committed PEM/DER/JWK-style fixture blobs outside approved paths

## Validation
- cargo fmt-check
- cargo check --workspace --all-targets
- cargo xtask fixture-blobs-check
- cargo test -p tokmd-test-support
- cargo test -p xtask fixture_blobs
- cargo test -p tokmd-analysis --features content,walk --test uselesskey_security_pipeline
- cargo test -p tokmd-analysis-entropy --test uselesskey_runtime_fixtures
