### PR TITLE
web-runner: guard capability matrix drift

### DIFF
--- a/docs/capabilities/wasm.json
+++ b/docs/capabilities/wasm.json
@@ -36,6 +36,10 @@
     },
     "analyze": {
       "browser_safe": "partial",
+      "browser_analyze_presets": [
+        "receipt",
+        "estimate"
+      ],
       "rootless_safe": "partial",
       "native_only": false,
       "requires_filesystem": "partial",

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
     MESSAGE_TYPES,
@@ -15,6 +16,23 @@ import {
     normalizeAnalyzePreset,
 } from "./messages.js";
 
+function wasmCapabilityMatrix() {
+    return JSON.parse(
+        readFileSync(
+            new URL("../../docs/capabilities/wasm.json", import.meta.url),
+            "utf8"
+        )
+    );
+}
+
+function isBrowserRunnable(capabilities) {
+    return (
+        (capabilities.browser_safe === true ||
+            capabilities.browser_safe === "partial") &&
+        capabilities.native_only === false
+    );
+}
+
 test("ready message exposes protocol version and capabilities", () => {
     const message = createReadyMessage();
 
@@ -27,6 +45,50 @@ test("ready message exposes protocol version and capabilities", () => {
     );
     assert.equal(message.capabilities.wasm, false);
     assert.equal(message.capabilities.zipball, false);
+});
+
+test("supported modes stay aligned with the WASM capability matrix", () => {
+    const matrix = wasmCapabilityMatrix();
+    const commands = matrix.commands;
+    const matrixModes = Object.entries(commands)
+        .filter(([, capabilities]) => isBrowserRunnable(capabilities))
+        .map(([command]) => command)
+        .sort();
+
+    assert.deepEqual([...SUPPORTED_MODES].sort(), matrixModes);
+
+    for (const mode of SUPPORTED_MODES) {
+        const capabilities = commands[mode];
+
+        assert.ok(capabilities, `${mode} missing from WASM capability matrix`);
+        assert.notEqual(capabilities.native_only, true);
+        assert.ok(
+            capabilities.rootless_safe === true ||
+                capabilities.rootless_safe === "partial",
+            `${mode} must be rootless-safe or partial in browser runner`
+        );
+    }
+
+    for (const [command, capabilities] of Object.entries(commands)) {
+        if (capabilities.native_only === true) {
+            assert.equal(
+                SUPPORTED_MODES.includes(command),
+                false,
+                `${command} is native-only and must not be a runner mode`
+            );
+        }
+    }
+});
+
+test("supported analyze presets stay aligned with the WASM capability matrix", () => {
+    const matrix = wasmCapabilityMatrix();
+    const analyze = matrix.commands.analyze;
+
+    assert.ok(analyze, "analyze missing from WASM capability matrix");
+    assert.deepEqual(
+        [...SUPPORTED_ANALYZE_PRESETS].sort(),
+        [...analyze.browser_analyze_presets].sort()
+    );
 });
 
 test("normalizeAnalyzePreset defaults to receipt", () => {

--- a/web/runner/runtime.test.mjs
+++ b/web/runner/runtime.test.mjs
@@ -1,8 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import { createCancelMessage, createRunMessage, MESSAGE_TYPES } from "./messages.js";
 import { handleRunnerMessage, isProtocolMessage } from "./runtime.js";
+
+function wasmCapabilityMatrix() {
+    return JSON.parse(
+        readFileSync(
+            new URL("../../docs/capabilities/wasm.json", import.meta.url),
+            "utf8"
+        )
+    );
+}
 
 function createStubRunner() {
     return {
@@ -71,6 +81,31 @@ test("runtime rejects native-only modes before runner execution", async () => {
     assert.equal(message.type, MESSAGE_TYPES.ERROR);
     assert.equal(message.error.code, "unsupported_mode");
     assert.equal(message.requestId, "run-native-mode");
+});
+
+test("runtime rejects every native-only matrix command", async () => {
+    const matrix = wasmCapabilityMatrix();
+    const nativeOnlyCommands = Object.entries(matrix.commands)
+        .filter(([, capabilities]) => capabilities.native_only === true)
+        .map(([command]) => command);
+
+    assert.ok(nativeOnlyCommands.length > 0);
+
+    for (const mode of nativeOnlyCommands) {
+        const message = await handleRunnerMessage(
+            createRunMessage({
+                requestId: `native-${mode}`,
+                mode,
+                args: {
+                    inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+                },
+            }),
+            { runner: createStubRunner() }
+        );
+
+        assert.equal(message.type, MESSAGE_TYPES.ERROR, mode);
+        assert.equal(message.error.code, "unsupported_mode", mode);
+    }
 });
 
 test("runtime uses runner-provided mode capabilities", async () => {


### PR DESCRIPTION
## Summary

- add runner-side tests that load `docs/capabilities/wasm.json` and assert `SUPPORTED_MODES` matches the current browser-runnable matrix entries
- add explicit matrix metadata for browser-supported analyze presets and assert it matches `SUPPORTED_ANALYZE_PRESETS`
- assert every native-only matrix command remains rejected by the browser runner

## Validation

- `npm test --prefix web/runner`
- `cargo test -p xtask wasm_capability_matrix`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`

## Deferred follow-ups

- browser-runner cache behavior
- browser-runner progress events
- retry / rate-limit UX
- optional authenticated fetch