### PR TITLE
action: add cockpit mode

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -54,6 +54,10 @@ jobs:
             echo "::error::gate-verdict output should be empty for omitted mode"
             exit 1
           fi
+          if [ -n "${{ steps.tokmd.outputs['cockpit-report'] }}" ]; then
+            echo "::error::cockpit-report output should be empty for omitted mode"
+            exit 1
+          fi
           echo "✓ Both receipt files generated successfully"
           echo "--- Summary preview ---"
           head -20 tokmd-summary.md
@@ -117,10 +121,14 @@ jobs:
             echo "::error::gate-verdict output should be empty in module mode"
             exit 1
           fi
+          if [ -n "${{ steps.module.outputs['cockpit-report'] }}" ]; then
+            echo "::error::cockpit-report output should be empty in module mode"
+            exit 1
+          fi
 
       - name: Clean generated files
         shell: bash
-        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd.toml
+        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd.toml
 
       - name: Run export mode
         id: export
@@ -149,10 +157,14 @@ jobs:
             echo "::error::gate-verdict output should be empty in export mode"
             exit 1
           fi
+          if [ -n "${{ steps.export.outputs['cockpit-report'] }}" ]; then
+            echo "::error::cockpit-report output should be empty in export mode"
+            exit 1
+          fi
 
       - name: Clean generated files
         shell: bash
-        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd.toml
+        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd.toml
 
       - name: Write gate policy
         shell: bash
@@ -190,6 +202,10 @@ jobs:
           fi
           if [ -n "${{ steps.gate.outputs.receipt }}" ]; then
             echo "::error::receipt output should be empty in gate mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.gate.outputs['cockpit-report'] }}" ]; then
+            echo "::error::cockpit-report output should be empty in gate mode"
             exit 1
           fi
           grep -q '"passed": true' tokmd-gate-verdict.json
@@ -231,3 +247,42 @@ jobs:
             echo "::error::gate mode should reject multiline multi-path input"
             exit 1
           fi
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd.toml
+
+      - name: Run cockpit mode
+        id: cockpit
+        uses: ./
+        with:
+          mode: cockpit
+          base: HEAD
+          head: HEAD
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify cockpit mode
+        shell: bash
+        run: |
+          if [ ! -f tokmd-cockpit-report.json ]; then
+            echo "::error::tokmd-cockpit-report.json not generated in cockpit mode"
+            exit 1
+          fi
+          if [ "${{ steps.cockpit.outputs['cockpit-report'] }}" != "tokmd-cockpit-report.json" ]; then
+            echo "::error::cockpit-report output did not point to tokmd-cockpit-report.json"
+            exit 1
+          fi
+          if [ -n "${{ steps.cockpit.outputs.summary }}" ]; then
+            echo "::error::summary output should be empty in cockpit mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.cockpit.outputs.receipt }}" ]; then
+            echo "::error::receipt output should be empty in cockpit mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.cockpit.outputs['gate-verdict'] }}" ]; then
+            echo "::error::gate-verdict output should be empty in cockpit mode"
+            exit 1
+          fi
+          grep -q '"mode": "cockpit"' tokmd-cockpit-report.json

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Use the root composite action when you want a workflow-friendly receipt and PR s
 
 - Installs a released `tokmd` binary for the current runner.
 - By default, generates `tokmd-summary.md` from `tokmd module` and a structured receipt file from `tokmd export`.
-- Can run a single explicit mode: `module`, `export`, or `gate`.
-- Optionally uploads both files as workflow artifacts.
+- Can run a single explicit mode: `module`, `export`, `gate`, or `cockpit`.
+- Optionally uploads generated files as workflow artifacts.
 - Optionally posts the summary as a pull request comment.
 
 ```yaml
@@ -52,13 +52,15 @@ Inputs:
 
 | Input | Required | Default | Purpose |
 | :---- | :------- | :------ | :------ |
-| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, or `gate`. Omit it for the existing module + export flow. |
+| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, `gate`, or `cockpit`. Omit it for the existing module + export flow. |
 | `version` | no | `latest` | `tokmd` release to install. Pass an explicit version if you want the action ref and binary version to stay aligned. |
 | `paths` | no | `.` | Paths to scan. Space/newline-delimited list; each entry is passed as a separate argument. |
 | `module-roots` | no | `crates,packages` | Module root prefixes for `tokmd module` and `tokmd export`. |
 | `top` | no | `20` | Number of rows shown in `tokmd-summary.md`. |
 | `format` | no | `json` | Receipt export format: `json`, `jsonl`, or `csv`. |
-| `artifact` | no | `true` | Upload `tokmd-summary.md` and the receipt as workflow artifacts. |
+| `base` | no | `main` | Base git ref for `mode: cockpit`. |
+| `head` | no | `HEAD` | Head git ref for `mode: cockpit`. |
+| `artifact` | no | `true` | Upload generated tokmd files as workflow artifacts. |
 | `comment` | no | `true` | Post `tokmd-summary.md` as a pull request comment when running on `pull_request` events. |
 
 Outputs:
@@ -68,12 +70,14 @@ Outputs:
 | `receipt` | Path to the generated receipt file. |
 | `summary` | Path to `tokmd-summary.md` when a summary is generated. |
 | `gate-verdict` | Path to `tokmd-gate-verdict.json` when `mode: gate` is used. |
+| `cockpit-report` | Path to `tokmd-cockpit-report.json` when `mode: cockpit` is used. |
 
 Notes:
 
 - PR commenting needs `pull-requests: write` and only runs for `pull_request` events.
 - `mode: gate` runs `tokmd gate --format json` and expects policy or ratchet rules from `tokmd.toml` in the checkout. A failing gate still writes `tokmd-gate-verdict.json` before the action fails.
 - `mode: gate` accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd gate` runs.
+- `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. Use `checkout` with enough git history for the configured `base` and `head` refs to resolve.
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
 - To scan multiple paths, pass whitespace-separated values (for example, `paths: "src crates"`), or use a multiline input:
@@ -91,6 +95,18 @@ Gate mode:
   with:
     mode: gate
     paths: .
+    artifact: 'true'
+    comment: 'false'
+```
+
+Cockpit mode:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    mode: cockpit
+    base: origin/main
+    head: HEAD
     artifact: 'true'
     comment: 'false'
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   mode:
-    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate.'
+    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit.'
     default: ''
   version:
     description: 'Version of tokmd to install. Defaults to the latest release.'
@@ -24,8 +24,14 @@ inputs:
   format:
     description: 'Export format (json, jsonl, csv)'
     default: 'json'
+  base:
+    description: 'Base git ref for mode: cockpit'
+    default: 'main'
+  head:
+    description: 'Head git ref for mode: cockpit'
+    default: 'HEAD'
   artifact:
-    description: 'Whether to upload tokmd-summary.md and the receipt as workflow artifacts'
+    description: 'Whether to upload generated tokmd files as workflow artifacts'
     default: 'true'
   comment:
     description: 'Whether to post tokmd-summary.md as a pull request comment'
@@ -41,6 +47,9 @@ outputs:
   gate-verdict:
     description: 'Path to the generated gate verdict JSON file'
     value: ${{ steps.generate.outputs['gate-verdict'] }}
+  cockpit-report:
+    description: 'Path to the generated cockpit report JSON file'
+    value: ${{ steps.generate.outputs['cockpit-report'] }}
 
 runs:
   using: "composite"
@@ -145,7 +154,9 @@ runs:
       id: generate
       shell: bash
       env:
+        TOKMD_ACTION_BASE: ${{ inputs.base }}
         TOKMD_ACTION_FORMAT: ${{ inputs.format }}
+        TOKMD_ACTION_HEAD: ${{ inputs.head }}
         TOKMD_ACTION_MODE: ${{ inputs.mode }}
         TOKMD_ACTION_MODULE_ROOTS: ${{ inputs.module-roots }}
         TOKMD_ACTION_PATHS: ${{ inputs.paths }}
@@ -181,6 +192,7 @@ runs:
         summary_file=""
         receipt_file=""
         gate_verdict_file=""
+        cockpit_report_file=""
         command_status=0
 
         case "$mode" in
@@ -228,8 +240,16 @@ runs:
             command_status=$?
             set -e
             ;;
+          cockpit)
+            cockpit_report_file="tokmd-cockpit-report.json"
+
+            tokmd cockpit \
+              --base "$TOKMD_ACTION_BASE" \
+              --head "$TOKMD_ACTION_HEAD" \
+              --format json > "$cockpit_report_file"
+            ;;
           *)
-            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate. Omit mode for the default module + export flow."
+            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit. Omit mode for the default module + export flow."
             exit 1
             ;;
         esac
@@ -238,6 +258,7 @@ runs:
           echo "receipt=$receipt_file"
           echo "summary=$summary_file"
           echo "gate-verdict=$gate_verdict_file"
+          echo "cockpit-report=$cockpit_report_file"
           echo "command-status=$command_status"
         } >> "$GITHUB_OUTPUT"
 
@@ -250,6 +271,7 @@ runs:
           ${{ steps.generate.outputs.summary }}
           ${{ steps.generate.outputs.receipt }}
           ${{ steps.generate.outputs['gate-verdict'] }}
+          ${{ steps.generate.outputs['cockpit-report'] }}
 
     - name: Comment on PR
       if: inputs.comment == 'true' && github.event_name == 'pull_request' && steps.generate.outputs.summary != ''


### PR DESCRIPTION
## Summary
- add `mode: cockpit` to the root composite action
- emit `tokmd-cockpit-report.json` through a new `cockpit-report` output and artifact path
- add `base`/`head` inputs for cockpit comparisons while preserving omitted/module/export/gate behavior
- extend the Action self-test workflow and README docs for cockpit mode

## Validation
- `target\debug\tokmd.exe cockpit --base HEAD --head HEAD --format json`
- `git diff --check`
- `cargo fmt-check`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check` (passes with existing duplicate/advisory warnings)

## Deferred
- Action `mode: sensor`
- Action `mode: baseline`
- browser-runner cache/progress/auth-fetch