### PR TITLE
docs: add implementation specifications and ADRs with BDD trace links

### DIFF
--- a/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "analysis")]
+//! Spec/ADR links: see `docs/specifications.md` and `docs/adrs/ADR-001-specification-traceability.md`.
 
 //! BDD-style scenario tests for the `analyze` command.
 //!

--- a/crates/tokmd/tests/bdd_diff_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_diff_scenarios_w50.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "analysis")]
+//! Spec/ADR links: see `docs/specifications.md` and `docs/adrs/ADR-001-specification-traceability.md`.
 
 //! BDD-style scenario tests for the `diff` command.
 //!

--- a/crates/tokmd/tests/bdd_export_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_export_scenarios_w50.rs
@@ -1,3 +1,4 @@
+//! Spec/ADR links: see `docs/specifications.md` and `docs/adrs/ADR-001-specification-traceability.md`.
 //! BDD-style scenario tests for the `export` command.
 //!
 //! Each test follows the Given/When/Then pattern to verify key user-facing

--- a/crates/tokmd/tests/bdd_lang_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_lang_scenarios_w50.rs
@@ -1,3 +1,4 @@
+//! Spec/ADR links: see `docs/specifications.md` and `docs/adrs/ADR-001-specification-traceability.md`.
 //! BDD-style scenario tests for the `lang` command.
 //!
 //! Each test follows the Given/When/Then pattern to verify key user-facing

--- a/crates/tokmd/tests/bdd_module_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_module_scenarios_w50.rs
@@ -1,3 +1,4 @@
+//! Spec/ADR links: see `docs/specifications.md` and `docs/adrs/ADR-001-specification-traceability.md`.
 //! BDD-style scenario tests for the `module` command.
 //!
 //! Each test follows the Given/When/Then pattern to verify key user-facing

--- a/crates/tokmd/tests/bdd_scenarios_w71.rs
+++ b/crates/tokmd/tests/bdd_scenarios_w71.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "analysis")]
+//! Spec/ADR links: see `docs/specifications.md` and `docs/adrs/ADR-001-specification-traceability.md`.
 
 //! BDD-style scenario tests describing real user workflows.
 //!

--- a/crates/tokmd/tests/bdd_scenarios_w75.rs
+++ b/crates/tokmd/tests/bdd_scenarios_w75.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "analysis")]
+//! Spec/ADR links: see `docs/specifications.md` and `docs/adrs/ADR-001-specification-traceability.md`.
 
 //! BDD-style scenario tests documenting user-facing behaviour.
 //!

--- a/docs/adrs/ADR-001-specification-traceability.md
+++ b/docs/adrs/ADR-001-specification-traceability.md
@@ -1,0 +1,28 @@
+# ADR-001: Specification and BDD Traceability
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+
+The project has broad BDD coverage across microcrates, but behavioral contracts were spread across test names and informal documentation. This made it harder to assess impact when evolving CLI behavior or output formats.
+
+## Decision
+
+Introduce a repository-level implementation specification document (`docs/specifications.md`) with stable `SPEC-*` identifiers and explicit links to BDD test modules.
+
+## Consequences
+
+### Positive
+- Clear forward traceability from specification to executable tests.
+- Easier review and release audit for behavior changes.
+- Better onboarding for contributors making cross-crate changes.
+
+### Trade-offs
+- Requires routine maintenance when adding or relocating BDD suites.
+- Adds one more doc artifact that can become stale without discipline.
+
+## Alternatives Considered
+
+1. Keep behavior solely in tests (rejected: discoverability is poor).
+2. Add inline spec comments only (rejected: fragmented and crate-local).

--- a/docs/adrs/ADR-002-deterministic-behavior-contracts.md
+++ b/docs/adrs/ADR-002-deterministic-behavior-contracts.md
@@ -1,0 +1,34 @@
+# ADR-002: Deterministic Behavior Contracts for Receipts
+
+- Status: Accepted
+- Date: 2026-04-29
+
+## Context
+
+`tokmd` is used in CI and AI pipelines where outputs are consumed programmatically and diffed over time. Nondeterministic ordering or platform-sensitive paths create noisy changes and unreliable gating.
+
+## Decision
+
+Formalize deterministic behavior as a specification-level contract:
+
+- Stable output ordering (descending by code, then lexical tie-breakers).
+- Normalized forward-slash paths in emitted artifacts.
+- Schema-versioned envelopes for machine-readable receipts.
+
+These constraints are represented in `docs/specifications.md` and validated by BDD and snapshot suites.
+
+## Consequences
+
+### Positive
+- Reproducible artifacts across OS and CI environments.
+- Lower false-positive churn in diffs and gates.
+- More reliable downstream automation.
+
+### Trade-offs
+- Some implementation choices prioritize determinism over minimal compute.
+- Schema changes require coordinated version and docs updates.
+
+## Alternatives Considered
+
+1. Best-effort deterministic behavior (rejected: too fragile for gates).
+2. Platform-specific output semantics (rejected: harms portability).

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -1,0 +1,44 @@
+# Implementation Specifications
+
+This document defines implementation-level specifications for the core `tokmd` workflows.
+
+## Purpose
+
+- Establish testable, behavior-oriented contracts for CLI and receipt outputs.
+- Provide traceability between product behavior, BDD scenarios, and architecture decisions.
+- Reduce ambiguity for future feature work and refactors.
+
+## Spec Index
+
+| Spec ID | Area | Source of Truth | BDD Coverage |
+|---|---|---|---|
+| `SPEC-LANG-001` | `tokmd lang` summary behavior | `tokmd` CLI + `tokmd-model` sorting | `crates/tokmd/tests/bdd_lang_scenarios_w50.rs`, `crates/tokmd/tests/bdd_scenarios_w75.rs` |
+| `SPEC-MODULE-001` | `tokmd module` aggregation behavior | module depth + normalized module keys | `crates/tokmd/tests/bdd_module_scenarios_w50.rs`, `crates/tokmd/tests/bdd_scenarios_w75.rs` |
+| `SPEC-EXPORT-001` | `tokmd export` line-oriented inventory contracts | JSONL/CSV export rows + metadata | `crates/tokmd/tests/bdd_export_scenarios_w50.rs`, `crates/tokmd/tests/bdd_scenarios_w75.rs` |
+| `SPEC-ANALYZE-001` | `tokmd analyze` enrichment contract | preset-driven analysis pipeline | `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs` |
+| `SPEC-DIFF-001` | `tokmd diff` change-analysis contract | receipt diff semantics | `crates/tokmd/tests/bdd_diff_scenarios_w50.rs` |
+
+## Behavioral Requirements
+
+### `SPEC-LANG-001`
+- Given a repository with supported source files, when `tokmd lang --format json` runs, then rows MUST include each detected language.
+- Language rows MUST be sorted by descending `code` and then by language name for deterministic output.
+
+### `SPEC-MODULE-001`
+- Given nested paths, when `tokmd module --module-depth N` runs, then module keys MUST reflect normalized path separators.
+- Module output MUST remain stable across platforms via path normalization.
+
+### `SPEC-EXPORT-001`
+- Given one or more files, when `tokmd export --format jsonl` runs, then output MUST include valid JSON lines.
+- Data rows MUST include file identity (`path`) and sizing fields (`code`, language).
+
+### `SPEC-ANALYZE-001`
+- Given an input receipt or direct scan target, when `tokmd analyze` runs with a preset, then output MUST include deterministic, schema-versioned analysis artifacts.
+
+### `SPEC-DIFF-001`
+- Given baseline and target receipts/refs, when `tokmd diff` runs, then deltas MUST reflect net additions/removals and preserve deterministic ordering in rendered output.
+
+## Traceability Conventions
+
+- BDD tests should keep `Given/When/Then` names and map to one or more `SPEC-*` IDs in module docs.
+- ADRs under `docs/adrs/` capture rationale for long-lived implementation choices used by these specs.


### PR DESCRIPTION
### Motivation

- Provide a single, discoverable repository-level spec mapping behavioral contracts to executable BDD tests to improve traceability. 
- Make deterministic output expectations explicit so downstream CI, gates, and AI pipelines have a stable contract.
- Surface ADRs to document rationale for the spec/traceability and deterministic behavior decisions.

### Description

- Add `docs/specifications.md` containing `SPEC-*` identifiers and behavioral requirements for `lang`, `module`, `export`, `analyze`, and `diff` workflows. 
- Add two ADRs at `docs/adrs/ADR-001-specification-traceability.md` and `docs/adrs/ADR-002-deterministic-behavior-contracts.md` documenting the decision and rationale. 
- Insert module-level doc comments into BDD scenario files under `crates/tokmd/tests/` to link tests to the new spec/ADR documents, with no runtime code changes.

### Testing

- Ran `cargo fmt-check` (which exercises the repo lint wrapper), and the formatting/lint-check step completed successfully. 
- The change is documentation-only and the existing test suites remain unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c6b16e88333a3c8bc968d21fc95)