### PR TITLE
test: clarify invariants for determinism outputs 🧪 Gatekeeper

### DIFF
--- a/.jules/friction/open/determinism_unwrap.md
+++ b/.jules/friction/open/determinism_unwrap.md
@@ -1,0 +1,5 @@
+# Determinism Unwraps in tests
+
+There are raw `unwrap()` calls on line ~243-246, 263-266, 283-286 of `determinism_hardening.rs` that should be `expect()` calls to clearly state what's failing if the CLI determinism outputs are malformed.
+
+Tags: test, quality, determinism

--- a/.jules/quality/envelopes/f27a8e06-2388-4eb3-8892-42df8a536b62.json
+++ b/.jules/quality/envelopes/f27a8e06-2388-4eb3-8892-42df8a536b62.json
@@ -1,0 +1,7 @@
+{
+  "id": "f27a8e06-2388-4eb3-8892-42df8a536b62",
+  "persona": "Gatekeeper",
+  "status": "completed",
+  "start_time": "2026-04-06T09:47:39Z",
+  "receipts": ["fmt", "clippy", "test"]
+}

--- a/.jules/quality/ledger.json
+++ b/.jules/quality/ledger.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "runs": [
+    {
+      "date": "2026-04-06",
+      "lane": "B",
+      "target": "determinism_unwrap",
+      "pr_link": "",
+      "gates": [
+        "fmt",
+        "clippy",
+        "test"
+      ],
+      "friction_ids": [
+        "determinism_unwrap"
+      ]
+    }
+  ]
+}

--- a/.jules/quality/runs/2026-04-06.md
+++ b/.jules/quality/runs/2026-04-06.md
@@ -1,0 +1,12 @@
+# Gatekeeper Run 2026-04-06
+
+## Target Selection
+
+- **Option A (Friction Backlog):** Not actionable, no pre-existing friction items related to determinism. I created one for context but it was based on scout discovery.
+- **Option B (Scout Discovery):** Chosen. Found numerous raw `unwrap()` calls in `crates/tokmd/tests/determinism_hardening.rs` asserting JSON fields that can cause panics with opaque errors if the schema changes or output drifts.
+
+## Plan
+Replace these `unwrap()` calls with `expect()` calls to explicitly state what variant/field is expected, making failures easier to debug and reducing blind panics.
+
+## Changes
+Modified `crates/tokmd/tests/determinism_hardening.rs`

--- a/crates/tokmd/tests/determinism_hardening.rs
+++ b/crates/tokmd/tests/determinism_hardening.rs
@@ -234,10 +234,18 @@ fn hardening_lang_rows_sorted_desc_code_then_asc_name() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().expect("missing 'code' field for a");
-        let b_code = pair[1]["code"].as_u64().expect("missing 'code' field for b");
-        let a_name = pair[0]["lang"].as_str().expect("missing 'lang' field for a");
-        let b_name = pair[1]["lang"].as_str().expect("missing 'lang' field for b");
+        let a_code = pair[0]["code"]
+            .as_u64()
+            .expect("missing 'code' field for a");
+        let b_code = pair[1]["code"]
+            .as_u64()
+            .expect("missing 'code' field for b");
+        let a_name = pair[0]["lang"]
+            .as_str()
+            .expect("missing 'lang' field for a");
+        let b_name = pair[1]["lang"]
+            .as_str()
+            .expect("missing 'lang' field for b");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
@@ -256,10 +264,18 @@ fn hardening_module_rows_sorted_desc_code_then_asc_name() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().expect("missing 'code' field for a");
-        let b_code = pair[1]["code"].as_u64().expect("missing 'code' field for b");
-        let a_name = pair[0]["module"].as_str().expect("missing 'module' field for a");
-        let b_name = pair[1]["module"].as_str().expect("missing 'module' field for b");
+        let a_code = pair[0]["code"]
+            .as_u64()
+            .expect("missing 'code' field for a");
+        let b_code = pair[1]["code"]
+            .as_u64()
+            .expect("missing 'code' field for b");
+        let a_name = pair[0]["module"]
+            .as_str()
+            .expect("missing 'module' field for a");
+        let b_name = pair[1]["module"]
+            .as_str()
+            .expect("missing 'module' field for b");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
@@ -278,10 +294,18 @@ fn hardening_export_rows_sorted_desc_code_then_asc_path() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().expect("missing 'code' field for a");
-        let b_code = pair[1]["code"].as_u64().expect("missing 'code' field for b");
-        let a_path = pair[0]["path"].as_str().expect("missing 'path' field for a");
-        let b_path = pair[1]["path"].as_str().expect("missing 'path' field for b");
+        let a_code = pair[0]["code"]
+            .as_u64()
+            .expect("missing 'code' field for a");
+        let b_code = pair[1]["code"]
+            .as_u64()
+            .expect("missing 'code' field for b");
+        let a_path = pair[0]["path"]
+            .as_str()
+            .expect("missing 'path' field for a");
+        let b_path = pair[1]["path"]
+            .as_str()
+            .expect("missing 'path' field for b");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),

--- a/crates/tokmd/tests/determinism_hardening.rs
+++ b/crates/tokmd/tests/determinism_hardening.rs
@@ -234,10 +234,10 @@ fn hardening_lang_rows_sorted_desc_code_then_asc_name() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["lang"].as_str().unwrap();
-        let b_name = pair[1]["lang"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("missing 'code' field for a");
+        let b_code = pair[1]["code"].as_u64().expect("missing 'code' field for b");
+        let a_name = pair[0]["lang"].as_str().expect("missing 'lang' field for a");
+        let b_name = pair[1]["lang"].as_str().expect("missing 'lang' field for b");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
@@ -256,10 +256,10 @@ fn hardening_module_rows_sorted_desc_code_then_asc_name() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_name = pair[0]["module"].as_str().unwrap();
-        let b_name = pair[1]["module"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("missing 'code' field for a");
+        let b_code = pair[1]["code"].as_u64().expect("missing 'code' field for b");
+        let a_name = pair[0]["module"].as_str().expect("missing 'module' field for a");
+        let b_name = pair[1]["module"].as_str().expect("missing 'module' field for b");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_name <= b_name),
@@ -278,10 +278,10 @@ fn hardening_export_rows_sorted_desc_code_then_asc_path() {
     let rows = v["rows"].as_array().expect("rows");
 
     for pair in rows.windows(2) {
-        let a_code = pair[0]["code"].as_u64().unwrap();
-        let b_code = pair[1]["code"].as_u64().unwrap();
-        let a_path = pair[0]["path"].as_str().unwrap();
-        let b_path = pair[1]["path"].as_str().unwrap();
+        let a_code = pair[0]["code"].as_u64().expect("missing 'code' field for a");
+        let b_code = pair[1]["code"].as_u64().expect("missing 'code' field for b");
+        let a_path = pair[0]["path"].as_str().expect("missing 'path' field for a");
+        let b_path = pair[1]["path"].as_str().expect("missing 'path' field for b");
 
         assert!(
             a_code > b_code || (a_code == b_code && a_path <= b_path),
@@ -304,10 +304,10 @@ fn hardening_export_json_no_backslash_in_paths() {
     let rows = v["rows"].as_array().expect("rows");
 
     for row in rows {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("missing 'path' field");
         assert!(!path.contains('\\'), "backslash in export path: {path}");
 
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("missing 'module' field");
         assert!(
             !module.contains('\\'),
             "backslash in export module: {module}"
@@ -325,7 +325,7 @@ fn hardening_module_json_no_backslash_in_modules() {
     let rows = v["rows"].as_array().expect("rows");
 
     for row in rows {
-        let module = row["module"].as_str().unwrap();
+        let module = row["module"].as_str().expect("missing 'module' field");
         assert!(!module.contains('\\'), "backslash in module name: {module}");
     }
 }
@@ -393,7 +393,7 @@ fn hardening_redact_produces_deterministic_output() {
     let rows = v["rows"].as_array().expect("rows");
     assert!(!rows.is_empty(), "redacted export must have rows");
     for row in rows {
-        let path = row["path"].as_str().unwrap();
+        let path = row["path"].as_str().expect("missing 'path' field");
         // Redacted paths are hex hashes, not readable source paths
         assert!(
             !path.starts_with("src/") && !path.starts_with("script"),


### PR DESCRIPTION
Gatekeeper run to burn down blind `unwrap()`s inside `determinism_hardening.rs` tests.

Options A/B -> Option B chosen (Scout Discovery).

These changes address raw `unwrap()`s in `determinism_hardening.rs` array indexing, making schema mismatch and logic failures clear with explicit `.expect()` calls containing context on what field invariant failed.

Receipts:
* `cargo fmt -- --check`
* `cargo clippy -p tokmd -- -D warnings`
* `cargo test -p tokmd`

---
*PR created automatically by Jules for task [11236591612006320447](https://jules.google.com/task/11236591612006320447) started by @EffortlessSteven*