### PR TITLE
chore: tighten git missing path handling

### DIFF
--- a/crates/tokmd-scan/src/path/bounded_path.rs
+++ b/crates/tokmd-scan/src/path/bounded_path.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io;
 use std::path::{Component, Path, PathBuf};
 
 use super::{PathViolation, ValidatedRoot};
@@ -80,16 +81,24 @@ pub(crate) fn normalize_bounded_relative_path(path: &Path) -> Result<PathBuf, Pa
 }
 
 fn canonicalize_existing(path: &Path) -> Result<PathBuf, PathViolation> {
-    fs::canonicalize(path).map_err(|source| {
-        if !path.exists() {
-            PathViolation::Missing(path.to_path_buf())
-        } else {
-            PathViolation::CanonicalizeFailed {
-                path: path.to_path_buf(),
-                source,
+    match fs::canonicalize(path) {
+        Ok(canonical) => Ok(canonical),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            match fs::symlink_metadata(path) {
+                Err(meta_err) if meta_err.kind() == io::ErrorKind::NotFound => {
+                    Err(PathViolation::Missing(path.to_path_buf()))
+                }
+                Ok(_) | Err(_) => Err(PathViolation::CanonicalizeFailed {
+                    path: path.to_path_buf(),
+                    source,
+                }),
             }
         }
-    })
+        Err(source) => Err(PathViolation::CanonicalizeFailed {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 fn ensure_under_root(root: &ValidatedRoot, canonical: &Path) -> Result<(), PathViolation> {

--- a/crates/tokmd-scan/src/path/tests.rs
+++ b/crates/tokmd-scan/src/path/tests.rs
@@ -84,6 +84,33 @@ fn bounded_existing_relative_rejects_symlink_escape_when_supported() {
     assert!(err.to_string().contains("escapes scan root"));
 }
 
+#[test]
+fn bounded_existing_relative_reports_missing_only_for_true_not_found() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let root = ValidatedRoot::new(root_dir.path()).unwrap();
+
+    let err = BoundedPath::existing_relative(&root, Path::new("missing.rs")).unwrap_err();
+
+    assert!(matches!(err, PathViolation::Missing(_)));
+}
+
+#[test]
+fn bounded_existing_relative_dangling_symlink_is_not_missing_when_supported() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let missing_target = root_dir.path().join("missing-target.txt");
+    let link = root_dir.path().join("dangling-link.txt");
+
+    if create_file_symlink(&missing_target, &link).is_err() {
+        return;
+    }
+
+    let root = ValidatedRoot::new(root_dir.path()).unwrap();
+    let err = BoundedPath::existing_relative(&root, Path::new("dangling-link.txt")).unwrap_err();
+
+    assert!(matches!(err, PathViolation::CanonicalizeFailed { .. }));
+    assert!(err.to_string().contains("Failed to resolve bounded path"));
+}
+
 #[cfg(unix)]
 fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::os::unix::fs::symlink(src, dst)

--- a/crates/tokmd-scan/src/walk/mod.rs
+++ b/crates/tokmd-scan/src/walk/mod.rs
@@ -42,20 +42,19 @@ pub fn list_files(root: &Path, max_files: Option<usize>) -> Result<Vec<PathBuf>>
 
     let root = ValidatedRoot::new(root)?;
 
-    if let Some(mut files) = git_ls_files(root.input())? {
-        files = files
-            .into_iter()
-            .map(|path| bound_git_relative_path(&root, &path))
-            .collect::<std::result::Result<Vec<_>, _>>()?
-            .into_iter()
-            .flatten()
-            .collect();
-        if let Some(limit) = max_files
-            && files.len() > limit
-        {
-            files.truncate(limit);
+    if let Some(files) = git_ls_files(root.input())? {
+        let mut bounded = Vec::new();
+        for path in files {
+            if let Some(path) = bound_git_relative_path(&root, &path)? {
+                bounded.push(path);
+            }
+            if let Some(limit) = max_files
+                && bounded.len() >= limit
+            {
+                break;
+            }
         }
-        return Ok(files);
+        return Ok(bounded);
     }
 
     let mut files: Vec<PathBuf> = Vec::new();

--- a/crates/tokmd-scan/tests/walk_git_env_boundaries.rs
+++ b/crates/tokmd-scan/tests/walk_git_env_boundaries.rs
@@ -146,6 +146,27 @@ fn list_files_git_fast_path_rejects_tracked_symlink_escape_when_supported() {
     );
 }
 
+#[test]
+fn list_files_git_fast_path_errors_on_tracked_dangling_symlink_when_supported() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+
+    let missing_target = repo.path().join("missing-target.txt");
+    let link = repo.path().join("broken-link.txt");
+    if create_file_symlink(&missing_target, &link).is_err() {
+        return;
+    }
+    git_add(repo.path(), "broken-link.txt");
+
+    let err = list_files(repo.path(), None).unwrap_err();
+    let message = err.to_string();
+
+    assert!(
+        message.contains("Failed to resolve bounded path"),
+        "expected dangling symlink to fail closed, got: {message}"
+    );
+}
+
 #[cfg(unix)]
 fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::os::unix::fs::symlink(src, dst)


### PR DESCRIPTION
## Summary

- Classify `PathViolation::Missing` only when canonicalization returns `NotFound` and `symlink_metadata` also confirms the path is not found.
- Keep deleted Git-index entries skippable, but fail closed for dangling symlinks and other non-missing canonicalization failures.
- Stop Git fast-path processing once `max_files` valid bounded paths have been returned.
- Add path-level and Git-fast-path regression coverage for dangling symlinks.

## Before / After

Before: `fs::canonicalize` failure plus `!path.exists()` became `Missing`, so broken links or permission-like cases could be skipped by the Git fast path.

After: only confirmed not-found entries become `Missing`; dangling symlinks and other canonicalization failures remain errors.

## Trust invariant

Every returned Git-listed path remains root-relative and resolves under `ValidatedRoot`; missing worktree entries are not returned, and suspicious entries fail closed.

## Validation

- `cargo fmt-check`
- `cargo check -p tokmd-scan -p tokmd-analysis -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-scan --test walk_git_env_boundaries`
- `cargo test -p tokmd-scan --lib path::`
- `cargo test -p tokmd-scan --test walk_boundary_w53`
- `cargo test -p tokmd-scan`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred

- MemFs root semantics
- WASM capability matrix
- WASM timestamp semantics
- Action `mode: gate`
