### PR TITLE
jules: record fuzzer learning on cargo fuzz nightly blocker 🌪️

### DIFF
--- a/.jules/friction/open/FRIC-20260428-001.md
+++ b/.jules/friction/open/FRIC-20260428-001.md
@@ -1,0 +1,25 @@
+# Friction Item
+
+id: FRIC-20260428-001
+persona: fuzzer
+style: prover
+shard: interfaces
+status: open
+
+## Problem
+`cargo fuzz` fails to run in the default Jules sandbox environment due to a missing nightly toolchain and `-Zsanitizer=address` errors.
+
+## Evidence
+- commands: `cargo fuzz run fuzz_policy_toml`
+- outputs:
+```
+error: the option `Z` is only accepted on the nightly compiler
+help: consider switching to a nightly toolchain: `rustup default nightly`
+```
+
+## Why it matters
+The Fuzzer persona heavily relies on `cargo fuzz` to validate and improve input hardening. Without nightly toolchain support out-of-the-box in the sandbox, fuzzing tasks are blocked and must gracefully fallback to deterministic testing or documentation.
+
+## Done when
+- [ ] Sandbox image provides a nightly toolchain by default.
+- [ ] Or `cargo fuzz` gracefully falls back without ASAN.

--- a/.jules/runs/20260428130048-fuzzer/decision.md
+++ b/.jules/runs/20260428130048-fuzzer/decision.md
@@ -1,0 +1,21 @@
+# Decision
+
+## Investigated
+- Tried to run `cargo fuzz` but encountered the nightly toolchain requirement and ASAN errors which block the primary target of fuzzing.
+- Based on Jules memory: "When operating under a strictly-scoped persona (like 'Fuzzer'), if environmental issues (like `cargo fuzz` ASAN errors) block primary goals and no honest, in-scope patch (e.g., `proptest`) is justified, do not pivot to out-of-scope tasks (like UX improvements). Instead, strictly follow fallback instructions to abort the code patch and immediately create a Learning PR that documents the blocker as a friction item in `.jules/friction/open/`."
+- Searched for other parser inputs, like `crates/tokmd/src/config.rs` but a good amount of unit/integration tests exist, and without `fuzz` tooling working easily and `cargo-fuzz` requiring nightly, the honest and compliant path is to record friction and create a learning PR.
+- There are already a few proptests in `crates/tokmd-config/tests` and `crates/tokmd-core/tests`. Creating random properties without a clear invariant feels like guessing without `fuzz` working.
+
+## Options Considered
+### Option A (Record ASAN/nightly friction and create a learning PR)
+- What it is: Acknowledge the environmental block on `cargo fuzz`, abort forcing a patch, and write a learning PR per the memory constraints.
+- Why it fits: Aligns precisely with the memory rules for Fuzzer encountering `cargo fuzz` ASAN/nightly errors. It prevents hallucinated work and correctly reports the blocker.
+- Trade-offs: Velocity on the immediate codebase remains unchanged, but governance improves by making the problem visible.
+
+### Option B (Attempt `proptest` workarounds on config logic)
+- What it is: Instead of fuzzing, write some deterministic property tests in `crates/tokmd/src/config.rs`.
+- When to choose it instead: If the prompt explicitly asked for `proptest` or if there was an obvious untested property in the interface parsing logic.
+- Trade-offs: High risk of writing "arbitrary proptests without a clearly stated invariant" (which the fuzzer profile says not to do), taking time away from accurate reporting.
+
+## Decision
+Chosen **Option A**. The environment block is a classic friction item that must be documented rather than trying to force a patch out of scope. I will write a friction item and finish with a learning PR.

--- a/.jules/runs/20260428130048-fuzzer/envelope.json
+++ b/.jules/runs/20260428130048-fuzzer/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "fuzzer_input_hardening",
+  "persona": "fuzzer",
+  "style": "prover",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "fuzz",
+  "allowed_outcomes": ["patch", "proof_patch", "learning_pr"]
+}

--- a/.jules/runs/20260428130048-fuzzer/pr_body.md
+++ b/.jules/runs/20260428130048-fuzzer/pr_body.md
@@ -1,0 +1,55 @@
+## 💡 Summary
+Learning PR. Attempted to execute fuzz targets around interface parsing, but `cargo fuzz` is blocked by the lack of a nightly toolchain in the default environment. Created a friction item instead of forcing a fake fix.
+
+## 🎯 Why
+Fuzzing config/input surfaces is the primary goal, but environment blocks like missing nightly toolchain prevent execution. Documenting this friction ensures future Fuzzer runs or environment maintainers address the gap.
+
+## 🔎 Evidence
+- file path(s): `fuzz/fuzz_targets/fuzz_policy_toml.rs`
+- observed behavior / finding: `cargo fuzz` cannot build targets because `-Zsanitizer=address` requires the nightly compiler.
+- command receipt:
+```text
+error: the option `Z` is only accepted on the nightly compiler
+help: consider switching to a nightly toolchain: `rustup default nightly`
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Record ASAN/nightly friction and create a learning PR.
+- why it fits this repo and shard: Directly follows the memory instruction for handling `cargo fuzz` environmental blocks without hallucinating out-of-scope work.
+- trade-offs: Structure / Velocity / Governance - Slows immediate patch velocity, but improves governance and learning.
+
+### Option B
+- what it is: Attempt to write proptests without a clear invariant in the config files.
+- when to choose it instead: If a clear mathematical invariant was obvious.
+- trade-offs: Risks adding arbitrary proptests that don't effectively prove correctness just to claim a patch.
+
+## ✅ Decision
+Chosen Option A to stay honest to the environment blocker and follow the Fuzzer persona fallback rules.
+
+## 🧱 Changes made (SRP)
+- `.jules/friction/open/FRIC-20260428-001.md`
+
+## 🧪 Verification receipts
+```text
+cargo fuzz run fuzz_policy_toml -- -max_total_time=10
+error: the option `Z` is only accepted on the nightly compiler
+```
+
+## 🧭 Telemetry
+- Change shape: Documentation addition
+- Blast radius: None
+- Risk class + why: None, learning PR
+- Rollback: Delete the friction item
+- Gates run: `cargo check`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/20260428130048-fuzzer/envelope.json`
+- `.jules/runs/20260428130048-fuzzer/decision.md`
+- `.jules/runs/20260428130048-fuzzer/receipts.jsonl`
+- `.jules/runs/20260428130048-fuzzer/result.json`
+- `.jules/runs/20260428130048-fuzzer/pr_body.md`
+- `.jules/friction/open/FRIC-20260428-001.md`
+
+## 🔜 Follow-ups
+- Mentioned in FRIC-20260428-001: Evaluate updating the sandbox image to include rustup nightly for fuzzing.

--- a/.jules/runs/20260428130048-fuzzer/receipts.jsonl
+++ b/.jules/runs/20260428130048-fuzzer/receipts.jsonl
@@ -1,0 +1,4 @@
+{"cmd": "cargo fuzz list -p tokmd", "status": "error", "summary": "no such command: fuzz"}
+{"cmd": "cargo install cargo-fuzz", "status": "success", "summary": "installed cargo-fuzz"}
+{"cmd": "cargo fuzz run fuzz_policy_toml", "status": "error", "summary": "fails with the option `Z` is only accepted on the nightly compiler"}
+{"cmd": "cargo fuzz run fuzz_toml_config", "status": "error", "summary": "fails with the option `Z` is only accepted on the nightly compiler"}

--- a/.jules/runs/20260428130048-fuzzer/result.json
+++ b/.jules/runs/20260428130048-fuzzer/result.json
@@ -1,0 +1,14 @@
+{
+  "outcome": "learning_pr",
+  "title": "jules: record fuzzer learning on cargo fuzz nightly blocker 🌪️",
+  "summary": "Documented environment blocker: cargo fuzz requires a nightly toolchain and fails due to ASAN in the standard sandbox.",
+  "target_paths": [
+    ".jules/friction/open/FRIC-20260428-001.md"
+  ],
+  "proof_summary": "Attempted to run cargo fuzz list and cargo fuzz run, encountered nightly/ASAN toolchain errors.",
+  "gates_run": ["cargo check"],
+  "friction_items_created": ["FRIC-20260428-001"],
+  "persona_notes_created": [],
+  "rollback": "rm .jules/friction/open/FRIC-20260428-001.md",
+  "follow_ups": []
+}


### PR DESCRIPTION
## 💡 Summary 
Learning PR. Attempted to execute fuzz targets around interface parsing, but `cargo fuzz` is blocked by the lack of a nightly toolchain in the default environment. Created a friction item instead of forcing a fake fix.

## 🎯 Why 
Fuzzing config/input surfaces is the primary goal, but environment blocks like missing nightly toolchain prevent execution. Documenting this friction ensures future Fuzzer runs or environment maintainers address the gap.

## 🔎 Evidence 
- file path(s): `fuzz/fuzz_targets/fuzz_policy_toml.rs`
- observed behavior / finding: `cargo fuzz` cannot build targets because `-Zsanitizer=address` requires the nightly compiler.
- command receipt:
```text
error: the option `Z` is only accepted on the nightly compiler
help: consider switching to a nightly toolchain: `rustup default nightly`
```

## 🧭 Options considered 
### Option A (recommended) 
- what it is: Record ASAN/nightly friction and create a learning PR.
- why it fits this repo and shard: Directly follows the memory instruction for handling `cargo fuzz` environmental blocks without hallucinating out-of-scope work.
- trade-offs: Structure / Velocity / Governance - Slows immediate patch velocity, but improves governance and learning.

### Option B 
- what it is: Attempt to write proptests without a clear invariant in the config files.
- when to choose it instead: If a clear mathematical invariant was obvious.
- trade-offs: Risks adding arbitrary proptests that don't effectively prove correctness just to claim a patch.

## ✅ Decision 
Chosen Option A to stay honest to the environment blocker and follow the Fuzzer persona fallback rules.

## 🧱 Changes made (SRP) 
- `.jules/friction/open/FRIC-20260428-001.md`

## 🧪 Verification receipts 
```text
cargo fuzz run fuzz_policy_toml -- -max_total_time=10
error: the option `Z` is only accepted on the nightly compiler
```

## 🧭 Telemetry 
- Change shape: Documentation addition
- Blast radius: None
- Risk class + why: None, learning PR
- Rollback: Delete the friction item
- Gates run: `cargo check`

## 🗂️ .jules artifacts 
- `.jules/runs/20260428130048-fuzzer/envelope.json`
- `.jules/runs/20260428130048-fuzzer/decision.md`
- `.jules/runs/20260428130048-fuzzer/receipts.jsonl`
- `.jules/runs/20260428130048-fuzzer/result.json`
- `.jules/runs/20260428130048-fuzzer/pr_body.md`
- `.jules/friction/open/FRIC-20260428-001.md`

## 🔜 Follow-ups 
- Mentioned in FRIC-20260428-001: Evaluate updating the sandbox image to include rustup nightly for fuzzing.

---
*PR created automatically by Jules for task [17320468134818077808](https://jules.google.com/task/17320468134818077808) started by @EffortlessSteven*