### PR TITLE
action: infer compare base refs

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -331,6 +331,34 @@ jobs:
         shell: bash
         run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
 
+      - name: Run cockpit mode with inferred pull request base
+        id: cockpit_inferred_base
+        uses: ./
+        env:
+          GITHUB_BASE_REF: main
+        with:
+          mode: cockpit
+          head: HEAD
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify cockpit inferred base
+        shell: bash
+        run: |
+          if [ ! -f tokmd-cockpit-report.json ]; then
+            echo "::error::tokmd-cockpit-report.json not generated with inferred base"
+            exit 1
+          fi
+          if [ "${{ steps.cockpit_inferred_base.outputs['cockpit-report'] }}" != "tokmd-cockpit-report.json" ]; then
+            echo "::error::cockpit-report output did not point to tokmd-cockpit-report.json with inferred base"
+            exit 1
+          fi
+          grep -q '"mode": "cockpit"' tokmd-cockpit-report.json
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
+
       - name: Run sensor mode
         id: sensor
         uses: ./
@@ -381,6 +409,61 @@ jobs:
             exit 1
           fi
           grep -q '"schema": "sensor.report.v1"' tokmd-sensor-report.json
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
+
+      - name: Run sensor mode with inferred pull request base
+        id: sensor_inferred_base
+        uses: ./
+        env:
+          GITHUB_BASE_REF: main
+        with:
+          mode: sensor
+          head: HEAD
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify sensor inferred base
+        shell: bash
+        run: |
+          if [ ! -f tokmd-sensor-report.json ]; then
+            echo "::error::tokmd-sensor-report.json not generated with inferred base"
+            exit 1
+          fi
+          if [ "${{ steps.sensor_inferred_base.outputs['sensor-report'] }}" != "tokmd-sensor-report.json" ]; then
+            echo "::error::sensor-report output did not point to tokmd-sensor-report.json with inferred base"
+            exit 1
+          fi
+          if [ ! -f comment.md ]; then
+            echo "::error::comment.md not generated in sensor mode with inferred base"
+            exit 1
+          fi
+          if [ "${{ steps.sensor_inferred_base.outputs.summary }}" != "comment.md" ]; then
+            echo "::error::summary output did not point to comment.md in sensor mode with inferred base"
+            exit 1
+          fi
+          grep -q '"schema": "sensor.report.v1"' tokmd-sensor-report.json
+
+      - name: Run cockpit mode with unresolved base
+        id: cockpit_unresolved_base
+        continue-on-error: true
+        uses: ./
+        with:
+          mode: cockpit
+          base: refs/heads/__tokmd_missing_base__
+          head: HEAD
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify unresolved cockpit base rejects
+        shell: bash
+        run: |
+          if [ "${{ steps.cockpit_unresolved_base.outcome }}" != "failure" ]; then
+            echo "::error::cockpit mode should reject an unresolved base ref"
+            exit 1
+          fi
 
       - name: Clean generated files
         shell: bash

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Inputs:
 | `module-roots` | no | `crates,packages` | Module root prefixes for `tokmd module` and `tokmd export`. |
 | `top` | no | `20` | Number of rows shown in `tokmd-summary.md`. |
 | `format` | no | `json` | Receipt export format: `json`, `jsonl`, or `csv`. |
-| `base` | no | `main` | Base git ref for `mode: cockpit` and `mode: sensor`. |
+| `base` | no | `(inferred)` | Base git ref for `mode: cockpit` and `mode: sensor`. Explicit values are used as provided. When omitted, pull request runs use `origin/$GITHUB_BASE_REF`; other runs use `origin/HEAD` when available. |
 | `head` | no | `HEAD` | Head git ref for `mode: cockpit` and `mode: sensor`. |
 | `artifact` | no | `true` | Upload generated tokmd files as workflow artifacts. |
 | `comment` | no | `true` | Post the generated Markdown summary as a pull request comment when running on `pull_request` events. |
@@ -79,8 +79,8 @@ Notes:
 - PR commenting needs `pull-requests: write` and only runs for `pull_request` events.
 - `mode: gate` runs `tokmd gate --format json` and expects policy or ratchet rules from `tokmd.toml` in the checkout. A failing gate still writes `tokmd-gate-verdict.json` before the action fails.
 - `mode: gate` accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd gate` runs.
-- `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. Use `checkout` with enough git history for the configured `base` and `head` refs to resolve.
-- `mode: sensor` runs `tokmd sensor --format json` and writes `tokmd-sensor-report.json`, `comment.md`, and the `extras/` sidecar directory. The `summary` output points to `comment.md`.
+- `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. If `base` is omitted, the action infers a repository-aware base from `origin/$GITHUB_BASE_REF` on pull requests or `origin/HEAD` on other events; if no base can be resolved, set `base` explicitly.
+- `mode: sensor` runs `tokmd sensor --format json` and writes `tokmd-sensor-report.json`, `comment.md`, and the `extras/` sidecar directory. The `summary` output points to `comment.md`. It uses the same inferred `base` behavior as cockpit mode.
 - `mode: baseline` runs `tokmd baseline --force` and writes `tokmd-baseline.json`. It accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd baseline` runs.
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,8 @@ inputs:
     description: 'Export format (json, jsonl, csv)'
     default: 'json'
   base:
-    description: 'Base git ref for mode: cockpit or mode: sensor'
-    default: 'main'
+    description: 'Base git ref for mode: cockpit or mode: sensor. Omit to infer from pull request base or origin/HEAD.'
+    default: ''
   head:
     description: 'Head git ref for mode: cockpit or mode: sensor'
     default: 'HEAD'
@@ -203,6 +203,49 @@ runs:
         baseline_report_file=""
         command_status=0
 
+        ensure_git_ref() {
+          local ref="$1"
+          git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null 2>&1
+        }
+
+        fetch_origin_branch() {
+          local branch="$1"
+          git fetch --no-tags --depth=1 origin "${branch}:refs/remotes/origin/${branch}" >/dev/null 2>&1
+        }
+
+        resolve_base_ref() {
+          local mode_name="$1"
+          local base_input="${TOKMD_ACTION_BASE:-}"
+          local resolved_base=""
+
+          if [ -n "$base_input" ]; then
+            resolved_base="$base_input"
+          elif [ -n "${GITHUB_BASE_REF:-}" ]; then
+            resolved_base="origin/${GITHUB_BASE_REF}"
+            if ! ensure_git_ref "$resolved_base"; then
+              fetch_origin_branch "$GITHUB_BASE_REF" || true
+            fi
+          else
+            if ! git symbolic-ref --quiet refs/remotes/origin/HEAD >/dev/null 2>&1; then
+              git remote set-head origin -a >/dev/null 2>&1 || true
+            fi
+
+            if git symbolic-ref --quiet refs/remotes/origin/HEAD >/dev/null 2>&1; then
+              resolved_base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD)"
+              if ! ensure_git_ref "$resolved_base"; then
+                fetch_origin_branch "${resolved_base#origin/}" || true
+              fi
+            fi
+          fi
+
+          if [ -z "$resolved_base" ] || ! ensure_git_ref "$resolved_base"; then
+            echo "::error::Unable to resolve base ref for mode=${mode_name}. Set the 'base' input explicitly or use actions/checkout with enough git history for the base ref." >&2
+            exit 1
+          fi
+
+          echo "$resolved_base"
+        }
+
         case "$mode" in
           "")
             summary_file="tokmd-summary.md"
@@ -250,18 +293,20 @@ runs:
             ;;
           cockpit)
             cockpit_report_file="tokmd-cockpit-report.json"
+            compare_base="$(resolve_base_ref cockpit)"
 
             tokmd cockpit \
-              --base "$TOKMD_ACTION_BASE" \
+              --base "$compare_base" \
               --head "$TOKMD_ACTION_HEAD" \
               --format json > "$cockpit_report_file"
             ;;
           sensor)
             summary_file="comment.md"
             sensor_report_file="tokmd-sensor-report.json"
+            compare_base="$(resolve_base_ref sensor)"
 
             tokmd sensor \
-              --base "$TOKMD_ACTION_BASE" \
+              --base "$compare_base" \
               --head "$TOKMD_ACTION_HEAD" \
               --output "$sensor_report_file" \
               --format json > /dev/null

--- a/action.yml
+++ b/action.yml
@@ -210,7 +210,7 @@ runs:
 
         fetch_origin_branch() {
           local branch="$1"
-          git fetch --no-tags --depth=1 origin "${branch}:refs/remotes/origin/${branch}" >/dev/null 2>&1
+          git fetch --no-tags --depth=1 origin "${branch}:refs/remotes/origin/${branch}" >/dev/null
         }
 
         resolve_base_ref() {
@@ -227,7 +227,7 @@ runs:
             fi
           else
             if ! git symbolic-ref --quiet refs/remotes/origin/HEAD >/dev/null 2>&1; then
-              git remote set-head origin -a >/dev/null 2>&1 || true
+              git remote set-head origin -a >/dev/null || true
             fi
 
             if git symbolic-ref --quiet refs/remotes/origin/HEAD >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- infer cockpit/sensor base refs when `base` is omitted instead of defaulting to hardcoded `main`
- use `origin/$GITHUB_BASE_REF` for pull request runs and `origin/HEAD` for other events, fetching refs when needed
- fail clearly when no base can be resolved and keep explicit `base` values unchanged
- document inferred base behavior and add Action self-tests for inferred cockpit/sensor runs plus unresolved-base rejection

## Validation
- `cargo fmt-check`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check` (passes with existing duplicate/advisory warnings)
- `npm test --prefix web/runner` (passes; existing real-wasm-bundle case remains skipped when bundle is absent)

## Deferred follow-ups
- browser-runner matrix consistency guard
- browser-runner cache/progress/auth-fetch
- queue cleanup pass