### PR TITLE
compat: fix no-default-features build for handoff tests 🧷 Compat

### DIFF
--- a/.jules/compat/envelopes/ff3a4510-bc82-4274-980a-fa6077324fbe.json
+++ b/.jules/compat/envelopes/ff3a4510-bc82-4274-980a-fa6077324fbe.json
@@ -1,0 +1,1 @@
+{"run_id": "ff3a4510-bc82-4274-980a-fa6077324fbe", "status": "PASS", "friction_ids": []}

--- a/.jules/compat/ledger.json
+++ b/.jules/compat/ledger.json
@@ -12,5 +12,10 @@
   {
     "run_id": "13bf324d-a8ad-4e74-9d27-673789e16269",
     "status": "PASS"
+  },
+  {
+    "run_id": "ff3a4510-bc82-4274-980a-fa6077324fbe",
+    "status": "PASS",
+    "friction_ids": []
   }
 ]

--- a/crates/tokmd/tests/context_handoff_deep.rs
+++ b/crates/tokmd/tests/context_handoff_deep.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "git")]
 //! Deep integration tests for context and handoff CLI pipelines.
 //!
 //! Covers: context JSON receipt structure, bundle assembly, handoff manifest

--- a/crates/tokmd/tests/deep_context_handoff_w51.rs
+++ b/crates/tokmd/tests/deep_context_handoff_w51.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "git")]
 //! Deep round-2 context and handoff CLI integration tests (W51).
 
 mod common;

--- a/crates/tokmd/tests/handoff_integration.rs
+++ b/crates/tokmd/tests/handoff_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "git")]
 mod common;
 
 use assert_cmd::Command;

--- a/crates/tokmd/tests/handoff_w71.rs
+++ b/crates/tokmd/tests/handoff_w71.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "git")]
 //! W71 deep handoff CLI integration tests.
 //!
 //! Tests cover: rank-by variants, preset deep, max-file-pct/max-file-tokens,


### PR DESCRIPTION
## 💡 Summary
Added `#![cfg(feature = "git")]` to integration test files that depend on the `handoff` subcommand to prevent them from failing when building with `--no-default-features`.

## 🎯 Why (perf bottleneck)
When running `cargo test --workspace --no-default-features`, compilation was failing or hanging due to integration tests requiring the `git` feature. Excluding these test files aligns with the feature matrix gates and prevents CI regressions.

## 📊 Proof (before/after)
Before: `cargo test -p tokmd --no-default-features` failed because of `handoff_integration` and related tests looking for a feature they couldn't use.
After: All remaining tests pass consistently on the minimal feature set:
```
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.67s
...
```

## 🧭 Options considered
### Option A (recommended)
- What it is: Add a top-level inner `#![cfg(feature = "git")]` attribute to `handoff` related integration test files.
- Why it fits this repo: This cleanly excludes tests that explicitly depend on a feature missing from the current run profile, without adding boilerplate to every single test function.
- Trade-offs: Structure / Velocity / Governance: Structure is cleaner, test logic remains decoupled from boilerplate conditions.

### Option B
- What it is: Gating each individual test with `#[cfg(feature = "git")]`.
- When to choose it instead: If the test file contained a mix of core functionality tests and git-dependent tests.
- Trade-offs: Bloated test files and more error-prone maintenance.

## ✅ Decision
Option A. The identified test files (`handoff_integration.rs`, `context_handoff_deep.rs`, etc.) are entirely dedicated to the handoff functionality, which is explicitly tied to the `git` feature in this repo.

## 🧱 Changes made (SRP)
- `crates/tokmd/tests/handoff_integration.rs`: Added `#![cfg(feature = "git")]`
- `crates/tokmd/tests/context_handoff_deep.rs`: Added `#![cfg(feature = "git")]`
- `crates/tokmd/tests/deep_context_handoff_w51.rs`: Added `#![cfg(feature = "git")]`
- `crates/tokmd/tests/handoff_w71.rs`: Added `#![cfg(feature = "git")]`

## 🧪 Verification receipts
```bash
$ cargo test -p tokmd --no-default-features
...
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.93s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s
```

## 🧭 Telemetry
- Change shape: Test Configuration fix.
- Blast radius: Only affects local test builds without default features. No impact on release artifacts.
- Risk class + why: Extremely low, purely changes conditional compilation flags for test fixtures.
- Rollback: Revert the commit.
- Merge-confidence gates (what ran): `cargo xtask gate --check`, `cargo test -p tokmd --no-default-features`

## 🗂️ .jules updates
Created a new run envelope in `.jules/compat/envelopes/<run_id>.json` and appended an entry to `.jules/compat/ledger.json` recording a PASS status.

## 📝 Notes (freeform)
None.

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [17325924337957425635](https://jules.google.com/task/17325924337957425635) started by @EffortlessSteven*