### PR TITLE
bridge: support base64 in-memory inputs in web runner 🌉

### DIFF
--- a/web/runner/messages.js
+++ b/web/runner/messages.js
@@ -84,13 +84,18 @@ export function createErrorMessage(requestId, code, message) {
 }
 
 export function isInMemoryInput(value) {
-    return Boolean(
-        value &&
-            typeof value === "object" &&
-            typeof value.path === "string" &&
-            value.path.trim().length > 0 &&
-            typeof value.text === "string"
-    );
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    if (typeof value.path !== "string" || value.path.trim().length === 0) {
+        return false;
+    }
+
+    const hasText = typeof value.text === "string";
+    const hasBase64 = typeof value.base64 === "string";
+
+    return (hasText && !hasBase64) || (!hasText && hasBase64);
 }
 
 export function isRunMessage(value) {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -56,6 +56,32 @@ test("run messages require ordered in-memory inputs", () => {
         isInMemoryInput({ path: "src/lib.rs", text: "pub fn alpha() {}\n" }),
         true
     );
+    assert.equal(
+        isInMemoryInput({
+            path: "src/lib.rs",
+            base64: "cHViIGZuIGFscGhhKCkge30K",
+        }),
+        true
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "b64",
+            mode: "lang",
+            args: {
+                inputs: [{ path: "src/lib.rs", base64: "cHViIGZuIGFscGhhKCkge30K" }],
+            },
+        }),
+        true
+    );
+    assert.equal(
+        isInMemoryInput({
+            path: "src/lib.rs",
+            text: "pub fn alpha() {}\n",
+            base64: "cHViIGZuIGFscGhhKCkge30K",
+        }),
+        false
+    );
     assert.equal(isRunMessage({ type: "run", requestId: "x", mode: "lang", args: {} }), false);
     assert.equal(
         isRunMessage({


### PR DESCRIPTION
Support `base64` in-memory inputs in the `web/runner` interface, resolving validation drift with `tokmd-core` Rust payload rules.

---
*PR created automatically by Jules for task [16811888775410597819](https://jules.google.com/task/16811888775410597819) started by @EffortlessSteven*