### PR TITLE
perf: eliminate unnecessary JSON Value cloning in FFI entrypoint ⚡ Bolt

### DIFF
--- a/.jules/bolt/envelopes/b2d12673-068e-4631-93eb-2762f180afec.json
+++ b/.jules/bolt/envelopes/b2d12673-068e-4631-93eb-2762f180afec.json
@@ -1,0 +1,25 @@
+{
+  "run_id": "b2d12673-068e-4631-93eb-2762f180afec",
+  "timestamp_utc": "2026-04-03T12:13:26Z",
+  "lane": "scout",
+  "target": "crates/tokmd-analysis-api-surface/tests/unit.rs",
+  "proof_method": "structural",
+  "commands": [],
+  "results": [
+    {
+      "cmd": "cargo fmt",
+      "status": "0",
+      "output": ""
+    },
+    {
+      "cmd": "cargo clippy",
+      "status": "0",
+      "output": "    Checking tokmd-types v1.9.0 (/app/crates/tokmd-types)\n    Checking tokmd-redact v1.9.0 (/app/crates/tokmd-redact)\n    Checking tokmd-path v1.9.0 (/app/crates/tokmd-path)"
+    },
+    {
+      "cmd": "cargo test",
+      "status": "0",
+      "output": "test crates/tokmd-core/src/lib.rs - diff_workflow (line 298) ... ok\n\ntest result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.25s\n\nall doctests ran in 1.02s; merged doctests compilation took 0.74s"
+    }
+  ]
+}

--- a/.jules/bolt/ledger.json
+++ b/.jules/bolt/ledger.json
@@ -49,5 +49,19 @@
       "clippy"
     ],
     "friction_ids": []
+  },
+  {
+    "date": "2026-04-03T12:21:58Z",
+    "run_id": "b2d12673-068e-4631-93eb-2762f180afec",
+    "lane": "scout",
+    "target": "crates/tokmd-core/src/ffi.rs",
+    "proof_method": "structural",
+    "pr_link": null,
+    "gates": [
+      "fmt",
+      "clippy",
+      "test"
+    ],
+    "friction_ids": []
   }
 ]

--- a/.jules/bolt/runs/2026-04-03.md
+++ b/.jules/bolt/runs/2026-04-03.md
@@ -1,0 +1,42 @@
+# Run Log 2026-04-03
+
+## Context
+Read: CI definitions and standard policies.
+
+## Selection
+Lane: scout
+Target: crates/tokmd-analysis-api-surface/tests/unit.rs and other tests in that crate cloning heavily.
+
+## Proof Method
+structural (avoiding wasted .clone() allocations in tests and assertions).
+
+## Receipts
+(to be populated)
+
+## Options considered
+### Option A (recommended)
+- What it is: Remove unnecessary  calls in  when deserializing settings from .  requires an owned  but we only have a reference. We can use  instead which can deserialize directly from a , avoiding the deep copy.
+- Why it fits this repo: Fits the performance criteria perfectly, avoids allocating/cloning json nodes during every single FFI call.
+- Trade-offs: Structure: none. Velocity: easy change. Governance: preserves output determinism.
+
+### Option B
+- What it is: Pre-parse strings using  and pattern match to avoid  completely.
+- When to choose it instead: If the enums are simple and we want to bypass serde overhead entirely.
+- Trade-offs: Might desync from serde implementations of the actual types and requires manual implementations.
+
+## Decision
+Option A. It's safe, localized, leverages serde's native capability to deserialize from references without cloning, and removes an O(N) allocation per FFI parse call for these fields.
+
+## Options considered
+### Option A (recommended)
+- What it is: Remove unnecessary `.clone()` calls in `crates/tokmd-core/src/ffi.rs` when deserializing settings from `serde_json::Value`. `serde_json::from_value` requires an owned `Value` but we only have a reference. We can use `serde::Deserialize::deserialize(v)` instead which can deserialize directly from a `&Value`, avoiding the deep copy.
+- Why it fits this repo: Fits the performance criteria perfectly, avoids allocating/cloning json nodes during every single FFI call.
+- Trade-offs: Structure: none. Velocity: easy change. Governance: preserves output determinism.
+
+### Option B
+- What it is: Pre-parse strings using `v.as_str()` and pattern match to avoid `serde_json::from_value` completely.
+- When to choose it instead: If the enums are simple and we want to bypass serde overhead entirely.
+- Trade-offs: Might desync from serde implementations of the actual types and requires manual implementations.
+
+## Decision
+Option A. It's safe, localized, leverages serde's native capability to deserialize from references without cloning, and removes an O(N) allocation per FFI parse call for these fields.

--- a/crates/tokmd-core/src/ffi.rs
+++ b/crates/tokmd-core/src/ffi.rs
@@ -364,7 +364,7 @@ fn parse_in_memory_inputs(args: &Value) -> Result<Option<Vec<InMemoryFile>>, Tok
 fn parse_children_mode(args: &Value, default: ChildrenMode) -> Result<ChildrenMode, TokmdError> {
     match args.get("children") {
         None => Ok(default),
-        Some(v) => serde_json::from_value::<ChildrenMode>(v.clone())
+        Some(v) => serde::Deserialize::deserialize(v)
             .map_err(|_| TokmdError::invalid_field("children", "'collapse' or 'separate'")),
     }
 }
@@ -376,7 +376,7 @@ fn parse_child_include_mode(
 ) -> Result<ChildIncludeMode, TokmdError> {
     match args.get("children") {
         None => Ok(default),
-        Some(v) => serde_json::from_value::<ChildIncludeMode>(v.clone())
+        Some(v) => serde::Deserialize::deserialize(v)
             .map_err(|_| TokmdError::invalid_field("children", "'separate' or 'parents-only'")),
     }
 }
@@ -385,7 +385,7 @@ fn parse_child_include_mode(
 fn parse_redact_mode(args: &Value, default: RedactMode) -> Result<RedactMode, TokmdError> {
     match args.get("redact") {
         None => Ok(default),
-        Some(v) => serde_json::from_value::<RedactMode>(v.clone())
+        Some(v) => serde::Deserialize::deserialize(v)
             .map_err(|_| TokmdError::invalid_field("redact", "'none', 'paths', or 'all'")),
     }
 }
@@ -429,7 +429,7 @@ fn parse_effort_layer(args: &Value, field: &str) -> Result<Option<String>, Tokmd
 fn parse_optional_redact_mode(args: &Value) -> Result<Option<RedactMode>, TokmdError> {
     match args.get("redact") {
         None => Ok(None),
-        Some(v) => serde_json::from_value::<RedactMode>(v.clone())
+        Some(v) => serde::Deserialize::deserialize(v)
             .map(Some)
             .map_err(|_| TokmdError::invalid_field("redact", "'none', 'paths', or 'all'")),
     }
@@ -439,7 +439,7 @@ fn parse_optional_redact_mode(args: &Value) -> Result<Option<RedactMode>, TokmdE
 fn parse_config_mode(args: &Value, default: ConfigMode) -> Result<ConfigMode, TokmdError> {
     match args.get("config") {
         None => Ok(default),
-        Some(v) => serde_json::from_value::<ConfigMode>(v.clone())
+        Some(v) => serde::Deserialize::deserialize(v)
             .map_err(|_| TokmdError::invalid_field("config", "'auto' or 'none'")),
     }
 }
@@ -448,7 +448,7 @@ fn parse_config_mode(args: &Value, default: ConfigMode) -> Result<ConfigMode, To
 fn parse_export_format(args: &Value, default: ExportFormat) -> Result<ExportFormat, TokmdError> {
     match args.get("format") {
         None => Ok(default),
-        Some(v) => serde_json::from_value::<ExportFormat>(v.clone()).map_err(|_| {
+        Some(v) => serde::Deserialize::deserialize(v).map_err(|_| {
             TokmdError::invalid_field("format", "'csv', 'jsonl', 'json', or 'cyclonedx'")
         }),
     }


### PR DESCRIPTION
Replaced `serde_json::from_value(v.clone())` with `serde::Deserialize::deserialize(v)` in the FFI parsing routines, eliminating unneeded deep cloning of `Value` objects during language bindings interactions.

---
*PR created automatically by Jules for task [559102162616174505](https://jules.google.com/task/559102162616174505) started by @EffortlessSteven*