### PR TITLE
chore: forbid unsafe code at primary interfaces

### DIFF
--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -47,6 +47,8 @@
 //! assert_eq!(parsed["ok"], true);
 //! ```
 
+#![forbid(unsafe_code)]
+
 use std::path::{Path, PathBuf};
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/tokmd/src/bin/tok.rs
+++ b/crates/tokmd/src/bin/tok.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 fn main() {
     if let Err(err) = tokmd::run() {
         eprintln!("{}", tokmd::format_error(&err));

--- a/crates/tokmd/src/bin/tokmd.rs
+++ b/crates/tokmd/src/bin/tokmd.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 fn main() {
     if let Err(err) = tokmd::run() {
         eprintln!("{}", tokmd::format_error(&err));

--- a/crates/tokmd/src/lib.rs
+++ b/crates/tokmd/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 //! This crate should contain minimal business logic.
 
+#![forbid(unsafe_code)]
+
 #[cfg(feature = "analysis")]
 mod analysis_explain;
 #[cfg(feature = "analysis")]


### PR DESCRIPTION
## Summary

Restacks the unsafe-boundary policy on current main with a narrow active-interface diff.

- adds #![forbid(unsafe_code)] to tokmd and tokmd-core
- applies the same boundary to the two tokmd binaries
- drops stale Cargo.lock/gate.log noise and the out-of-workspace tokmd-config hunk from the old draft

## Validation

- cargo fmt-check
- cargo check -p tokmd -p tokmd-core
- cargo xtask publish-surface --json
- git diff --check