### PR TITLE
compat: Conditionally enable uuid js feature 🧷

### DIFF
--- a/crates/tokmd-format/Cargo.toml
+++ b/crates/tokmd-format/Cargo.toml
@@ -17,11 +17,14 @@ csv = "1.4.0"
 serde.workspace = true
 serde_json.workspace = true
 time = { version = "0.3.47", features = ["formatting"] }
-uuid = { version = "1.23", features = ["v4", "js"] }
+uuid = { version = "1.23", features = ["v4"] }
 tokmd-redact.workspace = true
 tokmd-scan-args.workspace = true
 tokmd-settings.workspace = true
 tokmd-types.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.23", features = ["v4", "js"] }
 
 [dev-dependencies]
 proptest.workspace = true


### PR DESCRIPTION
## Summary
- keep native `tokmd-format` builds on `uuid` without the `js` feature
- enable `uuid/js` only for `wasm32` targets where browser-compatible randomness is required
- replace the earlier polluted draft head with a one-file clean reland from current `main`

## Why
The earlier lanes in this family mixed the right compatibility idea with stale branch residue. The actual fix is small: native builds do not need `uuid/js`, but wasm builds still do. Scoping the feature by target preserves wasm support without pulling the JS feature into non-wasm builds.

## Validation
- `cargo check -p tokmd-format`
- `cargo check -p tokmd-wasm --target wasm32-unknown-unknown`
- `cargo xtask gate --check`

## Supersedes
This clean reland keeps the keeper intent for the UUID/JS family. Older sibling drafts in the same family should be closed once this branch is green.
