### PR TITLE
test(content): obfuscate TODO tags in mock string literals

### DIFF
--- a/crates/tokmd-content/tests/deep_content_w48.rs
+++ b/crates/tokmd-content/tests/deep_content_w48.rs
@@ -136,20 +136,20 @@ fn entropy_compressed_data_high() {
 
 #[test]
 fn count_tags_finds_todo_in_code() {
-    let code = r#"
+    let code = "
 fn main() {
-    // TODO: implement this
+    // TO\x44O: implement this
     let x = 42;
-    // TODO: add error handling
+    // TO\x44O: add error handling
 }
-"#;
+";
     let tags = count_tags(code, &["TODO"]);
     assert_eq!(tags[0].1, 2, "Should find 2 TODOs");
 }
 
 #[test]
 fn count_tags_finds_fixme_and_hack() {
-    let code = "// FIXME: broken\n// HACK: workaround\n// FIXME: another";
+    let code = "// FI\x58ME: broken\n// HA\x43K: workaround\n// FI\x58ME: another";
     let tags = count_tags(code, &["FIXME", "HACK"]);
     assert_eq!(tags[0].1, 2, "FIXME count");
     assert_eq!(tags[1].1, 1, "HACK count");
@@ -157,7 +157,7 @@ fn count_tags_finds_fixme_and_hack() {
 
 #[test]
 fn count_tags_case_insensitive() {
-    let code = "todo Todo TODO tOdO";
+    let code = "to\x64o To\x64o TO\x44O tO\x64O";
     let tags = count_tags(code, &["TODO"]);
     assert_eq!(tags[0].1, 4, "All case variants should match");
 }
@@ -173,7 +173,7 @@ fn count_tags_no_false_positives_on_clean_code() {
 
 #[test]
 fn count_tags_preserves_order_and_names() {
-    let tags = count_tags("TODO FIXME", &["FIXME", "TODO", "HACK"]);
+    let tags = count_tags("TO\x44O FI\x58ME", &["FIXME", "TODO", "HACK"]);
     assert_eq!(tags[0].0, "FIXME");
     assert_eq!(tags[1].0, "TODO");
     assert_eq!(tags[2].0, "HACK");
@@ -188,7 +188,7 @@ fn count_tags_empty_text() {
 
 #[test]
 fn count_tags_adjacent_occurrences() {
-    let text = "TODOTODOTODO";
+    let text = "TO\x44OTO\x44OTO\x44O";
     let tags = count_tags(text, &["TODO"]);
     assert_eq!(tags[0].1, 3, "Adjacent TODOs should be counted separately");
 }


### PR DESCRIPTION
Fixes false positives generated by code-scanning tools by obfuscating plain text tags like "TODO", "FIXME", and "HACK" inside mock string literals used in `tokmd-content` tests.

Specifically, it replaces the raw string literal `r#"..."#` with a regular multiline string `"..."` to allow the use of hexadecimal escape sequences (e.g. `TO\x44O`). Because these escapes evaluate at compile time to the exact underlying character sequence, the tests continue to operate identically on the same runtime bytes while bypassing auto-generated issues.

---
*PR created automatically by Jules for task [9264721926006591321](https://jules.google.com/task/9264721926006591321) started by @EffortlessSteven*