### PR TITLE
Fix relative scan path normalization for duplicated slash prefixes

### DIFF
--- a/crates/tokmd-scan-args/src/lib.rs
+++ b/crates/tokmd-scan-args/src/lib.rs
@@ -10,9 +10,15 @@ use tokmd_types::{RedactMode, ScanArgs};
 #[must_use]
 pub fn normalize_scan_input(p: &Path) -> String {
     let mut normalized = tokmd_path::normalize_slashes(&p.display().to_string());
+    let mut stripped_relative_prefix = false;
 
     while let Some(stripped) = normalized.strip_prefix("./") {
         normalized = stripped.to_string();
+        stripped_relative_prefix = true;
+    }
+
+    if stripped_relative_prefix {
+        normalized = normalized.trim_start_matches('/').to_string();
     }
 
     if normalized.is_empty() {
@@ -66,6 +72,12 @@ mod tests {
     fn normalize_scan_input_keeps_dot_for_empty_relative() {
         let normalized = normalize_scan_input(Path::new("./"));
         assert_eq!(normalized, ".");
+    }
+
+    #[test]
+    fn normalize_scan_input_handles_redundant_separators_after_dot_slash() {
+        let normalized = normalize_scan_input(Path::new(".//src//lib.rs"));
+        assert_eq!(normalized, "src//lib.rs");
     }
 
     #[test]

--- a/crates/tokmd-scan-args/tests/bdd_scan_args.rs
+++ b/crates/tokmd-scan-args/tests/bdd_scan_args.rs
@@ -203,6 +203,19 @@ fn given_empty_paths_when_building_scan_args_then_result_has_empty_paths() {
     assert!(args.paths.is_empty());
 }
 
+#[test]
+fn given_dot_prefix_with_extra_slashes_when_normalizing_then_path_stays_relative() {
+    // Given: an explicitly relative path with duplicated separators after `./`
+    let input = PathBuf::from(".//src//main.rs");
+
+    // When: normalization runs
+    let normalized = normalize_scan_input(&input);
+
+    // Then: duplicated separators do not accidentally turn the path absolute
+    assert_eq!(normalized, "src//main.rs");
+    assert!(!normalized.starts_with('/'));
+}
+
 // ── Multiple exclusion patterns ──────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation
- Prevent a normalization bug where inputs like `.//src/main.rs` could be transformed into an absolute-looking path by accidentally trimming leading slashes, breaking relative semantics.

### Description
- Adjusted `normalize_scan_input` to track whether a `./` prefix was stripped and only trim leading `/` characters in that case, preserving absolute paths unchanged.
- Added a focused unit test `normalize_scan_input_handles_redundant_separators_after_dot_slash` in `crates/tokmd-scan-args/src/lib.rs` and a BDD-style regression `given_dot_prefix_with_extra_slashes_when_normalizing_then_path_stays_relative` in `crates/tokmd-scan-args/tests/bdd_scan_args.rs`.

### Testing
- Ran `cargo test -p tokmd-scan-args normalize_scan_input_handles_redundant_separators_after_dot_slash` and the test passed.
- Ran `cargo test -p tokmd-scan-args given_dot_prefix_with_extra_slashes_when_normalizing_then_path_stays_relative` and the test passed.
- Ran `cargo fmt-check` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578efb7c8333a59426c0eda1667e)