### PR TITLE
fuzzer: repair fuzz_toml_config by updating module path and dependencies 🌪️

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -85,10 +85,10 @@ exclude = ["dep:tokmd-exclude"]
 # Targets: fuzz_context_policy
 context_policy = ["dep:tokmd-context-policy", "dep:tokmd-types"]
 
-# Configuration file parsing (tokmd-config)
+# Configuration file parsing (tokmd-settings)
 # Targets: fuzz_toml_config
 # Needs serde_json and toml for round-trip testing
-config = ["dep:tokmd-config", "dep:serde_json", "dep:toml"]
+config = ["dep:tokmd-settings", "dep:serde_json", "dep:toml"]
 
 # Policy engine (tokmd-gate)
 # Targets: fuzz_policy_toml, fuzz_json_pointer, fuzz_policy_evaluate

--- a/fuzz/fuzz_targets/fuzz_toml_config.rs
+++ b/fuzz/fuzz_targets/fuzz_toml_config.rs
@@ -7,7 +7,7 @@
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use tokmd_config::TomlConfig;
+use tokmd_settings::TomlConfig;
 
 /// Max input size to prevent pathological parse times
 const MAX_INPUT_SIZE: usize = 64 * 1024; // 64KB


### PR DESCRIPTION
## 💡 Summary
Restored the `fuzz_toml_config` fuzz target by migrating its dependencies from `tokmd_config` to `tokmd_settings`. This ensures configuration parser input hardening remains actively fuzzable.

## 🎯 Why
During crate refactoring, `TomlConfig` and its related types were moved from `tokmd_config` to `tokmd_settings`. The corresponding fuzz target (`fuzz_toml_config`) was left pointing to the old crate and was broken. Restoring this ensures we maintain fuzzing coverage on the TOML configuration parser.

## 🔎 Evidence
- `fuzz/fuzz_targets/fuzz_toml_config.rs`
- Attempting to compile the fuzz target resulted in an unresolved import error for `tokmd_settings` after attempting to use it without updating `fuzz/Cargo.toml`.
- Cargo tree confirmed `TomlConfig` now resides in `tokmd_settings`.

## 🧭 Options considered
### Option A (recommended)
- Update the `tokmd-config` feature reference in `fuzz/Cargo.toml` and the module path in `fuzz_toml_config.rs` to point to the newly named crate `tokmd_settings`.
- This fits the repo and shard by restoring a broken fuzz target for configuration surfaces, improving input hardening.
- Trade-offs: Structure / Velocity / Governance - Restores existing testing infrastructure with minimal changes.

### Option B
- Remove the `fuzz_toml_config` target entirely.
- This would be chosen if the target were obsolete, but since `TomlConfig` still handles string-based parsing (via serde and TOML crates) which is an untrusted input parser surface, it should remain fuzzable.

## ✅ Decision
Selected Option A. It immediately restores a critical fuzz target that exercises the parser/config surface of `TomlConfig`, fulfilling the Fuzzer persona mission of hardening parsing inputs.

## 🧱 Changes made (SRP)
- Updated `fuzz/Cargo.toml` to change the `config` feature dependency from `dep:tokmd-config` to `dep:tokmd-settings`.
- Updated `fuzz/fuzz_targets/fuzz_toml_config.rs` to import from `tokmd_settings` instead of `tokmd_config`.

## 🧪 Verification receipts
```text
$ cargo build -p tokmd-fuzz --features="config" --bin fuzz_toml_config
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.73s

$ CI=true cargo test -p tokmd-settings
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.43s
```

## 🧭 Telemetry
- Change shape: Fuzz target repair
- Blast radius: None (tests only)
- Risk class: Low - touches only fuzzing infrastructure
- Rollback: Revert the PR
- Gates run: `cargo test -p tokmd-settings`, `cargo build -p tokmd-fuzz`

## 🗂️ .jules artifacts
- `.jules/runs/fuzzer_input_hardening/envelope.json`
- `.jules/runs/fuzzer_input_hardening/decision.md`
- `.jules/runs/fuzzer_input_hardening/receipts.jsonl`
- `.jules/runs/fuzzer_input_hardening/result.json`
- `.jules/runs/fuzzer_input_hardening/pr_body.md`

## 🔜 Follow-ups
- The ASAN linking errors for `cargo fuzz` on this specific runner toolchain might need upstream environmental investigation.

---
*PR created automatically by Jules for task [12874845454253351238](https://jules.google.com/task/12874845454253351238) started by @EffortlessSteven*