### PR TITLE
chore: bound git-listed scan paths

### DIFF
--- a/crates/tokmd-scan/src/walk/mod.rs
+++ b/crates/tokmd-scan/src/walk/mod.rs
@@ -45,7 +45,7 @@ pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
     if let Some(mut files) = git_ls_files(root.input())? {
         files = files
             .into_iter()
-            .map(|path| normalize_bounded_relative_path(&path))
+            .map(|path| bound_git_relative_path(&root, &path))
             .collect::<std::result::Result<Vec<_>, _>>()?;
         if let Some(limit) = max_files
             && files.len() > limit
@@ -174,6 +174,12 @@ fn git_ls_files(root: &Path) -> Result<Option<Vec<PathBuf>>> {
     }
 
     Ok(Some(files))
+}
+
+fn bound_git_relative_path(root: &ValidatedRoot, path: &Path) -> Result<PathBuf, PathViolation> {
+    Ok(BoundedPath::existing_relative(root, path)?
+        .relative()
+        .to_path_buf())
 }
 
 pub fn file_size(root: &Path, relative: &Path) -> Result<u64> {
@@ -378,5 +384,37 @@ mod tests {
             .collect();
         // They should already be sorted correctly, but if they aren't, the test will fail
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_bound_git_relative_path_accepts_existing_relative_file() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+        let root = ValidatedRoot::new(dir.path()).unwrap();
+
+        let bounded = bound_git_relative_path(&root, Path::new("./src/lib.rs")).unwrap();
+
+        assert_eq!(bounded, PathBuf::from("src/lib.rs"));
+    }
+
+    #[test]
+    fn test_bound_git_relative_path_rejects_parent_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = ValidatedRoot::new(dir.path()).unwrap();
+
+        let err = bound_git_relative_path(&root, Path::new("../secret.txt")).unwrap_err();
+
+        assert!(err.to_string().contains("parent traversal"));
+    }
+
+    #[test]
+    fn test_bound_git_relative_path_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = ValidatedRoot::new(dir.path()).unwrap();
+
+        let err = bound_git_relative_path(&root, Path::new("/secret.txt")).unwrap_err();
+
+        assert!(err.to_string().contains("must be relative"));
     }
 }

--- a/crates/tokmd-scan/tests/walk_git_env_boundaries.rs
+++ b/crates/tokmd-scan/tests/walk_git_env_boundaries.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use tempfile::TempDir;
@@ -43,13 +43,22 @@ fn poison_git_env(dir: &TempDir) -> GitEnvGuard {
     guard
 }
 
+fn init_git_repo(dir: &Path) {
+    let status = git_in(dir).arg("init").status().unwrap();
+    assert!(status.success(), "git init failed");
+}
+
+fn git_add(dir: &Path, path: &str) {
+    let status = git_in(dir).args(["add", path]).status().unwrap();
+    assert!(status.success(), "git add {path} failed");
+}
+
 #[test]
 fn list_files_ignores_inherited_git_env_overrides() {
     let repo = tempfile::tempdir().unwrap();
     let poison = tempfile::tempdir().unwrap();
 
-    let status = git_in(repo.path()).arg("init").status().unwrap();
-    assert!(status.success(), "git init failed");
+    init_git_repo(repo.path());
     let status = git_in(repo.path())
         .args(["config", "user.email", "tokmd@example.com"])
         .status()
@@ -62,11 +71,7 @@ fn list_files_ignores_inherited_git_env_overrides() {
     assert!(status.success(), "git config user.name failed");
 
     std::fs::write(repo.path().join("tracked.txt"), "tracked\n").unwrap();
-    let status = git_in(repo.path())
-        .args(["add", "tracked.txt"])
-        .status()
-        .unwrap();
-    assert!(status.success(), "git add tracked.txt failed");
+    git_add(repo.path(), "tracked.txt");
     let status = git_in(repo.path())
         .args(["commit", "-m", "tracked"])
         .status()
@@ -79,4 +84,58 @@ fn list_files_ignores_inherited_git_env_overrides() {
     let files = list_files(repo.path(), None).unwrap();
 
     assert_eq!(files, vec![std::path::PathBuf::from("tracked.txt")]);
+}
+
+#[test]
+fn list_files_git_fast_path_returns_root_relative_tracked_paths() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join("root.txt"), "root\n").unwrap();
+    std::fs::write(repo.path().join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+    std::fs::write(repo.path().join("untracked.txt"), "untracked\n").unwrap();
+    git_add(repo.path(), "root.txt");
+    git_add(repo.path(), "src/lib.rs");
+
+    let files = list_files(repo.path(), None).unwrap();
+
+    assert_eq!(
+        files,
+        vec![PathBuf::from("root.txt"), PathBuf::from("src/lib.rs")]
+    );
+    assert!(files.iter().all(|path| path.is_relative()));
+}
+
+#[test]
+fn list_files_git_fast_path_rejects_tracked_symlink_escape_when_supported() {
+    let repo = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+
+    let outside_file = outside.path().join("secret.txt");
+    let link = repo.path().join("secret-link.txt");
+    std::fs::write(&outside_file, "secret\n").unwrap();
+    if create_file_symlink(&outside_file, &link).is_err() {
+        return;
+    }
+    git_add(repo.path(), "secret-link.txt");
+
+    let err = list_files(repo.path(), None).unwrap_err();
+    let message = err.to_string();
+
+    assert!(
+        message.contains("escapes scan root"),
+        "expected symlink escape rejection, got: {message}"
+    );
+}
+
+#[cfg(unix)]
+fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(windows)]
+fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(src, dst)
 }


### PR DESCRIPTION
## Summary

- Route `git ls-files` results through the existing `ValidatedRoot` / `BoundedPath` containment substrate before returning scan paths.
- Keep Git fast-path outputs root-relative by returning the bounded relative path instead of only string-normalizing Git output.
- Add direct helper coverage for parent traversal and absolute Git-output shapes, plus integration coverage for tracked paths and tracked symlink escapes.

## Trust invariant improved

Every path returned by `tokmd-scan::walk::list_files` now has the same containment rule regardless of source: native-walk and Git-listed entries must resolve under the validated scan root before participating in scan results.

## Symlink escape policy

Tracked symlinks that resolve outside `ValidatedRoot` are rejected. This keeps the scan trust boundary stronger than Git-faithful inclusion of every tracked edge case.

## Validation

- `cargo fmt-check`
- `cargo check -p tokmd-scan -p tokmd-analysis -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-scan --test walk_git_env_boundaries`
- `cargo test -p tokmd-scan --lib bound_git_relative_path`
- `cargo test -p tokmd-scan --test walk_boundary_w53`
- `cargo test -p tokmd-scan --test walk_properties_traversal`
- `cargo test -p tokmd-scan`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred follow-ups

- MemFs root semantics
- WASM capability matrix
- WASM timestamp semantics
- GitHub Action `mode: gate`