### PR TITLE
test: replace unwrap with descriptive expect in determinism tests 🧪 Gatekeeper

### DIFF
--- a/.jules/quality/envelopes/53b384a0-1d6f-4f34-99da-22dd7017939c.json
+++ b/.jules/quality/envelopes/53b384a0-1d6f-4f34-99da-22dd7017939c.json
@@ -1,0 +1,5 @@
+{
+  "run_id": "53b384a0-1d6f-4f34-99da-22dd7017939c",
+  "task": "Replace unwrap with expect in determinism tests",
+  "command": "cargo test -p tokmd --test determinism*"
+}

--- a/.jules/quality/ledger.json
+++ b/.jules/quality/ledger.json
@@ -10,6 +10,13 @@
       "run_id": "3499475a-2ff1-49e1-b620-913909a040a8",
       "timestamp": "2026-03-22T10:25:31Z",
       "description": "test: lock deterministic ordering for outputs 🧪 Gatekeeper"
+    },
+    {
+      "run_id": "53b384a0-1d6f-4f34-99da-22dd7017939c",
+      "timestamp": "2026-03-30T10:16:19Z",
+      "description": "test: replace unwrap with descriptive expect in determinism tests 🧪 Gatekeeper",
+      "status": "PASS",
+      "friction_ids": []
     }
   ]
 }

--- a/crates/tokmd/tests/determinism.rs
+++ b/crates/tokmd/tests/determinism.rs
@@ -217,10 +217,10 @@ fn lang_rows_sorted_by_code_desc_then_name_asc() {
         .expect("rows array");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_lang = pair[0]["lang"].as_str().unwrap();
-        let b_lang = pair[1]["lang"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_lang = pair[0]["lang"].as_str().expect("row field should be a string");
+        let b_lang = pair[1]["lang"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_lang <= b_lang),
@@ -243,10 +243,10 @@ fn module_rows_sorted_by_code_desc_then_name_asc() {
         .expect("rows array");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_mod = pair[0]["module"].as_str().unwrap();
-        let b_mod = pair[1]["module"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_mod = pair[0]["module"].as_str().expect("row field should be a string");
+        let b_mod = pair[1]["module"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_mod <= b_mod),
@@ -269,10 +269,10 @@ fn export_rows_sorted_by_code_desc_then_path_asc() {
         .expect("rows array");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_path = pair[0]["path"].as_str().expect("row field should be a string");
+        let b_path = pair[1]["path"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),
@@ -354,7 +354,7 @@ fn export_paths_use_forward_slashes() {
         .expect("rows array");
 
     for row in rows {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         assert!(!path.contains('\\'), "path contains backslash: {path}");
     }
 }
@@ -372,7 +372,7 @@ fn export_modules_use_forward_slashes() {
         .expect("rows array");
 
     for row in rows {
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(
             !module.contains('\\'),
             "module key contains backslash: {module}"
@@ -483,7 +483,7 @@ fn redacted_paths_are_hashed_not_plaintext() {
         .expect("rows array");
 
     for row in rows {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         // Redacted paths should not contain directory separators
         assert!(
             !path.contains('/') || path.starts_with('('),
@@ -529,13 +529,13 @@ fn lang_totals_match_row_sums() {
     let rows = json["rows"].as_array().expect("rows array");
     let total = &json["total"];
 
-    let sum_code: u64 = rows.iter().map(|r| r["code"].as_u64().unwrap()).sum();
-    let sum_lines: u64 = rows.iter().map(|r| r["lines"].as_u64().unwrap()).sum();
-    let sum_files: u64 = rows.iter().map(|r| r["files"].as_u64().unwrap()).sum();
+    let sum_code: u64 = rows.iter().map(|r| r["code"].as_u64().expect("code row should be a u64 number")).sum();
+    let sum_lines: u64 = rows.iter().map(|r| r["lines"].as_u64().expect("code row should be a u64 number")).sum();
+    let sum_files: u64 = rows.iter().map(|r| r["files"].as_u64().expect("code row should be a u64 number")).sum();
 
-    assert_eq!(sum_code, total["code"].as_u64().unwrap(), "code total");
-    assert_eq!(sum_lines, total["lines"].as_u64().unwrap(), "lines total");
-    assert_eq!(sum_files, total["files"].as_u64().unwrap(), "files total");
+    assert_eq!(sum_code, total["code"].as_u64().expect("code row should be a u64 number"), "code total");
+    assert_eq!(sum_lines, total["lines"].as_u64().expect("code row should be a u64 number"), "lines total");
+    assert_eq!(sum_files, total["files"].as_u64().expect("code row should be a u64 number"), "files total");
 }
 
 // ---------------------------------------------------------------------------
@@ -555,7 +555,7 @@ fn module_json_keys_use_forward_slashes() {
         .expect("rows array");
 
     for row in rows {
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(
             !module.contains('\\'),
             "module key contains backslash: {module}"

--- a/crates/tokmd/tests/determinism_hardening.rs
+++ b/crates/tokmd/tests/determinism_hardening.rs
@@ -234,10 +234,10 @@ fn hardening_lang_rows_sorted_desc_code_then_asc_name() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["lang"].as_str().unwrap();
-        let b_name = pair[1]["lang"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_name = pair[0]["lang"].as_str().expect("row field should be a string");
+        let b_name = pair[1]["lang"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
@@ -256,10 +256,10 @@ fn hardening_module_rows_sorted_desc_code_then_asc_name() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["module"].as_str().unwrap();
-        let b_name = pair[1]["module"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_name = pair[0]["module"].as_str().expect("row field should be a string");
+        let b_name = pair[1]["module"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
@@ -278,10 +278,10 @@ fn hardening_export_rows_sorted_desc_code_then_asc_path() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_path = pair[0]["path"].as_str().expect("row field should be a string");
+        let b_path = pair[1]["path"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),
@@ -304,10 +304,10 @@ fn hardening_export_json_no_backslash_in_paths() {
     let rows = v["rows"].as_array().expect("rows");
 
     for row in rows {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         assert!(!path.contains('\\'), "backslash in export path: {path}");
 
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(
             !module.contains('\\'),
             "backslash in export module: {module}"
@@ -325,7 +325,7 @@ fn hardening_module_json_no_backslash_in_modules() {
     let rows = v["rows"].as_array().expect("rows");
 
     for row in rows {
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(!module.contains('\\'), "backslash in module name: {module}");
     }
 }
@@ -393,7 +393,7 @@ fn hardening_redact_produces_deterministic_output() {
     let rows = v["rows"].as_array().expect("rows");
     assert!(!rows.is_empty(), "redacted export must have rows");
     for row in rows {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         // Redacted paths are hex hashes, not readable source paths
         assert!(
             !path.starts_with("src/") && !path.starts_with("script"),

--- a/crates/tokmd/tests/determinism_hardening_w51.rs
+++ b/crates/tokmd/tests/determinism_hardening_w51.rs
@@ -305,10 +305,10 @@ fn w51_export_paths_sorted_lexicographically_on_forward_slash() {
 
     // Within same code-line bucket, paths must be in ascending lex order
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_path = pair[0]["path"].as_str().expect("row field should be a string");
+        let b_path = pair[1]["path"].as_str().expect("row field should be a string");
 
         if a_code == b_code {
             assert!(
@@ -338,8 +338,8 @@ fn w51_lang_rows_sorted_by_code_desc() {
     assert!(!rows.is_empty(), "lang must produce at least one row");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
         assert!(
             a_code >= b_code,
             "lang rows not sorted by code descending: {} < {}",
@@ -360,11 +360,11 @@ fn w51_lang_rows_tiebreak_by_name_asc() {
     let rows = json["rows"].as_array().expect("rows array");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
         if a_code == b_code {
-            let a_name = pair[0]["lang"].as_str().unwrap();
-            let b_name = pair[1]["lang"].as_str().unwrap();
+            let a_name = pair[0]["lang"].as_str().expect("row field should be a string");
+            let b_name = pair[1]["lang"].as_str().expect("row field should be a string");
             assert!(
                 a_name <= b_name,
                 "lang tie-break must be ascending by name: {a_name} > {b_name}"
@@ -385,8 +385,8 @@ fn w51_module_rows_sorted_by_code_desc() {
     assert!(!rows.is_empty(), "module must produce at least one row");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
         assert!(
             a_code >= b_code,
             "module rows not sorted by code descending: {} < {}",
@@ -409,10 +409,10 @@ fn w51_export_rows_deterministic_order() {
 
     // Export rows must be sorted by code desc, then path asc
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_path = pair[0]["path"].as_str().expect("row field should be a string");
+        let b_path = pair[1]["path"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),
@@ -434,23 +434,23 @@ fn w51_lang_totals_equal_row_sums() {
     let rows = json["rows"].as_array().expect("rows array");
     let total = &json["total"];
 
-    let sum_code: u64 = rows.iter().map(|r| r["code"].as_u64().unwrap()).sum();
-    let sum_lines: u64 = rows.iter().map(|r| r["lines"].as_u64().unwrap()).sum();
-    let sum_files: u64 = rows.iter().map(|r| r["files"].as_u64().unwrap()).sum();
+    let sum_code: u64 = rows.iter().map(|r| r["code"].as_u64().expect("code row should be a u64 number")).sum();
+    let sum_lines: u64 = rows.iter().map(|r| r["lines"].as_u64().expect("code row should be a u64 number")).sum();
+    let sum_files: u64 = rows.iter().map(|r| r["files"].as_u64().expect("code row should be a u64 number")).sum();
 
     assert_eq!(
         sum_code,
-        total["code"].as_u64().unwrap(),
+        total["code"].as_u64().expect("code row should be a u64 number"),
         "code total mismatch"
     );
     assert_eq!(
         sum_lines,
-        total["lines"].as_u64().unwrap(),
+        total["lines"].as_u64().expect("code row should be a u64 number"),
         "lines total mismatch"
     );
     assert_eq!(
         sum_files,
-        total["files"].as_u64().unwrap(),
+        total["files"].as_u64().expect("code row should be a u64 number"),
         "files total mismatch"
     );
 }
@@ -658,11 +658,11 @@ fn w51_module_tiebreak_by_name_asc() {
     let rows = json["rows"].as_array().expect("rows array");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
         if a_code == b_code {
-            let a_mod = pair[0]["module"].as_str().unwrap();
-            let b_mod = pair[1]["module"].as_str().unwrap();
+            let a_mod = pair[0]["module"].as_str().expect("row field should be a string");
+            let b_mod = pair[1]["module"].as_str().expect("row field should be a string");
             assert!(
                 a_mod <= b_mod,
                 "module tie-break must be ascending by name: {a_mod} > {b_mod}"

--- a/crates/tokmd/tests/determinism_regression.rs
+++ b/crates/tokmd/tests/determinism_regression.rs
@@ -147,9 +147,9 @@ fn export_json_no_backslash_in_path_or_module() {
     let rows = json["rows"].as_array().expect("rows");
 
     for (i, row) in rows.iter().enumerate() {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         assert!(!path.contains('\\'), "row[{i}].path has backslash: {path}");
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(
             !module.contains('\\'),
             "row[{i}].module has backslash: {module}"
@@ -167,7 +167,7 @@ fn module_json_no_backslash_in_module_keys() {
     let rows = json["rows"].as_array().expect("rows");
 
     for (i, row) in rows.iter().enumerate() {
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(
             !module.contains('\\'),
             "row[{i}].module has backslash: {module}"
@@ -348,10 +348,10 @@ fn lang_rows_descending_code_ascending_name() {
     let rows = json["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["lang"].as_str().unwrap();
-        let b_name = pair[1]["lang"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_name = pair[0]["lang"].as_str().expect("row field should be a string");
+        let b_name = pair[1]["lang"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
@@ -370,10 +370,10 @@ fn module_rows_descending_code_ascending_module() {
     let rows = json["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_mod = pair[0]["module"].as_str().unwrap();
-        let b_mod = pair[1]["module"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_mod = pair[0]["module"].as_str().expect("row field should be a string");
+        let b_mod = pair[1]["module"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_mod <= b_mod),
@@ -392,10 +392,10 @@ fn export_rows_descending_code_ascending_path() {
     let rows = json["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_path = pair[0]["path"].as_str().expect("row field should be a string");
+        let b_path = pair[1]["path"].as_str().expect("row field should be a string");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),
@@ -599,7 +599,7 @@ fn module_keys_deterministic_across_runs() {
             .as_array()
             .expect("rows")
             .iter()
-            .map(|r| r["module"].as_str().unwrap().to_string())
+            .map(|r| r["module"].as_str().expect("row field should be a string").to_string())
             .collect::<Vec<_>>()
     };
 
@@ -621,7 +621,7 @@ fn export_module_keys_match_module_command() {
             .as_array()
             .expect("rows")
             .iter()
-            .map(|r| r["module"].as_str().unwrap().to_string())
+            .map(|r| r["module"].as_str().expect("row field should be a string").to_string())
             .collect();
         mods.sort();
         mods.dedup();
@@ -638,7 +638,7 @@ fn export_module_keys_match_module_command() {
             .as_array()
             .expect("rows")
             .iter()
-            .map(|r| r["module"].as_str().unwrap().to_string())
+            .map(|r| r["module"].as_str().expect("row field should be a string").to_string())
             .collect();
         mods.sort();
         mods.dedup();

--- a/crates/tokmd/tests/determinism_w40.rs
+++ b/crates/tokmd/tests/determinism_w40.rs
@@ -161,10 +161,10 @@ fn lang_rows_sorted_desc_code_asc_name() {
     assert!(!rows.is_empty(), "must have at least one row");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["lang"].as_str().unwrap();
-        let b_name = pair[1]["lang"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_name = pair[0]["lang"].as_str().expect("row field should be a string");
+        let b_name = pair[1]["lang"].as_str().expect("row field should be a string");
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
             "lang sort violated: {a_name}({a_code}) before {b_name}({b_code})"
@@ -183,10 +183,10 @@ fn module_rows_sorted_consistently() {
     assert!(!rows.is_empty(), "must have at least one row");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_mod = pair[0]["module"].as_str().unwrap();
-        let b_mod = pair[1]["module"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_mod = pair[0]["module"].as_str().expect("row field should be a string");
+        let b_mod = pair[1]["module"].as_str().expect("row field should be a string");
         assert!(
             a_code > b_code || (a_code == b_code && a_mod <= b_mod),
             "module sort violated: {a_mod}({a_code}) before {b_mod}({b_code})"
@@ -205,10 +205,10 @@ fn file_rows_sorted_consistently() {
     assert!(!rows.is_empty(), "must have at least one row");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_path = pair[0]["path"].as_str().expect("row field should be a string");
+        let b_path = pair[1]["path"].as_str().expect("row field should be a string");
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),
             "file sort violated: {a_path}({a_code}) before {b_path}({b_code})"
@@ -230,12 +230,12 @@ fn all_paths_use_forward_slashes_in_export() {
     let rows = json["rows"].as_array().expect("rows");
 
     for (i, row) in rows.iter().enumerate() {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         assert!(
             !path.contains('\\'),
             "row[{i}].path contains backslash: {path}"
         );
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(
             !module.contains('\\'),
             "row[{i}].module contains backslash: {module}"
@@ -344,7 +344,7 @@ fn lang_names_deterministic_across_runs() {
             .as_array()
             .expect("rows")
             .iter()
-            .map(|r| r["lang"].as_str().unwrap().to_string())
+            .map(|r| r["lang"].as_str().expect("row field should be a string").to_string())
             .collect::<Vec<_>>()
     };
     let a = get_names();
@@ -365,7 +365,7 @@ fn export_file_kinds_deterministic() {
             .as_array()
             .expect("rows")
             .iter()
-            .map(|r| r["kind"].as_str().unwrap().to_string())
+            .map(|r| r["kind"].as_str().expect("row field should be a string").to_string())
             .collect::<Vec<_>>()
     };
     let a = get_kinds();

--- a/crates/tokmd/tests/determinism_w70.rs
+++ b/crates/tokmd/tests/determinism_w70.rs
@@ -219,10 +219,10 @@ fn w70_lang_rows_sorted_desc_code_then_name() {
     assert!(rows.len() >= 2, "need at least 2 lang rows for sort check");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["lang"].as_str().unwrap();
-        let b_name = pair[1]["lang"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_name = pair[0]["lang"].as_str().expect("row field should be a string");
+        let b_name = pair[1]["lang"].as_str().expect("row field should be a string");
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
             "lang sort violated: {a_name}({a_code}) before {b_name}({b_code})"
@@ -249,10 +249,10 @@ fn w70_module_rows_sorted_desc_code_then_name() {
     );
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["module"].as_str().unwrap();
-        let b_name = pair[1]["module"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_name = pair[0]["module"].as_str().expect("row field should be a string");
+        let b_name = pair[1]["module"].as_str().expect("row field should be a string");
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
             "module sort violated: {a_name}({a_code}) before {b_name}({b_code})"
@@ -273,7 +273,7 @@ fn w70_export_json_paths_use_forward_slashes() {
     assert!(out.status.success());
     let v: Value = serde_json::from_slice(&out.stdout).expect("parse");
     for row in v["rows"].as_array().expect("rows") {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         assert!(
             !path.contains('\\'),
             "backslash in export JSON path: {path}"
@@ -326,7 +326,7 @@ fn w70_module_json_paths_use_forward_slashes() {
     assert!(out.status.success());
     let v: Value = serde_json::from_slice(&out.stdout).expect("parse");
     for row in v["rows"].as_array().expect("rows") {
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(!module.contains('\\'), "backslash in module path: {module}");
     }
 }
@@ -442,7 +442,7 @@ fn w70_unicode_filenames_forward_slashes() {
     assert!(out.status.success());
     let v: Value = serde_json::from_slice(&out.stdout).expect("parse");
     for row in v["rows"].as_array().expect("rows") {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("row field should be a string");
         assert!(!path.contains('\\'), "backslash in Unicode path: {path}");
     }
 }
@@ -525,7 +525,7 @@ fn w70_nested_dirs_forward_slashes_in_module_names() {
     assert!(out.status.success());
     let v: Value = serde_json::from_slice(&out.stdout).expect("parse");
     for row in v["rows"].as_array().expect("rows") {
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("row field should be a string");
         assert!(
             !module.contains('\\'),
             "backslash in nested module path: {module}"
@@ -549,10 +549,10 @@ fn w70_nested_dirs_export_sort_stable() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_path = pair[0]["path"].as_str().expect("row field should be a string");
+        let b_path = pair[1]["path"].as_str().expect("row field should be a string");
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),
             "nested export sort violated: {a_path}({a_code}) before {b_path}({b_code})"
@@ -609,10 +609,10 @@ fn w70_mixed_languages_sorted_correctly() {
     assert!(rows.len() >= 2, "need multiple languages for sort check");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["lang"].as_str().unwrap();
-        let b_name = pair[1]["lang"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("code row should be a u64 number");
+        let b_code = pair[1]["code"].as_u64().expect("code row should be a u64 number");
+        let a_name = pair[0]["lang"].as_str().expect("row field should be a string");
+        let b_name = pair[1]["lang"].as_str().expect("row field should be a string");
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
             "mixed-case lang sort violated: {a_name}({a_code}) before {b_name}({b_code})"


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Replaced opaque `.unwrap()` calls with descriptive `.expect()` messages across all determinism tests in `tokmd/tests/determinism*.rs`.

## 🎯 Why (perf bottleneck)
Test failures involving Serde JSON extraction (like `.as_u64().unwrap()`) previously crashed with generic `unwrap on a None value` messages, requiring a debugger to pinpoint which invariant failed. Descriptive `expect` messages provide immediate context, speeding up test failure resolution and improving the overall Developer Experience (DX).

## 📊 Proof (before/after)
- **Before**: `thread 'test' panicked at 'called Option::unwrap() on a None value'`
- **After**: `thread 'test' panicked at 'code row should be a u64 number'`
Tested locally via `cargo test -p tokmd --test determinism*`

## 🧭 Options considered
### Option A (recommended)
- Replace `.unwrap()` with `.expect("<message>")` for all `Value` conversions in the determinism tests.
- **Why it fits:** Aligns with Rust idiomatic testing, enforces strict structural invariants, and provides actionable context upon failure.
- **Trade-offs:** Slightly more verbose test code, but the DX improvement outweighs the brevity loss.

### Option B
- Ignore the `unwrap` calls and wait for failures to debug manually.
- **When to choose:** In disposable scripts or exploratory code.
- **Trade-offs:** Saves upfront typing but significantly degrades debugging velocity during CI/CD.

## ✅ Decision
Option A was chosen to fulfill the Gatekeeper persona's goal of "tightening invariants with targeted tests" and improving test determinism observability.

## 🧱 Changes made (SRP)
- `crates/tokmd/tests/determinism.rs`
- `crates/tokmd/tests/determinism_hardening.rs`
- `crates/tokmd/tests/determinism_hardening_w51.rs`
- `crates/tokmd/tests/determinism_regression.rs`
- `crates/tokmd/tests/determinism_w40.rs`
- `crates/tokmd/tests/determinism_w70.rs`

## 🧪 Verification receipts
```bash
cargo test -p tokmd --test determinism*
# Output
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.31s
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.30s
test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.45s
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.45s
```

## 🧭 Telemetry
- Change shape: Shallow but wide across test files.
- Blast radius: Zero impact on production code. Confined to test suite.
- Risk class: Very Low.
- Rollback: `git revert`
- Merge-confidence gates: Run `cargo test`

## 🗂️ .jules updates
Appended run entry `53b384a0-1d6f-4f34-99da-22dd7017939c` to `.jules/quality/ledger.json` and saved run envelope.

## 📝 Notes (freeform)
N/A

## 🔜 Follow-ups
N/A
---

---
*PR created automatically by Jules for task [2517799820068152894](https://jules.google.com/task/2517799820068152894) started by @EffortlessSteven*