### PR TITLE
docs: add BDD specification, scenario registry, and ADR for facade traceability

### DIFF
--- a/docs/adrs/0001-tier-facade-and-bdd-traceability.md
+++ b/docs/adrs/0001-tier-facade-and-bdd-traceability.md
@@ -1,0 +1,49 @@
+# ADR-0001: Tier Facade Enforcement and BDD Traceability
+
+- Status: Accepted
+- Date: 2026-04-29
+- Deciders: tokmd maintainers
+
+## Context
+
+tokmd spans many crates with strict tiering and multiple product surfaces (CLI, Python, Node, wasm). Without explicit traceability, behavior changes can drift from requirements and become hard to validate consistently.
+
+The architecture already enforces a Tier 4 facade (`tokmd-core`) for Tier 5 product access into Tier 3 orchestration. We also maintain a growing BDD integration suite under `crates/tokmd/tests/`.
+
+## Decision
+
+1. Keep **Tier 4 facade enforcement** as a hard architectural rule for product surfaces.
+2. Adopt **specification-by-example** as the default for user-visible behavior documentation.
+3. Maintain a **single scenario registry** in `docs/specification-bdd.md` mapping:
+   - scenario ID → behavior contract
+   - behavior contract → owning module/crate
+   - behavior contract → executable BDD/integration test files
+4. Require behavioral PRs to update both specification and tests together.
+
+## Consequences
+
+### Positive
+
+- Faster review: expected behavior is visible in one place.
+- Better regression triage: failures map to explicit scenario IDs.
+- Less architecture erosion: product changes must route through stable facades.
+
+### Trade-offs
+
+- Documentation maintenance overhead per behavior change.
+- Scenario registry requires disciplined updates.
+
+## Compliance Checklist
+
+For any user-visible behavior change:
+
+- [ ] Update `docs/specification-bdd.md` scenario registry.
+- [ ] Add/update BDD or integration tests under `crates/tokmd/tests/`.
+- [ ] Confirm tier-boundary correctness against `docs/architecture.md`.
+- [ ] If architectural intent changed, add or supersede ADR.
+
+## Links
+
+- Architecture: `docs/architecture.md`
+- Testing strategy: `docs/testing.md`
+- Specification registry: `docs/specification-bdd.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ CLI/config/progress/tool-schema/explain wiring in `tokmd`.
 
 | Crate | Purpose |
 |-------|---------|
-| `tokmd-core` | Library facade with FFI layer; exposes analysis formatting via `analysis_facade` module (see ADR-001) |
+| `tokmd-core` | Library facade with FFI layer; exposes analysis formatting via `analysis_facade` module (see ADR-0001) |
 
 ### Tier 5: Products
 
@@ -100,7 +100,7 @@ CLI/config/progress/tool-schema/explain wiring in `tokmd`.
 
 1. **Contracts MUST NOT depend on clap** — Keep `tokmd-types` and `tokmd-analysis-types` pure
 2. **Lower tiers MUST NOT depend on higher tiers** — No upward dependencies
-3. **Tier boundary compliance via facade** — Tier 5 products access Tier 3 orchestration only through Tier 4 facades (e.g., `tokmd-core::analysis_facade`). See ADR-001.
+3. **Tier boundary compliance via facade** — Tier 5 products access Tier 3 orchestration only through Tier 4 facades (e.g., `tokmd-core::analysis_facade`). See ADR-0001 (`docs/adrs/0001-tier-facade-and-bdd-traceability.md`).
 4. **Feature flags control optional adapters** — `git`, `walk`, `content` features
 5. **IO adapters depend on domain/contracts, never reverse**
 

--- a/docs/specification-bdd.md
+++ b/docs/specification-bdd.md
@@ -1,0 +1,51 @@
+# Specification-by-Example and BDD Traceability
+
+This document defines how tokmd implementation behavior is specified, traced to code, and verified through BDD scenarios.
+
+## Goals
+
+- Keep behavior contracts human-readable and executable.
+- Link user-facing behavior to owning modules and integration tests.
+- Make regressions easy to triage by preserving scenario-level intent.
+
+## BDD Workflow
+
+1. **Specify behavior** in `Given / When / Then` form.
+2. **Map the behavior** to an owning workflow or module.
+3. **Implement/adjust code** at the owner boundary.
+4. **Add or update a BDD scenario test** in `crates/tokmd/tests/`.
+5. **Preserve traceability** by keeping scenario IDs stable.
+
+## Scenario Registry
+
+| Scenario ID | Behavior Contract | Primary Code Owner | BDD/Integration Tests |
+|---|---|---|---|
+| LANG-001 | Language totals are deterministic and ordered by code desc, name asc | `tokmd-model`, `tokmd-format` | `crates/tokmd/tests/bdd_lang_scenarios_w50.rs` |
+| MODULE-001 | Module keys derive from normalized slash paths | `tokmd-model` | `crates/tokmd/tests/bdd_module_scenarios_w50.rs` |
+| EXPORT-001 | Export emits stable file-level inventory contracts | `tokmd-format`, `tokmd-core` | `crates/tokmd/tests/bdd_export_scenarios_w50.rs` |
+| ANALYZE-001 | Preset-driven analysis enrichments remain contract-stable | `tokmd-analysis`, `tokmd-analysis-types` | `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`, `crates/tokmd/tests/analyze_integration.rs` |
+| DIFF-001 | Diff compares receipts/runs with deterministic reporting | `tokmd-core`, `tokmd-format` | `crates/tokmd/tests/bdd_diff_scenarios_w50.rs`, `crates/tokmd/tests/run_diff.rs` |
+| CLI-001 | End-to-end user workflows remain behaviorally stable | `crates/tokmd/src` command surface | `crates/tokmd/tests/bdd_scenarios_w71.rs`, `crates/tokmd/tests/bdd_scenarios_w75.rs` |
+
+## Spec Authoring Rules
+
+- Prefer behavior language over implementation details.
+- Every new user-visible behavior must reference at least one scenario ID.
+- Every scenario ID must map to at least one automated test file.
+- When behavior changes, update this registry and test comments in the same PR.
+
+## Definition of Done for Behavioral Changes
+
+A change is complete only when:
+
+- A behavior contract is documented in this file.
+- A code owner is identified.
+- A BDD or integration test asserts the contract.
+- Any affected architecture decision is captured under `docs/adrs/`.
+
+## Related Documents
+
+- `docs/requirements.md` for product-level requirements.
+- `docs/architecture.md` for crate boundaries and dependency constraints.
+- `docs/testing.md` for test pyramid and execution guidance.
+- `docs/adrs/0001-tier-facade-and-bdd-traceability.md` for decision rationale.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -97,6 +97,15 @@ Hermetic fixtures in `crates/tokmd/tests/data/`:
 - Configuration files (Cargo.toml, .gitignore)
 - Copied to temp directory with `.git/` marker for gitignore testing
 
+
+## BDD Traceability
+
+Behavior specifications and scenario-to-test mappings live in `docs/specification-bdd.md`.
+
+- Use stable scenario IDs when adding or modifying BDD tests.
+- Ensure each user-visible behavior is linked to at least one executable scenario.
+- Update ADR context in `docs/adrs/0001-tier-facade-and-bdd-traceability.md` when architecture-level behavior policy changes.
+
 ## Golden Snapshot Tests
 
 Using `insta` for output stability:


### PR DESCRIPTION
### Motivation

- Provide a single, discoverable place that specifies user-visible behavior as executable examples so reviewers and maintainers can quickly map regressions to intent. 
- Make the architectural rule about Tier-4 facade access explicit and traceable so product surfaces cannot bypass orchestration tiers. 
- Improve test-to-spec traceability by linking BDD/integration scenarios to owning crates and tests.

### Description

- Add `docs/specification-bdd.md` to define the specification-by-example workflow and a scenario registry mapping scenario IDs to behavior contracts, primary code owners, and existing BDD/integration test files. 
- Add ADR `docs/adrs/0001-tier-facade-and-bdd-traceability.md` that formalizes Tier-4 facade enforcement and the requirement to keep specs and tests in sync for user-visible behavioral changes. 
- Update `docs/architecture.md` to reference `ADR-0001` instead of the old implicit ADR reference. 
- Update `docs/testing.md` with a `BDD Traceability` section that points to the new specification registry and ADR and prescribes stable scenario IDs and update rules.

### Testing

- Ran `cargo test -p tokmd --test docs --verbose` to exercise the workspace build and documentation test targets, which started successfully and produced compilation output but did not complete to a final pass/fail within the session. 
- No new code was introduced beyond documentation changes, so existing automated tests remain the canonical validation and were not expected to fail as a result of these docs updates. 
- The PR includes a compliance checklist in the ADR that requires updating BDD scenarios and tests for any future behavioral changes, ensuring automated tests are updated alongside spec changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c7b3a28833389c735f6376a44ac)