### PR TITLE
gate: enforce strict RFC 6901 pointer token parsing

### DIFF
--- a/crates/tokmd-gate/src/pointer.rs
+++ b/crates/tokmd-gate/src/pointer.rs
@@ -39,13 +39,14 @@ pub fn resolve_pointer<'a>(value: &'a Value, pointer: &str) -> Option<&'a Value>
 
     for token in pointer[1..].split('/') {
         // Unescape tokens per RFC 6901
-        let unescaped = unescape_token(token);
+        let unescaped = unescape_token(token)?;
 
         current = match current {
             Value::Object(map) => map.get(&unescaped)?,
             Value::Array(arr) => {
-                // Try to parse as array index
-                let idx: usize = unescaped.parse().ok()?;
+                // Parse array index with RFC 6901 semantics:
+                // only unsigned base-10, no leading zeros except "0".
+                let idx = parse_array_index(&unescaped)?;
                 arr.get(idx)?
             }
             _ => return None,
@@ -58,8 +59,36 @@ pub fn resolve_pointer<'a>(value: &'a Value, pointer: &str) -> Option<&'a Value>
 /// Unescape a JSON Pointer token per RFC 6901.
 /// ~1 -> /
 /// ~0 -> ~
-fn unescape_token(token: &str) -> String {
-    token.replace("~1", "/").replace("~0", "~")
+fn unescape_token(token: &str) -> Option<String> {
+    let mut output = String::with_capacity(token.len());
+    let mut chars = token.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '~' {
+            output.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some('0') => output.push('~'),
+            Some('1') => output.push('/'),
+            _ => return None,
+        }
+    }
+
+    Some(output)
+}
+
+fn parse_array_index(token: &str) -> Option<usize> {
+    if token == "0" {
+        return Some(0);
+    }
+
+    if token.is_empty() || token.starts_with('0') || !token.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    token.parse().ok()
 }
 
 /// Escape a string for use in a JSON Pointer.
@@ -103,6 +132,13 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_escape_sequence() {
+        let doc = json!({"a~2b": 1, "a~b": 2});
+        assert_eq!(resolve_pointer(&doc, "/a~2b"), None);
+        assert_eq!(resolve_pointer(&doc, "/a~"), None);
+    }
+
+    #[test]
     fn test_invalid_pointer() {
         let doc = json!({"foo": 1});
         // Missing leading slash
@@ -116,6 +152,13 @@ mod tests {
         let doc = json!({"matrix": [[1, 2], [3, 4]]});
         assert_eq!(resolve_pointer(&doc, "/matrix/0/1"), Some(&json!(2)));
         assert_eq!(resolve_pointer(&doc, "/matrix/1/0"), Some(&json!(3)));
+    }
+
+    #[test]
+    fn test_invalid_array_indexes() {
+        let doc = json!({"items": ["zero", "one", "two"]});
+        assert_eq!(resolve_pointer(&doc, "/items/01"), None);
+        assert_eq!(resolve_pointer(&doc, "/items/+1"), None);
     }
 
     #[test]

--- a/crates/tokmd-gate/tests/bdd.rs
+++ b/crates/tokmd-gate/tests/bdd.rs
@@ -103,6 +103,21 @@ fn given_non_numeric_index_for_array_when_pointer_resolves_then_returns_none() {
     assert_eq!(resolve_pointer(&receipt, "/items/abc"), None);
 }
 
+#[test]
+fn given_array_index_with_leading_zero_when_pointer_resolves_then_returns_none() {
+    // RFC 6901 index tokens are base-10 without leading zeroes (except "0").
+    let receipt = json!({"items": ["zero", "one", "two"]});
+    assert_eq!(resolve_pointer(&receipt, "/items/01"), None);
+}
+
+#[test]
+fn given_invalid_tilde_escape_when_pointer_resolves_then_returns_none() {
+    // RFC 6901 only allows ~0 and ~1 escape forms.
+    let receipt = json!({"a~2b": 1, "a~b": 2});
+    assert_eq!(resolve_pointer(&receipt, "/a~2b"), None);
+    assert_eq!(resolve_pointer(&receipt, "/a~"), None);
+}
+
 // ============================================================================
 // Scenario: Threshold evaluation — numeric operators
 // ============================================================================


### PR DESCRIPTION
### Motivation

- Pointer resolution was accepting malformed RFC 6901 escape sequences (anything other than `~0`/`~1`) and treating them as literal tokens, which could cause accidental policy matches. 
- Array index tokens were permissive (e.g. `01` parsed), leading to ambiguous or unexpected array addressing against receipts.

### Description

- Tighten token unescaping by making `unescape_token` validate escape sequences and return `None` for invalid forms, so invalid `~` sequences fail pointer resolution instead of being treated as literals.
- Add `parse_array_index` to enforce RFC-style array index parsing: accept `0` or non-empty unsigned base-10 numbers without leading zeros, and reject tokens like `01` or `+1`.
- Update `resolve_pointer` to use the new `unescape_token` and `parse_array_index` helpers while traversing arrays and objects.
- Expand tests: add focused unit tests in `crates/tokmd-gate/src/pointer.rs` and BDD tests in `crates/tokmd-gate/tests/bdd.rs` to cover invalid tilde-escape sequences and invalid/leading-zero array index tokens.

### Testing

- Ran `cargo test -p tokmd-gate --tests --lib`, which executed the crate's unit, integration and BDD suites and completed with all tests passing.
- Ran `cargo fmt-check` to verify formatting, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578efb7c8333a59426c0eda1667e)