### PR TITLE
chore: settle memfs root semantics

### DIFF
--- a/crates/tokmd-scan/src/walk/mod.rs
+++ b/crates/tokmd-scan/src/walk/mod.rs
@@ -211,6 +211,10 @@ pub fn file_size_from_memfs(fs: &MemFs, root: &Path, relative: &Path) -> Result<
 }
 
 fn normalize_memfs_root(path: &Path) -> Result<PathBuf> {
+    // Native roots are filesystem-canonicalized through ValidatedRoot.
+    // MemFs roots are logical roots over an in-memory tree: empty and `.`
+    // are rootless, normal relative paths scope the tree, and absolute or
+    // parent-traversing roots are rejected.
     let mut normalized = PathBuf::new();
     if path.as_os_str().is_empty() {
         return Ok(normalized);

--- a/crates/tokmd-scan/tests/walk_memfs_api_w79.rs
+++ b/crates/tokmd-scan/tests/walk_memfs_api_w79.rs
@@ -13,6 +13,39 @@ fn sample_memfs() -> MemFs {
     fs
 }
 
+fn expected_all_files() -> Vec<std::path::PathBuf> {
+    vec![
+        Path::new("README.md").to_path_buf(),
+        Path::new("assets/logo.svg").to_path_buf(),
+        Path::new("src/lib.rs").to_path_buf(),
+        Path::new("src/main.rs").to_path_buf(),
+        Path::new("src/nested/mod.rs").to_path_buf(),
+    ]
+}
+
+fn assert_parent_traversal_error(message: &str) {
+    assert!(
+        message.contains("parent traversal"),
+        "expected parent traversal error, got: {message}"
+    );
+}
+
+fn assert_absolute_path_error(message: &str) {
+    assert!(
+        message.contains("must be relative"),
+        "expected absolute path error, got: {message}"
+    );
+}
+
+#[test]
+fn list_files_from_memfs_empty_root_returns_all_files() {
+    let fs = sample_memfs();
+
+    let files = list_files_from_memfs(&fs, Path::new(""), None).unwrap();
+
+    assert_eq!(files, expected_all_files());
+}
+
 #[test]
 fn list_files_from_memfs_returns_sorted_root_relative_paths() {
     let fs = sample_memfs();
@@ -35,16 +68,7 @@ fn list_files_from_memfs_root_dot_returns_all_files() {
 
     let files = list_files_from_memfs(&fs, Path::new("."), None).unwrap();
 
-    assert_eq!(
-        files,
-        vec![
-            Path::new("README.md").to_path_buf(),
-            Path::new("assets/logo.svg").to_path_buf(),
-            Path::new("src/lib.rs").to_path_buf(),
-            Path::new("src/main.rs").to_path_buf(),
-            Path::new("src/nested/mod.rs").to_path_buf(),
-        ]
-    );
+    assert_eq!(files, expected_all_files());
 }
 
 #[test]
@@ -100,6 +124,15 @@ fn file_size_from_memfs_reads_relative_bytes() {
 }
 
 #[test]
+fn file_size_from_memfs_empty_root_reads_root_relative_file() {
+    let fs = sample_memfs();
+
+    let size = file_size_from_memfs(&fs, Path::new(""), Path::new("README.md")).unwrap();
+
+    assert_eq!(size, "# repo".len() as u64);
+}
+
+#[test]
 fn file_size_from_memfs_dot_prefixed_root_matches_plain_root() {
     let fs = sample_memfs();
 
@@ -124,7 +157,52 @@ fn list_files_from_memfs_rejects_parent_root() {
 
     let result = list_files_from_memfs(&fs, Path::new("../src"), None);
 
-    assert!(result.is_err());
+    assert_parent_traversal_error(&result.unwrap_err().to_string());
+}
+
+#[test]
+fn file_size_from_memfs_rejects_parent_root() {
+    let fs = sample_memfs();
+
+    let result = file_size_from_memfs(&fs, Path::new("../src"), Path::new("lib.rs"));
+
+    assert_parent_traversal_error(&result.unwrap_err().to_string());
+}
+
+#[test]
+fn list_files_from_memfs_rejects_absolute_scoped_root() {
+    let fs = sample_memfs();
+
+    let result = list_files_from_memfs(&fs, Path::new("/src"), None);
+
+    assert_absolute_path_error(&result.unwrap_err().to_string());
+}
+
+#[test]
+fn file_size_from_memfs_rejects_absolute_scoped_root() {
+    let fs = sample_memfs();
+
+    let result = file_size_from_memfs(&fs, Path::new("/src"), Path::new("lib.rs"));
+
+    assert_absolute_path_error(&result.unwrap_err().to_string());
+}
+
+#[test]
+fn list_files_from_memfs_rejects_slash_root() {
+    let fs = sample_memfs();
+
+    let result = list_files_from_memfs(&fs, Path::new("/"), None);
+
+    assert_absolute_path_error(&result.unwrap_err().to_string());
+}
+
+#[test]
+fn file_size_from_memfs_rejects_slash_root() {
+    let fs = sample_memfs();
+
+    let result = file_size_from_memfs(&fs, Path::new("/"), Path::new("README.md"));
+
+    assert_absolute_path_error(&result.unwrap_err().to_string());
 }
 
 #[test]
@@ -133,5 +211,5 @@ fn file_size_from_memfs_rejects_parent_relative_path() {
 
     let result = file_size_from_memfs(&fs, Path::new("src"), Path::new("../README.md"));
 
-    assert!(result.is_err());
+    assert_parent_traversal_error(&result.unwrap_err().to_string());
 }


### PR DESCRIPTION
## Summary

- Document the MemFs root contract in `tokmd-scan::walk`.
- Add explicit coverage for rootless `""` and `"."`, scoped roots, parent traversal rejection, absolute scoped root rejection, and slash-root rejection.
- Verify `file_size_from_memfs` follows the same root contract as `list_files_from_memfs`.

## MemFs Root Contract

- `""` -> rootless MemFs root
- `"."` -> rootless MemFs root
- `"src"` -> scoped MemFs root
- `"../x"` -> reject
- `"/src"` -> reject
- `"/"` -> reject

## Before / After

Before: the implementation already rejected dangerous roots, but empty-root and slash-root semantics were not fully locked down by the MemFs API tests.

After: rootless, scoped, parent-traversing, absolute scoped, and slash-root behavior is explicit and covered for both listing and file-size lookup.

## Validation

- `cargo fmt-check`
- `cargo check -p tokmd-scan -p tokmd-analysis -p tokmd-core -p tokmd --all-targets`
- `cargo test -p tokmd-scan --test walk_memfs_api_w79`
- `cargo test -p tokmd-scan --test walk_boundary_w53`
- `cargo test -p tokmd-scan`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred

- WASM capability matrix (#1332)
- WASM timestamp semantics (#775)
- GitHub Action `mode: gate` (#1333)

Closes #979.
Updates #1301.