### PR TITLE
fix: satisfy linux clippy determinism lint

### DIFF
--- a/crates/tokmd/tests/determinism_hardening_w51.rs
+++ b/crates/tokmd/tests/determinism_hardening_w51.rs
@@ -270,11 +270,9 @@ fn w51_analyze_paths_use_forward_slashes() {
                     && !path.contains("integrity")
                     && s.contains('\\')
                     && s.contains(std::path::MAIN_SEPARATOR)
+                    && (s.contains(".rs") || s.contains(".js") || s.contains(".md"))
                 {
-                    // Only flag if it looks like a file path
-                    if s.contains(".rs") || s.contains(".js") || s.contains(".md") {
-                        panic!("backslash in path-like string at {path}: {s}");
-                    }
+                    panic!("backslash in path-like string at {path}: {s}");
                 }
             }
             Value::Object(map) => {


### PR DESCRIPTION
## Summary
- collapse the determinism path-like string check into one condition
- fixes the Linux clippy gate failure after #1288

## Validation
- cargo fmt-check
- cargo clippy -p tokmd --test determinism_hardening_w51 --all-features -- -D warnings