### PR TITLE
Normalize export tree path separators for cross-platform rendering

### DIFF
--- a/crates/tokmd-export-tree/src/lib.rs
+++ b/crates/tokmd-export-tree/src/lib.rs
@@ -53,7 +53,11 @@ fn render_analysis(node: &AnalysisNode, name: &str, indent: &str, out: &mut Stri
 pub fn render_analysis_tree(export: &ExportData) -> String {
     let mut root = AnalysisNode::default();
     for row in export.rows.iter().filter(|r| r.kind == FileKind::Parent) {
-        let parts: Vec<&str> = row.path.split('/').filter(|seg| !seg.is_empty()).collect();
+        let normalized = row.path.replace('\\', "/");
+        let parts: Vec<&str> = normalized
+            .split('/')
+            .filter(|seg| !seg.is_empty())
+            .collect();
         insert_analysis(&mut root, &parts, row.lines, row.tokens);
     }
 
@@ -136,7 +140,11 @@ pub fn render_handoff_tree(export: &ExportData, max_depth: usize) -> String {
 
     let mut root = HandoffNode::default();
     for row in parents {
-        let parts: Vec<&str> = row.path.split('/').filter(|seg| !seg.is_empty()).collect();
+        let normalized = row.path.replace('\\', "/");
+        let parts: Vec<&str> = normalized
+            .split('/')
+            .filter(|seg| !seg.is_empty())
+            .collect();
         insert_handoff(&mut root, &parts, row.lines, row.tokens);
     }
 
@@ -214,5 +222,29 @@ mod tests {
         assert!(out.contains("a/ (files: 1, lines: 10, tokens: 20)"));
         assert!(!out.contains("b/"));
         assert!(!out.contains("file.rs"));
+    }
+
+    #[test]
+    fn analysis_tree_normalizes_windows_separator() {
+        let out = render_analysis_tree(&export(vec![row(
+            "src\\nested\\main.rs",
+            FileKind::Parent,
+            12,
+            24,
+        )]));
+        assert!(out.contains("src (lines: 12, tokens: 24)"));
+        assert!(out.contains("nested (lines: 12, tokens: 24)"));
+        assert!(out.contains("main.rs (lines: 12, tokens: 24)"));
+    }
+
+    #[test]
+    fn handoff_tree_normalizes_windows_separator() {
+        let out = render_handoff_tree(
+            &export(vec![row("src\\nested\\main.rs", FileKind::Parent, 12, 24)]),
+            3,
+        );
+        assert!(out.contains("src/ (files: 1, lines: 12, tokens: 24)"));
+        assert!(out.contains("nested/ (files: 1, lines: 12, tokens: 24)"));
+        assert!(!out.contains("main.rs"));
     }
 }


### PR DESCRIPTION
### Motivation
- The export tree renderers assumed forward-slash separators when splitting paths, which produced incorrect hierarchy for backslash-delimited (Windows-style) input.
- Make the renderers defensive and platform-agnostic so mixed or legacy data with `\` separators produces correct trees.

### Description
- Normalize backslashes to forward slashes before splitting paths in both `render_analysis_tree` and `render_handoff_tree` in `crates/tokmd-export-tree/src/lib.rs`.
- Added focused BDD-style tests `analysis_tree_normalizes_windows_separator` and `handoff_tree_normalizes_windows_separator` to lock the behavior in the crate's test grid.
- Ensured code is formatted and consistent with project style using the workspace formatting rules.

### Testing
- Ran `cargo fmt-check` which passed after applying formatting fixes.
- Ran `cargo test -p tokmd-export-tree --tests` and all unit, integration, and property tests for the `tokmd-export-tree` crate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578d3ed0833390a14e39218536f3)