### PR TITLE
docs: add implementation specification and initial ADRs

### DIFF
--- a/docs/adr/0001-layered-receipt-pipeline.md
+++ b/docs/adr/0001-layered-receipt-pipeline.md
@@ -1,0 +1,37 @@
+# ADR 0001: Adopt layered receipt pipeline architecture
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd supports many user-facing surfaces (CLI, Python, Node, library) and many output modes. A direct, monolithic command implementation would tightly couple scanning, aggregation, formatting, and analysis concerns, making deterministic evolution difficult.
+
+## Decision
+
+Adopt and preserve a layered pipeline:
+
+`types -> scan -> model -> format -> analysis -> core facade -> clients`
+
+Where:
+- lower tiers define stable data primitives and deterministic transformations,
+- higher tiers orchestrate presentation and integration concerns.
+
+## Consequences
+
+### Positive
+- Better testability via smaller crate responsibilities.
+- Cleaner feature gating at boundaries (`git`, `content`, `walk`).
+- Lower risk of accidental output nondeterminism.
+- Easier cross-language bindings through `tokmd-core` facade.
+
+### Trade-offs
+- More crates and interfaces to maintain.
+- Requires stronger contract docs and version discipline.
+
+## Alternatives Considered
+
+1. Monolithic binary crate with internal modules.
+   - Rejected due to coupling and harder API reuse.
+2. Plugin-first runtime graph with dynamic loading.
+   - Rejected for complexity and reproducibility risk.

--- a/docs/adr/0002-per-family-schema-versioning.md
+++ b/docs/adr/0002-per-family-schema-versioning.md
@@ -1,0 +1,39 @@
+# ADR 0002: Use per-family schema versioning for receipts
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd emits multiple receipt families (core, analysis, cockpit, context, handoff, bundles). A single global schema version would force unrelated consumers to react to changes outside their contract area.
+
+## Decision
+
+Version receipt schemas by family rather than with a single global number.
+
+Active families and versions:
+- Core receipts: `SCHEMA_VERSION = 2`
+- Analysis receipts: `ANALYSIS_SCHEMA_VERSION = 9`
+- Cockpit receipts: `COCKPIT_SCHEMA_VERSION = 3`
+- Handoff manifests: `HANDOFF_SCHEMA_VERSION = 5`
+- Context receipts: `CONTEXT_SCHEMA_VERSION = 4`
+- Context bundles: `CONTEXT_BUNDLE_SCHEMA_VERSION = 2`
+- Sensor reports: semantic id `sensor.report.v1`
+
+## Consequences
+
+### Positive
+- Isolates blast radius of breaking changes.
+- Reduces unnecessary downstream migrations.
+- Supports independently evolving capability surfaces.
+
+### Trade-offs
+- Requires more explicit documentation and validation.
+- Version management becomes multi-track.
+
+## Alternatives Considered
+
+1. Global schema version across all outputs.
+   - Rejected due to excessive coupling.
+2. Unversioned JSON contracts with best-effort compatibility.
+   - Rejected due to ambiguity and CI break risk.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records (ADRs)
+
+This directory stores architecture and implementation decisions that affect tokmd behavior over time.
+
+## ADR Status Values
+
+- **Proposed**: Draft decision, not yet accepted.
+- **Accepted**: Approved and guiding implementation.
+- **Superseded**: Replaced by a newer ADR.
+
+## ADR Index
+
+- [0001 - Adopt layered receipt pipeline architecture](0001-layered-receipt-pipeline.md) — Accepted
+- [0002 - Use per-family schema versioning for receipts](0002-per-family-schema-versioning.md) — Accepted

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -52,7 +52,7 @@ tokmd produces deterministic code inventory receipts and PR-focused context for:
 
 Output MUST be stable and schemaed when `--format json/jsonl/csv`:
 - **Core receipts** (lang, module, export, diff, context, run): Schema v2
-- **Analysis receipts**: Schema v5
+- **Analysis receipts**: Schema v9
 - **Cockpit receipts**: Schema v3
 
 ### Library API (tokmd-core)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,109 @@
+# tokmd Implementation Specification
+
+## Purpose
+
+This specification defines the concrete implementation contracts for tokmd command surfaces, receipt outputs, determinism, and extension points. It complements `docs/requirements.md` (what) and `docs/design.md` (why/how) by pinning the operational behaviors expected from current implementations.
+
+## Scope
+
+This spec applies to:
+- CLI command behavior and exit semantics
+- Library facade (`tokmd-core`) contracts
+- Receipt envelope invariants and schema family versioning
+- Deterministic output requirements
+- Feature-gated enrichers and graceful degradation behavior
+
+It does **not** define orchestration policy for external systems.
+
+## Implementation Contracts
+
+### 1) Command Surface Contract
+
+Implemented command families:
+- Inventory: `lang`, `module`, `export`, `run`
+- Analysis: `analyze`, `baseline`, `cockpit`, `gate`, `diff`
+- LLM workflows: `context`, `handoff`, `tools`
+- Utilities: `sensor`, `badge`, `init`, `check-ignore`, `completions`
+
+Contract rules:
+1. Commands MUST provide stable help semantics and parse errors via clap.
+2. Commands producing machine outputs MUST support deterministic `json`/`jsonl`/`csv` modes where applicable.
+3. Commands SHOULD preserve backwards-compatible flag semantics within a minor release line.
+
+### 2) Receipt Envelope Contract
+
+For JSON family outputs, the implementation MUST emit versioned envelopes with:
+- tool identity (`tool`, `tool_version`)
+- generation metadata (`generated_at_ms`, command mode)
+- payload sections (`scan`, mode-specific sections)
+- integrity metadata when enabled
+
+Schema families and active versions:
+- Core receipts (`lang`, `module`, `export`, `diff`, `run`): `SCHEMA_VERSION = 2`
+- Analysis receipts: `ANALYSIS_SCHEMA_VERSION = 9`
+- Cockpit receipts: `COCKPIT_SCHEMA_VERSION = 3`
+- Handoff manifests: `HANDOFF_SCHEMA_VERSION = 5`
+- Context receipts: `CONTEXT_SCHEMA_VERSION = 4`
+- Context bundles: `CONTEXT_BUNDLE_SCHEMA_VERSION = 2`
+- Sensor reports: semantic schema id `sensor.report.v1`
+
+Any breaking structural change MUST increment the relevant schema family version.
+
+### 3) Determinism Contract
+
+Implementations MUST preserve byte-stable output for identical inputs and settings by enforcing:
+- Ordered maps/sets (`BTreeMap`, `BTreeSet`) at serialization boundaries
+- Stable sorting (`code desc`, `name asc` tie-break)
+- Path normalization to `/` separators
+- Stable truncation markers for budget-capped sections
+- Deterministic redaction hashing (BLAKE3)
+
+### 4) Execution and Exit Contract
+
+Exit behavior:
+- `0`: success
+- `1`: runtime/tooling failure
+- `2`: policy/gate failure
+
+Degradation behavior:
+- Missing optional evidence MUST produce explicit skipped/unknown semantics instead of silent pass.
+- Partial receipts MAY be emitted when failures occur after useful data has been derived.
+
+### 5) Feature-Gated Enricher Contract
+
+Feature flags define optional enrichers:
+- `git`: repository history and hotspot-derived signals
+- `content`: entropy/import/tag/hash signals
+- `walk`: asset and filesystem traversal signals
+
+Contract rules:
+1. Disabled features MUST not cause runtime panics.
+2. Presets MUST degrade predictably when an optional feature is not compiled.
+3. Output should explicitly indicate unavailable sections where relevant.
+
+### 6) API and Binding Contract
+
+`tokmd-core` provides clap-free workflow entrypoints and JSON FFI:
+- Workflow functions return typed receipts.
+- `ffi::run_json(mode, args_json)` returns a JSON envelope with `ok`, `data`, and `error` branches.
+
+Bindings contract:
+- Python bindings MUST return native Python dictionaries.
+- Node bindings MUST expose async APIs and avoid event loop blocking.
+
+## Validation Matrix
+
+Minimum validation before release:
+1. Workspace formatting and lint checks.
+2. CLI integration tests for command contracts.
+3. Snapshot tests for output stability.
+4. Property tests for deterministic invariants.
+5. Schema compatibility checks for modified receipt families.
+
+## Change Management
+
+When implementation behavior changes:
+1. Update this specification if contract-level semantics changed.
+2. Update corresponding ADRs under `docs/adr/` for architectural decisions.
+3. Update `docs/schema.json` and schema version constants for breaking envelope changes.
+4. Add migration notes in changelog/user-facing docs as needed.


### PR DESCRIPTION
### Motivation
- Provide a concrete implementation-level specification that pins operational contracts for commands, receipts, determinism, exit semantics, feature-gated enrichers, and API bindings to reduce ambiguity between design and code.
- Establish an ADR baseline to record and preserve architectural decisions about pipeline layering and schema versioning.
- Align existing requirements text with the active schema-family constants to avoid documentation drift.

### Description
- Add `docs/specification.md` defining implementation contracts for CLI surfaces, receipt envelopes, determinism guarantees, exit/degradation semantics, feature-gated enrichers, API/bindings, validation matrix, and change management.
- Add ADR scaffolding `docs/adr/README.md` and two accepted ADRs: `0001-layered-receipt-pipeline.md` (layered pipeline decision) and `0002-per-family-schema-versioning.md` (per-family schema versions).
- Update `docs/requirements.md` to align the Analysis receipt schema reference to `v9` to match current family constants.
- This is a documentation-only change and does not alter runtime code or behavior.

### Testing
- Verified new files and their contents were readable using `nl -ba docs/specification.md` and `nl -ba docs/adr/*` and confirmed expected sections printed successfully.
- Applied the local fix to `docs/requirements.md` using an in-repo `python` edit and validated the updated line appears as expected with `sed`/`nl` inspection.
- Performed workspace file discovery with `rg` and confirmed the ADR and spec files are present; no runtime or unit tests were required since this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c648b288333af0c144562c75e4c)