### PR TITLE
compat: Fix empty baseline metrics on non-complexity builds 🧷

### DIFF
--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -1235,18 +1235,18 @@ impl ComplexityBaseline {
     pub fn from_analysis(receipt: &AnalysisReceipt) -> Self {
         let generated_at = chrono_timestamp_iso8601(receipt.generated_at_ms);
 
-        let (metrics, files, complexity) = if let Some(ref complexity_report) = receipt.complexity {
-            let total_code_lines = receipt
-                .derived
-                .as_ref()
-                .map(|d| d.totals.code as u64)
-                .unwrap_or(0);
-            let total_files = receipt
-                .derived
-                .as_ref()
-                .map(|d| d.totals.files as u64)
-                .unwrap_or(0);
+        let total_code_lines = receipt
+            .derived
+            .as_ref()
+            .map(|d| d.totals.code as u64)
+            .unwrap_or(0);
+        let total_files = receipt
+            .derived
+            .as_ref()
+            .map(|d| d.totals.files as u64)
+            .unwrap_or(0);
 
+        let (metrics, files, complexity) = if let Some(ref complexity_report) = receipt.complexity {
             let metrics = BaselineMetrics {
                 total_code_lines,
                 total_files,
@@ -1290,7 +1290,12 @@ impl ComplexityBaseline {
 
             (metrics, files, Some(complexity_section))
         } else {
-            (BaselineMetrics::default(), Vec::new(), None)
+            let metrics = BaselineMetrics {
+                total_code_lines,
+                total_files,
+                ..Default::default()
+            };
+            (metrics, Vec::new(), None)
         };
 
         Self {


### PR DESCRIPTION
Fixes `tokmd baseline` to correctly extract and report `total_files` and `total_code_lines` when `tokmd-analysis-complexity` is not enabled, relying instead on `receipt.derived`.

## 🎯 Why
When `tokmd` is built without default features (like `walk`), running `tokmd baseline` would output `total_files: 0` because it fell back to a default `BaselineMetrics` when `receipt.complexity` was missing. This broke `baseline_metrics_has_total_files` test under the `--no-default-features --features walk` matrix combination. Fixing this improves feature-matrix compatibility.

## 🔎 Evidence
- File path: `crates/tokmd-analysis-types/src/lib.rs`
- Observed behavior: `baseline_metrics_has_total_files` test fails with `fixture should have at least one file`.
- Receipts: `cargo test -p tokmd --no-default-features --features walk --test baseline_w71` now passes.

## 🧭 Options considered
### Option A (recommended)
- Lift `total_code_lines` and `total_files` computation from `receipt.derived` to apply even if `receipt.complexity` is `None`. Use these values in the `else` branch.
- Fits the `interfaces` and `compat-matrix` shard perfectly.
- Trade-offs: Trivial structural change that preserves all functionality.

### Option B
- Modify the test to conditionally skip the `total_files > 0` check if `tokmd-analysis-complexity` is not enabled.
- When to choose it instead: If the `baseline` command explicitly required complexity analysis to produce file counts.
- Trade-offs: Masks the fact that `tokmd baseline` fails to report correctly parsed totals in `--no-default-features` builds.

## ✅ Decision
Option A. It correctly preserves parsing derived metrics over file trees even if complexity features are omitted, resolving the Wasm/feature-matrix drift and failing test.

## 🧱 Changes made (SRP)
- `crates/tokmd-analysis-types/src/lib.rs`: Extracted `total_code_lines` and `total_files` computation outside the `if let Some(ref complexity_report) = receipt.complexity` block so it correctly feeds into the `else` block metrics.

## 🧪 Verification receipts
`cargo test -p tokmd --no-default-features --features walk --test baseline_w71`
`cargo check --target wasm32-unknown-unknown -p tokmd --no-default-features`
`cargo test -p tokmd --all-features`

---
*PR created automatically by Jules for task [4955076703989649854](https://jules.google.com/task/4955076703989649854) started by @EffortlessSteven*