### PR TITLE
bridge: sync estimate preset to bindings types and docs 🌉

### DIFF
--- a/crates/tokmd-node/index.d.ts
+++ b/crates/tokmd-node/index.d.ts
@@ -70,8 +70,8 @@ export interface ExportOptions {
 export interface AnalyzeOptions {
   /** List of paths to scan (default: ["."]) */
   paths?: string[];
-  /** Analysis preset ("receipt", "health", "risk", "supply", "architecture", "topics", "security", "identity", "git", "deep", "fun") */
-  preset?: "receipt" | "health" | "risk" | "supply" | "architecture" | "topics" | "security" | "identity" | "git" | "deep" | "fun";
+  /** Analysis preset ("receipt", "estimate", "health", "risk", "supply", "architecture", "topics", "security", "identity", "git", "deep", "fun") */
+  preset?: "receipt" | "estimate" | "health" | "risk" | "supply" | "architecture" | "topics" | "security" | "identity" | "git" | "deep" | "fun";
   /** Context window size in tokens */
   window?: number;
   /** Force enable/disable git metrics */

--- a/crates/tokmd-node/npm/index.d.ts
+++ b/crates/tokmd-node/npm/index.d.ts
@@ -36,7 +36,7 @@ export interface ExportOptions {
 
 export interface AnalyzeOptions {
   paths?: string[]
-  preset?: 'receipt' | 'health' | 'risk' | 'supply' | 'architecture' | 'topics' | 'security' | 'identity' | 'git' | 'deep' | 'fun'
+  preset?: 'receipt' | 'estimate' | 'health' | 'risk' | 'supply' | 'architecture' | 'topics' | 'security' | 'identity' | 'git' | 'deep' | 'fun'
   window?: number
   git?: boolean
   max_files?: number

--- a/crates/tokmd-python/src/lib.rs
+++ b/crates/tokmd-python/src/lib.rs
@@ -428,7 +428,7 @@ fn export(
 ///
 /// Args:
 ///     paths: List of paths to scan (default: ["."])
-///     preset: Analysis preset ("receipt", "health", "risk", "supply", "architecture",
+///     preset: Analysis preset ("receipt", "estimate", "health", "risk", "supply", "architecture",
 ///             "topics", "security", "identity", "git", "deep", "fun", default: "receipt")
 ///     window: Context window size in tokens for utilization calculation
 ///     git: Force enable/disable git metrics (None = auto-detect)


### PR DESCRIPTION
The `estimate` analysis preset is fully supported by the core pipeline and by the `tokmd-wasm` browser runner. However, it was missing from the TypeScript typings in `tokmd-node` and the Python docstrings in `tokmd-python`. This PR synchronizes the bindings documentation and types to include `estimate` as an allowed preset.

## 🎯 Why 
Cross-surface drift: users consuming `tokmd-node` via TypeScript, or reading `tokmd-python` docs, would not know that `preset: "estimate"` is a valid request, even though the underlying core engine explicitly supports it for both filesystem and rootless in-memory execution.

## 🔎 Evidence 
- `web/runner/worker.test.mjs` explicitly tests `preset: "estimate"`.
- `crates/tokmd-node/index.d.ts` omitted it from the `"receipt" | "health" | ...` union.

## 🧭 Options considered 
### Option A (recommended)
- Add `estimate` to the typing in `crates/tokmd-node` and docs in `crates/tokmd-python`.
- Fits the repo since it fixes a pure interface drift without changing runtime behavior.
- Low-risk and closes a known gap in the schema.

### Option B 
- Remove `estimate` from `tokmd-wasm` tests.
- This is incorrect because `estimate` is a supported analysis mode.

## ✅ Decision 
Option A. It aligns the downstream binding types and docs with the capabilities actually exposed by the core engine.

## 🧱 Changes made (SRP) 
- `crates/tokmd-node/index.d.ts`: Added `"estimate"` to `preset` union type.
- `crates/tokmd-node/npm/index.d.ts`: Added `"estimate"` to `preset` union type.
- `crates/tokmd-python/src/lib.rs`: Added `"estimate"` to doc comment for Python bindings.

## 🧪 Verification receipts 
```text
> cd web/runner && npm run test
# tests 38
# pass 37
# skipped 1

> cargo test -p tokmd-node
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

> cargo test -p tokmd-python
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

> cargo test -p tokmd-wasm
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## 🧭 Telemetry 
- Change shape: Documentation and typings
- Blast radius: Typings only, no runtime changes. Safe.
- Risk class: Low
- Rollback: Revert changes in `index.d.ts` and `src/lib.rs`.
- Gates run: `compat-matrix` profile logic (cargo test, npm run test)

## 🗂️ .jules artifacts 
- `.jules/runs/bridge_bindings_wasm_1/envelope.json`
- `.jules/runs/bridge_bindings_wasm_1/decision.md`
- `.jules/runs/bridge_bindings_wasm_1/receipts.jsonl`
- `.jules/runs/bridge_bindings_wasm_1/result.json`
- `.jules/runs/bridge_bindings_wasm_1/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [14226771524874158314](https://jules.google.com/task/14226771524874158314) started by @EffortlessSteven*