### PR TITLE
auditor: remove unused error_anyhow feature from napi dependency in tokmd-node 🧾

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,6 @@ version = "3.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb7848c221fb7bb789e02f01875287ebb1e078b92a6566a34de01ef8806e7c2b"
 dependencies = [
- "anyhow",
  "bitflags",
  "ctor",
  "futures",

--- a/crates/tokmd-node/Cargo.toml
+++ b/crates/tokmd-node/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "3", features = ["async", "serde-json", "tokio_rt", "error_anyhow"] }
+napi = { version = "3", features = ["async", "serde-json", "tokio_rt"] }
 napi-derive = "3"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 serde_json.workspace = true


### PR DESCRIPTION
## 💡 Summary
Removed the unused `error_anyhow` feature flag from the `napi` dependency in the `tokmd-node` crate. This tightens the dependency surface by removing redundant features.

## 🎯 Why
The `tokmd-node` crate included the `error_anyhow` feature for `napi`, which brings in the `anyhow` crate to allow converting `anyhow::Error` to NAPI errors. However, `anyhow` is never actually used inside `tokmd-node/src` (the crate uses `napi::Error` natively). Removing unused feature flags keeps the compilation surface minimal and clean, adhering to the Auditor persona's mandate for dependency hygiene.

## 🔎 Evidence
- File: `crates/tokmd-node/Cargo.toml`
- Finding: `napi = { version = "3", features = ["async", "serde-json", "tokio_rt", "error_anyhow"] }`
- Receipt: `grep -rn "anyhow" crates/tokmd-node/src` returned absolutely no results, proving it was dead weight.

## 🧭 Options considered
### Option A (recommended)
- **What it is:** Remove the `error_anyhow` feature from the `napi` dependency.
- **Why it fits this repo and shard:** Removing unused dependencies or features is the primary goal of the Auditor persona (#1 target ranking). It cleanly tightens the crate's manifest without changing runtime behavior.
- **Trade-offs:** 
  - *Structure:* Cleaner dependency graph and tighter feature flags.
  - *Velocity:* Marginally faster compilation times, fewer crates to download.
  - *Governance:* Reduces attack surface and dependency bloat.

### Option B
- **What it is:** Do not touch the feature flag, leaving the `error_anyhow` feature enabled.
- **When to choose it instead:** Only if we had observed that `anyhow` was actually being used to cast or return errors via the `error_anyhow` extension trait provided by NAPI.
- **Trade-offs:** Maintains the status quo but fails to accomplish the Auditor persona mission of improving dependency hygiene by removing redundant declarations.

## ✅ Decision
**Option A**. Removing the unused feature tightens the compilation surface and adheres to the hygiene constraints with zero risk of breaking functionality.

## 🧱 Changes made (SRP)
- `crates/tokmd-node/Cargo.toml`

## 🧪 Verification receipts
```text
$ grep -rn "anyhow" crates/tokmd-node/src
(no output)

$ cargo test -p tokmd-node
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s

$ cargo clippy -p tokmd-node -- -D warnings
(no output, passed)

$ cargo xtask version-consistency
Version consistency checks passed.
```

## 🧭 Telemetry
- Change shape: Feature flag removal
- Blast radius: Compilation only (crates/tokmd-node)
- Risk class: Low - Does not impact runtime logic.
- Rollback: Revert the Cargo.toml change.
- Gates run: `cargo clippy`, `cargo test`, `cargo xtask version-consistency`

## 🗂️ .jules artifacts
- `.jules/runs/auditor_bindings_manifests/envelope.json`
- `.jules/runs/auditor_bindings_manifests/decision.md`
- `.jules/runs/auditor_bindings_manifests/receipts.jsonl`
- `.jules/runs/auditor_bindings_manifests/result.json`
- `.jules/runs/auditor_bindings_manifests/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [14178007072535039926](https://jules.google.com/task/14178007072535039926) started by @EffortlessSteven*