### PR TITLE
docs: add implementation specification, ADRs, and BDD traceability

### DIFF
--- a/docs/adr/0001-bdd-traceability-contract.md
+++ b/docs/adr/0001-bdd-traceability-contract.md
@@ -1,0 +1,27 @@
+# ADR-0001: BDD Traceability as a First-Class Contract
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+`tokmd` has broad surface area (scan/model/format/analyze/core/CLI and bindings). Behavior-focused tests already exist, but implementation intent and test mapping has been implicit and distributed.
+
+## Decision
+
+Adopt BDD traceability as documentation contract:
+
+1. Express core behaviors in `Given/When/Then` form.
+2. Link each behavior to implementation anchors and executable tests.
+3. Keep the matrix under version control in `docs/specifications/bdd-traceability.md`.
+
+## Consequences
+
+### Positive
+- Faster onboarding and design review for behavior changes.
+- Explicit verification path from docs -> code -> tests.
+- Improved release confidence for schema and deterministic output guarantees.
+
+### Trade-offs
+- Requires periodic maintenance when modules/tests move.
+- Adds lightweight process overhead for feature changes.

--- a/docs/adr/0002-receipt-schema-governance.md
+++ b/docs/adr/0002-receipt-schema-governance.md
@@ -1,0 +1,29 @@
+# ADR-0002: Stable Receipt Contracts and Schema Governance
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+`tokmd` is consumed by CLI users, automation pipelines, and language bindings. Contract drift in receipt shape or schema metadata can break downstream systems.
+
+## Decision
+
+1. Treat receipt schema/version changes as explicit contract events.
+2. Require synchronized updates across:
+   - implementation constants
+   - schema documents
+   - contract tests
+   - BDD traceability matrix
+3. Keep behavior-level acceptance criteria linked to schema contract tests.
+
+## Consequences
+
+### Positive
+- Clear lifecycle for breaking/non-breaking changes.
+- Better auditability for release notes and compatibility claims.
+- Lower risk for Python/Node/FFI consumers.
+
+### Trade-offs
+- Stricter change discipline for rapid experiments.
+- Requires comprehensive test updates for contract-evolving features.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -117,3 +117,10 @@ tokmd is a gatekeeper-class tool. Minimum evidence:
 - **Not a vulnerability scanner**: Use cargo-audit, npm audit
 - **Not a test runner**: Use cargo test, pytest
 - **Not a scorer**: Provides signals, not judgments
+
+## Specification and ADRs
+
+- `docs/specifications/implementation-spec.md`: behavior-level implementation specification.
+- `docs/specifications/bdd-traceability.md`: BDD traceability matrix mapping behavior -> code -> tests.
+- `docs/adr/0001-bdd-traceability-contract.md`: decision to treat BDD traceability as a contract.
+- `docs/adr/0002-receipt-schema-governance.md`: decision for receipt/schema governance and compatibility.

--- a/docs/specifications/bdd-traceability.md
+++ b/docs/specifications/bdd-traceability.md
@@ -1,0 +1,17 @@
+# BDD Traceability Matrix
+
+This matrix links behavior specifications to implementation modules and executable tests.
+
+| Behavior ID | BDD Scenario (Given / When / Then) | Implementation anchors | Primary executable tests |
+|---|---|---|---|
+| BDD-SCAN-01 | Given mixed separators + ignore rules, when scanning, then normalized deterministic file rows are emitted. | `crates/tokmd-scan/src/path/mod.rs`, `crates/tokmd-scan/src/tokeignore/mod.rs`, `crates/tokmd-scan/src/lib.rs` | `crates/tokmd-scan/src/path/tests.rs`, `crates/tokmd/tests/bdd_scenarios_w75.rs`, `crates/tokmd/tests/determinism_hardening_w51.rs` |
+| BDD-RECEIPT-01 | Given any scan result, when receipts are serialized, then schema/version envelope contracts hold. | `crates/tokmd-types`, `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | `crates/tokmd/tests/schema_sync.rs`, `crates/tokmd/tests/schema_doc_sync.rs`, `crates/tokmd/tests/receipt_contracts_w72.rs` |
+| BDD-FORMAT-01 | Given a receipt, when Markdown/TSV/JSON outputs are requested, then deterministic formatting is produced. | `crates/tokmd-format/src/lib.rs`, `crates/tokmd-format/src/analysis/markdown.rs`, `crates/tokmd-format/src/export_tree/mod.rs` | `crates/tokmd/tests/output_formats_w76.rs`, `crates/tokmd/tests/markdown_output.rs`, `crates/tokmd/tests/json_output.rs` |
+| BDD-DIFF-01 | Given two runs/baselines, when diff/cockpit is executed, then reproducible deltas and evidence are produced. | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/settings.rs`, CLI integration in `crates/tokmd` | `crates/tokmd/tests/bdd_diff_scenarios_w50.rs`, `crates/tokmd/tests/deep_run_cockpit_w52.rs`, `crates/tokmd/tests/diff_deep_w77.rs` |
+| BDD-ANALYZE-01 | Given a repository and presets, when analysis runs, then enrichments match preset contracts. | `crates/tokmd-analysis`, `crates/tokmd-format/src/analysis/mod.rs`, `crates/tokmd-core/src/lib.rs` | `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`, `crates/tokmd/tests/analyze_integration.rs`, `crates/tokmd/tests/full_pipeline_w55.rs` |
+
+## Usage
+
+1. Add or update BDD rows when behavior changes.
+2. Ensure each row has at least one executable regression test.
+3. Prefer scenario-focused test names (`bdd_*`/`*_integration`) for discoverability.

--- a/docs/specifications/implementation-spec.md
+++ b/docs/specifications/implementation-spec.md
@@ -1,0 +1,51 @@
+# Implementation Specification (BDD-Aligned)
+
+## Purpose
+
+This specification defines how `tokmd` implementation behaviors map to executable acceptance criteria (BDD-style) and stable architecture decisions (ADRs).
+
+## Scope
+
+The scope covers the end-to-end value stream:
+
+1. Repository scan and normalization.
+2. Receipt generation and formatting.
+3. Diff/analyze/cockpit enrichments.
+4. Contract and schema stability.
+
+## BDD Behavioral Contract
+
+### Epic: Deterministic repository receipts for AI-native workflows
+
+#### Capability 1: Scanning and path normalization
+- **Given** a repository tree with mixed path separators and ignore rules.
+- **When** users run `tokmd lang`, `tokmd module`, or `tokmd export`.
+- **Then** paths are normalized, excludes are honored, and scan rows are deterministic.
+
+#### Capability 2: Stable machine-readable outputs
+- **Given** default and feature-enabled runs.
+- **When** users export JSON/JSONL/CSV or run `tokmd run` artifacts.
+- **Then** output envelopes and schema versions remain contract-stable.
+
+#### Capability 3: Human-readable reporting
+- **Given** receipts from scan/model tiers.
+- **When** users render markdown/tsv/report outputs.
+- **Then** rendered content remains deterministic and snapshot-safe.
+
+#### Capability 4: Derived analysis and policy gates
+- **Given** a baseline or repository input.
+- **When** users run `tokmd analyze`, `tokmd diff`, `tokmd cockpit`, or `tokmd gate`.
+- **Then** higher-order metrics are reproducible and policy outcomes are auditable.
+
+## Traceability to Code and Tests
+
+Use `docs/specifications/bdd-traceability.md` as the authoritative mapping between:
+
+- BDD scenarios (`Given/When/Then`)
+- Production implementation modules
+- Regression and contract test files
+
+## Related ADRs
+
+- [ADR-0001: BDD Traceability as a First-Class Contract](../adr/0001-bdd-traceability-contract.md)
+- [ADR-0002: Stable Receipt Contracts and Schema Governance](../adr/0002-receipt-schema-governance.md)


### PR DESCRIPTION
### Motivation

- Make implementation intent explicit by expressing core behaviors as BDD-style acceptance criteria (`Given/When/Then`).
- Improve traceability between behavior-level specs, the implementation anchors, and executable regression/contract tests so changes are reviewable and auditable.
- Formalize schema/receipt change governance to reduce downstream breakage for CLI, FFI, and language bindings.

### Description

- Add a BDD-aligned implementation specification at `docs/specifications/implementation-spec.md` that enumerates key capabilities and acceptance criteria.
- Add a BDD traceability matrix at `docs/specifications/bdd-traceability.md` mapping behavior IDs to implementation anchors and primary executable tests.
- Add two ADRs: `docs/adr/0001-bdd-traceability-contract.md` to treat BDD traceability as a documentation contract and `docs/adr/0002-receipt-schema-governance.md` to formalize receipt/schema governance.
- Update `docs/requirements.md` to reference the new specification and ADR artifacts.

### Testing

- Ran `cargo test -p tokmd --test docs_sync_w72 -q` which executed the docs sync test suite and passed (16 passed; 0 failed).
- No code changes were made; validation focused on docs-sync tests to ensure documentation alignment with repository invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c7b3a28833389c735f6376a44ac)