### PR TITLE
palette: restore missing error details in ffi-envelope 🎨

### DIFF
--- a/crates/tokmd-ffi-envelope/src/lib.rs
+++ b/crates/tokmd-ffi-envelope/src/lib.rs
@@ -85,7 +85,12 @@ pub fn format_error_message(error_obj: Option<&Value>) -> String {
         .get("message")
         .and_then(Value::as_str)
         .unwrap_or("Unknown error");
-    format!("[{code}] {message}")
+
+    if let Some(details) = error_obj.get("details").and_then(Value::as_str) {
+        format!("[{code}] {message}: {details}")
+    } else {
+        format!("[{code}] {message}")
+    }
 }
 
 /// Extract `data` from an already-parsed envelope.
@@ -220,6 +225,20 @@ mod tests {
         );
         assert_eq!(format_error_message(None), "Unknown error");
         assert_eq!(format_error_message(Some(&json!("boom"))), "Unknown error");
+    }
+
+    #[test]
+    fn format_error_message_includes_string_details_when_present() {
+        let err = json!({
+            "code": "invalid_settings",
+            "message": "Invalid value for 'from': expected a string",
+            "details": "Check the spelling."
+        });
+
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[invalid_settings] Invalid value for 'from': expected a string: Check the spelling."
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Problem
When `tokmd` bindings (Node, Python, Wasm, browser-runner) encounter errors generated by the underlying core engine, they extract an error message from a JSON envelope using `tokmd_ffi_envelope`. However, `format_error_message` was completely dropping the `details` field present in many `tokmd` errors. This caused confusing, low-context error strings to propagate up to users, losing valuable hints and reasons.

# Solution
Updated `format_error_message` inside `tokmd-ffi-envelope` to extract the `details` field (if present) and format it exactly the same way `TokmdError::fmt` does: `[{code}] {message}: {details}`.

# Receipts
Verified `cargo test -p tokmd-ffi-envelope` and added a unit test guaranteeing that `details` context is included when present.

---
*PR created automatically by Jules for task [14633229927939449260](https://jules.google.com/task/14633229927939449260) started by @EffortlessSteven*