### PR TITLE
palette: unblock path and scan inputs in web runner validation 🎨

### DIFF
--- a/.jules/runs/run-palette-dx/decision.md
+++ b/.jules/runs/run-palette-dx/decision.md
@@ -1,0 +1,14 @@
+# Decision
+
+## Option A (recommended)
+Update `isRunMessage` in `web/runner/messages.js` to correctly accept `inputs` (in-memory file arrays), `paths` (string arrays), or `scan` (objects) as valid arguments. Update the `messages.test.mjs` test suite to assert these new supported argument structures.
+- Fits the shard (web/runner) and persona (Palette, fixing DX by unblocking valid runtime inputs).
+- Trade-offs: Structure is better as validation happens at the boundary; Governance is good as tests are included.
+
+## Option B
+Change `isRunMessage` to just check the envelope and let the underlying engine validate arguments instead.
+- When to choose: if argument structures are extremely complex or change frequently.
+- Trade-offs: Reduced structure and DX because validation errors would be more cryptic or deferred to lower layers.
+
+## Decision
+Proceeding with Option A because the structure of inputs/paths/scan is relatively stable and validating early improves runtime DX and error messages.

--- a/.jules/runs/run-palette-dx/envelope.json
+++ b/.jules/runs/run-palette-dx/envelope.json
@@ -1,0 +1,23 @@
+{
+  "prompt_id": "palette_binding_dx",
+  "persona": "Palette \ud83c\udfa8",
+  "style": "Prover",
+  "primary_shard": "bindings-targets",
+  "allowed_paths": [
+    "crates/tokmd-python/**",
+    "crates/tokmd-node/**",
+    "crates/tokmd-wasm/**",
+    "web/runner/**",
+    "crates/tokmd-core/**",
+    "docs/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": ["patch", "proof_patch", "learning_pr"],
+  "artifacts": [
+    ".jules/runs/run-palette-dx/envelope.json",
+    ".jules/runs/run-palette-dx/decision.md",
+    ".jules/runs/run-palette-dx/receipts.jsonl",
+    ".jules/runs/run-palette-dx/result.json",
+    ".jules/runs/run-palette-dx/pr_body.md"
+  ]
+}

--- a/.jules/runs/run-palette-dx/pr_body.md
+++ b/.jules/runs/run-palette-dx/pr_body.md
@@ -1,0 +1,61 @@
+## 💡 Summary
+Updated the `web/runner` message validation logic to accept `paths` (string arrays) and `scan` objects alongside the existing `inputs` arrays. This unblocks runner requests using alternative input targeting.
+
+## 🎯 Why
+In the browser-runner, valid arguments like `paths` or `scan` were previously rejected by `isRunMessage` because it rigidly required `inputs`. Fixing this aligns the validation logic with actual runner capabilities and drastically improves developer experience by not throwing generic or misleading validation errors.
+
+## 🔎 Evidence
+- Found in `web/runner/messages.js` `isRunMessage`.
+- Tested the failure behavior with a script validating `inputs`, `paths` and `scan`.
+- Output: `isRunMessage` returned `false` for valid `paths` and `scan` payloads before the fix.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Update `isRunMessage` to check for `inputs`, `paths`, or `scan`.
+- Fits the shard since `web/runner` acts as the target-specific binding/DX interface.
+- Trade-offs: Structure/Governance is preserved as tests directly guard these boundaries.
+
+### Option B
+- Defer validation to lower layers by completely removing the check in `isRunMessage`.
+- When to choose it: Only if argument shapes are incredibly dynamic.
+- Trade-offs: Degrades runtime DX because errors would become deferred or cryptically bubbling up from lower layers.
+
+## ✅ Decision
+Proceeded with Option A because early validation improves DX and the shape of runner inputs is relatively stable.
+
+## 🧱 Changes made (SRP)
+- `web/runner/messages.js`: Updated `isRunMessage` logic to return true for valid `paths` and `scan` definitions.
+- `web/runner/messages.test.mjs`: Added tests and updated names to verify `isRunMessage` behaviors.
+
+## 🧪 Verification receipts
+```text
+> test
+> node --test ./*.test.mjs
+
+...
+# Subtest: run messages require valid inputs, paths, or scan object
+ok 18 - run messages require valid inputs, paths, or scan object
+...
+# pass 39
+# fail 0
+# cancelled 0
+# skipped 1
+# todo 0
+```
+
+## 🧭 Telemetry
+- Change shape: Runtime input validation relaxation.
+- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): Compatibility.
+- Risk class + why: Low, unblocks existing valid configurations for web-runners.
+- Rollback: `git checkout HEAD -- web/runner/`
+- Gates run: `npm test`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-palette-dx/envelope.json`
+- `.jules/runs/run-palette-dx/decision.md`
+- `.jules/runs/run-palette-dx/receipts.jsonl`
+- `.jules/runs/run-palette-dx/result.json`
+- `.jules/runs/run-palette-dx/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-palette-dx/receipts.jsonl
+++ b/.jules/runs/run-palette-dx/receipts.jsonl
@@ -1,0 +1,1 @@
+{"cmd": "npm test --prefix web/runner", "status": "success", "summary": "All tests passed (1 skipped expectedly because wasm wasn't built)"}

--- a/.jules/runs/run-palette-dx/result.json
+++ b/.jules/runs/run-palette-dx/result.json
@@ -1,0 +1,17 @@
+{
+  "outcome": "proof_patch",
+  "title": "palette: unblock path and scan inputs in web runner validation 🎨",
+  "summary": "Updated `isRunMessage` to correctly accept `paths` and `scan` alongside the existing `inputs` property.",
+  "target_paths": [
+    "web/runner/messages.js",
+    "web/runner/messages.test.mjs"
+  ],
+  "proof_summary": "Tests for paths, scan, and inputs payload combinations now pass.",
+  "gates_run": [
+    "npm test --prefix web/runner"
+  ],
+  "friction_items_created": [],
+  "persona_notes_created": [],
+  "rollback": "git checkout HEAD -- web/runner/messages.js web/runner/messages.test.mjs",
+  "follow_ups": []
+}

--- a/web/runner/messages.js
+++ b/web/runner/messages.js
@@ -99,17 +99,23 @@ export function isInMemoryInput(value) {
 }
 
 export function isRunMessage(value) {
-    return Boolean(
-        value &&
-            value.type === MESSAGE_TYPES.RUN &&
-            typeof value.requestId === "string" &&
-            typeof value.mode === "string" &&
-            value.args &&
-            typeof value.args === "object" &&
-            !Array.isArray(value.args) &&
-            Array.isArray(value.args.inputs) &&
-            value.args.inputs.every(isInMemoryInput)
-    );
+    if (
+        !value ||
+        value.type !== MESSAGE_TYPES.RUN ||
+        typeof value.requestId !== "string" ||
+        typeof value.mode !== "string" ||
+        !value.args ||
+        typeof value.args !== "object" ||
+        Array.isArray(value.args)
+    ) {
+        return false;
+    }
+
+    const hasInputs = Array.isArray(value.args.inputs) && value.args.inputs.every(isInMemoryInput);
+    const hasPaths = Array.isArray(value.args.paths) && value.args.paths.every(p => typeof p === "string");
+    const hasScan = value.args.scan && typeof value.args.scan === "object" && !Array.isArray(value.args.scan);
+
+    return Boolean(hasInputs || hasPaths || hasScan);
 }
 
 export function isCancelMessage(value) {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -51,7 +51,7 @@ test("run and cancel helpers produce valid protocol messages", () => {
     assert.equal(isRunMessage(cancel), false);
 });
 
-test("run messages require ordered in-memory inputs", () => {
+test("run messages require valid inputs, paths, or scan object", () => {
     assert.equal(
         isInMemoryInput({ path: "src/lib.rs", text: "pub fn alpha() {}\n" }),
         true
@@ -74,6 +74,31 @@ test("run messages require ordered in-memory inputs", () => {
         }),
         true
     );
+
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "paths-1",
+            mode: "lang",
+            args: {
+                paths: ["src/lib.rs"],
+            },
+        }),
+        true
+    );
+
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "scan-1",
+            mode: "lang",
+            args: {
+                scan: { path: "src" },
+            },
+        }),
+        true
+    );
+
     assert.equal(
         isInMemoryInput({
             path: "src/lib.rs",
@@ -89,6 +114,15 @@ test("run messages require ordered in-memory inputs", () => {
             requestId: "x",
             mode: "lang",
             args: { inputs: [{ path: "", text: "bad\n" }] },
+        }),
+        false
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: { paths: [123] },
         }),
         false
     );


### PR DESCRIPTION
Updated `isRunMessage` to correctly handle `paths` and `scan` options and properly test it.

---
*PR created automatically by Jules for task [17086729117284477996](https://jules.google.com/task/17086729117284477996) started by @EffortlessSteven*