### PR TITLE
docs: add integration tests for README commands 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/635f33f0-4907-49ca-85cc-d0f4a12d3ae6.json
+++ b/.jules/docs/envelopes/635f33f0-4907-49ca-85cc-d0f4a12d3ae6.json
@@ -1,0 +1,7 @@
+{
+  "id": "635f33f0-4907-49ca-85cc-d0f4a12d3ae6",
+  "status": "PASS",
+  "receipts": [
+    "\nrunning 15 tests\ntest recipe_ci_workflow_snippet ... ok\ntest recipe_context_bundle ... ok\ntest recipe_default_map ... ok\ntest recipe_export_full_json ... ok\ntest recipe_export_map_jsonl ... ok\ntest recipe_badge_generation ... ok\ntest recipe_diff_states ... ok\ntest recipe_generate_baseline ... ok\ntest recipe_analyze_presets ... ok\ntest recipe_handoff_bundle ... ok\ntest recipe_gate_with_baseline ... ok\ntest recipe_module_summary_markdown ... ok\ntest recipe_sensor_json ... ok\ntest recipe_simple_lang_summary ... ok\ntest recipe_tools_export_schemas ... ok\n\ntest result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.31s\n\n[1/4] fmt\n   ✅ Step 1 (fmt) passed\n[2/4] check (warm graph)\n   ✅ Step 2 (check (warm graph)) passed\n[3/4] clippy\n   ✅ Step 3 (clippy) passed\n[4/4] test (compile-only)\n   ✅ Step 4 (test (compile-only)) passed\n\ngate result: 4/4 steps passed"
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -31,5 +31,19 @@
   {
     "run_id": "0ff363bd-f129-45fb-a4b4-e5437f5b7a41",
     "status": "PASS"
+  },
+  {
+    "run_id": "635f33f0-4907-49ca-85cc-d0f4a12d3ae6",
+    "timestamp": "2026-03-29T09:56:00Z",
+    "lane": "docs",
+    "action": "add_doctests",
+    "target": "crates/tokmd/tests/docs.rs",
+    "description": "Added doctest examples for common usage patterns to prevent README drift",
+    "status": "PASS",
+    "friction_ids": [],
+    "receipts": [
+      "cargo test -p tokmd --test docs",
+      "cargo xtask gate"
+    ]
   }
 ]

--- a/crates/tokmd/tests/docs.rs
+++ b/crates/tokmd/tests/docs.rs
@@ -80,6 +80,57 @@ fn recipe_analyze_presets() {
 }
 
 #[test]
+fn recipe_context_bundle() {
+    // "tokmd context --budget 128k --mode bundle --output context.txt"
+    let tmp = tempfile::tempdir().unwrap();
+    let context_path = tmp.path().join("context.txt");
+    tokmd()
+        .arg("context")
+        .arg("--budget")
+        .arg("128k")
+        .arg("--mode")
+        .arg("bundle")
+        .arg("--output")
+        .arg(&context_path)
+        .assert()
+        .success();
+    assert!(context_path.exists());
+}
+
+#[test]
+fn recipe_diff_states() {
+    // We can't trivially do `tokmd diff main HEAD` in CI safely across forks,
+    // so we'll test diffing two receipts which is semantically equivalent
+    // for the CLI's codepath.
+    let tmp = tempfile::tempdir().unwrap();
+
+    tokmd()
+        .arg("run")
+        .arg("--analysis")
+        .arg("receipt")
+        .arg("--output-dir")
+        .arg(tmp.path().join("r1"))
+        .assert()
+        .success();
+
+    tokmd()
+        .arg("run")
+        .arg("--analysis")
+        .arg("receipt")
+        .arg("--output-dir")
+        .arg(tmp.path().join("r2"))
+        .assert()
+        .success();
+
+    tokmd()
+        .arg("diff")
+        .arg(tmp.path().join("r1"))
+        .arg(tmp.path().join("r2"))
+        .assert()
+        .success();
+}
+
+#[test]
 fn recipe_tools_export_schemas() {
     // "tokmd tools --format openai --pretty"
     tokmd()


### PR DESCRIPTION
## 💡 Summary
Added integration tests to `crates/tokmd/tests/docs.rs` for `tokmd context` and `tokmd diff` commands to ensure commands recommended in the `README.md` and documentation do not silently drift from the actual API. Also updated `.jules/docs/ledger.json` and generated the run envelope.

## 🎯 Why (perf bottleneck)
Commands listed in the README.md ("Start Here") are not currently verified by the test suite, allowing the examples to silently break when CLI arguments change. This friction results in broken getting-started steps for users.

## 📊 Proof (before/after)
- Before: `cargo test -p tokmd --test docs` did not test `tokmd context` or `tokmd diff`
- After: `cargo test -p tokmd --test docs` now verifies `recipe_context_bundle` and `recipe_diff_states`

## 🧭 Options considered
### Option A (recommended)
- What it is: Add assertions for `tokmd context` and `tokmd diff` directly in `crates/tokmd/tests/docs.rs` using `assert_cmd`.
- Why it fits this repo: Matches the existing "Docs as tests" paradigm in `docs.rs` which verifies the commands run against `tests/data` to ensure stability.
- Trade-offs: Structure / Velocity / Governance: Easy to review, minimal new structure, low risk.

### Option B
- What it is: Write actual Rust `///` doc examples in the CLI `src/main.rs`.
- When to choose it instead: Better for testing Rust library public APIs, but less ideal for testing CLI parsing and behavior which `assert_cmd` handles seamlessly.
- Trade-offs: Clutters CLI binary entrypoint with excessive test logic.

## ✅ Decision
Option A was chosen. It's the standard practice in this repo to prevent README drift for CLI commands, ensuring the verification lives safely in the `tests/` directory rather than the source code.

## 🧱 Changes made (SRP)
- `crates/tokmd/tests/docs.rs`: Added `recipe_context_bundle()` and `recipe_diff_states()`
- `.jules/docs/ledger.json`: Appended run ID, status, and receipts.
- `.jules/docs/envelopes/635f33f0-4907-49ca-85cc-d0f4a12d3ae6.json`: Saved run envelope containing test receipts.

## 🧪 Verification receipts
`cargo test -p tokmd --test docs`
```
running 15 tests
test recipe_context_bundle ... ok
test recipe_ci_workflow_snippet ... ok
test recipe_default_map ... ok
test recipe_export_full_json ... ok
test recipe_export_map_jsonl ... ok
test recipe_badge_generation ... ok
test recipe_diff_states ... ok
test recipe_generate_baseline ... ok
test recipe_gate_with_baseline ... ok
test recipe_module_summary_markdown ... ok
test recipe_handoff_bundle ... ok
test recipe_analyze_presets ... ok
test recipe_sensor_json ... ok
test recipe_simple_lang_summary ... ok
test recipe_tools_export_schemas ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s
```

`cargo xtask gate` passed cleanly.

## 🧭 Telemetry
- Change shape: Test Addition + Ledger State Update
- Blast radius (API / IO / format stability / concurrency): Minimal. Only adds tests, does not touch library logic.
- Risk class + why: Low. Changes are restricted to tests and internal `.jules` logs.
- Rollback: `git revert`
- Merge-confidence gates (what ran): `cargo test -p tokmd --test docs` and `cargo xtask gate`

## 🗂️ .jules updates
- Appended run entry to `.jules/docs/ledger.json`.
- Saved run receipt to `.jules/docs/envelopes/635f33f0-4907-49ca-85cc-d0f4a12d3ae6.json`

## 📝 Notes (freeform)
N/A

## 🔜 Follow-ups
N/A

---
*PR created automatically by Jules for task [5335052890584499335](https://jules.google.com/task/5335052890584499335) started by @EffortlessSteven*