### PR TITLE
jules: record fuzzer learning on interfaces 🌪️

### DIFF
--- a/.jules/friction/open/FRIC-20260413-001.md
+++ b/.jules/friction/open/FRIC-20260413-001.md
@@ -1,0 +1,28 @@
+# Friction Item
+
+id: FRIC-20260413-001
+persona: fuzzer
+style: prover
+shard: interfaces
+status: open
+
+## Problem
+`cargo +nightly fuzz run fuzz_toml_config --features config -- -max_total_time=1` still fails on Windows/MSVC before the fuzz target can run.
+
+Current observed failure:
+- `rustc-LLVM ERROR: Associative COMDAT symbol '_RNvXsU_NtNtCsaknDtnpQqMJ_4core3fmt3numhNtB7_5Debug3fmt' does not exist.`
+- the build then exits while compiling `tokmd-fuzz` for `x86_64-pc-windows-msvc`
+
+## Evidence
+- command: `cargo +nightly fuzz run fuzz_toml_config --features config -- -max_total_time=1`
+- worktree: `C:\Code\Rust\tokmd-rerun-976b`
+- build target: `x86_64-pc-windows-msvc`
+- failure site: `fuzz/fuzz_targets/fuzz_toml_config.rs`
+
+## Why it matters
+This blocks fuzz coverage on the Windows/MSVC path for the `interfaces` shard. Until the toolchain failure is resolved, fuzzing work here should be treated as blocked infrastructure friction rather than a code defect in the target itself.
+
+## Done when
+- [ ] The fuzz target builds and starts on Windows/MSVC
+- [ ] The current COMDAT/LLVM failure no longer reproduces
+- [ ] A follow-up run can land a real fuzz or regression improvement instead of only recording friction


### PR DESCRIPTION
This is a learning PR documenting a durable Windows/MSVC fuzz-toolchain blocker in the `interfaces` shard.

Current observed failure:
- `cargo +nightly fuzz run fuzz_toml_config --features config -- -max_total_time=1`
- `rustc-LLVM ERROR: Associative COMDAT symbol '_RNvXsU_NtNtCsaknDtnpQqMJ_4core3fmt3numhNtB7_5Debug3fmt' does not exist.`
- build exits while compiling `tokmd-fuzz` for `x86_64-pc-windows-msvc`

The branch keeps only the durable friction note under `.jules/friction/open/` and drops run-packet state.
