### PR TITLE
docs: make analysis facade doctest executable

### DIFF
--- a/.jules/friction/open/librarian_doctest_git_dependency.md
+++ b/.jules/friction/open/librarian_doctest_git_dependency.md
@@ -1,0 +1,13 @@
+# Friction Item
+
+**Surface:** Doctests (`crates/tokmd-core/src/lib.rs`)
+
+**Problem:**
+The `cockpit_workflow` public API doctest is marked as `no_run` and skipping validation because it implicitly requires an active Git repository to execute (it fails with `not inside a git repository` when executed normally).
+
+**Why it matters:**
+This violates the `docs-executable` gate profile expectation. The inability to mock Git state easily without polluting the file system or creating complex temporary fixtures means we cannot test this public API in docs, risking silent drift.
+
+**Possible Solutions:**
+1. Provide a `MockGit` trait or abstraction over Git operations that can be swapped in tests.
+2. Provide a helper function in tests that safely creates a temporary directory, runs `git init`, creates a dummy commit, and executes the doctest inside that tempdir so that it correctly compiles and runs.

--- a/.jules/runs/librarian_api_doctests/decision.md
+++ b/.jules/runs/librarian_api_doctests/decision.md
@@ -1,0 +1,20 @@
+## Target Assessment
+
+The primary targets identified for improvement are the doctests within `crates/tokmd-core/src/lib.rs` and `crates/tokmd/src/config.rs`.
+
+1.  `cockpit_workflow` in `crates/tokmd-core/src/lib.rs` (lines 537-550): The doctest is marked with `no_run`. This violates the gate profile expectation (`docs-executable`) where doctests and examples should execute or compile where possible to prevent silent drift.
+2.  `analysis_facade` in `crates/tokmd-core/src/lib.rs` (lines 612-624): Similar to `cockpit_workflow`, the doctest is marked with `no_run`.
+3.  `resolve_export` and `resolve_export_with_config` in `crates/tokmd/src/config.rs`: The doctests initialize `CliExportArgs` but omit many fields recently added to the struct, causing warnings or errors if checked strictly, or simply lacking coverage of the full CLI arguments structure. However, in `config.rs`, these examples currently compile because they omit fields and Rust allows partial initialization with `..Default::default()` *if* the struct implements `Default`, BUT as per memory:
+    "In the `tokmd-config` crate, CLI argument struct types like `CliModuleArgs` and `CliExportArgs` do not derive `Default`. When initializing them in tests, you must explicitly provide all fields (usually as `None` or `false`) instead of using `..Default::default()`."
+    Looking at the current source code, the doctest just specifies fields individually up to `strip_prefix`. Let's check `CliExportArgs` definition. It might have new fields like `split` or `merge`.
+
+Let's inspect the `CliExportArgs` struct to see what fields are missing in the doctest.
+
+Option A (recommended)
+Update the `no_run` doctests in `tokmd-core` to be fully executable, removing the `no_run` attribute by using `#[cfg(feature = "cockpit")]` or similar conditional compilation around the doctest if needed, or just mocking the required arguments correctly. Also update the `tokmd/src/config.rs` doctests to ensure all fields of `CliExportArgs`, `CliLangArgs`, `CliModuleArgs` are correctly and fully specified.
+
+Option B
+Write a learning PR indicating that `no_run` is acceptable for features that require heavy Git context.
+
+Decision
+We will proceed with Option A. `no_run` should be avoided for public APIs if we can make them compile/run. We can change them to compile-only or fully executable tests by setting up minimal valid state. However, making them fully executable might be tricky if they require an active Git repository. In that case, we can keep them compile-only (by using `no_run` or by wrapping in a main function that isn't called, or ignoring the execution). Wait, removing `no_run` and replacing it with something that just verifies compilation is better than nothing, but let's see if we can make it run.

--- a/.jules/runs/librarian_api_doctests/envelope.json
+++ b/.jules/runs/librarian_api_doctests/envelope.json
@@ -1,0 +1,20 @@
+{
+  "run_id": "librarian_api_doctests",
+  "prompt_id": "librarian_api_doctests",
+  "persona": "Librarian",
+  "style": "Prover",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": [
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/librarian_api_doctests/pr_body.md
+++ b/.jules/runs/librarian_api_doctests/pr_body.md
@@ -1,0 +1,49 @@
+## 💡 Summary
+This is a learning PR. Made the `analysis_facade` doctest in `tokmd-core` executable to prevent silent drift, and recorded a friction item detailing why `cockpit_workflow` cannot easily be made executable without complex Git mocking.
+
+## 🎯 Why
+Several doctests in `tokmd-core` (like `cockpit_workflow` and `analysis_facade`) were marked with `no_run` which skips validation, potentially hiding compilation and runtime drift. This violates the `docs-executable` gate profile expectation. While `analysis_facade` was straightforward to fix, `cockpit_workflow` fails during `cargo test` because it implicitly relies on being executed inside an active Git repository.
+
+## 🔎 Evidence
+- `crates/tokmd-core/src/lib.rs` had `rust,no_run` applied to multiple facade and workflow routines.
+- Running `cockpit_workflow` in a test environment without a properly initialized Git repository causes it to error with "not inside a git repository", leading to a test failure if `no_run` is removed.
+
+## 🧭 Options considered
+### Option A
+- Wrap the `cockpit_workflow` assertion in an `if let Ok(receipt) = ...` block to swallow the Git error.
+- Trade-offs: This is an anti-pattern. If the workflow fails due to missing Git context in CI, the test silently passes without executing the assertions, which is functionally no better than `no_run`.
+
+### Option B (recommended)
+- Fix what can be cleanly executed (`analysis_facade`) and document the `cockpit_workflow` Git dependency issue as a friction item so that a proper mocking or temporary directory fixture solution can be implemented later.
+- Fits the `interfaces` shard properly without compromising test integrity.
+
+## ✅ Decision
+Selected Option B. We replaced `no_run` instances in `tokmd-core` for `analysis_facade` which has no external dependencies. We documented the `cockpit_workflow` issue as friction to avoid swallowing errors in tests.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-core/src/lib.rs`: Removed `no_run` from `analysis_facade`.
+
+## 🧪 Verification receipts
+```text
+{"command": "cargo test -p tokmd-core --doc", "outcome": "Success (9 passed)"}
+{"command": "cargo fmt-check", "outcome": "Success"}
+{"command": "git diff --check", "outcome": "Success"}
+```
+
+## 🧭 Telemetry
+- Change shape: Proof improvement and Learning.
+- Blast radius: API docs. Zero production logic altered.
+- Risk class: Low risk. Proof improvement.
+- Rollback: Safe to revert.
+- Gates run: `cargo test -p tokmd-core --doc`, `cargo fmt-check`, `git diff --check`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/librarian_api_doctests/envelope.json`
+- `.jules/runs/librarian_api_doctests/decision.md`
+- `.jules/runs/librarian_api_doctests/receipts.jsonl`
+- `.jules/runs/librarian_api_doctests/result.json`
+- `.jules/runs/librarian_api_doctests/pr_body.md`
+- `.jules/friction/open/librarian_doctest_git_dependency.md`
+
+## 🔜 Follow-ups
+- See friction item regarding `cockpit_workflow` needing a robust way to mock Git state in doctests.

--- a/.jules/runs/librarian_api_doctests/receipts.jsonl
+++ b/.jules/runs/librarian_api_doctests/receipts.jsonl
@@ -1,0 +1,3 @@
+{"command": "cargo test -p tokmd-core --doc", "outcome": "Success (9 passed)"}
+{"command": "cargo fmt-check", "outcome": "Success"}
+{"command": "git diff --check", "outcome": "Success"}

--- a/.jules/runs/librarian_api_doctests/result.json
+++ b/.jules/runs/librarian_api_doctests/result.json
@@ -1,0 +1,7 @@
+{
+  "outcome": "learning PR",
+  "files_changed": [
+    "crates/tokmd-core/src/lib.rs"
+  ],
+  "reason": "Made analysis_facade doctest executable. Could not safely make cockpit_workflow executable without suppressing errors or creating complex Git mock environments, which was logged as a friction item instead."
+}

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -669,7 +669,7 @@ use anyhow::Context as _;
 ///
 /// ## Example
 ///
-/// ```rust,no_run
+/// ```rust
 /// use tokmd_core::analysis_facade::{render, RenderedOutput};
 /// use tokmd_types::AnalysisFormat;
 /// use tokmd_analysis_types::AnalysisReceipt;


### PR DESCRIPTION
## 💡 Summary
This is a learning PR. Made the `analysis_facade` doctest in `tokmd-core` executable to prevent silent drift, and recorded a friction item detailing why `cockpit_workflow` cannot easily be made executable without complex Git mocking.

## 🎯 Why
Several doctests in `tokmd-core` (like `cockpit_workflow` and `analysis_facade`) were marked with `no_run` which skips validation, potentially hiding compilation and runtime drift. This violates the `docs-executable` gate profile expectation. While `analysis_facade` was straightforward to fix, `cockpit_workflow` fails during `cargo test` because it implicitly relies on being executed inside an active Git repository.

## 🔎 Evidence
- `crates/tokmd-core/src/lib.rs` had `rust,no_run` applied to multiple facade and workflow routines.
- Running `cockpit_workflow` in a test environment without a properly initialized Git repository causes it to error with "not inside a git repository", leading to a test failure if `no_run` is removed.

## 🧭 Options considered
### Option A
- Wrap the `cockpit_workflow` assertion in an `if let Ok(receipt) = ...` block to swallow the Git error.
- Trade-offs: This is an anti-pattern. If the workflow fails due to missing Git context in CI, the test silently passes without executing the assertions, which is functionally no better than `no_run`.

### Option B (recommended)
- Fix what can be cleanly executed (`analysis_facade`) and document the `cockpit_workflow` Git dependency issue as a friction item so that a proper mocking or temporary directory fixture solution can be implemented later.
- Fits the `interfaces` shard properly without compromising test integrity.

## ✅ Decision
Selected Option B. We replaced `no_run` instances in `tokmd-core` for `analysis_facade` which has no external dependencies. We documented the `cockpit_workflow` issue as friction to avoid swallowing errors in tests.

## 🧱 Changes made (SRP)
- `crates/tokmd-core/src/lib.rs`: Removed `no_run` from `analysis_facade`.

## 🧪 Verification receipts
```text
{"command": "cargo test -p tokmd-core --doc", "outcome": "Success (9 passed)"}
{"command": "cargo fmt-check", "outcome": "Success"}
{"command": "git diff --check", "outcome": "Success"}
```

## 🧭 Telemetry
- Change shape: Proof improvement and Learning.
- Blast radius: API docs. Zero production logic altered.
- Risk class: Low risk. Proof improvement.
- Rollback: Safe to revert.
- Gates run: `cargo test -p tokmd-core --doc`, `cargo fmt-check`, `git diff --check`.

## 🗂️ .jules artifacts
- `.jules/runs/librarian_api_doctests/envelope.json`
- `.jules/runs/librarian_api_doctests/decision.md`
- `.jules/runs/librarian_api_doctests/receipts.jsonl`
- `.jules/runs/librarian_api_doctests/result.json`
- `.jules/runs/librarian_api_doctests/pr_body.md`
- `.jules/friction/open/librarian_doctest_git_dependency.md`

## 🔜 Follow-ups
- See friction item regarding `cockpit_workflow` needing a robust way to mock Git state in doctests.
