### PR TITLE
Fix analysis feature gating: require walk+content for TODO/dup/import and add regression test

### DIFF
--- a/crates/tokmd-analysis-grid/src/lib.rs
+++ b/crates/tokmd-analysis-grid/src/lib.rs
@@ -454,10 +454,10 @@ impl DisabledFeature {
     pub const fn warning(self) -> &'static str {
         match self {
             Self::FileInventory => "walk feature disabled; skipping file inventory",
-            Self::TodoScan => "content feature disabled; skipping TODO scan",
-            Self::DuplicationScan => "content feature disabled; skipping duplication scan",
+            Self::TodoScan => "content/walk feature disabled; skipping TODO scan",
+            Self::DuplicationScan => "content/walk feature disabled; skipping duplication scan",
             Self::NearDuplicateScan => "content feature disabled; skipping near-dup scan",
-            Self::ImportScan => "content feature disabled; skipping import scan",
+            Self::ImportScan => "content/walk feature disabled; skipping import scan",
             Self::GitMetrics => "git feature disabled; skipping git metrics",
             Self::EntropyProfiling => "content/walk feature disabled; skipping entropy profiling",
             Self::LicenseRadar => "content/walk feature disabled; skipping license radar",

--- a/crates/tokmd-analysis/src/analysis.rs
+++ b/crates/tokmd-analysis/src/analysis.rs
@@ -17,7 +17,7 @@ use tokmd_types::{ExportData, ScanStatus, ToolInfo};
 
 #[cfg(feature = "git")]
 use crate::churn::build_predictive_churn_report;
-#[cfg(feature = "content")]
+#[cfg(all(feature = "content", feature = "walk"))]
 use crate::content::{build_duplicate_report, build_import_report, build_todo_report};
 use crate::derived::{build_tree, derive_report};
 #[cfg(feature = "git")]
@@ -96,7 +96,7 @@ fn preset_plan(preset: AnalysisPreset) -> PresetPlan {
 #[cfg(any(feature = "walk", feature = "content", feature = "git"))]
 const ROOTLESS_FILE_ANALYSIS_WARNING: &str =
     "in-memory analysis has no host root; skipping file-backed enrichers";
-#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
+#[cfg(feature = "git")]
 const ROOTLESS_GIT_ANALYSIS_WARNING: &str =
     "in-memory analysis has no host root; skipping git-backed enrichers";
 
@@ -143,6 +143,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
     #[cfg(not(feature = "walk"))]
     let deps: Option<DependencyReport> = None;
 
+    #[cfg_attr(not(all(feature = "content", feature = "walk")), allow(unused_mut))]
     #[cfg(feature = "content")]
     let mut imports: Option<ImportReport> = None;
     #[cfg(not(feature = "content"))]
@@ -200,6 +201,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
     let fun: Option<FunReport>;
 
     #[cfg(any(feature = "walk", feature = "content"))]
+    #[cfg_attr(not(feature = "walk"), allow(unused_mut, unused_variables))]
     let mut files: Option<Vec<PathBuf>> = None;
     #[cfg(not(any(feature = "walk", feature = "content")))]
     let _files: Option<Vec<PathBuf>> = None;
@@ -249,7 +251,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
     }
 
     if plan.todo {
-        #[cfg(feature = "content")]
+        #[cfg(all(feature = "content", feature = "walk"))]
         {
             if let Some(list) = files.as_deref() {
                 match build_todo_report(&ctx.root, list, &req.limits, derived.totals.code) {
@@ -258,7 +260,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
                 }
             }
         }
-        #[cfg(not(feature = "content"))]
+        #[cfg(not(all(feature = "content", feature = "walk")))]
         warnings.push(
             tokmd_analysis_grid::DisabledFeature::TodoScan
                 .warning()
@@ -267,7 +269,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
     }
 
     if plan.dup {
-        #[cfg(feature = "content")]
+        #[cfg(all(feature = "content", feature = "walk"))]
         {
             if let Some(list) = files.as_deref() {
                 match build_duplicate_report(&ctx.root, list, &ctx.export, &req.limits) {
@@ -276,7 +278,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
                 }
             }
         }
-        #[cfg(not(feature = "content"))]
+        #[cfg(not(all(feature = "content", feature = "walk")))]
         warnings.push(
             tokmd_analysis_grid::DisabledFeature::DuplicationScan
                 .warning()
@@ -332,7 +334,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
     }
 
     if plan.imports {
-        #[cfg(feature = "content")]
+        #[cfg(all(feature = "content", feature = "walk"))]
         {
             if let Some(list) = files.as_deref() {
                 match build_import_report(
@@ -347,7 +349,7 @@ pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisRec
                 }
             }
         }
-        #[cfg(not(feature = "content"))]
+        #[cfg(not(all(feature = "content", feature = "walk")))]
         warnings.push(
             tokmd_analysis_grid::DisabledFeature::ImportScan
                 .warning()

--- a/crates/tokmd-analysis/src/lib.rs
+++ b/crates/tokmd-analysis/src/lib.rs
@@ -19,7 +19,7 @@
 mod analysis;
 #[cfg(feature = "git")]
 mod churn;
-#[cfg(feature = "content")]
+#[cfg(all(feature = "content", feature = "walk"))]
 mod content;
 mod derived;
 #[cfg(feature = "git")]

--- a/crates/tokmd-analysis/tests/feature_gates_w71.rs
+++ b/crates/tokmd-analysis/tests/feature_gates_w71.rs
@@ -225,6 +225,39 @@ fn architecture_preset_content_gate() {
     }
 }
 
+/// Content-only builds (without walk) must still emit enricher-specific warnings
+/// instead of silently skipping TODO/import/dup analyzers.
+#[test]
+#[cfg(all(feature = "content", not(feature = "walk")))]
+fn content_without_walk_emits_specific_scan_warnings() {
+    let receipt = analyze(make_ctx(sample_export()), make_req(PresetKind::Deep)).unwrap();
+
+    assert!(
+        receipt
+            .warnings
+            .iter()
+            .any(|w| w.contains(DisabledFeature::TodoScan.warning())),
+        "missing TODO warning: {:?}",
+        receipt.warnings
+    );
+    assert!(
+        receipt
+            .warnings
+            .iter()
+            .any(|w| w.contains(DisabledFeature::DuplicationScan.warning())),
+        "missing duplication warning: {:?}",
+        receipt.warnings
+    );
+    assert!(
+        receipt
+            .warnings
+            .iter()
+            .any(|w| w.contains(DisabledFeature::ImportScan.warning())),
+        "missing import warning: {:?}",
+        receipt.warnings
+    );
+}
+
 /// Deep preset requests all content-dependent enrichers.
 #[test]
 fn deep_preset_requests_all_content_enrichers() {


### PR DESCRIPTION
### Motivation
- The analysis orchestration silently skipped some content-dependent enrichers when `content` was enabled but `walk` was not, producing no explicit warning and leading to misleading "green" results.
- The warning catalog text and module wiring did not accurately reflect the combined `content`+`walk` dependency for several enrichers.

### Description
- Tightened execution guards so TODO, duplication, and import enrichers only run when both `content` and `walk` are enabled by using `#[cfg(all(feature = "content", feature = "walk"))]` around their calls and imports in `tokmd-analysis`.
- Updated the `DisabledFeature::warning()` strings in `tokmd-analysis-grid` so messages reflect the `content/walk` dependency for TODO, duplication, and import scans.
- Changed the `tokmd-analysis` crate to only compile the internal `content` adapter module when `all(content, walk)` is enabled, and added `cfg_attr` allowances to suppress unused-item warnings in feature-matrix builds.
- Added a regression test `content_without_walk_emits_specific_scan_warnings` in the `feature_gates_w71` suite that asserts `content && !walk` builds emit explicit TODO/dup/import warnings instead of silently skipping.

### Testing
- Ran `cargo test -p tokmd-analysis-grid --quiet` and all tests passed.
- Ran `cargo test -p tokmd-analysis --test feature_gates_w71 --quiet` and all tests passed.
- Ran `cargo test -p tokmd-analysis --no-default-features --features content --test feature_gates_w71 --quiet` to validate content-only builds and the new regression test, and all tests passed.
- Ran `cargo fmt-check` to verify formatting, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578d3ed0833390a14e39218536f3)