### PR TITLE
docs: add doctests for run, diff, and context CLI examples 📚 Librarian

### DIFF
--- a/.jules/docs/envelopes/36cec87d-2836-42ed-9ae1-33dbf2702319.json
+++ b/.jules/docs/envelopes/36cec87d-2836-42ed-9ae1-33dbf2702319.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "36cec87d-2836-42ed-9ae1-33dbf2702319",
+  "date": "2026-04-06",
+  "lane": "scout",
+  "target": "docs-doctest",
+  "pr_link": "N/A",
+  "receipts": [
+    "cargo test -p tokmd --test docs",
+    "cargo fmt -- --check",
+    "cargo clippy -p tokmd -- -D warnings"
+  ]
+}

--- a/.jules/docs/ledger.json
+++ b/.jules/docs/ledger.json
@@ -1,0 +1,14 @@
+[
+  {
+    "run_id": "36cec87d-2836-42ed-9ae1-33dbf2702319",
+    "date": "2026-04-06",
+    "lane": "scout",
+    "target": "docs-doctest",
+    "pr_link": "N/A",
+    "receipts": [
+      "cargo test -p tokmd --test docs",
+      "cargo fmt -- --check",
+      "cargo clippy -p tokmd -- -D warnings"
+    ]
+  }
+]

--- a/.jules/docs/runs/2026-04-06.md
+++ b/.jules/docs/runs/2026-04-06.md
@@ -1,0 +1,12 @@
+# Librarian Run 2026-04-06
+
+## Selection
+- Lane: Scout Discovery
+- Target: Missing CLI doctests for tokmd run, diff, and context
+
+## Options
+- **Option A**: Add a doctest for `tokmd run` and `tokmd diff` which is prominently featured in README and tutorials but lacks test coverage in `docs.rs`.
+- **Option B**: Add a doctest for `tokmd context` only.
+
+## Decision
+Chose **Option A** combined with context tests to maximize value. Implemented `recipe_run_and_diff` and `recipe_context_budget` in `crates/tokmd/tests/docs.rs`.

--- a/crates/tokmd/tests/docs.rs
+++ b/crates/tokmd/tests/docs.rs
@@ -80,6 +80,54 @@ fn recipe_analyze_presets() {
 }
 
 #[test]
+fn recipe_run_and_diff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let baseline_dir = tmp.path().join(".runs").join("baseline");
+    let current_dir = tmp.path().join(".runs").join("current");
+
+    // "tokmd run --analysis receipt --output-dir .runs/baseline"
+    tokmd()
+        .arg("run")
+        .arg("--analysis")
+        .arg("receipt")
+        .arg("--output-dir")
+        .arg(&baseline_dir)
+        .assert()
+        .success();
+    assert!(baseline_dir.join("receipt.json").exists());
+
+    // "tokmd run --analysis receipt --output-dir .runs/current"
+    tokmd()
+        .arg("run")
+        .arg("--analysis")
+        .arg("receipt")
+        .arg("--output-dir")
+        .arg(&current_dir)
+        .assert()
+        .success();
+    assert!(current_dir.join("receipt.json").exists());
+
+    // "tokmd diff .runs/baseline .runs/current"
+    tokmd()
+        .arg("diff")
+        .arg(&baseline_dir)
+        .arg(&current_dir)
+        .assert()
+        .success();
+}
+
+#[test]
+fn recipe_context_budget() {
+    // "tokmd context --budget 128k"
+    tokmd()
+        .arg("context")
+        .arg("--budget")
+        .arg("128k")
+        .assert()
+        .success();
+}
+
+#[test]
 fn recipe_tools_export_schemas() {
     // "tokmd tools --format openai --pretty"
     tokmd()

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,32 @@
+## Glass Cockpit
+
+**Lane**: Scout Discovery
+**Target**: CLI Doctests (`tokmd run`, `tokmd diff`, `tokmd context`)
+
+### The Friction
+The README and official tutorials (`docs/tutorial.md`) heavily feature `tokmd run`, `tokmd diff`, and `tokmd context --budget 128k` as primary workflows. However, these commands lacked "Docs as tests" coverage in `crates/tokmd/tests/docs.rs`. This creates a risk of silent documentation drift if the CLI flags or behavior change.
+
+### Options Evaluated
+- **Option A (Recommended)**: Add tests matching the specific exact strings used in `docs/tutorial.md` and `README.md` for `tokmd run`, `tokmd diff`, and `tokmd context`.
+- **Option B**: Only test `tokmd diff` since `tokmd run` is indirectly covered by other integration tests.
+
+### The Fix
+Chose **Option A**. Appended `recipe_run_and_diff` and `recipe_context_budget` to `crates/tokmd/tests/docs.rs`, directly mapping to the user-facing documentation. The `run_and_diff` test correctly isolates execution by generating a pair of local temporary `.runs/` directories (baseline and current) and diffing them, fulfilling the architectural determinism invariants.
+
+### Receipts
+
+**doctest execution**
+```text
+running 16 tests
+test recipe_context_budget ... ok
+test recipe_run_and_diff ... ok
+[... truncated 14 others ...]
+test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s
+```
+
+**clippy & format**
+```text
+cargo fmt -- --check
+cargo clippy -p tokmd -- -D warnings
+# (passed cleanly)
+```


### PR DESCRIPTION
## Glass Cockpit

**Lane**: Scout Discovery
**Target**: CLI Doctests (`tokmd run`, `tokmd diff`, `tokmd context`)

### The Friction
The README and official tutorials (`docs/tutorial.md`) heavily feature `tokmd run`, `tokmd diff`, and `tokmd context --budget 128k` as primary workflows. However, these commands lacked "Docs as tests" coverage in `crates/tokmd/tests/docs.rs`. This creates a risk of silent documentation drift if the CLI flags or behavior change.

### Options Evaluated
- **Option A (Recommended)**: Add tests matching the specific exact strings used in `docs/tutorial.md` and `README.md` for `tokmd run`, `tokmd diff`, and `tokmd context`.
- **Option B**: Only test `tokmd diff` since `tokmd run` is indirectly covered by other integration tests.

### The Fix
Chose **Option A**. Appended `recipe_run_and_diff` and `recipe_context_budget` to `crates/tokmd/tests/docs.rs`, directly mapping to the user-facing documentation. The `run_and_diff` test correctly isolates execution by generating a pair of local temporary `.runs/` directories (baseline and current) and diffing them, fulfilling the architectural determinism invariants.

### Receipts

**doctest execution**
```text
running 16 tests
test recipe_context_budget ... ok
test recipe_run_and_diff ... ok
[... truncated 14 others ...]
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s
```

**clippy & format**
```text
cargo fmt -- --check
cargo clippy -p tokmd -- -D warnings
# (passed cleanly)
```

---
*PR created automatically by Jules for task [14599746166021932198](https://jules.google.com/task/14599746166021932198) started by @EffortlessSteven*