### PR TITLE
bolt: remove string allocations in derived report grouping ⚡

### DIFF
--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -46,8 +46,8 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         "total",
         totals.comments,
         totals.code + totals.comments,
-        group_ratio(&parents, |r| r.lang.clone(), |r| (r.comments, r.code)),
-        group_ratio(&parents, |r| r.module.clone(), |r| (r.comments, r.code)),
+        group_ratio(&parents, |r| r.lang.as_str(), |r| (r.comments, r.code)),
+        group_ratio(&parents, |r| r.module.as_str(), |r| (r.comments, r.code)),
     );
 
     let whitespace = build_ratio_report(
@@ -56,12 +56,12 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         totals.code + totals.comments,
         group_ratio(
             &parents,
-            |r| r.lang.clone(),
+            |r| r.lang.as_str(),
             |r| (r.blanks, r.code + r.comments),
         ),
         group_ratio(
             &parents,
-            |r| r.module.clone(),
+            |r| r.module.as_str(),
             |r| (r.blanks, r.code + r.comments),
         ),
     );
@@ -70,8 +70,8 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         "total",
         totals.bytes,
         totals.lines,
-        group_rate(&parents, |r| r.lang.clone(), |r| (r.bytes, r.lines)),
-        group_rate(&parents, |r| r.module.clone(), |r| (r.bytes, r.lines)),
+        group_rate(&parents, |r| r.lang.as_str(), |r| (r.bytes, r.lines)),
+        group_rate(&parents, |r| r.module.as_str(), |r| (r.bytes, r.lines)),
     );
 
     let file_stats = build_file_stats(&parents);
@@ -242,16 +242,16 @@ fn build_rate_rows(map: BTreeMap<String, (usize, usize)>) -> Vec<RateRow> {
     rows
 }
 
-fn group_ratio<FKey, FVals>(
-    rows: &[&FileRow],
+fn group_ratio<'a, FKey, FVals>(
+    rows: &'a [&'a FileRow],
     key_fn: FKey,
     vals_fn: FVals,
 ) -> BTreeMap<String, (usize, usize)>
 where
-    FKey: Fn(&FileRow) -> String,
-    FVals: Fn(&FileRow) -> (usize, usize),
+    FKey: Fn(&'a FileRow) -> &'a str,
+    FVals: Fn(&'a FileRow) -> (usize, usize),
 {
-    let mut map: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    let mut map: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
     for row in rows {
         let key = key_fn(row);
         let (numer, denom_part) = vals_fn(row);
@@ -259,19 +259,19 @@ where
         entry.0 += numer;
         entry.1 += denom_part;
     }
-    map
+    map.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
 }
 
-fn group_rate<FKey, FVals>(
-    rows: &[&FileRow],
+fn group_rate<'a, FKey, FVals>(
+    rows: &'a [&'a FileRow],
     key_fn: FKey,
     vals_fn: FVals,
 ) -> BTreeMap<String, (usize, usize)>
 where
-    FKey: Fn(&FileRow) -> String,
-    FVals: Fn(&FileRow) -> (usize, usize),
+    FKey: Fn(&'a FileRow) -> &'a str,
+    FVals: Fn(&'a FileRow) -> (usize, usize),
 {
-    let mut map: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    let mut map: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
     for row in rows {
         let key = key_fn(row);
         let (numer, denom) = vals_fn(row);
@@ -279,7 +279,7 @@ where
         entry.0 += numer;
         entry.1 += denom;
     }
-    map
+    map.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
 }
 
 fn build_file_stats(rows: &[&FileRow]) -> Vec<FileStatRow> {


### PR DESCRIPTION
## 💡 Summary 
Removed string allocations in derived report grouping by using borrowed closure outputs.

## 🎯 Why 
During derived report calculations (`derive_report`), `group_ratio` and `group_rate` were unnecessarily calling `.clone()` for `FileRow` strings on every loop cycle.

## 🔎 Evidence 
- `crates/tokmd-analysis/src/derived/mod.rs` mapping routines.
- `cargo bench -p tokmd-analysis` demonstrates an up to ~30% average execution time reduction on a 10,000 item derived array benchmark.

## 🧭 Options considered 
### Option A (recommended) 
- what it is: Refactor `group_ratio` and `group_rate` closures to use lifetimes to borrow fields like `&'a str` instead of returning `String`.
- why it fits this repo and shard: High impact on hot paths within the `tokmd-analysis` analysis stack with a minimal code footprint, matching the Bolt persona.
- trade-offs: Structure / Velocity / Governance: Minor structure overhead adding explicit lifetime parameters, greatly balances out with performance gains.

### Option B 
- what it is: Use a string interner globally.
- when to choose it instead: For codebase-wide massive deduplication requirements.
- trade-offs: Overly invasive for a localized hotspot.

## ✅ Decision 
Chose Option A to implement a low-friction local optimization that cuts out unnecessary allocations.

## 🧱 Changes made (SRP) 
- `crates/tokmd-analysis/src/derived/mod.rs`

## 🧪 Verification receipts 
```text
cargo bench -p tokmd-analysis
derive_report           time:   [46.748 ms 46.917 ms 47.092 ms]
                        change: [-39.879% -34.582% -28.488%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## 🧭 Telemetry 
- Change shape: Optimization
- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): Minor. Internal function changes in the Analysis stack.
- Risk class + why: Low. The grouping logic semantics were untouched, only the storage lifetime mapping.
- Rollback: Revert to string `.clone()`.
- Gates run: `cargo test -p tokmd-analysis --profile release`

## 🗂️ .jules artifacts 
- `.jules/runs/bolt_analysis_stack_builder/envelope.json`
- `.jules/runs/bolt_analysis_stack_builder/decision.md`
- `.jules/runs/bolt_analysis_stack_builder/result.json`
- `.jules/runs/bolt_analysis_stack_builder/receipts.jsonl`
- `.jules/runs/bolt_analysis_stack_builder/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [11591604398934092889](https://jules.google.com/task/11591604398934092889) started by @EffortlessSteven*