### PR TITLE
test(cli): lock in frobnicate unknown-subcommand output

### DIFF
--- a/crates/tokmd/tests/cli_e2e_w65.rs
+++ b/crates/tokmd/tests/cli_e2e_w65.rs
@@ -536,15 +536,6 @@ fn lang_exclude_multiple_patterns() {
 // ===========================================================================
 
 #[test]
-fn err_unknown_subcommand_fails() {
-    tokmd_bare()
-        .arg("frobnicate")
-        .assert()
-        .failure()
-        .stderr(predicate::str::is_empty().not());
-}
-
-#[test]
 fn err_typo_subcommand_fails() {
     tokmd_bare()
         .arg("lnag")
@@ -694,9 +685,21 @@ fn success_exit_code_is_zero() {
 }
 
 #[test]
-fn failure_exit_code_is_nonzero() {
+fn frobnicate_unknown_subcommand_has_stable_error_output() {
     let output = tokmd_bare().arg("frobnicate").output().expect("run");
-    assert_ne!(output.status.code(), Some(0));
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty(), "stdout should be empty");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: Path not found: frobnicate"),
+        "stderr should include the current path error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hints:"),
+        "stderr should include the stable hints block, got: {stderr}"
+    );
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- replace the scattered unknown-subcommand assertion churn with one focused CLI regression test
- lock the current `tokmd frobnicate` behavior to the real stable output on current `main`
- keep the scope to a single test file and one reviewer story

## Behavior Locked In
For `tokmd frobnicate`, the test asserts:
- non-zero exit
- empty stdout
- stderr contains `Error: Path not found: frobnicate`
- stderr contains `Hints:`

## Why
The older draft family overfit the wrong behavior or spread equivalent assertions across multiple files. The current CLI does not emit a bespoke "unknown subcommand" sentence here; it reports a path-not-found error with hints. This PR locks in the real behavior instead of encoding a stale expectation.

## Validation
- `cargo test -p tokmd --test cli_e2e_w65 frobnicate_unknown_subcommand_has_stable_error_output -- --exact --nocapture`

## Supersedes
This PR is the clean replacement for #1116 and #1125.
