### PR TITLE
perf: avoid SubstrateFile cloning in sensor ⚡ Bolt

### DIFF
--- a/crates/tokmd-sensor/src/substrate_builder.rs
+++ b/crates/tokmd-sensor/src/substrate_builder.rs
@@ -50,16 +50,16 @@ pub fn build_substrate(
 
     // Convert file rows to substrate files
     let files: Vec<SubstrateFile> = file_rows
-        .iter()
+        .into_iter()
         .map(|row| SubstrateFile {
-            path: row.path.clone(),
-            lang: row.lang.clone(),
+            in_diff: changed_set.contains(row.path.as_str()),
+            path: row.path,
+            lang: row.lang,
             code: row.code,
             lines: row.lines,
             bytes: row.bytes,
             tokens: row.tokens,
-            module: row.module.clone(),
-            in_diff: changed_set.contains(row.path.as_str()),
+            module: row.module,
         })
         .collect();
 


### PR DESCRIPTION
--- 
# PR Glass Cockpit 
 
Make review boring. Make truth cheap. 
 
## 💡 Summary 
Optimized the allocation of `SubstrateFile` objects in `tokmd-sensor` by eliminating the cloning of strings during the iteration sequence over `file_rows`.
 
## 🎯 Why (perf bottleneck) 
The loop iterating over `file_rows` was performing a `String::clone()` for the `path`, `lang`, and `module` fields for every single file in the repository. As the `file_rows` structure is not needed afterwards, this creates 3 unnecessary heap allocations per file processed. 
 
## 📊 Proof (before/after) 
- Structural proof: The loop iterating over the file rows was allocating string clones for the path, lang, and module for every single file. Switching the iter() to an into_iter() consumed the strings properly, avoiding 3x String::clone() calls per file processed across the entire repo surface.
 
## 🧭 Options considered 
### Option A (recommended) 
- What it is: Refactor the loop over `file_rows` from `.iter()` to `.into_iter()`.
- Why it fits this repo: Reduces heap allocations, keeping the `sensor` lane fast on large mono-repos. 
- Trade-offs: We consume `file_rows`, which is perfectly safe here as it is not used later in the function.
 
### Option B 
- What it is: Leave as is. 
- When to choose it instead: If `file_rows` was needed for further processing down the line. 
- Trade-offs: Wastes memory allocations for strings on every file processed in the repository.
 
## ✅ Decision 
Option A.
 
## 🧱 Changes made (SRP) 
- `crates/tokmd-sensor/src/substrate_builder.rs`
 
## 🧪 Verification receipts 
Commands + results:
```json
    {
      "cmd": "cargo build --verbose",
      "exit_status": "0",
      "summary": "PASS"
    },
    {
      "cmd": "cargo test -p tokmd-sensor --no-default-features",
      "exit_status": "0",
      "summary": "PASS"
    },
    {
      "cmd": "cargo clippy -p tokmd-sensor -- -D warnings",
      "exit_status": "0",
      "summary": "PASS"
    }
```
 
## 🧭 Telemetry 
- Change shape: Structural allocation reduction.
- Blast radius (API / IO / format stability / concurrency): Pure logic modification without external API changes.
- Risk class + why: Low. Standard Rust ownership transfer rules apply.
- Rollback: Revert commit.
- Merge-confidence gates (what ran): build, test, clippy
 
## 🗂️ .jules updates 
- Created `.jules/policy/scheduled_tasks.json`, `.jules/runbooks/PR_GLASS_COCKPIT.md`, `.jules/runbooks/FRICTION_ITEM.md`, `.jules/bolt/README.md`, `.jules/README.md` to ensure the repository standards exist.
- Generated `run-id` envelope and added this task as an entry to the Bolt ledger tracking in `.jules/bolt/ledger.json`.
 
## 📝 Notes (freeform) 
None.
 
## 🔜 Follow-ups 
None.
---

---
*PR created automatically by Jules for task [1035189325142410806](https://jules.google.com/task/1035189325142410806) started by @EffortlessSteven*