### PR TITLE
chore: preserve metadata path errors

### DIFF
--- a/crates/tokmd-scan/src/path/bounded_path.rs
+++ b/crates/tokmd-scan/src/path/bounded_path.rs
@@ -88,7 +88,11 @@ fn canonicalize_existing(path: &Path) -> Result<PathBuf, PathViolation> {
                 Err(meta_err) if meta_err.kind() == io::ErrorKind::NotFound => {
                     Err(PathViolation::Missing(path.to_path_buf()))
                 }
-                Ok(_) | Err(_) => Err(PathViolation::CanonicalizeFailed {
+                Ok(_) => Err(PathViolation::CanonicalizeFailed {
+                    path: path.to_path_buf(),
+                    source,
+                }),
+                Err(source) => Err(PathViolation::CanonicalizeFailed {
                     path: path.to_path_buf(),
                     source,
                 }),


### PR DESCRIPTION
## Summary

- Preserve the `symlink_metadata` error source when canonicalization first reports `NotFound` and metadata probing then fails for a different reason.
- Keep true not-found entries classified as `PathViolation::Missing` only when both canonicalization and metadata probing report `NotFound`.
- Keep dangling symlinks and suspicious missing-like cases failing closed as `CanonicalizeFailed`.

## Diagnostic behavior

Before: `canonicalize` returning `NotFound` followed by `symlink_metadata` returning a non-`NotFound` error still reported the original canonicalize `NotFound` source.

After: `symlink_metadata` non-`NotFound` errors are preserved as the `CanonicalizeFailed` source, so permission or environment failures report the more accurate filesystem error.

## Trust behavior

No trust-policy behavior changes. Dirty Git-index entries that are truly missing remain skippable, while dangling symlinks, permissions failures, root escapes, and other non-missing canonicalization failures fail closed.

## Validation

- `cargo fmt-check`
- `cargo check -p tokmd-scan -p tokmd-analysis -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-scan --lib path::`
- `cargo test -p tokmd-scan --test walk_git_env_boundaries`
- `cargo test -p tokmd-scan --test walk_boundary_w53`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred

- MemFs root semantics
- WASM capability matrix
- WASM timestamp semantics
- Action `mode: gate`
