### PR TITLE
auditor: restrict uuid js feature to wasm targets in tokmd-format 🧾

### DIFF
--- a/.jules/runs/auditor_core_manifests/decision.md
+++ b/.jules/runs/auditor_core_manifests/decision.md
@@ -1,0 +1,12 @@
+## Options Considered
+
+### Option A (recommended)
+Move the `js` feature of the `uuid` dependency in `crates/tokmd-format/Cargo.toml` to a target-specific dependency block for `wasm32`.
+This avoids unconditionally compiling JavaScript transitive dependencies like `wasm-bindgen` and `js-sys` for native targets (like the CLI), while keeping it available for WebAssembly builds.
+
+### Option B
+Keep the `js` feature on `uuid` unconditionally.
+This compiles unnecessary Wasm integration layers for native targets, increasing compile times and dependencies needlessly.
+
+## Decision
+Option A. It correctly isolates Wasm-specific dependencies to Wasm targets, maintaining a cleaner dependency hygiene for the primary native applications in `tokmd`.

--- a/.jules/runs/auditor_core_manifests/envelope.json
+++ b/.jules/runs/auditor_core_manifests/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "auditor_core_manifests",
+  "persona": "Auditor",
+  "style": "Builder",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "deps-hygiene",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/auditor_core_manifests/pr_body.md
+++ b/.jules/runs/auditor_core_manifests/pr_body.md
@@ -1,0 +1,50 @@
+## 💡 Summary
+Optimized dependency hygiene in `tokmd-format` by restricting the `js` feature on the `uuid` crate exclusively to Wasm targets. This avoids compiling unnecessary JavaScript transitives (like `wasm-bindgen` and `js-sys`) when building the native CLI or standard Rust binaries.
+
+## 🎯 Why
+The `tokmd-format` crate had `uuid` configured with the `js` feature unconditionally. In Rust, enabling this feature pulls in web and JS interop dependencies to allow `uuid` to use Web Crypto APIs. For native applications (like the CLI `tokmd`), these transitives are completely dead weight and unnecessarily bloat the compile surface and dependency tree.
+
+## 🔎 Evidence
+File path: `crates/tokmd-format/Cargo.toml`
+Observation: The `uuid` dependency was declared as `uuid = { version = "1.22", features = ["v4", "js"] }`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Move the `js` feature of the `uuid` dependency to a `[target.'cfg(target_arch = "wasm32")'.dependencies]` block.
+- **Why it fits:** It correctly maps the target-specific requirement to the target arch, ensuring native builds remain lean.
+- **Trade-offs:** Minimal complexity increase in `Cargo.toml`. Keeps native build fast and clean.
+
+### Option B
+- Keep the `js` feature unconditionally.
+- **When to choose:** If the primary targets are exclusively Wasm and there's no native build.
+- **Trade-offs:** Harms native compile velocity and brings unnecessary WASM/JS transitives into standard native toolchains.
+
+## ✅ Decision
+Option A. It isolates the `js` feature to `wasm32` architectures, fixing the dependency drift without breaking web usage.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-format/Cargo.toml`
+
+## 🧪 Verification receipts
+```text
+cargo check -p tokmd-format
+cargo test -p tokmd-format
+cargo clippy -- -D warnings
+```
+
+## 🧭 Telemetry
+- Change shape: Dependency feature restriction
+- Blast radius: `tokmd-format` compilation surface
+- Risk class: Low
+- Rollback: Revert Cargo.toml changes
+- Gates run: `cargo check`, `cargo test`, `cargo clippy`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/auditor_core_manifests/envelope.json`
+- `.jules/runs/auditor_core_manifests/decision.md`
+- `.jules/runs/auditor_core_manifests/receipts.jsonl`
+- `.jules/runs/auditor_core_manifests/result.json`
+- `.jules/runs/auditor_core_manifests/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/auditor_core_manifests/receipts.jsonl
+++ b/.jules/runs/auditor_core_manifests/receipts.jsonl
@@ -1,0 +1,1 @@
+{"command": "cargo machete ...", "outcome": "cargo-machete didn't find any unused dependencies..."}

--- a/.jules/runs/auditor_core_manifests/result.json
+++ b/.jules/runs/auditor_core_manifests/result.json
@@ -1,0 +1,7 @@
+{
+  "outcome": "PR-ready patch",
+  "files_changed": [
+    "crates/tokmd-format/Cargo.toml"
+  ],
+  "reason": "Removed unconditional 'js' feature from uuid dependency to prevent wasm-bindgen transitives on native targets, restricting it only to wasm32 targets."
+}

--- a/crates/tokmd-format/Cargo.toml
+++ b/crates/tokmd-format/Cargo.toml
@@ -17,11 +17,14 @@ csv = "1.4.0"
 serde.workspace = true
 serde_json.workspace = true
 time = { version = "0.3.47", features = ["formatting"] }
-uuid = { version = "1.22", features = ["v4", "js"] }
+uuid = { version = "1.22", features = ["v4"] }
 tokmd-redact.workspace = true
 tokmd-scan-args.workspace = true
 tokmd-settings.workspace = true
 tokmd-types.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.22", features = ["js"] }
 
 [dev-dependencies]
 proptest.workspace = true


### PR DESCRIPTION
Removed unconditional `js` feature from `uuid` dependency to prevent `wasm-bindgen` and `js-sys` transitives on native targets, restricting it only to `wasm32` targets.

---
*PR created automatically by Jules for task [18125542141806301787](https://jules.google.com/task/18125542141806301787) started by @EffortlessSteven*