### PR TITLE
cartographer: align roadmap and architecture docs with shipped v1.9 browser guardrails 🗺️

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Embed them in your own README:
 `tokmd-wasm` and `web/runner` expose a narrower browser-safe slice of the product.
 
 - Supported today: `lang`, `module`, `export`, and browser-safe `analyze` presets on ordered in-memory inputs.
-- Public repo ingestion uses GitHub tree and contents APIs, not zipball-first fetches.
+- Public repo ingestion uses GitHub tree and contents APIs with built-in caching, progress tracking, and auth handling.
 - Git-history enrichers and full native filesystem flows remain native-first.
 
 ## What `tokmd` Is Not

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -487,6 +487,8 @@ UX work is explicitly **incremental and non-breaking**:
 - [x] Native-vs-wasm parity coverage exists for `lang`, `module`, `export`, `analyze receipt`, and `analyze estimate`.
 - [x] `web/runner` boots the real `tokmd-wasm` bundle in a dedicated worker, reports capabilities, renders the latest successful result, and supports JSON download.
 - [x] Public GitHub repo acquisition uses the browser-safe GitHub tree and contents APIs to materialize deterministic ordered inputs locally in the page.
+- [x] `tokmd-wasm` browser bundle is deployed as a versioned release artifact consumed directly from `web/runner/vendor/tokmd-wasm`.
+- [x] Browser runner guardrails and UX hardening landed, including caching, progress, authenticated fetch options, and rate-limit handling.
 
 ### Supported browser-safe surface today
 
@@ -497,7 +499,6 @@ UX work is explicitly **incremental and non-breaking**:
 
 ### Current browser constraints
 
-- Browser guardrails and UX hardening still need more work, especially caching, progress, authenticated fetch options, and rate-limit handling.
 - Browser-safe analysis should expand only where the preset can stay rootless and capability-honest.
 
 ### Non-goals for v1.9.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,6 +276,8 @@ The browser/WASM lane is now a shipped product surface:
 - CI includes wasm compile/tests plus native-vs-wasm parity coverage for the browser-safe modes.
 - `web/runner` boots the real wasm bundle in a dedicated worker, renders capabilities, shows the latest successful result, and supports JSON download.
 - Public browser repo loading uses the GitHub tree and contents APIs to materialize ordered `{ path, text }` inputs locally.
+- The `tokmd-wasm` browser bundle is now a versioned release artifact consumed from `web/runner/vendor/tokmd-wasm`.
+- Browser runner guardrails already landed, including caching, authenticated fetch options, and rate-limit/progress handling.
 
 ### Supported browser-safe contract today
 
@@ -288,8 +290,6 @@ Host-backed enrichers remain explicit capability misses in browser mode. Git-his
 
 ### Current browser constraints
 
-- Host the `tokmd-wasm` browser bundle as a versioned release artifact and consume it from `web/runner/vendor/tokmd-wasm` so browser boot stays deterministic across environments.
-- Add browser guardrails such as caching, authenticated fetch options, and better rate-limit/progress handling.
 - Broaden browser analysis only where the preset can stay rootless and capability-honest.
 
 ### Non-goals for v1.9.0


### PR DESCRIPTION
## 💡 Summary 
Moved browser/WASM guardrails, caching, progress tracking, and versioned `tokmd-wasm` deployment architecture from 'Remaining' to 'Landed' sections in `ROADMAP.md` and `docs/architecture.md`, matching the actual shipped capabilities in `web/runner`.

## 🎯 Why 
To cure factual drift between the shipped reality and the planning documents. Leaving these items under "Remaining for v1.9.0" falsely signals to reviewers and contributors that foundational browser hardening and CI/CD artifact integration are incomplete.

## 🔎 Evidence 
- **Files**: `web/runner/ingest.js`, `web/runner/README.md`, `CHANGELOG.md`
- **Finding**: `web/runner/ingest.js` and tests already handle `fetchGitHubRepoInputs` with caching, progress emitted markers, auth mode parsing, and rate limit error classification. The runner's `README.md` explicitly instructs consuming the versioned release artifact `tokmd-wasm-<tag>.tar.gz`.

## 🧭 Options considered 
### Option A (recommended) 
- What it is: Update `ROADMAP.md` and `docs/architecture.md` by moving the completed browser hardening features from "Remaining" to "What has landed". Also update `README.md` to reflect the fortified ingestion.
- Why it fits: Fits the `tooling-governance` shard and the `Cartographer` mission of fixing roadmap/design requirements drift from shipped reality.
- Trade-offs: Structure / Velocity / Governance: High confidence structure alignment; removes stale implementation plan items that mislead contributors.

### Option B 
- What it is: Leave the planning documents stale until the final `1.9.0` release.
- When to choose it: When preferring to defer all documentation cleanup until major tag publication.
- Trade-offs: Misleads contributors and violates the Cartographer anti-drift rule.

## ✅ Decision 
Option A was selected to directly address the factual drift and keep the roadmap/architecture documents aligned with the current, provable capabilities of the `web/runner`.

## 🧱 Changes made (SRP) 
- `ROADMAP.md`: Moved `tokmd-wasm` browser bundle release artifact and browser guardrails from 'Remaining' to 'What has landed so far'.
- `docs/architecture.md`: Updated 'Landed foundation and product surface' and removed completed goals from 'Remaining v1.9.0 work'.
- `README.md`: Updated the Browser and WASM section to mention the built-in caching, progress tracking, and auth handling.

## 🧪 Verification receipts 
```text
$ cargo xtask docs --check
Documentation is up to date.

$ cargo test -p xtask
test result: ok. 50 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.98s
```

## 🧭 Telemetry 
- Change shape: Documentation only
- Blast radius: docs
- Risk class: Low
- Rollback: `git checkout -- ROADMAP.md docs/architecture.md README.md`
- Gates run: `cargo xtask docs --check`, `cargo test -p xtask`

## 🗂️ .jules artifacts 
- `.jules/runs/cartographer-run-1/envelope.json`
- `.jules/runs/cartographer-run-1/decision.md`
- `.jules/runs/cartographer-run-1/receipts.jsonl`
- `.jules/runs/cartographer-run-1/result.json`
- `.jules/runs/cartographer-run-1/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [11494556397696478717](https://jules.google.com/task/11494556397696478717) started by @EffortlessSteven*