### PR TITLE
docs: correct wasm capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Embed them in your own README:
 - Supported today: `lang`, `module`, `export`, and browser-safe `analyze` presets on ordered in-memory inputs.
 - Public repo ingestion uses GitHub tree and contents APIs with built-in caching, progress tracking, and auth handling.
 - Git-history enrichers and full native filesystem flows remain native-first.
-- The machine-readable browser capability contract lives in `docs/capabilities/wasm.json`.
+- The machine-readable browser capability contract lives in `docs/capabilities/wasm.json` and records current runner support, not future browser candidates.
 
 ## What `tokmd` Is Not
 

--- a/crates/tokmd-wasm/README.md
+++ b/crates/tokmd-wasm/README.md
@@ -27,7 +27,7 @@ Inputs are ordered `{ path, text | base64 }` rows.
 
 `lang`, `module`, `export`, and `analyze` are the supported browser workflows today. `analyze` currently accepts only `preset: "receipt"` or `preset: "estimate"`, and `analysisSchemaVersion()` is only exported when the `analysis` feature is enabled.
 
-The command-level browser/rootless capability matrix lives in `../../docs/capabilities/wasm.json`.
+The command-level browser/rootless capability matrix lives in `../../docs/capabilities/wasm.json` and reflects current runner support.
 
 ## Distribution
 

--- a/docs/capabilities/wasm.json
+++ b/docs/capabilities/wasm.json
@@ -43,37 +43,46 @@
       "requires_host_clock": "partial",
       "requires_validated_root": "partial"
     },
+    "run": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": true,
+      "requires_git_history": "partial",
+      "requires_host_clock": true,
+      "requires_validated_root": true
+    },
     "diff": {
-      "browser_safe": "partial",
-      "rootless_safe": "partial",
-      "native_only": false,
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
       "requires_filesystem": "partial",
       "requires_git_history": "native_only",
       "requires_host_clock": "partial",
       "requires_validated_root": "partial"
     },
     "badge": {
-      "browser_safe": "partial",
-      "rootless_safe": "partial",
-      "native_only": false,
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
       "requires_filesystem": "partial",
       "requires_git_history": "partial",
       "requires_host_clock": false,
       "requires_validated_root": "partial"
     },
     "gate": {
-      "browser_safe": "partial",
-      "rootless_safe": "partial",
-      "native_only": false,
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
       "requires_filesystem": "partial",
       "requires_git_history": false,
       "requires_host_clock": false,
       "requires_validated_root": false
     },
     "context": {
-      "browser_safe": "partial",
-      "rootless_safe": "partial",
-      "native_only": false,
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
       "requires_filesystem": "partial",
       "requires_git_history": "native_only",
       "requires_host_clock": "partial",
@@ -114,6 +123,42 @@
       "requires_git_history": "partial",
       "requires_host_clock": true,
       "requires_validated_root": true
+    },
+    "tools": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": false,
+      "requires_git_history": false,
+      "requires_host_clock": false,
+      "requires_validated_root": false
+    },
+    "init": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": true,
+      "requires_git_history": false,
+      "requires_host_clock": false,
+      "requires_validated_root": false
+    },
+    "check-ignore": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": true,
+      "requires_git_history": false,
+      "requires_host_clock": false,
+      "requires_validated_root": true
+    },
+    "completions": {
+      "browser_safe": false,
+      "rootless_safe": false,
+      "native_only": true,
+      "requires_filesystem": false,
+      "requires_git_history": false,
+      "requires_host_clock": false,
+      "requires_validated_root": false
     }
   }
 }

--- a/xtask/tests/docs_schema_w72.rs
+++ b/xtask/tests/docs_schema_w72.rs
@@ -4,6 +4,7 @@
 //! code: schema versions, CLI command tables, changelog references, and
 //! docs/schema.json structure.
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 /// Workspace root (one level above the xtask crate).
@@ -61,6 +62,11 @@ fn wasm_capability_matrix() -> serde_json::Value {
     let raw = std::fs::read_to_string(workspace_root().join("docs/capabilities/wasm.json"))
         .expect("docs/capabilities/wasm.json must exist");
     serde_json::from_str(&raw).expect("docs/capabilities/wasm.json must be valid JSON")
+}
+
+fn web_runner_messages_js() -> String {
+    std::fs::read_to_string(workspace_root().join("web/runner/messages.js"))
+        .expect("web/runner/messages.js must exist")
 }
 
 fn readme_md() -> String {
@@ -312,10 +318,7 @@ fn wasm_capability_matrix_declares_required_commands_and_fields() {
     let commands = matrix["commands"]
         .as_object()
         .expect("docs/capabilities/wasm.json commands must be an object");
-    let required_commands = [
-        "lang", "module", "export", "analyze", "diff", "badge", "gate", "context", "handoff",
-        "cockpit", "sensor", "baseline",
-    ];
+    let required_commands = readme_command_names(&readme_md());
     let required_fields = [
         "browser_safe",
         "rootless_safe",
@@ -326,9 +329,9 @@ fn wasm_capability_matrix_declares_required_commands_and_fields() {
         "requires_validated_root",
     ];
 
-    for command in required_commands {
+    for command in &required_commands {
         let entry = commands
-            .get(command)
+            .get(command.as_str())
             .unwrap_or_else(|| panic!("WASM capability matrix missing command {command}"));
         let object = entry
             .as_object()
@@ -339,6 +342,35 @@ fn wasm_capability_matrix_declares_required_commands_and_fields() {
                 "WASM capability entry {command} missing field {field}"
             );
         }
+    }
+}
+
+#[test]
+fn wasm_capability_matrix_matches_readme_command_surface() {
+    let matrix = wasm_capability_matrix();
+    let commands = matrix["commands"]
+        .as_object()
+        .expect("docs/capabilities/wasm.json commands must be an object");
+    let documented: BTreeSet<String> = readme_command_names(&readme_md()).into_iter().collect();
+    let matrix_commands: BTreeSet<String> = commands.keys().cloned().collect();
+
+    assert!(
+        !documented.is_empty(),
+        "README.md command table must define the command surface"
+    );
+
+    for command in &documented {
+        assert!(
+            matrix_commands.contains(command),
+            "WASM capability matrix missing README command {command}"
+        );
+    }
+
+    for command in &matrix_commands {
+        assert!(
+            documented.contains(command),
+            "WASM capability matrix lists undocumented command {command}"
+        );
     }
 }
 
@@ -374,6 +406,108 @@ fn wasm_capability_matrix_uses_allowed_values() {
             );
         }
     }
+}
+
+fn browser_runner_supported_modes() -> BTreeSet<String> {
+    let js = web_runner_messages_js();
+    let mut modes = BTreeSet::new();
+    let mut in_supported_modes = false;
+
+    for line in js.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("export const SUPPORTED_MODES") {
+            in_supported_modes = true;
+            continue;
+        }
+
+        if !in_supported_modes {
+            continue;
+        }
+
+        if trimmed.starts_with("]);") {
+            break;
+        }
+
+        let candidate = trimmed.trim_end_matches(',').trim();
+        if let Some(mode) = candidate
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+        {
+            modes.insert(mode.to_string());
+        }
+    }
+
+    assert!(
+        !modes.is_empty(),
+        "web/runner/messages.js SUPPORTED_MODES must not be empty"
+    );
+    modes
+}
+
+#[test]
+fn wasm_capability_matrix_browser_safe_matches_current_runner_modes() {
+    let matrix = wasm_capability_matrix();
+    let commands = matrix["commands"]
+        .as_object()
+        .expect("docs/capabilities/wasm.json commands must be an object");
+    let supported_modes = browser_runner_supported_modes();
+
+    for mode in &supported_modes {
+        assert!(
+            commands.contains_key(mode),
+            "WASM capability matrix missing browser runner mode {mode}"
+        );
+    }
+
+    for (command, entry) in commands {
+        let object = entry
+            .as_object()
+            .unwrap_or_else(|| panic!("WASM capability entry {command} must be an object"));
+        let browser_safe = object
+            .get("browser_safe")
+            .unwrap_or_else(|| panic!("WASM capability entry {command} missing browser_safe"));
+        let native_only = object
+            .get("native_only")
+            .unwrap_or_else(|| panic!("WASM capability entry {command} missing native_only"));
+
+        if supported_modes.contains(command) {
+            let runnable =
+                browser_safe.as_bool() == Some(true) || browser_safe.as_str() == Some("partial");
+            assert!(
+                runnable,
+                "browser runner mode {command} must be marked browser-safe or partial"
+            );
+            assert_eq!(
+                native_only.as_bool(),
+                Some(false),
+                "browser runner mode {command} must not be native_only"
+            );
+        } else {
+            assert_eq!(
+                browser_safe.as_bool(),
+                Some(false),
+                "non-runner command {command} must not claim browser safety"
+            );
+            assert_eq!(
+                native_only.as_bool(),
+                Some(true),
+                "non-runner command {command} must be marked native_only"
+            );
+        }
+    }
+
+    for mode in ["lang", "module", "export"] {
+        assert_eq!(
+            commands[mode]["browser_safe"].as_bool(),
+            Some(true),
+            "{mode} should be fully browser-safe in the current runner"
+        );
+    }
+    assert_eq!(
+        commands["analyze"]["browser_safe"].as_str(),
+        Some("partial"),
+        "analyze is browser-safe only for supported runner presets"
+    );
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Correct `docs/capabilities/wasm.json` so `browser_safe` reflects current `web/runner` execution support instead of future browser suitability.
- Mark only `lang`, `module`, `export`, and supported `analyze` presets as browser-runner capable today.
- Add the remaining README command-table entries: `run`, `tools`, `init`, `check-ignore`, and `completions`.
- Strengthen xtask validation so the matrix must match README commands and non-runner commands cannot claim browser safety.
- Clarify README wording that the matrix records current runner support.

## Matrix Semantics

Before this PR, `diff`, `badge`, `gate`, and `context` were marked `browser_safe: "partial"` even though `web/runner` dispatches only `lang`, `module`, `export`, and `analyze`.

After this PR:

- `lang`, `module`, and `export` are `browser_safe: true`.
- `analyze` is `browser_safe: "partial"` for the supported runner presets.
- Commands outside `SUPPORTED_MODES` are `browser_safe: false` and `native_only: true`.
- The matrix covers the full README command surface, with `tokmd` normalized to the `lang` mode.

## Validation

- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check`
- `cargo fmt-check`
- `cargo test -p xtask wasm_capability_matrix`
- `cargo test -p xtask publish`
- `cargo xtask docs --check`

## Deferred

- WASM timestamp semantics (#775)
- GitHub Action `mode: gate` (#1333)

Updates #1301.
Follow-up to #1353.