### PR TITLE
test: replace HashSet with BTreeSet for deterministic ordering 🧪 Gatekeeper

### DIFF
--- a/.jules/quality/envelopes/14776e42-d8d5-4858-9428-b0fc2eb3146b.json
+++ b/.jules/quality/envelopes/14776e42-d8d5-4858-9428-b0fc2eb3146b.json
@@ -1,0 +1,1 @@
+{"id":"14776e42-d8d5-4858-9428-b0fc2eb3146b","date":"2026-03-12","description":"test: replace HashSet with BTreeSet for deterministic ordering 🧪 Gatekeeper"}

--- a/.jules/quality/ledger.json
+++ b/.jules/quality/ledger.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "14776e42-d8d5-4858-9428-b0fc2eb3146b",
+    "date": "2026-03-12",
+    "description": "test: replace HashSet with BTreeSet for deterministic ordering 🧪 Gatekeeper"
+  }
+]

--- a/.jules/quality/runs/2026-03-12.md
+++ b/.jules/quality/runs/2026-03-12.md
@@ -1,0 +1,1 @@
+# Gatekeeper Run 2026-03-12\n\nReplaced HashSet with BTreeSet in tokmd-tokeignore tests for deterministic ordering.

--- a/crates/tokmd-tokeignore/tests/bdd.rs
+++ b/crates/tokmd-tokeignore/tests/bdd.rs
@@ -781,7 +781,7 @@ mod template_structure {
 
     #[test]
     fn no_duplicate_patterns_in_any_template() {
-        use std::collections::HashSet;
+        use std::collections::BTreeSet;
         for profile in ALL_PROFILES {
             let content = write_and_read(profile);
             let patterns: Vec<&str> = content
@@ -789,7 +789,7 @@ mod template_structure {
                 .map(|l| l.trim())
                 .filter(|l| !l.is_empty() && !l.starts_with('#'))
                 .collect();
-            let unique: HashSet<&str> = patterns.iter().copied().collect();
+            let unique: BTreeSet<&str> = patterns.iter().copied().collect();
             assert_eq!(
                 patterns.len(),
                 unique.len(),
@@ -807,7 +807,7 @@ mod template_structure {
 mod superset_relationships {
     use super::*;
 
-    fn pattern_set(content: &str) -> std::collections::HashSet<String> {
+    fn pattern_set(content: &str) -> std::collections::BTreeSet<String> {
         content
             .lines()
             .map(|l| l.trim().to_string())

--- a/crates/tokmd-tokeignore/tests/deep2.rs
+++ b/crates/tokmd-tokeignore/tests/deep2.rs
@@ -2,7 +2,7 @@
 //! comparison, pattern classification, and cross-profile consistency
 //! not covered by existing deep/bdd/properties/init/snapshot tests.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::PathBuf;
 
@@ -155,7 +155,7 @@ fn each_profile_has_unique_header_comment() {
         let header = content.lines().next().unwrap().to_string();
         headers.insert(format!("{profile:?}"), header);
     }
-    let unique: HashSet<&String> = headers.values().collect();
+    let unique: BTreeSet<&String> = headers.values().collect();
     assert_eq!(
         unique.len(),
         ALL_PROFILES.len(),

--- a/crates/tokmd-tokeignore/tests/deep_tokeignore_w49.rs
+++ b/crates/tokmd-tokeignore/tests/deep_tokeignore_w49.rs
@@ -1,7 +1,7 @@
 //! Wave-49 deep tests for tokmd-tokeignore: template generation, pattern
 //! validation, custom exclusion rules, property tests, and edge cases.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
 
@@ -344,7 +344,7 @@ fn refuse_overwrite_preserves_original_content() {
 
 #[test]
 fn all_profiles_produce_unique_content() {
-    let mut seen = HashSet::new();
+    let mut seen = BTreeSet::new();
     for profile in ALL_PROFILES {
         let content = write_template(profile);
         assert!(

--- a/crates/tokmd-tokeignore/tests/properties.rs
+++ b/crates/tokmd-tokeignore/tests/properties.rs
@@ -3,7 +3,7 @@
 //! These tests verify template selection properties, content properties,
 //! and enum coverage for InitProfile variants.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use proptest::prelude::*;
@@ -216,7 +216,7 @@ proptest! {
 /// Test that all InitProfile variants produce distinct templates.
 #[test]
 fn all_profiles_produce_distinct_templates() {
-    let mut templates: HashSet<String> = HashSet::new();
+    let mut templates: BTreeSet<String> = BTreeSet::new();
     let mut profile_contents: Vec<(InitProfile, String)> = Vec::new();
 
     for profile in ALL_PROFILES {
@@ -601,7 +601,7 @@ proptest! {
             .map(|l| l.trim())
             .filter(|l| !l.is_empty() && !l.starts_with('#'))
             .collect();
-        let unique: HashSet<&str> = patterns.iter().copied().collect();
+        let unique: BTreeSet<&str> = patterns.iter().copied().collect();
         prop_assert_eq!(
             patterns.len(),
             unique.len(),

--- a/crates/tokmd-tokeignore/tests/tokeignore_deep_w76.rs
+++ b/crates/tokmd-tokeignore/tests/tokeignore_deep_w76.rs
@@ -2,7 +2,7 @@
 //! structure, language-specific isolation, default exclusion invariants,
 //! and template generation quality.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
 
@@ -138,7 +138,7 @@ fn no_duplicate_patterns_within_a_template() {
     for profile in ALL_PROFILES {
         let content = write_template(profile);
         let patterns = pattern_lines(&content);
-        let unique: HashSet<&str> = patterns.iter().copied().collect();
+        let unique: BTreeSet<&str> = patterns.iter().copied().collect();
         assert_eq!(
             patterns.len(),
             unique.len(),


### PR DESCRIPTION
## 🧪 Gatekeeper 

**Goal:** Maximize SRP-quality improvement per reviewer minute. One meaningful improvement that is easy to trust and easy to review.

### Decision
- **Option A (Chosen):** Replace `HashSet` with `BTreeSet` in `crates/tokmd-tokeignore/tests/` to guarantee deterministic iteration and reproducible outputs, preventing test flakiness.
- **Option B:** Add a test case for missing edge cases in `tokeignore` parsing.

I chose Option A because the repository explicitly mandates preferring `BTreeSet` over `HashSet` to ensure deterministic ordering, making it a high-signal quality win aligned with the Gatekeeper persona.

### Implementation
- Substituted `HashSet` with `BTreeSet` across multiple test files in `crates/tokmd-tokeignore/tests/`.
- Updated `.jules/quality/` state (ledger, envelope, and run log) with the new task information.

### Receipts
```
$ cargo test -p tokmd-tokeignore
...
test properties::template_lines_are_valid_gitignore ... ok
test properties::template_is_deterministic ... ok
test properties::template_no_double_slash_comments ... ok

test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.47s
```

---
*PR created automatically by Jules for task [11058889615869122085](https://jules.google.com/task/11058889615869122085) started by @EffortlessSteven*