### PR TITLE
palette: Suggest correct subcommand on typos instead of generic path error 🎨

### DIFF
--- a/.jules/runs/run-palette-dx/decision.md
+++ b/.jules/runs/run-palette-dx/decision.md
@@ -1,0 +1,131 @@
+### Option A (recommended)
+Add the command name `export` explicitly to the error message when `--filter` is supplied because it is not supported in the root command and a confusing message is presented by Clap ("unexpected argument '--filter' found"). Actually, Clap produces the error message: `error: unexpected argument '--filter' found`.
+
+However, an even better improvement is improving the output from `path not found`. Right now it emits:
+```
+Error: Path not found: non_existent_file
+
+Hints:
+- Verify the input path exists and is readable.
+- Use an absolute path to avoid working-directory confusion.
+- If this was meant to be a subcommand, it is not recognized. Use `tokmd --help`.
+```
+Wait, the hints *are* already there.
+
+Let's look at `cargo run -- export --format foo .` which emits:
+```
+error: invalid value 'foo' for '--format <FORMAT>'
+  [possible values: csv, jsonl, json, cyclonedx]
+```
+This is clap's standard error.
+
+Let's look at `error_hints.rs`:
+```rust
+fn suggestions(err: &Error) -> Vec<String> {
+    // ...
+    if haystack.contains("path not found")
+        || haystack.contains("input path does not exist")
+        || haystack.contains("no such file or directory")
+    {
+        push_hint(&mut out, "Verify the input path exists and is readable.");
+        push_hint(
+            &mut out,
+            "Use an absolute path to avoid working-directory confusion.",
+        );
+        push_hint(
+            &mut out,
+            "If this was meant to be a subcommand, it is not recognized. Use `tokmd --help`.",
+        );
+    }
+```
+Wait, `path not found` error prints `If this was meant to be a subcommand, it is not recognized. Use tokmd --help.`
+This is because when you run `tokmd non_existent_command`, it treats `non_existent_command` as a `[PATH]` because `[PATH]...` is a positional argument, and it fails to find the path.
+
+What if we improve this by specifically checking if the missing path looks like a subcommand? If the path has no slashes or dots, and it's the only argument, it's highly likely they meant a subcommand. We can suggest the closest matching subcommand using something like Levenshtein distance, or at least suggest `Run tokmd help <command>` if it's close.
+
+Actually, we already have `difflib::get_close_matches` available in `crates/tokmd/src/error_hints.rs`? Let's check `cargo tree` or `Cargo.toml`. `difflib` is in `Cargo.toml` (`difflib = "0.4.0"`). Or we can just use `strsim` which is also compiled (`strsim v0.11.1`).
+Wait, `strsim` is used by `clap`. We can just write a simple levenshtein distance function or check known commands.
+
+Wait, the "path not found" error doesn't include the *name* of the path easily without regex, but we can extract it: `Path not found: tokmd` -> extract `tokmd`.
+
+Let's check `tokmd --help`. Available commands:
+`lang`, `module`, `export`, `analyze`, `badge`, `init`, `completions`, `run`, `diff`, `context`, `check-ignore`, `tools`, `gate`, `cockpit`, `baseline`, `handoff`, `sensor`, `help`.
+
+If someone types `tokmd runn`, it says:
+`Error: Path not found: runn`
+Hints:
+- If this was meant to be a subcommand, it is not recognized. Use `tokmd --help`.
+
+What if we explicitly add the actual CLI typo suggestion? e.g., "Did you mean 'run'?"
+
+Let's look at `crates/tokmd/src/error_hints.rs` again.
+If we can extract the path from the error message.
+```rust
+    if haystack.contains("path not found:") {
+        // extract path
+    }
+```
+
+Wait, another issue is:
+```bash
+cargo run -- tokmd
+```
+`Error: Path not found: tokmd` (if there's no folder named tokmd).
+Wait, if I run `tokmd init` it works. If I run `tokmd` with no args it runs `lang` (default). If I run `tokmd unknown_command`, clap parses it as `PATH` because `[PATH]...` is the first positional argument.
+
+In `crates/tokmd-config/src/cli_enums.rs` or `lib.rs`:
+```rust
+pub struct Cli {
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub paths: Option<Vec<PathBuf>>,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+```
+Wait, in `tokmd` the CLI usage is:
+```
+Usage: tokmd [OPTIONS] [PATH]... [COMMAND]
+```
+So `[PATH]` is parsed before `[COMMAND]`.
+If you pass a command it doesn't recognize, it treats it as a path.
+If that path doesn't exist, it errors out at the scan phase.
+
+Is there a way to make clap error out on unknown subcommands instead of treating them as paths, UNLESS they actually exist as paths?
+No, clap's parsing is fixed. But we can improve the hint.
+
+Let's improve `error_hints.rs` by adding a fuzzy-matching suggestion for subcommands.
+
+```rust
+    if haystack.contains("path not found:") {
+        // extract the missing path name
+        // if it's a single word with no slashes, compare it to known subcommands
+        // if close, add a hint: "Did you mean the subcommand `...`?"
+    }
+```
+
+Let's write a simple Levenshtein distance or just a hardcoded matcher.
+
+Another option: "confusing diagnostics" or "unclear or low-context error messages".
+What if we look at `tokmd-config`?
+
+Let's check what Option B could be.
+Option B:
+Improve `tokmd diff` missing source error message.
+Currently:
+```
+Error: Failed to load diff source 'missing_file.json': Failed to create worktree for 'missing_file.json': git worktree add failed for 'missing_file.json'
+
+Hints:
+- If you meant to compare files, ensure they both exist locally.
+- If you meant to compare git refs, ensure the branch, tag, or commit exists.
+```
+This is pretty good already.
+
+Let's implement Option A: Typo correction for subcommands that get swallowed as paths.
+
+When a user types `tokmd ran` instead of `tokmd run`, they get `Path not found: ran`.
+This is a classic "confusing diagnostic" because the tool implies they asked it to scan a file called "ran", when they clearly meant to invoke a command.
+Adding a typo suggestion "Did you mean the 'run' command?" makes this much clearer.
+
+I will write this into `decision.md` and proceed with Option A.

--- a/.jules/runs/run-palette-dx/envelope.json
+++ b/.jules/runs/run-palette-dx/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "palette_runtime_dx",
+  "persona": "palette",
+  "style": "builder",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": ["pr_ready_patch", "learning_pr"]
+}

--- a/.jules/runs/run-palette-dx/pr_body.md
+++ b/.jules/runs/run-palette-dx/pr_body.md
@@ -1,0 +1,72 @@
+## 💡 Summary
+Improved the `tokmd` "Path not found" error message to automatically detect and suggest subcommand typos. When a user runs `tokmd expor` (instead of `export`), the CLI now provides a helpful "did you mean `export`?" hint instead of only telling them that the path doesn't exist.
+
+## 🎯 Why
+When an unrecognized subcommand is passed to `tokmd` (e.g. `tokmd ran`), Clap naturally parses it as the `[PATH]...` positional argument. This means the user gets a confusing "Path not found: ran" error. While there was a generic hint about subcommands, adding a Levenshtein-based spell-checker makes the error significantly more actionable and reduces friction for common typos.
+
+## 🔎 Evidence
+* **Before:**
+  ```
+  $ cargo run -- expor
+  Error: Path not found: expor
+
+  Hints:
+  - Verify the input path exists and is readable.
+  - Use an absolute path to avoid working-directory confusion.
+  - If this was meant to be a subcommand, it is not recognized. Use `tokmd --help`.
+  ```
+* **After:**
+  ```
+  $ cargo run -- expor
+  Error: Path not found: expor
+
+  Hints:
+  - Verify the input path exists and is readable.
+  - Use an absolute path to avoid working-directory confusion.
+  - If this was meant to be a subcommand, did you mean `export`?
+  ```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add a lightweight, built-in Levenshtein distance check to `error_hints.rs`.
+- Why it fits: Solves a sharp edge natively in `tokmd` without adding a new heavy dependency or trying to hack clap's argument parsing behavior.
+- Structure / Velocity / Governance: No new dependencies needed (implemented a simple algorithm inline).
+
+### Option B
+- Modify Clap's parsing sequence to force subcommands to be checked first.
+- Why to choose it: Would avoid the "path not found" misclassification entirely.
+- Trade-offs: Clap doesn't easily support this without complex overrides that might break the standard `tokmd [OPTIONS] [PATH] [COMMAND]` fallback behavior where `[COMMAND]` can be omitted to default to `lang`.
+
+## ✅ Decision
+Option A was chosen. Adding a custom fuzzy match to the `suggestions()` function handles the UX papercut exactly at the moment the error is rendered, while maintaining standard `clap` parsing logic.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd/src/error_hints.rs`: Added `levenshtein()` string distance function and logic to extract the missing path and suggest known `tokmd` subcommands.
+
+## 🧪 Verification receipts
+```text
+cargo test -p tokmd --test cli_e2e_w65
+test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.55s
+
+cargo test -p tokmd
+test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out;
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out;
+test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out;
+```
+
+## 🧭 Telemetry
+- Change shape: CLI error hint enrichment
+- Blast radius: Only affects the text of the CLI output when a "Path not found" error is raised.
+- Risk class: Low
+- Rollback: Revert the `error_hints.rs` changes.
+- Gates run: `cargo test -p tokmd`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-palette-dx/envelope.json`
+- `.jules/runs/run-palette-dx/decision.md`
+- `.jules/runs/run-palette-dx/receipts.jsonl`
+- `.jules/runs/run-palette-dx/result.json`
+- `.jules/runs/run-palette-dx/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-palette-dx/receipts.jsonl
+++ b/.jules/runs/run-palette-dx/receipts.jsonl
@@ -1,0 +1,1 @@
+{"command": "cargo test -p tokmd --test cli_e2e_w65", "result": "ok"}

--- a/.jules/runs/run-palette-dx/result.json
+++ b/.jules/runs/run-palette-dx/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "change_type": "patch",
+  "reasoning": "Improved 'path not found' error to heuristically suggest if the user mistyped a subcommand (e.g. `tokmd expor`). Also used explicit paths to ensure correct error formats in tests."
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,6 +2849,7 @@ dependencies = [
 name = "tokmd-analysis-types"
 version = "1.9.0"
 dependencies = [
+ "chrono",
  "proptest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,7 +2849,6 @@ dependencies = [
 name = "tokmd-analysis-types"
 version = "1.9.0"
 dependencies = [
- "chrono",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -14,9 +14,46 @@ pub(crate) fn format(err: &Error) -> String {
     out
 }
 
+fn extract_path_from_error(haystack: &str) -> Option<String> {
+    if let Some(idx) = haystack.find("path not found: ") {
+        let path = &haystack[idx + "path not found: ".len()..];
+        // Take up to the first newline or end of string
+        let path = path.split('\n').next().unwrap_or(path).trim();
+        return Some(path.to_string());
+    }
+    None
+}
+
+// Simple Levenshtein distance since strsim isn't a direct dependency
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a_chars: Vec<char> = a.chars().collect();
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut dists = vec![vec![0; b_chars.len() + 1]; a_chars.len() + 1];
+
+    for i in 0..=a_chars.len() {
+        dists[i][0] = i;
+    }
+    for j in 0..=b_chars.len() {
+        dists[0][j] = j;
+    }
+
+    for i in 1..=a_chars.len() {
+        for j in 1..=b_chars.len() {
+            let cost = if a_chars[i - 1] == b_chars[j - 1] { 0 } else { 1 };
+            dists[i][j] = (dists[i - 1][j] + 1)
+                .min(dists[i][j - 1] + 1)
+                .min(dists[i - 1][j - 1] + cost);
+        }
+    }
+
+    dists[a_chars.len()][b_chars.len()]
+}
+
 fn suggestions(err: &Error) -> Vec<String> {
     let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
-    let haystack = chain.join(" | ").to_ascii_lowercase();
+    // Keep original case for path extraction, lowercased for general matching
+    let full_error_text = chain.join(" | ");
+    let haystack = full_error_text.to_ascii_lowercase();
     let mut out: Vec<String> = Vec::new();
 
     if haystack.contains("git is not available on path")
@@ -41,15 +78,40 @@ fn suggestions(err: &Error) -> Vec<String> {
         || haystack.contains("input path does not exist")
         || haystack.contains("no such file or directory")
     {
+        let mut subcommand_hint = "If this was meant to be a subcommand, it is not recognized. Use `tokmd --help`.".to_string();
+
+        // Try to identify if the missing path looks like a misspelled subcommand
+        if let Some(missing_path) = extract_path_from_error(&full_error_text.to_ascii_lowercase()) {
+            if !missing_path.contains('/') && !missing_path.contains('\\') && !missing_path.contains('.') {
+                let known_commands = [
+                    "lang", "module", "export", "analyze", "badge", "init",
+                    "completions", "run", "diff", "context", "check-ignore",
+                    "tools", "gate", "cockpit", "baseline", "handoff", "sensor", "help"
+                ];
+
+                let mut closest = None;
+                let mut best_dist = usize::MAX;
+
+                for cmd in &known_commands {
+                    let dist = levenshtein(cmd, &missing_path);
+                    if dist < 3 && dist < best_dist {
+                        closest = Some(*cmd);
+                        best_dist = dist;
+                    }
+                }
+
+                if let Some(cmd) = closest {
+                    subcommand_hint = format!("If this was meant to be a subcommand, did you mean `{}`?", cmd);
+                }
+            }
+        }
+
         push_hint(&mut out, "Verify the input path exists and is readable.");
         push_hint(
             &mut out,
             "Use an absolute path to avoid working-directory confusion.",
         );
-        push_hint(
-            &mut out,
-            "If this was meant to be a subcommand, it is not recognized. Use `tokmd --help`.",
-        );
+        push_hint(&mut out, &subcommand_hint);
     }
 
     if haystack.contains("base ref") && haystack.contains("not found") {
@@ -121,6 +183,13 @@ mod tests {
                 .iter()
                 .any(|h| h.contains("subcommand, it is not recognized"))
         );
+    }
+
+    #[test]
+    fn suggests_typo_for_missing_path() {
+        let err = anyhow!("Path not found: expor");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("did you mean `export`?")));
     }
 
     #[test]


### PR DESCRIPTION
Added a built-in string distance check in `error_hints.rs` to detect common subcommand typos that are mistakenly parsed as paths.

---
*PR created automatically by Jules for task [15547413599644349561](https://jules.google.com/task/15547413599644349561) started by @EffortlessSteven*