### PR TITLE
docs: clarify TODO density metrics field

### DIFF
--- a/crates/tokmd-node/index.d.ts
+++ b/crates/tokmd-node/index.d.ts
@@ -224,7 +224,7 @@ export interface DerivedMetrics {
     team_size: number;
     cost_usd: number;
   };
-  /** TODO density metrics */
+  /** Density metrics for TODOs */
   todo_density?: {
     total_todos: number;
     density_per_kloc: number;


### PR DESCRIPTION
Renames the docstring for `todo_density` from "TODO density metrics" to "Density metrics for TODOs" in `crates/tokmd-node/index.d.ts` to prevent it from being incorrectly flagged as an actionable "TODO" item by automated tools or developers reading the source.

---
*PR created automatically by Jules for task [11762081854348286933](https://jules.google.com/task/11762081854348286933) started by @EffortlessSteven*