### PR TITLE
docs: add wasm capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Embed them in your own README:
 - Supported today: `lang`, `module`, `export`, and browser-safe `analyze` presets on ordered in-memory inputs.
 - Public repo ingestion uses GitHub tree and contents APIs with built-in caching, progress tracking, and auth handling.
 - Git-history enrichers and full native filesystem flows remain native-first.
+- The machine-readable browser capability contract lives in `docs/capabilities/wasm.json`.
 
 ## What `tokmd` Is Not
 

--- a/crates/tokmd-wasm/README.md
+++ b/crates/tokmd-wasm/README.md
@@ -27,6 +27,8 @@ Inputs are ordered `{ path, text | base64 }` rows.
 
 `lang`, `module`, `export`, and `analyze` are the supported browser workflows today. `analyze` currently accepts only `preset: "receipt"` or `preset: "estimate"`, and `analysisSchemaVersion()` is only exported when the `analysis` feature is enabled.
 
+The command-level browser/rootless capability matrix lives in `../../docs/capabilities/wasm.json`.
+
 ## Distribution
 
 `tokmd-wasm` is intended to be consumed from a stable, versioned artifact in CI and releases, not from a mutable local directory.

--- a/docs/capabilities/wasm.json
+++ b/docs/capabilities/wasm.json
@@ -1,0 +1,119 @@
+{
+  "version": 1,
+  "value_legend": {
+    "true": "Supported for this capability dimension.",
+    "false": "Not required or not supported for this capability dimension.",
+    "partial": "Supported only for a documented subset of inputs, formats, or presets.",
+    "native_only": "Available only through native filesystem or git-backed execution."
+  },
+  "commands": {
+    "lang": {
+      "browser_safe": true,
+      "rootless_safe": true,
+      "native_only": false,
+      "requires_filesystem": false,
+      "requires_git_history": false,
+      "requires_host_clock": "partial",
+      "requires_validated_root": false
+    },
+    "module": {
+      "browser_safe": true,
+      "rootless_safe": true,
+      "native_only": false,
+      "requires_filesystem": false,
+      "requires_git_history": false,
+      "requires_host_clock": "partial",
+      "requires_validated_root": false
+    },
+    "export": {
+      "browser_safe": true,
+      "rootless_safe": true,
+      "native_only": false,
+      "requires_filesystem": false,
+      "requires_git_history": false,
+      "requires_host_clock": "partial",
+      "requires_validated_root": false
+    },
+    "analyze": {
+      "browser_safe": "partial",
+      "rootless_safe": "partial",
+      "native_only": false,
+      "requires_filesystem": "partial",
+      "requires_git_history": "partial",
+      "requires_host_clock": "partial",
+      "requires_validated_root": "partial"
+    },
+    "diff": {
+      "browser_safe": "partial",
+      "rootless_safe": "partial",
+      "native_only": false,
+      "requires_filesystem": "partial",
+      "requires_git_history": "native_only",
+      "requires_host_clock": "partial",
+      "requires_validated_root": "partial"
+    },
+    "badge": {
+      "browser_safe": "partial",
+      "rootless_safe": "partial",
+      "native_only": false,
+      "requires_filesystem": "partial",
+      "requires_git_history": "partial",
+      "requires_host_clock": false,
+      "requires_validated_root": "partial"
+    },
+    "gate": {
+      "browser_safe": "partial",
+      "rootless_safe": "partial",
+      "native_only": false,
+      "requires_filesystem": "partial",
+      "requires_git_history": false,
+      "requires_host_clock": false,
+      "requires_validated_root": false
+    },
+    "context": {
+      "browser_safe": "partial",
+      "rootless_safe": "partial",
+      "native_only": false,
+      "requires_filesystem": "partial",
+      "requires_git_history": "native_only",
+      "requires_host_clock": "partial",
+      "requires_validated_root": "partial"
+    },
+    "handoff": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": true,
+      "requires_git_history": "partial",
+      "requires_host_clock": true,
+      "requires_validated_root": true
+    },
+    "cockpit": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": true,
+      "requires_git_history": true,
+      "requires_host_clock": true,
+      "requires_validated_root": true
+    },
+    "sensor": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": true,
+      "requires_git_history": true,
+      "requires_host_clock": true,
+      "requires_validated_root": true
+    },
+    "baseline": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": true,
+      "requires_git_history": "partial",
+      "requires_host_clock": true,
+      "requires_validated_root": true
+    }
+  }
+}

--- a/xtask/tests/docs_schema_w72.rs
+++ b/xtask/tests/docs_schema_w72.rs
@@ -57,6 +57,12 @@ fn schema_json() -> serde_json::Value {
     serde_json::from_str(&raw).expect("docs/schema.json must be valid JSON")
 }
 
+fn wasm_capability_matrix() -> serde_json::Value {
+    let raw = std::fs::read_to_string(workspace_root().join("docs/capabilities/wasm.json"))
+        .expect("docs/capabilities/wasm.json must exist");
+    serde_json::from_str(&raw).expect("docs/capabilities/wasm.json must be valid JSON")
+}
+
 fn readme_md() -> String {
     std::fs::read_to_string(workspace_root().join("README.md")).expect("README.md must exist")
 }
@@ -291,7 +297,87 @@ fn schema_json_receipt_versions_match_source() {
 }
 
 // ===========================================================================
-// 4. Every CLI command in README.md Commands table actually exists
+// 4. Browser/WASM capability matrix structure
+// ===========================================================================
+
+#[test]
+fn wasm_capability_matrix_declares_required_commands_and_fields() {
+    let matrix = wasm_capability_matrix();
+    assert_eq!(
+        matrix["version"].as_u64(),
+        Some(1),
+        "WASM capability matrix version should be 1"
+    );
+
+    let commands = matrix["commands"]
+        .as_object()
+        .expect("docs/capabilities/wasm.json commands must be an object");
+    let required_commands = [
+        "lang", "module", "export", "analyze", "diff", "badge", "gate", "context", "handoff",
+        "cockpit", "sensor", "baseline",
+    ];
+    let required_fields = [
+        "browser_safe",
+        "rootless_safe",
+        "native_only",
+        "requires_filesystem",
+        "requires_git_history",
+        "requires_host_clock",
+        "requires_validated_root",
+    ];
+
+    for command in required_commands {
+        let entry = commands
+            .get(command)
+            .unwrap_or_else(|| panic!("WASM capability matrix missing command {command}"));
+        let object = entry
+            .as_object()
+            .unwrap_or_else(|| panic!("WASM capability entry {command} must be an object"));
+        for field in required_fields {
+            assert!(
+                object.contains_key(field),
+                "WASM capability entry {command} missing field {field}"
+            );
+        }
+    }
+}
+
+#[test]
+fn wasm_capability_matrix_uses_allowed_values() {
+    let matrix = wasm_capability_matrix();
+    let commands = matrix["commands"]
+        .as_object()
+        .expect("docs/capabilities/wasm.json commands must be an object");
+    let capability_fields = [
+        "browser_safe",
+        "rootless_safe",
+        "native_only",
+        "requires_filesystem",
+        "requires_git_history",
+        "requires_host_clock",
+        "requires_validated_root",
+    ];
+
+    for (command, entry) in commands {
+        let object = entry
+            .as_object()
+            .unwrap_or_else(|| panic!("WASM capability entry {command} must be an object"));
+        for field in capability_fields {
+            let value = object
+                .get(field)
+                .unwrap_or_else(|| panic!("WASM capability entry {command} missing {field}"));
+            let allowed =
+                value.is_boolean() || matches!(value.as_str(), Some("partial" | "native_only"));
+            assert!(
+                allowed,
+                "WASM capability entry {command}.{field} must be true, false, partial, or native_only; got {value}"
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// 5. Every CLI command in README.md Commands table actually exists
 // ===========================================================================
 
 /// Extract subcommand names from the README Commands table.
@@ -344,7 +430,7 @@ fn readme_commands_table_matches_reference_cli() {
 }
 
 // ===========================================================================
-// 5. docs/reference-cli.md consistency with subcommands
+// 6. docs/reference-cli.md consistency with subcommands
 // ===========================================================================
 
 #[test]
@@ -366,7 +452,7 @@ fn reference_cli_commands_section_exists() {
 }
 
 // ===========================================================================
-// 6. CHANGELOG.md mentions the latest workspace version
+// 7. CHANGELOG.md mentions the latest workspace version
 // ===========================================================================
 
 fn workspace_version() -> String {
@@ -413,7 +499,7 @@ fn changelog_follows_keepachangelog() {
 }
 
 // ===========================================================================
-// 7. Cross-doc consistency
+// 8. Cross-doc consistency
 // ===========================================================================
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `docs/capabilities/wasm.json` as the machine-readable browser/WASM capability matrix.
- Cover `lang`, `module`, `export`, `analyze`, `diff`, `badge`, `gate`, `context`, `handoff`, `cockpit`, `sensor`, and `baseline`.
- Track browser/rootless/native/filesystem/git/host-clock/validated-root dimensions for every command.
- Link the matrix from the root README and `tokmd-wasm` README.
- Add xtask docs-schema tests that validate required command keys, required fields, and allowed values.

## Matrix Summary

- `lang`, `module`, and `export` are browser-safe and rootless-safe on ordered in-memory inputs.
- `analyze` is partial: browser/rootless support is limited to the supported in-memory presets.
- `diff`, `badge`, `gate`, and `context` are marked partial because browser-safe behavior depends on inputs, policy/receipt sources, or native-only git data.
- `handoff`, `cockpit`, `sensor`, and `baseline` remain native-first/native-only in this first matrix.
- Host-clock dimensions stay explicit so #775 can remove the current silent-zero timestamp behavior in a focused follow-up.

## Validation

- `cargo fmt-check`
- `cargo test -p xtask wasm_capability_matrix`
- `cargo test -p xtask publish`
- `cargo xtask publish-surface --json`
- `cargo xtask docs --check`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred

- WASM timestamp semantics (#775)
- GitHub Action `mode: gate` (#1333)

Closes #1332.
Updates #1301.