### PR TITLE
docs: add behavioral specification and ADRs, linked to BDD guidance

### DIFF
--- a/docs/adrs/0001-deterministic-output-and-ordering.md
+++ b/docs/adrs/0001-deterministic-output-and-ordering.md
@@ -1,0 +1,22 @@
+# ADR-0001: Deterministic output and ordering
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+
+## Context
+
+`tokmd` outputs are consumed by automation (CI gates, snapshots, diff tooling, and LLM workflows). Non-deterministic ordering creates noisy diffs and brittle tests.
+
+## Decision
+
+Adopt deterministic ordering contracts for all exported structures:
+
+- Prefer stable map structures for key ordering.
+- Define explicit row sorting tiebreakers.
+- Normalize unstable fields in snapshot paths where appropriate.
+
+## Consequences
+
+- More predictable output and lower CI noise.
+- Slight implementation overhead for canonical ordering.
+- Stronger compatibility guarantee for downstream tooling.

--- a/docs/adrs/0002-path-normalization-contract.md
+++ b/docs/adrs/0002-path-normalization-contract.md
@@ -1,0 +1,23 @@
+# ADR-0002: Path normalization contract
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+
+## Context
+
+Cross-platform path differences (especially `\\` vs `/`) can fragment module keys, destabilize receipts, and break policy comparisons.
+
+## Decision
+
+Normalize paths to forward slashes at behavior boundaries before:
+
+- module aggregation,
+- rendering,
+- serialization,
+- and gate/comparison surfaces.
+
+## Consequences
+
+- Portable and stable receipts.
+- Clear interoperability behavior for Windows/Linux/macOS environments.
+- Requires disciplined path normalization at all output-producing edges.

--- a/docs/adrs/0003-feature-gated-capability-contract.md
+++ b/docs/adrs/0003-feature-gated-capability-contract.md
@@ -1,0 +1,22 @@
+# ADR-0003: Feature-gated capability contract
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+
+## Context
+
+`tokmd` supports minimal and full builds through optional features (`git`, `content`, `walk`, and others). Users need explicit behavior when capabilities are unavailable.
+
+## Decision
+
+Define a capability contract:
+
+- If a command strictly requires a disabled feature, return a clear, actionable error.
+- If a feature is optional for a report section, return explicit null/skipped metadata instead of silent omission.
+- Keep capability surfaces visible in machine outputs when relevant.
+
+## Consequences
+
+- Better UX for constrained builds.
+- Stronger machine readability for partial capability runs.
+- Additional testing requirements across feature combinations.

--- a/docs/adrs/0004-receipt-schema-versioning-policy.md
+++ b/docs/adrs/0004-receipt-schema-versioning-policy.md
@@ -1,0 +1,22 @@
+# ADR-0004: Receipt schema versioning policy
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+
+## Context
+
+Multiple receipt families exist, each with consumers that depend on stable JSON structure. Structural changes without version governance risk downstream breakage.
+
+## Decision
+
+Maintain per-family schema version governance:
+
+- Increment the relevant schema version when structure changes.
+- Update schema docs/artifacts in the same change.
+- Validate contracts in tests where possible.
+
+## Consequences
+
+- Safer upgrades for integrators.
+- More explicit maintenance responsibilities for contributors.
+- Slight process overhead when evolving output structures.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records (ADRs)
+
+This directory captures durable implementation decisions that shape `tokmd` behavior.
+
+## Index
+
+- [ADR-0001: Deterministic output and ordering](0001-deterministic-output-and-ordering.md)
+- [ADR-0002: Path normalization contract](0002-path-normalization-contract.md)
+- [ADR-0003: Feature-gated capability contract](0003-feature-gated-capability-contract.md)
+- [ADR-0004: Receipt schema versioning policy](0004-receipt-schema-versioning-policy.md)
+
+## ADR Status Values
+
+- **Accepted**: decision is active and binding.
+- **Superseded**: replaced by a newer ADR.
+- **Proposed**: under discussion; not yet normative.
+
+## ADR + BDD relationship
+
+Every accepted ADR should be testable through BDD, integration, property, or snapshot coverage.
+`docs/specification.md` is the behavior-facing index; ADRs provide design rationale.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,71 @@
+# tokmd Behavioral Specification
+
+This document defines the implementation-facing behavioral specification for `tokmd`.
+It is intentionally executable-by-convention: each section is written so it can be traced to BDD-style tests and architecture decisions.
+
+## Scope
+
+The specification covers:
+
+- CLI behavioral contracts (`tokmd`, `tokmd lang`, `module`, `export`, `run`, `analyze`, `diff`, `cockpit`, `gate`, `sensor`, and related helpers).
+- Receipt determinism and schema behavior.
+- Feature-gated behavior (`git`, `content`, `walk`, `halstead`).
+- Stability requirements for machine-facing outputs.
+
+It does not replace the full command reference in `docs/reference-cli.md`; it defines normative behavior and acceptance intent.
+
+## Specification Format
+
+Each requirement includes:
+
+- **Rule**: the normative behavioral statement.
+- **Rationale**: why the rule exists.
+- **Validation**: where the behavior should be covered in BDD/integration/property tests.
+- **Decision links**: ADRs that justify tradeoffs.
+
+## Core Behavioral Rules
+
+### SPEC-001: Deterministic output ordering
+
+- **Rule**: All machine outputs must be deterministic for equivalent inputs and settings.
+- **Rationale**: Enables reproducible pipelines, snapshot tests, and policy-gate confidence.
+- **Validation**: BDD + snapshot tests in format/model/types crates.
+- **Decision links**: [ADR-0001](adrs/0001-deterministic-output-and-ordering.md).
+
+### SPEC-002: Normalized path semantics
+
+- **Rule**: Output paths are normalized to forward slashes before rendering or serialization.
+- **Rationale**: Cross-platform consistency and stable module keys.
+- **Validation**: BDD and property tests in `tokmd-model`, `tokmd-scan`, `tokmd-format`.
+- **Decision links**: [ADR-0002](adrs/0002-path-normalization-contract.md).
+
+### SPEC-003: Feature-gated capability behavior
+
+- **Rule**: Commands that depend on optional capabilities must fail clearly or degrade explicitly when the feature is unavailable.
+- **Rationale**: Keeps minimal builds viable while preserving user trust.
+- **Validation**: BDD/integration tests for compile-time and runtime capability surfaces.
+- **Decision links**: [ADR-0003](adrs/0003-feature-gated-capability-contract.md).
+
+### SPEC-004: Schema version governance
+
+- **Rule**: JSON receipt shape changes require corresponding schema-version and schema-doc updates for the affected receipt family.
+- **Rationale**: Prevents silent contract breaks for downstream consumers.
+- **Validation**: schema validation tests + BDD coverage for envelope metadata.
+- **Decision links**: [ADR-0004](adrs/0004-receipt-schema-versioning-policy.md).
+
+## Traceability to BDD
+
+BDD tests are distributed across crates in `tests/bdd.rs` (and module-local `bdd.rs` for analysis subdomains).
+
+The BDD corpus should trace back to SPEC IDs (for example via scenario names, comments, or commit messages) and validate both positive and negative paths.
+
+See `docs/testing.md` for how BDD sits with integration, property, fuzz, and mutation layers.
+
+## Change Process
+
+When implementation behavior changes:
+
+1. Update this spec (add/modify SPEC entries).
+2. Add or update an ADR if the change introduces a durable design decision.
+3. Update BDD scenarios that assert the behavior.
+4. Update user-facing docs (`docs/reference-cli.md`, `docs/SCHEMA.md`) if externally visible.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -97,6 +97,22 @@ Hermetic fixtures in `crates/tokmd/tests/data/`:
 - Configuration files (Cargo.toml, .gitignore)
 - Copied to temp directory with `.git/` marker for gitignore testing
 
+
+## BDD Coverage and Traceability
+
+BDD-style scenarios are maintained across crates using `tests/bdd.rs` files (plus analysis module-local `bdd.rs` suites).
+
+Behavioral intent for those scenarios is defined in:
+
+- `docs/specification.md` (normative SPEC rules)
+- `docs/adrs/README.md` and `docs/adrs/*.md` (design rationale)
+
+When adding or changing BDD behavior:
+
+1. Update or add a SPEC entry.
+2. Add/update an ADR if the change is architectural.
+3. Update BDD scenarios to reflect acceptance behavior.
+
 ## Golden Snapshot Tests
 
 Using `insta` for output stability:


### PR DESCRIPTION
### Motivation

- Provide an implementation-facing behavioral specification that makes normative rules explicit and traceable to test scenarios. 
- Capture durable design rationale in ADRs so architectural tradeoffs are discoverable and tied to BDD/integration tests.

### Description

- Add `docs/specification.md` containing SPEC entries (SPEC-001..SPEC-004) for determinism, path normalization, feature-gated behavior, and schema-version governance. 
- Add `docs/adrs/README.md` and four ADR files `docs/adrs/0001-*` through `0004-*` documenting deterministic ordering, path normalization, feature-gated capability contract, and receipt schema versioning policy. 
- Update `docs/testing.md` to include a `BDD Coverage and Traceability` section linking the BDD suites to the new spec and ADRs. 
- This is documentation-only and does not modify runtime code or library behavior.

### Testing

- This is a docs-only change so no unit or integration test runs were required. 
- Verified files and content with local file checks and created a clean commit (commit `a9a3b99`), and the verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c6b16e88333a3c8bc968d21fc95)