### PR TITLE
release: prepare v1.10.0rc1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,11 @@ jobs:
         with:
           files: artifacts/**/*
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
 
       - name: Update major version tag
+        if: ${{ !contains(github.ref_name, '-') }}
         run: |
           # Extract major version from tag (v1.2.3 -> v1)
           TAG="${GITHUB_REF#refs/tags/}"
@@ -178,6 +181,8 @@ jobs:
   publish-crates:
     name: Publish to crates.io
     needs: create-release
+    # Prerelease tags are distributed as GitHub Release assets only.
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -193,6 +198,8 @@ jobs:
   docker:
     name: Build and Push Docker Image
     needs: create-release
+    # Stable-only: avoid moving Docker semver aliases for prerelease tags.
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.10.0] - 2026-04-29
+## [1.10.0-rc.1] - 2026-04-29
+
+Release candidate for `v1.10.0` (`v1.10.0rc1`).
 
 ### Added
 
 - GitHub Action mode dispatch for `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline`.
 - GitHub Action outputs for `receipt`, `summary`, `gate-verdict`, `cockpit-report`, `sensor-report`, and `baseline-report`.
 - GitHub Action base/head handling for cockpit and sensor workflows, including PR-base inference.
+- GitHub Action test workflow coverage for expanded modes, outputs, artifact behavior, and path handling.
 - Browser/WASM capability matrix documentation for current runner support versus native-only commands.
 - Browser-runner validation checks that keep supported modes and analyze presets aligned with the capability matrix.
 - Deterministic snapshot coverage for `tokmd analyze` JSON and Markdown output.
@@ -25,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Public crate surface is now enforced around product, contract, workflow, and capability crates.
-- Former support/helper crate families are collapsed into owner modules where appropriate.
+- Former support/helper crate families are collapsed into owner modules where appropriate, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
+- Internal crates are marked `publish = false`, while release and publish checks distinguish current and target public/support surfaces.
 - GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
 - Release and publish checks now verify the 16 published crates as the intentional crates.io surface.
@@ -35,11 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Tier Boundary Compliance**: Fixed architectural violation where `tokmd` CLI (Tier 5) directly depended on the analysis renderer, bypassing the `tokmd-core` facade (Tier 4) ([#996](https://github.com/EffortlessMetrics/tokmd/issues/996))
-  - Added `analysis_facade` module in `tokmd-core` with renderer re-exports
-  - Removed the direct analysis-renderer dependency from `tokmd` crate
-  - Restored proper tier hierarchy: Tier 5 → Tier 4 → Tier 3
-  - Feature-gated under `analysis` feature flag with explicit `#[cfg(feature = "analysis")]` guards
 - WASM timestamps now use real millisecond timestamps instead of silently emitting zero.
 - Bounded root/path handling rejects unsafe native, Git-listed, and MemFs/rootless paths consistently.
 - Git-listed paths are bounded under the validated root, including dirty-index and true-missing cases.
@@ -50,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `check-ignore` now fails loudly on missing paths.
 - No-git baseline and `tokmd_git` resolution edge cases now resolve consistently.
 - No-default-features integration tests are gated to avoid false failures in unsupported feature profiles.
+- Gate JSON pointer parsing now follows strict RFC 6901 token rules, and comparison failures include clearer diagnostics.
+- Cockpit `range_mode` parsing rejects invalid values instead of silently accepting drift.
+- Browser-runner errors preserve/extract codes from structured errors, duck-typed objects, and real `Error` instances.
+- Empty core scan paths default to the current directory.
+- Halstead tokenization handles CJK characters correctly.
+- Receipt normalizers tolerate harmless whitespace differences in determinism tests.
+- `normalize_path` prefix behavior has mutant-catching regression coverage.
 - Redacted path extension handling is limited to avoid extension leakage.
 - Context budget validation rejects invalid negative or non-finite values.
 - FFI in-memory path handling is hardened at the boundary.
@@ -61,8 +67,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added cargo-mutants schema cleanup and proof hardening.
 - Added derived-report allocation cleanup.
 - Added cockpit LCOV merge-path performance cleanup.
+- Removed the vulnerable RSA fixture dependency and added committed-fixture blob checks.
+- Forbid unsafe code at primary interfaces.
+- Consolidated Jules ledgers/instructions and generated run index rollups.
 - Jules provenance policy was clarified: intentional `.jules/**` provenance is allowed, while normal patch PRs should not carry accidental run packets.
 - Closed duplicate/stale PR families for pyo3 cleanup, no-default-features tests, analyze snapshots, browser-runner dynamic payloads, and docs-marker drift.
+
+## [1.9.2] - 2026-04-14
+
+### Fixed
+
+- GitHub Action path handling was polished for released action usage.
+- README guidance now distinguishes the action ref from the downloaded `tokmd` binary version.
+
+## [1.9.1] - 2026-04-13
+
+### Added
+
+- GitHub Action Marketplace publish surface.
+- Browser runner support for base64 in-memory inputs.
+- Additional executable doctests and docs-as-tests for public APIs, context, diff, check-ignore, cockpit, and tutorial examples.
+- Deterministic ordering coverage for format output, TODO tags, git commits, effort models, and model data generation.
+
+### Changed
+
+- PyO3 stack updated to `0.28.3`.
+- `jsonschema` features were tightened to drop unnecessary network and crypto crates.
+- Workspace dependency pins were normalized.
+- Analysis and redaction hot paths received allocation cleanups.
+
+### Fixed
+
+- **Tier Boundary Compliance**: Fixed architectural violation where `tokmd` CLI (Tier 5) directly depended on the analysis renderer, bypassing the `tokmd-core` facade (Tier 4) ([#996](https://github.com/EffortlessMetrics/tokmd/issues/996))
+  - Added `analysis_facade` module in `tokmd-core` with renderer re-exports
+  - Removed the direct analysis-renderer dependency from `tokmd` crate
+  - Restored proper tier hierarchy: Tier 5 -> Tier 4 -> Tier 3
+  - Feature-gated under `analysis` feature flag with explicit `#[cfg(feature = "analysis")]` guards
+- FFI calls no longer panic on non-object JSON payloads.
+- Browser runner protocol keeps `requestId` on error responses and extracts exact error codes.
+- `--no-default-features` builds were repaired by decoupling git utilities and feature-gating unsupported tests.
+- `--redact all` hides module roots and structural row names.
+- CI, format, and clippy gates were restored after docs and PyO3 updates.
 
 ## [1.9.0] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 - GitHub Action test workflow coverage for expanded modes, outputs, artifact behavior, and path handling.
 - Browser/WASM capability matrix documentation for current runner support versus native-only commands.
 - Browser-runner validation checks that keep supported modes and analyze presets aligned with the capability matrix.
+- Canonical publish-surface policy documentation for product, contract, workflow, capability, and non-crates.io package boundaries.
 - Deterministic snapshot coverage for `tokmd analyze` JSON and Markdown output.
 - Deterministic receipt coverage for `tokmd run` and `tokmd diff`.
 - BDD coverage for `tokmd analyze --preset estimate`.
@@ -34,7 +35,9 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
 - No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.
 - Browser-runner payload validation stays rootless/in-memory and rejects native-only command shapes unless the capability matrix changes.
-- Roadmap and implementation docs now separate shipped browser/WASM support from follow-up browser runtime polish.
+- README Action docs now cover explicit modes, outputs, artifacts, PR comments, base/head refs, and version pinning.
+- README, roadmap, and implementation docs now separate shipped browser/WASM support from follow-up browser runtime polish.
+- Architecture and testing docs now reflect the owner-module layout, current property-test entry points, and mutation-test paths.
 
 ### Fixed
 
@@ -48,6 +51,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 - Halstead tokenization handles CJK / multibyte text adjacent to operators without panicking on invalid UTF-8 byte slicing.
 - Redacted path extension handling is limited to avoid extension leakage.
 - Context budget validation rejects invalid negative or non-finite values.
+- GitHub Action path splitting handles same-line and multiline `paths` inputs before mode-specific validation.
 - Action gate and baseline modes reject multi-path input where the underlying command accepts exactly one path.
 - Action cockpit and sensor base refs no longer assume `main` is fetched.
 - `check-ignore` now fails loudly on missing paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,16 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 - Deterministic snapshot coverage for `tokmd analyze` JSON and Markdown output.
 - Deterministic receipt coverage for `tokmd run` and `tokmd diff`.
 - BDD coverage for `tokmd analyze --preset estimate`.
-- Additional config-resolution, tokmd-types, effort-model, env-interpreter, and in-memory workflow proof coverage.
+- Additional config-resolution, tokmd-types, effort-model, env-interpreter, module-children, and in-memory workflow proof coverage.
 - `run_json("version")` now exposes `analysis_schema_version` when `tokmd-core` is built with analysis support.
 
 ### Changed
 
+- Collapsed the previous support-crate sprawl into owner crates and SRP module families, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
 - Public crate surface is now enforced around product, contract, workflow, and capability crates.
-- Former support/helper crate families are collapsed into owner modules where appropriate, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
-- Internal crates are marked `publish = false`, while release and publish checks distinguish current and target public/support surfaces.
+- Internal crates are marked `publish = false`, while publish-surface verification and package-list proof treat the 16 published crates as the intentional crates.io boundary.
 - GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
-- Release and publish checks now verify the 16 published crates as the intentional crates.io surface.
 - No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.
 - Browser-runner payload validation stays rootless/in-memory and rejects native-only command shapes unless the capability matrix changes.
 - Roadmap and implementation docs now separate shipped browser/WASM support from follow-up browser runtime polish.
@@ -44,34 +43,40 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 - Git-listed paths are bounded under the validated root, including dirty-index and true-missing cases.
 - Metadata diagnostics preserve missing/broken-path classification instead of flattening useful path errors.
 - MemFs root semantics are explicit for `""`, `"."`, scoped subtrees, absolute paths, and parent traversal.
+- FFI in-memory path handling rejects absolute paths and parent traversal at the boundary.
+- Core workflows now default empty scan path lists to the current directory instead of reaching an upstream empty-path panic.
+- Halstead tokenization handles CJK / multibyte text adjacent to operators without panicking on invalid UTF-8 byte slicing.
+- Redacted path extension handling is limited to avoid extension leakage.
+- Context budget validation rejects invalid negative or non-finite values.
 - Action gate and baseline modes reject multi-path input where the underlying command accepts exactly one path.
 - Action cockpit and sensor base refs no longer assume `main` is fetched.
 - `check-ignore` now fails loudly on missing paths.
 - No-git baseline and `tokmd_git` resolution edge cases now resolve consistently.
 - No-default-features integration tests are gated to avoid false failures in unsupported feature profiles.
-- Gate JSON pointer parsing now follows strict RFC 6901 token rules, and comparison failures include clearer diagnostics.
-- Cockpit `range_mode` parsing rejects invalid values instead of silently accepting drift.
-- Browser-runner errors preserve/extract codes from structured errors, duck-typed objects, and real `Error` instances.
-- Empty core scan paths default to the current directory.
-- Halstead tokenization handles CJK characters correctly.
+- `tokmd-gate` now rejects malformed RFC 6901 pointer escapes and ambiguous array index tokens.
+- Gate rule comparison failures now surface diagnostic messages for missing or invalid operands while preserving explicit rule messages.
+- Cockpit `range_mode` parsing now validates accepted two-dot / three-dot values and fails clearly on invalid settings.
+- Browser-runner runtime errors now preserve duck-typed `message` and `code` fields across worker / WASM boundaries.
 - Receipt normalizers tolerate harmless whitespace differences in determinism tests.
 - `normalize_path` prefix behavior has mutant-catching regression coverage.
-- Redacted path extension handling is limited to avoid extension leakage.
-- Context budget validation rejects invalid negative or non-finite values.
-- FFI in-memory path handling is hardened at the boundary.
 
 ### Internal
 
 - Removed unused `pyo3-build-config` from `tokmd-python`.
+- Removed redundant `tokio_rt` from `tokmd-node` and tightened `tokmd-wasm` dependency edges.
 - Bumped dependency keepers including `jsonschema`, `clap_complete`, and `softprops/action-gh-release`.
-- Added cargo-mutants schema cleanup and proof hardening.
+- Updated cargo-mutants configuration for the current schema and restored mutation-test gate compatibility.
+- Updated cargo-deny metadata by removing deprecated/stale license configuration and reducing release-check warning noise.
 - Added derived-report allocation cleanup.
 - Added cockpit LCOV merge-path performance cleanup.
+- Added version-consistency allocation cleanup.
 - Removed the vulnerable RSA fixture dependency and added committed-fixture blob checks.
-- Forbid unsafe code at primary interfaces.
-- Consolidated Jules ledgers/instructions and generated run index rollups.
+- Added unsafe-code guardrails at primary interfaces.
+- Expanded Action self-tests across omitted mode, explicit modes, artifact outputs, inferred refs, and multi-path rejection rules.
 - Jules provenance policy was clarified: intentional `.jules/**` provenance is allowed, while normal patch PRs should not carry accidental run packets.
-- Closed duplicate/stale PR families for pyo3 cleanup, no-default-features tests, analyze snapshots, browser-runner dynamic payloads, and docs-marker drift.
+- Consolidated Jules persona guidance and run/provenance indexing so intentional learning packets are distinguishable from runtime debris.
+- Added/updated the Jules run index builder to aggregate historical ledgers without rewriting provenance history.
+- Closed duplicate/stale PR families for pyo3 cleanup, no-default-features tests, analyze snapshots, browser-runner dynamic payloads, docs-marker drift, and stale architecture-doc updates.
 
 ## [1.9.2] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-04-29
+
+### Added
+
+- GitHub Action control-plane support for explicit `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline` modes.
+- Browser/WASM capability matrix checks and runner contract guards for supported modes and analyze presets.
+- Additional deterministic receipt, analyze snapshot, and effort/property proof coverage.
+- `run_json("version")` now exposes `analysis_schema_version` when `tokmd-core` is built with analysis support.
+
+### Changed
+
+- Publish-surface proof now classifies product, contract, workflow, and capability crates explicitly.
+- CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
+- Roadmap and implementation docs now separate shipped browser/WASM support from follow-up browser runtime polish.
+
 ### Fixed
 
 - **Tier Boundary Compliance**: Fixed architectural violation where `tokmd` CLI (Tier 5) directly depended on the analysis renderer, bypassing the `tokmd-core` facade (Tier 4) ([#996](https://github.com/EffortlessMetrics/tokmd/issues/996))
@@ -14,8 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed the direct analysis-renderer dependency from `tokmd` crate
   - Restored proper tier hierarchy: Tier 5 → Tier 4 → Tier 3
   - Feature-gated under `analysis` feature flag with explicit `#[cfg(feature = "analysis")]` guards
+- WASM timestamps now use real millisecond timestamps instead of silently emitting zero.
+- Bounded path/root handling rejects unsafe native, Git, and in-memory filesystem paths.
+- Action gate and baseline modes reject multi-path input where the underlying command accepts exactly one path.
+- No-git baseline and `tokmd_git` resolution edge cases now resolve consistently.
+- No-default-features integration tests are gated to avoid false failures in unsupported feature profiles.
 
+### Internal
 
+- Jules provenance policy was clarified: intentional `.jules/**` provenance is allowed, while normal patch PRs should not carry accidental run packets.
+- Cargo-mutants, dependency metadata, and release proof tooling were cleaned up.
+- Duplicate proof/docs branches were closed after their keepers landed.
 
 ## [1.9.0] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- GitHub Action control-plane support for explicit `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline` modes.
-- Browser/WASM capability matrix checks and runner contract guards for supported modes and analyze presets.
-- Additional deterministic receipt, analyze snapshot, and effort/property proof coverage.
+- GitHub Action mode dispatch for `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline`.
+- GitHub Action outputs for `receipt`, `summary`, `gate-verdict`, `cockpit-report`, `sensor-report`, and `baseline-report`.
+- GitHub Action base/head handling for cockpit and sensor workflows, including PR-base inference.
+- Browser/WASM capability matrix documentation for current runner support versus native-only commands.
+- Browser-runner validation checks that keep supported modes and analyze presets aligned with the capability matrix.
+- Deterministic snapshot coverage for `tokmd analyze` JSON and Markdown output.
+- Deterministic receipt coverage for `tokmd run` and `tokmd diff`.
+- BDD coverage for `tokmd analyze --preset estimate`.
+- Additional config-resolution, tokmd-types, effort-model, env-interpreter, and in-memory workflow proof coverage.
 - `run_json("version")` now exposes `analysis_schema_version` when `tokmd-core` is built with analysis support.
 
 ### Changed
 
-- Publish-surface proof now classifies product, contract, workflow, and capability crates explicitly.
+- Public crate surface is now enforced around product, contract, workflow, and capability crates.
+- Former support/helper crate families are collapsed into owner modules where appropriate.
+- GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
+- Release and publish checks now verify the 16 published crates as the intentional crates.io surface.
+- No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.
+- Browser-runner payload validation stays rootless/in-memory and rejects native-only command shapes unless the capability matrix changes.
 - Roadmap and implementation docs now separate shipped browser/WASM support from follow-up browser runtime polish.
 
 ### Fixed
@@ -30,16 +41,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Restored proper tier hierarchy: Tier 5 → Tier 4 → Tier 3
   - Feature-gated under `analysis` feature flag with explicit `#[cfg(feature = "analysis")]` guards
 - WASM timestamps now use real millisecond timestamps instead of silently emitting zero.
-- Bounded path/root handling rejects unsafe native, Git, and in-memory filesystem paths.
+- Bounded root/path handling rejects unsafe native, Git-listed, and MemFs/rootless paths consistently.
+- Git-listed paths are bounded under the validated root, including dirty-index and true-missing cases.
+- Metadata diagnostics preserve missing/broken-path classification instead of flattening useful path errors.
+- MemFs root semantics are explicit for `""`, `"."`, scoped subtrees, absolute paths, and parent traversal.
 - Action gate and baseline modes reject multi-path input where the underlying command accepts exactly one path.
+- Action cockpit and sensor base refs no longer assume `main` is fetched.
+- `check-ignore` now fails loudly on missing paths.
 - No-git baseline and `tokmd_git` resolution edge cases now resolve consistently.
 - No-default-features integration tests are gated to avoid false failures in unsupported feature profiles.
+- Redacted path extension handling is limited to avoid extension leakage.
+- Context budget validation rejects invalid negative or non-finite values.
+- FFI in-memory path handling is hardened at the boundary.
 
 ### Internal
 
+- Removed unused `pyo3-build-config` from `tokmd-python`.
+- Bumped dependency keepers including `jsonschema`, `clap_complete`, and `softprops/action-gh-release`.
+- Added cargo-mutants schema cleanup and proof hardening.
+- Added derived-report allocation cleanup.
+- Added cockpit LCOV merge-path performance cleanup.
 - Jules provenance policy was clarified: intentional `.jules/**` provenance is allowed, while normal patch PRs should not carry accidental run packets.
-- Cargo-mutants, dependency metadata, and release proof tooling were cleaned up.
-- Duplicate proof/docs branches were closed after their keepers landed.
+- Closed duplicate/stale PR families for pyo3 cleanup, no-default-features tests, analyze snapshots, browser-runner dynamic payloads, and docs-marker drift.
 
 ## [1.9.0] - 2026-03-27
 
@@ -47,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Browser/WASM product surface for `tokmd` via the new `tokmd-wasm` crate and `web/runner` browser runner
 - In-browser `lang`, `module`, `export`, and rootless `analyze` support for ordered in-memory inputs
-- Public GitHub repo ingestion in the browser through tree + contents APIs with explicit progress, caching, and partial-load reporting
+- Public GitHub repo ingestion in the browser through tree + contents APIs with deterministic in-memory input materialization and partial-load reporting
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 - Bumped dependency keepers including `jsonschema`, `clap_complete`, and `softprops/action-gh-release`.
 - Updated cargo-mutants configuration for the current schema and restored mutation-test gate compatibility.
 - Updated cargo-deny metadata by removing deprecated/stale license configuration and reducing release-check warning noise.
+- Release workflow prerelease tags are marked as prereleases, excluded from `latest`, and kept away from stable crates.io, Docker, and major Action aliases.
 - Added derived-report allocation cleanup.
 - Added cockpit LCOV merge-path performance cleanup.
 - Added version-consistency allocation cleanup.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "blake3",
  "proptest",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "proptest",
  "serde",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "proptest",
  "serde",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "clap",
  "insta",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3534,7 +3534,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.10.0"
+version = "1.10.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "clap",
  "insta",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3534,7 +3534,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.9.0"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -56,22 +56,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.9.0" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.9.0" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.9.0" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.9.0" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.9.0" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.9.0" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.9.0" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.9.0" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.9.0" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.9.0" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.9.0" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.9.0" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.9.0" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.9.0" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.9.0" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.9.0" }
+tokmd = { path = "crates/tokmd", version = "1.10.0" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.10.0" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.10.0" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.10.0" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.10.0" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.10.0" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.10.0" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.10.0" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.10.0" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.10.0" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.10.0" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.10.0" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.10.0" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.10.0" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.10.0" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.10.0" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.10.0"
+version = "1.10.0-rc.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -56,22 +56,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.10.0" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.10.0" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.10.0" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.10.0" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.10.0" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.10.0" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.10.0" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.10.0" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.10.0" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.10.0" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.10.0" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.10.0" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.10.0" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.10.0" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.10.0" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.10.0" }
+tokmd = { path = "crates/tokmd", version = "1.10.0-rc.1" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.10.0-rc.1" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.10.0-rc.1" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.10.0-rc.1" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.10.0-rc.1" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.10.0-rc.1" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.10.0-rc.1" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.10.0-rc.1" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.10.0-rc.1" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.10.0-rc.1" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.10.0-rc.1" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.10.0-rc.1" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.10.0-rc.1" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.10.0-rc.1" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.10.0-rc.1" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.10.0-rc.1" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/crates/l/tokmd)](https://crates.io/crates/tokmd)
 [![Downloads](https://img.shields.io/crates/d/tokmd)](https://crates.io/crates/tokmd)
 
-`tokmd` turns a source tree into stable receipts you can diff, analyze, archive, gate, and pack for downstream automation. It starts with code inventory, then keeps going: saved artifacts, derived metrics, PR review surfaces, policy checks, sensor outputs, and browser-safe context bundles.
+`tokmd` turns a source tree into stable receipts you can diff, analyze, archive, gate, and pack for downstream automation. It starts with code inventory, then keeps going: saved artifacts, derived metrics, PR review surfaces, policy checks, sensor outputs, LLM-ready context bundles, and a browser-safe in-memory analysis slice.
 
 ## GitHub Action
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ Embed them in your own README:
 `tokmd-wasm` and `web/runner` expose a narrower browser-safe slice of the product.
 
 - Supported today: `lang`, `module`, `export`, and browser-safe `analyze` presets on ordered in-memory inputs.
-- Public repo ingestion uses GitHub tree and contents APIs with built-in caching, progress tracking, and auth handling.
+- Public repo ingestion uses GitHub tree and contents APIs with deterministic in-memory input materialization.
+- Explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch polish are follow-up browser-runtime work.
 - Git-history enrichers and full native filesystem flows remain native-first.
 - The machine-readable browser capability contract lives in `docs/capabilities/wasm.json` and records current runner support, not future browser candidates.
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,35 @@ jobs:
 
       - uses: EffortlessMetrics/tokmd@v1
         with:
-          version: 'x.y.z'
+          version: '1.10.0'
           paths: .
           module-roots: crates,packages
           top: '20'
           format: json
           artifact: 'true'
           comment: 'true'
+```
+
+For release-candidate smoke tests, pin both the Action ref and the downloaded binary:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1.10.0-rc.1
+  with:
+    version: '1.10.0-rc.1'
+    paths: .
+    artifact: 'true'
+    comment: 'false'
+```
+
+For stable workflows, use the stable Action ref and an explicit binary version:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    version: '1.10.0'
+    paths: .
+    artifact: 'true'
+    comment: 'true'
 ```
 
 Inputs:
@@ -82,7 +104,8 @@ Notes:
 - `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. If `base` is omitted, the action infers a repository-aware base from `origin/$GITHUB_BASE_REF` on pull requests or `origin/HEAD` on other events; if no base can be resolved, set `base` explicitly.
 - `mode: sensor` runs `tokmd sensor --format json` and writes `tokmd-sensor-report.json`, `comment.md`, and the `extras/` sidecar directory. The `summary` output points to `comment.md`. It uses the same inferred `base` behavior as cockpit mode.
 - `mode: baseline` runs `tokmd baseline --force` and writes `tokmd-baseline.json`. It accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd baseline` runs.
-- The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
+- For cockpit and sensor in external PR workflows, prefer `actions/checkout` with `fetch-depth: 0` so compare refs are available; otherwise set `base` explicitly.
+- The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: '1.10.0'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
 - To scan multiple paths, pass whitespace-separated values (for example, `paths: "src crates"`), or use a multiline input:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,8 @@ This document outlines the evolution of `tokmd` and the path forward.
 | **v1.7.x** | ✅ Complete | Deep test expansion across the workspace, sensor determinism, and the first `tokmd-io-port` seam. |
 | **v1.8.0** | ✅ Complete | Effort estimation, estimate preset/reporting, `tokmd-io-port` seam work, and release/devex hardening. |
 | **v1.9.0** | ✅ Complete | Browser/WASM productization: parity-covered wasm entrypoints, browser runner MVP, and public repo ingestion via tree+contents |
+| **v1.10.0** | ✅ Complete | CI control plane, bounded trust hardening, WASM truth, and proof stability. |
+| **v1.11.0** | 🔭 Planned | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
 | **v3.0.0** | 🔭 Long-term | Tree-sitter AST integration (requires significant R&D).      |
 | **v4.0.0** | 🔭 Long-term | Adze AST integration.      |
@@ -485,7 +487,7 @@ UX work is explicitly **incremental and non-breaking**:
 - [x] `web/runner` boots the real `tokmd-wasm` bundle in a dedicated worker, reports capabilities, renders the latest successful result, and supports JSON download.
 - [x] Public GitHub repo acquisition uses the browser-safe GitHub tree and contents APIs to materialize deterministic ordered inputs locally in the page.
 - [x] `tokmd-wasm` browser bundle is deployed as a versioned release artifact consumed directly from `web/runner/vendor/tokmd-wasm`.
-- [x] Browser runner guardrails and UX hardening landed, including caching, progress, authenticated fetch options, and rate-limit handling.
+- [x] Browser runner guardrails landed around capability reporting, supported modes, and in-memory input validation.
 
 ### Supported browser-safe surface today
 
@@ -503,6 +505,26 @@ UX work is explicitly **incremental and non-breaking**:
 - No browser-side git-history churn/hotspot metrics; keep those as explicit capability misses or backend follow-ups.
 - No browser zipball ingestion as the primary supported path for `v1.9.0`; tree+contents is the supported browser acquisition strategy.
 - No mutation testing or other heavy tooling in-browser.
+
+## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability
+
+**Goal:** Cut a stable release train after the Action, path-trust, WASM, publish-surface, and proof-hardening work landed.
+
+### What shipped in v1.10.0
+
+- [x] GitHub Action explicit modes for `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline`.
+- [x] Bounded path/root handling across native, Git, and in-memory flows.
+- [x] WASM capability truth through matrix checks, timestamp correctness, and runner contract validation.
+- [x] Publish-surface enforcement across product, contract, workflow, and capability crates.
+- [x] Determinism and proof coverage for analyze snapshots, run/diff receipts, effort serde, and core CLI behavior.
+- [x] CLI reference docs generated through checked HELP markers.
+
+### Deferred to v1.11.0
+
+- Browser cache key/invalidation semantics.
+- Browser progress events.
+- Retry and rate-limit UX.
+- Auth-safe fetch/cache boundaries.
 
 ## Future Horizons
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,8 @@ This document outlines the evolution of `tokmd` and the path forward.
 | **v1.7.x** | ✅ Complete | Deep test expansion across the workspace, sensor determinism, and the first `tokmd-io-port` seam. |
 | **v1.8.0** | ✅ Complete | Effort estimation, estimate preset/reporting, `tokmd-io-port` seam work, and release/devex hardening. |
 | **v1.9.0** | ✅ Complete | Browser/WASM productization: parity-covered wasm entrypoints, browser runner MVP, and public repo ingestion via tree+contents |
-| **v1.10.0** | ✅ Complete | CI control plane, bounded trust hardening, WASM truth, and proof stability. |
+| **v1.10.0-rc.1** | 🚢 RC | CI control plane, bounded trust hardening, WASM truth, and proof stability release candidate. |
+| **v1.10.0** | 🔜 Planned | Stable promotion after release-candidate proof. |
 | **v1.11.0** | 🔭 Planned | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
 | **v3.0.0** | 🔭 Long-term | Tree-sitter AST integration (requires significant R&D).      |
@@ -506,11 +507,11 @@ UX work is explicitly **incremental and non-breaking**:
 - No browser zipball ingestion as the primary supported path for `v1.9.0`; tree+contents is the supported browser acquisition strategy.
 - No mutation testing or other heavy tooling in-browser.
 
-## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability
+## v1.10.0-rc.1 — CI Control Plane, Trust Hardening, and Proof Stability
 
-**Goal:** Cut a stable release train after the Action, path-trust, WASM, publish-surface, and proof-hardening work landed.
+**Goal:** Cut a release candidate after the Action, path-trust, WASM, publish-surface, and proof-hardening work landed.
 
-### What shipped in v1.10.0
+### What is in v1.10.0-rc.1
 
 - [x] GitHub Action explicit modes for `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline`.
 - [x] Bounded path/root handling across native, Git, and in-memory flows.

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.9.0"
+        "version": "1.10.0-rc.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.9.0"
+        "version": "1.10.0-rc.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.9.0"
+        "version": "1.10.0-rc.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.9.0"
+        "version": "1.10.0-rc.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.9.0"
+        "version": "1.10.0-rc.1"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.9.0",
-    "@tokmd/core-darwin-x64": "1.9.0",
-    "@tokmd/core-linux-arm64-gnu": "1.9.0",
-    "@tokmd/core-linux-x64-gnu": "1.9.0",
-    "@tokmd/core-win32-x64-msvc": "1.9.0"
+    "@tokmd/core-darwin-arm64": "1.10.0",
+    "@tokmd/core-darwin-x64": "1.10.0",
+    "@tokmd/core-linux-arm64-gnu": "1.10.0",
+    "@tokmd/core-linux-x64-gnu": "1.10.0",
+    "@tokmd/core-win32-x64-msvc": "1.10.0"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.10.0",
+  "version": "1.10.0-rc.1",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.10.0",
-    "@tokmd/core-darwin-x64": "1.10.0",
-    "@tokmd/core-linux-arm64-gnu": "1.10.0",
-    "@tokmd/core-linux-x64-gnu": "1.10.0",
-    "@tokmd/core-win32-x64-msvc": "1.10.0"
+    "@tokmd/core-darwin-arm64": "1.10.0-rc.1",
+    "@tokmd/core-darwin-x64": "1.10.0-rc.1",
+    "@tokmd/core-linux-arm64-gnu": "1.10.0-rc.1",
+    "@tokmd/core-linux-x64-gnu": "1.10.0-rc.1",
+    "@tokmd/core-win32-x64-msvc": "1.10.0-rc.1"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.10.0",
+  "version": "1.10.0-rc.1",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.0.0-alpha.66"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.10.0",
-    "@tokmd/core-darwin-x64": "1.10.0",
-    "@tokmd/core-darwin-arm64": "1.10.0",
-    "@tokmd/core-linux-x64-gnu": "1.10.0",
-    "@tokmd/core-linux-x64-musl": "1.10.0",
-    "@tokmd/core-linux-arm64-gnu": "1.10.0",
-    "@tokmd/core-linux-arm64-musl": "1.10.0",
-    "@tokmd/core-win32-arm64-msvc": "1.10.0"
+    "@tokmd/core-win32-x64-msvc": "1.10.0-rc.1",
+    "@tokmd/core-darwin-x64": "1.10.0-rc.1",
+    "@tokmd/core-darwin-arm64": "1.10.0-rc.1",
+    "@tokmd/core-linux-x64-gnu": "1.10.0-rc.1",
+    "@tokmd/core-linux-x64-musl": "1.10.0-rc.1",
+    "@tokmd/core-linux-arm64-gnu": "1.10.0-rc.1",
+    "@tokmd/core-linux-arm64-musl": "1.10.0-rc.1",
+    "@tokmd/core-win32-arm64-msvc": "1.10.0-rc.1"
   }
 }

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.0.0-alpha.66"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.9.0",
-    "@tokmd/core-darwin-x64": "1.9.0",
-    "@tokmd/core-darwin-arm64": "1.9.0",
-    "@tokmd/core-linux-x64-gnu": "1.9.0",
-    "@tokmd/core-linux-x64-musl": "1.9.0",
-    "@tokmd/core-linux-arm64-gnu": "1.9.0",
-    "@tokmd/core-linux-arm64-musl": "1.9.0",
-    "@tokmd/core-win32-arm64-msvc": "1.9.0"
+    "@tokmd/core-win32-x64-msvc": "1.10.0",
+    "@tokmd/core-darwin-x64": "1.10.0",
+    "@tokmd/core-darwin-arm64": "1.10.0",
+    "@tokmd/core-linux-x64-gnu": "1.10.0",
+    "@tokmd/core-linux-x64-musl": "1.10.0",
+    "@tokmd/core-linux-arm64-gnu": "1.10.0",
+    "@tokmd/core-linux-arm64-musl": "1.10.0",
+    "@tokmd/core-win32-arm64-msvc": "1.10.0"
   }
 }

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # tokmd Implementation Plan
 
-This document records completed implementation phases through `1.10.0` and the next active buildout aligned with the roadmap.
+This document records completed implementation phases through `1.10.0-rc.1` and the next active buildout aligned with the roadmap.
 
 ## Phase 1: Baseline & Ratchet System (v1.5.0) ✅ Complete
 
@@ -348,9 +348,9 @@ fetch.
 
 ---
 
-## Phase 5b: Release Train Hardening (v1.10.0) ✅ Complete
+## Phase 5b: Release Train Hardening (v1.10.0-rc.1) 🚢 RC
 
-**Goal**: Stabilize the shipped control-plane and browser/WASM surfaces without widening product scope.
+**Goal**: Stabilize the shipped control-plane and browser/WASM surfaces in a release candidate without widening product scope.
 
 ### Release Fence
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # tokmd Implementation Plan
 
-This document records completed implementation phases through `1.9.0` and the next active buildout aligned with the roadmap.
+This document records completed implementation phases through `1.10.0` and the next active buildout aligned with the roadmap.
 
 ## Phase 1: Baseline & Ratchet System (v1.5.0) ✅ Complete
 
@@ -326,7 +326,7 @@ pub fn cockpit_workflow(settings: &CockpitSettings) -> Result<CockpitReceipt>;
 
 1. **Feature profile**: `wasm` / `web`
 2. **Crate**: `tokmd-wasm`
-3. **Runner**: static browser app using a Worker, repo tree + contents ingestion, caching, and artifact download
+3. **Runner**: static browser app using a Worker, repo tree + contents ingestion, and artifact download
 
 ### Work Items
 
@@ -345,6 +345,35 @@ pub fn cockpit_workflow(settings: &CockpitSettings) -> Result<CockpitReceipt>;
 Runtime hardening beyond the v1.9.0 browser baseline remains follow-up work:
 cache behavior, progress events, retry/rate-limit UX, and optional authenticated
 fetch.
+
+---
+
+## Phase 5b: Release Train Hardening (v1.10.0) ✅ Complete
+
+**Goal**: Stabilize the shipped control-plane and browser/WASM surfaces without widening product scope.
+
+### Release Fence
+
+1. **No crate-boundary work**: crate surface and facade boundaries stay frozen for the release.
+2. **No browser mode widening**: browser support remains governed by `docs/capabilities/wasm.json`.
+3. **No browser runtime feature expansion**: cache/progress/retry/auth polish moves to `v1.11.0`.
+
+### Work Items
+
+- [x] Ship GitHub Action explicit modes for `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline`
+- [x] Harden bounded path/root handling across native, Git, and in-memory surfaces
+- [x] Make WASM timestamp and capability reporting truthful
+- [x] Enforce publish-surface classification and verify package-list proof for the 16 published crates
+- [x] Replace manual CLI reference tables with checked HELP markers
+- [x] Add determinism, snapshot, and property-test proof coverage for release-critical paths
+- [x] Clarify Jules provenance policy without blanket-blocking intentional `.jules/**` history
+
+### Follow-Up: v1.11.0 Browser Runtime Polish
+
+- [ ] Define cache key and invalidation semantics
+- [ ] Emit explicit progress events
+- [ ] Improve retry and rate-limit UX
+- [ ] Partition authenticated fetch/cache behavior safely
 
 ---
 


### PR DESCRIPTION
## Summary
- prepare the `v1.10.0rc1` release candidate using semver package metadata `1.10.0-rc.1`
- update Cargo, lockfile, and Node package metadata for the RC
- expand CHANGELOG with the actual history across `v1.9.1`, `v1.9.2`, and the `v1.10.0-rc.1` range
- align README, ROADMAP, and implementation plan with the RC release fence
- add README examples for external Action consumers pinning `@v1.10.0-rc.1` with `version: '1.10.0-rc.1'`
- guard release workflow prerelease tags so RCs are prereleases, not latest, do not move `v1`, and skip stable-only crates.io/Docker publishing
- keep browser cache/progress/retry/auth explicitly deferred to the v1.11 lane

## Queue disposition before this PR
- merged proof keepers: #1151, #1234, #1194, #1141, #1184, #1164, #1210
- closed analyze snapshot duplicates: #1202, #1187, #1172, #1169, #1161
- closed stale architecture docs: #1160
- parked provenance/learning: #1214, #1156, #1144

## Changelog coverage
- Action modes, outputs, inferred refs, self-tests, and RC release workflow safeguards
- support-crate collapse and publish-surface/package-list proof
- bounded path/root trust across native, Git, MemFs, and FFI boundaries
- WASM timestamp/capability truth and browser-runner validation/error handling
- gate/cockpit contract hardening
- deterministic analyze/run/diff and proof coverage
- dependency, cargo-deny, cargo-mutants, fixture, and unsafe-code release hygiene
- Jules provenance policy, persona guidance, and run index governance

## Validation
- [x] cargo fmt-check
- [x] cargo xtask docs --check
- [x] cargo xtask version-consistency
- [x] cargo xtask publish-surface --json
- [x] cargo xtask publish-surface --json --verify-publish
- [x] cargo xtask gate --check
- [x] cargo deny --all-features check
- [x] npm test --prefix web/runner

Notes:
- publish-surface verify includes package-list checks for all 16 publishable crates.
- cargo deny passed with existing duplicate/stale-advisory warnings only.
- web/runner exits 0 with 48 pass / 1 skipped; Node still prints the known assertion diagnostic inside the skipped real-WASM test when the built wasm bundle is absent.
- `v1.10.0-rc.1` should be the deployment tag for the RC; stable aliases such as `v1` remain stable-only.