### PR TITLE
compat: fix web/runner payload validation to support paths 🧷

### DIFF
--- a/.jules/runs/compat_targets_matrix/decision.md
+++ b/.jules/runs/compat_targets_matrix/decision.md
@@ -1,0 +1,19 @@
+# Decision
+
+## 🧭 Options considered
+
+### Option A (recommended)
+- what it is: Update `isRunMessage` in `web/runner/messages.js` to correctly support `paths` or `scan` objects when validating `run` messages, rather than strictly requiring `inputs`.
+- why it fits this repo and shard: Memory indicates: "In the `tokmd` `web/runner`, run message arguments can be passed via `inputs` (in-memory file arrays), `paths` (string arrays), or `scan` objects. Validation logic (e.g., `isRunMessage`) must accept payloads utilizing any of these valid structures, not strictly requiring `inputs` in all cases." This fixes a validation compatibility issue when executing run modes via the `browser-runner`.
+- trade-offs:
+  - Structure: Aligns `web/runner` validation with the allowed schema from `tokmd` core arguments.
+  - Velocity: Quick fix for browser-runner execution paths.
+  - Governance: Ensures consistent capabilities across bindings without strict `inputs` requirement.
+
+### Option B
+- what it is: Update tests to always use `inputs` or fallback to proof-improvement.
+- when to choose it instead: If `paths` and `scan` aren't actually meant to be supported by `web/runner`.
+- trade-offs: Decreased compatibility with Core schema and violates documented memory.
+
+## ✅ Decision
+Option A. This fixes the compatibility issue directly matching the memory note about `isRunMessage` rejecting valid structural parameters like `paths` and `scan`.

--- a/.jules/runs/compat_targets_matrix/envelope.json
+++ b/.jules/runs/compat_targets_matrix/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "compat_targets_matrix",
+  "persona": "Compat",
+  "style": "Builder",
+  "primary_shard": "bindings-targets",
+  "allowed_paths": [
+    "crates/tokmd-python/**",
+    "crates/tokmd-node/**",
+    "crates/tokmd-wasm/**",
+    "web/runner/**",
+    "crates/tokmd-core/**",
+    "docs/**"
+  ],
+  "gate_profile": "compat-matrix",
+  "allowed_outcomes": ["pr_ready_patch", "learning_pr", "proof_improvement"]
+}

--- a/.jules/runs/compat_targets_matrix/pr_body.md
+++ b/.jules/runs/compat_targets_matrix/pr_body.md
@@ -1,0 +1,56 @@
+## 💡 Summary
+Updated the browser-runner's `isRunMessage` validation logic to accept `paths` or `scan` payloads as valid parameters, fixing a compatibility issue where valid configurations were rejected in Web/Node runner environments.
+
+## 🎯 Why
+The `web/runner` previously strictly required `inputs` to be present in a run message. However, the core `tokmd` schema and CLI natively support `paths` and `scan` configurations as arguments. This drift prevented the browser-runner from processing valid workloads utilizing non-memory inputs.
+
+## 🔎 Evidence
+- `web/runner/messages.js`
+- `isRunMessage` rejected a payload like `{ type: "run", requestId: "1", mode: "lang", args: { paths: ["."] } }`.
+- Verified via temporary script and new tests in `web/runner/messages.test.mjs` that failed prior to the patch.
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Update `isRunMessage` to correctly check for `inputs`, `paths`, or `scan.paths`.
+- why it fits this repo and shard: Directly aligns `browser-runner` payload validation with valid core structures for `tokmd`.
+- trade-offs:
+  - Structure: Aligns `web/runner` validation with the allowed schema.
+  - Velocity: Simple, contained fix.
+  - Governance: High.
+
+### Option B
+- what it is: Update tests and callers to strictly provide `inputs`.
+- when to choose it instead: If the browser-runner deliberately blocks non-memory inputs for all modes.
+- trade-offs: Restrictive and violates core capabilities.
+
+## ✅ Decision
+Option A. This fixes the compatibility issue directly matching the core capability of supplying paths.
+
+## 🧱 Changes made (SRP)
+- Modified `isRunMessage` in `web/runner/messages.js`.
+- Added test coverage in `web/runner/messages.test.mjs`.
+
+## 🧪 Verification receipts
+```text
+> npm test --prefix web/runner
+
+# Subtest: run messages support inputs, paths, and scan objects
+ok 18 - run messages support inputs, paths, and scan objects
+```
+
+## 🧭 Telemetry
+- Change shape: Logic tweak and test extension.
+- Blast radius: `web/runner` payload validation.
+- Risk class: Low - fixes a false negative validation error.
+- Rollback: Revert the JavaScript commit.
+- Gates run: `npm test` passing.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/compat_targets_matrix/envelope.json`
+- `.jules/runs/compat_targets_matrix/decision.md`
+- `.jules/runs/compat_targets_matrix/receipts.jsonl`
+- `.jules/runs/compat_targets_matrix/result.json`
+- `.jules/runs/compat_targets_matrix/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/compat_targets_matrix/receipts.jsonl
+++ b/.jules/runs/compat_targets_matrix/receipts.jsonl
@@ -1,0 +1,4 @@
+{"command": "cargo check -p tokmd-wasm --no-default-features", "status": "ok"}
+{"command": "npm test --prefix web/runner", "status": "failed before patch"}
+{"command": "patch web/runner/messages.js", "status": "ok"}
+{"command": "npm test --prefix web/runner", "status": "passed after patch"}

--- a/.jules/runs/compat_targets_matrix/result.json
+++ b/.jules/runs/compat_targets_matrix/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "summary": "Updated isRunMessage in web/runner to support paths and scan payloads in args.",
+  "patch_applied": true
+}

--- a/web/runner/messages.js
+++ b/web/runner/messages.js
@@ -99,17 +99,23 @@ export function isInMemoryInput(value) {
 }
 
 export function isRunMessage(value) {
-    return Boolean(
-        value &&
-            value.type === MESSAGE_TYPES.RUN &&
-            typeof value.requestId === "string" &&
-            typeof value.mode === "string" &&
-            value.args &&
-            typeof value.args === "object" &&
-            !Array.isArray(value.args) &&
-            Array.isArray(value.args.inputs) &&
-            value.args.inputs.every(isInMemoryInput)
-    );
+    if (
+        !value ||
+        value.type !== MESSAGE_TYPES.RUN ||
+        typeof value.requestId !== "string" ||
+        typeof value.mode !== "string" ||
+        !value.args ||
+        typeof value.args !== "object" ||
+        Array.isArray(value.args)
+    ) {
+        return false;
+    }
+
+    const hasInputs = Array.isArray(value.args.inputs) && value.args.inputs.every(isInMemoryInput);
+    const hasPaths = Array.isArray(value.args.paths) && value.args.paths.length > 0;
+    const hasScanPaths = value.args.scan && typeof value.args.scan === "object" && Array.isArray(value.args.scan.paths);
+
+    return Boolean(hasInputs || hasPaths || hasScanPaths);
 }
 
 export function isCancelMessage(value) {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -51,7 +51,7 @@ test("run and cancel helpers produce valid protocol messages", () => {
     assert.equal(isRunMessage(cancel), false);
 });
 
-test("run messages require ordered in-memory inputs", () => {
+test("run messages support inputs, paths, and scan objects", () => {
     assert.equal(
         isInMemoryInput({ path: "src/lib.rs", text: "pub fn alpha() {}\n" }),
         true
@@ -91,5 +91,23 @@ test("run messages require ordered in-memory inputs", () => {
             args: { inputs: [{ path: "", text: "bad\n" }] },
         }),
         false
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "paths-test",
+            mode: "lang",
+            args: { paths: ["src/lib.rs"] },
+        }),
+        true
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "scan-test",
+            mode: "lang",
+            args: { scan: { paths: ["src/lib.rs"] } },
+        }),
+        true
     );
 });


### PR DESCRIPTION
## 💡 Summary
Updated the browser-runner's `isRunMessage` validation logic to accept `paths` or `scan` payloads as valid parameters, fixing a compatibility issue where valid configurations were rejected in Web/Node runner environments.

## 🎯 Why
The `web/runner` previously strictly required `inputs` to be present in a run message. However, the core `tokmd` schema and CLI natively support `paths` and `scan` configurations as arguments. This drift prevented the browser-runner from processing valid workloads utilizing non-memory inputs.

## 🔎 Evidence
- `web/runner/messages.js`
- `isRunMessage` rejected a payload like `{ type: "run", requestId: "1", mode: "lang", args: { paths: ["."] } }`.
- Verified via temporary script and new tests in `web/runner/messages.test.mjs` that failed prior to the patch.

## 🧭 Options considered
### Option A (recommended)
- what it is: Update `isRunMessage` to correctly check for `inputs`, `paths`, or `scan.paths`.
- why it fits this repo and shard: Directly aligns `browser-runner` payload validation with valid core structures for `tokmd`.
- trade-offs: 
  - Structure: Aligns `web/runner` validation with the allowed schema.
  - Velocity: Simple, contained fix.
  - Governance: High.

### Option B
- what it is: Update tests and callers to strictly provide `inputs`.
- when to choose it instead: If the browser-runner deliberately blocks non-memory inputs for all modes.
- trade-offs: Restrictive and violates core capabilities.

## ✅ Decision
Option A. This fixes the compatibility issue directly matching the core capability of supplying paths.

## 🧱 Changes made (SRP)
- Modified `isRunMessage` in `web/runner/messages.js`.
- Added test coverage in `web/runner/messages.test.mjs`.

## 🧪 Verification receipts
```text
> npm test --prefix web/runner

# Subtest: run messages support inputs, paths, and scan objects
ok 18 - run messages support inputs, paths, and scan objects
```

## 🧭 Telemetry
- Change shape: Logic tweak and test extension.
- Blast radius: `web/runner` payload validation.
- Risk class: Low - fixes a false negative validation error.
- Rollback: Revert the JavaScript commit.
- Gates run: `npm test` passing.

## 🗂️ .jules artifacts
- `.jules/runs/compat_targets_matrix/envelope.json`
- `.jules/runs/compat_targets_matrix/decision.md`
- `.jules/runs/compat_targets_matrix/receipts.jsonl`
- `.jules/runs/compat_targets_matrix/result.json`
- `.jules/runs/compat_targets_matrix/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [17024628361380882396](https://jules.google.com/task/17024628361380882396) started by @EffortlessSteven*