### PR TITLE
specsmith: fix is_test_path to detect standalone test files 🧪

### DIFF
--- a/.jules/runs/specsmith-analysis-1/decision.md
+++ b/.jules/runs/specsmith-analysis-1/decision.md
@@ -1,0 +1,12 @@
+# Decision
+
+## Option A (recommended)
+Update `is_test_path` in `tokmd-analysis-util/src/lib.rs` to detect standard standalone test files such as `test.*`, `tests.*`, `spec.*`, and `specs.*` (e.g., `test.rs`, `tests.py`). Currently, these standalone files are completely missed by the heuristic which only handles test directory components and prefix/suffix underscores.
+
+We will add these cases to `is_test_path` and update BDD tests and properties to verify these scenarios, increasing test coverage.
+
+## Option B
+Leave the logic as is and rely on users to name their standalone test files `test_foo.rs` or put them in `tests/` directories. This is less ideal as many ecosystems use `test.js` or `tests.py` directly.
+
+## Decision
+Option A. It's an important edge-case regression/gap not locked in by tests, perfectly aligning with Specsmith's mission to improve scenario coverage and regression coverage.

--- a/.jules/runs/specsmith-analysis-1/envelope.json
+++ b/.jules/runs/specsmith-analysis-1/envelope.json
@@ -1,0 +1,22 @@
+{
+  "prompt_id": "specsmith_analysis_stack",
+  "persona": "specsmith",
+  "style": "builder",
+  "primary_shard": "analysis-stack",
+  "allowed_paths": [
+    "crates/tokmd-analysis*/**",
+    "crates/tokmd-fun/**",
+    "crates/tokmd-gate/**"
+  ],
+  "adjacent_paths": [
+    "crates/tokmd-core/**",
+    "crates/tokmd/tests/**",
+    "docs/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": [
+    "pr_ready_patch",
+    "proof_improvement_patch",
+    "learning_pr"
+  ]
+}

--- a/.jules/runs/specsmith-analysis-1/pr_body.md
+++ b/.jules/runs/specsmith-analysis-1/pr_body.md
@@ -1,0 +1,53 @@
+## 💡 Summary
+Updated the `is_test_path` heuristic in `tokmd-analysis-util` to correctly identify standalone test files (e.g., `test.rs`, `spec.js`, `tests.py`).
+
+## 🎯 Why
+Previously, the heuristic primarily relied on directory names (`/test/`, `/tests/`, `/spec/`, etc.) or specific prefixes/suffixes (`test_*.rs`, `*_test.rs`, `*.test.js`). It completely missed standalone files at the root or within standard directories that were simply named `test.rs` or `spec.js`. This resulted in inaccurate test density analysis, an important edge-case regression gap.
+
+## 🔎 Evidence
+- **File:** `crates/tokmd-analysis-util/src/lib.rs`
+- **Observed Behavior:** Calling `is_test_path("test.rs")` returned `false`.
+- **Receipt:** Before changes, `is_test_path_edge_cases::given_file_named_test_without_underscore_then_not_detected_as_file_pattern` was passing by asserting `!result`. Now, testing files properly correctly returns `true`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- **What it is:** Update `is_test_path` logic to accept files starting with `test.`, `tests.`, `spec.`, and `specs.`.
+- **Why it fits:** It directly addresses the coverage gap while maintaining deterministic heuristic matching.
+- **Trade-offs:** Structure is clean, slightly higher logic but minimal performance impact.
+
+### Option B
+- **What it is:** Leave the logic as is and require users to put test files in specific directories or rename them.
+- **When to choose it:** If we want strict control over test file naming conventions.
+- **Trade-offs:** Causes confusion for users with standard test file names in ecosystems like Python (`tests.py`) and JS (`spec.js`).
+
+## ✅ Decision
+Option A. It's an important edge-case regression/gap not locked in by tests, perfectly aligning with Specsmith's mission to improve scenario coverage and regression coverage.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-analysis-util/src/lib.rs`: Updated `is_test_path` string matching.
+- `crates/tokmd-analysis-util/tests/bdd.rs`: Added BDD scenarios for standalone test files.
+- `crates/tokmd-analysis-util/tests/bdd_expansion.rs`: Adjusted previous expectation that `test.rs` wouldn't be matched.
+
+## 🧪 Verification receipts
+```text
+test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s (tokmd-analysis-util)
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s (tokmd-analysis-derived)
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s (tokmd-analysis)
+```
+
+## 🧭 Telemetry
+- Change shape: Logic extension
+- Blast radius: API schema unchanged. Heuristics for analysis will identify slightly more files as tests.
+- Risk class: Low risk. Fixes a clear false negative.
+- Rollback: Revert `lib.rs` string checks.
+- Gates run: `cargo test`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/specsmith-analysis-1/envelope.json`
+- `.jules/runs/specsmith-analysis-1/decision.md`
+- `.jules/runs/specsmith-analysis-1/receipts.jsonl`
+- `.jules/runs/specsmith-analysis-1/result.json`
+- `.jules/runs/specsmith-analysis-1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/specsmith-analysis-1/receipts.jsonl
+++ b/.jules/runs/specsmith-analysis-1/receipts.jsonl
@@ -1,0 +1,3 @@
+{"command": "cargo test -p tokmd-analysis-util", "exit_code": 0, "output": "test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s\n..."}
+{"command": "cargo test -p tokmd-analysis-derived", "exit_code": 0, "output": "test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s\n..."}
+{"command": "cargo test -p tokmd-analysis", "exit_code": 0, "output": "test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n..."}

--- a/.jules/runs/specsmith-analysis-1/result.json
+++ b/.jules/runs/specsmith-analysis-1/result.json
@@ -1,0 +1,10 @@
+{
+  "status": "success",
+  "summary": "Updated `is_test_path` heuristic to properly identify standalone test files like `test.rs` and `spec.js`",
+  "files_changed": [
+    "crates/tokmd-analysis-util/src/lib.rs",
+    "crates/tokmd-analysis-util/tests/bdd.rs",
+    "crates/tokmd-analysis-util/tests/bdd_expansion.rs"
+  ],
+  "learning_pr": false
+}

--- a/crates/tokmd-analysis-util/src/lib.rs
+++ b/crates/tokmd-analysis-util/src/lib.rs
@@ -59,6 +59,10 @@ pub fn is_test_path(path: &str) -> bool {
         || name.contains(".spec.")
         || name.starts_with("test_")
         || name.ends_with("_test.rs")
+        || name.starts_with("test.")
+        || name.starts_with("tests.")
+        || name.starts_with("spec.")
+        || name.starts_with("specs.")
 }
 
 pub fn is_infra_lang(lang: &str) -> bool {

--- a/crates/tokmd-analysis-util/tests/bdd.rs
+++ b/crates/tokmd-analysis-util/tests/bdd.rs
@@ -212,6 +212,14 @@ fn is_test_path_rejects_partial_match_in_filename() {
 }
 
 #[test]
+fn is_test_path_detects_standalone_test_files() {
+    assert!(is_test_path("src/test.rs"));
+    assert!(is_test_path("tests.py"));
+    assert!(is_test_path("app/spec.js"));
+    assert!(is_test_path("lib/specs.ts"));
+}
+
+#[test]
 fn is_test_path_empty_string() {
     assert!(!is_test_path(""));
 }

--- a/crates/tokmd-analysis-util/tests/bdd_expansion.rs
+++ b/crates/tokmd-analysis-util/tests/bdd_expansion.rs
@@ -114,14 +114,10 @@ mod is_test_path_edge_cases {
     }
 
     #[test]
-    fn given_file_named_test_without_underscore_then_not_detected_as_file_pattern() {
-        // "test.rs" doesn't match _test or test_ patterns, but may match via
-        // dir patterns if "test" is in path. As a standalone basename, check behavior.
-        // "test.rs" → name = "test.rs", doesn't start with "test_" or contain "_test"
-        // or ".test." or ".spec."
+    fn given_file_named_test_without_underscore_then_detected_as_file_pattern() {
+        // "test.rs" used to not match, but now matches due to "test." check.
         let result = is_test_path("test.rs");
-        // The function checks name.starts_with("test_") — "test.rs" does not start with "test_"
-        assert!(!result);
+        assert!(result);
     }
 
     #[test]


### PR DESCRIPTION
Updated the `is_test_path` heuristic in `tokmd-analysis-util` to correctly identify standalone test files (e.g., `test.rs`, `spec.js`, `tests.py`).

Previously, the heuristic primarily relied on directory names (`/test/`, `/tests/`, `/spec/`, etc.) or specific prefixes/suffixes (`test_*.rs`, `*_test.rs`, `*.test.js`). It completely missed standalone files at the root or within standard directories that were simply named `test.rs` or `spec.js`. This resulted in inaccurate test density analysis, an important edge-case regression gap.

---
*PR created automatically by Jules for task [10722710421910410597](https://jules.google.com/task/10722710421910410597) started by @EffortlessSteven*