### PR TITLE
fix(content): enforce `read_lines` max-byte budget in tokmd-content

### DIFF
--- a/crates/tokmd-content/src/lib.rs
+++ b/crates/tokmd-content/src/lib.rs
@@ -83,9 +83,14 @@ pub fn read_lines(path: &Path, max_lines: usize, max_bytes: usize) -> Result<Vec
 
     for line in reader.lines() {
         let line = line?;
-        bytes += line.len();
+        let next_bytes = bytes.saturating_add(line.len());
+        if next_bytes > max_bytes {
+            break;
+        }
+
         lines.push(line);
-        if lines.len() >= max_lines || bytes >= max_bytes {
+        bytes = next_bytes;
+        if lines.len() >= max_lines {
             break;
         }
     }
@@ -320,11 +325,10 @@ mod tests {
         writeln!(f, "bbbbb").unwrap(); // 5 bytes (total 10)
         writeln!(f, "ccccc").unwrap(); // should not be read if limit is 9
 
-        // With limit of 9 bytes, we should get exactly 2 lines
-        // because after first line (5 bytes), bytes=5 < 9, continue
-        // after second line (5 bytes), bytes=10 >= 9, break
+        // With limit of 9 bytes, only the first 5-byte line fits.
         let lines = read_lines(&path, 100, 9).unwrap();
-        assert_eq!(lines.len(), 2);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "aaaaa");
     }
 
     // ========================

--- a/crates/tokmd-content/tests/deep_content_w48.rs
+++ b/crates/tokmd-content/tests/deep_content_w48.rs
@@ -513,12 +513,11 @@ fn edge_read_lines_bytes_limit_on_long_line() {
     let mut f = File::create(&path).unwrap();
     writeln!(f, "{line}").unwrap();
     writeln!(f, "second line").unwrap();
-    // Byte limit 500 is less than the first line, but read_lines counts
-    // accumulated bytes and breaks after reaching the threshold
+    // Byte limit 500 is less than the first line, so no lines fit.
     let lines = read_lines(&path, 100, 500).unwrap();
     assert_eq!(
         lines.len(),
-        1,
-        "Should stop after first long line exceeds byte limit"
+        0,
+        "Should stop before adding a line that exceeds the byte limit"
     );
 }

--- a/crates/tokmd-content/tests/error_edge_w73.rs
+++ b/crates/tokmd-content/tests/error_edge_w73.rs
@@ -133,10 +133,9 @@ fn read_lines_with_very_long_line_respects_byte_limit() {
     let lines = read_lines(&path, 100, 5000).unwrap();
     assert_eq!(
         lines.len(),
-        1,
-        "byte limit should stop after first long line"
+        0,
+        "byte limit should skip lines that cannot fit in the remaining budget"
     );
-    assert_eq!(lines[0].len(), 10_000);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- `read_lines` previously appended a line then checked the cumulative byte count, allowing the returned lines to exceed the configured `max_bytes` (including when the first line alone was larger than the budget).

### Description
- Changed `tokmd-content::read_lines` to compute `next_bytes` and enforce `max_bytes` before pushing a line, so lines that would exceed the remaining budget are skipped; `max_lines` semantics remain unchanged.
- Updated unit and integration tests to expect the strict-cap behavior in `crates/tokmd-content/src/lib.rs`, `crates/tokmd-content/tests/deep_content_w48.rs`, and `crates/tokmd-content/tests/error_edge_w73.rs`.
- Minor test text clarifications to reflect the new invariant that non-fitting lines are not returned.

### Testing
- Ran `cargo test -p tokmd-content` and all tests in that crate passed successfully.
- Ran `cargo fmt-check` and the workspace formatting check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894f50ccc8333b4c986b0d5ade610)