### PR TITLE
invariant: lock chrono timestamp invariants with proptest 🔬

### DIFF
--- a/crates/tokmd-analysis-types/Cargo.toml
+++ b/crates/tokmd-analysis-types/Cargo.toml
@@ -18,5 +18,5 @@ tokmd-envelope.workspace = true
 tokmd-types.workspace = true
 
 [dev-dependencies]
+chrono = "0.4.44"
 proptest.workspace = true
-

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -1585,6 +1585,8 @@ pub use tokmd_envelope::ToolMeta;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{SecondsFormat, TimeZone, Utc};
+    use proptest::prelude::*;
 
     // ── Schema version constant ───────────────────────────────────────
     #[test]
@@ -1853,5 +1855,23 @@ mod tests {
         assert!(result.ends_with(".500Z"));
         assert!(result.starts_with("2025-01-01"));
         Ok(())
+    }
+
+    proptest! {
+        #[test]
+        fn chrono_timestamp_matches_chrono(ms in 0u128..253_402_300_799_000u128) {
+            let chrono_dt = Utc
+                .timestamp_millis_opt(ms as i64)
+                .single()
+                .expect("timestamp within supported range");
+            let expected = chrono_dt.to_rfc3339_opts(SecondsFormat::Millis, true);
+            prop_assert_eq!(chrono_timestamp_iso8601(ms), expected);
+        }
+
+        #[test]
+        fn chrono_timestamp_is_rfc3339(ms in 0u128..253_402_300_799_000u128) {
+            let rendered = chrono_timestamp_iso8601(ms);
+            prop_assert!(chrono::DateTime::parse_from_rfc3339(&rendered).is_ok());
+        }
     }
 }


### PR DESCRIPTION
Add private-module proptest coverage for chrono_timestamp_iso8601 in tokmd-analysis-types. The reland keeps the helper private, compares its output against chrono, and checks that rendered timestamps parse as RFC 3339.\n\nChanges:\n- Add chrono as a dev-dependency for tokmd-analysis-types.\n- Add proptest coverage inside crates/tokmd-analysis-types/src/lib.rs rather than exposing the helper publicly.\n\nValidation:\n- cargo test -p tokmd-analysis-types\n- cargo fmt-check\n- git diff --check