### PR TITLE
mutant: Add missing tests for env_interpreter_token to kill mutants 🧬

### DIFF
--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -1100,4 +1100,92 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_looks_like_env_assignment() {
+        assert!(looks_like_env_assignment("FOO=bar"));
+        assert!(looks_like_env_assignment("_FOO=bar"));
+        assert!(looks_like_env_assignment("A_B_C=123"));
+
+        assert!(!looks_like_env_assignment("="));
+        assert!(!looks_like_env_assignment("=bar"));
+        assert!(!looks_like_env_assignment("1FOO=bar"));
+        assert!(!looks_like_env_assignment("FOO-BAR=baz"));
+    }
+
+    #[test]
+    fn test_env_interpreter_token() {
+        // Simple case
+        assert_eq!(
+            env_interpreter_token(vec!["python"].into_iter()),
+            Some("python")
+        );
+
+        // Skip env assignments
+        assert_eq!(
+            env_interpreter_token(vec!["FOO=bar", "python"].into_iter()),
+            Some("python")
+        );
+
+        // Skip common env flags without args
+        assert_eq!(
+            env_interpreter_token(vec!["-S", "-i", "python"].into_iter()),
+            Some("python")
+        );
+
+        // Skip flags with next argument
+        assert_eq!(
+            env_interpreter_token(vec!["-u", "FOO", "-C", "/tmp", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--unset", "FOO", "python"].into_iter()),
+            Some("python")
+        );
+
+        // Skip long flags with = assignment
+        assert_eq!(
+            env_interpreter_token(vec!["--unset=FOO", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--chdir=/tmp", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--default-path=/bin", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--argv0=sh", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--default-signal=SIGINT", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--ignore-signal=SIGINT", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--block-signal=SIGINT", "python"].into_iter()),
+            Some("python")
+        );
+
+        // Unknown flags starting with - are skipped (mimicking coreutils env behavior)
+        assert_eq!(
+            env_interpreter_token(vec!["--unknown-flag", "python"].into_iter()),
+            Some("python")
+        );
+
+        // Empty words
+        assert_eq!(
+            env_interpreter_token(vec!["", "python"].into_iter()),
+            Some("python")
+        );
+
+        // No interpreter found
+        assert_eq!(env_interpreter_token(vec!["FOO=bar"].into_iter()), None);
+    }
 }


### PR DESCRIPTION
## 💡 Summary 
Added unit tests to `crates/tokmd-model/src/lib.rs` for `env_interpreter_token` and `looks_like_env_assignment`. This closes a missed mutant in the model crate's shebang environment parsing logic.

## 🎯 Why 
Running `cargo mutants` on `crates/tokmd-model/src/lib.rs` revealed an unkilled mutant in `env_interpreter_token` inside the environment variable flag checking logic (`||` mutated to `&&`). This indicated weak test coverage around the language detection logic that interprets `#!/usr/bin/env` shebangs, a high-value production surface.

## 🔎 Evidence 
Minimal proof:
- file path(s): `crates/tokmd-model/src/lib.rs`
- observed behavior / finding: `cargo mutants` missed a mutation in `env_interpreter_token`: `crates/tokmd-model/src/lib.rs:141:17: replace || with && in env_interpreter_token`.
- receipts demonstrating it: Added targeted tests that assert the function properly skips specific environment assignment arguments (`--unset=`, `--chdir=`, etc) and `FOO=bar` variables, killing the mutant.

## 🧭 Options considered 
### Option A (recommended)
- Add unit tests for `env_interpreter_token` and `looks_like_env_assignment` functions in `crates/tokmd-model/src/lib.rs`.
- why it fits this repo and shard: Directly improves behavioral assertions in `core-pipeline`, specifically around the language detection phase. Fits the "Prover" persona perfectly by adding proof.
- trade-offs: Structure / Velocity / Governance: Direct, robust, fast to run. Ensures test coverage explicitly maps to unit implementation.

### Option B
- Add a full file shebang detection test in `crates/tokmd/tests/`.
- when to choose it instead: If internal logic testing was hard.
- trade-offs: Integration tests are slower, and could still miss specific branch logic at the unit level if not comprehensive.

## ✅ Decision 
Chosen Option A. Adding unit tests ensures the private parsing helpers correctly handle edge cases, directly targeting the missed mutant while providing faster feedback than full integration tests.

## 🧱 Changes made (SRP) 
- `crates/tokmd-model/src/lib.rs`: Added `test_env_interpreter_token` and `test_looks_like_env_assignment`.

## 🧪 Verification receipts 
```text
cargo test -p tokmd-model
cargo mutants --file crates/tokmd-model/src/lib.rs
```

## 🧭 Telemetry 
- Change shape: Test improvement
- Blast radius: None (tests only)
- Risk class: Low
- Rollback: Revert the added test lines
- Gates run: `cargo mutants`, `cargo test`, `cargo fmt`, `cargo clippy`

## 🗂️ .jules artifacts 
- `.jules/runs/mutant_high_value/envelope.json`
- `.jules/runs/mutant_high_value/decision.md`
- `.jules/runs/mutant_high_value/receipts.jsonl`
- `.jules/runs/mutant_high_value/result.json`
- `.jules/runs/mutant_high_value/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [12677543726543731979](https://jules.google.com/task/12677543726543731979) started by @EffortlessSteven*