### PR TITLE
action: prepare Marketplace publish surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,67 @@
 
 `tokmd` turns a source tree into stable receipts you can diff, analyze, archive, gate, and pack for downstream automation. It starts with code inventory, then keeps going: saved artifacts, derived metrics, PR review surfaces, policy checks, sensor outputs, and browser-safe context bundles.
 
+## GitHub Action
+
+Use the root composite action when you want a workflow-friendly receipt and PR summary without scripting `tokmd` installation yourself.
+
+- Installs a released `tokmd` binary for the current runner.
+- Generates `tokmd-summary.md` from `tokmd module`.
+- Generates a structured receipt file from `tokmd export`.
+- Optionally uploads both files as workflow artifacts.
+- Optionally posts the summary as a pull request comment.
+
+```yaml
+name: tokmd receipt
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  receipt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: EffortlessMetrics/tokmd@v1
+        with:
+          version: '1.9.0'
+          paths: .
+          module-roots: crates,packages
+          top: '20'
+          format: json
+          artifact: 'true'
+          comment: 'true'
+```
+
+Inputs:
+
+| Input | Required | Default | Purpose |
+| :---- | :------- | :------ | :------ |
+| `version` | no | `latest` | `tokmd` release to install. Pass an explicit version if you want the action ref and binary version to stay aligned. |
+| `paths` | no | `.` | Paths to scan. |
+| `module-roots` | no | `crates,packages` | Module root prefixes for `tokmd module` and `tokmd export`. |
+| `top` | no | `20` | Number of rows shown in `tokmd-summary.md`. |
+| `format` | no | `json` | Receipt export format: `json`, `jsonl`, or `csv`. |
+| `artifact` | no | `true` | Upload `tokmd-summary.md` and the receipt as workflow artifacts. |
+| `comment` | no | `true` | Post `tokmd-summary.md` as a pull request comment when running on `pull_request` events. |
+
+Outputs:
+
+| Output | Description |
+| :----- | :---------- |
+| `receipt` | Path to the generated receipt file. |
+
+Notes:
+
+- PR commenting needs `pull-requests: write` and only runs for `pull_request` events.
+- The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
+- Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
+
 ## The Problem
 
 Raw LOC counts are easy to produce and hard to reuse.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'tokmd-receipt'
-description: 'Generate a repository receipt (markdown summary + JSON inventory) using tokmd'
+name: 'tokmd'
+description: 'Generate repository receipts and PR summaries with tokmd'
 
 branding:
   icon: 'file-text'
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   version:
-    description: 'Version of tokmd to use'
+    description: 'Version of tokmd to install. Defaults to the latest release.'
     default: 'latest'
   paths:
     description: 'Paths to scan'
@@ -22,10 +22,10 @@ inputs:
     description: 'Export format (json, jsonl, csv)'
     default: 'json'
   artifact:
-    description: 'Whether to upload receipts as artifacts'
+    description: 'Whether to upload tokmd-summary.md and the receipt as workflow artifacts'
     default: 'true'
   comment:
-    description: 'Whether to post a comment on the PR'
+    description: 'Whether to post tokmd-summary.md as a pull request comment'
     default: 'true'
 
 outputs:
@@ -47,11 +47,27 @@ runs:
 
         version="${{ inputs.version }}"
         os="${RUNNER_OS}"
+        arch="${RUNNER_ARCH:-X64}"
+
+        case "$arch" in
+          X64|AMD64) arch_suffix="amd64" ;;
+          ARM64) arch_suffix="arm64" ;;
+          *)
+            echo "Unsupported runner architecture: $arch" >&2
+            exit 1
+            ;;
+        esac
 
         case "$os" in
-          Linux) asset="tokmd-linux-amd64" ;;
-          macOS) asset="tokmd-macos-amd64" ;;
-          Windows) asset="tokmd-windows-amd64.exe" ;;
+          Linux) asset="tokmd-linux-$arch_suffix" ;;
+          macOS) asset="tokmd-macos-$arch_suffix" ;;
+          Windows)
+            if [ "${arch_suffix:-}" != "amd64" ]; then
+              echo "Unsupported runner architecture for Windows releases: $arch" >&2
+              exit 1
+            fi
+            asset="tokmd-windows-amd64.exe"
+            ;;
           *) echo "Unsupported runner OS: $os" >&2; exit 1 ;;
         esac
 
@@ -141,7 +157,7 @@ runs:
 
     - name: Upload Artifact
       if: inputs.artifact == 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: tokmd-receipts
         path: |
@@ -150,7 +166,7 @@ runs:
 
     - name: Comment on PR
       if: inputs.comment == 'true' && github.event_name == 'pull_request'
-      uses: thollander/actions-comment-pull-request@v3
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
       with:
-        filePath: tokmd-summary.md
+        file-path: tokmd-summary.md
         comment_tag: tokmd-summary


### PR DESCRIPTION
## Summary
- rename the Marketplace action metadata from `tokmd-receipt` to `tokmd`
- add an action-first README section with workflow example, inputs, outputs, permissions, and support notes
- make the installer architecture-aware for released assets and pin nested actions to immutable SHAs
- fix the PR comment step to use the action's documented `file-path` input

## Why
The current action surface is publishable, but it is not yet shaped like a long-term Marketplace product:
- the listing name would publish as `tokmd-receipt`
- the README leads with the broader product, not the action workflow surface
- the installer assumes `amd64` assets only even though release artifacts include Linux/macOS arm64
- nested actions were tag-pinned rather than SHA-pinned

## Validation
- `git diff --check`
- verified release asset names against `.github/workflows/release.yml`
- verified `thollander/actions-comment-pull-request` expects `file-path`
- resolved current `actions/upload-artifact` and `thollander/actions-comment-pull-request` tags to full commit SHAs before pinning

## Notes
This intentionally keeps the current `version: latest` behavior, but the README now documents that behavior explicitly so users can pin `with: version:` when they need the binary version to match the action ref.