### PR TITLE
compat: fix web runner message validation for paths and scan payloads 🧷

### DIFF
--- a/.jules/runs/compat_targets_matrix/decision.md
+++ b/.jules/runs/compat_targets_matrix/decision.md
@@ -1,0 +1,10 @@
+# Decision
+
+## Option A
+Fix the validation logic in `web/runner/messages.js` to correctly support `paths` and `scan` payloads as memory notes. The current validation `isRunMessage` enforces that only `inputs` array can be used, which is overly restrictive. Update the validation logic and the tests in `web/runner/messages.test.mjs`.
+
+## Option B
+Do not touch the JS implementation and document this as a limitation.
+
+## Choice
+**Option A**. The issue perfectly matches the memory notes about `tokmd`'s `web/runner` where run message arguments can be passed via `inputs`, `paths`, or `scan` objects, but the validation strictly requires `inputs`. This fixes a target-specific compatibility issue (browser-runner messages).

--- a/.jules/runs/compat_targets_matrix/envelope.json
+++ b/.jules/runs/compat_targets_matrix/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "compat_targets_matrix",
+  "persona": "Compat",
+  "style": "Builder",
+  "primary_shard": "bindings-targets",
+  "allowed_paths": [
+    "crates/tokmd-python/**",
+    "crates/tokmd-node/**",
+    "crates/tokmd-wasm/**",
+    "web/runner/**",
+    "crates/tokmd-core/**",
+    "docs/**"
+  ],
+  "gate_profile": "compat-matrix",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/compat_targets_matrix/pr_body.md
+++ b/.jules/runs/compat_targets_matrix/pr_body.md
@@ -1,0 +1,67 @@
+## 💡 Summary
+Updates the message validation logic in the `web/runner` protocol to correctly accept run messages that use `paths` or `scan` payloads instead of only `inputs`.
+
+## 🎯 Why
+The `isRunMessage` validator in `web/runner/messages.js` previously strictly enforced the presence of an `inputs` array. However, `tokmd` runner payloads are allowed to pass arguments via `inputs` (in-memory file arrays), `paths` (string arrays), or `scan` objects. This over-strict validation prevented valid messages from being processed by the runner runtime.
+
+## 🔎 Evidence
+- `web/runner/messages.js` lines 101-112 incorrectly required `Array.isArray(value.args.inputs)`.
+- Creating a valid run message with paths (`{ type: "run", requestId: "x", mode: "lang", args: { paths: ["src/lib.rs"] } }`) returned `false` from `isRunMessage`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Loosen the validation logic in `isRunMessage` to permit `inputs`, `paths`, or `scan` properties.
+- Fits the repo and shard because it aligns the browser interface's protocol validation with the actual core capability of the bindings/targets.
+- Trade-offs: Structure is improved by correctness. Minimal velocity cost.
+
+### Option B
+- Change the core WASM module or runtime to only accept `inputs` and reject `paths` and `scan`.
+- Choose when: we want to force all payloads into memory explicitly.
+- Trade-offs: Breaks existing functionality that relies on path strings or scan capabilities where applicable.
+
+## ✅ Decision
+Option A. It's the correct fix to align the runner's protocol validation with the target capabilities, fixing the drift.
+
+## 🧱 Changes made (SRP)
+- `web/runner/messages.js`: Updated `isRunMessage` to accept `inputs`, `paths`, or `scan`.
+- `web/runner/messages.test.mjs`: Updated test cases to assert correctness for `paths` and `scan` payloads.
+
+## 🧪 Verification receipts
+```text
+> test
+> node --test ./*.test.mjs
+
+TAP version 13
+# Subtest: parseGitHubRepo accepts owner/repo and GitHub URLs
+ok 1 - parseGitHubRepo accepts owner/repo and GitHub URLs
+...
+# Subtest: run messages accept inputs, paths, or scan objects
+ok 18 - run messages accept inputs, paths, or scan objects
+...
+1..40
+# tests 40
+# suites 0
+# pass 39
+# fail 0
+# cancelled 0
+# skipped 1
+# todo 0
+# duration_ms 819.109234
+```
+
+## 🧭 Telemetry
+- Change shape: Protocol validation logic fix and test update
+- Blast radius: Web runner (protocol messages)
+- Risk class: Low, only expands accepted payload types and prevents valid messages from being rejected.
+- Rollback: Revert the JS changes.
+- Gates run: `npm test` inside `web/runner`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/compat_targets_matrix/envelope.json`
+- `.jules/runs/compat_targets_matrix/decision.md`
+- `.jules/runs/compat_targets_matrix/receipts.jsonl`
+- `.jules/runs/compat_targets_matrix/result.json`
+- `.jules/runs/compat_targets_matrix/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/compat_targets_matrix/receipts.jsonl
+++ b/.jules/runs/compat_targets_matrix/receipts.jsonl
@@ -1,0 +1,3 @@
+{"command": "cd web/runner && npm test"}
+{"command": "python3 patch.py"}
+{"command": "cd web/runner && npm test"}

--- a/.jules/runs/compat_targets_matrix/result.json
+++ b/.jules/runs/compat_targets_matrix/result.json
@@ -1,0 +1,7 @@
+{
+  "outcome": "PR-ready patch",
+  "patch_files": [
+    "web/runner/messages.js",
+    "web/runner/messages.test.mjs"
+  ]
+}

--- a/web/runner/messages.js
+++ b/web/runner/messages.js
@@ -99,17 +99,42 @@ export function isInMemoryInput(value) {
 }
 
 export function isRunMessage(value) {
-    return Boolean(
-        value &&
-            value.type === MESSAGE_TYPES.RUN &&
-            typeof value.requestId === "string" &&
-            typeof value.mode === "string" &&
-            value.args &&
-            typeof value.args === "object" &&
-            !Array.isArray(value.args) &&
-            Array.isArray(value.args.inputs) &&
-            value.args.inputs.every(isInMemoryInput)
-    );
+    if (
+        !value ||
+        value.type !== MESSAGE_TYPES.RUN ||
+        typeof value.requestId !== "string" ||
+        typeof value.mode !== "string" ||
+        !value.args ||
+        typeof value.args !== "object" ||
+        Array.isArray(value.args)
+    ) {
+        return false;
+    }
+
+    let hasValidPayload = false;
+
+    if (value.args.inputs !== undefined) {
+        if (!Array.isArray(value.args.inputs) || !value.args.inputs.every(isInMemoryInput)) {
+            return false;
+        }
+        hasValidPayload = true;
+    }
+
+    if (value.args.paths !== undefined) {
+        if (!Array.isArray(value.args.paths) || !value.args.paths.every((p) => typeof p === "string")) {
+            return false;
+        }
+        hasValidPayload = true;
+    }
+
+    if (value.args.scan !== undefined) {
+        if (!value.args.scan || typeof value.args.scan !== "object" || Array.isArray(value.args.scan)) {
+            return false;
+        }
+        hasValidPayload = true;
+    }
+
+    return hasValidPayload;
 }
 
 export function isCancelMessage(value) {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -51,7 +51,7 @@ test("run and cancel helpers produce valid protocol messages", () => {
     assert.equal(isRunMessage(cancel), false);
 });
 
-test("run messages require ordered in-memory inputs", () => {
+test("run messages accept inputs, paths, or scan objects", () => {
     assert.equal(
         isInMemoryInput({ path: "src/lib.rs", text: "pub fn alpha() {}\n" }),
         true
@@ -83,6 +83,42 @@ test("run messages require ordered in-memory inputs", () => {
         false
     );
     assert.equal(isRunMessage({ type: "run", requestId: "x", mode: "lang", args: {} }), false);
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: { paths: ["src/lib.rs"] },
+        }),
+        true
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: { scan: { target: "foo" } },
+        }),
+        true
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: { paths: [123] },
+        }),
+        false
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: { scan: [] },
+        }),
+        false
+    );
     assert.equal(
         isRunMessage({
             type: "run",


### PR DESCRIPTION
## 💡 Summary 
Updates the message validation logic in the `web/runner` protocol to correctly accept run messages that use `paths` or `scan` payloads instead of only `inputs`.

## 🎯 Why 
The `isRunMessage` validator in `web/runner/messages.js` previously strictly enforced the presence of an `inputs` array. However, `tokmd` runner payloads are allowed to pass arguments via `inputs` (in-memory file arrays), `paths` (string arrays), or `scan` objects. This over-strict validation prevented valid messages from being processed by the runner runtime.

## 🔎 Evidence 
- `web/runner/messages.js` lines 101-112 incorrectly required `Array.isArray(value.args.inputs)`.
- Creating a valid run message with paths (`{ type: "run", requestId: "x", mode: "lang", args: { paths: ["src/lib.rs"] } }`) returned `false` from `isRunMessage`.

## 🧭 Options considered 
### Option A (recommended) 
- Loosen the validation logic in `isRunMessage` to permit `inputs`, `paths`, or `scan` properties. 
- Fits the repo and shard because it aligns the browser interface's protocol validation with the actual core capability of the bindings/targets. 
- Trade-offs: Structure is improved by correctness. Minimal velocity cost.

### Option B 
- Change the core WASM module or runtime to only accept `inputs` and reject `paths` and `scan`.
- Choose when: we want to force all payloads into memory explicitly.
- Trade-offs: Breaks existing functionality that relies on path strings or scan capabilities where applicable.

## ✅ Decision 
Option A. It's the correct fix to align the runner's protocol validation with the target capabilities, fixing the drift.

## 🧱 Changes made (SRP) 
- `web/runner/messages.js`: Updated `isRunMessage` to accept `inputs`, `paths`, or `scan`.
- `web/runner/messages.test.mjs`: Updated test cases to assert correctness for `paths` and `scan` payloads.

## 🧪 Verification receipts 
```text
> test
> node --test ./*.test.mjs

TAP version 13
# Subtest: parseGitHubRepo accepts owner/repo and GitHub URLs
ok 1 - parseGitHubRepo accepts owner/repo and GitHub URLs
...
# Subtest: run messages accept inputs, paths, or scan objects
ok 18 - run messages accept inputs, paths, or scan objects
...
1..40
# tests 40
# suites 0
# pass 39
# fail 0
# cancelled 0
# skipped 1
# todo 0
# duration_ms 819.109234
```

## 🧭 Telemetry 
- Change shape: Protocol validation logic fix and test update
- Blast radius: Web runner (protocol messages)
- Risk class: Low, only expands accepted payload types and prevents valid messages from being rejected.
- Rollback: Revert the JS changes.
- Gates run: `npm test` inside `web/runner`.

## 🗂️ .jules artifacts 
- `.jules/runs/compat_targets_matrix/envelope.json`
- `.jules/runs/compat_targets_matrix/decision.md`
- `.jules/runs/compat_targets_matrix/receipts.jsonl`
- `.jules/runs/compat_targets_matrix/result.json`
- `.jules/runs/compat_targets_matrix/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [9382161403573514282](https://jules.google.com/task/9382161403573514282) started by @EffortlessSteven*