### PR TITLE
docs: add implementation specification and ADR set

### DIFF
--- a/docs/adr/ADR-001-analysis-facade-boundary.md
+++ b/docs/adr/ADR-001-analysis-facade-boundary.md
@@ -1,0 +1,30 @@
+# ADR-001: Enforce analysis facade boundary at Tier 4
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+
+The repository uses a strict tiered microcrate architecture. Historically, Tier-5 product surfaces (CLI/bindings) could accidentally couple directly to Tier-3 analysis formatting/orchestration crates, which increased dependency sprawl and made interface stabilization harder.
+
+## Decision
+
+Analysis formatting and orchestration entrypoints used by product surfaces must route through `tokmd-core` (Tier 4) facade APIs (e.g., `analysis_facade`) rather than direct Tier-5 → Tier-3 usage when a facade is available.
+
+## Consequences
+
+### Positive
+
+- Clear dependency direction and reduced architectural drift.
+- Better API stability for external bindings by centralizing boundaries in `tokmd-core`.
+- Easier future refactors inside analysis crates without cascading CLI/binding changes.
+
+### Negative
+
+- Minor indirection overhead in implementation.
+- Requires maintaining facade passthroughs and tests.
+
+## Rollout
+
+- Keep CLI helper modules and bindings aligned with `tokmd-core` facade calls.
+- Review PRs for tier-boundary violations as part of architecture checks.

--- a/docs/adr/ADR-002-deterministic-output-contract.md
+++ b/docs/adr/ADR-002-deterministic-output-contract.md
@@ -1,0 +1,37 @@
+# ADR-002: Deterministic output as a first-class contract
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd outputs are consumed by CI gates, snapshot tests, and machine pipelines where nondeterministic key ordering or unstable sorting causes noisy diffs and brittle automation.
+
+## Decision
+
+Deterministic output is a non-negotiable implementation contract across all receipt families and formatters.
+
+Required implementation patterns:
+
+1. Prefer deterministic map types in receipt-facing data structures.
+2. Normalize paths before grouping, sorting, and emission.
+3. Apply stable sort tie-breakers (`code desc`, then `name asc`).
+4. Preserve deterministic ordering through formatting layers.
+
+## Consequences
+
+### Positive
+
+- Reproducible artifacts and stable snapshots.
+- Lower CI noise and clearer semantic diffs.
+- Predictable downstream parsing for AI/data tooling.
+
+### Negative
+
+- Slightly stricter coding constraints for contributors.
+- Additional review burden to catch accidental nondeterminism.
+
+## Rollout
+
+- Keep deterministic ordering assertions in tests.
+- Require explicit rationale in PRs that touch ordering or key-container choices.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains accepted architecture and implementation decisions for tokmd.
+
+## Index
+
+- [ADR-001: Enforce analysis facade boundary at Tier 4](./ADR-001-analysis-facade-boundary.md)
+- [ADR-002: Deterministic output as a first-class contract](./ADR-002-deterministic-output-contract.md)
+
+## Conventions
+
+- ADR filenames follow `ADR-XXX-short-title.md`.
+- ADR numbers are append-only.
+- Superseding decisions should reference prior ADRs and explicitly state migration impact.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,174 @@
+# tokmd Implementation Specification
+
+## Status
+
+Draft v1 (April 29, 2026).
+
+## Purpose
+
+This specification translates product requirements into implementation-level contracts for maintainers and contributors. It is intended to be read alongside:
+
+- `docs/requirements.md` (what must be true)
+- `docs/design.md` (why the system is shaped this way)
+- `docs/architecture.md` (where behavior lives)
+- `docs/SCHEMA.md` + `docs/schema.json` (what is serialized)
+
+## Scope
+
+This document defines implementation contracts for:
+
+1. Scan and aggregation workflows (`lang`, `module`, `export`, `run`, `diff`)
+2. Analysis orchestration and presets (`analyze` and enrichers)
+3. Deterministic output behavior and ordering guarantees
+4. Schema versioning and compatibility rules
+5. Runtime-facing interfaces (CLI, FFI, Python, Node)
+
+It does **not** redefine every CLI option; see `docs/reference-cli.md` for flag details.
+
+---
+
+## 1. System Invariants
+
+### 1.1 Determinism Invariant
+
+For a fixed repository state, configuration, and feature set, tokmd outputs must be stable across repeated executions on the same platform and equivalent across platforms after path normalization.
+
+Implementation obligations:
+
+- Use deterministic key/value containers in output paths (prefer `BTreeMap` over `HashMap` in receipt-facing structures).
+- Apply explicit sort ordering to row collections:
+  - primary: descending `code`
+  - secondary: ascending normalized `name`
+- Normalize paths to forward-slash form before formatting and serialization.
+
+### 1.2 Envelope Invariant
+
+JSON receipt families must include envelope metadata with schema identifiers and version constants from the relevant `*-types` crate.
+
+Implementation obligations:
+
+- Do not introduce JSON shape changes without incrementing the corresponding schema constant.
+- Keep schema docs synchronized with code changes (`docs/SCHEMA.md`, `docs/schema.json`, and any family-specific schema docs).
+
+### 1.3 Tier Boundary Invariant
+
+Tier-5 crates (`tokmd`, bindings) must consume analysis orchestration via Tier-4 facades instead of importing Tier-3 formatting/orchestration crates directly where a facade exists.
+
+Implementation obligations:
+
+- Keep analysis formatting calls routed through `tokmd-core::analysis_facade`.
+- Maintain architecture constraints documented in ADR-001.
+
+---
+
+## 2. Workflow Contracts
+
+### 2.1 Scan Contract
+
+Input: scan settings + include/exclude controls.  
+Output: normalized inventory of language/file/module-level counters.
+
+Required behavior:
+
+- Respect ignore rules and explicit include/exclude patterns.
+- Support children handling modes:
+  - `Collapse`: embedded/child language stats roll into parent totals.
+  - `Separate`: embedded contributions appear as explicit `(embedded)` rows.
+
+### 2.2 Modeling Contract
+
+Input: scan inventory.  
+Output: grouped rows (language/module/file) with totals and percentages.
+
+Required behavior:
+
+- Percentage math must be derived from canonical total code lines.
+- Grouping keys must operate on normalized paths.
+- Sorting and tie-breaking must be deterministic (see 1.1).
+
+### 2.3 Formatting Contract
+
+Input: typed receipts from model/analysis layers.  
+Output: Markdown/TSV/JSON/JSONL/CSV rendering.
+
+Required behavior:
+
+- No formatter is allowed to mutate semantic payload values.
+- Human-readable outputs must preserve deterministic order from receipts.
+- Machine-readable outputs must preserve envelope metadata and schema versions.
+
+### 2.4 Analysis Contract
+
+Input: baseline receipts plus enabled enrichers/preset.  
+Output: analysis receipt with derived metrics and optional enrichments.
+
+Required behavior:
+
+- Presets are additive bundles; each preset must map to a documented feature set.
+- Missing optional enrichers (e.g., feature-gated or environment-limited sources) must degrade gracefully with explicit omission rather than invalid placeholder metrics.
+- Analysis schema evolution is independent from core receipt schema evolution.
+
+### 2.5 Diff Contract
+
+Input: two receipts/runs or git references.  
+Output: directional delta summaries.
+
+Required behavior:
+
+- Use two-dot range semantics (`A..B`) for release/tag comparison behavior where range syntax is used.
+- Preserve per-row stability and deterministic ordering in delta output.
+
+---
+
+## 3. Interface Contracts
+
+### 3.1 CLI Contract
+
+- CLI commands are thin orchestration surfaces over typed workflows.
+- User-facing behavior must remain backward compatible unless a documented breaking release is planned.
+- Help and reference docs must be updated with option changes.
+
+### 3.2 FFI Contract (`tokmd-core`)
+
+- `ffi::run_json(mode, args_json)` is the stable polyglot boundary.
+- Responses must be envelope-shaped (`ok`, `data`/`error`).
+- Error payloads must be serializable and structured (not ad-hoc plaintext only).
+
+### 3.3 Python/Node Bindings Contract
+
+- Bindings expose the same semantic modes as Rust workflows/FFI.
+- Long-running operations must avoid blocking host runtime critical paths (GIL release / blocking task offload).
+- Binding-level API changes must be documented in release notes and migration guidance.
+
+---
+
+## 4. Quality Gates
+
+Minimum pre-merge validation for implementation changes should include:
+
+1. Formatting check (`cargo fmt-check`)
+2. Lint check (`cargo clippy -- -D warnings` or repo gate equivalent)
+3. Relevant tests (`cargo test --verbose` or targeted crate/test scope)
+4. Schema sync checks when JSON shape changes are introduced
+
+For output-affecting changes, update golden snapshots where applicable.
+
+---
+
+## 5. Change Control
+
+A change requires an ADR when it modifies one or more of the following:
+
+- Tier boundaries or crate dependency direction
+- Determinism/ordering rules
+- Serialization envelope semantics or schema version policy
+- Runtime interface contracts (CLI compatibility policy, FFI envelope model)
+
+Recommended ADR template fields:
+
+- Context
+- Decision
+- Consequences (positive/negative)
+- Rollout / migration notes
+
+See `docs/adr/` for accepted ADRs.


### PR DESCRIPTION
### Motivation

- Codify implementation-level contracts to reduce ambiguity between product requirements and code-level obligations.
- Record architecture decisions that affect crate boundaries and output determinism to guide reviewers and maintainers. 
- Provide a single reference for invariants (determinism, envelope/schema rules), workflow contracts, and change-control triggers for ADRs.

### Description

- Add `docs/specification.md` that defines implementation contracts for scan/model/format/analysis/diff workflows and interface semantics. 
- Add `docs/adr/README.md` as an index and conventions file for Architecture Decision Records. 
- Add `docs/adr/ADR-001-analysis-facade-boundary.md` to require Tier-5 product surfaces to use the `tokmd-core` Tier-4 analysis facade. 
- Add `docs/adr/ADR-002-deterministic-output-contract.md` to require deterministic output practices (map type choices, path normalization, and stable sort rules).

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c648b288333af0c144562c75e4c)