### PR TITLE
chore: Update comment to avoid false positive FIXME scanning

### DIFF
--- a/crates/tokmd/src/export_bundle.rs
+++ b/crates/tokmd/src/export_bundle.rs
@@ -118,7 +118,7 @@ fn load_export_from_receipt(
     // Recurse to load the data file referenced by the receipt
     let mut bundle = load_export_from_file(&export_path, Some(base), global)?;
 
-    // Fix the entry point to point to the receipt we loaded
+    // Update the entry point to point to the receipt we loaded
     bundle.entry_point = Some(path.clone());
     Ok(bundle)
 }


### PR DESCRIPTION
Renamed 'Fix the entry point' to 'Update the entry point' to prevent issue tracking tools from wrongly capturing the code block explanation as an actionable task.

---
*PR created automatically by Jules for task [14490869091797291023](https://jules.google.com/task/14490869091797291023) started by @EffortlessSteven*