### PR TITLE
gatekeeper: align tool schema definitions across docs ✅

### DIFF
--- a/crates/tokmd/schemas/schema.json
+++ b/crates/tokmd/schemas/schema.json
@@ -12,7 +12,8 @@
     { "$ref": "#/definitions/CockpitReceipt" },
     { "$ref": "#/definitions/Envelope" },
     { "$ref": "#/definitions/ComplexityBaseline" },
-    { "$ref": "#/definitions/DeterminismBaseline" }
+    { "$ref": "#/definitions/DeterminismBaseline" },
+    { "$ref": "#/definitions/ToolSchemaOutput" }
   ],
   "definitions": {
     "ScanStatus": {
@@ -2123,6 +2124,41 @@
         "excluded_by_policy": { "type": "array", "items": { "$ref": "#/definitions/PolicyExcludedFile" }, "description": "Files excluded by classification policy." },
         "token_estimation": { "oneOf": [{ "type": "null" }, { "$ref": "#/definitions/TokenEstimationMeta" }], "description": "Token estimation envelope with uncertainty bounds." },
         "bundle_audit": { "oneOf": [{ "type": "null" }, { "$ref": "#/definitions/TokenAudit" }], "description": "Post-bundle audit comparing actual bundle bytes to estimates." }
+      }
+    },
+    "ToolSchemaOutput": {
+      "type": "object",
+      "description": "Top-level schema output with envelope metadata for generated AI tools.",
+      "required": ["schema_version", "name", "version", "description", "tools"],
+      "properties": {
+        "schema_version": { "type": "integer", "const": 1, "description": "Schema version for tool definitions." },
+        "name": { "type": "string", "description": "Tool name." },
+        "version": { "type": "string", "description": "Tool version." },
+        "description": { "type": "string", "description": "Tool description." },
+        "tools": { "type": "array", "items": { "$ref": "#/definitions/ToolDefinition" }, "description": "Available commands/tools." }
+      }
+    },
+    "ToolDefinition": {
+      "type": "object",
+      "description": "Definition of a single command/tool.",
+      "required": ["name", "description", "parameters"],
+      "properties": {
+        "name": { "type": "string", "description": "Command name." },
+        "description": { "type": "string", "description": "Command description." },
+        "parameters": { "type": "array", "items": { "$ref": "#/definitions/ParameterSchema" }, "description": "Parameters/arguments." }
+      }
+    },
+    "ParameterSchema": {
+      "type": "object",
+      "description": "Schema for a single parameter/argument.",
+      "required": ["name", "param_type", "required"],
+      "properties": {
+        "name": { "type": "string", "description": "Parameter name." },
+        "description": { "type": ["string", "null"], "description": "Parameter description." },
+        "param_type": { "type": "string", "description": "Parameter type." },
+        "required": { "type": "boolean", "description": "Whether the parameter is required." },
+        "default": { "type": ["string", "null"], "description": "Default value if any." },
+        "enum_values": { "type": ["array", "null"], "items": { "type": "string" }, "description": "Enum values if applicable." }
       }
     }
   }

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -22,6 +22,7 @@ tokmd uses **separate schema versions** for different receipt families. Each rec
 | **Context Bundle** | 2 | `CONTEXT_BUNDLE_SCHEMA_VERSION` | `context` bundle manifest |
 | **Analysis** | 9 | `ANALYSIS_SCHEMA_VERSION` | `analyze` |
 | **Cockpit** | 3 | `COCKPIT_SCHEMA_VERSION` | `cockpit` |
+| **Tool** | 1 | `TOOL_SCHEMA_VERSION` | `tools` |
 | **Envelope** | `"sensor.report.v1"` | `SENSOR_REPORT_SCHEMA` | ecosystem envelope |
 | **Baseline** | 1 | `BASELINE_VERSION` | complexity/determinism baselines |
 | **Handoff** | 5 | `HANDOFF_SCHEMA_VERSION` | `handoff` manifest |
@@ -86,6 +87,7 @@ tokmd uses **separate schema versions** for different receipt families. Each rec
 - **Core**: `crates/tokmd-types/src/lib.rs` - `pub const SCHEMA_VERSION: u32 = 2;`
 - **Analysis**: `crates/tokmd-analysis-types/src/lib.rs` - `pub const ANALYSIS_SCHEMA_VERSION: u32 = 9;`
 - **Cockpit**: `crates/tokmd-types/src/cockpit.rs` - `pub const COCKPIT_SCHEMA_VERSION: u32 = 3;`
+- **Tool**: `crates/tokmd-tool-schema/src/lib.rs` - `pub const TOOL_SCHEMA_VERSION: u32 = 1;`
 - **Envelope**: `crates/tokmd-envelope/src/lib.rs` - `pub const SENSOR_REPORT_SCHEMA: &str = "sensor.report.v1";` (back-compat alias `ENVELOPE_SCHEMA` in `tokmd-analysis-types`)
 - **Baseline**: `crates/tokmd-analysis-types/src/lib.rs` - `pub const BASELINE_VERSION: u32 = 1;`
 - **Handoff**: `crates/tokmd-types/src/lib.rs` - `pub const HANDOFF_SCHEMA_VERSION: u32 = 5;`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,7 @@ Tier 5 (Products)      tokmd (CLI), tokmd-python, tokmd-node, tokmd-wasm
 - Handoff manifests: `HANDOFF_SCHEMA_VERSION = 5`
 - Analysis receipts: `ANALYSIS_SCHEMA_VERSION = 9`
 - Cockpit receipts: `COCKPIT_SCHEMA_VERSION = 3`
+- Tool schemas: `TOOL_SCHEMA_VERSION = 1`
 
 ### Tier 1: Core Processing
 

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -12,7 +12,8 @@
     { "$ref": "#/definitions/CockpitReceipt" },
     { "$ref": "#/definitions/Envelope" },
     { "$ref": "#/definitions/ComplexityBaseline" },
-    { "$ref": "#/definitions/DeterminismBaseline" }
+    { "$ref": "#/definitions/DeterminismBaseline" },
+    { "$ref": "#/definitions/ToolSchemaOutput" }
   ],
   "definitions": {
     "ScanStatus": {
@@ -2123,6 +2124,41 @@
         "excluded_by_policy": { "type": "array", "items": { "$ref": "#/definitions/PolicyExcludedFile" }, "description": "Files excluded by classification policy." },
         "token_estimation": { "oneOf": [{ "type": "null" }, { "$ref": "#/definitions/TokenEstimationMeta" }], "description": "Token estimation envelope with uncertainty bounds." },
         "bundle_audit": { "oneOf": [{ "type": "null" }, { "$ref": "#/definitions/TokenAudit" }], "description": "Post-bundle audit comparing actual bundle bytes to estimates." }
+      }
+    },
+    "ToolSchemaOutput": {
+      "type": "object",
+      "description": "Top-level schema output with envelope metadata for generated AI tools.",
+      "required": ["schema_version", "name", "version", "description", "tools"],
+      "properties": {
+        "schema_version": { "type": "integer", "const": 1, "description": "Schema version for tool definitions." },
+        "name": { "type": "string", "description": "Tool name." },
+        "version": { "type": "string", "description": "Tool version." },
+        "description": { "type": "string", "description": "Tool description." },
+        "tools": { "type": "array", "items": { "$ref": "#/definitions/ToolDefinition" }, "description": "Available commands/tools." }
+      }
+    },
+    "ToolDefinition": {
+      "type": "object",
+      "description": "Definition of a single command/tool.",
+      "required": ["name", "description", "parameters"],
+      "properties": {
+        "name": { "type": "string", "description": "Command name." },
+        "description": { "type": "string", "description": "Command description." },
+        "parameters": { "type": "array", "items": { "$ref": "#/definitions/ParameterSchema" }, "description": "Parameters/arguments." }
+      }
+    },
+    "ParameterSchema": {
+      "type": "object",
+      "description": "Schema for a single parameter/argument.",
+      "required": ["name", "param_type", "required"],
+      "properties": {
+        "name": { "type": "string", "description": "Parameter name." },
+        "description": { "type": ["string", "null"], "description": "Parameter description." },
+        "param_type": { "type": "string", "description": "Parameter type." },
+        "required": { "type": "boolean", "description": "Whether the parameter is required." },
+        "default": { "type": ["string", "null"], "description": "Default value if any." },
+        "enum_values": { "type": ["array", "null"], "items": { "type": "string" }, "description": "Enum values if applicable." }
       }
     }
   }


### PR DESCRIPTION
This PR fixes contract drift by properly documenting the `TOOL_SCHEMA_VERSION` in the official JSON Schema and markdown docs. The `crates/tokmd-tool-schema` crate exposed a new output format defining tools to be used by AI agents, but the schema documentation (`docs/schema.json`, `docs/SCHEMA.md`, and `docs/architecture.md`) had not been updated.

Receipts:
- Investigated schema definitions using `grep` across the codebase.
- Verified missing `TOOL_SCHEMA_VERSION` definitions.
- Ran tests: `cargo test -p tokmd-tool-schema` and `cargo xtask gate --check` to verify no regressions were introduced.

Determinism/Gates:
- Aligned `docs/schema.json` with the exact implementation from `crates/tokmd-tool-schema/src/lib.rs`.
- `cargo xtask gate --check` is fully passing.

Verification:
- Option A was chosen to fix the missing documentation and align the schema definitions with the contract.

---
*PR created automatically by Jules for task [7233442728956306679](https://jules.google.com/task/7233442728956306679) started by @EffortlessSteven*