### PR TITLE
docs: add implementation specifications and ADRs

### DIFF
--- a/docs/adrs/ADR-001-analysis-facade-boundary.md
+++ b/docs/adrs/ADR-001-analysis-facade-boundary.md
@@ -1,0 +1,21 @@
+# ADR-001: Analysis Facade Boundary in `tokmd-core`
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+Tier-5 products (CLI and language bindings) need analysis functionality from Tier-3 crates. Direct dependency fan-out from Tier 5 to Tier 3 increases coupling and weakens architecture boundaries.
+
+## Decision
+Expose analysis orchestration to Tier-5 consumers via Tier-4 `tokmd-core` facade modules (for example, `analysis_facade`) rather than direct Tier-5 calls into Tier-3 implementation crates.
+
+## Consequences
+
+### Positive
+- Preserves declared tiering discipline.
+- Reduces API surface area exposed to bindings.
+- Enables compatibility controls at a single façade boundary.
+
+### Tradeoffs
+- Adds façade maintenance overhead.
+- Requires explicit pass-through when analysis capabilities expand.

--- a/docs/adrs/ADR-002-deterministic-receipt-ordering.md
+++ b/docs/adrs/ADR-002-deterministic-receipt-ordering.md
@@ -1,0 +1,25 @@
+# ADR-002: Deterministic Receipt Ordering and Keying
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+The project relies on snapshot tests, reproducible outputs, and stable machine-consumed artifacts. Non-deterministic maps/orderings make diffs noisy and degrade trust in outputs.
+
+## Decision
+Adopt deterministic ordering/keying across receipt generation:
+
+- Use stable map semantics (`BTreeMap` class behavior) for keyed structures.
+- Normalize output paths to forward slashes before key generation.
+- Sort rows by descending code lines, then by stable name key.
+
+## Consequences
+
+### Positive
+- Stable receipts across machines and runs.
+- Cleaner code review diffs and predictable snapshots.
+- Improved downstream cacheability and comparability.
+
+### Tradeoffs
+- Slightly higher complexity versus ad-hoc ordering.
+- Potential micro-performance cost versus hash-based containers.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,6 @@
+# Architecture Decision Records
+
+- [ADR-001: Analysis Facade Boundary in `tokmd-core`](ADR-001-analysis-facade-boundary.md)
+- [ADR-002: Deterministic Receipt Ordering and Keying](ADR-002-deterministic-receipt-ordering.md)
+
+ADRs capture durable implementation decisions and their rationale.

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -1,0 +1,12 @@
+# Implementation Specifications
+
+This folder holds implementation-level specifications that complement high-level design docs.
+
+## Specs
+
+- `receipt-pipeline-spec.md` — End-to-end scan → model → format pipeline contracts.
+- `ffi-contract-spec.md` — `tokmd-core` JSON FFI interface and error envelope semantics.
+
+## Relationship to ADRs
+
+Use specs to define *how* components work. Use ADRs (`docs/adrs/`) to capture *why* major implementation choices were made.

--- a/docs/specifications/ffi-contract-spec.md
+++ b/docs/specifications/ffi-contract-spec.md
@@ -1,0 +1,52 @@
+# FFI Contract Specification (`tokmd-core`)
+
+## Status
+Accepted
+
+## Entry Point
+`ffi::run_json(mode, args_json) -> String`
+
+- `mode` identifies workflow: `lang`, `module`, `export`, `analyze`, `diff`, `version`.
+- `args_json` MUST be valid JSON object payload for the selected mode.
+
+## Response Envelope
+All responses are serialized JSON objects:
+
+```json
+{
+  "ok": true,
+  "data": {"...": "mode-specific payload"},
+  "error": null
+}
+```
+
+or on failure:
+
+```json
+{
+  "ok": false,
+  "data": null,
+  "error": {
+    "code": "invalid_args",
+    "message": "human-readable summary"
+  }
+}
+```
+
+## Behavioral Requirements
+
+- The top-level envelope shape is stable across modes.
+- On success, `ok=true` and `error` MUST be `null`.
+- On failure, `ok=false` and `data` MUST be `null`.
+- Error messages SHOULD be human-readable; `code` SHOULD be machine-stable.
+- Versioned payloads MUST include the matching schema version family where applicable.
+
+## Compatibility Requirements
+
+- Additive fields in `data` are allowed in minor releases when existing fields are preserved.
+- Renaming/removing fields in existing payloads requires a schema version bump and migration note in `CHANGELOG.md`.
+
+## Binding Notes
+
+- Python bindings return native dictionaries derived from this envelope.
+- Node bindings return Promise-resolved objects derived from this envelope.

--- a/docs/specifications/receipt-pipeline-spec.md
+++ b/docs/specifications/receipt-pipeline-spec.md
@@ -1,0 +1,48 @@
+# Receipt Pipeline Specification
+
+## Status
+Accepted
+
+## Scope
+Defines invariants and interfaces for the core inventory receipt path used by:
+
+- `tokmd lang`
+- `tokmd module`
+- `tokmd export`
+- `tokmd run`
+
+## Pipeline Stages
+
+1. **Scan** (`tokmd-scan`)
+   - Input: repository root, include/exclude filters, child-language mode.
+   - Output: normalized file/language counts.
+2. **Model** (`tokmd-model`)
+   - Input: scan aggregates.
+   - Output: language/module/file rows with deterministic ordering.
+3. **Format** (`tokmd-format`)
+   - Input: model receipts.
+   - Output: Markdown/TSV/JSON/JSONL/CSV representations.
+4. **Delivery** (`tokmd`, `tokmd-core`)
+   - Output adapters: CLI stdout/files, FFI JSON envelopes, language bindings.
+
+## Required Invariants
+
+- Paths MUST be normalized to forward slashes (`/`) prior to any keying or output.
+- Ordered output MUST be deterministic:
+  - sort descending by `code` lines,
+  - then ascending by stable name key.
+- Embedded language behavior MUST honor `ChildrenMode` consistently:
+  - `Collapse`: merge into parent totals,
+  - `Separate`: emit explicit embedded rows.
+- Core receipt JSON outputs MUST include envelope metadata with `schema_version = 2`.
+
+## Error Semantics
+
+- Scan-stage file permission/decoding failures SHOULD be represented as structured warnings when recoverable.
+- Irrecoverable configuration or I/O failures MUST produce a non-zero command exit (CLI) or `ok=false` envelope (FFI).
+
+## Test Expectations
+
+- Golden snapshot coverage for representative repos and child-language fixtures.
+- Property tests for ordering and aggregation invariants.
+- Cross-output parity tests ensuring JSON/Markdown/TSV totals align for the same run.


### PR DESCRIPTION
### Motivation
- Provide concrete, implementation-level specifications to complement existing high-level design docs and capture how core subsystems must behave.
- Record durable architecture decisions (ADRs) that justify and stabilize cross-crate boundaries and ordering invariants.

### Description
- Add `docs/specifications/` with an index and two specs: `receipt-pipeline-spec.md` describing scan→model→format→delivery contracts and invariants, and `ffi-contract-spec.md` documenting the `tokmd-core` `ffi::run_json` envelope and compatibility rules.
- Add `docs/adrs/` with an ADR index and two ADRs: `ADR-001` (analysis facade boundary via `tokmd-core`) and `ADR-002` (deterministic receipt ordering and keying).
- The specs define required invariants such as path normalization to `/`, deterministic ordering (sort by descending `code` then name), `ChildrenMode` semantics, and that core receipts include `schema_version = 2`.
- All changes are documentation-only and do not modify runtime code or library APIs.

### Testing
- Ran repository formatting check via `cargo fmt-check`, which completed successfully.
- No code or unit tests were required because this PR only adds documentation files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c648b288333af0c144562c75e4c)