### PR TITLE
palette: extract exact error code in browser runner 🎨

### DIFF
--- a/web/runner/runtime.js
+++ b/web/runner/runtime.js
@@ -27,16 +27,21 @@ function formatSupportedList(values) {
     return values.length > 0 ? values.join(", ") : "no supported entries";
 }
 
-function formatRunnerError(error) {
+function extractRunnerError(error) {
+    let message = "unknown runner error";
+
     if (error instanceof Error && typeof error.message === "string") {
-        return error.message;
+        message = error.message;
+    } else if (typeof error === "string") {
+        message = error;
     }
 
-    if (typeof error === "string") {
-        return error;
+    const match = message.match(/^\[([^\]]+)\]\s*(.*)$/);
+    if (match) {
+        return { code: match[1], message: match[2] || message };
     }
 
-    return "unknown runner error";
+    return { code: "run_failed", message };
 }
 
 async function invokeRunner(runner, mode, args) {
@@ -81,7 +86,7 @@ export async function handleRunnerMessage(message, options = {}) {
         return createErrorMessage(
             message.requestId,
             "wasm_boot_failed",
-            `browser runner failed to initialize tokmd-wasm: ${formatRunnerError(bootError)}`
+            `browser runner failed to initialize tokmd-wasm: ${extractRunnerError(bootError).message}`
         );
     }
 
@@ -125,10 +130,11 @@ export async function handleRunnerMessage(message, options = {}) {
         const data = await invokeRunner(runner, message.mode, message.args);
         return createResultMessage(message.requestId, data);
     } catch (error) {
+        const extracted = extractRunnerError(error);
         return createErrorMessage(
             message.requestId,
-            "run_failed",
-            formatRunnerError(error)
+            extracted.code,
+            extracted.message
         );
     }
 }

--- a/web/runner/runtime.test.mjs
+++ b/web/runner/runtime.test.mjs
@@ -179,6 +179,52 @@ test("runtime reserves cancel without promising it", async () => {
     assert.equal(message.error.code, "cancel_unavailable");
 });
 
+test("runtime extracts error codes from structured runner errors", async () => {
+    const runner = {
+        runExport() {
+            throw new Error("[invalid_settings] Cannot use both paths and inputs");
+        },
+    };
+
+    const message = await handleRunnerMessage(
+        createRunMessage({
+            requestId: "run-err-code",
+            mode: "export",
+            args: {
+                inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+            },
+        }),
+        { runner }
+    );
+
+    assert.equal(message.type, MESSAGE_TYPES.ERROR);
+    assert.equal(message.error.code, "invalid_settings");
+    assert.equal(message.error.message, "Cannot use both paths and inputs");
+});
+
+test("runtime extracts error codes from fallback string errors", async () => {
+    const runner = {
+        runExport() {
+            throw "[unknown_mode] What is this?";
+        },
+    };
+
+    const message = await handleRunnerMessage(
+        createRunMessage({
+            requestId: "run-err-code-str",
+            mode: "export",
+            args: {
+                inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+            },
+        }),
+        { runner }
+    );
+
+    assert.equal(message.type, MESSAGE_TYPES.ERROR);
+    assert.equal(message.error.code, "unknown_mode");
+    assert.equal(message.error.message, "What is this?");
+});
+
 test("runtime returns results once a runner is available", async () => {
     const message = await handleRunnerMessage(
         createRunMessage({


### PR DESCRIPTION
Fixed a runtime DX issue in `web/runner` where error codes generated by the WebAssembly bindings (such as `invalid_settings`) were being lost and lumped into the generic string `run_failed`. Extracted the exact error code via `extractRunnerError` to improve structural error recovery capabilities in JS contexts. Added relevant test validations in `web/runner/runtime.test.mjs`.

---
*PR created automatically by Jules for task [4050770549502264289](https://jules.google.com/task/4050770549502264289) started by @EffortlessSteven*