### PR TITLE
action: add baseline mode

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -62,6 +62,10 @@ jobs:
             echo "::error::sensor-report output should be empty for omitted mode"
             exit 1
           fi
+          if [ -n "${{ steps.tokmd.outputs['baseline-report'] }}" ]; then
+            echo "::error::baseline-report output should be empty for omitted mode"
+            exit 1
+          fi
           echo "✓ Both receipt files generated successfully"
           echo "--- Summary preview ---"
           head -20 tokmd-summary.md
@@ -133,10 +137,14 @@ jobs:
             echo "::error::sensor-report output should be empty in module mode"
             exit 1
           fi
+          if [ -n "${{ steps.module.outputs['baseline-report'] }}" ]; then
+            echo "::error::baseline-report output should be empty in module mode"
+            exit 1
+          fi
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
 
       - name: Run export mode
         id: export
@@ -173,10 +181,14 @@ jobs:
             echo "::error::sensor-report output should be empty in export mode"
             exit 1
           fi
+          if [ -n "${{ steps.export.outputs['baseline-report'] }}" ]; then
+            echo "::error::baseline-report output should be empty in export mode"
+            exit 1
+          fi
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
 
       - name: Write gate policy
         shell: bash
@@ -224,6 +236,10 @@ jobs:
             echo "::error::sensor-report output should be empty in gate mode"
             exit 1
           fi
+          if [ -n "${{ steps.gate.outputs['baseline-report'] }}" ]; then
+            echo "::error::baseline-report output should be empty in gate mode"
+            exit 1
+          fi
           grep -q '"passed": true' tokmd-gate-verdict.json
 
       - name: Run gate mode with same-line multiple paths
@@ -266,7 +282,7 @@ jobs:
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
 
       - name: Run cockpit mode
         id: cockpit
@@ -305,11 +321,15 @@ jobs:
             echo "::error::sensor-report output should be empty in cockpit mode"
             exit 1
           fi
+          if [ -n "${{ steps.cockpit.outputs['baseline-report'] }}" ]; then
+            echo "::error::baseline-report output should be empty in cockpit mode"
+            exit 1
+          fi
           grep -q '"mode": "cockpit"' tokmd-cockpit-report.json
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd.toml comment.md extras
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
 
       - name: Run sensor mode
         id: sensor
@@ -356,4 +376,84 @@ jobs:
             echo "::error::cockpit-report output should be empty in sensor mode"
             exit 1
           fi
+          if [ -n "${{ steps.sensor.outputs['baseline-report'] }}" ]; then
+            echo "::error::baseline-report output should be empty in sensor mode"
+            exit 1
+          fi
           grep -q '"schema": "sensor.report.v1"' tokmd-sensor-report.json
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras baseline-fixture
+
+      - name: Prepare baseline fixture
+        shell: bash
+        run: |
+          mkdir -p baseline-fixture/src
+          cat > baseline-fixture/src/lib.rs <<'RS'
+          pub fn add(a: i32, b: i32) -> i32 {
+              a + b
+          }
+          RS
+
+      - name: Run baseline mode
+        id: baseline
+        uses: ./
+        with:
+          mode: baseline
+          paths: baseline-fixture
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify baseline mode
+        shell: bash
+        run: |
+          if [ ! -f tokmd-baseline.json ]; then
+            echo "::error::tokmd-baseline.json not generated in baseline mode"
+            exit 1
+          fi
+          if [ "${{ steps.baseline.outputs['baseline-report'] }}" != "tokmd-baseline.json" ]; then
+            echo "::error::baseline-report output did not point to tokmd-baseline.json"
+            exit 1
+          fi
+          if [ -n "${{ steps.baseline.outputs.summary }}" ]; then
+            echo "::error::summary output should be empty in baseline mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.baseline.outputs.receipt }}" ]; then
+            echo "::error::receipt output should be empty in baseline mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.baseline.outputs['gate-verdict'] }}" ]; then
+            echo "::error::gate-verdict output should be empty in baseline mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.baseline.outputs['cockpit-report'] }}" ]; then
+            echo "::error::cockpit-report output should be empty in baseline mode"
+            exit 1
+          fi
+          if [ -n "${{ steps.baseline.outputs['sensor-report'] }}" ]; then
+            echo "::error::sensor-report output should be empty in baseline mode"
+            exit 1
+          fi
+          grep -q '"baseline_version": 1' tokmd-baseline.json
+
+      - name: Run baseline mode with multiline paths
+        id: baseline_multiline_paths
+        continue-on-error: true
+        uses: ./
+        with:
+          mode: baseline
+          paths: |
+            baseline-fixture
+            README.md
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify multiline baseline paths reject
+        shell: bash
+        run: |
+          if [ "${{ steps.baseline_multiline_paths.outcome }}" != "failure" ]; then
+            echo "::error::baseline mode should reject multiline multi-path input"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use the root composite action when you want a workflow-friendly receipt and PR s
 
 - Installs a released `tokmd` binary for the current runner.
 - By default, generates `tokmd-summary.md` from `tokmd module` and a structured receipt file from `tokmd export`.
-- Can run a single explicit mode: `module`, `export`, `gate`, `cockpit`, or `sensor`.
+- Can run a single explicit mode: `module`, `export`, `gate`, `cockpit`, `sensor`, or `baseline`.
 - Optionally uploads generated files as workflow artifacts.
 - Optionally posts the summary as a pull request comment.
 
@@ -52,7 +52,7 @@ Inputs:
 
 | Input | Required | Default | Purpose |
 | :---- | :------- | :------ | :------ |
-| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, `gate`, `cockpit`, or `sensor`. Omit it for the existing module + export flow. |
+| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, `gate`, `cockpit`, `sensor`, or `baseline`. Omit it for the existing module + export flow. |
 | `version` | no | `latest` | `tokmd` release to install. Pass an explicit version if you want the action ref and binary version to stay aligned. |
 | `paths` | no | `.` | Paths to scan. Space/newline-delimited list; each entry is passed as a separate argument. |
 | `module-roots` | no | `crates,packages` | Module root prefixes for `tokmd module` and `tokmd export`. |
@@ -72,6 +72,7 @@ Outputs:
 | `gate-verdict` | Path to `tokmd-gate-verdict.json` when `mode: gate` is used. |
 | `cockpit-report` | Path to `tokmd-cockpit-report.json` when `mode: cockpit` is used. |
 | `sensor-report` | Path to `tokmd-sensor-report.json` when `mode: sensor` is used. |
+| `baseline-report` | Path to `tokmd-baseline.json` when `mode: baseline` is used. |
 
 Notes:
 
@@ -80,6 +81,7 @@ Notes:
 - `mode: gate` accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd gate` runs.
 - `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. Use `checkout` with enough git history for the configured `base` and `head` refs to resolve.
 - `mode: sensor` runs `tokmd sensor --format json` and writes `tokmd-sensor-report.json`, `comment.md`, and the `extras/` sidecar directory. The `summary` output points to `comment.md`.
+- `mode: baseline` runs `tokmd baseline --force` and writes `tokmd-baseline.json`. It accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd baseline` runs.
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
 - To scan multiple paths, pass whitespace-separated values (for example, `paths: "src crates"`), or use a multiline input:
@@ -121,6 +123,17 @@ Sensor mode:
     mode: sensor
     base: origin/main
     head: HEAD
+    artifact: 'true'
+    comment: 'false'
+```
+
+Baseline mode:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    mode: baseline
+    paths: .
     artifact: 'true'
     comment: 'false'
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   mode:
-    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit, sensor.'
+    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit, sensor, baseline.'
     default: ''
   version:
     description: 'Version of tokmd to install. Defaults to the latest release.'
@@ -53,6 +53,9 @@ outputs:
   sensor-report:
     description: 'Path to the generated sensor report JSON file'
     value: ${{ steps.generate.outputs['sensor-report'] }}
+  baseline-report:
+    description: 'Path to the generated baseline JSON file'
+    value: ${{ steps.generate.outputs['baseline-report'] }}
 
 runs:
   using: "composite"
@@ -197,6 +200,7 @@ runs:
         gate_verdict_file=""
         cockpit_report_file=""
         sensor_report_file=""
+        baseline_report_file=""
         command_status=0
 
         case "$mode" in
@@ -262,8 +266,21 @@ runs:
               --output "$sensor_report_file" \
               --format json > /dev/null
             ;;
+          baseline)
+            if [ ${#scan_paths[@]} -ne 1 ]; then
+              echo "::error::mode=baseline accepts exactly one input path; received ${#scan_paths[@]} paths"
+              exit 1
+            fi
+
+            baseline_report_file="tokmd-baseline.json"
+
+            tokmd baseline "${scan_paths[0]}" \
+              --output "$baseline_report_file" \
+              --force \
+              --no-progress
+            ;;
           *)
-            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit, sensor. Omit mode for the default module + export flow."
+            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit, sensor, baseline. Omit mode for the default module + export flow."
             exit 1
             ;;
         esac
@@ -274,6 +291,7 @@ runs:
           echo "gate-verdict=$gate_verdict_file"
           echo "cockpit-report=$cockpit_report_file"
           echo "sensor-report=$sensor_report_file"
+          echo "baseline-report=$baseline_report_file"
           echo "command-status=$command_status"
         } >> "$GITHUB_OUTPUT"
 
@@ -288,6 +306,7 @@ runs:
           ${{ steps.generate.outputs['gate-verdict'] }}
           ${{ steps.generate.outputs['cockpit-report'] }}
           ${{ steps.generate.outputs['sensor-report'] }}
+          ${{ steps.generate.outputs['baseline-report'] }}
           extras/
 
     - name: Comment on PR

--- a/crates/tokmd-analysis/src/halstead/mod.rs
+++ b/crates/tokmd-analysis/src/halstead/mod.rs
@@ -382,12 +382,12 @@ pub(crate) fn tokenize_for_halstead(text: &str, lang: &str) -> FileTokenCounts {
 
             // Try to match multi-char operators (longest first)
             if ch.is_ascii_punctuation() && ch != '_' && ch != '"' && ch != '\'' {
-                let remaining: String = chars.clone().take(4).collect();
+                let remaining: Vec<char> = chars.clone().take(4).collect();
                 let mut matched = false;
-                for len in (1..=remaining.len().min(4)).rev() {
-                    let candidate = &remaining[..len];
-                    if op_set.contains(candidate) {
-                        *operators.entry(candidate.to_string()).or_insert(0) += 1;
+                for len in (1..=remaining.len()).rev() {
+                    let candidate: String = remaining.iter().take(len).collect();
+                    if op_set.contains(candidate.as_str()) {
+                        *operators.entry(candidate).or_insert(0) += 1;
                         total_operators += 1;
                         for _ in 0..len {
                             chars.next();
@@ -614,5 +614,11 @@ def add(a, b):
         let counts = tokenize_for_halstead("", "rust");
         assert_eq!(counts.total_operators, 0);
         assert_eq!(counts.total_operands, 0);
+    }
+
+    #[test]
+    fn tokenize_handles_non_ascii_after_operator() {
+        let counts = tokenize_for_halstead(r#"let locale = ("日本", "ja");"#, "rust");
+        assert!(counts.total_operators > 0);
     }
 }


### PR DESCRIPTION
## Summary
- add `mode: baseline` to the root GitHub Action
- add a `baseline-report` output pointing to `tokmd-baseline.json`
- require exactly one parsed path for baseline mode, matching the single-path CLI contract
- include the baseline file in uploaded artifacts
- preserve omitted/module/export/gate/cockpit/sensor behavior and the gate single-path guard
- document baseline mode in the README and add Action self-test coverage
- fix a small Halstead tokenizer UTF-8 panic discovered by running baseline against the repo

## Validation
- `cargo run -p tokmd -- baseline . --output $env:TEMP\\tokmd-baseline-action-smoke.json --force --no-progress`
- `cargo test -p tokmd-analysis --features halstead tokenize_handles_non_ascii_after_operator`
- `git diff --check`
- `cargo fmt-check`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check` (passed with existing duplicate/advisory warnings)

## Deferred
- browser-runner cache/progress/auth-fetch
- v2 performance/cache work