### PR TITLE
specsmith: add estimate preset scenario tests 🧪

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,6 +2849,7 @@ dependencies = [
 name = "tokmd-analysis-types"
 version = "1.9.0"
 dependencies = [
+ "chrono",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/tokmd/tests/analyze_integration.rs
+++ b/crates/tokmd/tests/analyze_integration.rs
@@ -155,6 +155,39 @@ fn analyze_fun_preset_returns_eco_label() {
 }
 
 #[test]
+fn analyze_estimate_preset_returns_effort_model() {
+    // Given: the same fixture repository used by other analysis tests
+    // When: analyze is run with --preset estimate and json output
+    // Then: effort model and drivers are present in the output
+    let output = tokmd_cmd()
+        .arg("analyze")
+        .arg(".")
+        .arg("--preset")
+        .arg("estimate")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("failed to execute tokmd analyze");
+
+    assert!(
+        output.status.success(),
+        "tokmd analyze failed: {:?}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let json: Value = serde_json::from_str(&stdout).expect("analysis JSON output is invalid");
+
+    let effort = json["effort"].as_object().expect("effort should be object");
+    assert!(effort.get("model").is_some(), "model missing");
+    let drivers = effort
+        .get("drivers")
+        .and_then(Value::as_array)
+        .expect("drivers should be array");
+    assert!(!drivers.is_empty(), "drivers array empty");
+}
+
+#[test]
 fn analyze_topics_preset_returns_topic_cloud() {
     // Given: the same fixture repository used by other analysis tests
     // When: analyze is run with --preset topics and json output

--- a/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
@@ -174,7 +174,37 @@ fn given_project_when_analyze_md_then_markdown_table() {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 7: Fun preset returns eco-label
+// Scenario 7: Estimate preset includes effort model
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_analyze_estimate_then_effort_model_present() {
+    // Given: a project with source files
+    // When: I analyze with `estimate` preset and JSON format
+    let output = tokmd_cmd()
+        .args(["analyze", ".", "--preset", "estimate", "--format", "json"])
+        .output()
+        .expect("failed to execute tokmd analyze --preset estimate");
+
+    // Then: estimate metadata is present
+    assert!(
+        output.status.success(),
+        "analyze should succeed: {:?}",
+        output.status
+    );
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let json: Value = serde_json::from_str(&stdout).expect("output should be valid JSON");
+
+    let effort = json["effort"].as_object().expect("effort should be object");
+    assert!(effort.get("model").is_some(), "effort should have model");
+    assert!(
+        effort.get("drivers").is_some(),
+        "effort should have drivers"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 8: Fun preset returns eco-label
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/crates/tokmd/tests/bdd_scenarios_w71.rs
+++ b/crates/tokmd/tests/bdd_scenarios_w71.rs
@@ -717,6 +717,23 @@ fn given_project_when_analyze_receipt_then_has_derived_metrics() {
     assert!(json["derived"].is_object(), "should have derived metrics");
 }
 
+#[test]
+fn given_project_when_analyze_estimate_then_has_effort_metrics() {
+    let output = tokmd_fixture()
+        .args(["analyze", "--preset", "estimate", "--format", "json"])
+        .output()
+        .expect("run");
+
+    assert!(output.status.success());
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("failed to parse JSON from stdout");
+    assert!(json["effort"].is_object(), "should have effort metrics");
+    assert!(
+        json["effort"]["drivers"].is_array(),
+        "should have effort drivers"
+    );
+}
+
 // ===========================================================================
 // 25. Exclude with wildcard removes all matching files
 // ===========================================================================


### PR DESCRIPTION
This patch adds missing integration and BDD scenario tests for the `estimate` analysis preset, securing the `effort.model` and `effort.drivers` output contract.

## 💡 Summary
Added explicit integration scenario tests for the `estimate` analysis preset. This ensures the output shape (including `effort.model` and `effort.drivers`) is firmly locked in the CLI behavior contract.

## 🎯 Why
The `estimate` analysis preset drives complex effort scoring (via `tokmd-analysis-effort` models like COCOMO) based on gathered context properties. While the models had internal unit tests, the CLI contract mapping (e.g. `tokmd analyze --preset estimate --format json`) lacked high-level BDD coverage. Adding these scenarios guards against accidental regressions in how derived effort metrics are exposed.

## 🔎 Evidence
- **File paths**: `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`, `crates/tokmd/tests/bdd_scenarios_w71.rs`, `crates/tokmd/tests/analyze_integration.rs`
- **Observed behavior**: Tests for `receipt` and `fun` presets existed, but `estimate` was not locked in.
- **Verification**: Running `cargo run --bin tokmd -- analyze --preset estimate --format json | jq '.effort.drivers'` yields a valid array, confirming the behavior is testable and robust.

## 🧭 Options considered
### Option A (recommended)
- **What it is**: Implement BDD tests across the three main analyze integration suites explicitly asserting that `effort.model` and `effort.drivers` exist when using `--preset estimate`.
- **Why it fits this repo and shard**: Specsmith's role is to ensure regression coverage and edge-case polish within the `analysis-stack` shard. Securing output assumptions for complex derivations like `estimate` is a direct alignment.
- **Trade-offs**: Low risk, improves coverage without changing application logic.

### Option B
- **What it is**: Do a generic assertion cleanup without mapping it to the specific BDD `Given/When/Then` paradigm for effort drivers.
- **Why it was rejected**: Violates the anti-drift rules to avoid generic cleanup lanes that aren't tied directly to scenarios.

## ✅ Decision
Chose Option A to lock in behavior using existing `tokmd_fixture` and `tokmd_cmd` helpers to test the CLI output natively.

## 🧱 Changes made (SRP)
- Added `given_project_when_analyze_estimate_then_effort_model_present` to `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`
- Added `given_project_when_analyze_estimate_then_has_effort_metrics` to `crates/tokmd/tests/bdd_scenarios_w71.rs`
- Added `analyze_estimate_preset_returns_effort_model` to `crates/tokmd/tests/analyze_integration.rs`

## 🧪 Verification receipts
```text
cargo test -p tokmd --test bdd_analyze_scenarios_w50
cargo test -p tokmd --test bdd_scenarios_w71
cargo test -p tokmd --test analyze_integration
```

## 🧭 Telemetry
- Change shape: Test additions
- Blast radius: Tests only
- Risk class: Low - no functional code changed, purely tests
- Rollback: Revert the test additions
- Gates run: `cargo test -p tokmd --test bdd_analyze_scenarios_w50`, `cargo test -p tokmd --test bdd_scenarios_w71`, `cargo test -p tokmd --test analyze_integration`

## 🗂️ .jules artifacts
- `.jules/runs/specsmith_analysis_stack/envelope.json`
- `.jules/runs/specsmith_analysis_stack/decision.md`
- `.jules/runs/specsmith_analysis_stack/receipts.jsonl`
- `.jules/runs/specsmith_analysis_stack/result.json`
- `.jules/runs/specsmith_analysis_stack/pr_body.md`

## 🔜 Follow-ups
None

---
*PR created automatically by Jules for task [11049658083020592928](https://jules.google.com/task/11049658083020592928) started by @EffortlessSteven*