### PR TITLE
bolt: optimize BTreeMap lang allocation in tokmd-model ⚡

### DIFF
--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -41,9 +41,9 @@ struct Agg {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct Key {
+struct Key<'a> {
     path: String,
-    lang: String,
+    lang: &'a str,
     kind: FileKind,
 }
 
@@ -208,9 +208,9 @@ fn detect_in_memory_language(
         .or_else(|| language_from_in_memory_shebang(bytes))
 }
 
-fn insert_row(
-    map: &mut BTreeMap<Key, (String, Agg)>,
-    key: Key,
+fn insert_row<'a>(
+    map: &mut BTreeMap<Key<'a>, (String, Agg)>,
+    key: Key<'a>,
     module: String,
     stats: &CodeStats,
     bytes: usize,
@@ -224,14 +224,14 @@ fn insert_row(
     entry.1.tokens += tokens;
 }
 
-fn rows_from_map(map: BTreeMap<Key, (String, Agg)>) -> Vec<FileRow> {
+fn rows_from_map<'a>(map: BTreeMap<Key<'a>, (String, Agg)>) -> Vec<FileRow> {
     map.into_iter()
         .map(|(key, (module, agg))| {
             let lines = agg.code + agg.comments + agg.blanks;
             FileRow {
                 path: key.path,
                 module,
-                lang: key.lang,
+                lang: key.lang.to_string(),
                 kind: key.kind,
                 code: agg.code,
                 comments: agg.comments,
@@ -255,7 +255,7 @@ pub fn collect_in_memory_file_rows(
     children: ChildIncludeMode,
     config: &Config,
 ) -> Vec<FileRow> {
-    let mut map: BTreeMap<Key, (String, Agg)> = BTreeMap::new();
+    let mut map = BTreeMap::new();
 
     for input in inputs {
         let Some(lang_type) = detect_in_memory_language(input.logical_path, input.bytes, config)
@@ -276,7 +276,7 @@ pub fn collect_in_memory_file_rows(
                     &mut map,
                     Key {
                         path: path.clone(),
-                        lang: child_type.name().to_string(),
+                        lang: child_type.name(),
                         kind: FileKind::Child,
                     },
                     module.clone(),
@@ -291,7 +291,7 @@ pub fn collect_in_memory_file_rows(
             &mut map,
             Key {
                 path,
-                lang: lang_type.name().to_string(),
+                lang: lang_type.name(),
                 kind: FileKind::Parent,
             },
             module,
@@ -653,7 +653,7 @@ pub fn collect_file_rows(
     children: ChildIncludeMode,
     strip_prefix: Option<&Path>,
 ) -> Vec<FileRow> {
-    let mut map: BTreeMap<Key, (String /*module*/, Agg)> = BTreeMap::new();
+    let mut map = BTreeMap::new();
 
     // Parent reports
     for (lang_type, lang) in languages.iter() {
@@ -666,7 +666,7 @@ pub fn collect_file_rows(
                 &mut map,
                 Key {
                     path,
-                    lang: lang_type.name().to_string(),
+                    lang: lang_type.name(),
                     kind: FileKind::Parent,
                 },
                 module,
@@ -688,7 +688,7 @@ pub fn collect_file_rows(
                         &mut map,
                         Key {
                             path,
-                            lang: child_type.name().to_string(),
+                            lang: child_type.name(),
                             kind: FileKind::Child,
                         },
                         module,


### PR DESCRIPTION
## 💡 Summary
Refactored `BTreeMap` keys in `tokmd-model` to borrow `&str` for language names instead of taking owned `String`s. This removes unnecessary allocation (`.to_string()`) on every iteration inside hot aggregation paths (`collect_file_rows` and `collect_in_memory_file_rows`).

## 🎯 Why
In tight aggregation loops, mapping a compound key into a `BTreeMap` forced a `.to_string()` allocation per parsed file or embedded language snippet. Changing `Key` to `Key<'a>` and binding the `lang` field directly to `tokei`'s statically borrowed `LanguageType::name()` strings eliminates repeated memory allocations during structural model building, honoring the memory management rule to "prefer using BTreeMap<&str, V> instead of BTreeMap<String, V> to avoid .clone() or .to_string() allocations".

## 🔎 Evidence
- **Observed Behavior**: `collect_file_rows` eagerly allocated string names from `LanguageType` on every file report traversal and embedded chunk detection via `lang_type.name().to_string()`.
- **Finding**: Refactoring `Key<'a>` allows passing `&str` instead, deferring owned String construction strictly to the `.to_string()` operation at the final export edge (`rows_from_map`).
- **Command receipt**: `cargo test -p tokmd-model` validates deterministic output and invariants are kept.

## 🧭 Options considered
### Option A (recommended)
- Borrow `&str` in `Key<'a>` and defer ownership logic to the final `rows_from_map` collection step.
- Why it fits: Matches the Refactorer persona mandate exactly. Reduces allocation in hot loops while fully preserving the deterministic output behavior.
- Trade-offs: Minor explicit lifetime bounds attached to the local model accumulation.

### Option B
- Continue allocating strings immediately inside the loop or switch to an internal arena string interner.
- When to choose: If languages names could be dynamically generated beyond `.name()` enum statics.
- Trade-offs: Heavier refactoring scope and unneeded complexity since `tokei` strictly provides `&'static str` names.

## ✅ Decision
Option A was chosen. It cleanly and safely bypasses `lang` allocs via simple lifetime mapping without introducing any external complexity or state.

## 🧱 Changes made (SRP)
- `crates/tokmd-model/src/lib.rs`: 
  - Refactored `Key` to `Key<'a>`.
  - Modified `lang` field from `String` to `&'a str`.
  - Updated `insert_row` and `rows_from_map` signatures to propagate the lifetime mapping constraint.
  - Eliminated `.to_string()` usages on `LanguageType::name()` occurrences within `collect_file_rows` and `collect_in_memory_file_rows`.
  - Deferred string ownership conversion until mapped output construction `key.lang.to_string()`.

## 🧪 Verification receipts
```text
$ cargo test -p tokmd-model
test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.29s
```

## 🧭 Telemetry
- Change shape: Optimization
- Blast radius: `tokmd-model` memory footprint
- Risk class: Low, pure struct lifetime annotation matching standard semantics
- Rollback: Safe to revert
- Gates run: `cargo test -p tokmd-model`

## 🗂️ .jules artifacts
- `.jules/runs/bolt_core_pipeline_refactorer/envelope.json`
- `.jules/runs/bolt_core_pipeline_refactorer/decision.md`
- `.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl`
- `.jules/runs/bolt_core_pipeline_refactorer/result.json`
- `.jules/runs/bolt_core_pipeline_refactorer/pr_body.md`

## 🔜 Follow-ups
None

---
*PR created automatically by Jules for task [18167268170591864246](https://jules.google.com/task/18167268170591864246) started by @EffortlessSteven*