### PR TITLE
compat: fix --no-default-features build by decoupling git utilities 🧷

### DIFF
--- a/crates/tokmd/src/commands/check_ignore.rs
+++ b/crates/tokmd/src/commands/check_ignore.rs
@@ -4,6 +4,8 @@ use std::process::Stdio;
 use anyhow::Result;
 use tokmd_config as cli;
 
+use crate::git_support::git_cmd;
+
 /// Exit codes for check-ignore:
 /// - 0: Path is ignored
 /// - 1: Path is not ignored
@@ -120,7 +122,7 @@ fn check_path(path: &Path, global: &cli::GlobalArgs, verbose: bool) -> Result<Ch
 
 fn check_git_ignore(path: &Path, verbose: bool) -> Option<IgnoreReason> {
     // Try to use git check-ignore -v
-    let output = tokmd_git::git_cmd()
+    let output = git_cmd()
         .args(["check-ignore", "-v", "--"])
         .arg(path)
         .stdout(Stdio::piped())
@@ -176,7 +178,7 @@ fn check_git_ignore(path: &Path, verbose: bool) -> Option<IgnoreReason> {
 }
 
 fn is_git_tracked(path: &Path) -> bool {
-    tokmd_git::git_cmd()
+    git_cmd()
         .args(["ls-files", "--error-unmatch", "--"])
         .arg(path)
         .stdout(Stdio::null())

--- a/crates/tokmd/src/commands/handoff.rs
+++ b/crates/tokmd/src/commands/handoff.rs
@@ -26,6 +26,7 @@ use tokmd_types::{
 };
 
 use crate::context_pack;
+use crate::git_support::git_cmd;
 use tokmd_progress::Progress;
 
 const DEFAULT_TREE_DEPTH: usize = 4;
@@ -275,7 +276,7 @@ fn detect_capabilities(root: &Path, args: &cli::HandoffArgs) -> Vec<CapabilitySt
     let mut capabilities = Vec::new();
 
     // Check git availability
-    let git_available = tokmd_git::git_cmd()
+    let git_available = git_cmd()
         .arg("--version")
         .output()
         .map(|o| o.status.success())
@@ -305,7 +306,7 @@ fn detect_capabilities(root: &Path, args: &cli::HandoffArgs) -> Vec<CapabilitySt
     #[cfg(feature = "git")]
     let in_repo = tokmd_git::repo_root(root).is_some();
     #[cfg(not(feature = "git"))]
-    let in_repo = tokmd_git::git_cmd()
+    let in_repo = git_cmd()
         .args(["rev-parse", "--git-dir"])
         .current_dir(root)
         .output()
@@ -333,7 +334,7 @@ fn detect_capabilities(root: &Path, args: &cli::HandoffArgs) -> Vec<CapabilitySt
     }
 
     // Check for shallow clone
-    let shallow = tokmd_git::git_cmd()
+    let shallow = git_cmd()
         .args(["rev-parse", "--is-shallow-repository"])
         .current_dir(root)
         .output()

--- a/crates/tokmd/src/git_support.rs
+++ b/crates/tokmd/src/git_support.rs
@@ -1,0 +1,8 @@
+use std::process::Command;
+
+/// Create a `git` command without inheriting repo-shaping overrides.
+pub(crate) fn git_cmd() -> Command {
+    let mut cmd = Command::new("git");
+    cmd.env_remove("GIT_DIR").env_remove("GIT_WORK_TREE");
+    cmd
+}

--- a/crates/tokmd/src/lib.rs
+++ b/crates/tokmd/src/lib.rs
@@ -25,6 +25,7 @@ mod config;
 mod context_pack;
 mod error_hints;
 mod export_bundle;
+mod git_support;
 #[cfg(feature = "ui")]
 mod interactive;
 


### PR DESCRIPTION
## Summary
- fix `tokmd` CLI compilation under `--no-default-features` by routing the simple git shell-out sites through a crate-local helper instead of the optional `tokmd-git` crate
- keep the existing `tokmd_git::repo_root` path where the `git` feature is enabled, but use the shared helper for `git --version`, `git rev-parse`, `git check-ignore`, and `git ls-files`
- preserve the same process-environment isolation by stripping `GIT_DIR` and `GIT_WORK_TREE` in the helper

## Why
Current `origin/main` still fails `cargo check --no-default-features -p tokmd` because `check_ignore.rs` and `handoff.rs` unconditionally reference `tokmd_git::git_cmd()` even when the optional `git` feature is off.

## Scope
- `crates/tokmd/src/git_support.rs`
- `crates/tokmd/src/commands/check_ignore.rs`
- `crates/tokmd/src/commands/handoff.rs`
- `crates/tokmd/src/lib.rs`

## Validation
- `cargo fmt-fix`
- `cargo check --no-default-features -p tokmd`
- `cargo test -p tokmd --all-features --test analyze_integration --no-run`
- `cargo xtask gate --check`

## Notes
- This reland intentionally drops the prior `.jules/**` packet noise and unrelated dead-code/test-plan changes.
- Older sibling lanes `#1107` and `#1009` should be treated as superseded once this branch is green.