### PR TITLE
content: enforce token boundaries in tag counting

### DIFF
--- a/crates/tokmd-content/src/lib.rs
+++ b/crates/tokmd-content/src/lib.rs
@@ -115,11 +115,43 @@ pub fn hash_file(path: &Path, max_bytes: usize) -> Result<String> {
 }
 
 pub fn count_tags(text: &str, tags: &[&str]) -> Vec<(String, usize)> {
-    let upper = text.to_uppercase();
+    fn is_token_char(byte: u8) -> bool {
+        byte.is_ascii_alphanumeric() || byte == b'_' || !byte.is_ascii()
+    }
+
+    fn count_tag_matches(text: &str, tag: &str) -> usize {
+        if tag.is_empty() {
+            return 0;
+        }
+
+        let haystack = text.as_bytes();
+        let needle = tag.as_bytes();
+
+        if needle.len() > haystack.len() {
+            return 0;
+        }
+
+        let mut count = 0usize;
+        for start in 0..=(haystack.len() - needle.len()) {
+            let end = start + needle.len();
+            if !haystack[start..end].eq_ignore_ascii_case(needle) {
+                continue;
+            }
+
+            let leading_boundary = start == 0 || !is_token_char(haystack[start - 1]);
+            let trailing_boundary = end == haystack.len() || !is_token_char(haystack[end]);
+
+            if leading_boundary && trailing_boundary {
+                count += 1;
+            }
+        }
+
+        count
+    }
+
     tags.iter()
         .map(|tag| {
-            let needle = tag.to_uppercase();
-            let count = upper.matches(&needle).count();
+            let count = count_tag_matches(text, tag);
             (tag.to_string(), count)
         })
         .collect()

--- a/crates/tokmd-content/tests/bdd.rs
+++ b/crates/tokmd-content/tests/bdd.rs
@@ -343,6 +343,17 @@ mod tag_counting {
     }
 
     #[test]
+    fn scenario_does_not_count_tags_inside_words() {
+        // Given text where tags appear inside larger words
+        let text = "important import_data TODO";
+        // When we count import and TODO tags
+        let result = count_tags(text, &["import", "TODO"]);
+        // Then only standalone TODO is counted
+        assert_eq!(result[0], ("import".to_string(), 0));
+        assert_eq!(result[1], ("TODO".to_string(), 1));
+    }
+
+    #[test]
     fn scenario_empty_text_yields_zero_counts() {
         // Given empty text
         let result = count_tags("", &["TODO", "FIXME", "HACK"]);
@@ -801,13 +812,13 @@ mod tag_counting_edge_cases {
     }
 
     #[test]
-    fn scenario_count_tags_adjacent_occurrences() {
-        // Given text with adjacent tag occurrences
+    fn scenario_count_tags_adjacent_occurrences_require_boundaries() {
+        // Given text with adjacent tag occurrences but no separators
         let text = "TODOTODOTODO";
         // When we count TODO
         let result = count_tags(text, &["TODO"]);
-        // Then all occurrences found
-        assert_eq!(result[0].1, 3);
+        // Then no standalone token is counted
+        assert_eq!(result[0].1, 0);
     }
 }
 

--- a/crates/tokmd-content/tests/bdd_extended.rs
+++ b/crates/tokmd-content/tests/bdd_extended.rs
@@ -256,8 +256,8 @@ fn test_given_overlapping_tags_when_counted_then_independent() {
     // "TODO" and "TODOS" searched independently
     let text = "TODO TODOS TODO";
     let result = count_tags(text, &["TODO", "TODOS"]);
-    // "TODO" appears at positions 0, 5 (inside TODOS), and 11 → 3 matches
-    assert_eq!(result[0], ("TODO".to_string(), 3));
+    // "TODO" appears only as a standalone token at positions 0 and 11.
+    assert_eq!(result[0], ("TODO".to_string(), 2));
     // "TODOS" appears at position 5 → 1 match
     assert_eq!(result[1], ("TODOS".to_string(), 1));
 }
@@ -270,10 +270,10 @@ fn test_given_tag_at_start_and_end_when_counted_then_both_found() {
 }
 
 #[test]
-fn test_given_adjacent_tags_when_counted_then_all_found() {
+fn test_given_adjacent_tags_when_counted_then_none_found_without_separators() {
     let text = "TODOTODOTODO";
     let result = count_tags(text, &["TODO"]);
-    assert_eq!(result[0].1, 3);
+    assert_eq!(result[0].1, 0);
 }
 
 // ============================================================================

--- a/crates/tokmd-content/tests/content_depth_w60.rs
+++ b/crates/tokmd-content/tests/content_depth_w60.rs
@@ -210,18 +210,26 @@ mod tag_detection {
     }
 
     #[test]
-    fn adjacent_tags_all_counted() {
-        // "TODOTODO" contains "TODO" starting at 0 and at 4
+    fn adjacent_tags_without_separator_are_not_counted() {
+        // "TODOTODO" has no token boundary between tags.
         let result = count_tags("TODOTODO", &["TODO"]);
-        assert_eq!(result[0].1, 2);
+        assert_eq!(result[0].1, 0);
     }
 
     #[test]
-    fn overlapping_tags_counted_by_matches() {
-        // str::matches is non-overlapping
+    fn repeated_tags_without_separator_are_not_counted() {
+        // Tokens must be separated by non-word boundaries.
         let text = "TODOTODOTODO";
         let result = count_tags(text, &["TODO"]);
-        assert_eq!(result[0].1, 3);
+        assert_eq!(result[0].1, 0);
+    }
+
+    #[test]
+    fn tags_inside_identifiers_are_not_counted() {
+        let text = "important TODO import_data imported";
+        let result = count_tags(text, &["import", "TODO"]);
+        assert_eq!(result[0].1, 0);
+        assert_eq!(result[1].1, 1);
     }
 
     #[test]

--- a/crates/tokmd-content/tests/content_depth_w63.rs
+++ b/crates/tokmd-content/tests/content_depth_w63.rs
@@ -178,12 +178,11 @@ fn count_tags_custom_markers() {
 }
 
 #[test]
-fn count_tags_partial_match_counted() {
-    // "TODOLIST" contains "TODO"
+fn count_tags_partial_match_not_counted() {
+    // "TODOLIST" contains "TODO" but not as a standalone token.
     let text = "TODOLIST is not a real tag\n";
     let tags = count_tags(text, &["TODO"]);
-    // Substring match — "TODO" appears in "TODOLIST"
-    assert_eq!(tags[0].1, 1);
+    assert_eq!(tags[0].1, 0);
 }
 
 // ============================================================================

--- a/crates/tokmd-content/tests/deep.rs
+++ b/crates/tokmd-content/tests/deep.rs
@@ -117,12 +117,8 @@ fn high_entropy_vs_low_entropy_ordering() {
 fn rust_use_statements_detected() {
     let code = "use std::io;\nuse std::fs;\nlet x = use_something();";
     let result = count_tags(code, &["use"]);
-    // "use" appears in all three lines (case-insensitive match)
-    assert!(
-        result[0].1 >= 3,
-        "expected >=3 'use' matches, got {}",
-        result[0].1
-    );
+    // Only standalone "use" tokens are counted.
+    assert_eq!(result[0].1, 2, "expected 2 standalone 'use' matches");
 }
 
 #[test]
@@ -191,10 +187,10 @@ fn main() {
 }
 
 #[test]
-fn adjacent_tags_counted() {
+fn adjacent_tags_require_token_boundaries() {
     let text = "TODOTODOTODO";
     let result = count_tags(text, &["TODO"]);
-    assert_eq!(result[0].1, 3);
+    assert_eq!(result[0].1, 0);
 }
 
 #[test]

--- a/crates/tokmd-content/tests/deep_content_w48.rs
+++ b/crates/tokmd-content/tests/deep_content_w48.rs
@@ -190,7 +190,10 @@ fn count_tags_empty_text() {
 fn count_tags_adjacent_occurrences() {
     let text = "TODOTODOTODO";
     let tags = count_tags(text, &["TODO"]);
-    assert_eq!(tags[0].1, 3, "Adjacent TODOs should be counted separately");
+    assert_eq!(
+        tags[0].1, 0,
+        "Adjacent TODOs without separators are not standalone tokens"
+    );
 }
 
 // ============================================================================

--- a/crates/tokmd-content/tests/proptest_w56.rs
+++ b/crates/tokmd-content/tests/proptest_w56.rs
@@ -112,7 +112,7 @@ proptest! {
         tag_case in prop::sample::select(vec!["todo", "Todo", "TODO", "tOdO"]),
         suffix in "[a-zA-Z ]{0,20}",
     ) {
-        let text = format!("{}{}{}", prefix, tag_case, suffix);
+        let text = format!("{} {} {}", prefix, tag_case, suffix);
         let results = tokmd_content::count_tags(&text, &["TODO"]);
         prop_assert!(results[0].1 >= 1,
             "Should find at least 1 TODO in '{}', got {}", text, results[0].1);


### PR DESCRIPTION
### Motivation
- The previous `count_tags` used raw substring matching which produced false positives when tags appeared inside identifiers or adjacent without separators, skewing analysis metrics.

### Description
- Replace substring-based counting with a boundary-aware matcher that searches bytes with `eq_ignore_ascii_case` and validates token boundaries via `is_token_char`, preserving case-insensitive matching and input tag order.
- Implemented `count_tag_matches(text, tag)` and updated `count_tags` to call it, returning `Vec<(String, usize)>` as before.
- Updated BDD, deep and property tests to lock in the new semantics (reject tags inside words, require non-word boundaries between adjacent occurrences, and preserve standalone matches).
- Adjusted the property-based case-insensitivity test input to include separators so it exercises the token-boundary contract.

### Testing
- Ran `cargo test -p tokmd-content` (including `proptest_w56`, `bdd`, `deep`, `content_depth_*`, and other crate tests) and all tests in the `tokmd-content` crate passed.
- Ran `cargo fmt-check` / workspace lint steps and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578ad58c833392ff3380ba04d17d)