### PR TITLE
test: fix non-deterministic sorts in tokmd-cockpit ReviewItem and change_surface 🧪 Gatekeeper

### DIFF
--- a/.jules/quality/envelopes/6fb606c1-4206-4cc0-bce1-4e6443c03714.json
+++ b/.jules/quality/envelopes/6fb606c1-4206-4cc0-bce1-4e6443c03714.json
@@ -1,0 +1,1 @@
+{"id": "6fb606c1-4206-4cc0-bce1-4e6443c03714", "persona": "Gatekeeper", "lane": "B"}

--- a/.jules/quality/ledger.json
+++ b/.jules/quality/ledger.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "6fb606c1-4206-4cc0-bce1-4e6443c03714",
+    "date": "2026-04-07T20:12:25Z",
+    "type": "determinism",
+    "description": "Fix non-deterministic sorts in tokmd-cockpit ReviewItem and change_surface"
+  }
+]

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -19,7 +19,6 @@
 pub mod determinism;
 pub mod render;
 
-use std::cmp::Reverse;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -1818,15 +1817,15 @@ fn compute_change_surface(
     };
 
     // Simple change concentration: what % of changes are in top 20% of files
-    let mut changes: Vec<usize> = file_stats
+    let mut changes: Vec<(usize, &String)> = file_stats
         .iter()
-        .map(|s| s.insertions + s.deletions)
+        .map(|s| (s.insertions + s.deletions, &s.path))
         .collect();
-    changes.sort_by_key(|&c| Reverse(c));
+    changes.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(b.1)));
 
     let top_count = (files_changed as f64 * 0.2).ceil() as usize;
-    let total_changes: usize = changes.iter().sum();
-    let top_changes: usize = changes.iter().take(top_count).sum();
+    let total_changes: usize = changes.iter().map(|(c, _)| c).sum();
+    let top_changes: usize = changes.iter().take(top_count).map(|(c, _)| c).sum();
 
     let change_concentration = if total_changes > 0 {
         top_changes as f64 / total_changes as f64
@@ -2067,7 +2066,7 @@ pub fn generate_review_plan(file_stats: &[FileStat], _contracts: &Contracts) -> 
         });
     }
 
-    items.sort_by_key(|i| i.priority);
+    items.sort_by(|a, b| a.priority.cmp(&b.priority).then_with(|| a.path.cmp(&b.path)));
     items
 }
 

--- a/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_large_files.snap
+++ b/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_large_files.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/tokmd-cockpit/tests/snapshot_w45.rs
+assertion_line: 250
 expression: md
 ---
 ## Glass Cockpit
@@ -65,14 +66,14 @@ expression: md
 
 ### Review Plan
 
-- **src/mega.rs** (priority: 1)
-  - Reason: 600 lines changed
-  - Complexity: 5
-  - Lines changed: 600
 - **src/another_big.rs** (priority: 1)
   - Reason: 550 lines changed
   - Complexity: 5
   - Lines changed: 550
+- **src/mega.rs** (priority: 1)
+  - Reason: 600 lines changed
+  - Complexity: 5
+  - Lines changed: 600
 - **src/small.rs** (priority: 3)
   - Reason: 12 lines changed
   - Complexity: 1

--- a/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_multi_file.snap
+++ b/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_multi_file.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/tokmd-cockpit/tests/snapshot_w45.rs
+assertion_line: 113
 expression: md
 ---
 ## Glass Cockpit
@@ -67,11 +68,11 @@ expression: md
   - Reason: 60 lines changed
   - Complexity: 1
   - Lines changed: 60
-- **README.md** (priority: 3)
-  - Reason: 25 lines changed
-  - Complexity: 1
-  - Lines changed: 25
 - **Cargo.toml** (priority: 3)
   - Reason: 7 lines changed
   - Complexity: 1
   - Lines changed: 7
+- **README.md** (priority: 3)
+  - Reason: 25 lines changed
+  - Complexity: 1
+  - Lines changed: 25


### PR DESCRIPTION
test: fix non-deterministic sorts in tokmd-cockpit ReviewItem and change_surface 🧪 Gatekeeper

Replaced `sort_by_key` on integers (which can cause unstable order for ties) with `sort_by` that explicitly breaks ties using file paths. This fixes determinism issues in change surface concentration logic and generated review plans. Receipts included in the PR body.

---
*PR created automatically by Jules for task [4701111885043403835](https://jules.google.com/task/4701111885043403835) started by @EffortlessSteven*