### PR TITLE
docs: add BDD specifications, traceability matrix, and ADRs

### DIFF
--- a/docs/adrs/0001-bdd-first-traceability.md
+++ b/docs/adrs/0001-bdd-first-traceability.md
@@ -1,0 +1,28 @@
+# ADR 0001: Adopt BDD-first specification traceability
+
+- Status: **Accepted**
+- Date: 2026-04-29
+
+## Context
+
+`tokmd` already has broad integration and BDD-oriented coverage. However, behavior expectations were spread across tests and command docs, making it harder to trace a requirement to code and proof.
+
+## Decision
+
+Adopt BDD-first behavior specification in `docs/specifications/` with explicit links to:
+
+1. Command/core implementation files.
+2. Integration and BDD tests validating the behavior.
+
+## Consequences
+
+### Positive
+
+- Faster onboarding for contributors.
+- Reduced ambiguity in behavior changes.
+- Explicit audit trail from requirement -> code -> tests.
+
+### Trade-offs
+
+- Requires ongoing matrix maintenance.
+- Minor documentation overhead for each feature change.

--- a/docs/adrs/0002-spec-implementation-test-linkage.md
+++ b/docs/adrs/0002-spec-implementation-test-linkage.md
@@ -1,0 +1,28 @@
+# ADR 0002: Standardize spec/implementation/test linkage
+
+- Status: **Accepted**
+- Date: 2026-04-29
+
+## Context
+
+The project has many crates and layered responsibilities, so specification drift can happen when implementation or tests evolve independently.
+
+## Decision
+
+Use a single traceability matrix (`docs/specifications/bdd-traceability.md`) with stable IDs (`BDD-*-###`) and require each row to include:
+
+- One concise BDD behavior summary.
+- At least one implementation file.
+- At least one validating test file.
+
+## Consequences
+
+### Positive
+
+- Enables deterministic review checklist for behavior changes.
+- Simplifies release-readiness checks for regression coverage.
+- Supports future automation for docs-to-tests verification.
+
+### Trade-offs
+
+- Introduces process discipline that must be followed consistently.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records (ADRs)
+
+This directory captures durable architectural decisions for behavior specification and verification strategy.
+
+## Index
+
+- [0001: Adopt BDD-first specification traceability](./0001-bdd-first-traceability.md)
+- [0002: Standardize spec/implementation/test linkage](./0002-spec-implementation-test-linkage.md)
+
+## ADR status labels
+
+- **Accepted**: Active and expected to guide current changes.
+- **Superseded**: Replaced by a newer ADR.
+- **Proposed**: Candidate decision under review.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -24,6 +24,16 @@ tokmd produces deterministic code inventory receipts and PR-focused context for:
 2. **Tool schemas**: Generate OpenAI/Anthropic/JSON Schema tool definitions
 3. **Inventory-first**: Provide map before dump (what languages, which modules, will it fit?)
 
+## Behavior Specifications and ADRs
+
+Detailed behavior contracts and BDD traceability live in:
+- `docs/specifications/core-workflows.md`
+- `docs/specifications/bdd-traceability.md`
+
+Architectural rationale for this documentation strategy lives in:
+- `docs/adrs/0001-bdd-first-traceability.md`
+- `docs/adrs/0002-spec-implementation-test-linkage.md`
+
 ## Interfaces
 
 ### CLI (Stable Surfaces)

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -1,0 +1,21 @@
+# Specifications
+
+This directory contains implementation-facing product specifications for `tokmd`.
+
+## Goals
+
+- Express behavior in clear, testable statements.
+- Tie expectations directly to code paths and automated tests.
+- Use BDD-style scenarios (`Given/When/Then`) so behavior stays executable in spirit.
+
+## Specification index
+
+- [Core workflow specification](./core-workflows.md)
+- [BDD traceability matrix](./bdd-traceability.md)
+
+## How to use
+
+1. Start with `core-workflows.md` to understand expected behavior.
+2. Follow links into implementation crates to inspect code.
+3. Use `bdd-traceability.md` to identify validating test suites.
+4. For architectural decisions, see [ADRs](../adrs/README.md).

--- a/docs/specifications/bdd-traceability.md
+++ b/docs/specifications/bdd-traceability.md
@@ -1,0 +1,20 @@
+# BDD Traceability Matrix
+
+This matrix links behavior statements to implementation and tests.
+
+| ID | Behavior (Given/When/Then summary) | Implementation | Tests |
+|---|---|---|---|
+| BDD-LANG-001 | Given source files, when `lang` runs, then deterministic language receipt is produced. | `crates/tokmd/src/commands/lang.rs` | `crates/tokmd/tests/bdd_lang_scenarios_w50.rs`, `crates/tokmd/tests/cli_snapshot_golden.rs` |
+| BDD-MOD-001 | Given normalized paths, when module workflow runs, then module ordering and grouping are stable. | `crates/tokmd-core/src/lib.rs` | `crates/tokmd-core/tests/workflows.rs`, `crates/tokmd/tests/bdd_module_scenarios_w50.rs` |
+| BDD-EXP-001 | Given repository inventory, when export renders JSON/JSONL/CSV, then semantics remain equivalent across formats. | `crates/tokmd/src/commands/export.rs`, `crates/tokmd/src/export_bundle.rs` | `crates/tokmd/tests/bdd_export_scenarios_w50.rs`, `crates/tokmd/tests/cli_output_formats.rs` |
+| BDD-DIFF-001 | Given baseline and candidate receipts, when diff executes, then deltas are reported with documented range rules. | `crates/tokmd/src/commands/diff.rs`, `crates/tokmd/src/git_support.rs` | `crates/tokmd/tests/bdd_diff_scenarios_w50.rs`, `crates/tokmd/tests/diff_w71.rs` |
+| BDD-FFI-001 | Given `run_json` request, when mode is valid, then response envelope is stable and mode-consistent. | `crates/tokmd-core/src/ffi.rs` | `crates/tokmd-core/tests/ffi_contract.rs`, `crates/tokmd-core/tests/json_api.rs` |
+
+## Maintenance rule
+
+Whenever behavior changes:
+
+1. Update the relevant scenario text in `core-workflows.md`.
+2. Update this matrix row(s).
+3. Add or adjust at least one corresponding automated test.
+4. If architectural rationale changed, add or supersede an ADR.

--- a/docs/specifications/core-workflows.md
+++ b/docs/specifications/core-workflows.md
@@ -1,0 +1,85 @@
+# Core Workflow Specification (BDD)
+
+This specification defines minimum contract behavior for `lang`, `module`, `export`, and `diff` workflows through both CLI and core library interfaces.
+
+## Invariants
+
+1. Output ordering must be deterministic for equivalent inputs.
+2. Paths emitted in receipts must be normalized for cross-platform parity.
+3. JSON interfaces must return schema-tagged envelopes.
+4. CLI and core workflows should preserve behavioral parity for shared modes.
+
+## Scenario: language summary via CLI
+
+**Given** a repository with supported source files  
+**When** a user runs `tokmd lang --format json`  
+**Then** the command returns a stable JSON receipt with deterministic language rows.
+
+Implementation links:
+- CLI command handler: `crates/tokmd/src/commands/lang.rs`
+- Parser wiring: `crates/tokmd/src/cli/parser.rs`
+
+Validation links:
+- `crates/tokmd/tests/bdd_lang_scenarios_w50.rs`
+- `crates/tokmd/tests/cli_snapshot_golden.rs`
+- `crates/tokmd/tests/determinism.rs`
+
+## Scenario: module breakdown via core workflow
+
+**Given** normalized scan input  
+**When** `module_workflow` runs in `tokmd-core`  
+**Then** it returns module-grouped output that follows deterministic sort behavior.
+
+Implementation links:
+- Core facade: `crates/tokmd-core/src/lib.rs`
+- Settings and mode wiring: `crates/tokmd-core/src/settings.rs`
+
+Validation links:
+- `crates/tokmd-core/tests/workflows.rs`
+- `crates/tokmd/tests/bdd_module_scenarios_w50.rs`
+- `crates/tokmd/tests/determinism_hardening.rs`
+
+## Scenario: export file inventory
+
+**Given** a mixed-language repository  
+**When** a user runs `tokmd export` in JSON/JSONL/CSV variants  
+**Then** each format reflects the same inventory semantics.
+
+Implementation links:
+- Export command: `crates/tokmd/src/commands/export.rs`
+- Output bundling helpers: `crates/tokmd/src/export_bundle.rs`
+
+Validation links:
+- `crates/tokmd/tests/bdd_export_scenarios_w50.rs`
+- `crates/tokmd/tests/json_output.rs`
+- `crates/tokmd/tests/cli_output_formats.rs`
+
+## Scenario: diff contract across tags or receipts
+
+**Given** two comparable scans or receipt inputs  
+**When** `tokmd diff` runs with release-style comparisons  
+**Then** it reports meaningful deltas under the documented range semantics.
+
+Implementation links:
+- Diff command: `crates/tokmd/src/commands/diff.rs`
+- Git range support: `crates/tokmd/src/git_support.rs`
+
+Validation links:
+- `crates/tokmd/tests/bdd_diff_scenarios_w50.rs`
+- `crates/tokmd/tests/diff_w71.rs`
+- `crates/tokmd/tests/run_diff.rs`
+
+## Scenario: JSON FFI envelope stability
+
+**Given** a consumer calling `run_json(mode, args_json)`  
+**When** a valid mode is requested  
+**Then** response is wrapped in `{ ok, data | error }` envelope and preserves schema contract.
+
+Implementation links:
+- FFI entrypoint: `crates/tokmd-core/src/ffi.rs`
+- Error mapping: `crates/tokmd-core/src/error.rs`
+
+Validation links:
+- `crates/tokmd-core/tests/ffi_contract.rs`
+- `crates/tokmd-core/tests/json_api.rs`
+- `crates/tokmd-core/tests/bindings_parity.rs`


### PR DESCRIPTION
### Motivation

- Make behavior expectations explicit and traceable by adopting BDD-style specifications that link requirements -> implementation -> tests. 
- Reduce specification drift across the multi-crate codebase by providing a single traceability matrix and formal ADRs for the documentation strategy.

### Description

- Add `docs/specifications/` with `README.md`, `core-workflows.md` (BDD scenarios for `lang`, `module`, `export`, `diff`, and FFI envelope), and `bdd-traceability.md` (traceability matrix linking behaviors to implementation and tests). 
- Add `docs/adrs/` with `README.md` and two ADRs: `0001-bdd-first-traceability.md` and `0002-spec-implementation-test-linkage.md` formalizing the BDD-first and linkage rules. 
- Update `docs/requirements.md` to reference the new specifications and ADR artifacts so requirements point to executable-style behavior contracts and rationale. 

### Testing

- Ran the docs-focused test suite with `cargo test -p tokmd --test docs`, which executed the `docs.rs` tests. 
- Test result: `29 passed; 0 failed`, indicating the recipe/doc tests succeeded. 
- No functional code changes were made; the test run validates the documentation recipes and associated test fixtures remain passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c7b3a28833389c735f6376a44ac)