### PR TITLE
test: tolerate whitespace in receipt normalizers

### DIFF
--- a/crates/tokmd/tests/cli_snapshot_golden.rs
+++ b/crates/tokmd/tests/cli_snapshot_golden.rs
@@ -17,12 +17,13 @@ fn tokmd_cmd() -> Command {
 /// Replace dynamic values (timestamps, versions, absolute paths) with stable
 /// placeholders so snapshots are deterministic across machines and runs.
 fn normalize(output: &str) -> String {
-    let re_ts = regex::Regex::new(r#""generated_at_ms":\d+"#).unwrap();
+    let re_ts = regex::Regex::new(r#""generated_at_ms":\s*\d+"#).unwrap();
     let s = re_ts
         .replace_all(output, r#""generated_at_ms":0"#)
         .to_string();
 
-    let re_ver = regex::Regex::new(r#"("tool":\{"name":"tokmd","version":")[^"]+"#).unwrap();
+    let re_ver =
+        regex::Regex::new(r#"("tool":\s*\{\s*"name":\s*"tokmd",\s*"version":\s*")[^"]+"#).unwrap();
     let s = re_ver.replace_all(&s, r#"${1}0.0.0"#).to_string();
 
     // Normalize --version output line (e.g. "tokmd 0.42.1" -> "tokmd <VERSION>")

--- a/crates/tokmd/tests/determinism.rs
+++ b/crates/tokmd/tests/determinism.rs
@@ -16,12 +16,12 @@ fn tokmd_cmd() -> Command {
 /// Normalize non-deterministic fields (timestamps, tool version) so we can
 /// compare outputs byte-for-byte.
 fn normalize_envelope(output: &str) -> String {
-    let re_ts = regex::Regex::new(r#""generated_at_ms":\d+"#).expect("valid regex");
+    let re_ts = regex::Regex::new(r#""generated_at_ms":\s*\d+"#).expect("valid regex");
     let s = re_ts
         .replace_all(output, r#""generated_at_ms":0"#)
         .to_string();
-    let re_ver =
-        regex::Regex::new(r#"("tool":\{"name":"tokmd","version":")[^"]+"#).expect("valid regex");
+    let re_ver = regex::Regex::new(r#"("tool":\s*\{\s*"name":\s*"tokmd",\s*"version":\s*")[^"]+"#)
+        .expect("valid regex");
     re_ver.replace_all(&s, r#"${1}0.0.0"#).to_string()
 }
 

--- a/crates/tokmd/tests/integration_w70.rs
+++ b/crates/tokmd/tests/integration_w70.rs
@@ -90,11 +90,12 @@ fn tokmd_at(dir: &std::path::Path) -> Command {
 }
 
 fn normalize_envelope(output: &str) -> String {
-    let re_ts = regex::Regex::new(r#""generated_at_ms":\d+"#).unwrap();
+    let re_ts = regex::Regex::new(r#""generated_at_ms":\s*\d+"#).unwrap();
     let s = re_ts
         .replace_all(output, r#""generated_at_ms":0"#)
         .to_string();
-    let re_ver = regex::Regex::new(r#"("tool":\{"name":"tokmd","version":")[^"]+"#).unwrap();
+    let re_ver =
+        regex::Regex::new(r#"("tool":\s*\{\s*"name":\s*"tokmd",\s*"version":\s*")[^"]+"#).unwrap();
     re_ver.replace_all(&s, r#"${1}0.0.0"#).to_string()
 }
 


### PR DESCRIPTION
## Summary

Restacks the determinism normalizer hardening on current main with only the test-infra regex changes.

- normalizes generated_at_ms with optional whitespace after the colon
- normalizes tool.version when pretty JSON includes whitespace around the tool object fields
- drops run packet files from the stale draft because this is now a normal test hardening patch

## Validation

- cargo test -p tokmd --test determinism
- cargo test -p tokmd --test cli_snapshot_golden
- cargo test -p tokmd --test integration_w70
- cargo fmt-check
- cargo xtask publish-surface --json
- git diff --check