### PR TITLE
compat: fix `--no-default-features` build failure by adding `git` feature gates 🧷

### DIFF
--- a/.jules/runs/compat-interfaces-001/decision.md
+++ b/.jules/runs/compat-interfaces-001/decision.md
@@ -1,0 +1,8 @@
+# Option A: Conditionally Compile Git Interactions
+Use `#[cfg(feature = "git")]` in commands like `baseline`, `check_ignore`, and `handoff` when calling out to `tokmd_git`. When the `git` feature is not enabled, use fallback logic (e.g. returning `None`, `false`, or assuming Git is not available) so that `cargo build --no-default-features` or missing the `git` feature compiles successfully.
+
+# Option B: Always Require Git Feature
+Force the `git` feature to always be enabled by modifying `Cargo.toml`. This prevents the compatibility issue but defeats the purpose of the feature flags which allow the crate to be built minimally without `tokmd_git` dependencies.
+
+## Decision
+I will proceed with Option A because it correctly addresses the `--no-default-features` compilation failure while respecting the crate's modular feature flags. This is the recommended approach for Rust compatibility across feature matrices.

--- a/.jules/runs/compat-interfaces-001/envelope.json
+++ b/.jules/runs/compat-interfaces-001/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "compat_interfaces_matrix",
+  "persona": "Compat",
+  "style": "Builder",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "compat-matrix",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/compat-interfaces-001/pr_body.md
+++ b/.jules/runs/compat-interfaces-001/pr_body.md
@@ -1,0 +1,58 @@
+## 💡 Summary
+Fixed a compilation failure when building `tokmd` without default features. The crate could not be built with `cargo check -p tokmd --no-default-features` because several modules (`baseline`, `check_ignore`, `handoff`) blindly called `tokmd_git` without feature gating. Added proper `#[cfg(feature = "git")]` and fallback paths.
+
+## 🎯 Why
+Building the crate with `--no-default-features` resulted in `error[E0433]: failed to resolve: use of unresolved module or unlinked crate tokmd_git`. Respecting feature boundaries is necessary for platform and downstream dependency compatibility.
+
+## 🔎 Evidence
+- `crates/tokmd/src/commands/check_ignore.rs`
+- `crates/tokmd/src/commands/baseline.rs`
+- `crates/tokmd/src/commands/handoff.rs`
+- `cargo check -p tokmd --no-default-features` failed with:
+  ```
+  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`
+  ```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Conditionally compile the `tokmd_git` checks using `#[cfg(feature = "git")]` and provide `#[cfg(not(feature = "git"))]` fallbacks (e.g., returning `false` or `None`).
+- Respects the modular architecture of the crate and avoids forcing the `git` dependency.
+- Trade-offs: Requires a bit more boilerplate code for the fallback implementations.
+
+### Option B
+- Always require the `git` feature in `Cargo.toml`.
+- When to choose it instead: If the application cannot function at all without `git`.
+- Trade-offs: Defeats the purpose of the feature flags and prevents minimal builds.
+
+## ✅ Decision
+Chose Option A to cleanly fix the compilation issue while maintaining feature modularity.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd/src/commands/check_ignore.rs`
+- `crates/tokmd/src/commands/baseline.rs`
+- `crates/tokmd/src/commands/handoff.rs`
+
+## 🧪 Verification receipts
+```text
+cargo check -p tokmd --no-default-features
+cargo check -p tokmd --all-features
+cargo test -p tokmd --no-default-features
+cargo test -p tokmd --all-features
+```
+
+## 🧭 Telemetry
+- Change shape: Adding feature flags and simple fallbacks
+- Blast radius: compatibility
+- Risk class + why: low, because the changes merely compile out code when features are omitted
+- Rollback: git revert
+- Gates run: `cargo check` and `cargo test` with varying feature flags
+
+## 🗂️ .jules artifacts
+- `.jules/runs/compat-interfaces-001/envelope.json`
+- `.jules/runs/compat-interfaces-001/decision.md`
+- `.jules/runs/compat-interfaces-001/receipts.jsonl`
+- `.jules/runs/compat-interfaces-001/result.json`
+- `.jules/runs/compat-interfaces-001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/compat-interfaces-001/receipts.jsonl
+++ b/.jules/runs/compat-interfaces-001/receipts.jsonl
@@ -1,0 +1,1 @@
+{"command":"cargo check -p tokmd --no-default-features","status":"failed","evidence":"error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`"}

--- a/.jules/runs/compat-interfaces-001/result.json
+++ b/.jules/runs/compat-interfaces-001/result.json
@@ -1,0 +1,15 @@
+{
+  "summary": "Fix compilation error with `--no-default-features` by adding correct `#[cfg(feature = \"git\")]` and `#[cfg(not(feature = \"git\"))]` bounds and fallbacks in `check_ignore.rs`, `baseline.rs`, and `handoff.rs`.",
+  "telemetry": {
+    "change_shape": "Adding feature flags and simple fallbacks",
+    "blast_radius": "compatibility",
+    "risk_class": "low",
+    "rollback": "revert commit",
+    "gates_run": [
+      "cargo check -p tokmd --no-default-features",
+      "cargo check -p tokmd --all-features",
+      "cargo test -p tokmd --no-default-features",
+      "cargo test -p tokmd --all-features"
+    ]
+  }
+}

--- a/crates/tokmd/src/commands/baseline.rs
+++ b/crates/tokmd/src/commands/baseline.rs
@@ -185,6 +185,7 @@ fn compute_determinism_baseline(root: &Path, file_paths: &[String]) -> Result<De
 ///
 /// Returns `Some(sha)` if the path is inside a git repository,
 /// `None` otherwise or if git is not available.
+#[cfg(feature = "git")]
 fn capture_git_commit(path: &Path) -> Option<String> {
     let output = tokmd_git::git_cmd()
         .arg("-C")
@@ -201,6 +202,11 @@ fn capture_git_commit(path: &Path) -> Option<String> {
         }
     }
 
+    None
+}
+
+#[cfg(not(feature = "git"))]
+fn capture_git_commit(_path: &Path) -> Option<String> {
     None
 }
 

--- a/crates/tokmd/src/commands/check_ignore.rs
+++ b/crates/tokmd/src/commands/check_ignore.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+#[cfg(feature = "git")]
 use std::process::Stdio;
 
 use anyhow::Result;
@@ -43,6 +44,7 @@ struct CheckResult {
 
 #[derive(Clone)]
 enum IgnoreReason {
+    #[allow(dead_code)]
     Git {
         source: String,
         pattern: String,
@@ -118,6 +120,7 @@ fn check_path(path: &Path, global: &cli::GlobalArgs, verbose: bool) -> Result<Ch
     })
 }
 
+#[cfg(feature = "git")]
 fn check_git_ignore(path: &Path, verbose: bool) -> Option<IgnoreReason> {
     // Try to use git check-ignore -v
     let output = tokmd_git::git_cmd()
@@ -175,6 +178,12 @@ fn check_git_ignore(path: &Path, verbose: bool) -> Option<IgnoreReason> {
     None
 }
 
+#[cfg(not(feature = "git"))]
+fn check_git_ignore(_path: &Path, _verbose: bool) -> Option<IgnoreReason> {
+    None
+}
+
+#[cfg(feature = "git")]
 fn is_git_tracked(path: &Path) -> bool {
     tokmd_git::git_cmd()
         .args(["ls-files", "--error-unmatch", "--"])
@@ -184,6 +193,11 @@ fn is_git_tracked(path: &Path) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+#[cfg(not(feature = "git"))]
+fn is_git_tracked(_path: &Path) -> bool {
+    false
 }
 
 fn check_tokeignore(base_path: &Path, path_str: &str) -> Option<IgnoreReason> {

--- a/crates/tokmd/src/commands/handoff.rs
+++ b/crates/tokmd/src/commands/handoff.rs
@@ -271,15 +271,20 @@ pub(crate) fn handle(args: cli::HandoffArgs, global: &cli::GlobalArgs) -> Result
 }
 
 /// Detect available capabilities for the handoff.
+#[allow(unused_variables)]
 fn detect_capabilities(root: &Path, args: &cli::HandoffArgs) -> Vec<CapabilityStatus> {
     let mut capabilities = Vec::new();
 
     // Check git availability
+    #[cfg(feature = "git")]
     let git_available = tokmd_git::git_cmd()
         .arg("--version")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
+
+    #[cfg(not(feature = "git"))]
+    let git_available = false;
 
     if args.no_git {
         capabilities.push(CapabilityStatus {
@@ -305,12 +310,7 @@ fn detect_capabilities(root: &Path, args: &cli::HandoffArgs) -> Vec<CapabilitySt
     #[cfg(feature = "git")]
     let in_repo = tokmd_git::repo_root(root).is_some();
     #[cfg(not(feature = "git"))]
-    let in_repo = tokmd_git::git_cmd()
-        .args(["rev-parse", "--git-dir"])
-        .current_dir(root)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    let in_repo = false;
 
     if args.no_git {
         capabilities.push(CapabilityStatus {
@@ -333,12 +333,15 @@ fn detect_capabilities(root: &Path, args: &cli::HandoffArgs) -> Vec<CapabilitySt
     }
 
     // Check for shallow clone
+    #[cfg(feature = "git")]
     let shallow = tokmd_git::git_cmd()
         .args(["rev-parse", "--is-shallow-repository"])
         .current_dir(root)
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "true")
         .unwrap_or(false);
+    #[cfg(not(feature = "git"))]
+    let shallow = false;
 
     if args.no_git || !in_repo {
         capabilities.push(CapabilityStatus {


### PR DESCRIPTION
## 💡 Summary 
Fixed a compilation failure when building `tokmd` without default features. The crate could not be built with `cargo check -p tokmd --no-default-features` because several modules (`baseline`, `check_ignore`, `handoff`) blindly called `tokmd_git` without feature gating. Added proper `#[cfg(feature = "git")]` and fallback paths.

## 🎯 Why 
Building the crate with `--no-default-features` resulted in `error[E0433]: failed to resolve: use of unresolved module or unlinked crate tokmd_git`. Respecting feature boundaries is necessary for platform and downstream dependency compatibility.

## 🔎 Evidence 
- `crates/tokmd/src/commands/check_ignore.rs`
- `crates/tokmd/src/commands/baseline.rs`
- `crates/tokmd/src/commands/handoff.rs`
- `cargo check -p tokmd --no-default-features` failed with:
  ```
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`
  ```

## 🧭 Options considered 
### Option A (recommended) 
- Conditionally compile the `tokmd_git` checks using `#[cfg(feature = "git")]` and provide `#[cfg(not(feature = "git"))]` fallbacks (e.g., returning `false` or `None`).
- Respects the modular architecture of the crate and avoids forcing the `git` dependency.
- Trade-offs: Requires a bit more boilerplate code for the fallback implementations.

### Option B 
- Always require the `git` feature in `Cargo.toml`.
- When to choose it instead: If the application cannot function at all without `git`.
- Trade-offs: Defeats the purpose of the feature flags and prevents minimal builds.

## ✅ Decision 
Chose Option A to cleanly fix the compilation issue while maintaining feature modularity.

## 🧱 Changes made (SRP) 
- `crates/tokmd/src/commands/check_ignore.rs`
- `crates/tokmd/src/commands/baseline.rs`
- `crates/tokmd/src/commands/handoff.rs`

## 🧪 Verification receipts 
```text
cargo check -p tokmd --no-default-features
cargo check -p tokmd --all-features
cargo test -p tokmd --no-default-features
cargo test -p tokmd --all-features
```

## 🧭 Telemetry 
- Change shape: Adding feature flags and simple fallbacks
- Blast radius: compatibility
- Risk class + why: low, because the changes merely compile out code when features are omitted
- Rollback: git revert
- Gates run: `cargo check` and `cargo test` with varying feature flags

## 🗂️ .jules artifacts 
- `.jules/runs/compat-interfaces-001/envelope.json`
- `.jules/runs/compat-interfaces-001/decision.md`
- `.jules/runs/compat-interfaces-001/receipts.jsonl`
- `.jules/runs/compat-interfaces-001/result.json`
- `.jules/runs/compat-interfaces-001/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [2766173428515922666](https://jules.google.com/task/2766173428515922666) started by @EffortlessSteven*