### PR TITLE
gatekeeper: Add deterministic JSON serialize property tests ✅

### DIFF
--- a/crates/tokmd-types/tests/determinism_proptest_w80.rs
+++ b/crates/tokmd-types/tests/determinism_proptest_w80.rs
@@ -1,0 +1,129 @@
+use proptest::prelude::*;
+use tokmd_types::{DiffRow, DiffTotals, FileKind, FileRow, LangRow, ModuleRow};
+
+proptest! {
+    #[test]
+    fn diff_totals_serialize_roundtrip_stable(
+        old_code in 0usize..50_000,
+        new_code in 0usize..50_000,
+        delta_code in -50_000i64..50_000i64,
+        old_lines in 0usize..100_000,
+        new_lines in 0usize..100_000,
+        delta_lines in -100_000i64..100_000i64,
+        old_files in 1usize..5_000,
+        new_files in 1usize..5_000,
+        delta_files in -5_000i64..5_000i64,
+        old_bytes in 0usize..5_000_000,
+        new_bytes in 0usize..5_000_000,
+        delta_bytes in -5_000_000i64..5_000_000i64,
+        old_tokens in 0usize..500_000,
+        new_tokens in 0usize..500_000,
+        delta_tokens in -500_000i64..500_000i64
+    ) {
+        let totals = DiffTotals {
+            old_code, new_code, delta_code,
+            old_lines, new_lines, delta_lines,
+            old_files, new_files, delta_files,
+            old_bytes, new_bytes, delta_bytes,
+            old_tokens, new_tokens, delta_tokens,
+        };
+        let json1 = serde_json::to_string(&totals).expect("serialize");
+        let back: DiffTotals = serde_json::from_str(&json1).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        prop_assert_eq!(&json1, &json2, "JSON -> deserialize -> JSON must be stable for DiffTotals");
+    }
+
+    #[test]
+    fn diff_row_serialize_roundtrip_stable(
+        lang in "[A-Za-z][A-Za-z0-9 ]{0,15}",
+        old_code in 0usize..50_000,
+        new_code in 0usize..50_000,
+        delta_code in -50_000i64..50_000i64,
+        old_lines in 0usize..100_000,
+        new_lines in 0usize..100_000,
+        delta_lines in -100_000i64..100_000i64,
+        old_files in 1usize..5_000,
+        new_files in 1usize..5_000,
+        delta_files in -5_000i64..5_000i64,
+        old_bytes in 0usize..5_000_000,
+        new_bytes in 0usize..5_000_000,
+        delta_bytes in -5_000_000i64..5_000_000i64,
+        old_tokens in 0usize..500_000,
+        new_tokens in 0usize..500_000,
+        delta_tokens in -500_000i64..500_000i64
+    ) {
+        let row = DiffRow {
+            lang, old_code, new_code, delta_code,
+            old_lines, new_lines, delta_lines,
+            old_files, new_files, delta_files,
+            old_bytes, new_bytes, delta_bytes,
+            old_tokens, new_tokens, delta_tokens,
+        };
+        let json1 = serde_json::to_string(&row).expect("serialize");
+        let back: DiffRow = serde_json::from_str(&json1).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        prop_assert_eq!(&json1, &json2, "JSON -> deserialize -> JSON must be stable for DiffRow");
+    }
+}
+
+proptest! {
+    #[test]
+    fn file_row_serialize_roundtrip_stable(
+        path in "[a-z][a-z0-9_/]{1,30}\\.[a-z]{1,4}",
+        module in "[a-z][a-z0-9_/]{0,15}",
+        lang in "[A-Za-z][A-Za-z0-9 ]{0,10}",
+        kind in prop_oneof![Just(FileKind::Parent), Just(FileKind::Child)],
+        code in 0usize..50_000,
+        comments in 0usize..10_000,
+        blanks in 0usize..10_000,
+        lines in 0usize..100_000,
+        bytes in 0usize..5_000_000,
+        tokens in 0usize..500_000
+    ) {
+        let row = FileRow {
+            path, module, lang, kind, code, comments, blanks, lines, bytes, tokens,
+        };
+        let json1 = serde_json::to_string(&row).expect("serialize");
+        let back: FileRow = serde_json::from_str(&json1).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        prop_assert_eq!(&json1, &json2, "JSON -> deserialize -> JSON must be stable for FileRow");
+    }
+
+    #[test]
+    fn lang_row_serialize_roundtrip_stable(
+        lang in "[A-Za-z][A-Za-z0-9 ]{0,15}",
+        code in 0usize..50_000,
+        lines in 0usize..100_000,
+        files in 1usize..5_000,
+        bytes in 0usize..5_000_000,
+        tokens in 0usize..500_000,
+        avg_lines in 0usize..500
+    ) {
+        let row = LangRow {
+            lang, code, lines, files, bytes, tokens, avg_lines,
+        };
+        let json1 = serde_json::to_string(&row).expect("serialize");
+        let back: LangRow = serde_json::from_str(&json1).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        prop_assert_eq!(&json1, &json2, "JSON -> deserialize -> JSON must be stable for LangRow");
+    }
+
+    #[test]
+    fn module_row_serialize_roundtrip_stable(
+        module in "[a-z][a-z0-9_/]{0,20}",
+        code in 0usize..50_000,
+        lines in 0usize..100_000,
+        files in 1usize..5_000,
+        bytes in 0usize..5_000_000,
+        tokens in 0usize..500_000,
+        avg_lines in 0usize..500
+    ) {
+        let row = ModuleRow {
+            module, code, lines, files, bytes, tokens, avg_lines,
+        };
+        let json1 = serde_json::to_string(&row).expect("serialize");
+        let back: ModuleRow = serde_json::from_str(&json1).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        prop_assert_eq!(&json1, &json2, "JSON -> deserialize -> JSON must be stable for ModuleRow");
+    }
+}


### PR DESCRIPTION
## 💡 Summary 
Added JSON serialization stability property tests under `proptest` for the core pipeline outputs (`FileRow`, `ModuleRow`, `LangRow`, `DiffRow`, `DiffTotals`). This hardens the core types against arbitrary randomized data without changing production code. (Note: previous sort-property tests were removed to avoid duplicating and re-implementing logic belonging to `tokmd-model`).

## 🎯 Why 
Our core structural stability invariants are documented and checked against fixed snapshots or limited unit tests, but they were not exhaustively fuzzed or stressed under `proptest` for complex fields like `DiffRow` containing negative values, zeroes, or large scale deltas. The Gatekeeper `contracts-determinism` profile prioritizes proving that contract-bearing surfaces (like our JSON output rows) correctly round-trip safely.

## 🔎 Evidence 
- Run `cargo test -p tokmd-types --test determinism_proptest_w80` and observe new exhaustively generated property tests for JSON stability logic over `tokmd_types`.

## 🧭 Options considered 
### Option A (recommended) 
- Add comprehensive `proptest` files verifying determinism of core output structs.
- Fits the Gatekeeper profile and Shard assignments since it expands proof surface without risking production code changes.
- trade-offs: Structure is improved, Velocity may decrease if people accidentally break tie-break invariants, Governance is enforced.

### Option B 
- Tweak minor description drifts in `docs/schema.json` without code change.
- When to choose: if significant drift exists in schema docs. 
- Trade-offs: lower leverage impact, no new proof properties added.

## ✅ Decision 
Chosen **Option A**. Adding property tests directly hits the highest priority Gatekeeper objective: tightening invariants around deterministic outputs. 

## 🧱 Changes made (SRP) 
- Added `crates/tokmd-types/tests/determinism_proptest_w80.rs`

## 🧪 Verification receipts 
```text
cargo test -p tokmd-types --test determinism_proptest_w80

running 5 tests
test diff_totals_serialize_roundtrip_stable ... ok
test lang_row_serialize_roundtrip_stable ... ok
test module_row_serialize_roundtrip_stable ... ok
test diff_row_serialize_roundtrip_stable ... ok
test file_row_serialize_roundtrip_stable ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s
```

## 🧭 Telemetry 
- Change shape: New test file added.
- Blast radius: Zero API/IO/runtime impact. `tokmd-types` test-only change.
- Risk class: Low, only runs during tests.
- Rollback: `git restore crates/tokmd-types/tests/determinism_proptest_w80.rs`
- Gates run: `cargo test -p tokmd-types`, `cargo fmt`, `cargo clippy`.

## 🗂️ .jules artifacts 
- `.jules/runs/gatekeeper_determinism/envelope.json`
- `.jules/runs/gatekeeper_determinism/decision.md`
- `.jules/runs/gatekeeper_determinism/receipts.jsonl`
- `.jules/runs/gatekeeper_determinism/result.json`
- `.jules/runs/gatekeeper_determinism/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [7197006816813085837](https://jules.google.com/task/7197006816813085837) started by @EffortlessSteven*