### PR TITLE
specsmith: tighten unknown subcommand test assertions 🧪

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,6 +2849,7 @@ dependencies = [
 name = "tokmd-analysis-types"
 version = "1.9.0"
 dependencies = [
+ "chrono",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/tokmd/tests/cli_comprehensive.rs
+++ b/crates/tokmd/tests/cli_comprehensive.rs
@@ -825,7 +825,9 @@ fn invalid_subcommand_fails() {
         .arg("this-subcommand-does-not-exist")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]

--- a/crates/tokmd/tests/cli_e2e_w58.rs
+++ b/crates/tokmd/tests/cli_e2e_w58.rs
@@ -43,7 +43,9 @@ fn err_completely_unknown_subcommand() {
         .arg("frobnicate")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cli_e2e_w69.rs
+++ b/crates/tokmd/tests/cli_e2e_w69.rs
@@ -616,7 +616,9 @@ fn w69_error_unknown_subcommand() {
         .arg("nonexistent_subcommand_xyz")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -222,7 +222,9 @@ fn unknown_subcommand_fails() {
         .arg("nonexistent-subcommand")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 /// Verify that every expected subcommand responds to --help without error.

--- a/crates/tokmd/tests/cli_errors_w66.rs
+++ b/crates/tokmd/tests/cli_errors_w66.rs
@@ -257,7 +257,9 @@ fn unknown_subcommand_produces_helpful_error() {
         .arg("not-a-real-command")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]

--- a/crates/tokmd/tests/cli_pipeline_e2e_w54.rs
+++ b/crates/tokmd/tests/cli_pipeline_e2e_w54.rs
@@ -570,7 +570,9 @@ fn invalid_subcommand_fails() {
         .arg("not-a-real-command")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]

--- a/crates/tokmd/tests/e2e_extended.rs
+++ b/crates/tokmd/tests/e2e_extended.rs
@@ -270,7 +270,9 @@ fn nonexistent_subcommand_fails() {
     tokmd_cmd()
         .arg("this-subcommand-does-not-exist")
         .assert()
-        .failure();
+        .failure()
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tokmd/tests/error_handling.rs
+++ b/crates/tokmd/tests/error_handling.rs
@@ -105,7 +105,9 @@ fn unknown_subcommand_fails() {
         .arg("this-subcommand-does-not-exist")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tokmd/tests/error_handling_w70.rs
+++ b/crates/tokmd/tests/error_handling_w70.rs
@@ -156,7 +156,9 @@ fn unknown_subcommand_fails_with_stderr() {
         .arg("nonexistent_subcommand_w70")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::is_empty().not())
+        .stderr(predicate::str::contains("not recognized"))
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 // ===========================================================================


### PR DESCRIPTION
Tightens regression coverage around unknown subcommands across multiple end-to-end integration test suites. The CLI translates unknown subcommands into a "Path not found" error with a hint mentioning the unrecognized subcommand. This PR explicitly checks for those specific hint strings, turning weak "is_not_empty()" checks into true behavioral validations.

---
*PR created automatically by Jules for task [15487036509734552759](https://jules.google.com/task/15487036509734552759) started by @EffortlessSteven*