### PR TITLE
chore: tighten path error classification

### DIFF
--- a/crates/tokmd-core/src/error.rs
+++ b/crates/tokmd-core/src/error.rs
@@ -331,8 +331,6 @@ fn is_bounded_path_violation(haystack: &str) -> bool {
         || haystack.contains("bounded path must be relative")
         || haystack.contains("bounded path must not contain parent traversal")
         || haystack.contains("bounded path escapes scan root")
-        || haystack.contains("failed to resolve scan root")
-        || haystack.contains("failed to resolve bounded path")
 }
 
 impl From<serde_json::Error> for TokmdError {
@@ -547,6 +545,24 @@ mod tests {
             anyhow::anyhow!("Bounded path escapes scan root C:/repo: C:/secret.txt").into();
         assert_eq!(err.code, ErrorCode::InvalidPath);
         assert!(err.message.contains("escapes scan root"));
+    }
+
+    #[test]
+    fn anyhow_scan_root_resolve_failure_stays_internal() {
+        let err: TokmdError =
+            anyhow::anyhow!("Failed to resolve scan root C:/repo: permission denied").into();
+        assert_eq!(err.code, ErrorCode::InternalError);
+        assert!(err.message.contains("Failed to resolve scan root"));
+        assert!(err.suggestions.is_none());
+    }
+
+    #[test]
+    fn anyhow_bounded_path_resolve_failure_stays_internal() {
+        let err: TokmdError =
+            anyhow::anyhow!("Failed to resolve bounded path src/lib.rs: permission denied").into();
+        assert_eq!(err.code, ErrorCode::InternalError);
+        assert!(err.message.contains("Failed to resolve bounded path"));
+        assert!(err.suggestions.is_none());
     }
 
     #[test]

--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -279,6 +279,17 @@ mod tests {
     }
 
     #[test]
+    fn resolve_failures_do_not_get_bounded_path_hints() {
+        let err = anyhow!("Failed to resolve scan root C:/repo: permission denied");
+        let hints = suggestions(&err);
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.contains("parent traversal") || h.contains("root-relative"))
+        );
+    }
+
+    #[test]
     fn suggests_for_unknown_explain_key() {
         let err = anyhow!("Unknown metric/finding key 'foo'.");
         let hints = suggestions(&err);


### PR DESCRIPTION
## Summary

- Tighten the bounded-path classifier added in #1329.
- Keep precise path-contract failures mapped to `invalid_path`.
- Stop treating generic canonicalization/resolve failures as invalid user paths.
- Add regression coverage so resolve failures do not receive parent-traversal/root-relative guidance.

## Classifier rule

Before:

- `Path not found: ...` -> `path_not_found`
- bounded path contract failures -> `invalid_path`
- `Failed to resolve scan root ...` -> `invalid_path`
- `Failed to resolve bounded path ...` -> `invalid_path`

After:

- `Path not found: ...` -> `path_not_found`
- parent traversal, non-relative paths, empty bounded paths, and root escapes -> `invalid_path`
- generic scan-root/bounded-path canonicalization failures -> `internal_error` unless a more precise typed filesystem error is added later

## Validation

- `cargo fmt-check`
- `cargo check -p tokmd-scan -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-core`
- `cargo test -p tokmd --lib error_hints`
- `cargo test -p tokmd --test boundary_verification`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred

- Git-listed path bounding
- MemFs root semantics
- WASM capability matrix
- WASM timestamp semantics

Refs #1301
