### PR TITLE
auditor: remove redundant tokmd-analysis-types dep from tokmd-wasm 🧾

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,6 @@ version = "1.9.0"
 dependencies = [
  "js-sys",
  "serde_json",
- "tokmd-analysis-types",
  "tokmd-core",
  "tokmd-envelope",
  "tokmd-types",

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -1071,6 +1071,10 @@ fn redact_export_data(data: ExportData, mode: RedactMode) -> ExportData {
 /// Re-export schema version for bindings.
 pub const CORE_SCHEMA_VERSION: u32 = SCHEMA_VERSION;
 
+/// Re-export analysis schema version for bindings.
+#[cfg(feature = "analysis")]
+pub const CORE_ANALYSIS_SCHEMA_VERSION: u32 = tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION;
+
 /// Get the current tokmd version.
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")

--- a/crates/tokmd-wasm/Cargo.toml
+++ b/crates/tokmd-wasm/Cargo.toml
@@ -16,12 +16,11 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["analysis"]
-analysis = ["dep:tokmd-analysis-types", "tokmd-core/analysis"]
+analysis = ["tokmd-core/analysis"]
 
 [dependencies]
 js-sys = "0.3.91"
 serde_json.workspace = true
-tokmd-analysis-types = { workspace = true, optional = true }
 tokmd-core.workspace = true
 tokmd-envelope.workspace = true
 wasm-bindgen = "0.2.114"

--- a/crates/tokmd-wasm/src/lib.rs
+++ b/crates/tokmd-wasm/src/lib.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(test)]
 use serde_json::Value;
 #[cfg(feature = "analysis")]
-use tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION;
+use tokmd_core::CORE_ANALYSIS_SCHEMA_VERSION;
 use tokmd_core::error::{ResponseEnvelope, TokmdError};
 
 fn to_js_error(message: impl Into<String>) -> JsValue {
@@ -103,7 +103,7 @@ pub fn schema_version() -> u32 {
 #[cfg(feature = "analysis")]
 #[wasm_bindgen(js_name = analysisSchemaVersion)]
 pub fn analysis_schema_version() -> u32 {
-    ANALYSIS_SCHEMA_VERSION
+    CORE_ANALYSIS_SCHEMA_VERSION
 }
 
 /// Run a tokmd mode and return the raw JSON response envelope.
@@ -409,7 +409,7 @@ mod tests {
     #[cfg(feature = "analysis")]
     #[test]
     fn analysis_schema_version_matches_analysis_receipts() {
-        assert_eq!(analysis_schema_version(), ANALYSIS_SCHEMA_VERSION);
+        assert_eq!(analysis_schema_version(), CORE_ANALYSIS_SCHEMA_VERSION);
     }
 }
 
@@ -639,7 +639,7 @@ mod wasm_tests {
         let mut parsed = js_value_to_json(&data);
         let mut expected = core_mode_value("analyze", args_json);
 
-        assert_eq!(analysis_schema_version(), ANALYSIS_SCHEMA_VERSION);
+        assert_eq!(analysis_schema_version(), CORE_ANALYSIS_SCHEMA_VERSION);
         assert_eq!(parsed["mode"], "analysis");
         assert_eq!(parsed["source"]["inputs"][0], "crates/app/src/lib.rs");
         assert_eq!(parsed["effort"]["model"], "cocomo81-basic");


### PR DESCRIPTION
Removed the unused direct dependency on `tokmd-analysis-types` from `tokmd-wasm` by re-exporting `ANALYSIS_SCHEMA_VERSION` in `tokmd-core`. This tightens the dependency graph in the wasm surface.

---
*PR created automatically by Jules for task [16491942329137396819](https://jules.google.com/task/16491942329137396819) started by @EffortlessSteven*