### PR TITLE
fix(content): avoid bogus matches for empty tag needles

### DIFF
--- a/crates/tokmd-content/src/lib.rs
+++ b/crates/tokmd-content/src/lib.rs
@@ -118,6 +118,9 @@ pub fn count_tags(text: &str, tags: &[&str]) -> Vec<(String, usize)> {
     let upper = text.to_uppercase();
     tags.iter()
         .map(|tag| {
+            if tag.is_empty() {
+                return (tag.to_string(), 0);
+            }
             let needle = tag.to_uppercase();
             let count = upper.matches(&needle).count();
             (tag.to_string(), count)
@@ -421,5 +424,11 @@ mod tests {
         // Full hash should be different
         let hash_full = hash_file(&path, 1000).unwrap();
         assert_ne!(hash_limited, hash_full);
+    }
+
+    #[test]
+    fn test_count_tags_empty_tag_has_zero_matches() {
+        let result = count_tags("TODO", &[""]);
+        assert_eq!(result, vec![("".to_string(), 0)]);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent inflated tag counts when an empty string is passed to `count_tags`, because `str::matches("")` returns `text_len + 1` and can corrupt TODO/FIXME metrics.

### Description
- Add a guard in `crates/tokmd-content/src/lib.rs` so `count_tags` returns `0` for empty tag needles and keep existing case-insensitive matching for non-empty tags, and add a unit test `test_count_tags_empty_tag_has_zero_matches` to lock in the behavior.

### Testing
- Ran `cargo test -p tokmd-content --quiet` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894f27e348333be4594b0031611cb)