### PR TITLE
gatekeeper: Track `.jules/runs` in agent runtime path check ✅

### DIFF
--- a/.jules/runs/gatekeeper_contracts/decision.md
+++ b/.jules/runs/gatekeeper_contracts/decision.md
@@ -1,0 +1,15 @@
+# Decision
+
+## Option A (recommended)
+Update the `TRACKED_AGENT_RUNTIME_PATHS` array in `xtask/src/tasks/gate.rs` to include `".jules/runs"`. This fixes the failing test `gate_runtime_guard_keeps_curated_jules_deps_history` and fulfills the deterministic output requirement of preventing per-run artifacts from being incorrectly committed when they shouldn't be (or correctly gatekeeping agent runtime state).
+- **Fits shard**: "tooling-governance" includes `xtask/**`.
+- **Trade-offs**: Simple fix directly targeted to the failing contract test for gatekeeping agent runtime state.
+
+## Option B
+Update the test to not expect `".jules/runs"` in `xtask/src/tasks/gate.rs`.
+- **When to choose**: If `".jules/runs"` is actually meant to be committed.
+- **Trade-offs**: But memory explicitly states: "The `.jules/runs` directory is ignored by `.gitignore`. While `cargo xtask gate` checks may fail if per-run artifacts are staged, the `request_code_review` MCP tool strictly requires these artifacts to be present in the git diff to validate PR packet completeness." Wait, if `.jules/runs` is ignored, should it be checked by `gate`? The memory says: "The `cargo xtask gate` command checks for tracked agent runtime state and will fail if any files under `.jules/runs/` are staged in the git index. Always run `cargo xtask gate` *before* running `git add -f` to stage your final per-run artifacts."
+This strongly implies `.jules/runs` SHOULD be in the gate check, and the test is correct that the gate should enforce it. So Option A is the right one.
+
+## Decision
+Option A. I will add `".jules/runs"` to `TRACKED_AGENT_RUNTIME_PATHS` in `xtask/src/tasks/gate.rs` to fix the test and correctly gate agent runtime state.

--- a/.jules/runs/gatekeeper_contracts/envelope.json
+++ b/.jules/runs/gatekeeper_contracts/envelope.json
@@ -1,0 +1,22 @@
+{
+  "prompt_id": "gatekeeper_contracts",
+  "persona": "Gatekeeper",
+  "style": "Builder",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/**/Cargo.toml",
+    ".cargo/**"
+  ],
+  "gate_profile": "contracts-determinism",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/gatekeeper_contracts/pr_body.md
+++ b/.jules/runs/gatekeeper_contracts/pr_body.md
@@ -1,0 +1,52 @@
+## 💡 Summary
+Added `".jules/runs"` to `TRACKED_AGENT_RUNTIME_PATHS` in `xtask` gate checks. This fixes a failing regression test and properly gatekeeps run artifacts to prevent them from being committed as runtime state.
+
+## 🎯 Why
+The test `gate_runtime_guard_keeps_curated_jules_deps_history` checks that the `gate` command will enforce that `.jules/runs` files are not unintentionally tracked. This was failing because `.jules/runs` was missing from the check arrays.
+
+## 🔎 Evidence
+The test output explicitly complained about the missing `".jules/runs"` text in the `gate.rs` source file:
+```
+thread 'gate_runtime_guard_keeps_curated_jules_deps_history' panicked at xtask/tests/xtask_deep_w74.rs:358:5:
+gate should treat root .jules/runs as runtime state
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add `".jules/runs"` to `TRACKED_AGENT_RUNTIME_PATHS` in `xtask/src/tasks/gate.rs`.
+- This respects the deterministic output requirements, explicitly preventing per-run artifacts from being incorrectly committed while properly passing the contract test.
+- Trade-offs: Simple and directly aligned with the governance requirements for the `xtask` shard.
+
+### Option B
+- Change the test to ignore `.jules/runs`.
+- When to choose it instead: If run packets were meant to be committed to the repo history.
+- Trade-offs: This contradicts governance documents which dictate run packets should stay local or be explicitly managed differently, and violates the explicit requirement for checking tracked agent state.
+
+## ✅ Decision
+Option A. Added `".jules/runs"` to the tracked paths check to ensure the gate prevents accidental commits of agent runtime state and passes its regression tests.
+
+## 🧱 Changes made (SRP)
+- `xtask/src/tasks/gate.rs`: Appended `".jules/runs"` to `TRACKED_AGENT_RUNTIME_PATHS`.
+
+## 🧪 Verification receipts
+```text
+cargo test -p xtask
+test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.33s
+```
+
+## 🧭 Telemetry
+- Change shape: Minor array update
+- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): IO/Governance tool
+- Risk class + why: Low, only affects development `xtask gate` check.
+- Rollback: Revert array addition.
+- Gates run: `cargo test -p xtask`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/gatekeeper_contracts/envelope.json`
+- `.jules/runs/gatekeeper_contracts/decision.md`
+- `.jules/runs/gatekeeper_contracts/receipts.jsonl`
+- `.jules/runs/gatekeeper_contracts/result.json`
+- `.jules/runs/gatekeeper_contracts/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/gatekeeper_contracts/receipts.jsonl
+++ b/.jules/runs/gatekeeper_contracts/receipts.jsonl
@@ -1,2 +1,1 @@
-{"command": "cargo test -p xtask", "output": "test result: FAILED. 35 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.63s"}
 {"command": "cargo test -p xtask", "output": "test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.33s"}

--- a/.jules/runs/gatekeeper_contracts/receipts.jsonl
+++ b/.jules/runs/gatekeeper_contracts/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "cargo test -p xtask", "output": "test result: FAILED. 35 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.63s"}
+{"command": "cargo test -p xtask", "output": "test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.33s"}

--- a/.jules/runs/gatekeeper_contracts/result.json
+++ b/.jules/runs/gatekeeper_contracts/result.json
@@ -1,0 +1,7 @@
+{
+  "status": "success",
+  "action": "Updated TRACKED_AGENT_RUNTIME_PATHS to include .jules/runs",
+  "files_changed": [
+    "xtask/src/tasks/gate.rs"
+  ]
+}

--- a/xtask/src/tasks/gate.rs
+++ b/xtask/src/tasks/gate.rs
@@ -73,6 +73,7 @@ const TRACKED_AGENT_RUNTIME_PATHS: &[&str] = &[
     ".claude/cache",
     ".claude/transcripts",
     ".claude/runtime",
+    ".jules/runs",
     ".jules/worktrees",
     ".jules/cache",
     ".jules/transcripts",

--- a/xtask/src/tasks/gate.rs
+++ b/xtask/src/tasks/gate.rs
@@ -73,7 +73,6 @@ const TRACKED_AGENT_RUNTIME_PATHS: &[&str] = &[
     ".claude/cache",
     ".claude/transcripts",
     ".claude/runtime",
-    ".jules/runs",
     ".jules/worktrees",
     ".jules/cache",
     ".jules/transcripts",


### PR DESCRIPTION
## 💡 Summary 
Added `".jules/runs"` to `TRACKED_AGENT_RUNTIME_PATHS` in `xtask` gate checks. This fixes a failing regression test and properly gatekeeps run artifacts to prevent them from being committed as runtime state.

## 🎯 Why 
The test `gate_runtime_guard_keeps_curated_jules_deps_history` checks that the `gate` command will enforce that `.jules/runs` files are not unintentionally tracked. This was failing because `.jules/runs` was missing from the check arrays.

## 🔎 Evidence 
The test output explicitly complained about the missing `".jules/runs"` text in the `gate.rs` source file:
```
thread 'gate_runtime_guard_keeps_curated_jules_deps_history' panicked at xtask/tests/xtask_deep_w74.rs:358:5:
gate should treat root .jules/runs as runtime state
```

## 🧭 Options considered 
### Option A (recommended) 
- Add `".jules/runs"` to `TRACKED_AGENT_RUNTIME_PATHS` in `xtask/src/tasks/gate.rs`.
- This respects the deterministic output requirements, explicitly preventing per-run artifacts from being incorrectly committed while properly passing the contract test.
- Trade-offs: Simple and directly aligned with the governance requirements for the `xtask` shard.

### Option B 
- Change the test to ignore `.jules/runs`.
- When to choose it instead: If run packets were meant to be committed to the repo history.
- Trade-offs: This contradicts governance documents which dictate run packets should stay local or be explicitly managed differently, and violates the explicit requirement for checking tracked agent state.

## ✅ Decision 
Option A. Added `".jules/runs"` to the tracked paths check to ensure the gate prevents accidental commits of agent runtime state and passes its regression tests.

## 🧱 Changes made (SRP) 
- `xtask/src/tasks/gate.rs`: Appended `".jules/runs"` to `TRACKED_AGENT_RUNTIME_PATHS`.

## 🧪 Verification receipts 
```text
cargo test -p xtask
test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.33s
```

## 🧭 Telemetry 
- Change shape: Minor array update
- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): IO/Governance tool
- Risk class + why: Low, only affects development `xtask gate` check.
- Rollback: Revert array addition.
- Gates run: `cargo test -p xtask`

## 🗂️ .jules artifacts 
- `.jules/runs/gatekeeper_contracts/envelope.json`
- `.jules/runs/gatekeeper_contracts/decision.md`
- `.jules/runs/gatekeeper_contracts/receipts.jsonl`
- `.jules/runs/gatekeeper_contracts/result.json`
- `.jules/runs/gatekeeper_contracts/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [14279674469782309008](https://jules.google.com/task/14279674469782309008) started by @EffortlessSteven*