### PR TITLE
policy: classify publish surface by boundary role

### DIFF
--- a/docs/publish-surface.md
+++ b/docs/publish-surface.md
@@ -1,35 +1,110 @@
 # Tokmd Publish Surface and Closure Policy
 
-Status: canonical current/target publish policy baseline.
+Status: canonical publish-surface classification baseline.
 
 ## Why this exists (ADR-level rationale)
 
 The current architecture moved too far from microcrate-as-architecture to microcrate-as-surface-area.
 
-The packaging direction is now explicit:
+The packaging direction is explicit:
 
-- keep an intentional published/public surface;
-- keep genuine reusable contracts as published support crates;
-- absorb everything else into SRP folders inside owning public crates;
+- publish product, contract, workflow, and capability boundaries;
+- keep internal SRP seams as module families under owner crates;
+- treat conditional public crates as pending boundary decisions, not default promises;
+- keep dev/tool/binding packages off the crates.io dependency closure;
 - enforce publishability with a closure proof, not package-count aesthetics.
 
 This is the hard rule: publishing correctness is defined by dependency closure, not by a broad `publish = false` pass.
+
+A published crate is a support promise. A module folder is an architecture seam.
 
 ## Publication model
 
 `publish = false` is policy-only and valid only for crates that are truly outside the crates.io closure.
 
 For publishability, every intended public crate must have a full non-dev workspace dependency closure that references only:
-- published public crates
-- published support crates
-- crates intentionally outside the product surface (4 non-crates.io packages)
+- classified published crates
+- conditional public crates while their boundary memo is still pending
+- crates intentionally outside the product surface only when they are not in the non-dev closure
 
-If a public or support crate depends on anything else, that dependency must be merged into an owner module first.
+If a published crate depends on anything else through a normal or build dependency, that dependency must be classified for publication or merged into an owner module first. Dev-dependencies are not part of the publish closure.
 
-## Current publish surface (36 crates published + 4 non-crates.io)
+## Forward policy classes
 
-This is the current honest crates.io closure, and it matches the encoded target
-publish surface.
+These are the policy classes the checker now reports. The older `public_surface`
+and `support_surface` JSON fields remain compatibility fields for existing
+automation.
+
+### Public product crates (3)
+
+- `tokmd`
+- `tokmd-core`
+- `tokmd-wasm`
+
+### Public contract crates (5)
+
+- `tokmd-analysis-types`
+- `tokmd-envelope`
+- `tokmd-io-port`
+- `tokmd-settings`
+- `tokmd-types`
+
+### Public workflow crates (3)
+
+- `tokmd-cockpit`
+- `tokmd-gate`
+- `tokmd-sensor`
+
+### Public capability crates (5)
+
+- `tokmd-analysis`
+- `tokmd-format`
+- `tokmd-git`
+- `tokmd-model`
+- `tokmd-scan`
+
+### Conditional public crates (5)
+
+These packages need focused boundary memos before the repo decides whether they
+remain public or collapse into owner modules.
+
+- `tokmd-content`
+- `tokmd-ffi-envelope`
+- `tokmd-fun`
+- `tokmd-substrate`
+- `tokmd-walk`
+
+### Internal module families still packaged today (14)
+
+These are current crates.io package boundaries that should be treated as
+transitional implementation seams, not the desired final registry surface.
+
+- `tokmd-analysis-api-surface`
+- `tokmd-analysis-complexity`
+- `tokmd-analysis-content`
+- `tokmd-analysis-effort`
+- `tokmd-analysis-entropy`
+- `tokmd-analysis-explain`
+- `tokmd-analysis-format`
+- `tokmd-analysis-git`
+- `tokmd-analysis-halstead`
+- `tokmd-analysis-html`
+- `tokmd-analysis-imports`
+- `tokmd-analysis-license`
+- `tokmd-analysis-maintainability`
+- `tokmd-analysis-near-dup`
+
+### Dev-only package under policy review (1)
+
+- `tokmd-test-support`
+
+It remains publishable in the compatibility support surface until a focused
+test reproducibility decision changes that policy.
+
+## Current compatibility surface (36 crates published + 4 non-crates.io)
+
+This is the current honest crates.io closure. It matches the encoded
+compatibility target, but it is not the final product/contract/capability model.
 
 ### Supported public crates (13)
 
@@ -47,7 +122,7 @@ publish surface.
 - `tokmd-types`
 - `tokmd-wasm`
 
-### Published support crates (23)
+### Published support crates (23, compatibility classification)
 
 - `tokmd-analysis`
 - `tokmd-analysis-api-surface`
@@ -75,6 +150,9 @@ publish surface.
 
 **Count:** 23 published support crates.
 
+Support is now a compatibility classification for existing automation. It is
+not the final desired category.
+
 ## Non-crates.io packages (intentional exceptions) (4)
 
 - `tokmd-fuzz`
@@ -84,10 +162,11 @@ publish surface.
 
 **Count:** 4 non-crates.io packages.
 
-## Target publish surface
+## Compatibility target surface
 
-The target public surface remains the supported public API surface. The target
-support surface now matches the current closure. `target_gap` is zero.
+The compatibility target public surface remains the supported public API
+surface. The compatibility support surface now matches the current closure.
+`target_gap` is zero.
 
 ### Target public crates (13)
 
@@ -119,7 +198,7 @@ Same as the current supported public crates.
 - `tokmd-test-support`
 - `tokmd-walk`
 
-### Target gap: planned support retirements (0)
+### Target gap: planned compatibility support retirements (0)
 
 The checker hard-fails if a current support crate is not classified as either
 target support or target gap.
@@ -135,18 +214,17 @@ dev-dependencies alone do not force this crate into the support surface.
 Changing `tokmd-test-support` back to internal/dev-only should be a focused
 follow-up that decides the test reproducibility contract first.
 
-## PR A scope guardrail
+## Scope guardrail
 
-PR A is **truth-first**:
+Publish-surface policy work is **truth-first**:
 
 - publish-surface documentation
 - closure/reporting command
 - machine-readable classification
 - CI `--json --verify-publish` checks
 
-It makes only the owner-module moves that are needed to remove already-decided
-packaging helper crates from the publish closure. Deeper analysis-crate
-consolidation remains future work.
+Crate-collapse work should stay in focused follow-ups. Deeper analysis-crate
+consolidation, renderer migration, and gray-zone decisions remain future work.
 
 ## Hard rule
 
@@ -191,6 +269,14 @@ The JSON report includes:
 - `summary.target_support_surface`
 - `summary.target_gap`
 - `summary.new_unapproved_support_crates`
+- `summary.public_product_crates`
+- `summary.public_contract_crates`
+- `summary.public_workflow_crates`
+- `summary.public_capability_crates`
+- `summary.conditional_public_crates`
+- `summary.internal_module_families`
+- `summary.dev_only_packages`
+- `summary.new_unclassified_packages`
 - per-target `non_dev_workspace_closure`
 - per-target `required_public`, `required_support`, `required_internal`, `required_non_crates_io`
 - `violations`
@@ -204,4 +290,6 @@ Violations include:
 - non-publishable crates in the current non-dev publish closure
 - current support crates not classified as target support or target gap
 - stale target support or target-gap entries after a crate is retired
+- workspace packages not classified in the forward policy model
+- stale forward policy entries after a package is removed
 - Cargo packaging validation failures

--- a/xtask/src/tasks/publish_surface.rs
+++ b/xtask/src/tasks/publish_surface.rs
@@ -48,6 +48,53 @@ const PUBLISHED_SUPPORT_CRATES: &[&str] = &[
     "tokmd-walk",
 ];
 
+const PUBLIC_PRODUCT_CRATES: &[&str] = &["tokmd", "tokmd-core", "tokmd-wasm"];
+
+const PUBLIC_CONTRACT_CRATES: &[&str] = &[
+    "tokmd-analysis-types",
+    "tokmd-envelope",
+    "tokmd-io-port",
+    "tokmd-settings",
+    "tokmd-types",
+];
+
+const PUBLIC_WORKFLOW_CRATES: &[&str] = &["tokmd-cockpit", "tokmd-gate", "tokmd-sensor"];
+
+const PUBLIC_CAPABILITY_CRATES: &[&str] = &[
+    "tokmd-analysis",
+    "tokmd-format",
+    "tokmd-git",
+    "tokmd-model",
+    "tokmd-scan",
+];
+
+const CONDITIONAL_PUBLIC_CRATES: &[&str] = &[
+    "tokmd-content",
+    "tokmd-ffi-envelope",
+    "tokmd-fun",
+    "tokmd-substrate",
+    "tokmd-walk",
+];
+
+const INTERNAL_MODULE_FAMILIES: &[&str] = &[
+    "tokmd-analysis-api-surface",
+    "tokmd-analysis-complexity",
+    "tokmd-analysis-content",
+    "tokmd-analysis-effort",
+    "tokmd-analysis-entropy",
+    "tokmd-analysis-explain",
+    "tokmd-analysis-format",
+    "tokmd-analysis-git",
+    "tokmd-analysis-halstead",
+    "tokmd-analysis-html",
+    "tokmd-analysis-imports",
+    "tokmd-analysis-license",
+    "tokmd-analysis-maintainability",
+    "tokmd-analysis-near-dup",
+];
+
+const DEV_ONLY_PACKAGES: &[&str] = &["tokmd-test-support"];
+
 const TARGET_SUPPORT_CRATES: &[&str] = &[
     "tokmd-analysis",
     "tokmd-analysis-api-surface",
@@ -102,6 +149,14 @@ struct PublishSurfaceSummary {
     target_support_surface: Vec<String>,
     target_gap: Vec<String>,
     new_unapproved_support_crates: Vec<String>,
+    public_product_crates: Vec<String>,
+    public_contract_crates: Vec<String>,
+    public_workflow_crates: Vec<String>,
+    public_capability_crates: Vec<String>,
+    conditional_public_crates: Vec<String>,
+    internal_module_families: Vec<String>,
+    dev_only_packages: Vec<String>,
+    new_unclassified_packages: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -160,6 +215,13 @@ pub fn run(args: PublishSurfaceArgs) -> Result<()> {
     let target_public_surface = public_surface.clone();
     let target_support_surface = sort_unique(TARGET_SUPPORT_CRATES);
     let target_gap = sort_unique(TARGET_SUPPORT_GAP_CRATES);
+    let public_product_crates = sort_unique(PUBLIC_PRODUCT_CRATES);
+    let public_contract_crates = sort_unique(PUBLIC_CONTRACT_CRATES);
+    let public_workflow_crates = sort_unique(PUBLIC_WORKFLOW_CRATES);
+    let public_capability_crates = sort_unique(PUBLIC_CAPABILITY_CRATES);
+    let conditional_public_crates = sort_unique(CONDITIONAL_PUBLIC_CRATES);
+    let internal_module_families = sort_unique(INTERNAL_MODULE_FAMILIES);
+    let dev_only_packages = sort_unique(DEV_ONLY_PACKAGES);
 
     let publish_surface: BTreeSet<String> = public_surface
         .iter()
@@ -174,6 +236,24 @@ pub fn run(args: PublishSurfaceArgs) -> Result<()> {
     let target_gap_set: BTreeSet<String> = target_gap.iter().cloned().collect();
     let new_unapproved_support_crates =
         new_unapproved_support_crates(&support_surface_set, &target_support_set, &target_gap_set);
+    let workspace_package_names: BTreeSet<String> = workspace_packages
+        .iter()
+        .map(|package| package.name.to_string())
+        .collect();
+    let policy_classification_set = union_policy_classifications(&[
+        public_product_crates.as_slice(),
+        public_contract_crates.as_slice(),
+        public_workflow_crates.as_slice(),
+        public_capability_crates.as_slice(),
+        conditional_public_crates.as_slice(),
+        internal_module_families.as_slice(),
+        dev_only_packages.as_slice(),
+        non_crates_io_packages.as_slice(),
+    ]);
+    let new_unclassified_packages: Vec<String> = workspace_package_names
+        .difference(&policy_classification_set)
+        .cloned()
+        .collect();
 
     let mut violations = Vec::new();
     classify_target_surface_violations(
@@ -182,6 +262,12 @@ pub fn run(args: PublishSurfaceArgs) -> Result<()> {
         &target_support_set,
         &target_gap_set,
         &new_unapproved_support_crates,
+    );
+    classify_policy_surface_violations(
+        &mut violations,
+        &workspace_package_names,
+        &policy_classification_set,
+        &new_unclassified_packages,
     );
 
     let mut crate_reports = Vec::new();
@@ -309,6 +395,14 @@ pub fn run(args: PublishSurfaceArgs) -> Result<()> {
             target_support_surface,
             target_gap,
             new_unapproved_support_crates,
+            public_product_crates,
+            public_contract_crates,
+            public_workflow_crates,
+            public_capability_crates,
+            conditional_public_crates,
+            internal_module_families,
+            dev_only_packages,
+            new_unclassified_packages,
         },
         crates: crate_reports,
         packaging_checks,
@@ -461,6 +555,72 @@ fn print_human_report(report: &PublishSurface) {
     }
 
     println!(
+        "Public product crates ({}):",
+        report.summary.public_product_crates.len()
+    );
+    for item in &report.summary.public_product_crates {
+        println!("  - {item}");
+    }
+
+    println!(
+        "Public contract crates ({}):",
+        report.summary.public_contract_crates.len()
+    );
+    for item in &report.summary.public_contract_crates {
+        println!("  - {item}");
+    }
+
+    println!(
+        "Public workflow crates ({}):",
+        report.summary.public_workflow_crates.len()
+    );
+    for item in &report.summary.public_workflow_crates {
+        println!("  - {item}");
+    }
+
+    println!(
+        "Public capability crates ({}):",
+        report.summary.public_capability_crates.len()
+    );
+    for item in &report.summary.public_capability_crates {
+        println!("  - {item}");
+    }
+
+    println!(
+        "Conditional public crates ({}):",
+        report.summary.conditional_public_crates.len()
+    );
+    for item in &report.summary.conditional_public_crates {
+        println!("  - {item}");
+    }
+
+    println!(
+        "Internal module families ({}):",
+        report.summary.internal_module_families.len()
+    );
+    for item in &report.summary.internal_module_families {
+        println!("  - {item}");
+    }
+
+    println!(
+        "Dev-only packages ({}):",
+        report.summary.dev_only_packages.len()
+    );
+    for item in &report.summary.dev_only_packages {
+        println!("  - {item}");
+    }
+
+    if !report.summary.new_unclassified_packages.is_empty() {
+        println!(
+            "New unclassified packages ({}):",
+            report.summary.new_unclassified_packages.len()
+        );
+        for item in &report.summary.new_unclassified_packages {
+            println!("  - {item}");
+        }
+    }
+
+    println!(
         "Non-crates.io packages: {}",
         report.summary.current_non_crates_io_surface.len()
     );
@@ -514,6 +674,13 @@ fn sort_unique(values: &[&str]) -> Vec<String> {
     out.sort();
     out.dedup();
     out
+}
+
+fn union_policy_classifications(groups: &[&[String]]) -> BTreeSet<String> {
+    groups
+        .iter()
+        .flat_map(|group| group.iter().cloned())
+        .collect()
 }
 
 fn new_unapproved_support_crates(
@@ -582,6 +749,33 @@ fn classify_target_surface_violations(
     }
 }
 
+fn classify_policy_surface_violations(
+    violations: &mut Vec<PublishViolation>,
+    workspace_package_names: &BTreeSet<String>,
+    policy_classification_set: &BTreeSet<String>,
+    new_unclassified_packages: &[String],
+) {
+    if !new_unclassified_packages.is_empty() {
+        violations.push(PublishViolation {
+            crate_name: "publish-surface".to_string(),
+            reason: "Workspace package is not classified in publish-surface policy".to_string(),
+            details: new_unclassified_packages.to_vec(),
+        });
+    }
+
+    let stale_policy_entries: Vec<String> = policy_classification_set
+        .difference(workspace_package_names)
+        .cloned()
+        .collect();
+    if !stale_policy_entries.is_empty() {
+        violations.push(PublishViolation {
+            crate_name: "publish-surface".to_string(),
+            reason: "Publish-surface policy class references missing workspace package".to_string(),
+            details: stale_policy_entries,
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -616,6 +810,31 @@ mod tests {
         assert!(current_support.contains("tokmd-test-support"));
         assert!(target_support.contains("tokmd-test-support"));
         assert!(!target_gap.contains("tokmd-test-support"));
+    }
+
+    #[test]
+    fn publish_surface_policy_classes_cover_current_workspace_packages() {
+        let classified = union_policy_classifications(&[
+            &sort_unique(PUBLIC_PRODUCT_CRATES),
+            &sort_unique(PUBLIC_CONTRACT_CRATES),
+            &sort_unique(PUBLIC_WORKFLOW_CRATES),
+            &sort_unique(PUBLIC_CAPABILITY_CRATES),
+            &sort_unique(CONDITIONAL_PUBLIC_CRATES),
+            &sort_unique(INTERNAL_MODULE_FAMILIES),
+            &sort_unique(DEV_ONLY_PACKAGES),
+            &sort_unique(NON_CRATES_IO_PACKAGES),
+        ]);
+        let legacy_surface: BTreeSet<String> = PUBLISHED_PUBLIC_CRATES
+            .iter()
+            .chain(PUBLISHED_SUPPORT_CRATES.iter())
+            .chain(NON_CRATES_IO_PACKAGES.iter())
+            .map(|value| (*value).to_string())
+            .collect();
+
+        assert_eq!(
+            classified, legacy_surface,
+            "new policy classes must account for every current workspace package"
+        );
     }
 
     #[test]

--- a/xtask/tests/publish_w71.rs
+++ b/xtask/tests/publish_w71.rs
@@ -89,12 +89,44 @@ fn publish_surface_json_distinguishes_current_and_target_surfaces() {
     let new_unapproved = summary["new_unapproved_support_crates"]
         .as_array()
         .expect("new_unapproved_support_crates should be an array");
+    let public_product = summary["public_product_crates"]
+        .as_array()
+        .expect("public_product_crates should be an array");
+    let public_contract = summary["public_contract_crates"]
+        .as_array()
+        .expect("public_contract_crates should be an array");
+    let public_workflow = summary["public_workflow_crates"]
+        .as_array()
+        .expect("public_workflow_crates should be an array");
+    let public_capability = summary["public_capability_crates"]
+        .as_array()
+        .expect("public_capability_crates should be an array");
+    let conditional_public = summary["conditional_public_crates"]
+        .as_array()
+        .expect("conditional_public_crates should be an array");
+    let internal_modules = summary["internal_module_families"]
+        .as_array()
+        .expect("internal_module_families should be an array");
+    let dev_only = summary["dev_only_packages"]
+        .as_array()
+        .expect("dev_only_packages should be an array");
+    let new_unclassified = summary["new_unclassified_packages"]
+        .as_array()
+        .expect("new_unclassified_packages should be an array");
 
     assert_eq!(current_public.len(), 13);
     assert_eq!(current_support.len(), 23);
     assert_eq!(target_support.len(), 23);
     assert!(target_gap.is_empty());
     assert!(new_unapproved.is_empty());
+    assert_eq!(public_product.len(), 3);
+    assert_eq!(public_contract.len(), 5);
+    assert_eq!(public_workflow.len(), 3);
+    assert_eq!(public_capability.len(), 5);
+    assert_eq!(conditional_public.len(), 5);
+    assert_eq!(internal_modules.len(), 14);
+    assert_eq!(dev_only.len(), 1);
+    assert!(new_unclassified.is_empty());
     assert_eq!(summary["public_surface"], summary["current_public_surface"]);
     assert_eq!(
         summary["support_surface"],


### PR DESCRIPTION
## Summary

- Reframe the publish-surface documentation around product, contract, workflow, capability, conditional, internal-module, dev-only, and non-crates.io package classes.
- Add those forward policy classes to `cargo xtask publish-surface --json` while keeping the existing `public_surface`, `support_surface`, current/target, and target-gap fields as compatibility output.
- Add `summary.new_unclassified_packages` and make unclassified workspace packages or stale policy entries fail the checker.
- Keep the current compatibility surface unchanged: 13 current public crates, 23 current support crates, 4 non-crates.io packages, target gap 0.

Closes #1296.

## Counts

- Current public surface: 13 unchanged
- Current support surface: 23 unchanged
- Target gap: 0 unchanged
- New unapproved support crates: 0
- New unclassified packages: 0
- Packaging checks: 36
- Violations: 0

## New policy fields

- `public_product_crates`
- `public_contract_crates`
- `public_workflow_crates`
- `public_capability_crates`
- `conditional_public_crates`
- `internal_module_families`
- `dev_only_packages`
- `new_unclassified_packages`

## Validation

- `cargo fmt-check`
- `git diff --check`
- `cargo test -p xtask publish_surface`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred

- Collapse the remaining analysis implementation lattice (#1298).
- Move analysis rendering into `tokmd-format` (#1299).
- Resolve gray-zone support-only crates with focused boundary memos (#1300).
- Add bounded root/path trust substrate after crate surface stabilization (#1301).