### PR TITLE
deps: remove duplicate dev-dependencies already in dependencies 🧾 Auditor

### DIFF
--- a/crates/tokmd-cockpit/Cargo.toml
+++ b/crates/tokmd-cockpit/Cargo.toml
@@ -32,5 +32,4 @@ tokmd-git = { workspace = true, optional = true }
 [dev-dependencies]
 insta = { workspace = true }
 proptest.workspace = true
-serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/tokmd-config/Cargo.toml
+++ b/crates/tokmd-config/Cargo.toml
@@ -24,4 +24,3 @@ tokmd-types = { workspace = true, features = ["clap"] }
 proptest.workspace = true
 tempfile.workspace = true
 toml = "1.0"
-tokmd-settings.workspace = true

--- a/crates/tokmd-core/Cargo.toml
+++ b/crates/tokmd-core/Cargo.toml
@@ -49,8 +49,5 @@ tokmd-cockpit = { workspace = true, optional = true }
 tokmd-git = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow.workspace = true
 proptest.workspace = true
-serde_json.workspace = true
 tempfile.workspace = true
-tokmd-format.workspace = true

--- a/crates/tokmd-format/Cargo.toml
+++ b/crates/tokmd-format/Cargo.toml
@@ -26,5 +26,4 @@ tokmd-types.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 insta = { workspace = true }
-serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/tokmd-scan/Cargo.toml
+++ b/crates/tokmd-scan/Cargo.toml
@@ -20,5 +20,4 @@ tokmd-types.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-tempfile.workspace = true
 tokmd-model.workspace = true


### PR DESCRIPTION
## 💡 Summary
Removed duplicate `[dev-dependencies]` that were already declared under `[dependencies]` in multiple workspace crates (`tokmd-scan`, `tokmd-cockpit`, `tokmd-config`, `tokmd-core`, `tokmd-format`) to reduce manifest noise and compile surface.

## 🎯 Why (perf bottleneck)
Duplicated dependencies in `Cargo.toml` manifests add unnecessary visual noise and slightly increase parsing/resolution time during cargo operations, though the primary benefit is organizational hygiene and clarity.

## 📊 Proof (before/after)
Structural proof: Work eliminated by removing redundant configuration lines. The dependencies are already available to tests because they are listed under `[dependencies]`.

## 🧭 Options considered
### Option A (recommended)
- Remove the duplicates entirely.
- Why it fits this repo: Reduces clutter and adheres to Cargo's behavior where normal dependencies are implicitly available for tests.
- Trade-offs: Structure / Velocity / Governance - Cleaner manifests, slightly easier to maintain.

### Option B
- Leave the duplicates.
- When to choose it instead: Never, unless the dependency is marked as `optional = true` in `[dependencies]`, which was checked and handled (none of the removed ones were optional).
- Trade-offs: Unnecessary clutter.

## ✅ Decision
Chose Option A. It's a clean, zero-risk hygiene improvement.

## 🧱 Changes made (SRP)
- `crates/tokmd-scan/Cargo.toml`: Removed `tempfile` from `[dev-dependencies]`
- `crates/tokmd-cockpit/Cargo.toml`: Removed `serde_json` from `[dev-dependencies]`
- `crates/tokmd-config/Cargo.toml`: Removed `tokmd-settings` from `[dev-dependencies]`
- `crates/tokmd-core/Cargo.toml`: Removed `anyhow`, `serde_json`, and `tokmd-format` from `[dev-dependencies]`
- `crates/tokmd-format/Cargo.toml`: Removed `serde_json` from `[dev-dependencies]`

## 🧪 Verification receipts
- `cargo test -p tokmd-scan -p tokmd-cockpit -p tokmd-config -p tokmd-core -p tokmd-format --no-default-features`
- `cargo test -p tokmd-scan -p tokmd-cockpit -p tokmd-config -p tokmd-core -p tokmd-format`
- `cargo clippy -p tokmd-cockpit -p tokmd-config -p tokmd-core -p tokmd-format -p tokmd-scan -- -D warnings`

## 🧭 Telemetry
- Change shape: Manifest cleanup
- Blast radius: None (dev-dependencies only)
- Risk class: Very Low
- Rollback: Revert the commit
- Merge-confidence gates: `cargo test` and `cargo clippy` passed on affected crates.

## 🗂️ .jules updates
- Appended run entry to `.jules/deps/ledger.json`
- Created run envelope at `.jules/deps/envelopes/babc3896-0516-458c-b48d-84818b4589b7.json`
- Created run log at `.jules/deps/runs/2026-04-01.md`

---
*PR created automatically by Jules for task [12235727051419469142](https://jules.google.com/task/12235727051419469142) started by @EffortlessSteven*