### PR TITLE
refactor: burn down unwraps in tokmd-cockpit determinism tests 🛡️ Sentinel

### DIFF
--- a/.jules/security/envelopes/40c329df-9aad-42bb-9d47-f522bac12c6c.json
+++ b/.jules/security/envelopes/40c329df-9aad-42bb-9d47-f522bac12c6c.json
@@ -1,0 +1,24 @@
+{
+  "run_id": "40c329df-9aad-42bb-9d47-f522bac12c6c",
+  "timestamp_utc": "2026-03-30T12:04:47Z",
+  "lane": "scout",
+  "target": "tokmd-cockpit determinism tests",
+  "commands": [
+    {
+      "cmd": "cargo test -p tokmd-cockpit",
+      "status": "PASS",
+      "summary": "tokmd-cockpit tests pass after unwrap removal"
+    },
+    {
+      "cmd": "cargo clippy -p tokmd-cockpit -- -D warnings",
+      "status": "PASS",
+      "summary": "tokmd-cockpit clippy passes after unwrap removal"
+    },
+    {
+      "cmd": "cargo build -p tokmd-cockpit",
+      "status": "PASS",
+      "summary": "tokmd-cockpit builds successfully after unwrap removal"
+    }
+  ],
+  "results": {}
+}

--- a/.jules/security/ledger.json
+++ b/.jules/security/ledger.json
@@ -65,5 +65,19 @@
     ],
     "status": "PASS",
     "friction_ids": []
+  },
+  {
+    "date": "2026-03-30T12:04:47Z",
+    "lane": "scout",
+    "target": "Burn down test unwraps in tokmd-cockpit/src/determinism.rs",
+    "pr_link": "PENDING",
+    "gates": [
+      "build",
+      "test",
+      "fmt",
+      "clippy"
+    ],
+    "status": "PASS",
+    "friction_ids": []
   }
 ]

--- a/.jules/security/runs/2026-03-30.md
+++ b/.jules/security/runs/2026-03-30.md
@@ -1,0 +1,22 @@
+# Security Run: 2026-03-30
+
+**Run ID:** [40c329df-9aad-42bb-9d47-f522bac12c6c](../envelopes/40c329df-9aad-42bb-9d47-f522bac12c6c.json)
+**Lane:** scout
+**Target:** tokmd-cockpit determinism tests (unwrap/expect burn-down)
+
+## Findings
+- Identified ~46 instances of \`.unwrap()\` in \`crates/tokmd-cockpit/src/determinism.rs\` tests.
+- These panics make test failures less actionable and obscure underlying errors (especially related to I/O and tempfile generation).
+
+## Options Considered
+### Option A (recommended)
+- Refactor \`#[test]\` functions in \`determinism.rs\` to return \`anyhow::Result<()>\`.
+- Replace \`.unwrap()\` with \`?\` to propagate errors properly.
+- Why it fits: Matches repo goal of "treat unwrap/expect/panic as candidates everywhere" and improves Developer Experience (DX) when tests fail.
+
+### Option B
+- Replace \`.unwrap()\` with \`.expect("detailed message")\`.
+- Trade-offs: Still causes panics rather than clean error propagation, doesn't improve test determinism failures as much as Result-based errors.
+
+## Decision
+Selected Option A. It's the most idiomatic Rust approach for test error handling and provides the cleanest burn-down of unwraps.

--- a/crates/tokmd-cockpit/src/determinism.rs
+++ b/crates/tokmd-cockpit/src/determinism.rs
@@ -150,135 +150,148 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn test_hash_files_deterministic() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_hash_files_deterministic() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
 
         let paths = vec!["a.rs", "b.rs"];
-        let h1 = hash_files_from_paths(dir.path(), &paths).unwrap();
-        let h2 = hash_files_from_paths(dir.path(), &paths).unwrap();
+        let h1 = hash_files_from_paths(dir.path(), &paths)?;
+        let h2 = hash_files_from_paths(dir.path(), &paths)?;
 
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // BLAKE3 hex digest
+        Ok(())
     }
 
     #[test]
-    fn test_hash_files_order_independent() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_hash_files_order_independent() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
 
-        let h1 = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"]).unwrap();
-        let h2 = hash_files_from_paths(dir.path(), &["b.rs", "a.rs"]).unwrap();
+        let h1 = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"])?;
+        let h2 = hash_files_from_paths(dir.path(), &["b.rs", "a.rs"])?;
 
         assert_eq!(h1, h2, "hash should be order-independent");
+
+        Ok(())
     }
 
     #[test]
-    fn test_hash_files_changes_on_modification() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
+    fn test_hash_files_changes_on_modification() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
 
-        let h1 = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let h1 = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
-        fs::write(dir.path().join("a.rs"), "fn main() { panic!(); }").unwrap();
+        fs::write(dir.path().join("a.rs"), "fn main() { panic!(); }")?;
 
-        let h2 = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let h2 = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
         assert_ne!(h1, h2, "hash should change when file content changes");
+
+        Ok(())
     }
 
     #[test]
-    fn test_hash_cargo_lock_present() {
-        let dir = tempfile::tempdir().unwrap();
+    fn test_hash_cargo_lock_present() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
         fs::write(
             dir.path().join("Cargo.lock"),
             "[[package]]\nname = \"test\"",
-        )
-        .unwrap();
+        )?;
 
-        let result = hash_cargo_lock(dir.path()).unwrap();
+        let result = hash_cargo_lock(dir.path())?;
         assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), 64);
+        assert_eq!(result.unwrap_or_default().len(), 64);
+        Ok(())
     }
 
     #[test]
-    fn test_hash_cargo_lock_absent() {
-        let dir = tempfile::tempdir().unwrap();
+    fn test_hash_cargo_lock_absent() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
 
-        let result = hash_cargo_lock(dir.path()).unwrap();
+        let result = hash_cargo_lock(dir.path())?;
         assert!(result.is_none());
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_hash_files_from_walk_deterministic() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_hash_files_from_walk_deterministic() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
 
-        let h1 = hash_files_from_walk(dir.path(), &[]).unwrap();
-        let h2 = hash_files_from_walk(dir.path(), &[]).unwrap();
+        let h1 = hash_files_from_walk(dir.path(), &[])?;
+        let h2 = hash_files_from_walk(dir.path(), &[])?;
 
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64);
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_walk_and_paths_produce_same_hash() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_walk_and_paths_produce_same_hash() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
         // Create .git marker so ignore crate works properly
-        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::create_dir_all(dir.path().join(".git"))?;
 
-        let from_paths = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"]).unwrap();
-        let from_walk = hash_files_from_walk(dir.path(), &[]).unwrap();
+        let from_paths = hash_files_from_paths(dir.path(), &["a.rs", "b.rs"])?;
+        let from_walk = hash_files_from_walk(dir.path(), &[])?;
 
         assert_eq!(
             from_paths, from_walk,
             "walk and explicit paths should produce same hash for same files"
         );
+
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_walk_excludes_specified_paths() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
-        fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+    fn test_walk_excludes_specified_paths() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
+        fs::write(dir.path().join("b.rs"), "fn test() {}")?;
         // Create .git marker so ignore crate works properly
-        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::create_dir_all(dir.path().join(".git"))?;
 
         // Walk excluding b.rs should match paths-only hash of just a.rs
-        let walk_excluded = hash_files_from_walk(dir.path(), &["b.rs"]).unwrap();
-        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let walk_excluded = hash_files_from_walk(dir.path(), &["b.rs"])?;
+        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
         assert_eq!(
             walk_excluded, paths_only,
             "excluding b.rs from walk should match paths-only a.rs"
         );
+
+        Ok(())
     }
 
     #[cfg(feature = "git")]
     #[test]
-    fn test_walk_excludes_tokmd_directory() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
+    fn test_walk_excludes_tokmd_directory() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join("a.rs"), "fn main() {}")?;
         // Create .git marker so ignore crate works properly
-        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::create_dir_all(dir.path().join(".git"))?;
         // Create .tokmd directory with a baseline file -- should be auto-excluded
-        fs::create_dir_all(dir.path().join(".tokmd")).unwrap();
-        fs::write(dir.path().join(".tokmd/baseline.json"), "{}").unwrap();
+        fs::create_dir_all(dir.path().join(".tokmd"))?;
+        fs::write(dir.path().join(".tokmd/baseline.json"), "{}")?;
 
-        let with_tokmd = hash_files_from_walk(dir.path(), &[]).unwrap();
-        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"]).unwrap();
+        let with_tokmd = hash_files_from_walk(dir.path(), &[])?;
+        let paths_only = hash_files_from_paths(dir.path(), &["a.rs"])?;
 
         assert_eq!(
             with_tokmd, paths_only,
             ".tokmd/ directory should be auto-excluded from walk hash"
         );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Refactored `crates/tokmd-cockpit/src/determinism.rs` tests to return `anyhow::Result<()>` and replaced all instances of `.unwrap()` with `?`. 

## 🎯 Why / Threat model
Panicking within tests (especially for I/O operations and tempfile generation) obscures test failures by dumping stack traces and hiding the underlying cause of failure. Returning `Result` handles errors idiomatically and gracefully bubbles them up to the test runner. This adheres to the repository's explicit goal to "treat unwrap/expect/panic as candidates everywhere" and improves overall code quality and Developer Experience (DX).

## 🔎 Finding (evidence)
Observed ~46 instances of `.unwrap()` in `crates/tokmd-cockpit/src/determinism.rs` using `rg -n "unwrap" crates/tokmd-cockpit/src/determinism.rs`.

## 🧭 Options considered
### Option A (recommended)
- Refactor `#[test]` functions to return `anyhow::Result<()>`.
- Replace `.unwrap()` with `?`.
- Trade-offs: Requires a slightly different test signature and explicit `Ok(())` returns, but provides significantly cleaner error propagation and strictly removes panics.

### Option B
- Replace `.unwrap()` with `.expect("detailed reason")`.
- Trade-offs: Still relies on panics and doesn't improve test failure legibility as cleanly as proper error handling.

## ✅ Decision
Selected Option A. It's the most idiomatic Rust approach for test error handling and provides the cleanest burn-down of unwraps.

## 🧱 Changes made (SRP)
- `crates/tokmd-cockpit/src/determinism.rs`

## 🧪 Verification receipts
- `cargo test -p tokmd-cockpit`: PASS
- `cargo clippy -p tokmd-cockpit -- -D warnings`: PASS
- `cargo build -p tokmd-cockpit`: PASS

## 🧭 Telemetry
- Change shape: Test refactoring only.
- Blast radius: `crates/tokmd-cockpit` testing module. No API or IO boundaries changed.
- Risk class: Low. Test logic unmodified.
- Merge-confidence gates: `build`, `test`, `clippy`

## 🗂️ .jules updates
- Updated `.jules/security/ledger.json` with the scout target run entry.
- Created `.jules/security/runs/2026-03-30.md` detailing the investigation and decision.
- Created `.jules/security/envelopes/40c329df-9aad-42bb-9d47-f522bac12c6c.json` with execution receipts.

## 📝 Notes (freeform)
N/A

## 🔜 Follow-ups
N/A
---

---
*PR created automatically by Jules for task [16187616763370984202](https://jules.google.com/task/16187616763370984202) started by @EffortlessSteven*