### PR TITLE
docs: fix sensor integration test reference

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,7 +79,7 @@ The cockpit command's evidence gates are tested in `crates/tokmd/tests/cockpit_i
 Envelope format is validated through:
 
 - Property tests for serialization roundtrips
-- Integration tests for `tokmd sensor cockpit` command
+- Integration tests for `tokmd sensor` command
 
 ### Baseline System Testing
 


### PR DESCRIPTION
## Summary

Restacks the docs typo fix onto current main and keeps the PR docs-only.

- updates the testing guide to reference the current tokmd sensor command
- drops stale tokmd-python changes from the old branch

## Validation

- cargo xtask docs --check
- git diff --check