### PR TITLE
chore: bound scan roots and paths

### DIFF
--- a/crates/tokmd-scan/src/lib.rs
+++ b/crates/tokmd-scan/src/lib.rs
@@ -20,6 +20,7 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use tokei::{Config, Languages};
 
+use crate::path::ValidatedRoot;
 use tokmd_settings::ScanOptions;
 use tokmd_types::ConfigMode;
 
@@ -105,14 +106,17 @@ impl MaterializedScan {
 pub fn scan(paths: &[PathBuf], args: &ScanOptions) -> Result<Languages> {
     let cfg = config_from_scan_options(args);
     let ignores = ignored_patterns(args);
-    for path in paths {
-        if !path.exists() {
-            anyhow::bail!("Path not found: {}", path.display());
-        }
-    }
+    let roots: Vec<ValidatedRoot> = paths
+        .iter()
+        .map(ValidatedRoot::new)
+        .collect::<std::result::Result<_, _>>()?;
+    let scan_paths: Vec<PathBuf> = roots
+        .iter()
+        .map(|root| root.input().to_path_buf())
+        .collect();
 
     let mut languages = Languages::new();
-    languages.get_statistics(paths, &ignores, &cfg);
+    languages.get_statistics(&scan_paths, &ignores, &cfg);
 
     Ok(languages)
 }

--- a/crates/tokmd-scan/src/path/bounded_path.rs
+++ b/crates/tokmd-scan/src/path/bounded_path.rs
@@ -1,0 +1,104 @@
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use super::{PathViolation, ValidatedRoot};
+
+#[derive(Debug, Clone)]
+pub(crate) struct BoundedPath {
+    relative: PathBuf,
+    canonical: PathBuf,
+}
+
+impl BoundedPath {
+    pub(crate) fn existing_relative(
+        root: &ValidatedRoot,
+        relative: &Path,
+    ) -> Result<Self, PathViolation> {
+        let normalized = normalize_bounded_relative_path(relative)?;
+        let candidate = root.canonical().join(&normalized);
+        let canonical = canonicalize_existing(&candidate)?;
+        ensure_under_root(root, &canonical)?;
+
+        Ok(Self {
+            relative: normalized,
+            canonical,
+        })
+    }
+
+    pub(crate) fn existing_child(
+        root: &ValidatedRoot,
+        child: &Path,
+    ) -> Result<Self, PathViolation> {
+        let canonical = canonicalize_existing(child)?;
+        ensure_under_root(root, &canonical)?;
+        let relative = canonical
+            .strip_prefix(root.canonical())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| child.file_name().map(PathBuf::from).unwrap_or_default());
+
+        if relative.as_os_str().is_empty() {
+            return Err(PathViolation::Empty);
+        }
+
+        Ok(Self {
+            relative,
+            canonical,
+        })
+    }
+
+    pub(crate) fn relative(&self) -> &Path {
+        &self.relative
+    }
+
+    pub(crate) fn canonical(&self) -> &Path {
+        &self.canonical
+    }
+}
+
+pub(crate) fn normalize_bounded_relative_path(path: &Path) -> Result<PathBuf, PathViolation> {
+    if path.as_os_str().is_empty() {
+        return Err(PathViolation::Empty);
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => normalized.push(segment),
+            Component::CurDir => {}
+            Component::ParentDir => return Err(PathViolation::ParentTraversal(path.to_path_buf())),
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(PathViolation::Absolute(path.to_path_buf()));
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return Err(PathViolation::Empty);
+    }
+
+    Ok(normalized)
+}
+
+fn canonicalize_existing(path: &Path) -> Result<PathBuf, PathViolation> {
+    fs::canonicalize(path).map_err(|source| {
+        if !path.exists() {
+            PathViolation::Missing(path.to_path_buf())
+        } else {
+            PathViolation::CanonicalizeFailed {
+                path: path.to_path_buf(),
+                source,
+            }
+        }
+    })
+}
+
+fn ensure_under_root(root: &ValidatedRoot, canonical: &Path) -> Result<(), PathViolation> {
+    if canonical.starts_with(root.canonical()) {
+        Ok(())
+    } else {
+        Err(PathViolation::RootEscape {
+            root: root.canonical().to_path_buf(),
+            path: canonical.to_path_buf(),
+        })
+    }
+}

--- a/crates/tokmd-scan/src/path/error.rs
+++ b/crates/tokmd-scan/src/path/error.rs
@@ -1,0 +1,84 @@
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub(crate) enum RootViolation {
+    Empty,
+    Missing(PathBuf),
+    CanonicalizeFailed { path: PathBuf, source: io::Error },
+}
+
+impl fmt::Display for RootViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "Scan root must not be empty"),
+            Self::Missing(path) => write!(f, "Path not found: {}", path.display()),
+            Self::CanonicalizeFailed { path, source } => {
+                write!(
+                    f,
+                    "Failed to resolve scan root {}: {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RootViolation {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CanonicalizeFailed { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum PathViolation {
+    Empty,
+    Absolute(PathBuf),
+    ParentTraversal(PathBuf),
+    Missing(PathBuf),
+    RootEscape { root: PathBuf, path: PathBuf },
+    CanonicalizeFailed { path: PathBuf, source: io::Error },
+}
+
+impl fmt::Display for PathViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "Bounded path must not be empty"),
+            Self::Absolute(path) => write!(f, "Bounded path must be relative: {}", path.display()),
+            Self::ParentTraversal(path) => {
+                write!(
+                    f,
+                    "Bounded path must not contain parent traversal: {}",
+                    path.display()
+                )
+            }
+            Self::Missing(path) => write!(f, "Bounded path not found: {}", path.display()),
+            Self::RootEscape { root, path } => write!(
+                f,
+                "Bounded path escapes scan root {}: {}",
+                root.display(),
+                path.display()
+            ),
+            Self::CanonicalizeFailed { path, source } => {
+                write!(
+                    f,
+                    "Failed to resolve bounded path {}: {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PathViolation {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CanonicalizeFailed { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}

--- a/crates/tokmd-scan/src/path/mod.rs
+++ b/crates/tokmd-scan/src/path/mod.rs
@@ -1,4 +1,14 @@
-//! Single-responsibility path normalization for deterministic matching.
+//! Single-responsibility path normalization and root bounding.
+
+mod bounded_path;
+mod error;
+#[cfg(test)]
+mod tests;
+mod validated_root;
+
+pub(crate) use bounded_path::{BoundedPath, normalize_bounded_relative_path};
+pub(crate) use error::{PathViolation, RootViolation};
+pub(crate) use validated_root::ValidatedRoot;
 
 /// Normalize path separators to `/`.
 ///
@@ -65,7 +75,7 @@ pub fn normalize_rel_path(path: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+mod normalization_tests {
     use super::*;
     use proptest::prelude::*;
 

--- a/crates/tokmd-scan/src/path/tests.rs
+++ b/crates/tokmd-scan/src/path/tests.rs
@@ -1,0 +1,95 @@
+use std::path::{Path, PathBuf};
+
+use super::*;
+
+#[test]
+fn validated_root_accepts_existing_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = ValidatedRoot::new(dir.path()).unwrap();
+
+    assert_eq!(root.input(), dir.path());
+    assert!(root.canonical().is_absolute());
+}
+
+#[test]
+fn validated_root_rejects_missing_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = ValidatedRoot::new(dir.path().join("missing")).unwrap_err();
+
+    assert!(err.to_string().contains("Path not found"));
+}
+
+#[test]
+fn bounded_relative_path_strips_current_directory_segments() {
+    let normalized = normalize_bounded_relative_path(Path::new("./src/./lib.rs")).unwrap();
+
+    assert_eq!(normalized, PathBuf::from("src/lib.rs"));
+}
+
+#[test]
+fn bounded_relative_path_rejects_absolute_path() {
+    let err = normalize_bounded_relative_path(Path::new("/src/lib.rs")).unwrap_err();
+
+    assert!(err.to_string().contains("must be relative"));
+}
+
+#[test]
+fn bounded_relative_path_rejects_parent_traversal() {
+    let err = normalize_bounded_relative_path(Path::new("../secret.txt")).unwrap_err();
+
+    assert!(err.to_string().contains("parent traversal"));
+}
+
+#[test]
+fn bounded_existing_relative_returns_root_relative_path() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+    let root = ValidatedRoot::new(dir.path()).unwrap();
+
+    let bounded = BoundedPath::existing_relative(&root, Path::new("./src/lib.rs")).unwrap();
+
+    assert_eq!(bounded.relative(), Path::new("src/lib.rs"));
+    assert!(bounded.canonical().starts_with(root.canonical()));
+}
+
+#[test]
+fn bounded_existing_child_rejects_path_outside_root() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let outside_file = outside.path().join("secret.txt");
+    std::fs::write(&outside_file, "secret").unwrap();
+    let root = ValidatedRoot::new(root_dir.path()).unwrap();
+
+    let err = BoundedPath::existing_child(&root, &outside_file).unwrap_err();
+
+    assert!(err.to_string().contains("escapes scan root"));
+}
+
+#[test]
+fn bounded_existing_relative_rejects_symlink_escape_when_supported() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let outside_file = outside.path().join("secret.txt");
+    let link = root_dir.path().join("secret-link.txt");
+    std::fs::write(&outside_file, "secret").unwrap();
+
+    if create_file_symlink(&outside_file, &link).is_err() {
+        return;
+    }
+
+    let root = ValidatedRoot::new(root_dir.path()).unwrap();
+    let err = BoundedPath::existing_relative(&root, Path::new("secret-link.txt")).unwrap_err();
+
+    assert!(err.to_string().contains("escapes scan root"));
+}
+
+#[cfg(unix)]
+fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(windows)]
+fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(src, dst)
+}

--- a/crates/tokmd-scan/src/path/validated_root.rs
+++ b/crates/tokmd-scan/src/path/validated_root.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::RootViolation;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ValidatedRoot {
+    input: PathBuf,
+    canonical: PathBuf,
+}
+
+impl ValidatedRoot {
+    pub(crate) fn new(path: impl AsRef<Path>) -> Result<Self, RootViolation> {
+        let input = path.as_ref().to_path_buf();
+        if input.as_os_str().is_empty() {
+            return Err(RootViolation::Empty);
+        }
+        if !input.exists() {
+            return Err(RootViolation::Missing(input));
+        }
+
+        let canonical =
+            fs::canonicalize(&input).map_err(|source| RootViolation::CanonicalizeFailed {
+                path: input.clone(),
+                source,
+            })?;
+
+        Ok(Self { input, canonical })
+    }
+
+    pub(crate) fn input(&self) -> &Path {
+        &self.input
+    }
+
+    pub(crate) fn canonical(&self) -> &Path {
+        &self.canonical
+    }
+}

--- a/crates/tokmd-scan/src/walk/mod.rs
+++ b/crates/tokmd-scan/src/walk/mod.rs
@@ -20,6 +20,8 @@ use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 use tokmd_io_port::MemFs;
 
+use crate::path::{BoundedPath, PathViolation, ValidatedRoot, normalize_bounded_relative_path};
+
 #[derive(Debug, Clone)]
 pub struct LicenseCandidates {
     pub license_files: Vec<PathBuf>,
@@ -38,7 +40,13 @@ pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
         return Ok(Vec::new());
     }
 
-    if let Some(mut files) = git_ls_files(root)? {
+    let root = ValidatedRoot::new(root)?;
+
+    if let Some(mut files) = git_ls_files(root.input())? {
+        files = files
+            .into_iter()
+            .map(|path| normalize_bounded_relative_path(&path))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         if let Some(limit) = max_files
             && files.len() > limit
         {
@@ -48,7 +56,7 @@ pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
     }
 
     let mut files: Vec<PathBuf> = Vec::new();
-    let mut builder = WalkBuilder::new(root);
+    let mut builder = WalkBuilder::new(root.input());
     builder.hidden(false);
     builder.git_ignore(true);
     builder.git_exclude(true);
@@ -60,8 +68,9 @@ pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
         if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
             continue;
         }
-        let path = entry.path().to_path_buf();
-        let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+        let rel = BoundedPath::existing_child(&root, entry.path())?
+            .relative()
+            .to_path_buf();
         files.push(rel);
         if let Some(limit) = max_files
             && files.len() >= limit
@@ -86,7 +95,7 @@ pub fn list_files_from_memfs(
         return Ok(Vec::new());
     }
 
-    let normalized_root = normalize_memfs_path(root);
+    let normalized_root = normalize_memfs_root(root)?;
     let mut files: Vec<PathBuf> = fs
         .file_paths()
         .filter_map(|path| memfs_relative_path(path, &normalized_root))
@@ -168,35 +177,44 @@ fn git_ls_files(root: &Path) -> Result<Option<Vec<PathBuf>>> {
 }
 
 pub fn file_size(root: &Path, relative: &Path) -> Result<u64> {
-    let path = root.join(relative);
-    let meta =
-        std::fs::metadata(&path).with_context(|| format!("Failed to stat {}", path.display()))?;
+    let root = ValidatedRoot::new(root)?;
+    let path = BoundedPath::existing_relative(&root, relative)?;
+    let meta = std::fs::metadata(path.canonical())
+        .with_context(|| format!("Failed to stat {}", path.canonical().display()))?;
     Ok(meta.len())
 }
 
 /// Query a file size from an in-memory filesystem backend.
 pub fn file_size_from_memfs(fs: &MemFs, root: &Path, relative: &Path) -> Result<u64> {
-    let normalized_root = normalize_memfs_path(root);
+    let normalized_root = normalize_memfs_root(root)?;
+    let normalized_relative = normalize_bounded_relative_path(relative)?;
     let path = if normalized_root.as_os_str().is_empty() {
-        normalize_memfs_path(relative)
+        normalized_relative
     } else {
-        normalize_memfs_path(&normalized_root.join(relative))
+        normalized_root.join(normalized_relative)
     };
     fs.file_size(&path)
         .with_context(|| format!("Failed to stat {}", path.display()))
 }
 
-fn normalize_memfs_path(path: &Path) -> PathBuf {
+fn normalize_memfs_root(path: &Path) -> Result<PathBuf> {
     let mut normalized = PathBuf::new();
+    if path.as_os_str().is_empty() {
+        return Ok(normalized);
+    }
     for component in path.components() {
         match component {
-            Component::CurDir | Component::RootDir => {}
+            Component::CurDir => {}
             Component::Normal(part) => normalized.push(part),
-            Component::ParentDir => normalized.push(".."),
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::ParentDir => {
+                return Err(PathViolation::ParentTraversal(path.to_path_buf()).into());
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(PathViolation::Absolute(path.to_path_buf()).into());
+            }
         }
     }
-    normalized
+    Ok(normalized)
 }
 
 fn memfs_relative_path(path: &Path, root: &Path) -> Option<PathBuf> {

--- a/crates/tokmd-scan/tests/walk_boundary_w53.rs
+++ b/crates/tokmd-scan/tests/walk_boundary_w53.rs
@@ -4,7 +4,7 @@
 //! paths, ignored files, and asset detection edge cases gracefully.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tokmd_scan::walk::{file_size, license_candidates, list_files};
 
@@ -179,4 +179,16 @@ fn file_size_nonexistent_file_returns_error() {
     let dir = TempDir::new().unwrap();
     let result = file_size(dir.path(), &PathBuf::from("missing.txt"));
     assert!(result.is_err(), "non-existent file should return error");
+}
+
+#[test]
+fn file_size_rejects_parent_traversal() {
+    let outer = TempDir::new().unwrap();
+    let root = outer.path().join("root");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(outer.path().join("secret.txt"), "secret").unwrap();
+
+    let result = file_size(&root, Path::new("../secret.txt"));
+
+    assert!(result.is_err(), "parent traversal should be rejected");
 }

--- a/crates/tokmd-scan/tests/walk_memfs_api_w79.rs
+++ b/crates/tokmd-scan/tests/walk_memfs_api_w79.rs
@@ -117,3 +117,21 @@ fn file_size_from_memfs_missing_file_errors() {
 
     assert!(result.is_err());
 }
+
+#[test]
+fn list_files_from_memfs_rejects_parent_root() {
+    let fs = sample_memfs();
+
+    let result = list_files_from_memfs(&fs, Path::new("../src"), None);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn file_size_from_memfs_rejects_parent_relative_path() {
+    let fs = sample_memfs();
+
+    let result = file_size_from_memfs(&fs, Path::new("src"), Path::new("../README.md"));
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

- Add internal `ValidatedRoot`, `BoundedPath`, `RootViolation`, and `PathViolation` seams under `tokmd-scan::path`.
- Validate scan roots before invoking tokei while preserving existing path-not-found error wording.
- Bound native walk entries and `file_size` lookups to the validated scan root, including symlink escape rejection where supported.
- Make rootless/memfs walk helpers reject absolute roots and parent traversal.

## Notes

This starts #1301 as an internal `tokmd-scan` trust substrate. It does not create a public `tokmd-path` crate and does not change the publish surface.

## Validation

- `cargo fmt-fix`
- `cargo check -p tokmd-scan --all-targets`
- `cargo test -p tokmd-scan path::`
- `cargo test -p tokmd-scan --test walk_boundary_w53`
- `cargo test -p tokmd-scan --test walk_memfs_api_w79`
- `cargo test -p tokmd-scan`
- `cargo check -p tokmd-analysis -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-analysis --all-features --lib assets::`
- `cargo fmt-check`
- `cargo xtask publish-surface --json`
- `cargo test -p tokmd --test boundary_verification`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`