### PR TITLE
test: lock deterministic ordering for format outputs 🧪 Gatekeeper

### DIFF
--- a/crates/tokmd-analysis-format/src/lib.rs
+++ b/crates/tokmd-analysis-format/src/lib.rs
@@ -1302,6 +1302,112 @@ mod tests {
 
     // Test render_md with predictive churn empty
     #[test]
+    fn test_render_md_churn_deterministic_tiebreak() {
+        use std::collections::BTreeMap;
+
+        let mut receipt = minimal_receipt();
+        let mut per_module = BTreeMap::new();
+        per_module.insert(
+            "z_module".to_string(),
+            tokmd_analysis_types::ChurnTrend {
+                slope: -0.5,
+                r2: 0.8,
+                recent_change: 5,
+                classification: tokmd_analysis_types::TrendClass::Rising,
+            },
+        );
+        per_module.insert(
+            "a_module".to_string(),
+            tokmd_analysis_types::ChurnTrend {
+                slope: -0.5,
+                r2: 0.8,
+                recent_change: 5,
+                classification: tokmd_analysis_types::TrendClass::Rising,
+            },
+        );
+        receipt.predictive_churn = Some(tokmd_analysis_types::PredictiveChurnReport { per_module });
+
+        let result = render_md(&receipt);
+        let a_idx = result.find("|a_module|-0.5000|0.80|5|Rising|").unwrap();
+        let z_idx = result.find("|z_module|-0.5000|0.80|5|Rising|").unwrap();
+        assert!(
+            a_idx < z_idx,
+            "a_module should appear before z_module for identical slopes"
+        );
+    }
+
+    #[test]
+    fn test_render_md_maintenance_deterministic_tiebreak() {
+        let mut receipt = minimal_receipt();
+        receipt.git = Some(tokmd_analysis_types::GitReport {
+            commits_scanned: 10,
+            files_seen: 10,
+            hotspots: vec![],
+            bus_factor: vec![],
+            freshness: tokmd_analysis_types::FreshnessReport {
+                threshold_days: 90,
+                stale_files: 0,
+                total_files: 0,
+                stale_pct: 0.0,
+                by_module: vec![],
+            },
+            age_distribution: None,
+            coupling: vec![],
+            intent: Some(tokmd_analysis_types::CommitIntentReport {
+                overall: tokmd_analysis_types::CommitIntentCounts::default(),
+                by_module: vec![
+                    tokmd_analysis_types::ModuleIntentRow {
+                        module: "z_module".to_string(),
+                        counts: tokmd_analysis_types::CommitIntentCounts {
+                            total: 10,
+                            feat: 0,
+                            fix: 5,
+                            refactor: 0,
+                            chore: 0,
+                            revert: 0,
+                            docs: 0,
+                            test: 0,
+                            ci: 0,
+                            build: 0,
+                            perf: 0,
+                            style: 0,
+                            other: 0,
+                        },
+                    },
+                    tokmd_analysis_types::ModuleIntentRow {
+                        module: "a_module".to_string(),
+                        counts: tokmd_analysis_types::CommitIntentCounts {
+                            total: 10,
+                            feat: 0,
+                            fix: 5,
+                            refactor: 0,
+                            chore: 0,
+                            revert: 0,
+                            docs: 0,
+                            test: 0,
+                            ci: 0,
+                            build: 0,
+                            perf: 0,
+                            style: 0,
+                            other: 0,
+                        },
+                    },
+                ],
+                unknown_pct: 0.0,
+                corrective_ratio: Some(0.0),
+            }),
+        });
+
+        let result = render_md(&receipt);
+        let a_idx = result.find("|a_module|5|10|50.0%|").unwrap();
+        let z_idx = result.find("|z_module|5|10|50.0%|").unwrap();
+        assert!(
+            a_idx < z_idx,
+            "a_module should appear before z_module for identical maintenance shares"
+        );
+    }
+
+    #[test]
     fn test_render_md_churn_empty() {
         use std::collections::BTreeMap;
         let mut receipt = minimal_receipt();


### PR DESCRIPTION
---
# PR Glass Cockpit

Make review boring. Make truth cheap.

## 💡 Summary
Adds missing test coverage for edge-case determinism in `tokmd-analysis-format`. Specifically, this ensures that the markdown rendering logic correctly falls back to alphabetical module sorting when primary metrics (like churn slope or fix share) are numerically identical.

## 🎯 Why (perf bottleneck)
While the production code already correctly included a `.then_with` string comparison to break floating-point ties in both the predictive churn and maintenance hotspots tables, there were *no tests* enforcing this invariant. Without tests, future refactoring could silently remove the tie-breakers, leading to non-deterministic receipt generation and test flakiness across the fleet.

## 📊 Proof (before/after)
Structural proof: The tests explicitly inject identically scored items and verify the generated markdown strings present them in correct alphabetical order. This guarantees the stable output invariant is protected by the test suite.

## 🧭 Options considered
### Option A (recommended)
- Add targeted unit tests to `tokmd-analysis-format` verifying tie-breaker sorting for `maintenance` and `predictive_churn`.
- Why it fits this repo: Maximizes SRP-quality improvement per reviewer minute by directly tightening invariants with targeted tests, satisfying the Gatekeeper "scout discovery" mandate.
- Trade-offs: Minor addition to test compile time, but zero runtime overhead.

### Option B
- Refactor the underlying `BTreeMap` structures in the analysis models to enforce sorted iteration prior to formatting.
- When to choose it instead: If the data models themselves required sorted access across multiple formatters.
- Trade-offs: Unnecessary overhead for models that only require sorting during the final presentation layer.

## ✅ Decision
Proceeded with Option A. It correctly scopes the determinism requirement to the formatting layer where the `Vec` sorting occurs and directly protects the invariant with new tests.

## 🧱 Changes made (SRP)
- `crates/tokmd-analysis-format/src/lib.rs`: Added `test_render_md_churn_deterministic_tiebreak` and `test_render_md_maintenance_deterministic_tiebreak`.

## 🧪 Verification receipts
```bash
cargo test -p tokmd-analysis-format
```
(All 52 tests passed, verifying deterministic rendering for maintenance and predictive churn).

## 🧭 Telemetry
- Change shape: Test-only addition.
- Blast radius: None (Test code only).
- Risk class: Low (Tightens existing invariants).
- Rollback: Revert the test additions.
- Merge-confidence gates: `cargo test -p tokmd-analysis-format`, `cargo check`

## 🗂️ .jules updates
Appended run entry to `.jules/quality/ledger.json` and created corresponding run envelope/log.
---

---
*PR created automatically by Jules for task [16764850452412057706](https://jules.google.com/task/16764850452412057706) started by @EffortlessSteven*