### PR TITLE
action: add gate mode

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run tokmd-receipt action
+        id: tokmd
         uses: ./
         with:
           comment: 'false'
@@ -39,6 +40,18 @@ jobs:
           fi
           if [ ! -f tokmd-receipt.json ]; then
             echo "::error::tokmd-receipt.json not generated"
+            exit 1
+          fi
+          if [ "${{ steps.tokmd.outputs.summary }}" != "tokmd-summary.md" ]; then
+            echo "::error::summary output did not point to tokmd-summary.md"
+            exit 1
+          fi
+          if [ "${{ steps.tokmd.outputs.receipt }}" != "tokmd-receipt.json" ]; then
+            echo "::error::receipt output did not point to tokmd-receipt.json"
+            exit 1
+          fi
+          if [ -n "${{ steps.tokmd.outputs['gate-verdict'] }}" ]; then
+            echo "::error::gate-verdict output should be empty for omitted mode"
             exit 1
           fi
           echo "✓ Both receipt files generated successfully"
@@ -69,3 +82,114 @@ jobs:
             exit 1
           fi
           echo "✓ tokmd-receipt.${{ matrix.format }} generated successfully"
+
+  test-modes:
+    name: Test explicit modes
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run module mode
+        id: module
+        uses: ./
+        with:
+          mode: module
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify module mode
+        shell: bash
+        run: |
+          if [ ! -f tokmd-summary.md ]; then
+            echo "::error::tokmd-summary.md not generated in module mode"
+            exit 1
+          fi
+          if [ "${{ steps.module.outputs.summary }}" != "tokmd-summary.md" ]; then
+            echo "::error::summary output did not point to tokmd-summary.md"
+            exit 1
+          fi
+          if [ -n "${{ steps.module.outputs.receipt }}" ]; then
+            echo "::error::receipt output should be empty in module mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.module.outputs['gate-verdict'] }}" ]; then
+            echo "::error::gate-verdict output should be empty in module mode"
+            exit 1
+          fi
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd.toml
+
+      - name: Run export mode
+        id: export
+        uses: ./
+        with:
+          mode: export
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify export mode
+        shell: bash
+        run: |
+          if [ ! -f tokmd-receipt.json ]; then
+            echo "::error::tokmd-receipt.json not generated in export mode"
+            exit 1
+          fi
+          if [ "${{ steps.export.outputs.receipt }}" != "tokmd-receipt.json" ]; then
+            echo "::error::receipt output did not point to tokmd-receipt.json"
+            exit 1
+          fi
+          if [ -n "${{ steps.export.outputs.summary }}" ]; then
+            echo "::error::summary output should be empty in export mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.export.outputs['gate-verdict'] }}" ]; then
+            echo "::error::gate-verdict output should be empty in export mode"
+            exit 1
+          fi
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd.toml
+
+      - name: Write gate policy
+        shell: bash
+        run: |
+          cat > tokmd.toml <<'TOML'
+          [[gate.rules]]
+          name = "has_files"
+          pointer = "/derived/totals/files"
+          op = "gte"
+          value = 1
+          TOML
+
+      - name: Run gate mode
+        id: gate
+        uses: ./
+        with:
+          mode: gate
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify gate mode
+        shell: bash
+        run: |
+          if [ ! -f tokmd-gate-verdict.json ]; then
+            echo "::error::tokmd-gate-verdict.json not generated in gate mode"
+            exit 1
+          fi
+          if [ "${{ steps.gate.outputs['gate-verdict'] }}" != "tokmd-gate-verdict.json" ]; then
+            echo "::error::gate-verdict output did not point to tokmd-gate-verdict.json"
+            exit 1
+          fi
+          if [ -n "${{ steps.gate.outputs.summary }}" ]; then
+            echo "::error::summary output should be empty in gate mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.gate.outputs.receipt }}" ]; then
+            echo "::error::receipt output should be empty in gate mode"
+            exit 1
+          fi
+          grep -q '"passed": true' tokmd-gate-verdict.json

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 Use the root composite action when you want a workflow-friendly receipt and PR summary without scripting `tokmd` installation yourself.
 
 - Installs a released `tokmd` binary for the current runner.
-- Generates `tokmd-summary.md` from `tokmd module`.
-- Generates a structured receipt file from `tokmd export`.
+- By default, generates `tokmd-summary.md` from `tokmd module` and a structured receipt file from `tokmd export`.
+- Can run a single explicit mode: `module`, `export`, or `gate`.
 - Optionally uploads both files as workflow artifacts.
 - Optionally posts the summary as a pull request comment.
 
@@ -52,6 +52,7 @@ Inputs:
 
 | Input | Required | Default | Purpose |
 | :---- | :------- | :------ | :------ |
+| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, or `gate`. Omit it for the existing module + export flow. |
 | `version` | no | `latest` | `tokmd` release to install. Pass an explicit version if you want the action ref and binary version to stay aligned. |
 | `paths` | no | `.` | Paths to scan. Space/newline-delimited list; each entry is passed as a separate argument. |
 | `module-roots` | no | `crates,packages` | Module root prefixes for `tokmd module` and `tokmd export`. |
@@ -65,10 +66,13 @@ Outputs:
 | Output | Description |
 | :----- | :---------- |
 | `receipt` | Path to the generated receipt file. |
+| `summary` | Path to `tokmd-summary.md` when a summary is generated. |
+| `gate-verdict` | Path to `tokmd-gate-verdict.json` when `mode: gate` is used. |
 
 Notes:
 
 - PR commenting needs `pull-requests: write` and only runs for `pull_request` events.
+- `mode: gate` runs `tokmd gate --format json` and expects policy or ratchet rules from `tokmd.toml` in the checkout. A failing gate still writes `tokmd-gate-verdict.json` before the action fails.
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
 - To scan multiple paths, pass whitespace-separated values (for example, `paths: "src crates"`), or use a multiline input:
@@ -78,6 +82,17 @@ Notes:
     src
     packages
   ```
+
+Gate mode:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    mode: gate
+    paths: .
+    artifact: 'true'
+    comment: 'false'
+```
 
 ## The Problem
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ branding:
   color: 'blue'
 
 inputs:
+  mode:
+    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate.'
+    default: ''
   version:
     description: 'Version of tokmd to install. Defaults to the latest release.'
     default: 'latest'
@@ -32,6 +35,12 @@ outputs:
   receipt:
     description: 'Path to the generated receipt file'
     value: ${{ steps.generate.outputs.receipt }}
+  summary:
+    description: 'Path to the generated Markdown summary'
+    value: ${{ steps.generate.outputs.summary }}
+  gate-verdict:
+    description: 'Path to the generated gate verdict JSON file'
+    value: ${{ steps.generate.outputs['gate-verdict'] }}
 
 runs:
   using: "composite"
@@ -151,20 +160,69 @@ runs:
         fi
 
         format="${{ inputs.format }}"
-        receipt_file="tokmd-receipt.${format}"
+        mode="${{ inputs.mode }}"
+        summary_file=""
+        receipt_file=""
+        gate_verdict_file=""
+        command_status=0
 
-        tokmd module \
-          "${scan_paths[@]}" \
-          --module-roots "${{ inputs.module-roots }}" \
-          --top ${{ inputs.top }} \
-          --format md > tokmd-summary.md
+        case "$mode" in
+          "")
+            summary_file="tokmd-summary.md"
+            receipt_file="tokmd-receipt.${format}"
 
-        tokmd export \
-          "${scan_paths[@]}" \
-          --module-roots "${{ inputs.module-roots }}" \
-          --format "$format" > "$receipt_file"
+            tokmd module \
+              "${scan_paths[@]}" \
+              --module-roots "${{ inputs.module-roots }}" \
+              --top ${{ inputs.top }} \
+              --format md > "$summary_file"
 
-        echo "receipt=$receipt_file" >> $GITHUB_OUTPUT
+            tokmd export \
+              "${scan_paths[@]}" \
+              --module-roots "${{ inputs.module-roots }}" \
+              --format "$format" > "$receipt_file"
+            ;;
+          module)
+            summary_file="tokmd-summary.md"
+
+            tokmd module \
+              "${scan_paths[@]}" \
+              --module-roots "${{ inputs.module-roots }}" \
+              --top ${{ inputs.top }} \
+              --format md > "$summary_file"
+            ;;
+          export)
+            receipt_file="tokmd-receipt.${format}"
+
+            tokmd export \
+              "${scan_paths[@]}" \
+              --module-roots "${{ inputs.module-roots }}" \
+              --format "$format" > "$receipt_file"
+            ;;
+          gate)
+            if [ ${#scan_paths[@]} -gt 1 ]; then
+              echo "::error::mode=gate accepts a single input path because 'tokmd gate' accepts one INPUT"
+              exit 1
+            fi
+
+            gate_verdict_file="tokmd-gate-verdict.json"
+            set +e
+            tokmd gate "${scan_paths[0]}" --format json > "$gate_verdict_file"
+            command_status=$?
+            set -e
+            ;;
+          *)
+            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate. Omit mode for the default module + export flow."
+            exit 1
+            ;;
+        esac
+
+        {
+          echo "receipt=$receipt_file"
+          echo "summary=$summary_file"
+          echo "gate-verdict=$gate_verdict_file"
+          echo "command-status=$command_status"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Upload Artifact
       if: inputs.artifact == 'true'
@@ -172,12 +230,18 @@ runs:
       with:
         name: tokmd-receipts
         path: |
-          tokmd-summary.md
+          ${{ steps.generate.outputs.summary }}
           ${{ steps.generate.outputs.receipt }}
+          ${{ steps.generate.outputs['gate-verdict'] }}
 
     - name: Comment on PR
-      if: inputs.comment == 'true' && github.event_name == 'pull_request'
+      if: inputs.comment == 'true' && github.event_name == 'pull_request' && steps.generate.outputs.summary != ''
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
       with:
-        file-path: tokmd-summary.md
+        file-path: ${{ steps.generate.outputs.summary }}
         comment_tag: tokmd-summary
+
+    - name: Fail on gate verdict
+      if: steps.generate.outputs['command-status'] != '0'
+      shell: bash
+      run: exit ${{ steps.generate.outputs['command-status'] }}


### PR DESCRIPTION
## Summary

- Add a `mode` input to the root composite Action.
- Preserve omitted mode as the existing module + export flow.
- Add explicit `module`, `export`, and `gate` modes.
- Add `summary` and `gate-verdict` outputs while preserving `receipt`.
- Keep PR comments tied to generated summaries and upload generated artifacts by output path.
- Add Action self-tests for omitted mode outputs and explicit module/export/gate modes.
- Document Action modes and gate usage in the README.

## Behavior

- `mode` omitted: writes `tokmd-summary.md` and `tokmd-receipt.<format>`.
- `mode: module`: writes `tokmd-summary.md`.
- `mode: export`: writes `tokmd-receipt.<format>`.
- `mode: gate`: writes `tokmd-gate-verdict.json`; failing gates still produce the verdict before the action fails.

## Validation

- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check` (warnings only)

Fixes #1333.

## Deferred

- `mode: cockpit`
- `mode: sensor`
- `mode: baseline`
- browser-runner duplicate cleanup