### PR TITLE
jules: record compat learning on tokmd-cli 🧷

### DIFF
--- a/.jules/friction/open/tokmd-no-default-features-git.md
+++ b/.jules/friction/open/tokmd-no-default-features-git.md
@@ -1,0 +1,13 @@
+# `tokmd` crate fails to compile with `--no-default-features`
+
+The `tokmd` crate contains multiple unguarded usages of `tokmd_git::git_cmd` which cause compilation to fail when the `git` feature is disabled (e.g. `cargo check -p tokmd --no-default-features`).
+
+Errors appear in:
+- `crates/tokmd/src/commands/baseline.rs:189`
+- `crates/tokmd/src/commands/check_ignore.rs:123`
+- `crates/tokmd/src/commands/check_ignore.rs:179`
+- `crates/tokmd/src/commands/handoff.rs:278`
+- `crates/tokmd/src/commands/handoff.rs:308`
+- `crates/tokmd/src/commands/handoff.rs:336`
+
+This needs to be fixed in the `tokmd` crate, which is outside the `bindings-targets` shard. The `tokmd` crate should properly guard `tokmd_git::git_cmd()` with `#[cfg(feature = "git")]` or avoid importing it unconditionally.

--- a/.jules/runs/compat-targets-matrix-1/decision.md
+++ b/.jules/runs/compat-targets-matrix-1/decision.md
@@ -1,0 +1,18 @@
+# Decision: Create a learning PR detailing friction.
+
+## Problem
+The assigned shard is `bindings-targets` (`crates/tokmd-wasm`, `crates/tokmd-node`, `crates/tokmd-python`, `web/runner`).
+However, testing `--no-default-features` on the workspace revealed a failure in `crates/tokmd` (which is outside the assigned shard). `crates/tokmd` incorrectly imports `tokmd_git::git_cmd` without `#[cfg(feature = "git")]` checks.
+
+The prompt requires:
+"If the strongest target you find is outside the shard, record it as friction instead of chasing it. If no honest code/docs/test patch is justified, finish with a learning PR instead of forcing a fake fix. ... Do not touch: unrelated interface ergonomics or docs-only rewrites"
+
+Wait, is there any actual issue I can patch in `bindings-targets`?
+I did notice `crates/tokmd-python/Cargo.toml` has `test = false` already applied as per `AGENTS.md` rules.
+`tokmd-wasm` compiles to `wasm32-unknown-unknown` without issues, and its test suite passes both with `--no-default-features` and `--all-features`.
+`tokmd-node` compiles and tests pass with `--no-default-features` and `--all-features`.
+`web/runner` passes its tests (`npm run test`).
+`tokmd-python` passes its tests with `--no-default-features` and `--all-features`.
+The only problem I've discovered is `tokio` complaining about wasm in `tokmd-node`, but `tokmd-node` is a Node addon which relies on N-API and isn't meant for `wasm32-unknown-unknown`. Similarly, `pyo3` in `tokmd-python` does not support wasm out-of-the-box in this configuration and isn't intended to.
+
+Given the constraints, I must create a learning PR documenting the `--no-default-features` compilation failure in `crates/tokmd` as a friction item, and avoid touching files outside the `bindings-targets` shard.

--- a/.jules/runs/compat-targets-matrix-1/envelope.json
+++ b/.jules/runs/compat-targets-matrix-1/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "compat_targets_matrix",
+  "persona": "Compat",
+  "style": "Builder",
+  "primary_shard": "bindings-targets",
+  "allowed_paths": [
+    "crates/tokmd-python/**",
+    "crates/tokmd-node/**",
+    "crates/tokmd-wasm/**",
+    "web/runner/**"
+  ],
+  "gate_profile": "compat-matrix",
+  "allowed_outcomes": [
+    "pr_ready_patch",
+    "learning_pr"
+  ]
+}

--- a/.jules/runs/compat-targets-matrix-1/pr_body.md
+++ b/.jules/runs/compat-targets-matrix-1/pr_body.md
@@ -1,0 +1,59 @@
+## 💡 Summary
+This is a learning PR. The `bindings-targets` shard passes all feature and target matrix compatibility checks, but a workspace-wide `--no-default-features` check uncovered a compilation error in the adjacent `tokmd` CLI crate.
+
+## 🎯 Why
+The `tokmd` crate unconditionally references `tokmd_git::git_cmd` without properly gating it under the `#[cfg(feature = "git")]` attribute. Since the issue lives outside the assigned `bindings-targets` shard, it has been logged as a friction item to preserve the single-responsibility boundary of the shard.
+
+## 🔎 Evidence
+File: `crates/tokmd/src/commands/check_ignore.rs`
+Observed behavior:
+When compiled without default features, the build fails with:
+```
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`
+   --> crates/tokmd/src/commands/baseline.rs:189:18
+    |
+189 |     let output = tokmd_git::git_cmd()
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Submit a learning PR and record the friction item for the out-of-shard compilation error.
+- Fits the repo guidelines which instruct agents not to chase issues outside of their assigned paths, optimizing for bounded, safe exploration.
+- Trade-offs: Structure is preserved by not muddying the PR with out-of-scope files; Governance rules are respected; Velocity might slightly reduce on this specific fix but remains focused.
+
+### Option B
+- Forcibly fix the `tokmd` CLI crate in this run.
+- Should be chosen only if the explicit instruction allowed arbitrary scope creep.
+- Trade-offs: Breaks the `bindings-targets` shard isolation and conflates binding matrices with CLI architecture.
+
+## ✅ Decision
+Option A. I am respecting the shard isolation constraint and filing the issue as a friction item.
+
+## 🧱 Changes made (SRP)
+- Added `.jules/friction/open/tokmd-no-default-features-git.md` to document the out-of-shard failure.
+
+## 🧪 Verification receipts
+```text
+cargo check -p tokmd-wasm --no-default-features (Success)
+cargo check -p tokmd-wasm --all-features (Success)
+cargo test --target wasm32-unknown-unknown -p tokmd-wasm --no-default-features (Success)
+cargo check -p tokmd --no-default-features (Failed: error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`)
+```
+
+## 🧭 Telemetry
+- Change shape: Documentation / Friction Logging
+- Blast radius: None (documentation only)
+- Risk class: Low - no code changes applied.
+- Rollback: Revert the added friction file.
+- Gates run: `cargo check` and `cargo test` across features and targets.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/compat-targets-matrix-1/envelope.json`
+- `.jules/runs/compat-targets-matrix-1/decision.md`
+- `.jules/runs/compat-targets-matrix-1/receipts.jsonl`
+- `.jules/runs/compat-targets-matrix-1/result.json`
+- `.jules/runs/compat-targets-matrix-1/pr_body.md`
+- Friction item: `.jules/friction/open/tokmd-no-default-features-git.md`
+
+## 🔜 Follow-ups
+- A subsequent agent assigned to `tokmd` or `core-cli` should resolve the `tokmd` `--no-default-features` compilation failure documented in `.jules/friction/open/tokmd-no-default-features-git.md`.

--- a/.jules/runs/compat-targets-matrix-1/receipts.jsonl
+++ b/.jules/runs/compat-targets-matrix-1/receipts.jsonl
@@ -1,0 +1,16 @@
+{"command": "cargo check -p tokmd-wasm --no-default-features", "status": "success"}
+{"command": "cargo check -p tokmd-wasm --all-features", "status": "success"}
+{"command": "cargo check -p tokmd-python --no-default-features", "status": "success"}
+{"command": "cargo check -p tokmd-python --all-features", "status": "success"}
+{"command": "cargo check -p tokmd-node --no-default-features", "status": "success"}
+{"command": "cargo check -p tokmd-node --all-features", "status": "success"}
+{"command": "cargo test -p tokmd-wasm --no-default-features", "status": "success"}
+{"command": "cargo test -p tokmd-wasm --all-features", "status": "success"}
+{"command": "cargo test -p tokmd-python --no-default-features", "status": "success"}
+{"command": "cargo test -p tokmd-python --all-features", "status": "success"}
+{"command": "cargo test -p tokmd-node --no-default-features", "status": "success"}
+{"command": "cargo test -p tokmd-node --all-features", "status": "success"}
+{"command": "cargo test --target wasm32-unknown-unknown -p tokmd-wasm --no-default-features", "status": "success"}
+{"command": "cargo test --target wasm32-unknown-unknown -p tokmd-wasm --all-features", "status": "success"}
+{"command": "cargo check -p tokmd --no-default-features", "status": "failure", "stdout": "error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`"}
+{"command": "cd web/runner && npm run test", "status": "success"}

--- a/.jules/runs/compat-targets-matrix-1/result.json
+++ b/.jules/runs/compat-targets-matrix-1/result.json
@@ -1,0 +1,4 @@
+{
+  "status": "learning_pr",
+  "reason": "The bindings-targets crates pass compat checks, but the workspace-level `--no-default-features` exposes an issue in the `tokmd` crate outside the assigned shard."
+}


### PR DESCRIPTION
## 💡 Summary 
This is a learning PR. The `bindings-targets` shard passes all feature and target matrix compatibility checks, but a workspace-wide `--no-default-features` check uncovered a compilation error in the adjacent `tokmd` CLI crate.

## 🎯 Why 
The `tokmd` crate unconditionally references `tokmd_git::git_cmd` without properly gating it under the `#[cfg(feature = "git")]` attribute. Since the issue lives outside the assigned `bindings-targets` shard, it has been logged as a friction item to preserve the single-responsibility boundary of the shard.

## 🔎 Evidence 
File: `crates/tokmd/src/commands/check_ignore.rs`
Observed behavior:
When compiled without default features, the build fails with:
```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`
   --> crates/tokmd/src/commands/baseline.rs:189:18
    |
189 |     let output = tokmd_git::git_cmd()
```

## 🧭 Options considered 
### Option A (recommended) 
- Submit a learning PR and record the friction item for the out-of-shard compilation error.
- Fits the repo guidelines which instruct agents not to chase issues outside of their assigned paths, optimizing for bounded, safe exploration.
- Trade-offs: Structure is preserved by not muddying the PR with out-of-scope files; Governance rules are respected; Velocity might slightly reduce on this specific fix but remains focused.

### Option B 
- Forcibly fix the `tokmd` CLI crate in this run.
- Should be chosen only if the explicit instruction allowed arbitrary scope creep.
- Trade-offs: Breaks the `bindings-targets` shard isolation and conflates binding matrices with CLI architecture.

## ✅ Decision 
Option A. I am respecting the shard isolation constraint and filing the issue as a friction item.

## 🧱 Changes made (SRP) 
- Added `.jules/friction/open/tokmd-no-default-features-git.md` to document the out-of-shard failure.

## 🧪 Verification receipts 
```text
cargo check -p tokmd-wasm --no-default-features (Success)
cargo check -p tokmd-wasm --all-features (Success)
cargo test --target wasm32-unknown-unknown -p tokmd-wasm --no-default-features (Success)
cargo check -p tokmd --no-default-features (Failed: error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokmd_git`)
```

## 🧭 Telemetry 
- Change shape: Documentation / Friction Logging
- Blast radius: None (documentation only)
- Risk class: Low - no code changes applied.
- Rollback: Revert the added friction file.
- Gates run: `cargo check` and `cargo test` across features and targets.

## 🗂️ .jules artifacts 
- `.jules/runs/compat-targets-matrix-1/envelope.json`
- `.jules/runs/compat-targets-matrix-1/decision.md`
- `.jules/runs/compat-targets-matrix-1/receipts.jsonl`
- `.jules/runs/compat-targets-matrix-1/result.json`
- `.jules/runs/compat-targets-matrix-1/pr_body.md`
- Friction item: `.jules/friction/open/tokmd-no-default-features-git.md`

## 🔜 Follow-ups 
- A subsequent agent assigned to `tokmd` or `core-cli` should resolve the `tokmd` `--no-default-features` compilation failure documented in `.jules/friction/open/tokmd-no-default-features-git.md`.

---
*PR created automatically by Jules for task [540840296559865568](https://jules.google.com/task/540840296559865568) started by @EffortlessSteven*