### PR TITLE
specsmith: expand semantic BDD coverage for metric explanations 🧪

### DIFF
--- a/crates/tokmd-analysis-explain/tests/bdd.rs
+++ b/crates/tokmd-analysis-explain/tests/bdd.rs
@@ -23,6 +23,34 @@ fn given_canonical_key_when_lookup_then_returns_explanation() {
 }
 
 #[test]
+fn given_key_metrics_when_lookup_then_mentions_core_concepts() {
+    let cases = [
+        ("whitespace_ratio", "blank lines"),
+        ("test_density", "test files"),
+        ("todo_density", "TODO/FIXME/HACK/XXX"),
+        ("polyglot_entropy", "Language distribution entropy"),
+        ("gini", "Inequality of file sizes"),
+        ("avg_cyclomatic", "branching complexity"),
+        ("avg_cognitive", "human understandability cost"),
+        ("maintainability_index", "maintainability score"),
+        ("predictive_churn", "Trend model of module change velocity"),
+        ("duplicate_waste", "Redundant bytes"),
+        ("imports", "dependency edges across files/modules"),
+        ("entropy_suspects", "suspiciously high entropy"),
+        ("license_radar", "Heuristic SPDX/license"),
+        ("context_window_fit", "Estimated token fit"),
+    ];
+
+    for (key, concept) in cases {
+        let text = lookup(key).expect("key should resolve");
+        assert!(
+            text.contains(concept),
+            "explanation for '{key}' should mention '{concept}', got: {text}"
+        );
+    }
+}
+
+#[test]
 fn given_every_canonical_key_when_lookup_then_all_resolve() {
     let canonical_keys = [
         "doc_density",


### PR DESCRIPTION
## Overview
Clean reland of the semantic BDD coverage for tokmd-analysis-explain. This keeps the branch tests-only and limits the change to `crates/tokmd-analysis-explain/tests/bdd.rs`.

## What changed
- added semantic-content assertions for key explanation metrics
- verified that representative lookups mention their core concepts, not just that they resolve
- kept the existing catalog, alias, and formatting coverage intact

## Validation
- `cargo test -p tokmd-analysis-explain`
- `cargo fmt-check`
- `git diff --check`