### PR TITLE
chore: surface bounded path violations

### DIFF
--- a/crates/tokmd-core/src/error.rs
+++ b/crates/tokmd-core/src/error.rs
@@ -216,6 +216,18 @@ impl TokmdError {
         Self::new(ErrorCode::PathNotFound, format!("Path not found: {}", path))
     }
 
+    /// Create an invalid path error.
+    pub fn invalid_path(message: impl Into<String>) -> Self {
+        Self::with_suggestions(
+            ErrorCode::InvalidPath,
+            message.into(),
+            vec![
+                "Use paths inside the selected scan root".to_string(),
+                "Avoid parent traversal (`..`) in root-relative paths".to_string(),
+            ],
+        )
+    }
+
     /// Create an invalid JSON error.
     pub fn invalid_json(err: impl fmt::Display) -> Self {
         Self::new(ErrorCode::InvalidJson, format!("Invalid JSON: {}", err))
@@ -268,6 +280,22 @@ impl TokmdError {
             format!(r#"{{"code":"{}","message":"{}"}}"#, self.code, self.message)
         })
     }
+
+    fn from_anyhow(err: anyhow::Error) -> Self {
+        let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+        let primary = chain.first().cloned().unwrap_or_else(|| err.to_string());
+        let haystack = chain.join(" | ").to_ascii_lowercase();
+
+        if let Some(path) = extract_path_not_found(&chain) {
+            return Self::path_not_found_with_suggestions(&path);
+        }
+
+        if is_bounded_path_violation(&haystack) {
+            return Self::invalid_path(primary);
+        }
+
+        Self::internal(primary)
+    }
 }
 
 impl fmt::Display for TokmdError {
@@ -284,8 +312,27 @@ impl std::error::Error for TokmdError {}
 
 impl From<anyhow::Error> for TokmdError {
     fn from(err: anyhow::Error) -> Self {
-        Self::internal(err)
+        Self::from_anyhow(err)
     }
+}
+
+fn extract_path_not_found(chain: &[String]) -> Option<String> {
+    for message in chain {
+        if let Some((_, path)) = message.split_once("Path not found: ") {
+            return Some(path.trim().to_string());
+        }
+    }
+    None
+}
+
+fn is_bounded_path_violation(haystack: &str) -> bool {
+    haystack.contains("scan root must not be empty")
+        || haystack.contains("bounded path must not be empty")
+        || haystack.contains("bounded path must be relative")
+        || haystack.contains("bounded path must not contain parent traversal")
+        || haystack.contains("bounded path escapes scan root")
+        || haystack.contains("failed to resolve scan root")
+        || haystack.contains("failed to resolve bounded path")
 }
 
 impl From<serde_json::Error> for TokmdError {
@@ -475,5 +522,36 @@ mod tests {
         assert_eq!(err.code, ErrorCode::NotGitRepository);
         assert!(err.details.is_some());
         assert!(err.suggestions.is_some());
+    }
+
+    #[test]
+    fn anyhow_path_not_found_maps_to_path_not_found() {
+        let err: TokmdError = anyhow::anyhow!("Path not found: missing-dir").into();
+        assert_eq!(err.code, ErrorCode::PathNotFound);
+        assert!(err.message.contains("missing-dir"));
+        assert!(err.suggestions.is_some());
+    }
+
+    #[test]
+    fn anyhow_parent_traversal_maps_to_invalid_path() {
+        let err: TokmdError =
+            anyhow::anyhow!("Bounded path must not contain parent traversal: ../secret.txt").into();
+        assert_eq!(err.code, ErrorCode::InvalidPath);
+        assert!(err.message.contains("parent traversal"));
+        assert!(err.suggestions.is_some());
+    }
+
+    #[test]
+    fn anyhow_root_escape_maps_to_invalid_path() {
+        let err: TokmdError =
+            anyhow::anyhow!("Bounded path escapes scan root C:/repo: C:/secret.txt").into();
+        assert_eq!(err.code, ErrorCode::InvalidPath);
+        assert!(err.message.contains("escapes scan root"));
+    }
+
+    #[test]
+    fn generic_anyhow_stays_internal() {
+        let err: TokmdError = anyhow::anyhow!("unexpected failure").into();
+        assert_eq!(err.code, ErrorCode::InternalError);
     }
 }

--- a/crates/tokmd-core/tests/error_boundary.rs
+++ b/crates/tokmd-core/tests/error_boundary.rs
@@ -116,10 +116,12 @@ fn ffi_lang_nonexistent_path_returns_error() {
     );
     let parsed = assert_err(&result);
     let code = parsed["error"]["code"].as_str().unwrap();
-    // Could be scan_error or path_not_found depending on how error is wrapped
+    assert_eq!(code, "path_not_found");
     assert!(
-        code == "scan_error" || code == "path_not_found" || code == "internal_error",
-        "unexpected error code: {code}"
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("tokmd-absolutely-nonexistent-path-xyz")
     );
 }
 

--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -37,6 +37,29 @@ fn suggestions(err: &Error) -> Vec<String> {
         push_hint(&mut out, "Initialize git first if needed: `git init`.");
     }
 
+    if haystack.contains("parent traversal")
+        || haystack.contains("must be relative")
+        || haystack.contains("escapes scan root")
+        || haystack.contains("scan root must not be empty")
+        || haystack.contains("bounded path must not be empty")
+    {
+        push_hint(
+            &mut out,
+            "Pass paths inside the selected scan root; parent traversal (`..`) is rejected.",
+        );
+        push_hint(
+            &mut out,
+            "Use root-relative paths for scanned entries, or choose the containing directory as the root.",
+        );
+
+        if haystack.contains("escapes scan root") {
+            push_hint(
+                &mut out,
+                "Avoid symlinked or redirected paths that resolve outside the scan root.",
+            );
+        }
+    }
+
     if haystack.contains("path not found")
         || haystack.contains("input path does not exist")
         || haystack.contains("no such file or directory")
@@ -231,6 +254,28 @@ mod tests {
                 .iter()
                 .any(|h| h.contains("subcommand, it is not recognized"))
         );
+    }
+
+    #[test]
+    fn suggests_for_parent_traversal() {
+        let err = anyhow!("Bounded path must not contain parent traversal: ../secret.txt");
+        let hints = suggestions(&err);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("inside the selected scan root"))
+        );
+        assert!(hints.iter().any(|h| h.contains("root-relative paths")));
+    }
+
+    #[test]
+    fn suggests_for_root_escape() {
+        let err = anyhow!("Bounded path escapes scan root C:/repo: C:/secret.txt");
+        let rendered = format(&err);
+        assert!(rendered.contains("Error:"));
+        assert!(rendered.contains("Hints:"));
+        assert!(rendered.contains("inside the selected scan root"));
+        assert!(rendered.contains("resolve outside the scan root"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Map scan path/root failures crossing the `tokmd-core` error boundary to specific structured errors.
- Return `path_not_found` for scan roots reported as missing instead of falling back to `internal_error`.
- Return `invalid_path` for bounded-path violations such as parent traversal, non-relative paths, and root escapes.
- Add CLI hints for bounded-path failures while keeping `ValidatedRoot` and `BoundedPath` internal to `tokmd-scan`.

## Trust invariant improved

Bounded root/path violations created by the internal `tokmd-scan` substrate now survive the core/FFI and CLI boundaries as recognizable product errors instead of generic internal failures.

## Validation

- `cargo fmt-fix`
- `cargo fmt-check`
- `cargo check -p tokmd-scan -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-core`
- `cargo test -p tokmd --lib error_hints`
- `cargo test -p tokmd-scan`
- `cargo test -p tokmd --test boundary_verification`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred

- Git-listed path bounding
- MemFs root semantics
- WASM capability matrix

Refs #1301
