### PR TITLE
chore: skip missing git-index scan paths

### DIFF
--- a/crates/tokmd-scan/src/walk/mod.rs
+++ b/crates/tokmd-scan/src/walk/mod.rs
@@ -46,7 +46,10 @@ pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
         files = files
             .into_iter()
             .map(|path| bound_git_relative_path(&root, &path))
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect();
         if let Some(limit) = max_files
             && files.len() > limit
         {
@@ -176,10 +179,15 @@ fn git_ls_files(root: &Path) -> Result<Option<Vec<PathBuf>>> {
     Ok(Some(files))
 }
 
-fn bound_git_relative_path(root: &ValidatedRoot, path: &Path) -> Result<PathBuf, PathViolation> {
-    Ok(BoundedPath::existing_relative(root, path)?
-        .relative()
-        .to_path_buf())
+fn bound_git_relative_path(
+    root: &ValidatedRoot,
+    path: &Path,
+) -> Result<Option<PathBuf>, PathViolation> {
+    match BoundedPath::existing_relative(root, path) {
+        Ok(path) => Ok(Some(path.relative().to_path_buf())),
+        Err(PathViolation::Missing(_)) => Ok(None),
+        Err(err) => Err(err),
+    }
 }
 
 pub fn file_size(root: &Path, relative: &Path) -> Result<u64> {
@@ -393,9 +401,21 @@ mod tests {
         fs::write(dir.path().join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
         let root = ValidatedRoot::new(dir.path()).unwrap();
 
-        let bounded = bound_git_relative_path(&root, Path::new("./src/lib.rs")).unwrap();
+        let bounded = bound_git_relative_path(&root, Path::new("./src/lib.rs"))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(bounded, PathBuf::from("src/lib.rs"));
+    }
+
+    #[test]
+    fn test_bound_git_relative_path_skips_missing_worktree_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = ValidatedRoot::new(dir.path()).unwrap();
+
+        let bounded = bound_git_relative_path(&root, Path::new("missing.rs")).unwrap();
+
+        assert!(bounded.is_none());
     }
 
     #[test]

--- a/crates/tokmd-scan/tests/walk_git_env_boundaries.rs
+++ b/crates/tokmd-scan/tests/walk_git_env_boundaries.rs
@@ -108,6 +108,22 @@ fn list_files_git_fast_path_returns_root_relative_tracked_paths() {
 }
 
 #[test]
+fn list_files_git_fast_path_skips_tracked_files_missing_from_worktree() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+
+    std::fs::write(repo.path().join("keep.txt"), "keep\n").unwrap();
+    std::fs::write(repo.path().join("gone.txt"), "gone\n").unwrap();
+    git_add(repo.path(), "keep.txt");
+    git_add(repo.path(), "gone.txt");
+    std::fs::remove_file(repo.path().join("gone.txt")).unwrap();
+
+    let files = list_files(repo.path(), None).unwrap();
+
+    assert_eq!(files, vec![PathBuf::from("keep.txt")]);
+}
+
+#[test]
 fn list_files_git_fast_path_rejects_tracked_symlink_escape_when_supported() {
     let repo = tempfile::tempdir().unwrap();
     let outside = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Keep bounding Git-listed paths through `ValidatedRoot` / `BoundedPath`.
- Treat tracked files missing from the working tree as absent and skip them instead of failing the whole Git fast path.
- Preserve hard errors for malformed paths, parent traversal, absolute paths, root escapes, symlink escapes, and non-missing canonicalization failures.
- Add regression coverage for a dirty Git index where `gone.txt` is still tracked but deleted from the working tree.

## Dirty Git Index Behavior

Before:

```text
git ls-files includes deleted indexed file -> BoundedPath::existing_relative returns Missing -> list_files errors
```

After:

```text
git ls-files includes deleted indexed file -> Missing maps to None -> list_files returns remaining valid tracked files
```

## Trust Invariant Preserved

Every returned Git-listed path is still root-relative and must resolve under `ValidatedRoot`. Missing worktree entries are not returned; escaping entries still fail closed.

## Validation

- `cargo fmt-check`
- `cargo check -p tokmd-scan -p tokmd-analysis -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-scan --test walk_git_env_boundaries`
- `cargo test -p tokmd-scan --lib bound_git_relative_path`
- `cargo test -p tokmd-scan --test walk_boundary_w53`
- `cargo test -p tokmd-scan`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred Follow-ups

- MemFs root semantics
- WASM capability matrix
- WASM timestamp semantics
- GitHub Action `mode: gate`