### PR TITLE
[codex] guard local validation builds against target bloat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,14 +320,18 @@ exclude_re = ["impl.*Display", "fn main\\("]
 -   Run `cargo fmt-fix` for a fast, Windows-safe fmt-only fix.
 -   Run `cargo fmt-check` to verify formatting only.
 -   Run `cargo xtask gate --check` to verify the full quality gate locally.
+-   `cargo xtask gate --check` now uses a disposable temp `CARGO_TARGET_DIR` and forces `CARGO_INCREMENTAL=0` unless you override `CARGO_TARGET_DIR` yourself, so repeated gate runs do not leave a huge `target/` tree behind.
+-   On Unix-like systems, `cargo xtask gate --check` also refuses to start when free disk drops below the `TOKMD_MIN_FREE_GB` threshold.
 -   Run `cargo trim-target --check` to inspect reclaimable `target/debug` footprint.
 -   Run `cargo trim-target` to drop Windows PDBs and incremental state from `target/debug` without a full `cargo clean`.
 -   If you need full local symbols on Windows for a debugging session, use `$env:RUSTFLAGS='-C debuginfo=2'; cargo test ...`.
 -   Run `cargo sccache-check` to verify the optional local compiler cache.
 -   Run `cargo with-sccache test --workspace --all-features` for cache-friendly local rebuilds.
+-   `cargo with-sccache check|clippy|test ...` now uses a disposable temp `CARGO_TARGET_DIR` by default when you have not already set one, so validation runs clean up after themselves.
 -   The repo-native `sccache` wrapper uses a deterministic per-workspace `SCCACHE_SERVER_PORT`; set `SCCACHE_SERVER_PORT` yourself if you need to override it.
 -   For cross-worktree cache reuse, run `cargo xtask sccache --basedir <PATH> -- test --workspace --all-features`.
 -   Expect the biggest `sccache` wins on repeated library and dependency compiles; final binary and test-binary link steps still run uncached.
+-   On Unix-like systems, both wrappers refuse to start when free disk drops below the `TOKMD_MIN_FREE_GB` threshold. Override that env var if you need a different floor for a larger machine.
 
 ## Contribution Areas
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -580,6 +580,12 @@ cargo fmt-check
 cargo gate-check
 ```
 
+`cargo gate-check` now uses a disposable temp `CARGO_TARGET_DIR` and forces
+`CARGO_INCREMENTAL=0` unless you override `CARGO_TARGET_DIR` yourself, so the
+quality gate does not leave a long-lived local build tree behind.
+On Unix-like systems, `cargo gate-check` also refuses to start when free disk
+drops below the `TOKMD_MIN_FREE_GB` threshold.
+
 This repo also defaults Windows MSVC builds to line-table debuginfo so future local builds generate much smaller symbol files than full PDB output.
 If you need full local symbols for a debugging session, use:
 ```powershell
@@ -608,6 +614,10 @@ cargo sccache-check
 cargo with-sccache test --workspace --all-features
 ```
 
+For `check`, `clippy`, and `test`, the wrapper now uses a disposable temp
+`CARGO_TARGET_DIR` when you have not already set one, so validation runs clean
+up after themselves instead of accreting under the repo-local `target/`.
+
 **2. Inspect hit rates**:
 ```bash
 cargo sccache-stats
@@ -627,6 +637,10 @@ If you want cache reuse across multiple worktrees or checkout roots, use:
 ```bash
 cargo xtask sccache --basedir <PATH> -- test --workspace --all-features
 ```
+
+On Unix-like systems, both `cargo gate-check` and `cargo with-sccache ...`
+refuse to start once free disk drops below the `TOKMD_MIN_FREE_GB` threshold,
+which defaults to `8`.
 
 The repo-native wrapper also picks a deterministic per-workspace `SCCACHE_SERVER_PORT` so it does not collide with another local `sccache` server already using the default `127.0.0.1:4226`. If you need a different port, set `SCCACHE_SERVER_PORT` explicitly before running the wrapper.
 

--- a/xtask/src/tasks/build_guard.rs
+++ b/xtask/src/tasks/build_guard.rs
@@ -1,0 +1,156 @@
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
+const DEFAULT_MIN_FREE_GIB: u64 = 8;
+
+pub struct ScopedTempDir {
+    path: PathBuf,
+}
+
+impl ScopedTempDir {
+    pub fn new(label: &str) -> Result<Self> {
+        let path = std::env::temp_dir().join(format!(
+            "tokmd-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create temp dir {}", path.display()))?;
+        Ok(Self { path })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScopedTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+pub fn ensure_min_free_space(path: &Path, label: &str) -> Result<()> {
+    let min_free_bytes = configured_min_free_bytes();
+    let Some(available_bytes) = available_space_bytes(path)? else {
+        return Ok(());
+    };
+
+    if available_bytes >= min_free_bytes {
+        return Ok(());
+    }
+
+    bail!(
+        "{label}: only {} free on {} (need at least {}). Clean old target directories or set TOKMD_MIN_FREE_GB to override the threshold.",
+        human_bytes(available_bytes),
+        path.display(),
+        human_bytes(min_free_bytes)
+    );
+}
+
+fn configured_min_free_bytes() -> u64 {
+    configured_min_free_gib(std::env::var("TOKMD_MIN_FREE_GB").ok().as_deref()) * BYTES_PER_GIB
+}
+
+fn configured_min_free_gib(value: Option<&str>) -> u64 {
+    value
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_MIN_FREE_GIB)
+}
+
+fn available_space_bytes(path: &Path) -> Result<Option<u64>> {
+    if !cfg!(unix) {
+        return Ok(None);
+    }
+
+    let output = Command::new("df")
+        .arg("-Pk")
+        .arg(path)
+        .output()
+        .with_context(|| format!("failed to run `df -Pk {}`", path.display()))?;
+
+    if !output.status.success() {
+        bail!(
+            "`df -Pk {}` failed with exit code {}",
+            path.display(),
+            output.status.code().unwrap_or(-1)
+        );
+    }
+
+    Ok(parse_df_pk_available_bytes(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+fn parse_df_pk_available_bytes(output: &str) -> Option<u64> {
+    output
+        .lines()
+        .nth(1)?
+        .split_whitespace()
+        .nth(3)?
+        .parse::<u64>()
+        .ok()
+        .map(|blocks| blocks.saturating_mul(1024))
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+
+    let mut value = bytes as f64;
+    let mut unit_idx = 0usize;
+    while value >= 1024.0 && unit_idx + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit_idx += 1;
+    }
+
+    if unit_idx == 0 {
+        format!("{bytes} {}", UNITS[unit_idx])
+    } else {
+        format!("{value:.1} {}", UNITS[unit_idx])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BYTES_PER_GIB, configured_min_free_bytes, configured_min_free_gib,
+        parse_df_pk_available_bytes,
+    };
+
+    #[test]
+    fn parse_df_pk_available_bytes_extracts_available_column() {
+        let output = "\
+Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/sda1 157286400 80111236 69175164 54% /\n";
+
+        assert_eq!(
+            parse_df_pk_available_bytes(output),
+            Some(69_175_164u64 * 1024)
+        );
+    }
+
+    #[test]
+    fn configured_min_free_gib_defaults_when_env_is_missing() {
+        assert_eq!(configured_min_free_gib(None), 8);
+    }
+
+    #[test]
+    fn configured_min_free_gib_honors_env_override() {
+        assert_eq!(configured_min_free_gib(Some("12")), 12);
+        assert_eq!(configured_min_free_gib(Some("0")), 8);
+        assert_eq!(configured_min_free_gib(Some("bogus")), 8);
+    }
+
+    #[test]
+    fn configured_min_free_bytes_uses_current_env_or_default() {
+        let expected = configured_min_free_gib(std::env::var("TOKMD_MIN_FREE_GB").ok().as_deref())
+            * BYTES_PER_GIB;
+        assert_eq!(configured_min_free_bytes(), expected);
+    }
+}

--- a/xtask/src/tasks/gate.rs
+++ b/xtask/src/tasks/gate.rs
@@ -1,4 +1,5 @@
 use crate::cli::GateArgs;
+use crate::tasks::build_guard::{ScopedTempDir, ensure_min_free_space};
 use crate::tasks::workspace::run_workspace_fmt;
 use anyhow::{Result, bail};
 use std::process::Command;
@@ -118,6 +119,14 @@ fn ensure_no_tracked_agent_runtime_state() -> Result<()> {
 pub fn run(args: GateArgs) -> Result<()> {
     ensure_no_tracked_agent_runtime_state()?;
 
+    let ephemeral_target = if std::env::var_os("CARGO_TARGET_DIR").is_none() {
+        let dir = ScopedTempDir::new("gate-target")?;
+        println!("gate: using disposable target dir {}", dir.path().display());
+        Some(dir)
+    } else {
+        None
+    };
+
     let total = STEPS.len();
     let mut failures = Vec::new();
 
@@ -140,8 +149,20 @@ pub fn run(args: GateArgs) -> Result<()> {
                 }
             }
         } else {
+            ensure_min_free_space(
+                ephemeral_target
+                    .as_ref()
+                    .map(ScopedTempDir::path)
+                    .unwrap_or(std::path::Path::new(".")),
+                step.label,
+            )?;
+
             let mut command = Command::new(step.cmd);
             command.args(effective_args);
+            command.env("CARGO_INCREMENTAL", "0");
+            if let Some(dir) = ephemeral_target.as_ref() {
+                command.env("CARGO_TARGET_DIR", dir.path());
+            }
             if cfg!(windows) && step.label == "test (compile-only)" {
                 // Windows keeps the running xtask binary locked, so compile
                 // the rest of the workspace here and let xtask's own tests
@@ -158,10 +179,10 @@ pub fn run(args: GateArgs) -> Result<()> {
         };
 
         if exit_code != 0 {
-            println!("   \u{274C} Step {} ({}) failed", idx, step.label);
+            println!("   ❌ Step {} ({}) failed", idx, step.label);
             failures.push((step.label, exit_code));
         } else {
-            println!("   \u{2705} Step {} ({}) passed", idx, step.label);
+            println!("   ✅ Step {} ({}) passed", idx, step.label);
         }
     }
 

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,4 +1,5 @@
 pub mod boundaries_check;
+pub mod build_guard;
 pub mod bump;
 pub mod cockpit;
 pub mod docs;

--- a/xtask/src/tasks/sccache.rs
+++ b/xtask/src/tasks/sccache.rs
@@ -1,4 +1,5 @@
 use crate::cli::SccacheArgs;
+use crate::tasks::build_guard::{ScopedTempDir, ensure_min_free_space};
 use anyhow::{Context, Result, bail};
 use cargo_metadata::MetadataCommand;
 use std::ffi::{OsStr, OsString};
@@ -25,6 +26,18 @@ pub fn run(args: SccacheArgs) -> Result<()> {
     let (sccache_program, _) = ensure_sccache_available()?;
     let server_port = resolved_server_port()?;
     let basedirs = resolved_basedirs(&args.basedirs)?;
+    let temp_target_dir = redirected_target_dir(
+        &args.cargo_args,
+        std::env::var_os("CARGO_TARGET_DIR").is_some(),
+    )?;
+
+    ensure_min_free_space(
+        temp_target_dir
+            .as_ref()
+            .map(ScopedTempDir::path)
+            .unwrap_or(std::path::Path::new(".")),
+        "sccache",
+    )?;
 
     let mut command = Command::new("cargo");
     command.args(&args.cargo_args);
@@ -34,9 +47,12 @@ pub fn run(args: SccacheArgs) -> Result<()> {
         command.env("SCCACHE_BASEDIRS", value);
         println!("sccache: SCCACHE_BASEDIRS={}", value.to_string_lossy());
     }
-    if let Some(target_dir) = redirected_target_dir(&args.cargo_args)? {
-        command.env("CARGO_TARGET_DIR", &target_dir);
-        println!("sccache: CARGO_TARGET_DIR={}", target_dir.display());
+    if let Some(target_dir) = temp_target_dir.as_ref() {
+        command.env("CARGO_TARGET_DIR", target_dir.path());
+        println!(
+            "sccache: CARGO_TARGET_DIR={} (disposable)",
+            target_dir.path().display()
+        );
     }
 
     let disable_incremental = should_disable_incremental(args.keep_incremental);
@@ -282,16 +298,12 @@ fn read_dir_paths(root: &Path) -> std::io::Result<Vec<PathBuf>> {
         .collect()
 }
 
-fn redirected_target_dir(args: &[String]) -> Result<Option<PathBuf>> {
-    if !should_isolate_xtask_tests(
-        args,
-        cfg!(windows),
-        std::env::var_os("CARGO_TARGET_DIR").is_some(),
-    ) {
+fn redirected_target_dir(args: &[String], has_target_dir: bool) -> Result<Option<ScopedTempDir>> {
+    if !should_use_ephemeral_target_dir(args, has_target_dir) {
         return Ok(None);
     }
 
-    Ok(Some(workspace_root()?.join("target").join("xtask-sccache")))
+    Ok(Some(ScopedTempDir::new("sccache-target")?))
 }
 
 fn default_server_port_for_key(key: &str) -> u16 {
@@ -319,21 +331,15 @@ fn workspace_root() -> Result<std::path::PathBuf> {
     Ok(metadata.workspace_root.into_std_path_buf())
 }
 
-fn should_isolate_xtask_tests(args: &[String], is_windows: bool, has_target_dir: bool) -> bool {
-    if !is_windows || has_target_dir || args.first().map(String::as_str) != Some("test") {
+fn should_use_ephemeral_target_dir(args: &[String], has_target_dir: bool) -> bool {
+    if has_target_dir {
         return false;
     }
 
-    let mut iter = args.iter();
-    while let Some(arg) = iter.next() {
-        if matches!(arg.as_str(), "-p" | "--package")
-            && iter.next().map(String::as_str) == Some("xtask")
-        {
-            return true;
-        }
-    }
-
-    false
+    matches!(
+        args.first().map(String::as_str),
+        Some("check" | "clippy" | "test")
+    )
 }
 
 fn should_disable_incremental(keep_incremental: bool) -> bool {
@@ -358,7 +364,7 @@ fn install_hint() -> &'static str {
 mod tests {
     use super::{
         compose_basedirs, default_server_port_for_key, display_cargo_args, install_hint,
-        should_disable_incremental, should_isolate_xtask_tests, stable_hash64,
+        should_disable_incremental, should_use_ephemeral_target_dir, stable_hash64,
         windows_explicit_sccache_candidates, winget_sccache_path,
     };
     use std::ffi::OsStr;
@@ -486,7 +492,7 @@ mod tests {
     }
 
     #[test]
-    fn should_isolate_windows_xtask_test_runs() {
+    fn should_use_ephemeral_target_dir_for_heavy_validation_commands() {
         let args = vec![
             "test".to_string(),
             "-p".to_string(),
@@ -494,18 +500,14 @@ mod tests {
             "--no-run".to_string(),
         ];
 
-        assert!(should_isolate_xtask_tests(&args, true, false));
-        assert!(!should_isolate_xtask_tests(&args, true, true));
-        assert!(!should_isolate_xtask_tests(&args, false, false));
+        assert!(should_use_ephemeral_target_dir(&args, false));
+        assert!(!should_use_ephemeral_target_dir(&args, true));
     }
 
     #[test]
-    fn should_not_isolate_non_xtask_or_non_test_invocations() {
-        let check_args = vec!["check".to_string(), "-p".to_string(), "xtask".to_string()];
-        let other_pkg_args = vec!["test".to_string(), "-p".to_string(), "tokmd".to_string()];
-
-        assert!(!should_isolate_xtask_tests(&check_args, true, false));
-        assert!(!should_isolate_xtask_tests(&other_pkg_args, true, false));
+    fn should_not_use_ephemeral_target_dir_for_build_runs() {
+        let args = vec!["build".to_string(), "-p".to_string(), "tokmd".to_string()];
+        assert!(!should_use_ephemeral_target_dir(&args, false));
     }
 
     fn temp_dir(label: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

This changes the local heavy-validation path so repeated `tokmd` checks do not leave behind large persistent `target/` trees.

## What changed

- added `xtask::build_guard` with a reusable free-space preflight and disposable temp target-dir helper
- updated `cargo xtask gate --check` to:
  - use a disposable temp `CARGO_TARGET_DIR` when the caller has not already set one
  - force `CARGO_INCREMENTAL=0` for the heavy cargo steps
  - fail fast when free disk drops below the `TOKMD_MIN_FREE_GB` floor
- updated the `cargo with-sccache ...` wrapper so `check`, `clippy`, and `test` runs also use a disposable temp target dir by default when no target dir is already configured
- documented the new local behavior in `CONTRIBUTING.md` and `docs/troubleshooting.md`

## Why

The root cause on the workstation was not stale git worktrees. It was repeated local validation runs in a large Rust workspace accumulating tens of gigabytes under repo-local `target/debug`, especially `deps` and `incremental`. CI already protects itself with a non-incremental configuration and an off-repo target dir; local heavy workflows did not.

This aligns the local heavy-validation path more closely with CI and makes the safe behavior automatic.

## Impact

- repeated local gate and sccache-backed validation runs clean up after themselves instead of accreting under the checkout
- low-disk situations fail early with an actionable message instead of running until the machine is effectively full
- interactive builds that explicitly set `CARGO_TARGET_DIR` keep their existing behavior

## Validation

- `cargo test -p xtask`
- `cargo fmt --package xtask -- --check`

## Notes

The machine-side cleanup was handled separately by removing rebuildable `target/` directories from the heavy worktrees. This PR only contains the repo improvement to reduce recurrence.