### PR TITLE
fix(content): count newline bytes when enforcing `read_lines` max_bytes

### DIFF
--- a/crates/tokmd-content/src/lib.rs
+++ b/crates/tokmd-content/src/lib.rs
@@ -77,13 +77,27 @@ pub fn read_lines(path: &Path, max_lines: usize, max_bytes: usize) -> Result<Vec
         return Ok(Vec::new());
     }
     let file = File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut lines = Vec::new();
     let mut bytes = 0usize;
 
-    for line in reader.lines() {
-        let line = line?;
-        bytes += line.len();
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line)?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        bytes += bytes_read;
+
+        // Keep parity with BufRead::lines() output by stripping newline endings.
+        if line.ends_with('\n') {
+            line.pop();
+            if line.ends_with('\r') {
+                line.pop();
+            }
+        }
+
         lines.push(line);
         if lines.len() >= max_lines || bytes >= max_bytes {
             break;
@@ -296,6 +310,19 @@ mod tests {
         assert_eq!(lines.len(), 2, "Should stop after reaching 10 bytes");
         assert_eq!(lines[0], "12345");
         assert_eq!(lines[1], "67890");
+    }
+
+    #[test]
+    fn test_read_lines_max_bytes_counts_newline_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("newline_bytes.txt");
+        let mut f = File::create(&path).unwrap();
+        writeln!(f, "abc").unwrap();
+        writeln!(f, "def").unwrap();
+
+        // "abc\n" is 4 bytes. With a max of 4, the second line should not be read.
+        let lines = read_lines(&path, 100, 4).unwrap();
+        assert_eq!(lines, vec!["abc"]);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `read_lines` previously measured consumed bytes using `line.len()`, which ignored newline characters and could allow reading past the configured `max_bytes` cap on multi-line files.
- Accurate byte accounting is important for callers that rely on a strict `max_bytes` cap when sampling file contents for analysis or hashing.

### Description
- Updated `tokmd-content::read_lines` to read lines using `BufRead::read_line` and accumulate the actual bytes read (including newline bytes) so the `max_bytes` limit is correctly enforced while reading from disk.
- Preserved prior behavior for returned lines by trimming trailing `\n` and optional `\r` so callers still receive lines without newline endings.
- Added a regression unit test `test_read_lines_max_bytes_counts_newline_bytes` that verifies a `max_bytes` equal to a single line plus newline prevents reading the next line.

### Testing
- Ran the new and related unit tests: `cargo test -p tokmd-content test_read_lines_max_bytes_counts_newline_bytes -- --exact` and `cargo test -p tokmd-content test_read_lines_bytes_accumulate_correctly -- --exact`, both of which passed.
- Ran `cargo fmt-check` to verify formatting, which completed successfully.
- Also ran the crate test suite iteratively while developing; the targeted tests passed and no regressions were introduced in `tokmd-content` unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578ad58c833392ff3380ba04d17d)