### PR TITLE
auditor: remove unused pyo3-build-config from tokmd-python 🧾

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,7 +2743,6 @@ version = "1.9.0"
 dependencies = [
  "proptest",
  "pyo3",
- "pyo3-build-config",
  "serde_json",
  "tempfile",
  "tokmd-core",

--- a/crates/tokmd-python/Cargo.toml
+++ b/crates/tokmd-python/Cargo.toml
@@ -27,8 +27,6 @@ tokmd-envelope.workspace = true
 default = ["extension-module"]
 extension-module = ["pyo3/extension-module"]
 
-[build-dependencies]
-pyo3-build-config = "0.28.3"
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
Removed unused `pyo3-build-config` from `tokmd-python` `Cargo.toml`.

---
*PR created automatically by Jules for task [14682462600309846384](https://jules.google.com/task/14682462600309846384) started by @EffortlessSteven*