### PR TITLE
gatekeeper: add golden snapshot coverage for analyze subcommand ✅

### DIFF
--- a/crates/tokmd/tests/cli_snapshot_golden.rs
+++ b/crates/tokmd/tests/cli_snapshot_golden.rs
@@ -36,6 +36,24 @@ fn normalize(output: &str) -> String {
     let re_abs = regex::Regex::new(r#""paths":\["[^"]*"\]"#).unwrap();
     let s = re_abs.replace_all(&s, r#""paths":["<ROOT>"]"#).to_string();
 
+    // Normalize analysis-specific dynamic fields.
+    let re_target = regex::Regex::new(r#""target_path":\s*"[^"]*""#).unwrap();
+    let s = re_target
+        .replace_all(&s, r#""target_path":"<ROOT>""#)
+        .to_string();
+    let re_base_signature = regex::Regex::new(r#""base_signature":\s*"[^"]+""#).unwrap();
+    let s = re_base_signature
+        .replace_all(&s, r#""base_signature":"<BASE_SIGNATURE>""#)
+        .to_string();
+    let re_integrity_hash = regex::Regex::new(r#""hash":\s*"[0-9a-f]{64}""#).unwrap();
+    let s = re_integrity_hash
+        .replace_all(&s, r#""hash":"<INTEGRITY_HASH>""#)
+        .to_string();
+    let re_markdown_hash = regex::Regex::new(r#"Hash: `[0-9a-f]{64}`"#).unwrap();
+    let s = re_markdown_hash
+        .replace_all(&s, "Hash: `<INTEGRITY_HASH>`")
+        .to_string();
+
     // Normalize binary name across platforms (tokmd.exe on Windows -> tokmd)
     s.replace("tokmd.exe", "tokmd")
 }
@@ -188,7 +206,39 @@ fn snapshot_export_csv() {
 }
 
 // ---------------------------------------------------------------------------
-// 6. Version output snapshot
+// 6. Analyze output snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_analyze_json() {
+    let output = tokmd_cmd()
+        .args([
+            "analyze", ".", "--preset", "receipt", "--format", "json", "--no-git",
+        ])
+        .output()
+        .expect("failed to run tokmd analyze --format json");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    insta::assert_snapshot!("analyze_json", normalize(&stdout));
+}
+
+#[test]
+fn snapshot_analyze_markdown() {
+    let output = tokmd_cmd()
+        .args([
+            "analyze", ".", "--preset", "receipt", "--format", "md", "--no-git",
+        ])
+        .output()
+        .expect("failed to run tokmd analyze --format md");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    insta::assert_snapshot!("analyze_markdown", normalize(&stdout));
+}
+
+// ---------------------------------------------------------------------------
+// 7. Version output snapshot
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -204,7 +254,7 @@ fn snapshot_version() {
 }
 
 // ---------------------------------------------------------------------------
-// 7. Help output snapshot
+// 8. Help output snapshot
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/crates/tokmd/tests/snapshots/cli_snapshot_golden__analyze_json.snap
+++ b/crates/tokmd/tests/snapshots/cli_snapshot_golden__analyze_json.snap
@@ -1,0 +1,922 @@
+---
+source: crates/tokmd/tests/cli_snapshot_golden.rs
+expression: normalize(&stdout)
+---
+{
+  "schema_version": 9,
+  "generated_at_ms":0,
+  "tool": {
+    "name": "tokmd",
+    "version": "0.0.0"
+  },
+  "mode": "analysis",
+  "status": "complete",
+  "warnings": [],
+  "source": {
+    "inputs": [
+      "."
+    ],
+    "export_path": null,
+    "base_receipt_path": null,
+    "export_schema_version": null,
+    "export_generated_at_ms": null,
+    "base_signature":"<BASE_SIGNATURE>",
+    "module_roots": [
+      "crates",
+      "packages",
+      "src"
+    ],
+    "module_depth": 2,
+    "children": "separate"
+  },
+  "args": {
+    "preset": "receipt",
+    "format": "json",
+    "window_tokens": null,
+    "git": false,
+    "max_files": null,
+    "max_bytes": null,
+    "max_commits": null,
+    "max_commit_files": null,
+    "max_file_bytes": null,
+    "import_granularity": "module"
+  },
+  "archetype": null,
+  "topics": null,
+  "entropy": null,
+  "predictive_churn": null,
+  "corporate_fingerprint": null,
+  "license": null,
+  "derived": {
+    "totals": {
+      "files": 7,
+      "code": 26,
+      "comments": 8,
+      "blanks": 3,
+      "lines": 37,
+      "bytes": 583,
+      "tokens": 143
+    },
+    "doc_density": {
+      "total": {
+        "key": "total",
+        "numerator": 8,
+        "denominator": 34,
+        "ratio": 0.2353
+      },
+      "by_lang": [
+        {
+          "key": "Markdown",
+          "numerator": 6,
+          "denominator": 4,
+          "ratio": 1.5
+        },
+        {
+          "key": "Rust",
+          "numerator": 2,
+          "denominator": 13,
+          "ratio": 0.1538
+        },
+        {
+          "key": "JavaScript",
+          "numerator": 0,
+          "denominator": 1,
+          "ratio": 0.0
+        },
+        {
+          "key": "TOML",
+          "numerator": 0,
+          "denominator": 8,
+          "ratio": 0.0
+        }
+      ],
+      "by_module": [
+        {
+          "key": "(root)",
+          "numerator": 8,
+          "denominator": 23,
+          "ratio": 0.3478
+        },
+        {
+          "key": "src",
+          "numerator": 0,
+          "denominator": 3,
+          "ratio": 0.0
+        }
+      ]
+    },
+    "whitespace": {
+      "total": {
+        "key": "total",
+        "numerator": 3,
+        "denominator": 34,
+        "ratio": 0.0882
+      },
+      "by_lang": [
+        {
+          "key": "Markdown",
+          "numerator": 2,
+          "denominator": 10,
+          "ratio": 0.2
+        },
+        {
+          "key": "TOML",
+          "numerator": 1,
+          "denominator": 8,
+          "ratio": 0.125
+        },
+        {
+          "key": "JavaScript",
+          "numerator": 0,
+          "denominator": 1,
+          "ratio": 0.0
+        },
+        {
+          "key": "Rust",
+          "numerator": 0,
+          "denominator": 15,
+          "ratio": 0.0
+        }
+      ],
+      "by_module": [
+        {
+          "key": "(root)",
+          "numerator": 3,
+          "denominator": 31,
+          "ratio": 0.0968
+        },
+        {
+          "key": "src",
+          "numerator": 0,
+          "denominator": 3,
+          "ratio": 0.0
+        }
+      ]
+    },
+    "verbosity": {
+      "total": {
+        "key": "total",
+        "numerator": 583,
+        "denominator": 37,
+        "rate": 15.7568
+      },
+      "by_lang": [
+        {
+          "key": "JavaScript",
+          "numerator": 30,
+          "denominator": 1,
+          "rate": 30.0
+        },
+        {
+          "key": "TOML",
+          "numerator": 165,
+          "denominator": 9,
+          "rate": 18.3333
+        },
+        {
+          "key": "Rust",
+          "numerator": 240,
+          "denominator": 15,
+          "rate": 16.0
+        },
+        {
+          "key": "Markdown",
+          "numerator": 148,
+          "denominator": 12,
+          "rate": 12.3333
+        }
+      ],
+      "by_module": [
+        {
+          "key": "(root)",
+          "numerator": 538,
+          "denominator": 34,
+          "rate": 15.8235
+        },
+        {
+          "key": "src",
+          "numerator": 45,
+          "denominator": 3,
+          "rate": 15.0
+        }
+      ]
+    },
+    "max_file": {
+      "overall": {
+        "path": "mixed.md",
+        "module": "(root)",
+        "lang": "Markdown",
+        "code": 4,
+        "comments": 5,
+        "blanks": 2,
+        "lines": 11,
+        "bytes": 118,
+        "tokens": 29,
+        "doc_pct": 0.5556,
+        "bytes_per_line": 10.7273,
+        "depth": 1
+      },
+      "by_lang": [
+        {
+          "key": "JavaScript",
+          "file": {
+            "path": "script.js",
+            "module": "(root)",
+            "lang": "JavaScript",
+            "code": 1,
+            "comments": 0,
+            "blanks": 0,
+            "lines": 1,
+            "bytes": 30,
+            "tokens": 7,
+            "doc_pct": 0.0,
+            "bytes_per_line": 30.0,
+            "depth": 1
+          }
+        },
+        {
+          "key": "Markdown",
+          "file": {
+            "path": "mixed.md",
+            "module": "(root)",
+            "lang": "Markdown",
+            "code": 4,
+            "comments": 5,
+            "blanks": 2,
+            "lines": 11,
+            "bytes": 118,
+            "tokens": 29,
+            "doc_pct": 0.5556,
+            "bytes_per_line": 10.7273,
+            "depth": 1
+          }
+        },
+        {
+          "key": "Rust",
+          "file": {
+            "path": "large.rs",
+            "module": "(root)",
+            "lang": "Rust",
+            "code": 9,
+            "comments": 2,
+            "blanks": 0,
+            "lines": 11,
+            "bytes": 182,
+            "tokens": 45,
+            "doc_pct": 0.1818,
+            "bytes_per_line": 16.5455,
+            "depth": 1
+          }
+        },
+        {
+          "key": "TOML",
+          "file": {
+            "path": "Cargo.toml",
+            "module": "(root)",
+            "lang": "TOML",
+            "code": 8,
+            "comments": 0,
+            "blanks": 1,
+            "lines": 9,
+            "bytes": 165,
+            "tokens": 41,
+            "doc_pct": 0.0,
+            "bytes_per_line": 18.3333,
+            "depth": 1
+          }
+        }
+      ],
+      "by_module": [
+        {
+          "key": "(root)",
+          "file": {
+            "path": "large.rs",
+            "module": "(root)",
+            "lang": "Rust",
+            "code": 9,
+            "comments": 2,
+            "blanks": 0,
+            "lines": 11,
+            "bytes": 182,
+            "tokens": 45,
+            "doc_pct": 0.1818,
+            "bytes_per_line": 16.5455,
+            "depth": 1
+          }
+        },
+        {
+          "key": "src",
+          "file": {
+            "path": "src/main.rs",
+            "module": "src",
+            "lang": "Rust",
+            "code": 3,
+            "comments": 0,
+            "blanks": 0,
+            "lines": 3,
+            "bytes": 45,
+            "tokens": 11,
+            "doc_pct": 0.0,
+            "bytes_per_line": 15.0,
+            "depth": 2
+          }
+        }
+      ]
+    },
+    "lang_purity": {
+      "rows": [
+        {
+          "module": "(root)",
+          "lang_count": 4,
+          "dominant_lang": "Markdown",
+          "dominant_lines": 12,
+          "dominant_pct": 0.3529
+        },
+        {
+          "module": "src",
+          "lang_count": 1,
+          "dominant_lang": "Rust",
+          "dominant_lines": 3,
+          "dominant_pct": 1.0
+        }
+      ]
+    },
+    "nesting": {
+      "max": 2,
+      "avg": 1.14,
+      "by_module": [
+        {
+          "key": "(root)",
+          "max": 1,
+          "avg": 1.0
+        },
+        {
+          "key": "src",
+          "max": 2,
+          "avg": 2.0
+        }
+      ]
+    },
+    "test_density": {
+      "test_lines": 0,
+      "prod_lines": 26,
+      "test_files": 0,
+      "prod_files": 7,
+      "ratio": 0.0
+    },
+    "boilerplate": {
+      "infra_lines": 21,
+      "logic_lines": 16,
+      "ratio": 0.5676,
+      "infra_langs": [
+        "Markdown",
+        "TOML"
+      ]
+    },
+    "polyglot": {
+      "lang_count": 4,
+      "entropy": 1.6195,
+      "dominant_lang": "Rust",
+      "dominant_lines": 13,
+      "dominant_pct": 0.5
+    },
+    "distribution": {
+      "count": 7,
+      "min": 1,
+      "max": 11,
+      "mean": 5.29,
+      "median": 3.0,
+      "p90": 11.0,
+      "p99": 11.0,
+      "gini": 0.4479
+    },
+    "histogram": [
+      {
+        "label": "Tiny",
+        "min": 0,
+        "max": 50,
+        "files": 7,
+        "pct": 1.0
+      },
+      {
+        "label": "Small",
+        "min": 51,
+        "max": 200,
+        "files": 0,
+        "pct": 0.0
+      },
+      {
+        "label": "Medium",
+        "min": 201,
+        "max": 500,
+        "files": 0,
+        "pct": 0.0
+      },
+      {
+        "label": "Large",
+        "min": 501,
+        "max": 1000,
+        "files": 0,
+        "pct": 0.0
+      },
+      {
+        "label": "Huge",
+        "min": 1001,
+        "max": null,
+        "files": 0,
+        "pct": 0.0
+      }
+    ],
+    "top": {
+      "largest_lines": [
+        {
+          "path": "large.rs",
+          "module": "(root)",
+          "lang": "Rust",
+          "code": 9,
+          "comments": 2,
+          "blanks": 0,
+          "lines": 11,
+          "bytes": 182,
+          "tokens": 45,
+          "doc_pct": 0.1818,
+          "bytes_per_line": 16.5455,
+          "depth": 1
+        },
+        {
+          "path": "mixed.md",
+          "module": "(root)",
+          "lang": "Markdown",
+          "code": 4,
+          "comments": 5,
+          "blanks": 2,
+          "lines": 11,
+          "bytes": 118,
+          "tokens": 29,
+          "doc_pct": 0.5556,
+          "bytes_per_line": 10.7273,
+          "depth": 1
+        },
+        {
+          "path": "Cargo.toml",
+          "module": "(root)",
+          "lang": "TOML",
+          "code": 8,
+          "comments": 0,
+          "blanks": 1,
+          "lines": 9,
+          "bytes": 165,
+          "tokens": 41,
+          "doc_pct": 0.0,
+          "bytes_per_line": 18.3333,
+          "depth": 1
+        },
+        {
+          "path": "src/main.rs",
+          "module": "src",
+          "lang": "Rust",
+          "code": 3,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 3,
+          "bytes": 45,
+          "tokens": 11,
+          "doc_pct": 0.0,
+          "bytes_per_line": 15.0,
+          "depth": 2
+        },
+        {
+          "path": "README.md",
+          "module": "(root)",
+          "lang": "Markdown",
+          "code": 0,
+          "comments": 1,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 30,
+          "tokens": 7,
+          "doc_pct": 1.0,
+          "bytes_per_line": 30.0,
+          "depth": 1
+        },
+        {
+          "path": "script.js",
+          "module": "(root)",
+          "lang": "JavaScript",
+          "code": 1,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 30,
+          "tokens": 7,
+          "doc_pct": 0.0,
+          "bytes_per_line": 30.0,
+          "depth": 1
+        },
+        {
+          "path": "space file.rs",
+          "module": "(root)",
+          "lang": "Rust",
+          "code": 1,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 13,
+          "tokens": 3,
+          "doc_pct": 0.0,
+          "bytes_per_line": 13.0,
+          "depth": 1
+        }
+      ],
+      "largest_tokens": [
+        {
+          "path": "large.rs",
+          "module": "(root)",
+          "lang": "Rust",
+          "code": 9,
+          "comments": 2,
+          "blanks": 0,
+          "lines": 11,
+          "bytes": 182,
+          "tokens": 45,
+          "doc_pct": 0.1818,
+          "bytes_per_line": 16.5455,
+          "depth": 1
+        },
+        {
+          "path": "Cargo.toml",
+          "module": "(root)",
+          "lang": "TOML",
+          "code": 8,
+          "comments": 0,
+          "blanks": 1,
+          "lines": 9,
+          "bytes": 165,
+          "tokens": 41,
+          "doc_pct": 0.0,
+          "bytes_per_line": 18.3333,
+          "depth": 1
+        },
+        {
+          "path": "mixed.md",
+          "module": "(root)",
+          "lang": "Markdown",
+          "code": 4,
+          "comments": 5,
+          "blanks": 2,
+          "lines": 11,
+          "bytes": 118,
+          "tokens": 29,
+          "doc_pct": 0.5556,
+          "bytes_per_line": 10.7273,
+          "depth": 1
+        },
+        {
+          "path": "src/main.rs",
+          "module": "src",
+          "lang": "Rust",
+          "code": 3,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 3,
+          "bytes": 45,
+          "tokens": 11,
+          "doc_pct": 0.0,
+          "bytes_per_line": 15.0,
+          "depth": 2
+        },
+        {
+          "path": "README.md",
+          "module": "(root)",
+          "lang": "Markdown",
+          "code": 0,
+          "comments": 1,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 30,
+          "tokens": 7,
+          "doc_pct": 1.0,
+          "bytes_per_line": 30.0,
+          "depth": 1
+        },
+        {
+          "path": "script.js",
+          "module": "(root)",
+          "lang": "JavaScript",
+          "code": 1,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 30,
+          "tokens": 7,
+          "doc_pct": 0.0,
+          "bytes_per_line": 30.0,
+          "depth": 1
+        },
+        {
+          "path": "space file.rs",
+          "module": "(root)",
+          "lang": "Rust",
+          "code": 1,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 13,
+          "tokens": 3,
+          "doc_pct": 0.0,
+          "bytes_per_line": 13.0,
+          "depth": 1
+        }
+      ],
+      "largest_bytes": [
+        {
+          "path": "large.rs",
+          "module": "(root)",
+          "lang": "Rust",
+          "code": 9,
+          "comments": 2,
+          "blanks": 0,
+          "lines": 11,
+          "bytes": 182,
+          "tokens": 45,
+          "doc_pct": 0.1818,
+          "bytes_per_line": 16.5455,
+          "depth": 1
+        },
+        {
+          "path": "Cargo.toml",
+          "module": "(root)",
+          "lang": "TOML",
+          "code": 8,
+          "comments": 0,
+          "blanks": 1,
+          "lines": 9,
+          "bytes": 165,
+          "tokens": 41,
+          "doc_pct": 0.0,
+          "bytes_per_line": 18.3333,
+          "depth": 1
+        },
+        {
+          "path": "mixed.md",
+          "module": "(root)",
+          "lang": "Markdown",
+          "code": 4,
+          "comments": 5,
+          "blanks": 2,
+          "lines": 11,
+          "bytes": 118,
+          "tokens": 29,
+          "doc_pct": 0.5556,
+          "bytes_per_line": 10.7273,
+          "depth": 1
+        },
+        {
+          "path": "src/main.rs",
+          "module": "src",
+          "lang": "Rust",
+          "code": 3,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 3,
+          "bytes": 45,
+          "tokens": 11,
+          "doc_pct": 0.0,
+          "bytes_per_line": 15.0,
+          "depth": 2
+        },
+        {
+          "path": "README.md",
+          "module": "(root)",
+          "lang": "Markdown",
+          "code": 0,
+          "comments": 1,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 30,
+          "tokens": 7,
+          "doc_pct": 1.0,
+          "bytes_per_line": 30.0,
+          "depth": 1
+        },
+        {
+          "path": "script.js",
+          "module": "(root)",
+          "lang": "JavaScript",
+          "code": 1,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 30,
+          "tokens": 7,
+          "doc_pct": 0.0,
+          "bytes_per_line": 30.0,
+          "depth": 1
+        },
+        {
+          "path": "space file.rs",
+          "module": "(root)",
+          "lang": "Rust",
+          "code": 1,
+          "comments": 0,
+          "blanks": 0,
+          "lines": 1,
+          "bytes": 13,
+          "tokens": 3,
+          "doc_pct": 0.0,
+          "bytes_per_line": 13.0,
+          "depth": 1
+        }
+      ],
+      "least_documented": [],
+      "most_dense": [
+        {
+          "path": "large.rs",
+          "module": "(root)",
+          "lang": "Rust",
+          "code": 9,
+          "comments": 2,
+          "blanks": 0,
+          "lines": 11,
+          "bytes": 182,
+          "tokens": 45,
+          "doc_pct": 0.1818,
+          "bytes_per_line": 16.5455,
+          "depth": 1
+        },
+        {
+          "path": "mixed.md",
+          "module": "(root)",
+          "lang": "Markdown",
+          "code": 4,
+          "comments": 5,
+          "blanks": 2,
+          "lines": 11,
+          "bytes": 118,
+          "tokens": 29,
+          "doc_pct": 0.5556,
+          "bytes_per_line": 10.7273,
+          "depth": 1
+        }
+      ]
+    },
+    "tree": null,
+    "reading_time": {
+      "minutes": 1.3,
+      "lines_per_minute": 20,
+      "basis_lines": 26
+    },
+    "context_window": null,
+    "cocomo": {
+      "mode": "organic",
+      "kloc": 0.026,
+      "effort_pm": 0.05,
+      "duration_months": 0.81,
+      "staff": 0.06,
+      "a": 2.4,
+      "b": 1.05,
+      "c": 2.5,
+      "d": 0.38
+    },
+    "todo": null,
+    "integrity": {
+      "algo": "blake3",
+      "hash":"<INTEGRITY_HASH>",
+      "entries": 7
+    }
+  },
+  "assets": null,
+  "deps": null,
+  "git": null,
+  "imports": null,
+  "dup": {
+    "groups": [],
+    "wasted_bytes": 0,
+    "strategy": "exact-blake3",
+    "density": {
+      "duplicate_groups": 0,
+      "duplicate_files": 0,
+      "duplicated_bytes": 0,
+      "wasted_bytes": 0,
+      "wasted_pct_of_codebase": 0.0,
+      "by_module": []
+    }
+  },
+  "complexity": {
+    "total_functions": 3,
+    "avg_function_length": 3.75,
+    "max_function_length": 11,
+    "avg_cyclomatic": 1.0,
+    "max_cyclomatic": 1,
+    "avg_cognitive": 0.0,
+    "max_cognitive": 0,
+    "avg_nesting_depth": 1.33,
+    "max_nesting_depth": 2,
+    "high_risk_files": 0,
+    "histogram": {
+      "buckets": [
+        0,
+        5,
+        10,
+        15,
+        20,
+        25,
+        30
+      ],
+      "counts": [
+        4,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "total": 4
+    },
+    "maintainability_index": {
+      "score": 149.53,
+      "avg_cyclomatic": 1.0,
+      "avg_loc": 3.71,
+      "grade": "A"
+    },
+    "technical_debt": {
+      "ratio": 153.85,
+      "complexity_points": 4,
+      "code_kloc": 0.026,
+      "level": "critical"
+    },
+    "files": [
+      {
+        "path": "large.rs",
+        "module": "(root)",
+        "function_count": 1,
+        "max_function_length": 11,
+        "cyclomatic_complexity": 1,
+        "cognitive_complexity": 0,
+        "max_nesting": 2,
+        "risk_level": "low"
+      },
+      {
+        "path": "script.js",
+        "module": "(root)",
+        "function_count": 0,
+        "max_function_length": 0,
+        "cyclomatic_complexity": 1,
+        "risk_level": "low"
+      },
+      {
+        "path": "space file.rs",
+        "module": "(root)",
+        "function_count": 1,
+        "max_function_length": 1,
+        "cyclomatic_complexity": 1,
+        "cognitive_complexity": 0,
+        "max_nesting": 1,
+        "risk_level": "low"
+      },
+      {
+        "path": "src/main.rs",
+        "module": "src",
+        "function_count": 1,
+        "max_function_length": 3,
+        "cyclomatic_complexity": 1,
+        "cognitive_complexity": 0,
+        "max_nesting": 1,
+        "risk_level": "low"
+      }
+    ]
+  },
+  "api_surface": {
+    "total_items": 3,
+    "public_items": 0,
+    "internal_items": 3,
+    "public_ratio": 0.0,
+    "documented_ratio": 0.0,
+    "by_language": {
+      "Rust": {
+        "total_items": 3,
+        "public_items": 0,
+        "internal_items": 3,
+        "public_ratio": 0.0
+      }
+    },
+    "by_module": [
+      {
+        "module": "(root)",
+        "total_items": 2,
+        "public_items": 0,
+        "public_ratio": 0.0
+      },
+      {
+        "module": "src",
+        "total_items": 1,
+        "public_items": 0,
+        "public_ratio": 0.0
+      }
+    ],
+    "top_exporters": []
+  },
+  "effort": null,
+  "fun": null
+}

--- a/crates/tokmd/tests/snapshots/cli_snapshot_golden__analyze_markdown.snap
+++ b/crates/tokmd/tests/snapshots/cli_snapshot_golden__analyze_markdown.snap
@@ -1,0 +1,233 @@
+---
+source: crates/tokmd/tests/cli_snapshot_golden.rs
+expression: normalize(&stdout)
+---
+# tokmd analysis
+
+Preset: `receipt`
+
+## Inputs
+
+- `.`
+
+## Totals
+
+|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|
+|---:|---:|---:|---:|---:|---:|---:|
+|7|26|8|3|37|583|143|
+
+## Ratios
+
+|Metric|Value|
+|---|---:|
+|Doc density|23.5%|
+|Whitespace ratio|8.8%|
+|Bytes per line|15.76|
+
+### Doc density by language
+
+|Lang|Doc%|Comments|Code|
+|---|---:|---:|---:|
+|Markdown|150.0%|6|0|
+|Rust|15.4%|2|11|
+|JavaScript|0.0%|0|1|
+|TOML|0.0%|0|8|
+
+### Whitespace ratio by language
+
+|Lang|Blank%|Blanks|Code+Comments|
+|---|---:|---:|---:|
+|Markdown|20.0%|2|10|
+|TOML|12.5%|1|8|
+|JavaScript|0.0%|0|1|
+|Rust|0.0%|0|15|
+
+### Verbosity by language
+
+|Lang|Bytes/Line|Bytes|Lines|
+|---|---:|---:|---:|
+|JavaScript|30.00|30|1|
+|TOML|18.33|165|9|
+|Rust|16.00|240|15|
+|Markdown|12.33|148|12|
+
+## Distribution
+
+|Count|Min|Max|Mean|Median|P90|P99|Gini|
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|7|1|11|5.29|3.00|11.00|11.00|0.4479|
+
+## File size histogram
+
+|Bucket|Min|Max|Files|Pct|
+|---|---:|---:|---:|---:|
+|Tiny|0|50|7|100.0%|
+|Small|51|200|0|0.0%|
+|Medium|201|500|0|0.0%|
+|Large|501|1000|0|0.0%|
+|Huge|1001|∞|0|0.0%|
+
+## Top offenders
+
+### Largest files by lines
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|large.rs|Rust|11|9|182|45|18.2%|16.55|
+|mixed.md|Markdown|11|4|118|29|55.6%|10.73|
+|Cargo.toml|TOML|9|8|165|41|0.0%|18.33|
+|src/main.rs|Rust|3|3|45|11|0.0%|15.00|
+|README.md|Markdown|1|0|30|7|100.0%|30.00|
+|script.js|JavaScript|1|1|30|7|0.0%|30.00|
+|space file.rs|Rust|1|1|13|3|0.0%|13.00|
+
+### Largest files by tokens
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|large.rs|Rust|11|9|182|45|18.2%|16.55|
+|Cargo.toml|TOML|9|8|165|41|0.0%|18.33|
+|mixed.md|Markdown|11|4|118|29|55.6%|10.73|
+|src/main.rs|Rust|3|3|45|11|0.0%|15.00|
+|README.md|Markdown|1|0|30|7|100.0%|30.00|
+|script.js|JavaScript|1|1|30|7|0.0%|30.00|
+|space file.rs|Rust|1|1|13|3|0.0%|13.00|
+
+### Largest files by bytes
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|large.rs|Rust|11|9|182|45|18.2%|16.55|
+|Cargo.toml|TOML|9|8|165|41|0.0%|18.33|
+|mixed.md|Markdown|11|4|118|29|55.6%|10.73|
+|src/main.rs|Rust|3|3|45|11|0.0%|15.00|
+|README.md|Markdown|1|0|30|7|100.0%|30.00|
+|script.js|JavaScript|1|1|30|7|0.0%|30.00|
+|space file.rs|Rust|1|1|13|3|0.0%|13.00|
+
+### Least documented (min LOC)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+
+### Most dense (bytes/line)
+
+|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|
+|---|---|---:|---:|---:|---:|---:|---:|
+|large.rs|Rust|11|9|182|45|18.2%|16.55|
+|mixed.md|Markdown|11|4|118|29|55.6%|10.73|
+
+## Structure
+
+- Max depth: `2`
+- Avg depth: `1.14`
+
+## Test density
+
+- Test lines: `0`
+- Prod lines: `26`
+- Test ratio: `0.0%`
+
+## Boilerplate ratio
+
+- Infra lines: `21`
+- Logic lines: `16`
+- Infra ratio: `56.8%`
+
+## Polyglot
+
+- Languages: `4`
+- Dominant: `Rust` (50.0%)
+- Entropy: `1.6195`
+
+## Reading time
+
+- Minutes: `1.30` (20 lines/min)
+
+## Effort estimate
+
+### Size basis
+
+- Source lines: `26`
+- Total lines: `37`
+- KLOC: `0.0260`
+
+### Headline
+
+- Effort: `0.05` person-months
+- Duration: `0.81` months
+- Staff: `0.06`
+
+### Why
+
+- Model: `COCOMO` (`organic` mode)
+- Formula: `E = a * KLOC^b`
+- Coefficients: `a=2.40`, `b=1.05`, `c=2.50`, `d=0.38`
+
+### Delta
+
+- Baseline comparison is not available for this receipt.
+
+## Integrity
+
+- Hash: `<INTEGRITY_HASH>` (`blake3`)
+- Entries: `7`
+
+## Duplicates
+
+- Wasted bytes: `0`
+- Strategy: `exact-blake3`
+
+### Duplication density
+
+- Duplicate groups: `0`
+- Duplicate files: `0`
+- Duplicated bytes: `0`
+- Waste vs codebase: `0.0%`
+
+## Complexity
+
+|Metric|Value|
+|---|---:|
+|Total functions|3|
+|Avg function length|3.8|
+|Max function length|11|
+|Avg cyclomatic|1.00|
+|Max cyclomatic|1|
+|Avg cognitive|0.00|
+|Max cognitive|0|
+|Avg nesting depth|1.33|
+|Max nesting depth|2|
+|High risk files|0|
+
+### Top complex files
+
+|Path|CC|Functions|Max fn length|
+|---|---:|---:|---:|
+|large.rs|1|1|11|
+|script.js|1|0|0|
+|space file.rs|1|1|1|
+|src/main.rs|1|1|3|
+
+## API surface
+
+|Metric|Value|
+|---|---:|
+|Total items|3|
+|Public items|0|
+|Internal items|3|
+|Public ratio|0.0%|
+|Documented ratio|0.0%|
+
+### By language
+
+|Language|Total|Public|Internal|Public%|
+|---|---:|---:|---:|---:|
+|Rust|3|0|3|0.0%|
+
+### By module
+
+|Module|Total|Public|Public%|
+|---|---:|---:|---:|
+|(root)|2|0|0.0%|
+|src|1|0|0.0%|


### PR DESCRIPTION
## 💡 Summary 
Added golden snapshot tests for the `analyze` subcommand to ensure its output (both JSON and Markdown) remains deterministic and contract-compliant.

## 🎯 Why 
The `cli_snapshot_golden.rs` test suite was missing coverage for the `analyze` subcommand, leaving a gap in our snapshot testing for this important contract surface. Adding these tests helps prevent accidental regressions or drift in the `analyze` output formatting.

## 🔎 Evidence 
- `crates/tokmd/tests/cli_snapshot_golden.rs` was missing `snapshot_analyze_json` and `snapshot_analyze_markdown`.
- Running `cargo test -p tokmd --test cli_snapshot_golden` now passes with the new snapshots.

## 🧭 Options considered 
### Option A (recommended) 
- Add snapshot tests for `analyze` in `cli_snapshot_golden.rs` and properly normalize dynamic fields like `target_path` and `generated_at_ms`.
- Why it fits: Follows the existing golden snapshot testing pattern perfectly and closes a direct coverage gap.
- Trade-offs: Structure is highly aligned; Velocity is fast; Governance is improved by locking in the format contract.

### Option B 
- Introduce property-based tests for output determinism using `proptest`.
- When to choose it instead: If we needed to test determinism across highly varied, randomly generated directory structures rather than fixed fixtures.
- Trade-offs: Slower to implement, higher maintenance cost, and less direct for verifying output format shapes.

## ✅ Decision 
Chose Option A to quickly and directly lock down the `analyze` output format using our existing, proven snapshot testing infrastructure.

## 🧱 Changes made (SRP) 
- `crates/tokmd/tests/cli_snapshot_golden.rs`: Added `snapshot_analyze_json` and `snapshot_analyze_markdown` tests. Updated `normalize` function to handle `target_path` and strict `generated_at_ms` matching.
- `crates/tokmd/tests/snapshots/cli_snapshot_golden__analyze_json.snap`: New snapshot.
- `crates/tokmd/tests/snapshots/cli_snapshot_golden__analyze_markdown.snap`: New snapshot.

## 🧪 Verification receipts 
```text
cargo test -p tokmd --test cli_snapshot_golden
```

## 🧭 Telemetry 
- Change shape: Test addition (proof improvement).
- Blast radius: None (tests only).
- Risk class: Low (no production code changed).
- Rollback: Revert the test additions.
- Gates run: `cargo test -p tokmd --test cli_snapshot_golden`, `cargo fmt -- --check`.

## 🗂️ .jules artifacts 
- `.jules/runs/run-gatekeeper-determinism/envelope.json`
- `.jules/runs/run-gatekeeper-determinism/decision.md`
- `.jules/runs/run-gatekeeper-determinism/receipts.jsonl`
- `.jules/runs/run-gatekeeper-determinism/result.json`
- `.jules/runs/run-gatekeeper-determinism/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [15438020882713736402](https://jules.google.com/task/15438020882713736402) started by @EffortlessSteven*