### PR TITLE
sentinel: harden `--redact all` boundary to hide module roots and structural row names 🛡️

### DIFF
--- a/crates/tokmd-format/src/lib.rs
+++ b/crates/tokmd-format/src/lib.rs
@@ -710,7 +710,19 @@ pub fn write_module_json_to_file(
     report: &ModuleReport,
     scan: &ScanArgs,
     args_meta: &ModuleArgsMeta,
+    redact: RedactMode,
 ) -> Result<()> {
+    let mut final_args = args_meta.clone();
+    let mut final_report = report.clone();
+
+    if redact == RedactMode::All {
+        final_args.module_roots = redact_module_roots(&final_args.module_roots, redact);
+        final_report.module_roots = redact_module_roots(&final_report.module_roots, redact);
+        for row in &mut final_report.rows {
+            row.module = short_hash(&row.module);
+        }
+    }
+
     let receipt = ModuleReceipt {
         schema_version: tokmd_types::SCHEMA_VERSION,
         generated_at_ms: now_ms(),
@@ -719,8 +731,8 @@ pub fn write_module_json_to_file(
         status: ScanStatus::Complete,
         warnings: vec![],
         scan: scan.clone(),
-        args: args_meta.clone(),
-        report: report.clone(),
+        args: final_args,
+        report: final_report,
     };
     let file = File::create(path)?;
     serde_json::to_writer(file, &receipt)?;
@@ -741,6 +753,9 @@ pub fn write_export_jsonl_to_file(
     let file = File::create(path)?;
     let mut out = BufWriter::new(file);
 
+    let mut final_args = args_meta.clone();
+    final_args.module_roots = redact_module_roots(&final_args.module_roots, args_meta.redact);
+
     let meta = ExportMeta {
         ty: "meta",
         schema_version: tokmd_types::SCHEMA_VERSION,
@@ -750,7 +765,7 @@ pub fn write_export_jsonl_to_file(
         status: ScanStatus::Complete,
         warnings: vec![],
         scan: scan.clone(),
-        args: args_meta.clone(),
+        args: final_args,
     };
     writeln!(out, "{}", serde_json::to_string(&meta)?)?;
 

--- a/crates/tokmd-format/tests/format_tests.rs
+++ b/crates/tokmd-format/tests/format_tests.rs
@@ -1530,7 +1530,7 @@ fn test_write_module_json_to_file_writes_valid_json() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let file_path = temp_dir.path().join("module.json");
 
-    write_module_json_to_file(&file_path, &report, &scan, &args_meta)
+    write_module_json_to_file(&file_path, &report, &scan, &args_meta, RedactMode::None)
         .expect("write_module_json_to_file should succeed");
 
     // Verify file exists and contains valid JSON

--- a/crates/tokmd/src/commands/run.rs
+++ b/crates/tokmd/src/commands/run.rs
@@ -94,8 +94,14 @@ pub(crate) fn handle(args: cli::RunArgs, global: &cli::GlobalArgs) -> Result<()>
         module_depth: 2,
         children: tokmd_types::ChildIncludeMode::Separate,
     };
-    format::write_module_json_to_file(&module_path, &module_report, &scan_args, &module_args_meta)
-        .context("Failed to write module.json")?;
+    format::write_module_json_to_file(
+        &module_path,
+        &module_report,
+        &scan_args,
+        &module_args_meta,
+        redact_mode,
+    )
+    .context("Failed to write module.json")?;
 
     // Write export.jsonl (with redaction support)
     let export_path = output_dir.join("export.jsonl");

--- a/crates/tokmd/tests/run_diff.rs
+++ b/crates/tokmd/tests/run_diff.rs
@@ -685,6 +685,53 @@ fn test_run_redact_all_hashes_modules_too() {
 }
 
 #[test]
+fn test_run_redact_all_hides_module_roots_in_artifacts() {
+    let dir = tempdir().unwrap();
+    let output_dir = dir.path().join("run-redact-module-roots");
+
+    let proprietary_module = dir.path().join("proprietary_module");
+    fs::create_dir_all(&proprietary_module).unwrap();
+    fs::write(
+        proprietary_module.join("secret.rs"),
+        "fn secret() {}\n",
+    )
+    .unwrap();
+
+    let mut cmd: Command = cargo_bin_cmd!("tokmd");
+    cmd.current_dir(dir.path())
+        .arg("run")
+        .arg("--output-dir")
+        .arg(output_dir.to_str().unwrap())
+        .arg("--redact")
+        .arg("all")
+        .arg("proprietary_module")
+        .assert()
+        .success();
+
+    let module_content = fs::read_to_string(output_dir.join("module.json")).unwrap();
+    let export_content = fs::read_to_string(output_dir.join("export.jsonl")).unwrap();
+
+    assert!(
+        module_content.contains(r#""module_roots""#),
+        "module.json should include module_roots metadata"
+    );
+    assert!(
+        export_content.contains(r#""module_roots""#),
+        "export.jsonl should include module_roots metadata"
+    );
+    assert!(
+        !module_content.contains("proprietary_module"),
+        "module.json should not leak raw module roots when --redact all is used.\nContent: {}",
+        module_content
+    );
+    assert!(
+        !export_content.contains("proprietary_module"),
+        "export.jsonl should not leak raw module roots when --redact all is used.\nContent: {}",
+        export_content
+    );
+}
+
+#[test]
 fn test_run_redact_consistency_across_artifacts() {
     // Given: Same scan with redaction
     // When: We check lang.json, module.json, and export.jsonl


### PR DESCRIPTION
## 💡 Summary 
Patched a redaction leak in `tokmd run` where `module.json` and `export.jsonl` inadvertently exposed unredacted module names and `module_roots` configurations, even when `--redact all` was enabled.

## 🎯 Why 
When users invoked `tokmd run --redact all`, the tool successfully hashed individual file paths but leaked actual package or proprietary project module names (like `proprietary_module`) into `module.json` and the metadata of `export.jsonl`. This compromised the trust-bearing nature of redacted exports when sharing telemetry or metadata over boundaries.

## 🔎 Evidence 
- `crates/tokmd-format/src/lib.rs` and `crates/tokmd/src/commands/run.rs`
- Running a test simulation with `--redact all` produced `export.jsonl` with cleartext `module_roots` and `module.json` with unredacted module structural keys.
- `cargo test --test redact_run_leak` was created to prove `module.json` exposed `"proprietary_module"`.

## 🧭 Options considered 
### Option A (recommended) 
- Add `redact: RedactMode` to the `write_module_json_to_file` call signature and redact `module_roots` + row keys prior to generating receipts, while matching this logic for `write_export_jsonl_to_file`.
- Highly targeted, maintains exact shape and data structures without altering serialization formats across the `tokmd-types` crate.
- Trade-offs: Structure is completely stable, governance is respected.

### Option B 
- Introduce a new `module_roots_redacted: bool` and `redact` fields directly into `ModuleArgsMeta` and `ExportArgsMeta` structs in `tokmd-types`.
- This would require changing public schema contracts, generating larger code churn, and adding breaking changes to downstream integration pipelines.
- Trade-offs: High risk class, breaks schema version invariants.

## ✅ Decision 
Selected Option A. This hardens the redaction pipeline cleanly across `tokmd-format` without requiring public CLI API redesigns or breaking metadata schema contracts.

## 🧱 Changes made (SRP) 
- `crates/tokmd-format/src/lib.rs`: Updated `write_module_json_to_file` and `write_export_jsonl_to_file` to ingest and properly redact `args_meta.module_roots` and `report.rows` when `RedactMode::All` is active.
- `crates/tokmd/src/commands/run.rs`: Passed `redact_mode` directly to `write_module_json_to_file`.
- `crates/tokmd-format/tests/format_tests.rs`: Adjusted formatting function invocations to provide `RedactMode::None`.

## 🧪 Verification receipts 
```text
cargo test --test redact_run_leak -> success
cargo test -p tokmd-format -p tokmd -> success (100% pass)
```

## 🧭 Telemetry 
- Change shape: Hardening
- Blast radius: Core pipeline formatting layer, resolving a leak without changing default (non-redacted) outputs.
- Risk class: Low - pure security boundary improvement that only applies when opt-in redaction configurations are invoked.
- Rollback: Safe (git revert)
- Gates run: `cargo check`, `cargo test`

## 🗂️ .jules artifacts 
- `.jules/runs/sentinel_redaction/envelope.json`
- `.jules/runs/sentinel_redaction/decision.md`
- `.jules/runs/sentinel_redaction/receipts.jsonl`
- `.jules/runs/sentinel_redaction/result.json`
- `.jules/runs/sentinel_redaction/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [13623965669448875612](https://jules.google.com/task/13623965669448875612) started by @EffortlessSteven*