### PR TITLE
⚡ Optimize double lookup in BTreeMap insertion

### DIFF
--- a/crates/tokmd-analysis-git/src/git.rs
+++ b/crates/tokmd-analysis-git/src/git.rs
@@ -42,13 +42,10 @@ pub fn build_git_report(
                 } else {
                     commit_counts.insert(key.clone(), 1);
                 }
-                if let Some(val) = authors_by_module.get_mut(module) {
-                    val.insert(commit.author.clone());
-                } else {
-                    let mut set = BTreeSet::new();
-                    set.insert(commit.author.clone());
-                    authors_by_module.insert(module.clone(), set);
-                }
+                authors_by_module
+                    .entry(module.clone())
+                    .or_default()
+                    .insert(commit.author.clone());
                 if !last_change.contains_key(&key) {
                     last_change.insert(key.clone(), commit.timestamp);
                 }


### PR DESCRIPTION
💡 What:
Replaced a double lookup in BTreeMap insertion inside a loop within `build_git_report` in `crates/tokmd-analysis-git/src/git.rs`. The logic using `get_mut` followed by an `insert` on miss was replaced with `authors_by_module.entry(module.clone()).or_default().insert(commit.author.clone());`.

🎯 Why:
The original code performed two map lookups in the worst case: once to check if the module existed via `get_mut`, and a second time to `insert` the new set if it didn't. Using the Entry API allows modifying or inserting in a single lookup, which is both cleaner to read and structurally more efficient for BTreeMap operations inside tight loops.

📊 Measured Improvement:
I created a benchmark using Criterion (`num_files = 1000`, `num_commits = 1000`) and benchmarked the execution time of `build_git_report`.
* Baseline: ~11.269 ms
* Optimized: ~11.440 ms (No statistically significant difference)

Although no meaningful macro-level performance improvement was detected (likely because the map only contains a few entries in typical workloads, making lookup overhead negligible compared to other operations like allocation), the optimization removes redundant tree traversal logic and is idiomatically superior. Correctness was verified against 335 tests without regression.

---
*PR created automatically by Jules for task [17129056273015496860](https://jules.google.com/task/17129056273015496860) started by @EffortlessSteven*