### PR TITLE
docs: add specification roadmap and initial ADRs

### DIFF
--- a/docs/adrs/0001-adr-program-and-format.md
+++ b/docs/adrs/0001-adr-program-and-format.md
@@ -1,0 +1,35 @@
+# 0001: Establish ADR program and canonical template
+
+- Status: accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd spans multiple crates, bindings, and output surfaces. Design choices are currently distributed across code comments and docs, which makes historical rationale hard to locate.
+
+## Decision
+
+Adopt an ADR program in `docs/adrs/` using a lightweight, consistent format:
+
+- status
+- context
+- decision
+- consequences
+- alternatives considered
+
+## Consequences
+
+### Benefits
+- Faster onboarding and review context.
+- Clearer traceability for cross-cutting changes.
+
+### Costs
+- Small maintenance overhead per major decision.
+
+### Follow-ups
+- Add ADR references to major architectural docs where relevant.
+
+## Alternatives Considered
+
+- Keep rationale only in PR history.
+  - Rejected due to poor discoverability over time.

--- a/docs/adrs/0002-schema-versions-per-receipt-family.md
+++ b/docs/adrs/0002-schema-versions-per-receipt-family.md
@@ -1,0 +1,30 @@
+# 0002: Keep schema versions per receipt family
+
+- Status: accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd produces multiple receipt families (core, analysis, cockpit, handoff, context) that evolve at different rates and have different downstream consumers.
+
+## Decision
+
+Retain independent schema version constants per receipt family rather than a single global schema version.
+
+## Consequences
+
+### Benefits
+- Version bumps are scoped to impacted consumers.
+- Reduces unnecessary churn for unaffected integrations.
+
+### Costs
+- Requires explicit governance and contributor education.
+
+### Follow-ups
+- Maintain clear docs mapping family → version constant.
+- Add validation checks around schema and version updates.
+
+## Alternatives Considered
+
+- One global schema version for all receipts.
+  - Rejected because it couples unrelated evolution and increases upgrade burden.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,27 @@
+# ADR Index and Process
+
+ADRs capture architecture decisions that affect tokmd across crates or surfaces.
+
+## Naming
+
+- File format: `NNNN-short-title.md`
+- Example: `0001-adr-program-and-format.md`
+
+## Status Values
+
+- `proposed`
+- `accepted`
+- `superseded`
+- `deprecated`
+
+## Lifecycle
+
+1. Add ADR with `proposed` status.
+2. Discuss during PR review.
+3. Mark `accepted` when merged.
+4. If replaced, mark old ADR as `superseded` and reference the new one.
+
+## ADR List
+
+- [0001: Establish ADR program and canonical template](./0001-adr-program-and-format.md)
+- [0002: Keep schema versions per receipt family](./0002-schema-versions-per-receipt-family.md)

--- a/docs/specification-roadmap.md
+++ b/docs/specification-roadmap.md
@@ -1,0 +1,58 @@
+# Specification & ADR Program
+
+This document defines how tokmd captures implementation intent in **specifications** and durable design decisions in **ADRs** (Architecture Decision Records).
+
+## Goals
+
+- Keep major features traceable from requirement → implementation → validation.
+- Make design tradeoffs explicit and reviewable.
+- Prevent drift between CLI behavior, library APIs, and receipt schemas.
+
+## Deliverables
+
+- `docs/specs/` — implementation-level specifications.
+- `docs/adrs/` — architecture decision records.
+- `docs/adrs/README.md` — ADR lifecycle and status conventions.
+
+## Specification Standard
+
+Each spec should include:
+
+1. **Problem Statement**
+2. **Scope** (in/out)
+3. **User-facing behavior**
+4. **Data/API contracts**
+5. **Implementation plan**
+6. **Validation plan**
+7. **Rollout and compatibility notes**
+
+## ADR Standard
+
+Each ADR should include:
+
+1. **Status** (`proposed`, `accepted`, `superseded`, `deprecated`)
+2. **Context**
+3. **Decision**
+4. **Consequences** (benefits, costs, follow-ups)
+5. **Alternatives considered**
+
+## Traceability Conventions
+
+- Reference specs in PR descriptions and implementation comments where meaningful.
+- Reference ADR IDs in affected docs and major modules.
+- If output structure changes, increment the relevant schema version and update schema docs.
+
+## Initial Scope
+
+The initial pass covers:
+
+- Receipt schema governance
+- Cross-surface API consistency (CLI, core facade, FFI, Python/Node bindings)
+- Deterministic output guarantees
+
+## Maintenance
+
+- New platform-level behavior should land with either:
+  - a new spec + optional ADR, or
+  - an ADR update if the behavior is a policy change.
+- Superseded ADRs remain in-place for historical context and must link to successors.

--- a/docs/specs/receipt-schema-governance.md
+++ b/docs/specs/receipt-schema-governance.md
@@ -1,0 +1,45 @@
+# Spec: Receipt Schema Governance
+
+## Problem Statement
+
+tokmd emits multiple receipt families with independent schema versions. Without explicit governance, contributors can unintentionally break downstream parsers.
+
+## Scope
+
+### In Scope
+- JSON structure compatibility expectations.
+- Schema version bump rules.
+- Validation and release checks.
+
+### Out of Scope
+- Serialization format redesign.
+- Backfilling migration tooling.
+
+## User-facing Behavior
+
+- Every receipt envelope reports a schema version.
+- Breaking structural changes require version bump + schema/docs updates.
+- Additive changes should preserve backward compatibility when possible.
+
+## Data/API Contracts
+
+- Core receipts follow `SCHEMA_VERSION` in `tokmd-types`.
+- Analysis receipts follow `ANALYSIS_SCHEMA_VERSION` in `tokmd-analysis-types`.
+- Other families maintain their dedicated constants and docs.
+
+## Implementation Plan
+
+1. Define a contributor checklist in docs.
+2. Add CI checks that ensure schema docs are touched when version constants change.
+3. Add targeted tests asserting envelope version values per receipt family.
+
+## Validation Plan
+
+- Golden snapshot tests for representative receipts.
+- Schema linting/validation in CI.
+- Focused compatibility tests for parsers in bindings.
+
+## Rollout & Compatibility
+
+- Introduce as policy first.
+- Enforce CI guardrails after one release cycle to minimize contributor friction.


### PR DESCRIPTION
### Motivation

- Establish a formal program to capture implementation-level specifications and durable design decisions so rationale is discoverable and reviewable. 
- Provide explicit governance for receipt schema evolution to avoid accidental downstream breakages. 
- Improve traceability between requirements, implementation, and schema changes across CLI, library, and bindings.

### Description

- Add a top-level specification roadmap at `docs/specification-roadmap.md` describing deliverables, standards, and traceability conventions. 
- Add an implementation-level spec `docs/specs/receipt-schema-governance.md` that defines schema version rules, validation, and rollout guidance. 
- Introduce an ADR program with `docs/adrs/README.md` and two initial accepted ADRs: `docs/adrs/0001-adr-program-and-format.md` and `docs/adrs/0002-schema-versions-per-receipt-family.md`.

### Testing

- Documentation-only change; no code or tests were modified and no automated tests were required. 
- Existing CI and test suites remain applicable and unchanged for subsequent code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c648b288333af0c144562c75e4c)