### PR TITLE
fix: use host time for wasm receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,7 @@ name = "tokmd-analysis-types"
 version = "1.9.0"
 dependencies = [
  "chrono",
+ "js-sys",
  "proptest",
  "serde",
  "serde_json",
@@ -2604,6 +2605,7 @@ version = "1.9.0"
 dependencies = [
  "anyhow",
  "base64",
+ "js-sys",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/tokmd-analysis-types/Cargo.toml
+++ b/crates/tokmd-analysis-types/Cargo.toml
@@ -17,6 +17,9 @@ serde_json.workspace = true
 tokmd-envelope.workspace = true
 tokmd-types.workspace = true
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+js-sys = "0.3.91"
+
 [dev-dependencies]
 chrono = "0.4.44"
 proptest.workspace = true

--- a/crates/tokmd-analysis-types/src/util.rs
+++ b/crates/tokmd-analysis-types/src/util.rs
@@ -15,9 +15,8 @@ pub struct AnalysisLimits {
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub fn now_ms() -> u128 {
-    // `std::time` is not implemented on bare wasm. Keep analysis receipts
-    // deterministic until the browser path provides a host clock explicitly.
-    0
+    // Keep wasm receipts from reusing zero as a fake wall-clock sentinel.
+    js_sys::Date::now().max(1.0) as u128
 }
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]

--- a/crates/tokmd-core/Cargo.toml
+++ b/crates/tokmd-core/Cargo.toml
@@ -50,6 +50,9 @@ tokmd-analysis-types = { workspace = true, optional = true }
 tokmd-cockpit = { workspace = true, optional = true }
 tokmd-git = { workspace = true, optional = true }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+js-sys = "0.3.91"
+
 [dev-dependencies]
 proptest.workspace = true
 tempfile.workspace = true

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -77,9 +77,8 @@ use tokmd_types::{
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn now_ms() -> u128 {
-    // `std::time` is not implemented on bare wasm. Keep receipts buildable and
-    // deterministic until the browser runner supplies an explicit clock surface.
-    0
+    // Keep wasm receipts from reusing zero as a fake wall-clock sentinel.
+    js_sys::Date::now().max(1.0) as u128
 }
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]

--- a/crates/tokmd-wasm/src/lib.rs
+++ b/crates/tokmd-wasm/src/lib.rs
@@ -439,6 +439,36 @@ mod wasm_tests {
         serde_json::from_str(&data_json).expect("valid core JSON value")
     }
 
+    fn assert_generated_at_ms_nonzero(label: &str, value: &Value) {
+        let timestamp = value
+            .get("generated_at_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or_else(|| panic!("{label} missing numeric generated_at_ms"));
+        assert!(timestamp > 0, "{label} generated_at_ms must not be 0");
+    }
+
+    fn normalize_volatile_timestamps(value: &mut Value) {
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    normalize_volatile_timestamps(item);
+                }
+            }
+            Value::Object(object) => {
+                for (key, value) in object {
+                    if key == "generated_at_ms" || key == "export_generated_at_ms" {
+                        if !value.is_null() {
+                            *value = Value::from(1);
+                        }
+                    } else {
+                        normalize_volatile_timestamps(value);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn values_match_js_boundary(actual: &Value, expected: &Value) -> bool {
         match (actual, expected) {
             (Value::Null, Value::Null)
@@ -510,12 +540,16 @@ mod wasm_tests {
             "files": true
         }"#;
         let data = run_lang(parse_js_args(args_json)).expect("lang data");
-        let parsed = js_value_to_json(&data);
-        let expected = core_mode_value("lang", args_json);
+        let mut parsed = js_value_to_json(&data);
+        let mut expected = core_mode_value("lang", args_json);
 
         assert_eq!(parsed["mode"], "lang");
         assert_eq!(parsed["scan"]["paths"][0], "src/lib.rs");
         assert_eq!(parsed["total"]["files"], 2);
+        assert_generated_at_ms_nonzero("lang wasm payload", &parsed);
+        assert_generated_at_ms_nonzero("lang core payload", &expected);
+        normalize_volatile_timestamps(&mut parsed);
+        normalize_volatile_timestamps(&mut expected);
         assert!(
             values_match_js_boundary(&parsed, &expected),
             "wasm payload diverged from core payload\nactual: {parsed}\nexpected: {expected}"
@@ -531,12 +565,16 @@ mod wasm_tests {
             ]
         }"#;
         let data = run_module(parse_js_args(args_json)).expect("module data");
-        let parsed = js_value_to_json(&data);
-        let expected = core_mode_value("module", args_json);
+        let mut parsed = js_value_to_json(&data);
+        let mut expected = core_mode_value("module", args_json);
 
         assert_eq!(parsed["mode"], "module");
         assert_eq!(parsed["scan"]["paths"][0], "src/lib.rs");
         assert!(parsed["rows"].as_array().is_some());
+        assert_generated_at_ms_nonzero("module wasm payload", &parsed);
+        assert_generated_at_ms_nonzero("module core payload", &expected);
+        normalize_volatile_timestamps(&mut parsed);
+        normalize_volatile_timestamps(&mut expected);
         assert!(
             values_match_js_boundary(&parsed, &expected),
             "wasm payload diverged from core payload\nactual: {parsed}\nexpected: {expected}"
@@ -552,12 +590,16 @@ mod wasm_tests {
             ]
         }"#;
         let data = run_export(parse_js_args(args_json)).expect("export data");
-        let parsed = js_value_to_json(&data);
-        let expected = core_mode_value("export", args_json);
+        let mut parsed = js_value_to_json(&data);
+        let mut expected = core_mode_value("export", args_json);
 
         assert_eq!(parsed["mode"], "export");
         assert_eq!(parsed["scan"]["paths"][0], "src/lib.rs");
         assert_eq!(parsed["rows"][0]["path"], "src/lib.rs");
+        assert_generated_at_ms_nonzero("export wasm payload", &parsed);
+        assert_generated_at_ms_nonzero("export core payload", &expected);
+        normalize_volatile_timestamps(&mut parsed);
+        normalize_volatile_timestamps(&mut expected);
         assert!(
             values_match_js_boundary(&parsed, &expected),
             "wasm payload diverged from core payload\nactual: {parsed}\nexpected: {expected}"
@@ -594,13 +636,17 @@ mod wasm_tests {
             "preset": "estimate"
         }"#;
         let data = run_analyze(parse_js_args(args_json)).expect("analysis data");
-        let parsed = js_value_to_json(&data);
-        let expected = core_mode_value("analyze", args_json);
+        let mut parsed = js_value_to_json(&data);
+        let mut expected = core_mode_value("analyze", args_json);
 
         assert_eq!(analysis_schema_version(), ANALYSIS_SCHEMA_VERSION);
         assert_eq!(parsed["mode"], "analysis");
         assert_eq!(parsed["source"]["inputs"][0], "crates/app/src/lib.rs");
         assert_eq!(parsed["effort"]["model"], "cocomo81-basic");
+        assert_generated_at_ms_nonzero("analysis estimate wasm payload", &parsed);
+        assert_generated_at_ms_nonzero("analysis estimate core payload", &expected);
+        normalize_volatile_timestamps(&mut parsed);
+        normalize_volatile_timestamps(&mut expected);
         assert!(
             values_match_js_boundary(&parsed, &expected),
             "wasm payload diverged from core payload\nactual: {parsed}\nexpected: {expected}"
@@ -617,13 +663,17 @@ mod wasm_tests {
             "preset": "receipt"
         }"#;
         let data = run_analyze(parse_js_args(args_json)).expect("analysis data");
-        let parsed = js_value_to_json(&data);
-        let expected = core_mode_value("analyze", args_json);
+        let mut parsed = js_value_to_json(&data);
+        let mut expected = core_mode_value("analyze", args_json);
 
         assert_eq!(parsed["mode"], "analysis");
         assert_eq!(parsed["source"]["inputs"][0], "src/lib.rs");
         assert_eq!(parsed["derived"]["totals"]["files"], 1);
         assert_eq!(parsed["effort"], Value::Null);
+        assert_generated_at_ms_nonzero("analysis receipt wasm payload", &parsed);
+        assert_generated_at_ms_nonzero("analysis receipt core payload", &expected);
+        normalize_volatile_timestamps(&mut parsed);
+        normalize_volatile_timestamps(&mut expected);
         assert!(
             values_match_js_boundary(&parsed, &expected),
             "wasm payload diverged from core payload\nactual: {parsed}\nexpected: {expected}"


### PR DESCRIPTION
## Summary

- Replace wasm32 timestamp fallbacks in `tokmd-core` and `tokmd-analysis-types` with JS host wall-clock time via `js_sys::Date::now()`.
- Clamp wasm timestamps away from zero so `generated_at_ms: 0` is no longer emitted as a fake real timestamp.
- Update wasm JS-boundary tests to assert nonzero `generated_at_ms` values, then normalize volatile timestamp fields before comparing wrapper and core payloads.
- Add target-specific `js-sys` dependencies where the wasm timestamp helpers live.

## Before / After

- Before: wasm32 receipt generation returned `generated_at_ms: 0`.
- After: wasm32 receipt generation uses host JS time and does not silently treat zero as wall-clock time.

## Validation

- `cargo fmt-check`
- `cargo check -p tokmd-wasm --all-targets`
- `cargo check -p tokmd-core --features analysis --target wasm32-unknown-unknown`
- `cargo check -p tokmd-wasm --no-default-features --target wasm32-unknown-unknown`
- `cargo check -p tokmd-wasm --features analysis --target wasm32-unknown-unknown`
- `cargo test -p tokmd-wasm`
- `cargo test -p tokmd-core`
- `cargo test -p xtask publish`
- `wasm-pack test --node crates/tokmd-wasm --no-default-features`
- `wasm-pack test --node crates/tokmd-wasm --features analysis`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

Fixes #775.

## Deferred

- Action mode: gate (#1333)