### PR TITLE
core: validate and test cockpit range_mode parsing

### DIFF
--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -560,10 +560,7 @@ pub fn cockpit_workflow(
     let repo_root =
         tokmd_git::repo_root(&cwd).ok_or_else(|| anyhow::anyhow!("not inside a git repository"))?;
 
-    let range_mode = match settings.range_mode.as_str() {
-        "three-dot" | "3dot" => tokmd_git::GitRangeMode::ThreeDot,
-        _ => tokmd_git::GitRangeMode::TwoDot,
-    };
+    let range_mode = parse_cockpit_range_mode(&settings.range_mode)?;
 
     let resolved_base =
         tokmd_git::resolve_base_ref(&repo_root, &settings.base).ok_or_else(|| {
@@ -592,6 +589,20 @@ pub fn cockpit_workflow(
     }
 
     Ok(receipt)
+}
+
+#[cfg(feature = "cockpit")]
+fn parse_cockpit_range_mode(value: &str) -> Result<tokmd_git::GitRangeMode> {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "two-dot" | "2dot" => Ok(tokmd_git::GitRangeMode::TwoDot),
+        "three-dot" | "3dot" => Ok(tokmd_git::GitRangeMode::ThreeDot),
+        _ => Err(error::TokmdError::invalid_field(
+            "range_mode",
+            "'two-dot', '2dot', 'three-dot', or '3dot'",
+        )
+        .into()),
+    }
 }
 
 #[cfg(feature = "cockpit")]
@@ -1527,34 +1538,37 @@ mod mutation_tests {
     #[cfg(feature = "cockpit")]
     #[test]
     fn cockpit_workflow_range_mode_parsing() {
-        use tokmd_settings::CockpitSettings;
+        assert!(matches!(
+            parse_cockpit_range_mode("three-dot").expect("three-dot should parse"),
+            tokmd_git::GitRangeMode::ThreeDot
+        ));
+        assert!(matches!(
+            parse_cockpit_range_mode("3dot").expect("3dot should parse"),
+            tokmd_git::GitRangeMode::ThreeDot
+        ));
+        assert!(matches!(
+            parse_cockpit_range_mode("two-dot").expect("two-dot should parse"),
+            tokmd_git::GitRangeMode::TwoDot
+        ));
+        assert!(matches!(
+            parse_cockpit_range_mode("2dot").expect("2dot should parse"),
+            tokmd_git::GitRangeMode::TwoDot
+        ));
+        assert!(matches!(
+            parse_cockpit_range_mode("  THREE-DOT  ").expect("trimmed/case-insensitive parse"),
+            tokmd_git::GitRangeMode::ThreeDot
+        ));
+    }
 
-        // This tests the range_mode match logic that was flagged as untested
-        // We can't fully test cockpit_workflow without a git repo, but we can
-        // at least verify the range_mode parsing logic directly
-
-        let test_cases = [
-            ("three-dot", "three-dot matches GitRangeMode::ThreeDot"),
-            ("3dot", "3dot matches GitRangeMode::ThreeDot"),
-            ("two-dot", "two-dot falls through to GitRangeMode::TwoDot"),
-            ("", "empty string falls through to GitRangeMode::TwoDot"),
-            (
-                "invalid",
-                "invalid string falls through to GitRangeMode::TwoDot",
-            ),
-        ];
-
-        for (mode, _description) in &test_cases {
-            let settings = CockpitSettings {
-                base: "HEAD~1".to_string(),
-                head: "HEAD".to_string(),
-                range_mode: mode.to_string(),
-                baseline: None,
-            };
-
-            // Verify the match arms don't panic
-            let _ = settings.range_mode.as_str();
-        }
+    #[cfg(feature = "cockpit")]
+    #[test]
+    fn cockpit_workflow_range_mode_invalid_rejected() {
+        let err = parse_cockpit_range_mode("invalid").expect_err("invalid mode should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("range_mode"),
+            "Error should reference range_mode field; got: {msg}"
+        );
     }
 }
 


### PR DESCRIPTION
### Motivation

- The cockpit workflow previously treated any unknown `range_mode` value as `two-dot`, which could silently produce incorrect git-range semantics. 
- Explicit validation of `range_mode` improves observability for library/FFI consumers and prevents accidental analysis mistakes due to typos. 
- Tests that were previously no-ops for range-mode parsing needed to be replaced with behavioral checks that cover aliases and invalid inputs.

### Description

- Replaced the inline match in `cockpit_workflow` with a dedicated parser `parse_cockpit_range_mode` that normalizes input via `trim()` + `to_ascii_lowercase()` and accepts `two-dot|2dot` and `three-dot|3dot` only. 
- `parse_cockpit_range_mode` returns a structured `invalid_field("range_mode", ...)` error for invalid values so callers receive explicit failures. 
- Updated `cockpit_workflow` to call `parse_cockpit_range_mode(&settings.range_mode)?` and pass the validated `GitRangeMode` into `tokmd_cockpit::compute_cockpit`. 
- Reworked unit tests to assert accepted aliases, whitespace/case normalization, and that invalid values are rejected with an error mentioning `range_mode`.

### Testing

- Ran `cargo test -p tokmd-core --lib cockpit_workflow_range_mode --features cockpit` and the new unit tests passed. 
- Ran `cargo test -p tokmd-core --lib --features cockpit` (filtered) and observed the two new mutation-targeting tests pass. 
- Ran `cargo fmt-check` and the workspace formatting checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894f5db648333999be6b85c0e5e66)