### PR TITLE
docs: add doctests for core types 📚 Librarian

### DIFF
--- a/crates/tokmd-types/src/lib.rs
+++ b/crates/tokmd-types/src/lib.rs
@@ -100,6 +100,40 @@ pub struct LangRow {
     pub avg_lines: usize,
 }
 
+/// A report detailing language statistics.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_types::{LangReport, LangRow, Totals, ChildrenMode};
+///
+/// let report = LangReport {
+///     rows: vec![
+///         LangRow {
+///             lang: "Rust".to_string(),
+///             code: 5000,
+///             lines: 6500,
+///             files: 42,
+///             bytes: 180_000,
+///             tokens: 45_000,
+///             avg_lines: 154,
+///         }
+///     ],
+///     total: Totals {
+///         code: 5000,
+///         lines: 6500,
+///         files: 42,
+///         bytes: 180_000,
+///         tokens: 45_000,
+///         avg_lines: 154,
+///     },
+///     with_files: false,
+///     children: ChildrenMode::Collapse,
+///     top: 10,
+/// };
+/// assert_eq!(report.rows.len(), 1);
+/// assert_eq!(report.total.files, 42);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LangReport {
     pub rows: Vec<LangRow>,
@@ -193,6 +227,34 @@ pub struct FileRow {
     pub tokens: usize,
 }
 
+/// Detailed export data containing individual file statistics.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_types::{ExportData, FileRow, FileKind, ChildIncludeMode};
+///
+/// let data = ExportData {
+///     rows: vec![
+///         FileRow {
+///             path: "src/main.rs".to_string(),
+///             module: "src".to_string(),
+///             lang: "Rust".to_string(),
+///             kind: FileKind::Parent,
+///             code: 120,
+///             comments: 30,
+///             blanks: 20,
+///             lines: 170,
+///             bytes: 4_800,
+///             tokens: 1_200,
+///         }
+///     ],
+///     module_roots: vec![],
+///     module_depth: 1,
+///     children: ChildIncludeMode::Separate,
+/// };
+/// assert_eq!(data.rows.len(), 1);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportData {
     pub rows: Vec<FileRow>,


### PR DESCRIPTION
## 💡 Summary
Added comprehensive, compiling doctests for the `LangReport` and `ExportData` structures in `crates/tokmd-types/src/lib.rs`.

## 🎯 Why (perf bottleneck)
This is a documentation and safety improvement. Adding runnable doctests ensures that the examples for our core data structures remain valid as the API evolves, preventing documentation drift and providing immediate, verifiable usage examples for downstream consumers.

## 📊 Proof (before/after)
N/A - Documentation only.

## 🧭 Options considered
### Option A (recommended)
- Add complete, structured, and compiling doctests showing exactly how to instantiate `LangReport` and `ExportData` with mock data, verifying the shape of the data structures.
- **Why it fits**: Adheres to the "docs as code" and "executable examples" philosophy required by the Librarian persona.
- **Trade-offs**: Slightly increases file length.

### Option B
- Add conceptual Markdown descriptions without code.
- **When to choose**: High-level architecture docs.
- **Trade-offs**: Prone to silent drift.

## ✅ Decision
Option A. Added full `/// ```rust` doctests that construct the objects and perform basic assertions.

## 🧱 Changes made (SRP)
- `crates/tokmd-types/src/lib.rs`: Inserted doctest blocks for `LangReport` and `ExportData`.

## 🧪 Verification receipts
```bash
cargo test -p tokmd-types --doc
```
```text
running 14 tests
test crates/tokmd-types/src/lib.rs - CONTEXT_BUNDLE_SCHEMA_VERSION (line 704) ... ok
test crates/tokmd-types/src/lib.rs - DiffRow (line 508) ... ok
test crates/tokmd-types/src/lib.rs - DiffTotals (line 545) ... ok
test crates/tokmd-types/src/lib.rs - CONTEXT_SCHEMA_VERSION (line 711) ... ok
test crates/tokmd-types/src/lib.rs - ExportData (line 234) ... ok
test crates/tokmd-types/src/lib.rs - LangReport (line 107) ... ok
test crates/tokmd-types/src/lib.rs - FileRow (line 197) ... ok
test crates/tokmd-types/src/lib.rs - HANDOFF_SCHEMA_VERSION (line 697) ... ok
test crates/tokmd-types/src/lib.rs - LangRow (line 77) ... ok
test crates/tokmd-types/src/lib.rs - ModuleRow (line 150) ... ok
test crates/tokmd-types/src/lib.rs - SCHEMA_VERSION (line 41) ... ok
test crates/tokmd-types/src/lib.rs - TokenAudit::from_output (line 809) ... ok
test crates/tokmd-types/src/lib.rs - TokenEstimationMeta::from_bytes (line 757) ... ok
test crates/tokmd-types/src/lib.rs - Totals (line 50) ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

all doctests ran in 0.45s; merged doctests compilation took 0.43s
```

## 🧭 Telemetry
- Change shape: Internal library documentation addition.
- Blast radius: Zero runtime impact.
- Risk class: None.
- Rollback: Standard git revert.
- Merge-confidence gates: `cargo test --doc` passed.

## 🗂️ .jules updates
- Appended run entry to `.jules/docs/ledger.json`.
- Logged receipts to `.jules/docs/envelopes/<run_id>.json`.

---
*PR created automatically by Jules for task [2905842815005112579](https://jules.google.com/task/2905842815005112579) started by @EffortlessSteven*