### PR TITLE
librarian: fix CLI argument documentation drift in reference-cli.md 📚

### DIFF
--- a/.jules/runs/librarian_docs_examples/decision.md
+++ b/.jules/runs/librarian_docs_examples/decision.md
@@ -1,0 +1,19 @@
+# Decision
+
+## Inspected
+- `xtask/src/tasks/docs.rs` where the `cargo xtask docs --check` is defined.
+- `docs/reference-cli.md` which has CLI documentation including manually maintained tables.
+- Various `tokmd <cmd> --help` outputs.
+
+## Options
+### Option A
+Update the manual tables in `docs/reference-cli.md` to match the actual CLI arguments. The documentation for `tokmd diff`, `tokmd module`, `tokmd export`, and `tokmd cockpit` has drifted from the actual flags (e.g., missing `--exclude`, `--profile`, `--no-progress`, changing `--format <FMT>` to `--format <FORMAT>`).
+
+### Option B
+Remove the manual tables entirely and just rely on the embedded `--help` blocks. This avoids future drift completely but removes descriptive examples from the manual texts.
+
+## Selection
+Option A. It's best to maintain the detailed explanatory tables for the web documentation while syncing them with the truth from the CLI `--help` outputs. This fulfills the `Librarian` persona mandate to fix factual docs drift.
+
+## Not Pursued
+- Fixing other subcommands unless clear drift is identified.

--- a/.jules/runs/librarian_docs_examples/envelope.json
+++ b/.jules/runs/librarian_docs_examples/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "librarian_docs_examples",
+  "persona": "Librarian",
+  "style": "Builder",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/librarian_docs_examples/pr_body.md
+++ b/.jules/runs/librarian_docs_examples/pr_body.md
@@ -1,0 +1,50 @@
+## 💡 Summary
+Fixed documentation drift in `docs/reference-cli.md` where the manually maintained argument tables were missing recently added CLI options. The tables for `tokmd diff`, `tokmd module`, `tokmd export`, and `tokmd cockpit` have been updated to reflect the true `--help` outputs.
+
+## 🎯 Why
+`cargo xtask docs --check` only verifies that the embedded `<!-- HELP: cmd -->` output blocks match the CLI exactly. However, the manually written argument tables immediately preceding these blocks had silently drifted out of sync, missing flags like `--exclude`, `--profile`, and `--no-progress`. This fixes the drift so users don't see conflicting options.
+
+## 🔎 Evidence
+- `docs/reference-cli.md`
+- `tokmd diff --help` output shows `--exclude <PATTERN>` but the manual table did not include it.
+- Replaced the outdated tables with the true flag structures.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Update the manual markdown tables to mirror the true `--help` output while keeping their descriptive value.
+- Fits the `tooling-governance` shard and the `Librarian` persona by explicitly addressing factual documentation drift.
+- Trade-offs: Requires continued maintenance, but preserves the high-quality layout.
+
+### Option B
+- Delete the manual tables entirely and rely solely on the generated `--help` outputs in the docs.
+- When to choose: If drift happens constantly and maintenance becomes too high.
+- Trade-offs: Lowers the quality of the reading experience.
+
+## ✅ Decision
+Option A was chosen to fix the factual drift while preserving the high-quality, readable format of the reference CLI documentation.
+
+## 🧱 Changes made (SRP)
+- `docs/reference-cli.md`: Updated argument tables for `diff`, `module`, `export`, and `cockpit` to match the exact CLI help text.
+
+## 🧪 Verification receipts
+```text
+cargo xtask docs --check
+Documentation is up to date.
+```
+
+## 🧭 Telemetry
+- Change shape: Docs update
+- Blast radius: API (None), IO (None), docs (Medium), schema (None)
+- Risk class: Low
+- Rollback: `git checkout docs/reference-cli.md`
+- Gates run: `cargo xtask docs --check`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/librarian_docs_examples/envelope.json`
+- `.jules/runs/librarian_docs_examples/decision.md`
+- `.jules/runs/librarian_docs_examples/receipts.jsonl`
+- `.jules/runs/librarian_docs_examples/result.json`
+- `.jules/runs/librarian_docs_examples/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/librarian_docs_examples/receipts.jsonl
+++ b/.jules/runs/librarian_docs_examples/receipts.jsonl
@@ -1,0 +1,2 @@
+{"cmd": "cargo xtask docs --check", "status": "success", "summary": "Checked docs", "artifacts": []}
+{"cmd": "python3 fix_docs_precise.py", "status": "success", "summary": "Updated docs/reference-cli.md tables correctly", "artifacts": ["docs/reference-cli.md"]}

--- a/.jules/runs/librarian_docs_examples/result.json
+++ b/.jules/runs/librarian_docs_examples/result.json
@@ -1,0 +1,16 @@
+{
+  "outcome": "patch",
+  "title": "Fix CLI argument documentation drift in reference-cli.md",
+  "summary": "Updated manual markdown tables in docs/reference-cli.md for `tokmd diff`, `tokmd module`, `tokmd export`, and `tokmd cockpit` to align with their actual `--help` command outputs.",
+  "target_paths": [
+    "docs/reference-cli.md"
+  ],
+  "proof_summary": "Manual inspection showed missing arguments like `--exclude`, `--profile`, and `--no-progress` in the markdown tables compared to CLI help output.",
+  "gates_run": [
+    "cargo xtask docs --check"
+  ],
+  "friction_items_created": [],
+  "persona_notes_created": [],
+  "rollback": "git checkout docs/reference-cli.md",
+  "follow_ups": []
+}

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -105,11 +105,14 @@ Generates a summary grouped by **Module** (directory structure).
 
 | Option | Description | Default |
 | :--- | :--- | :--- |
-| `-f, --format <FMT>` | Output format: `md` (Markdown table), `tsv`, `json`. | `md` |
-| `-t, --top <N>` | Only show the top N modules. | `0` (all) |
-| `--children <MODE>` | Handling of embedded languages: `separate` or `parents-only`. | `separate` |
+| `--exclude <PATTERN>` | Exclude pattern(s) using gitignore syntax. | `(none)` |
+| `--format <FORMAT>` | Output format: `md` (Markdown table), `tsv`, `json`. | `md` |
+| `--top <TOP>` | Only show the top N modules. | `0` (all) |
 | `--module-roots <DIRS>` | Comma-separated roots to treat as module roots. | `crates,packages` |
 | `--module-depth <N>` | How many path segments to keep under module roots. | `2` |
+| `--children <MODE>` | Handling of embedded languages: `separate` or `parents-only`. | `separate` |
+| `--no-progress` | Disable progress spinners. | `false` |
+| `--profile <PROFILE>` | Configuration profile to use. | `(none)` |
 
 **Example**:
 ```bash
@@ -125,19 +128,22 @@ Generates a row-level inventory of files. Best for machine processing.
 
 | Option | Description | Default |
 | :--- | :--- | :--- |
-| `-f, --format <FMT>` | Output format: `jsonl`, `json`, `csv`, `cyclonedx`. | `jsonl` |
+| `--exclude <PATTERN>` | Exclude pattern(s) using gitignore syntax. | `(none)` |
+| `--format <FORMAT>` | Output format: `jsonl`, `json`, `csv`, `cyclonedx`. | `jsonl` |
 | `--output <PATH>` | Write output to a file instead of stdout. | stdout |
 | `--module-roots <DIRS>` | Module roots used for module key generation. | `crates,packages` |
 | `--module-depth <N>` | Depth used for module key generation. | `2` |
+| `--children <MODE>` | Handling of embedded languages: `separate` or `parents-only`. | `separate` |
 | `--min-code <N>` | Exclude files with fewer than N lines of code. | `0` |
 | `--max-rows <N>` | Limit output to the top N largest files. | `0` (unlimited) |
-| `--children <MODE>` | Handling of embedded languages: `separate` or `parents-only`. | `separate` |
 | `--meta <BOOL>` | Include a meta record in JSON / JSONL output. | `true` |
 | `--redact <MODE>` | Redaction strategy for paths/names. | `none` |
 | | `none`: Show full paths. | |
 | | `paths`: Hash file paths (preserve extension). | |
 | | `all`: Hash paths and module names. | |
 | `--strip-prefix <PATH>` | Remove a prefix from file paths in the output. | `None` |
+| `--no-progress` | Disable progress spinners. | `false` |
+| `--profile <PROFILE>` | Configuration profile to use. | `(none)` |
 
 **Sorting**: Output is automatically sorted by lines of code (descending), then by path. This ensures deterministic, reproducible output across all runs. There is no `--sort` flag.
 
@@ -315,11 +321,14 @@ Compares two runs, receipts, or directories and shows the delta.
 
 | Option | Description | Default |
 | :--- | :--- | :--- |
+| `--exclude <PATTERN>` | Exclude pattern(s) using gitignore syntax. | `(none)` |
 | `--from <FROM>` | Base receipt/run or git ref to compare from. | `(none)` |
 | `--to <TO>` | Target receipt/run or git ref to compare to. | `(none)` |
-| `--format <FMT>` | Output format: `md`, `json`. | `md` |
+| `--format <FORMAT>` | Output format: `md`, `json`. | `md` |
 | `--compact` | Summary-only markdown table for narrow terminals. | `false` |
-| `--color <MODE>` | Color policy: `auto`, `always`, `never`. | `auto` |
+| `--color <COLOR>` | Color policy: `auto`, `always`, `never`. | `auto` |
+| `--no-progress` | Disable progress spinners. | `false` |
+| `--profile <PROFILE>` | Configuration profile to use. | `(none)` |
 
 **Examples**:
 ```bash
@@ -607,14 +616,16 @@ Options:
 | Option | Description | Default |
 | :--- | :--- | :--- |
 | `--base <REF>` | Base reference to compare from (e.g., `main`, commit SHA). | `main` |
+| `--exclude <PATTERN>` | Exclude pattern(s) using gitignore syntax. | `(none)` |
 | `--head <REF>` | Head reference to compare to (e.g., `HEAD`, branch name). | `HEAD` |
-| `--format <FMT>` | Output format: `json`, `md`, `sections`. | `json` |
+| `--format <FORMAT>` | Output format: `json`, `md`, `sections`. | `json` |
 | `--output <PATH>` | Write output to file instead of stdout. | `(stdout)` |
 | `--artifacts-dir <DIR>` | In standard cockpit mode, write `cockpit.json`, `report.json`, and `comment.md` to a directory. | `(none)` |
-| `--sensor-mode` | Run in sensor mode for CI integration (see below). | `false` |
 | `--baseline <PATH>` | Path to baseline receipt for trend comparison. | `(none)` |
 | `--diff-range <MODE>` | Diff range syntax: `two-dot` or `three-dot`. | `two-dot` |
+| `--sensor-mode` | Run in sensor mode for CI integration (see below). | `false` |
 | `--no-progress` | Disable progress spinners. | `false` |
+| `--profile <PROFILE>` | Configuration profile to use. | `(none)` |
 
 **Output Formats**:
 


### PR DESCRIPTION
## 💡 Summary
Fixed documentation drift in `docs/reference-cli.md` where the manually maintained argument tables were missing recently added CLI options. The tables for `tokmd diff`, `tokmd module`, `tokmd export`, and `tokmd cockpit` have been updated to reflect the true `--help` outputs.

## 🎯 Why
`cargo xtask docs --check` only verifies that the embedded `<!-- HELP: cmd -->` output blocks match the CLI exactly. However, the manually written argument tables immediately preceding these blocks had silently drifted out of sync, missing flags like `--exclude`, `--profile`, and `--no-progress`. This fixes the drift so users don't see conflicting options.

## 🔎 Evidence
- `docs/reference-cli.md`
- `tokmd diff --help` output shows `--exclude <PATTERN>` but the manual table did not include it.
- Replaced the outdated tables with the true flag structures.

## 🧭 Options considered
### Option A (recommended)
- Update the manual markdown tables to mirror the true `--help` output while keeping their descriptive value.
- Fits the `tooling-governance` shard and the `Librarian` persona by explicitly addressing factual documentation drift.
- Trade-offs: Requires continued maintenance, but preserves the high-quality layout.

### Option B
- Delete the manual tables entirely and rely solely on the generated `--help` outputs in the docs.
- When to choose: If drift happens constantly and maintenance becomes too high.
- Trade-offs: Lowers the quality of the reading experience.

## ✅ Decision
Option A was chosen to fix the factual drift while preserving the high-quality, readable format of the reference CLI documentation.

## 🧱 Changes made (SRP)
- `docs/reference-cli.md`: Updated argument tables for `diff`, `module`, `export`, and `cockpit` to match the exact CLI help text.

## 🧪 Verification receipts
```text
cargo xtask docs --check
Documentation is up to date.
```

## 🧭 Telemetry
- Change shape: Docs update
- Blast radius: API (None), IO (None), docs (Medium), schema (None)
- Risk class: Low
- Rollback: `git checkout docs/reference-cli.md`
- Gates run: `cargo xtask docs --check`

## 🗂️ .jules artifacts
- `.jules/runs/librarian_docs_examples/envelope.json`
- `.jules/runs/librarian_docs_examples/decision.md`
- `.jules/runs/librarian_docs_examples/receipts.jsonl`
- `.jules/runs/librarian_docs_examples/result.json`
- `.jules/runs/librarian_docs_examples/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [9460839681908660829](https://jules.google.com/task/9460839681908660829) started by @EffortlessSteven*