### PR TITLE
jules: record steward learning on release validation 🚢

### DIFF
--- a/.jules/friction/open/steward-gitkeep.md
+++ b/.jules/friction/open/steward-gitkeep.md
@@ -1,0 +1,18 @@
+# Tracked agent runtime state detected on fresh clone
+
+## Finding
+When running `cargo xtask gate --check` to validate repository state, it immediately fails because of an untracked (or inappropriately tracked) `.jules/runs/.gitkeep` file in the git index:
+
+```text
+Tracked agent runtime state detected:
+  - .jules/runs/.gitkeep
+
+Remove these paths from the Git index and re-run the gate.
+```
+
+## Context
+As an async one-shot agent ("Steward" running under `governance-release` profile), the first step to run validation gates triggered a fatal failure. A quick `git rm --cached .jules/runs/.gitkeep` clears the state and allows `cargo xtask gate --check` to continue. Additionally, `cargo deny --all-features check` outputted several duplicate dependency version warnings (e.g., `winnow`, `thiserror`).
+
+## Proposed Resolution
+1. Remove `.jules/runs/.gitkeep` from the repository tracking permanently to prevent CI/gate pipeline disruption for fresh clones.
+2. Consider dedicating a dependency update chore (like an `Auditor` agent run) to unify duplicate dependencies via `cargo update` so `cargo deny` passes cleanly.

--- a/.jules/runs/steward_release/decision.md
+++ b/.jules/runs/steward_release/decision.md
@@ -1,0 +1,14 @@
+# Decision
+
+## Option A
+- **What it is**: Address `cargo deny` warnings by applying fixes to the root `Cargo.lock` via `cargo update` and remove the untracked `.jules/runs/.gitkeep`.
+- **Why it fits this repo and shard**: Resolves failing workspace quality checks related to `.gitkeep` and dependencies.
+- **Trade-offs**: Fixing dependency versions in `Cargo.lock` and `.jules/runs/.gitkeep` falls primarily under the `Auditor` (dependency hygiene) or `Archivist`/`Gatekeeper` personas. The current `Steward` prompt strictly governs release/governance paths (version consistency, publish plans, documentation drift). Pursuing this fix broadens the scope and violates the instruction to avoid broad code changes unless directly required for release/governance.
+
+## Option B (recommended)
+- **What it is**: Create a **learning PR** since there is no honest release/governance patch justified. Document the `.gitkeep` gate failure and the `cargo deny` duplicate warnings as friction items.
+- **When to choose it instead**: When release and governance checks pass perfectly (`cargo xtask version-consistency`, `cargo xtask docs --check`, `cargo xtask publish --plan --verbose`) but unrelated repo hygiene issues are detected.
+- **Trade-offs**: Does not patch any code, but properly records the system state and limits scope creep per the mission ("If no honest code/docs/test patch is justified, finish with a learning PR instead of forcing a fake fix").
+
+## Decision
+Selected **Option B**. The primary responsibility of Steward (release metadata, publish plans, version consistency) is perfectly sound on `main`. No drift was found. The failures encountered (`.jules/runs/.gitkeep` causing `cargo xtask gate --check` failure and `cargo deny` multiple-versions warnings) are outside the core release-governance focus of this shard. Expanding scope to patch them violates instructions.

--- a/.jules/runs/steward_release/envelope.json
+++ b/.jules/runs/steward_release/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "steward_release",
+  "persona": "Steward",
+  "style": "Stabilizer",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock"
+  ],
+  "gate_profile": "governance-release",
+  "allowed_outcomes": ["patch", "proof_patch", "learning_pr"]
+}

--- a/.jules/runs/steward_release/pr_body.md
+++ b/.jules/runs/steward_release/pr_body.md
@@ -1,0 +1,73 @@
+## 💡 Summary
+This is a learning PR. The `governance-release` validations for version drift, document drift, and publishing alignment pass flawlessly. However, the repository suffers from baseline state friction (`.jules/runs/.gitkeep` tracking and dependency duplications) that disrupts pipeline onboarding and should be patched under another persona.
+
+## 🎯 Why
+A fresh checkout of `tokmd` immediately fails `cargo xtask gate --check` due to a tracked agent runtime state file (`.jules/runs/.gitkeep`). In addition, `cargo deny --all-features check` issues multiple duplication warnings. Addressing these hygiene defects directly would violate the `Steward` constraints, which prioritize release and metadata adjustments. Documenting these ensures future runs can execute cleanly if they are correctly patched.
+
+## 🔎 Evidence
+- File path: `.jules/runs/.gitkeep`
+- Observed behavior: `cargo xtask gate --check` fails instantly.
+- Receipt:
+```text
+Tracked agent runtime state detected:
+  - .jules/runs/.gitkeep
+
+Remove these paths from the Git index and re-run the gate.
+```
+
+## 🧭 Options considered
+
+### Option A
+- **What it is**: Remove the tracked file from git and bump dependencies in `Cargo.lock` to unify `cargo deny` warnings, bypassing the Steward boundaries.
+- **Why it fits this repo and shard**: Resolves the friction items immediately.
+- **Trade-offs**: Violates SRP and persona boundary ("Steward" is not the "Auditor" dependency persona). This expands the codebase delta into untested dependency updates.
+
+### Option B (recommended)
+- **What it is**: Halt with a Learning PR. Write out a `friction` item describing the state.
+- **When to choose it instead**: When the core focus of the shard (release metadata, publish plans, documentation drift) are perfectly sound and require no actionable diffs.
+- **Trade-offs**: Keeps the repo in a flawed state but documents it faithfully without scope creep.
+
+## ✅ Decision
+Selected Option B. The release checks proved `main` is clean for versioning and publishing. The friction requires either an `Archivist` to adjust scaffolding or an `Auditor` to bump dependencies.
+
+## 🧱 Changes made (SRP)
+- (None - Learning PR)
+
+## 🧪 Verification receipts
+```text
+$ cargo xtask docs --check
+Documentation is up to date.
+
+$ cargo xtask version-consistency
+Version consistency checks passed.
+
+$ cargo xtask publish --plan --verbose
+=== Publish Plan ===
+Workspace version: 1.9.0
+Publish order (57 crates)...
+
+$ cargo xtask gate --check
+Error: tracked agent runtime state found in 1 path(s)
+
+$ cargo deny --all-features check
+advisories ok, bans ok, licenses ok, sources ok
+... [Multiple warnings about duplicate versions]
+```
+
+## 🧭 Telemetry
+- **Change shape**: Documentation/Friction
+- **Blast radius**: Documentation only.
+- **Risk class + why**: None. (Learning PR).
+- **Rollback**: Trivial.
+- **Gates run**: `xtask docs`, `xtask version-consistency`, `xtask publish`, `xtask gate`, `cargo deny`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/steward_release/envelope.json`
+- `.jules/runs/steward_release/decision.md`
+- `.jules/runs/steward_release/receipts.jsonl`
+- `.jules/runs/steward_release/result.json`
+- `.jules/runs/steward_release/pr_body.md`
+- `.jules/friction/open/steward-gitkeep.md`
+
+## 🔜 Follow-ups
+- An `Auditor` or `Archivist` should resolve the `.jules/runs/.gitkeep` tracking and unifying `Cargo.lock` duplicates via `cargo update`.

--- a/.jules/runs/steward_release/receipts.jsonl
+++ b/.jules/runs/steward_release/receipts.jsonl
@@ -1,0 +1,5 @@
+{"command": "cargo xtask docs --check", "status": 0, "output": "Documentation is up to date."}
+{"command": "cargo xtask version-consistency", "status": 0, "output": "Version consistency checks passed."}
+{"command": "cargo xtask publish --plan --verbose", "status": 0, "output": "=== Publish Plan ===\nWorkspace version: 1.9.0\nPublish order (57 crates)..."}
+{"command": "cargo xtask gate --check", "status": 1, "output": "Tracked agent runtime state detected: - .jules/runs/.gitkeep"}
+{"command": "cargo deny --all-features check", "status": 0, "output": "advisories ok, bans ok, licenses ok, sources ok... [Multiple warnings about duplicate versions]"}

--- a/.jules/runs/steward_release/result.json
+++ b/.jules/runs/steward_release/result.json
@@ -1,0 +1,6 @@
+{
+  "status": "learning_pr",
+  "reason": "No honest release/governance patches justified. The only drift found was in generic repository hygiene outside the scope of Steward.",
+  "friction_items_created": ["steward-gitkeep.md"],
+  "gate_success": false
+}


### PR DESCRIPTION
## 💡 Summary
This is a learning PR. The `governance-release` validations for version drift, document drift, and publishing alignment pass flawlessly. However, the repository suffers from baseline state friction (`.jules/runs/.gitkeep` tracking and dependency duplications) that disrupts pipeline onboarding and should be patched under another persona.

## 🎯 Why
A fresh checkout of `tokmd` immediately fails `cargo xtask gate --check` due to a tracked agent runtime state file (`.jules/runs/.gitkeep`). In addition, `cargo deny --all-features check` issues multiple duplication warnings. Addressing these hygiene defects directly would violate the `Steward` constraints, which prioritize release and metadata adjustments. Documenting these ensures future runs can execute cleanly if they are correctly patched.

## 🔎 Evidence
- File path: `.jules/runs/.gitkeep`
- Observed behavior: `cargo xtask gate --check` fails instantly.
- Receipt:
```text
Tracked agent runtime state detected:
  - .jules/runs/.gitkeep

Remove these paths from the Git index and re-run the gate.
```

## 🧭 Options considered

### Option A
- **What it is**: Remove the tracked file from git and bump dependencies in `Cargo.lock` to unify `cargo deny` warnings, bypassing the Steward boundaries.
- **Why it fits this repo and shard**: Resolves the friction items immediately.
- **Trade-offs**: Violates SRP and persona boundary ("Steward" is not the "Auditor" dependency persona). This expands the codebase delta into untested dependency updates.

### Option B (recommended)
- **What it is**: Halt with a Learning PR. Write out a `friction` item describing the state.
- **When to choose it instead**: When the core focus of the shard (release metadata, publish plans, documentation drift) are perfectly sound and require no actionable diffs.
- **Trade-offs**: Keeps the repo in a flawed state but documents it faithfully without scope creep.

## ✅ Decision
Selected Option B. The release checks proved `main` is clean for versioning and publishing. The friction requires either an `Archivist` to adjust scaffolding or an `Auditor` to bump dependencies.

## 🧱 Changes made (SRP)
- (None - Learning PR)

## 🧪 Verification receipts
```text
$ cargo xtask docs --check
Documentation is up to date.

$ cargo xtask version-consistency
Version consistency checks passed.

$ cargo xtask publish --plan --verbose
=== Publish Plan ===
Workspace version: 1.9.0
Publish order (57 crates)...

$ cargo xtask gate --check
Error: tracked agent runtime state found in 1 path(s)

$ cargo deny --all-features check
advisories ok, bans ok, licenses ok, sources ok
... [Multiple warnings about duplicate versions]
```

## 🧭 Telemetry
- **Change shape**: Documentation/Friction
- **Blast radius**: Documentation only.
- **Risk class + why**: None. (Learning PR).
- **Rollback**: Trivial.
- **Gates run**: `xtask docs`, `xtask version-consistency`, `xtask publish`, `xtask gate`, `cargo deny`

## 🗂️ .jules artifacts
- `.jules/runs/steward_release/envelope.json`
- `.jules/runs/steward_release/decision.md`
- `.jules/runs/steward_release/receipts.jsonl`
- `.jules/runs/steward_release/result.json`
- `.jules/runs/steward_release/pr_body.md`
- `.jules/friction/open/steward-gitkeep.md`

## 🔜 Follow-ups
- An `Auditor` or `Archivist` should resolve the `.jules/runs/.gitkeep` tracking and unifying `Cargo.lock` duplicates via `cargo update`.

---
*PR created automatically by Jules for task [3684475942485199472](https://jules.google.com/task/3684475942485199472) started by @EffortlessSteven*