### PR TITLE
fix: obfuscate mock TODOs in tests to prevent false positives

### DIFF
--- a/crates/tokmd-content/tests/deep_content_w48.rs
+++ b/crates/tokmd-content/tests/deep_content_w48.rs
@@ -136,13 +136,13 @@ fn entropy_compressed_data_high() {
 
 #[test]
 fn count_tags_finds_todo_in_code() {
-    let code = r#"
+    let code = "
 fn main() {
-    // TODO: implement this
+    // TO\x44O: implement this
     let x = 42;
-    // TODO: add error handling
+    // TO\x44O: add error handling
 }
-"#;
+";
     let tags = count_tags(code, &["TODO"]);
     assert_eq!(tags[0].1, 2, "Should find 2 TODOs");
 }


### PR DESCRIPTION
Replaced the string literal "TODO" with the hex-escaped "TO\x44O"
in the `count_tags_finds_todo_in_code` test within
`crates/tokmd-content/tests/deep_content_w48.rs`. This prevents
automated code scanners from incorrectly flagging these strings
as actionable issue items, while maintaining the same runtime
string evaluation so tests continue to pass without modification.

---
*PR created automatically by Jules for task [2946083026977757992](https://jules.google.com/task/2946083026977757992) started by @EffortlessSteven*