### PR TITLE
action: reject multi-path gate inputs

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -193,3 +193,41 @@ jobs:
             exit 1
           fi
           grep -q '"passed": true' tokmd-gate-verdict.json
+
+      - name: Run gate mode with same-line multiple paths
+        id: gate_same_line_paths
+        continue-on-error: true
+        uses: ./
+        with:
+          mode: gate
+          paths: ". README.md"
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify same-line gate paths reject
+        shell: bash
+        run: |
+          if [ "${{ steps.gate_same_line_paths.outcome }}" != "failure" ]; then
+            echo "::error::gate mode should reject same-line multi-path input"
+            exit 1
+          fi
+
+      - name: Run gate mode with multiline paths
+        id: gate_multiline_paths
+        continue-on-error: true
+        uses: ./
+        with:
+          mode: gate
+          paths: |
+            .
+            README.md
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify multiline gate paths reject
+        shell: bash
+        run: |
+          if [ "${{ steps.gate_multiline_paths.outcome }}" != "failure" ]; then
+            echo "::error::gate mode should reject multiline multi-path input"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Notes:
 
 - PR commenting needs `pull-requests: write` and only runs for `pull_request` events.
 - `mode: gate` runs `tokmd gate --format json` and expects policy or ratchet rules from `tokmd.toml` in the checkout. A failing gate still writes `tokmd-gate-verdict.json` before the action fails.
+- `mode: gate` accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd gate` runs.
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
 - To scan multiple paths, pass whitespace-separated values (for example, `paths: "src crates"`), or use a multiline input:

--- a/action.yml
+++ b/action.yml
@@ -144,14 +144,31 @@ runs:
     - name: Generate Receipts
       id: generate
       shell: bash
+      env:
+        TOKMD_ACTION_FORMAT: ${{ inputs.format }}
+        TOKMD_ACTION_MODE: ${{ inputs.mode }}
+        TOKMD_ACTION_MODULE_ROOTS: ${{ inputs.module-roots }}
+        TOKMD_ACTION_PATHS: ${{ inputs.paths }}
+        TOKMD_ACTION_TOP: ${{ inputs.top }}
       run: |
         set -euo pipefail
         echo "Generating receipts..."
 
         # Split paths input into argv-style arguments so callers can provide
         # multiple paths (space/newline separated) instead of a single quoted blob.
-        IFS=$' \t\n'
-        read -r -a scan_paths <<< "${{ inputs.paths }}"
+        # Keep the complete multiline input; bash `read -a` would only parse the
+        # first line and could make mode=gate silently scan a narrower path set.
+        paths_input="${TOKMD_ACTION_PATHS//$'\r'/ }"
+        scan_paths=()
+        set -f
+        while IFS= read -r path_line || [ -n "$path_line" ]; do
+          for path in $path_line; do
+            scan_paths+=(
+              "$path"
+            )
+          done
+        done <<< "$paths_input"
+        set +f
 
         if [ ${#scan_paths[@]} -eq 0 ]; then
           scan_paths=(
@@ -159,8 +176,8 @@ runs:
           )
         fi
 
-        format="${{ inputs.format }}"
-        mode="${{ inputs.mode }}"
+        format="$TOKMD_ACTION_FORMAT"
+        mode="$TOKMD_ACTION_MODE"
         summary_file=""
         receipt_file=""
         gate_verdict_file=""
@@ -173,13 +190,13 @@ runs:
 
             tokmd module \
               "${scan_paths[@]}" \
-              --module-roots "${{ inputs.module-roots }}" \
-              --top ${{ inputs.top }} \
+              --module-roots "$TOKMD_ACTION_MODULE_ROOTS" \
+              --top "$TOKMD_ACTION_TOP" \
               --format md > "$summary_file"
 
             tokmd export \
               "${scan_paths[@]}" \
-              --module-roots "${{ inputs.module-roots }}" \
+              --module-roots "$TOKMD_ACTION_MODULE_ROOTS" \
               --format "$format" > "$receipt_file"
             ;;
           module)
@@ -187,8 +204,8 @@ runs:
 
             tokmd module \
               "${scan_paths[@]}" \
-              --module-roots "${{ inputs.module-roots }}" \
-              --top ${{ inputs.top }} \
+              --module-roots "$TOKMD_ACTION_MODULE_ROOTS" \
+              --top "$TOKMD_ACTION_TOP" \
               --format md > "$summary_file"
             ;;
           export)
@@ -196,12 +213,12 @@ runs:
 
             tokmd export \
               "${scan_paths[@]}" \
-              --module-roots "${{ inputs.module-roots }}" \
+              --module-roots "$TOKMD_ACTION_MODULE_ROOTS" \
               --format "$format" > "$receipt_file"
             ;;
           gate)
-            if [ ${#scan_paths[@]} -gt 1 ]; then
-              echo "::error::mode=gate accepts a single input path because 'tokmd gate' accepts one INPUT"
+            if [ ${#scan_paths[@]} -ne 1 ]; then
+              echo "::error::mode=gate accepts exactly one input path; received ${#scan_paths[@]} paths"
               exit 1
             fi
 


### PR DESCRIPTION
## Summary

- Parse the complete Action `paths` input before dispatching modes, including multiline values.
- Pass Action inputs through environment variables before shell parsing.
- Keep omitted/module/export behavior unchanged for multi-path scans.
- Require `mode: gate` to receive exactly one input path and fail before `tokmd gate` runs otherwise.
- Add Action self-tests for same-line and multiline multi-path gate rejection.
- Document the single-path gate requirement.

## Behavior

Before this change, multiline `paths` could be reduced to the first line before the gate-mode path-count guard ran. That could make `mode: gate` evaluate a narrower scope than the workflow requested.

After this change:

- blank or omitted `paths` still defaults to `.`
- default/module/export modes still accept same-line or multiline multi-path inputs
- `mode: gate` accepts exactly one parsed path
- `mode: gate` rejects same-line and multiline multi-path inputs with a clear error before invoking `tokmd gate`

## Validation

- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check` (warnings only)

Follow-up to #1356 / #1333.

## Deferred

- `mode: cockpit`
- `mode: sensor`
- `mode: baseline`
- browser-runner duplicate cleanup