### PR TITLE
action: add sensor mode

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -58,6 +58,10 @@ jobs:
             echo "::error::cockpit-report output should be empty for omitted mode"
             exit 1
           fi
+          if [ -n "${{ steps.tokmd.outputs['sensor-report'] }}" ]; then
+            echo "::error::sensor-report output should be empty for omitted mode"
+            exit 1
+          fi
           echo "✓ Both receipt files generated successfully"
           echo "--- Summary preview ---"
           head -20 tokmd-summary.md
@@ -125,10 +129,14 @@ jobs:
             echo "::error::cockpit-report output should be empty in module mode"
             exit 1
           fi
+          if [ -n "${{ steps.module.outputs['sensor-report'] }}" ]; then
+            echo "::error::sensor-report output should be empty in module mode"
+            exit 1
+          fi
 
       - name: Clean generated files
         shell: bash
-        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd.toml
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
 
       - name: Run export mode
         id: export
@@ -161,10 +169,14 @@ jobs:
             echo "::error::cockpit-report output should be empty in export mode"
             exit 1
           fi
+          if [ -n "${{ steps.export.outputs['sensor-report'] }}" ]; then
+            echo "::error::sensor-report output should be empty in export mode"
+            exit 1
+          fi
 
       - name: Clean generated files
         shell: bash
-        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd.toml
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
 
       - name: Write gate policy
         shell: bash
@@ -206,6 +218,10 @@ jobs:
           fi
           if [ -n "${{ steps.gate.outputs['cockpit-report'] }}" ]; then
             echo "::error::cockpit-report output should be empty in gate mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.gate.outputs['sensor-report'] }}" ]; then
+            echo "::error::sensor-report output should be empty in gate mode"
             exit 1
           fi
           grep -q '"passed": true' tokmd-gate-verdict.json
@@ -250,7 +266,7 @@ jobs:
 
       - name: Clean generated files
         shell: bash
-        run: rm -f tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd.toml
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
 
       - name: Run cockpit mode
         id: cockpit
@@ -285,4 +301,59 @@ jobs:
             echo "::error::gate-verdict output should be empty in cockpit mode"
             exit 1
           fi
+          if [ -n "${{ steps.cockpit.outputs['sensor-report'] }}" ]; then
+            echo "::error::sensor-report output should be empty in cockpit mode"
+            exit 1
+          fi
           grep -q '"mode": "cockpit"' tokmd-cockpit-report.json
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
+
+      - name: Run sensor mode
+        id: sensor
+        uses: ./
+        with:
+          mode: sensor
+          base: HEAD
+          head: HEAD
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify sensor mode
+        shell: bash
+        run: |
+          if [ ! -f tokmd-sensor-report.json ]; then
+            echo "::error::tokmd-sensor-report.json not generated in sensor mode"
+            exit 1
+          fi
+          if [ "${{ steps.sensor.outputs['sensor-report'] }}" != "tokmd-sensor-report.json" ]; then
+            echo "::error::sensor-report output did not point to tokmd-sensor-report.json"
+            exit 1
+          fi
+          if [ ! -f comment.md ]; then
+            echo "::error::comment.md not generated in sensor mode"
+            exit 1
+          fi
+          if [ "${{ steps.sensor.outputs.summary }}" != "comment.md" ]; then
+            echo "::error::summary output did not point to comment.md in sensor mode"
+            exit 1
+          fi
+          if [ ! -f extras/cockpit_receipt.json ]; then
+            echo "::error::sensor sidecar extras/cockpit_receipt.json not generated"
+            exit 1
+          fi
+          if [ -n "${{ steps.sensor.outputs.receipt }}" ]; then
+            echo "::error::receipt output should be empty in sensor mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.sensor.outputs['gate-verdict'] }}" ]; then
+            echo "::error::gate-verdict output should be empty in sensor mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.sensor.outputs['cockpit-report'] }}" ]; then
+            echo "::error::cockpit-report output should be empty in sensor mode"
+            exit 1
+          fi
+          grep -q '"schema": "sensor.report.v1"' tokmd-sensor-report.json

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use the root composite action when you want a workflow-friendly receipt and PR s
 
 - Installs a released `tokmd` binary for the current runner.
 - By default, generates `tokmd-summary.md` from `tokmd module` and a structured receipt file from `tokmd export`.
-- Can run a single explicit mode: `module`, `export`, `gate`, or `cockpit`.
+- Can run a single explicit mode: `module`, `export`, `gate`, `cockpit`, or `sensor`.
 - Optionally uploads generated files as workflow artifacts.
 - Optionally posts the summary as a pull request comment.
 
@@ -52,25 +52,26 @@ Inputs:
 
 | Input | Required | Default | Purpose |
 | :---- | :------- | :------ | :------ |
-| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, `gate`, or `cockpit`. Omit it for the existing module + export flow. |
+| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, `gate`, `cockpit`, or `sensor`. Omit it for the existing module + export flow. |
 | `version` | no | `latest` | `tokmd` release to install. Pass an explicit version if you want the action ref and binary version to stay aligned. |
 | `paths` | no | `.` | Paths to scan. Space/newline-delimited list; each entry is passed as a separate argument. |
 | `module-roots` | no | `crates,packages` | Module root prefixes for `tokmd module` and `tokmd export`. |
 | `top` | no | `20` | Number of rows shown in `tokmd-summary.md`. |
 | `format` | no | `json` | Receipt export format: `json`, `jsonl`, or `csv`. |
-| `base` | no | `main` | Base git ref for `mode: cockpit`. |
-| `head` | no | `HEAD` | Head git ref for `mode: cockpit`. |
+| `base` | no | `main` | Base git ref for `mode: cockpit` and `mode: sensor`. |
+| `head` | no | `HEAD` | Head git ref for `mode: cockpit` and `mode: sensor`. |
 | `artifact` | no | `true` | Upload generated tokmd files as workflow artifacts. |
-| `comment` | no | `true` | Post `tokmd-summary.md` as a pull request comment when running on `pull_request` events. |
+| `comment` | no | `true` | Post the generated Markdown summary as a pull request comment when running on `pull_request` events. |
 
 Outputs:
 
 | Output | Description |
 | :----- | :---------- |
 | `receipt` | Path to the generated receipt file. |
-| `summary` | Path to `tokmd-summary.md` when a summary is generated. |
+| `summary` | Path to `tokmd-summary.md` or a mode-specific Markdown summary when one is generated. |
 | `gate-verdict` | Path to `tokmd-gate-verdict.json` when `mode: gate` is used. |
 | `cockpit-report` | Path to `tokmd-cockpit-report.json` when `mode: cockpit` is used. |
+| `sensor-report` | Path to `tokmd-sensor-report.json` when `mode: sensor` is used. |
 
 Notes:
 
@@ -78,6 +79,7 @@ Notes:
 - `mode: gate` runs `tokmd gate --format json` and expects policy or ratchet rules from `tokmd.toml` in the checkout. A failing gate still writes `tokmd-gate-verdict.json` before the action fails.
 - `mode: gate` accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd gate` runs.
 - `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. Use `checkout` with enough git history for the configured `base` and `head` refs to resolve.
+- `mode: sensor` runs `tokmd sensor --format json` and writes `tokmd-sensor-report.json`, `comment.md`, and the `extras/` sidecar directory. The `summary` output points to `comment.md`.
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
 - To scan multiple paths, pass whitespace-separated values (for example, `paths: "src crates"`), or use a multiline input:
@@ -105,6 +107,18 @@ Cockpit mode:
 - uses: EffortlessMetrics/tokmd@v1
   with:
     mode: cockpit
+    base: origin/main
+    head: HEAD
+    artifact: 'true'
+    comment: 'false'
+```
+
+Sensor mode:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    mode: sensor
     base: origin/main
     head: HEAD
     artifact: 'true'

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   mode:
-    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit.'
+    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit, sensor.'
     default: ''
   version:
     description: 'Version of tokmd to install. Defaults to the latest release.'
@@ -25,16 +25,16 @@ inputs:
     description: 'Export format (json, jsonl, csv)'
     default: 'json'
   base:
-    description: 'Base git ref for mode: cockpit'
+    description: 'Base git ref for mode: cockpit or mode: sensor'
     default: 'main'
   head:
-    description: 'Head git ref for mode: cockpit'
+    description: 'Head git ref for mode: cockpit or mode: sensor'
     default: 'HEAD'
   artifact:
     description: 'Whether to upload generated tokmd files as workflow artifacts'
     default: 'true'
   comment:
-    description: 'Whether to post tokmd-summary.md as a pull request comment'
+    description: 'Whether to post the generated Markdown summary as a pull request comment'
     default: 'true'
 
 outputs:
@@ -42,7 +42,7 @@ outputs:
     description: 'Path to the generated receipt file'
     value: ${{ steps.generate.outputs.receipt }}
   summary:
-    description: 'Path to the generated Markdown summary'
+    description: 'Path to the generated Markdown summary/comment file'
     value: ${{ steps.generate.outputs.summary }}
   gate-verdict:
     description: 'Path to the generated gate verdict JSON file'
@@ -50,6 +50,9 @@ outputs:
   cockpit-report:
     description: 'Path to the generated cockpit report JSON file'
     value: ${{ steps.generate.outputs['cockpit-report'] }}
+  sensor-report:
+    description: 'Path to the generated sensor report JSON file'
+    value: ${{ steps.generate.outputs['sensor-report'] }}
 
 runs:
   using: "composite"
@@ -193,6 +196,7 @@ runs:
         receipt_file=""
         gate_verdict_file=""
         cockpit_report_file=""
+        sensor_report_file=""
         command_status=0
 
         case "$mode" in
@@ -248,8 +252,18 @@ runs:
               --head "$TOKMD_ACTION_HEAD" \
               --format json > "$cockpit_report_file"
             ;;
+          sensor)
+            summary_file="comment.md"
+            sensor_report_file="tokmd-sensor-report.json"
+
+            tokmd sensor \
+              --base "$TOKMD_ACTION_BASE" \
+              --head "$TOKMD_ACTION_HEAD" \
+              --output "$sensor_report_file" \
+              --format json > /dev/null
+            ;;
           *)
-            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit. Omit mode for the default module + export flow."
+            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit, sensor. Omit mode for the default module + export flow."
             exit 1
             ;;
         esac
@@ -259,6 +273,7 @@ runs:
           echo "summary=$summary_file"
           echo "gate-verdict=$gate_verdict_file"
           echo "cockpit-report=$cockpit_report_file"
+          echo "sensor-report=$sensor_report_file"
           echo "command-status=$command_status"
         } >> "$GITHUB_OUTPUT"
 
@@ -272,6 +287,8 @@ runs:
           ${{ steps.generate.outputs.receipt }}
           ${{ steps.generate.outputs['gate-verdict'] }}
           ${{ steps.generate.outputs['cockpit-report'] }}
+          ${{ steps.generate.outputs['sensor-report'] }}
+          extras/
 
     - name: Comment on PR
       if: inputs.comment == 'true' && github.event_name == 'pull_request' && steps.generate.outputs.summary != ''


### PR DESCRIPTION
## Summary
- add `mode: sensor` to the root GitHub Action
- add a `sensor-report` output pointing to `tokmd-sensor-report.json`
- reuse the existing `base` / `head` inputs for sensor comparisons
- include the sensor report in uploaded artifacts
- preserve omitted/module/export/gate/cockpit behavior and the gate single-path guard
- document sensor mode in the README and add Action self-test coverage

## Validation
- `target\\debug\\tokmd.exe sensor --base HEAD --head HEAD --output $env:TEMP\\tokmd-sensor-action-smoke.json --format json`
- `git diff --check`
- `cargo fmt-check`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check` (passed with existing duplicate/advisory warnings)

## Deferred
- Action `mode: baseline`
- browser-runner cache/progress/auth-fetch