### PR TITLE
docs: add BDD specification and ADR traceability

### DIFF
--- a/docs/adr/0001-specification-traceability.md
+++ b/docs/adr/0001-specification-traceability.md
@@ -1,0 +1,34 @@
+# ADR-0001: Specification-as-Behavior with Executable Traceability
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd has strong design and testing documentation, but product behaviors are not consistently expressed as BDD scenarios with explicit links to implementation and tests.
+
+## Decision
+
+Adopt a specification model where each core capability is documented as:
+1. BDD scenario(s) (`Given/When/Then`)
+2. Implementation anchors (crate/module paths)
+3. Verification anchors (test files/suites)
+
+Use `docs/specification.md` as the canonical behavior index.
+
+## Consequences
+
+### Positive
+- Faster onboarding from requirements to code paths
+- Better release confidence via visible test traceability
+- Clearer contract for CLI/library consumers
+
+### Trade-offs
+- Requires discipline to keep traceability updated as modules/tests move
+- Adds documentation maintenance in feature PRs
+
+## Compliance
+
+Feature PRs that alter behavior should update:
+- BDD scenario text
+- Implementation/test links in the traceability matrix

--- a/docs/adr/0002-bdd-mapping-standard.md
+++ b/docs/adr/0002-bdd-mapping-standard.md
@@ -1,0 +1,31 @@
+# ADR-0002: BDD Mapping Standard for Code and Tests
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+The project uses unit, integration, property, fuzz, and mutation tests. Without a consistent BDD mapping standard, behavior coverage is harder to audit.
+
+## Decision
+
+Define a lightweight mapping rule:
+
+- Each top-level behavior spec in `docs/specification.md` has an ID (`Spec-XX`).
+- The spec entry must include:
+  - at least one `Given/When/Then` scenario,
+  - implementation anchors,
+  - verification anchors.
+- Relevant integration tests should reference the behavior ID in comments or test names when practical.
+
+## Mapping Guidelines
+
+1. **User-observable behaviors first** (CLI/API contracts).
+2. **One behavior, many tests** is preferred over duplicating scenarios.
+3. **Prefer existing test suites**; only add new tests when coverage is missing.
+4. **Keep matrix high-signal**; list primary anchors, not every helper.
+
+## Consequences
+
+- Improves BDD-style auditability without forcing a new test framework.
+- Preserves existing Rust test stack and tooling.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -24,6 +24,12 @@ tokmd produces deterministic code inventory receipts and PR-focused context for:
 2. **Tool schemas**: Generate OpenAI/Anthropic/JSON Schema tool definitions
 3. **Inventory-first**: Provide map before dump (what languages, which modules, will it fit?)
 
+
+## Behavioral Specification and ADRs
+
+- Behavioral spec and BDD traceability matrix: `docs/specification.md`
+- Architecture Decision Records (ADRs): `docs/adr/`
+
 ## Interfaces
 
 ### CLI (Stable Surfaces)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,93 @@
+# tokmd Specification by Behavior
+
+This specification defines product behavior using BDD-style scenarios and links each behavior to implementation modules and executable tests.
+
+## How to read this document
+
+Each behavior includes:
+- **Given/When/Then** scenarios (human contract)
+- **Implementation links** (where behavior lives)
+- **Verification links** (which tests enforce it)
+
+## Spec-01: Deterministic receipts
+
+### Scenario: identical inputs produce stable receipts
+- **Given** the same repository contents, flags, and schema version
+- **When** `tokmd run`, `tokmd lang`, or `tokmd export` is executed repeatedly
+- **Then** output ordering and normalized paths are stable and deterministic
+
+**Implementation**
+- `tokmd-model` aggregation and ordering rules.  
+- `tokmd-format` rendering and stable row output.
+
+**Verification**
+- Property tests for normalization and ordering invariants.  
+- Snapshot tests validating stable rendered output.
+
+## Spec-02: Schema-versioned JSON contracts
+
+### Scenario: machine consumers can validate outputs
+- **Given** JSON-producing commands
+- **When** a receipt is emitted
+- **Then** it includes schema metadata and conforms to documented schema families
+
+**Implementation**
+- `tokmd-types` schema constants and DTO envelopes.  
+- `docs/schema.json` and related schema docs.
+
+**Verification**
+- CLI schema validation tests in integration suite.
+
+## Spec-03: PR risk and evidence gates
+
+### Scenario: cockpit highlights review risk with hard gates
+- **Given** base/head refs and optional evidence artifacts
+- **When** `tokmd cockpit` runs
+- **Then** it returns review-focused metrics and gate outcomes with explainable reasons
+
+**Implementation**
+- `tokmd-git`, `tokmd-analysis`, and `tokmd-gate` integrations in cockpit workflow.
+
+**Verification**
+- `cockpit_integration` tests for coverage, supply-chain, contract, determinism, and complexity gates.
+
+## Spec-04: LLM-safe context packing
+
+### Scenario: bounded context selection for AI workflows
+- **Given** a token budget and path selection rules
+- **When** `tokmd context` is executed
+- **Then** selected files fit budget constraints and include explicit truncation markers when needed
+
+**Implementation**
+- Context selection logic in `tokmd-core`/CLI command flow.
+
+**Verification**
+- Context-focused integration tests and deterministic output assertions.
+
+## Spec-05: Redaction and privacy guarantees
+
+### Scenario: shareable receipts avoid sensitive paths
+- **Given** redaction mode (`paths` or `all`)
+- **When** artifacts are generated
+- **Then** sensitive path material is replaced deterministically using stable hashing
+
+**Implementation**
+- Redaction helpers and rendering hooks in `tokmd-format`.
+
+**Verification**
+- Unit + property tests for deterministic redaction.
+
+## Traceability matrix (BDD → code → tests)
+
+| Spec | BDD focus | Implementation anchors | Primary tests |
+|---|---|---|---|
+| Spec-01 | Deterministic receipts | `crates/tokmd-model`, `crates/tokmd-format` | crate property tests, snapshot suites |
+| Spec-02 | Schema contracts | `crates/tokmd-types`, `docs/schema.json` | `crates/tokmd/tests/schema_validation.rs` |
+| Spec-03 | Cockpit evidence gates | `crates/tokmd/src/cmd/cockpit.rs`, `crates/tokmd-gate` | `crates/tokmd/tests/cockpit_integration.rs` |
+| Spec-04 | Context budget behavior | `crates/tokmd/src/cmd/context.rs`, `crates/tokmd-core` | context-related integration coverage |
+| Spec-05 | Redaction determinism | `crates/tokmd-format/src/redact/` | tokmd-format redaction tests + properties |
+
+## ADR index
+
+- [ADR-0001: Specification-as-Behavior with Executable Traceability](adr/0001-specification-traceability.md)
+- [ADR-0002: BDD Mapping Standard for Code and Tests](adr/0002-bdd-mapping-standard.md)


### PR DESCRIPTION
### Motivation
- Provide a single, behavior-first specification that expresses product behavior as BDD-style scenarios and maps those behaviors to implementation and test anchors. 
- Make it straightforward to audit that a documented behavior is covered by the existing Rust test stack and to speed feature PR review by surfacing traceability. 
- Formalize a lightweight ADR-backed mapping standard so future changes maintain the BDD → code → tests linkage.

### Description
- Add `docs/specification.md` containing five BDD-style specs (`Spec-01`..`Spec-05`) and a traceability matrix linking behaviors to crates and primary tests. 
- Add ADRs `docs/adr/0001-specification-traceability.md` and `docs/adr/0002-bdd-mapping-standard.md` that record the decision and mapping standard. 
- Update `docs/requirements.md` to reference the new behavioral specification and ADR directory. 
- The spec explicitly references implementation anchors like `crates/tokmd-model`, `crates/tokmd-format`, `crates/tokmd-types`, `crates/tokmd-gate`, and test anchors such as `crates/tokmd/tests/cockpit_integration.rs`.

### Testing
- Ran `cargo fmt-check`, which completed successfully. 
- Invoked `cargo test -p tokmd --test docs --verbose`, which compiled dependencies and started the test run but did not fully finish within this session (no failing tests observed in the captured output). 
- Documentation changes are limited to new/updated Markdown files and do not modify production code behavior, and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c7b3a28833389c735f6376a44ac)