### PR TITLE
fix(archetype): tighten Next.js config detection

### DIFF
--- a/crates/tokmd-analysis-archetype/src/lib.rs
+++ b/crates/tokmd-analysis-archetype/src/lib.rs
@@ -79,19 +79,10 @@ fn rust_workspace(files: &BTreeSet<String>) -> Option<Archetype> {
 
 fn nextjs_app(files: &BTreeSet<String>) -> Option<Archetype> {
     let has_package = files.contains("package.json");
-    let has_next_config = files.iter().any(|p| {
-        p.starts_with("next.config.")
-            || p.ends_with("/next.config.js")
-            || p.ends_with("/next.config.mjs")
-            || p.ends_with("/next.config.ts")
-    });
+    let has_next_config = files.iter().any(|p| is_next_config_path(p));
     if has_package && has_next_config {
         let mut evidence = vec!["package.json".to_string()];
-        if let Some(cfg) = files.iter().find(|p| {
-            p.ends_with("next.config.js")
-                || p.ends_with("next.config.mjs")
-                || p.ends_with("next.config.ts")
-        }) {
+        if let Some(cfg) = files.iter().find(|p| is_next_config_path(p)) {
             evidence.push(cfg.clone());
         }
         return Some(Archetype {
@@ -100,6 +91,14 @@ fn nextjs_app(files: &BTreeSet<String>) -> Option<Archetype> {
         });
     }
     None
+}
+
+fn is_next_config_path(path: &str) -> bool {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    let Some(ext) = basename.strip_prefix("next.config.") else {
+        return false;
+    };
+    matches!(ext, "js" | "mjs" | "ts" | "cjs" | "cts" | "mts")
 }
 
 fn containerized_service(files: &BTreeSet<String>) -> Option<Archetype> {
@@ -366,6 +365,27 @@ mod tests {
             "evidence must contain apps/web/next.config.ts: {:?}",
             archetype.evidence
         );
+    }
+
+    #[test]
+    fn nextjs_with_subdir_next_config_cjs() {
+        let files = files_set(&["package.json", "apps/web/next.config.cjs"]);
+        let archetype = nextjs_app(&files).unwrap();
+        assert_eq!(archetype.kind, "Next.js app");
+        assert!(
+            archetype
+                .evidence
+                .iter()
+                .any(|e| e == "apps/web/next.config.cjs"),
+            "evidence must contain apps/web/next.config.cjs: {:?}",
+            archetype.evidence
+        );
+    }
+
+    #[test]
+    fn nextjs_ignores_non_next_config_extensions() {
+        let files = files_set(&["package.json", "next.config.json"]);
+        assert!(nextjs_app(&files).is_none());
     }
 
     // =============================================================================

--- a/crates/tokmd-analysis-archetype/tests/archetype_depth_w61.rs
+++ b/crates/tokmd-analysis-archetype/tests/archetype_depth_w61.rs
@@ -137,14 +137,10 @@ fn rust_workspace_only_packages_no_crates() {
 
 #[test]
 fn nextjs_with_starts_with_next_config_dot() {
-    // next.config.json should NOT trigger (only .js/.mjs/.ts)
+    // next.config.json should NOT trigger Next.js detection
     let export = export_with_paths(&["package.json", "next.config.json"]);
-    // next.config.json starts with "next.config." so the first check passes
-    let a = detect_archetype(&export);
-    // If detected, must be Next.js due to starts_with("next.config.") check
-    if let Some(arch) = &a {
-        assert_eq!(arch.kind, "Next.js app");
-    }
+    let a = detect_archetype(&export).unwrap();
+    assert_eq!(a.kind, "Node package");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Prevent false-positive Next.js detection from broad `next.config.*` matching which misclassified files like `next.config.json` as Next.js evidence. 
- Make the matching logic explicit and maintainable so supported config types are clear and nested monorepo paths are handled consistently.

### Description
- Introduced a helper `is_next_config_path(path: &str) -> bool` in `crates/tokmd-analysis-archetype/src/lib.rs` that recognizes Next.js config basenames with explicit extensions `js`, `mjs`, `ts`, `cjs`, `cts`, and `mts`.
- Replaced ad-hoc `starts_with`/`ends_with` logic in `nextjs_app` with the new helper for both detection and evidence selection.
- Added unit tests to cover nested `.cjs` configs and to ensure unsupported extensions (e.g., `next.config.json`) do not trigger Next.js detection.
- Updated deep test expectations so `package.json + next.config.json` resolves to `Node package` instead of being accepted as Next.js (file: `crates/tokmd-analysis-archetype/tests/archetype_depth_w61.rs`).

### Testing
- Ran `cargo test -p tokmd-analysis-archetype` and all tests passed (unit and integration suites for the crate). 
- New/updated tests exercised nested config detection and rejection of non-supported extensions and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894f5db648333999be6b85c0e5e66)