### PR TITLE
palette: fix requestId retention in browser runner protocol 🎨

### DIFF
--- a/web/runner/runtime.js
+++ b/web/runner/runtime.js
@@ -75,8 +75,10 @@ export async function handleRunnerMessage(message, options = {}) {
     }
 
     if (!isRunMessage(message)) {
+        const requestId =
+            message && typeof message.requestId === "string" ? message.requestId : null;
         return createErrorMessage(
-            null,
+            requestId,
             "invalid_message",
             "expected { type: \"run\", requestId, mode, args }"
         );

--- a/web/runner/runtime.test.mjs
+++ b/web/runner/runtime.test.mjs
@@ -42,7 +42,7 @@ test("runtime rejects malformed messages", async () => {
     assert.equal(isProtocolMessage(message), true);
 });
 
-test("runtime rejects run messages without valid inputs", async () => {
+test("runtime rejects run messages without valid inputs and retains requestId", async () => {
     const message = await handleRunnerMessage(
         createRunMessage({
             requestId: "run-2",
@@ -53,6 +53,7 @@ test("runtime rejects run messages without valid inputs", async () => {
 
     assert.equal(message.type, MESSAGE_TYPES.ERROR);
     assert.equal(message.error.code, "invalid_message");
+    assert.equal(message.requestId, "run-2");
 });
 
 test("runtime uses runner-provided mode capabilities", async () => {


### PR DESCRIPTION
## Summary
- retain a string `requestId` when the browser runner receives an invalid run message
- keep the current runner error-extraction behavior introduced on `main`
- replace the older polluted draft head with a clean two-file reland from current `main`

## Why
The browser runner already returns a protocol error for malformed run messages, but it was dropping a valid `requestId` in that path. That makes client correlation worse than it needs to be. The fix is small and protocol-local: preserve the caller-provided `requestId` when it is still a valid string.

## Validation
- `node --check web/runner/runtime.js`
- `node --test web/runner/runtime.test.mjs`

## Notes
The previous draft head for this PR also regressed newer browser-runner error handling that has already landed on `main`. This reland keeps the current runtime behavior and applies only the `requestId` retention fix.
