### PR TITLE
docs: fix module children recipe

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -117,7 +117,7 @@ If you vendor dependencies (e.g., in `vendor/` or `node_modules/` that are check
 
 ```bash
 # Assuming 'vendor' is a top-level directory
-tokmd module --module-roots vendor,src --children collapse
+tokmd module --module-roots vendor,src --children parents-only
 ```
 
 Output:


### PR DESCRIPTION
## Summary

Restacks the factual docs fix onto current main with a docs-only diff.

- updates the module recipe to use the current parents-only children mode
- drops unrelated stale Cargo.lock churn from the old branch

## Validation

- cargo xtask docs --check
- git diff --check