### PR TITLE
fix: reject invalid context budgets

### DIFF
--- a/crates/tokmd/src/context_pack.rs
+++ b/crates/tokmd/src/context_pack.rs
@@ -107,6 +107,12 @@ pub fn parse_budget(budget: &str) -> anyhow::Result<usize> {
     })?;
 
     let result = n * multiplier;
+    if !result.is_finite() || result < 0.0 {
+        anyhow::bail!(
+            "Invalid budget '{}': value must be a finite non-negative number",
+            budget.trim()
+        );
+    }
     if result > usize::MAX as f64 {
         anyhow::bail!(
             "Invalid budget '{}': value overflows (max is {})",
@@ -1498,6 +1504,19 @@ mod tests {
         assert!(parse_budget("k").is_err());
         assert!(parse_budget("m").is_err());
         assert!(parse_budget("g").is_err());
+    }
+
+    #[test]
+    fn test_parse_budget_rejects_negative_values() {
+        assert!(parse_budget("-1").is_err());
+        assert!(parse_budget("-1k").is_err());
+    }
+
+    #[test]
+    fn test_parse_budget_rejects_non_finite_values() {
+        assert!(parse_budget("NaN").is_err());
+        assert!(parse_budget("inf").is_err());
+        assert!(parse_budget("-inf").is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Harden budget parsing so malformed numeric inputs (e.g. `-1k`, `NaN`, `inf`) cannot silently coerce to unexpected values when converting to `usize` in the `context` packing logic.

### Description
- Add validation in `crates/tokmd/src/context_pack.rs::parse_budget` to bail if the computed result is not finite or is negative before casting to `usize`.
- Add focused unit tests to assert negative and non-finite budget strings return errors (`test_parse_budget_rejects_negative_values`, `test_parse_budget_rejects_non_finite_values`).

### Testing
- Ran the targeted unit tests with `cargo test -p tokmd context_pack::tests::test_parse_budget -- --nocapture` and all tests passed.
- Ran formatting check with `cargo fmt-check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894f7e53c83339a311eb88deb92e6)