### PR TITLE
sentinel: harden module_roots redaction in json formats 🛡️

### DIFF
--- a/.jules/runs/sentinel_redaction/decision.md
+++ b/.jules/runs/sentinel_redaction/decision.md
@@ -1,0 +1,15 @@
+# Sentinel Redaction Decision
+
+## Option A (recommended)
+Patch `crates/tokmd-format/src/lib.rs` to correctly redact `module_roots` in `ExportArgsMeta` (which leaks in JSON and JSONL exports) when `RedactMode::All` is set. Currently, `module_roots` is just cloned, allowing module paths to leak out even when full redaction is requested.
+
+- Why it fits: Directly patches a trust boundary leakage point within the `core-pipeline` shard (`crates/tokmd-format`).
+- Trade-offs: Increases complexity slightly by mapping over elements, but closes an obvious security and trust boundary gap.
+
+## Option B
+Focus on hardening `redact_rows` to optionally remove rows completely or filter out unknown extensions.
+- When to choose: If there is evidence that the rows themselves are a structural leak beyond file sizes.
+- Trade-offs: Changes structural validity of the BOM/output, and risks dropping valid datasets.
+
+## Decision
+Choosing Option A because `module_roots` in the export envelope is explicitly a metadata array representing file paths that need redaction when `RedactMode::All` is configured.

--- a/.jules/runs/sentinel_redaction/envelope.json
+++ b/.jules/runs/sentinel_redaction/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "sentinel_redaction",
+  "persona": "Sentinel 🛡️",
+  "style": "Stabilizer",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "security-boundary",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/sentinel_redaction/pr_body.md
+++ b/.jules/runs/sentinel_redaction/pr_body.md
@@ -1,0 +1,54 @@
+## 💡 Summary
+Hardened `tokmd-format` JSON and JSONL exports to correctly redact structural array `module_roots` when `RedactMode::All` is set. Previously, `module_roots` was merely cloned and bypassed redaction.
+
+## 🎯 Why
+When using `RedactMode::All`, users expect both filenames and module paths to be completely anonymized before structural metadata is exported. However, the `ExportArgsMeta` payload exported with JSON and JSONL datasets was passing `module_roots` in plaintext, leaking directory names.
+
+## 🔎 Evidence
+- File: `crates/tokmd-format/src/lib.rs`
+- Finding: `module_roots` in `write_export_jsonl` and `write_export_json` were being populated with `export.module_roots.clone()` instead of applying `short_hash()` when `RedactMode::All` was active.
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Conditionally iterate over `export.module_roots` and apply `short_hash` if `RedactMode::All`.
+- why it fits this repo and shard: Fixes a security regression in the `core-pipeline` shard (`tokmd-format`) directly relating to redaction expectations.
+- trade-offs: Minor computational overhead on export to hash structural arrays.
+
+### Option B
+- what it is: Remove `module_roots` from exports completely if `RedactMode::All`.
+- when to choose it instead: If the cardinality of `module_roots` provides a structural risk.
+- trade-offs: Breaks downstream analysis tools expecting the array to be present and sized correctly.
+
+## ✅ Decision
+Option A was chosen. Preserving the structure of `module_roots` while redacting the contents using `short_hash` aligns with how the actual `.module` columns are handled in the CSV/TSV table outputs.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-format/src/lib.rs`
+  - Patched `write_export_jsonl` to redact `module_roots` under `RedactMode::All`.
+  - Patched `write_export_json` to redact `module_roots` inside `ExportArgsMeta` and `ExportData` under `RedactMode::All`.
+
+## 🧪 Verification receipts
+```text
+{"command": "python3 patch.py", "outcome": "Success, applied redaction to module_roots"}
+{"command": "cargo build -p tokmd-format", "outcome": "Success, compiles without errors"}
+{"command": "cd crates/tokmd-format && cargo test", "outcome": "Success, all tests passed"}
+{"command": "cargo fmt -- --check", "outcome": "Success"}
+{"command": "cargo clippy -p tokmd-format -- -D warnings", "outcome": "Success"}
+```
+
+## 🧭 Telemetry
+- Change shape: Hardening patch
+- Blast radius: `tokmd-format` (JSON/JSONL outputs only)
+- Risk class: Low risk. Does not break downstream schemas, only hashes strings in arrays.
+- Rollback: Revert the PR.
+- Gates run: targeted `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/sentinel_redaction/envelope.json`
+- `.jules/runs/sentinel_redaction/decision.md`
+- `.jules/runs/sentinel_redaction/receipts.jsonl`
+- `.jules/runs/sentinel_redaction/result.json`
+- `.jules/runs/sentinel_redaction/pr_body.md`
+
+## 🔜 Follow-ups
+None

--- a/.jules/runs/sentinel_redaction/receipts.jsonl
+++ b/.jules/runs/sentinel_redaction/receipts.jsonl
@@ -1,0 +1,5 @@
+{"command": "python3 patch.py", "outcome": "Success, applied redaction to module_roots"}
+{"command": "cargo build -p tokmd-format", "outcome": "Success, compiles without errors"}
+{"command": "cd crates/tokmd-format && cargo test", "outcome": "Success, all tests passed"}
+{"command": "cargo fmt -- --check", "outcome": "Success"}
+{"command": "cargo clippy -p tokmd-format -- -D warnings", "outcome": "Success"}

--- a/.jules/runs/sentinel_redaction/result.json
+++ b/.jules/runs/sentinel_redaction/result.json
@@ -1,0 +1,7 @@
+{
+  "status": "success",
+  "patched": true,
+  "files_changed": [
+    "crates/tokmd-format/src/lib.rs"
+  ]
+}

--- a/crates/tokmd-format/src/lib.rs
+++ b/crates/tokmd-format/src/lib.rs
@@ -407,7 +407,11 @@ fn write_export_jsonl<W: Write>(
             scan: scan_args(&args.paths, global, Some(args.redact)),
             args: ExportArgsMeta {
                 format: args.format,
-                module_roots: export.module_roots.clone(),
+                module_roots: if args.redact == RedactMode::All {
+                    export.module_roots.iter().map(|s| short_hash(s)).collect()
+                } else {
+                    export.module_roots.clone()
+                },
                 module_depth: export.module_depth,
                 children: export.children,
                 min_code: args.min_code,
@@ -458,7 +462,11 @@ fn write_export_json<W: Write>(
             scan: scan_args(&args.paths, global, Some(args.redact)),
             args: ExportArgsMeta {
                 format: args.format,
-                module_roots: export.module_roots.clone(),
+                module_roots: if args.redact == RedactMode::All {
+                    export.module_roots.iter().map(|s| short_hash(s)).collect()
+                } else {
+                    export.module_roots.clone()
+                },
                 module_depth: export.module_depth,
                 children: export.children,
                 min_code: args.min_code,
@@ -479,7 +487,11 @@ fn write_export_json<W: Write>(
                 rows: redact_rows(&export.rows, args.redact)
                     .map(|c| c.into_owned())
                     .collect(),
-                module_roots: export.module_roots.clone(),
+                module_roots: if args.redact == RedactMode::All {
+                    export.module_roots.iter().map(|s| short_hash(s)).collect()
+                } else {
+                    export.module_roots.clone()
+                },
                 module_depth: export.module_depth,
                 children: export.children,
             },


### PR DESCRIPTION
Hardened tokmd-format JSON and JSONL exports to correctly redact structural array module_roots when RedactMode::All is set. Previously, module_roots was merely cloned and bypassed redaction.

---
*PR created automatically by Jules for task [7735945739047308915](https://jules.google.com/task/7735945739047308915) started by @EffortlessSteven*