### PR TITLE
archivist: keep prompt-critical persona guidance in persona READMEs

### DIFF
--- a/.jules/README.md
+++ b/.jules/README.md
@@ -70,6 +70,15 @@ The primary truth for any run is the **per-run packet** under:
 - `runs/` — per-run packets
 - `index/` — optional generated summaries
 
+## Persona instruction surface
+
+Prompt-critical guidance must live in the individual persona README files under
+`.jules/personas/<persona>/README.md`.
+
+Those files are the direct execution surface for persona-specific Jules runs.
+Shared docs in `.jules/README.md`, `runbooks/`, or `policy/` may summarize or
+reinforce that guidance, but they do not replace persona-local instructions.
+
 ## Learning and improvement intent
 
 The intent of keeping run packets, friction items, and persona notes in-repo is to:

--- a/.jules/personas/archivist/README.md
+++ b/.jules/personas/archivist/README.md
@@ -10,7 +10,8 @@ Improve Jules itself by consolidating run packets, friction, learnings, and shar
 1. consolidate recurring friction themes into better templates/policy/docs
 2. summarize per-run packets into generated indexes/rollups
 3. clean up prompt/runtime documentation so future runs improve
-4. move duplicated persona-local conventions into neutral shared guidance
+4. move only neutral shared conventions into shared guidance; keep prompt-critical
+   persona instructions in the individual persona README files
 
 ## Proof expectations
 Preserve per-run packets as primary truth. Never rewrite history; summarize or supersede it.
@@ -21,3 +22,5 @@ Do not perform unrelated repo code changes in this lane.
 ## Notes
 Use this persona's `notes/` directory only for **reusable learnings** that later runs can benefit from.
 Do not write per-run summaries here; per-run packets belong under `.jules/runs/<run-id>/`.
+Do not remove prompt-critical instructions from persona README files just because
+they also appear in shared docs; personas are sent individually.


### PR DESCRIPTION
## Summary
- state explicitly in `.jules/README.md` that shared docs do not replace persona-local instructions
- narrow the Archivist guidance so only neutral shared conventions move to shared docs
- encode the repo rule that prompt-critical persona guidance stays in `.jules/personas/<persona>/README.md`

## Validation
- `git diff --check`