### PR TITLE
Fix max-bytes budget enforcement for TODO/import scanners

### DIFF
--- a/crates/tokmd-analysis-content/src/content.rs
+++ b/crates/tokmd-analysis-content/src/content.rs
@@ -42,8 +42,15 @@ pub fn build_todo_report(
         if max_total.is_some_and(|limit| total_bytes >= limit) {
             break;
         }
+        let remaining_budget = max_total.map(|limit| limit.saturating_sub(total_bytes));
+        let file_limit = remaining_budget
+            .map(|remaining| remaining.min(per_file_limit as u64) as usize)
+            .unwrap_or(per_file_limit);
+        if file_limit == 0 {
+            break;
+        }
         let path = root.join(rel);
-        let bytes = tokmd_content::read_head(&path, per_file_limit)?;
+        let bytes = tokmd_content::read_head(&path, file_limit)?;
         total_bytes += bytes.len() as u64;
         if !tokmd_content::is_text_like(&bytes) {
             continue;
@@ -256,6 +263,13 @@ pub fn build_import_report(
         if max_total.is_some_and(|limit| total_bytes >= limit) {
             break;
         }
+        let remaining_budget = max_total.map(|limit| limit.saturating_sub(total_bytes));
+        let file_limit = remaining_budget
+            .map(|remaining| remaining.min(per_file_limit as u64) as usize)
+            .unwrap_or(per_file_limit);
+        if file_limit == 0 {
+            break;
+        }
         let rel_str = rel.to_string_lossy().replace('\\', "/");
         let row = match map.get(&rel_str) {
             Some(r) => *r,
@@ -265,7 +279,7 @@ pub fn build_import_report(
             continue;
         }
         let path = root.join(rel);
-        let lines = match tokmd_content::read_lines(&path, IMPORT_MAX_LINES, per_file_limit) {
+        let lines = match tokmd_content::read_lines(&path, IMPORT_MAX_LINES, file_limit) {
             Ok(lines) => lines,
             Err(_) => continue,
         };

--- a/crates/tokmd-analysis-content/tests/bdd.rs
+++ b/crates/tokmd-analysis-content/tests/bdd.rs
@@ -160,6 +160,25 @@ fn given_max_bytes_limit_when_building_todo_report_then_stops_early() {
 }
 
 #[test]
+fn given_todo_past_remaining_budget_when_building_todo_report_then_not_counted() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    let mut content = "1234".repeat(6);
+    content.push_str("TODO: hidden");
+    std::fs::write(root.join("budget.rs"), content).unwrap();
+
+    let files = vec![PathBuf::from("budget.rs")];
+    let limits = ContentLimits {
+        max_bytes: Some(24),
+        max_file_bytes: None,
+    };
+    let report = build_todo_report(root, &files, &limits, 1000).unwrap();
+
+    assert_eq!(report.total, 0);
+}
+
+#[test]
 fn given_empty_file_list_when_building_todo_report_then_zero_total() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = temp.path();
@@ -491,6 +510,34 @@ fn given_max_bytes_limit_when_building_import_report_then_budget_respected() {
 
     // With a 5-byte budget, at most one file can be processed
     assert!(report.edges.len() <= 1);
+}
+
+#[test]
+fn given_import_past_remaining_budget_when_building_import_report_then_not_detected() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+
+    std::fs::write(
+        root.join("late.py"),
+        format!("{}\nimport os\n", "12345".repeat(6)),
+    )
+    .unwrap();
+
+    let files = vec![PathBuf::from("late.py")];
+    let export = ExportData {
+        rows: vec![file_row("late.py", "root", "Python", 40)],
+        module_roots: vec!["root".to_string()],
+        module_depth: 1,
+        children: ChildIncludeMode::Separate,
+    };
+    let limits = ContentLimits {
+        max_bytes: Some(10),
+        max_file_bytes: None,
+    };
+    let report =
+        build_import_report(root, &files, &export, ImportGranularity::Module, &limits).unwrap();
+
+    assert!(report.edges.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The content scanners used a global `max_bytes` check before opening each file but still read with the full per-file cap, allowing analysis to observe content beyond the remaining global budget.  
- This can cause TODO markers and import edges to be counted even when the global byte budget should have prevented scanning that portion of the file.  
- Make the budget enforcement precise so scanning honors the remaining global byte budget per-file.

### Description
- Compute a per-file `file_limit` from the remaining global budget (`max_bytes - total_bytes`) and the configured per-file cap, and stop when the remaining budget reaches zero in `build_todo_report` and `build_import_report` in `crates/tokmd-analysis-content/src/content.rs` by using `file_limit` for reads.  
- Use the computed `file_limit` when calling `tokmd_content::read_head` for TODO scanning and `tokmd_content::read_lines` for import scanning so no more bytes than the remaining budget are read.  
- Add BDD-style tests in `crates/tokmd-analysis-content/tests/bdd.rs` to cover the new behavior: one test ensures TODO markers past the remaining budget are not counted, and another ensures imports past the remaining budget are not detected.  
- Run and apply formatting fixes so the changes pass `cargo fmt-check`.

### Testing
- Ran `cargo test -p tokmd-analysis-content --test bdd --verbose` and the test suite passed (all BDD tests passed).  
- Ran the focused tests `given_todo_past_remaining_budget_when_building_todo_report_then_not_counted` and `given_import_past_remaining_budget_when_building_import_report_then_not_detected`, both passed.  
- Ran `cargo fmt-check` (after `cargo fmt-fix`) to ensure formatting rules are satisfied and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578efb7c8333a59426c0eda1667e)