### PR TITLE
palette: unify diff API parameters to options dictionary in bindings 🎨

### DIFF
--- a/crates/tokmd-node/README.md
+++ b/crates/tokmd-node/README.md
@@ -20,7 +20,7 @@ import { lang, analyze, diff } from '@tokmd/core';
 
 const summary = await lang({ paths: ['src'], top: 5 });
 const analysis = await analyze({ paths: ['.'], preset: 'estimate' });
-const delta = await diff('.runs/base/lang.json', '.runs/current/lang.json');
+const delta = await diff({ from: '.runs/base/lang.json', to: '.runs/current/lang.json' });
 ```
 
 The published npm package is `@tokmd/core`. Exact TypeScript shapes live in `index.d.ts`.

--- a/crates/tokmd-node/__test__/index.spec.mjs
+++ b/crates/tokmd-node/__test__/index.spec.mjs
@@ -84,6 +84,17 @@ test('diff compares paths', async (t) => {
   }
 })
 
+test('diff accepts options object', async (t) => {
+  try {
+    const { diff } = await import('../npm/index.js')
+    const result = await diff({ from: 'src', to: 'src' })
+    t.is(result.mode, 'diff')
+    t.truthy(result.totals)
+  } catch (e) {
+    t.pass('Native module not built, skipping')
+  }
+})
+
 test('lang with options', async (t) => {
   try {
     const { lang } = await import('../npm/index.js')

--- a/crates/tokmd-node/index.d.ts
+++ b/crates/tokmd-node/index.d.ts
@@ -21,6 +21,16 @@ export interface LangOptions {
 }
 
 /**
+ * Options for the diff command.
+ */
+export interface DiffOptions {
+  /** Base receipt file or path to scan */
+  from: string;
+  /** Target receipt file or path to scan */
+  to: string;
+}
+
+/**
  * Options for the module command.
  */
 export interface ModuleOptions {
@@ -429,15 +439,23 @@ export function analyze(options?: AnalyzeOptions): Promise<AnalyzeReceipt>;
 /**
  * Compare two receipts or paths and return a diff.
  *
- * @param fromPath - Base receipt file or path to scan
- * @param toPath - Target receipt file or path to scan
+ * Backward-compatible call form:
+ * `diff(fromPath, toPath)`.
+ */
+export function diff(fromPath: string, toPath: string): Promise<DiffReceipt>;
+/**
+ * Preferred call form using an options object.
+ *
+ * @param options - Diff options
+ * @param options.from - Base receipt file or path to scan
+ * @param options.to - Target receipt file or path to scan
  * @returns Promise resolving to diff receipt
  *
  * @example
  * ```javascript
  * import { diff } from '@tokmd/core';
- * const result = await diff("old_receipt.json", "new_receipt.json");
+ * const result = await diff({ from: "old_receipt.json", to: "new_receipt.json" });
  * console.log(`Total delta: ${result.totals.delta_code} lines`);
  * ```
  */
-export function diff(fromPath: string, toPath: string): Promise<DiffReceipt>;
+export function diff(options?: DiffOptions | undefined | null): Promise<DiffReceipt>;

--- a/crates/tokmd-node/npm/index.d.ts
+++ b/crates/tokmd-node/npm/index.d.ts
@@ -223,10 +223,21 @@ export { exportFn as export }
  */
 export function analyze(options?: AnalyzeOptions): Promise<object>
 
+export interface DiffOptions {
+  from: string
+  to: string
+}
+
 /**
  * Compare two receipts or paths and return a diff.
- * @param fromPath - Base receipt file or path to scan
- * @param toPath - Target receipt file or path to scan
+ * Backward-compatible call form:
+ * `diff(fromPath, toPath)`.
  * @returns Promise resolving to diff receipt
  */
 export function diff(fromPath: string, toPath: string): Promise<DiffReceipt>
+/**
+ * Preferred call form using an options object.
+ * @param options - Diff options
+ * @returns Promise resolving to diff receipt
+ */
+export function diff(options?: DiffOptions | null): Promise<DiffReceipt>

--- a/crates/tokmd-node/npm/index.js
+++ b/crates/tokmd-node/npm/index.js
@@ -156,7 +156,14 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { version, schemaVersion, runJson, run, lang, module, export: exportFn, analyze, diff } = nativeBinding
+const { version, schemaVersion, runJson, run, lang, module, export: exportFn, analyze, diff: nativeDiff } = nativeBinding
+
+function diff(arg1, arg2) {
+  if (typeof arg1 === 'string' && typeof arg2 === 'string') {
+    return nativeDiff({ from: arg1, to: arg2 })
+  }
+  return nativeDiff(arg1 ?? {})
+}
 
 module.exports.version = version
 module.exports.schemaVersion = schemaVersion

--- a/crates/tokmd-node/src/lib.rs
+++ b/crates/tokmd-node/src/lib.rs
@@ -240,22 +240,20 @@ pub async fn cockpit(options: Option<serde_json::Value>) -> Result<serde_json::V
 
 /// Compare two receipts or paths and return a diff.
 ///
-/// @param fromPath - Base receipt file or path to scan
-/// @param toPath - Target receipt file or path to scan
+/// @param options - Diff options
+/// @param options.from - Base receipt file or path to scan
+/// @param options.to - Target receipt file or path to scan
 /// @returns Promise resolving to diff receipt
 ///
 /// @example
 /// ```javascript
 /// import { diff } from '@tokmd/core';
-/// const result = await diff("old_receipt.json", "new_receipt.json");
+/// const result = await diff({ from: "old_receipt.json", to: "new_receipt.json" });
 /// console.log(`Total delta: ${result.totals.delta_code} lines`);
 /// ```
-#[cfg_attr(not(test), napi)]
-pub async fn diff(from_path: String, to_path: String) -> Result<serde_json::Value> {
-    let args = serde_json::json!({
-        "from": from_path,
-        "to": to_path
-    });
+#[cfg_attr(not(test), napi(ts_args_type = "options?: DiffOptions"))]
+pub async fn diff(options: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let args = options_or_empty(options);
     run("diff".to_string(), args).await
 }
 
@@ -386,7 +384,11 @@ mod tests {
         let path_a = repo_a.path().to_string_lossy().to_string();
         let path_b = repo_b.path().to_string_lossy().to_string();
 
-        let diff_result = block_on(diff(path_a, path_b)).expect("diff should succeed");
+        let diff_result = block_on(diff(Some(json!({
+            "from": path_a,
+            "to": path_b
+        }))))
+        .expect("diff should succeed");
         assert_eq!(diff_result["mode"].as_str().unwrap_or(""), "diff");
         assert!(diff_result.get("totals").is_some());
     }

--- a/crates/tokmd-python/src/lib.rs
+++ b/crates/tokmd-python/src/lib.rs
@@ -502,13 +502,18 @@ fn analyze(
 ///
 /// Example:
 ///     >>> import tokmd
-///     >>> result = tokmd.diff("old_receipt.json", "new_receipt.json")
+///     >>> result = tokmd.diff(from_path="old_receipt.json", to_path="new_receipt.json")
 ///     >>> print(f"Total delta: {result['totals']['delta_code']} lines")
 #[cfg_attr(not(test), pyfunction)]
-fn diff(py: Python<'_>, from_path: &str, to_path: &str) -> PyResult<PyObject> {
+#[pyo3(signature = (from_path=None, to_path=None))]
+fn diff(py: Python<'_>, from_path: Option<&str>, to_path: Option<&str>) -> PyResult<PyObject> {
     let args = PyDict::new(py);
-    args.set_item("from", from_path)?;
-    args.set_item("to", to_path)?;
+    if let Some(f) = from_path {
+        args.set_item("from", f)?;
+    }
+    if let Some(t) = to_path {
+        args.set_item("to", t)?;
+    }
     run(py, "diff", &args)
 }
 
@@ -1126,7 +1131,8 @@ mod tests {
             let path_a = repo_a.path().to_string_lossy().to_string();
             let path_b = repo_b.path().to_string_lossy().to_string();
 
-            let diff_result = diff(py, &path_a, &path_b).expect("diff should succeed");
+            let diff_result =
+                diff(py, Some(&path_a), Some(&path_b)).expect("diff should succeed");
             let diff_dict = diff_result.downcast_bound::<PyDict>(py).expect("diff dict");
             assert_eq!(
                 diff_dict
@@ -1479,7 +1485,7 @@ mod tests {
             }
 
             // diff() - should return PyResult
-            match diff(py, &temp_path, &temp_path) {
+            match diff(py, Some(&temp_path), Some(&temp_path)) {
                 Ok(_) => (),
                 Err(_) => (),
             }

--- a/crates/tokmd-python/src/lib.rs
+++ b/crates/tokmd-python/src/lib.rs
@@ -504,8 +504,7 @@ fn analyze(
 ///     >>> import tokmd
 ///     >>> result = tokmd.diff(from_path="old_receipt.json", to_path="new_receipt.json")
 ///     >>> print(f"Total delta: {result['totals']['delta_code']} lines")
-#[cfg_attr(not(test), pyfunction)]
-#[pyo3(signature = (from_path=None, to_path=None))]
+#[cfg_attr(not(test), pyfunction(signature = (from_path=None, to_path=None)))]
 fn diff(py: Python<'_>, from_path: Option<&str>, to_path: Option<&str>) -> PyResult<PyObject> {
     let args = PyDict::new(py);
     if let Some(f) = from_path {


### PR DESCRIPTION
Unified the `diff` API parameters across Node and Python bindings to use an options dictionary structure, matching all other runtime-facing commands like `lang`, `module`, and `analyze`.

The `diff` binding deviated from the standard library API design pattern. While `lang`, `analyze`, and other endpoints accepted an optional configuration dictionary/object, `diff` explicitly required two positional arguments (`from_path` and `to_path`). This created a confusing, inconsistent developer experience where users had to mentally juggle different function signatures for sibling methods within the same SDK. By normalizing `diff` to an options dictionary (`{ from, to }`), we ensure a unified DX.

---
*PR created automatically by Jules for task [14686978169998438953](https://jules.google.com/task/14686978169998438953) started by @EffortlessSteven*