### PR TITLE
specsmith: add bdd test for analyze --preset estimate 🧪

### DIFF
--- a/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
@@ -206,3 +206,36 @@ fn given_project_when_analyze_fun_then_eco_label_present() {
         "eco_label should have score"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 8: Estimate preset returns effort model
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_analyze_estimate_then_effort_model_present() {
+    // Given: a project with source files
+    // When: I analyze with `estimate` preset and JSON format
+    let output = tokmd_cmd()
+        .args([
+            "analyze", ".", "--preset", "estimate", "--format", "json", "--no-git",
+        ])
+        .output()
+        .expect("failed to execute tokmd analyze --preset estimate");
+
+    // Then: effort model and drivers are present
+    assert!(
+        output.status.success(),
+        "analyze should succeed: {:?}",
+        output.status
+    );
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let json: Value = serde_json::from_str(&stdout).expect("output should be valid JSON");
+
+    let effort = json["effort"].as_object().expect("effort should be object");
+    assert!(effort.get("model").is_some(), "effort should have model");
+    let drivers = effort
+        .get("drivers")
+        .and_then(Value::as_array)
+        .expect("effort drivers should be an array");
+    assert!(!drivers.is_empty(), "effort should have drivers");
+}


### PR DESCRIPTION
Added integration test coverage for the `estimate` analysis preset to lock in its output behavior.

## 🎯 Why 
The `estimate` analysis preset produces an `effort` JSON payload (containing `model` and `drivers`). This is an important user-facing structure generated by `tokmd-analysis-effort`. Adding a behavior-driven scenario test ensures that regressions breaking this structure will be caught immediately.

## 🔎 Evidence 
- `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`
- Ran tests with the `--features=analysis` gate correctly and the new `given_project_when_analyze_estimate_then_effort_model_present` test passes, proving the JSON structure is emitted as expected.

## 🧭 Options considered 
### Option A (recommended) 
- Add a new integration test for `--preset estimate` in `bdd_analyze_scenarios_w50.rs`.
- Validates the surface JSON structure directly.
- Trade-offs: Structure is strong, governance locks in output format.

### Option B 
- Add a unit test directly in `tokmd-analysis-effort`.
- Tests the model struct internal but not the CLI integration.
- Trade-offs: Lower value compared to testing the user-facing CLI behavior.

## ✅ Decision 
Chose Option A to align with the prompt's instruction to improve scenario coverage around analysis behavior.

## 🧱 Changes made (SRP) 
- `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`
  - Added `given_project_when_analyze_estimate_then_effort_model_present` scenario to verify `effort.model` and `effort.drivers`.

## 🧪 Verification receipts 
```text
cargo test -p tokmd --test bdd_analyze_scenarios_w50 --features=analysis
running 8 tests
...
test given_project_when_analyze_estimate_then_effort_model_present ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
```

## 🧭 Telemetry 
- Change shape: Test Addition
- Blast radius: `crates/tokmd/tests`
- Risk class: Low - strictly test additions.
- Rollback: Revert the test commit.
- Gates run: `cargo test`, `cargo fmt`, `cargo clippy`

## 🗂️ .jules artifacts 
- `.jules/runs/specsmith_analysis_stack/envelope.json`
- `.jules/runs/specsmith_analysis_stack/decision.md`
- `.jules/runs/specsmith_analysis_stack/receipts.jsonl`
- `.jules/runs/specsmith_analysis_stack/result.json`
- `.jules/runs/specsmith_analysis_stack/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [15468939697077075803](https://jules.google.com/task/15468939697077075803) started by @EffortlessSteven*