### PR TITLE
docs: add BDD implementation specification and ADR, link into testing guide

### DIFF
--- a/docs/adrs/ADR-0001-bdd-specification-and-traceability.md
+++ b/docs/adrs/ADR-0001-bdd-specification-and-traceability.md
@@ -1,0 +1,40 @@
+# ADR-0001: Establish BDD Specification and ADR Traceability
+
+- Status: Accepted
+- Date: 2026-04-29
+- Deciders: tokmd maintainers
+- Technical Story: Align executable behavior tests with explicit documentation and decision records.
+
+## Context
+
+The workspace already contains broad BDD-style scenario coverage, but behavior contracts were
+implicitly encoded in tests and spread across crates. This made it harder to:
+
+- on-board contributors to expected BDD patterns,
+- reason about cross-crate behavioral invariants,
+- and review behavioral regressions against explicit design intent.
+
+## Decision
+
+We will:
+
+1. Introduce a canonical BDD implementation specification in `docs/specifications/`.
+2. Link that specification from testing documentation so contributors can discover it quickly.
+3. Track this choice via an ADR and require future BDD policy shifts to update ADR history.
+
+## Consequences
+
+### Positive
+
+- Shared language for Given/When/Then expectations.
+- Better discoverability of behavioral contracts and deterministic testing expectations.
+- Stronger review posture for schema, path normalization, and ordering behavior.
+
+### Negative
+
+- Ongoing maintenance burden to keep specification and ADRs synced with evolving test surface.
+
+## Follow-up
+
+- Add additional ADRs when BDD policy meaningfully changes (e.g., snapshot policy or naming rules).
+- Keep `docs/testing.md` links current when new spec documents are introduced.

--- a/docs/specifications/bdd-implementation-spec.md
+++ b/docs/specifications/bdd-implementation-spec.md
@@ -1,0 +1,76 @@
+# BDD Implementation Specification
+
+## Purpose
+
+This specification defines how tokmd uses Behavior-Driven Development (BDD) tests to express
+cross-crate behavior contracts in executable form.
+
+## Scope
+
+This spec applies to BDD-style tests named `bdd*.rs` across workspace crates, including:
+
+- `tokmd-types`
+- `tokmd-scan`
+- `tokmd-model`
+- `tokmd-format`
+- `tokmd-analysis*`
+- `tokmd-gate`
+- `tokmd-git`
+- `tokmd-sensor`
+- `tokmd` (CLI scenarios)
+
+## BDD Contract
+
+Every BDD test should be written in **Given / When / Then** shape (comments or test naming) and
+validate externally visible behavior rather than private implementation details.
+
+### Required Structure
+
+1. **Given**: fixture/setup state that is deterministic and explicit.
+2. **When**: one action under test.
+3. **Then**: assertions on stable outputs, invariants, or policy decisions.
+
+### Naming Convention
+
+- BDD scenario files: `bdd.rs`, `bdd_*.rs`, or `*_bdd.rs`
+- Test names should encode scenario intent, e.g.:
+  - `given_valid_receipt_when_roundtrip_then_schema_version_preserved`
+
+## Determinism Requirements
+
+BDD tests MUST avoid non-deterministic sources unless normalized:
+
+- Wall clock timestamps
+- Randomized map ordering
+- Host-dependent path separators
+- Environment-specific absolute paths
+
+Where needed, normalize output using existing project helpers and snapshot normalization patterns.
+
+## Assertion Strategy
+
+Prefer assertions in this order:
+
+1. Semantic equality of typed structures
+2. Stable field-level assertions for critical contract fields
+3. Snapshot assertions only when shape/readability is the target behavior
+
+## Cross-Crate Consistency Rules
+
+- Shared receipt families must preserve schema constants and field semantics.
+- Path fields must be normalized to forward slashes.
+- Sort ordering must remain deterministic (code desc, then name asc where applicable).
+
+## Validation Workflow
+
+Recommended commands:
+
+```bash
+cargo test --verbose
+cargo test bdd --verbose
+cargo test -p tokmd --test bdd_lang_scenarios_w50 --verbose
+```
+
+## Traceability
+
+Architecture decisions that shape this specification are tracked in ADRs under `docs/adrs/`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,6 +39,19 @@ This document describes the testing infrastructure and strategy for tokmd.
 | `cargo-mutants` | Mutation testing | `.cargo/mutants.toml` |
 | `tempfile` | Isolated test fixtures | Various |
 
+
+## BDD Specifications and ADRs
+
+Behavior-driven contracts are documented in:
+
+- [`docs/specifications/bdd-implementation-spec.md`](./specifications/bdd-implementation-spec.md)
+
+Architecture Decision Records for BDD policy and traceability live in:
+
+- [`docs/adrs/ADR-0001-bdd-specification-and-traceability.md`](./adrs/ADR-0001-bdd-specification-and-traceability.md)
+
+Use these documents as the documentation baseline when adding or refactoring any `bdd*.rs` tests.
+
 ## Unit Tests
 
 In-module tests for domain logic:


### PR DESCRIPTION
### Motivation

- Formalize how BDD-style `bdd*.rs` scenarios express cross-crate behavior contracts and record the decision so contributors can discover and follow a canonical policy (`Given/When/Then`, determinism, naming, and assertion guidance).

### Description

- Add `docs/specifications/bdd-implementation-spec.md` and `docs/adrs/ADR-0001-bdd-specification-and-traceability.md`, and link both from `docs/testing.md` via an inserted "BDD Specifications and ADRs" section.

### Testing

- No automated tests were required or run for this docs-only change; the update is limited to documentation files (`docs/specifications/*`, `docs/adrs/*`, and `docs/testing.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c6b16e88333a3c8bc968d21fc95)