### PR TITLE
Respect global byte budgets in content analyzers

### DIFF
--- a/crates/tokmd-analysis-content/src/content.rs
+++ b/crates/tokmd-analysis-content/src/content.rs
@@ -14,6 +14,24 @@ use tokmd_math::round_f64;
 const DEFAULT_MAX_FILE_BYTES: u64 = 128 * 1024;
 const IMPORT_MAX_LINES: usize = 200;
 
+fn effective_file_limit(
+    max_total: Option<u64>,
+    total_bytes: u64,
+    default_per_file_limit: usize,
+) -> Option<usize> {
+    match max_total {
+        Some(cap) => {
+            let remaining = cap.saturating_sub(total_bytes) as usize;
+            if remaining == 0 {
+                None
+            } else {
+                Some(default_per_file_limit.min(remaining))
+            }
+        }
+        None => Some(default_per_file_limit),
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum ImportGranularity {
     Module,
@@ -43,7 +61,11 @@ pub fn build_todo_report(
             break;
         }
         let path = root.join(rel);
-        let bytes = tokmd_content::read_head(&path, per_file_limit)?;
+        let this_file_limit = match effective_file_limit(max_total, total_bytes, per_file_limit) {
+            Some(limit) => limit,
+            None => break,
+        };
+        let bytes = tokmd_content::read_head(&path, this_file_limit)?;
         total_bytes += bytes.len() as u64;
         if !tokmd_content::is_text_like(&bytes) {
             continue;
@@ -256,6 +278,10 @@ pub fn build_import_report(
         if max_total.is_some_and(|limit| total_bytes >= limit) {
             break;
         }
+        let this_file_limit = match effective_file_limit(max_total, total_bytes, per_file_limit) {
+            Some(limit) => limit,
+            None => break,
+        };
         let rel_str = rel.to_string_lossy().replace('\\', "/");
         let row = match map.get(&rel_str) {
             Some(r) => *r,
@@ -265,7 +291,7 @@ pub fn build_import_report(
             continue;
         }
         let path = root.join(rel);
-        let lines = match tokmd_content::read_lines(&path, IMPORT_MAX_LINES, per_file_limit) {
+        let lines = match tokmd_content::read_lines(&path, IMPORT_MAX_LINES, this_file_limit) {
             Ok(lines) => lines,
             Err(_) => continue,
         };

--- a/crates/tokmd-analysis-content/tests/bdd.rs
+++ b/crates/tokmd-analysis-content/tests/bdd.rs
@@ -144,19 +144,18 @@ fn given_max_bytes_limit_when_building_todo_report_then_stops_early() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = temp.path();
 
-    // First file is small, second file should be skipped
-    std::fs::write(root.join("first.rs"), "// TODO: counted\n").unwrap();
-    std::fs::write(root.join("second.rs"), "// TODO: skipped\n").unwrap();
+    // First file fits exactly in the byte budget; second file should be skipped.
+    std::fs::write(root.join("first.rs"), "// TODO:A\n").unwrap();
+    std::fs::write(root.join("second.rs"), "// TODO:B\n").unwrap();
 
     let files = vec![PathBuf::from("first.rs"), PathBuf::from("second.rs")];
     let limits = ContentLimits {
-        max_bytes: Some(10), // very small budget
+        max_bytes: Some(10),
         max_file_bytes: None,
     };
     let report = build_todo_report(root, &files, &limits, 1000).unwrap();
 
-    // Only the first file should be processed
-    assert!(report.total <= 1);
+    assert_eq!(report.total, 1);
 }
 
 #[test]
@@ -483,14 +482,14 @@ fn given_max_bytes_limit_when_building_import_report_then_budget_respected() {
     };
 
     let limits = ContentLimits {
-        max_bytes: Some(5), // very small budget
+        max_bytes: Some(1),
         max_file_bytes: None,
     };
     let report =
         build_import_report(root, &files, &export, ImportGranularity::Module, &limits).unwrap();
 
-    // With a 5-byte budget, at most one file can be processed
-    assert!(report.edges.len() <= 1);
+    assert_eq!(report.edges.len(), 1);
+    assert_eq!(report.edges[0].to, "os");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- TODO and import scanning could read the full per-file cap even when a global `ContentLimits.max_bytes` budget was nearly exhausted, allowing a single read to overshoot the configured total budget. 
- Tests relied on deterministic budget behavior and were tightened to assert exact one-file processing under strict budgets.

### Description
- Add `effective_file_limit(...)` to compute a per-file read cap based on the remaining `max_bytes` budget or the default per-file cap. 
- Use the helper in `build_todo_report` and `build_import_report` so each file read is limited to the remaining global budget and scanning stops when budget is exhausted. 
- Update BDD tests in `crates/tokmd-analysis-content/tests/bdd.rs` to assert deterministic single-file processing and the expected import edge when budgets are tight. 
- Files changed: `crates/tokmd-analysis-content/src/content.rs` and `crates/tokmd-analysis-content/tests/bdd.rs`.

### Testing
- Ran `cargo test -p tokmd-analysis-content --test bdd --quiet` and the `bdd` test file passed. 
- Ran `cargo test -p tokmd-analysis-content --quiet` and all crate tests passed. 
- Ran `cargo fmt-check` and formatting/lint check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894f7e53c83339a311eb88deb92e6)