### PR TITLE
fix(gate): restore fmt-clean mainline tests

### DIFF
--- a/crates/tokmd-python/src/lib.rs
+++ b/crates/tokmd-python/src/lib.rs
@@ -1130,8 +1130,7 @@ mod tests {
             let path_a = repo_a.path().to_string_lossy().to_string();
             let path_b = repo_b.path().to_string_lossy().to_string();
 
-            let diff_result =
-                diff(py, Some(&path_a), Some(&path_b)).expect("diff should succeed");
+            let diff_result = diff(py, Some(&path_a), Some(&path_b)).expect("diff should succeed");
             let diff_dict = diff_result.downcast_bound::<PyDict>(py).expect("diff dict");
             assert_eq!(
                 diff_dict

--- a/crates/tokmd/tests/docs.rs
+++ b/crates/tokmd/tests/docs.rs
@@ -359,7 +359,9 @@ fn recipe_check_ignore_verbose() {
         .arg("node_modules/lodash/index.js")
         .assert()
         .success()
-        .stdout(predicate::str::contains("node_modules/lodash/index.js: ignored"))
+        .stdout(predicate::str::contains(
+            "node_modules/lodash/index.js: ignored",
+        ))
         .stdout(predicate::str::contains(".tokeignore: node_modules/**"));
 }
 

--- a/crates/tokmd/tests/run_diff.rs
+++ b/crates/tokmd/tests/run_diff.rs
@@ -691,11 +691,7 @@ fn test_run_redact_all_hides_module_roots_in_artifacts() {
 
     let proprietary_module = dir.path().join("proprietary_module");
     fs::create_dir_all(&proprietary_module).unwrap();
-    fs::write(
-        proprietary_module.join("secret.rs"),
-        "fn secret() {}\n",
-    )
-    .unwrap();
+    fs::write(proprietary_module.join("secret.rs"), "fn secret() {}\n").unwrap();
 
     let mut cmd: Command = cargo_bin_cmd!("tokmd");
     cmd.current_dir(dir.path())


### PR DESCRIPTION
## Summary
Current \main\ is not fmt-clean, so unrelated PRs inherit a red \Quality Gate\ before their own diffs are evaluated.

## Why
- a clean detached worktree at current \origin/main\ failed \cargo fmt-check\
- the drift is mechanical formatting in three tracked test files
- \cargo xtask gate --check\ passes end-to-end once those files are reformatted

## Changes
- reformat \crates/tokmd/tests/docs.rs\
- reformat \crates/tokmd/tests/run_diff.rs\
- reformat \crates/tokmd-python/src/lib.rs\

## Verification
- \cargo fmt-check\
- \cargo xtask gate --check\
