### PR TITLE
docs: add implementation specification, ADRs, and BDD

### DIFF
--- a/docs/adr/ADR-0001-deterministic-ordering.md
+++ b/docs/adr/ADR-0001-deterministic-ordering.md
@@ -1,0 +1,34 @@
+# ADR-0001: Deterministic Receipt Ordering and Stable Serialization
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+
+## Context
+
+tokmd outputs are consumed by CI, diff pipelines, and LLM workflows that depend on repeatable artifacts. Non-deterministic map iteration or unstable ordering causes noisy diffs and weakens gate confidence.
+
+## Decision
+
+We standardize deterministic output semantics:
+- deterministic key ordering structures in aggregation paths;
+- canonical sort order (code desc, name asc);
+- normalized path representation (`/` separators);
+- stable rendering conventions across JSON/JSONL/CSV/TSV.
+
+## Consequences
+
+### Positive
+- Byte-stable receipts for equivalent inputs.
+- Lower diff noise and improved trust in change detection.
+- Stronger snapshot/property test value.
+
+### Tradeoffs
+- Some data structures may incur minor performance overhead versus hash-based alternatives.
+- Contributors must preserve ordering guarantees when adding new fields/aggregations.
+
+## Compliance
+
+Changes that alter ordering or serialization behavior must:
+1. document the intended behavior in specification docs;
+2. update/validate golden snapshots and deterministic tests;
+3. call out compatibility impact when schema evolution is needed.

--- a/docs/adr/ADR-0002-cli-core-bindings-parity.md
+++ b/docs/adr/ADR-0002-cli-core-bindings-parity.md
@@ -1,0 +1,33 @@
+# ADR-0002: Unified Contract Between CLI, Core, and Language Bindings
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+
+## Context
+
+tokmd behavior is surfaced via multiple interfaces (CLI, Rust core facade, FFI, Python, Node). Divergence across these layers creates inconsistent automation behavior and difficult debugging.
+
+## Decision
+
+We enforce contract parity:
+- CLI modes map to equivalent core workflow semantics;
+- FFI responses maintain a consistent envelope (`ok`, `data`, `error`);
+- language bindings remain thin adapters that preserve core behavior.
+
+## Consequences
+
+### Positive
+- Predictable semantics independent of entrypoint.
+- Simpler test strategy through shared contract assertions.
+- Lower support burden for multi-runtime users.
+
+### Tradeoffs
+- Interface-specific features require explicit justification and documentation.
+- Some adapter-level ergonomics may be constrained by envelope compatibility.
+
+## Compliance
+
+When adding/changing behavior:
+1. define expected parity in specs and BDD scenarios;
+2. verify at least CLI + one non-CLI interface where practical;
+3. document any intentional mismatch with rationale and migration guidance.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records (ADR)
+
+This directory captures decision records for significant implementation choices.
+
+## ADR Index
+- [ADR-0001: Deterministic Receipt Ordering and Stable Serialization](./ADR-0001-deterministic-ordering.md)
+- [ADR-0002: Unified Contract Between CLI, Core, and Language Bindings](./ADR-0002-cli-core-bindings-parity.md)
+
+## Status Legend
+- **Accepted**: Current decision in force.
+- **Superseded**: Replaced by a newer ADR.
+- **Proposed**: Draft for review.

--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -1,0 +1,64 @@
+# Behavior-Driven Development (BDD)
+
+This document tracks behavior-level scenarios for tokmd capabilities and links each scenario set to implementation specifications and ADR rationale.
+
+## Linked Design Inputs
+
+- Specification: [`docs/specifications/implementation-spec.md`](./specifications/implementation-spec.md)
+- ADR Index: [`docs/adr/README.md`](./adr/README.md)
+- ADR-0001: Deterministic ordering and serialization
+- ADR-0002: CLI/Core/bindings parity
+
+## Feature: Deterministic Receipts
+
+**Given** a repository and fixed scan settings  
+**When** I run `tokmd lang --format json` repeatedly  
+**Then** the serialized output is byte-identical for equivalent inputs.
+
+**Given** a repository with embedded languages  
+**When** I run with children mode `collapse`  
+**Then** embedded counts are merged into parent totals consistently.
+
+**Given** a repository with embedded languages  
+**When** I run with children mode `separate`  
+**Then** embedded rows are emitted consistently and clearly labeled.
+
+_References_: Implementation Spec §1-§3, ADR-0001.
+
+## Feature: Cross-Interface Contract Parity
+
+**Given** equivalent arguments  
+**When** I execute a workflow from CLI and `tokmd-core`  
+**Then** both results represent the same domain semantics.
+
+**Given** a valid `run_json` invocation  
+**When** a mode completes  
+**Then** response envelope fields include `ok`, `data`, and `error` consistently.
+
+**Given** Python/Node bindings for a workflow  
+**When** the same logical options are supplied  
+**Then** results remain semantically equivalent to the core workflow.
+
+_References_: Implementation Spec §4, ADR-0002.
+
+## Feature: Policy Gate Behavior
+
+**Given** policy inputs and evidence receipts  
+**When** all required checks pass  
+**Then** exit code is `0` and verdict is pass.
+
+**Given** a policy violation  
+**When** `tokmd gate` evaluates rules  
+**Then** exit code is `2` with machine-readable failure reasons.
+
+**Given** missing optional evidence  
+**When** a policy is evaluated  
+**Then** the result is explicit skip/unknown rather than silent success.
+
+_References_: Implementation Spec §5.
+
+## Maintenance Rules
+
+- Add/adjust BDD scenarios whenever behavior changes.
+- Link behavior changes to relevant ADRs (new or existing).
+- Treat this file as the top-level behavior index and keep it current with implementation contracts.

--- a/docs/specifications/implementation-spec.md
+++ b/docs/specifications/implementation-spec.md
@@ -1,0 +1,40 @@
+# Implementation Specification
+
+## Scope
+
+This specification defines implementation contracts for tokmd's core workflows and outputs, with emphasis on deterministic receipts, schema governance, and CLI/API parity.
+
+## Contract Areas
+
+### 1) Scan and Inventory
+- The scan layer MUST normalize all paths to `/` separators before model aggregation.
+- Embedded language accounting MUST follow a single selectable policy (`collapse` or `separate`) for each run.
+- File inclusion MUST honor `.gitignore` and `.tokeignore` unless explicitly overridden.
+
+### 2) Modeling and Ordering
+- Aggregations MUST use deterministic map/set structures.
+- Sort precedence MUST be: descending code lines, then ascending stable name key.
+- Null/empty result sets MUST still serialize valid envelopes with schema metadata.
+
+### 3) Output Receipts
+- JSON-family outputs MUST include schema version metadata and generation context.
+- CSV/TSV headers MUST remain stable and additive-only inside a schema major.
+- Redacted outputs MUST preserve deterministic hashing behavior for the same inputs.
+
+### 4) CLI, Core, and Bindings Parity
+- CLI command modes and `tokmd-core` workflow entry points MUST represent equivalent behaviors.
+- FFI `run_json` modes MUST preserve response envelope shape (`ok`, `data`, `error`).
+- Python and Node bindings MUST not mutate domain semantics relative to core workflows.
+
+### 5) Policy and Gates
+- `gate` evaluation MUST support explicit failure reasons and machine-readable JSON pointers.
+- Missing optional evidence MUST produce "skipped/unknown" semantics, not silent pass.
+- Exit code semantics MUST match requirements: `0` success, `1` runtime/tool error, `2` policy failure.
+
+## Acceptance Criteria
+
+A change is implementation-complete when:
+1. Behavior is represented by BDD scenarios in `docs/bdd.md`.
+2. Schema-impacting changes include schema/version notes.
+3. Determinism is validated by snapshots/property tests where applicable.
+4. Any architectural tradeoff is captured by a linked ADR in `docs/adr/`.


### PR DESCRIPTION
### Motivation
- Capture and formalize implementation contracts for deterministic receipts, schema governance, CLI/core/bindings parity, and policy/gate semantics so contributors and automation have a clear reference. 
- Anchor those contracts to behavior-driven scenarios to ensure changes are represented by tests and linked ADR rationale.

### Description
- Add `docs/specifications/implementation-spec.md` which defines concrete contracts for scan/model/output/parity/gate behavior and acceptance criteria. 
- Add `docs/adr/` containing `README.md`, `ADR-0001-deterministic-ordering.md`, and `ADR-0002-cli-core-bindings-parity.md` to record accepted architecture decisions. 
- Add `docs/bdd.md` that links the specification and ADRs and provides BDD scenarios for deterministic receipts, cross-interface parity, and policy gate behavior. 

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c6b16e88333a3c8bc968d21fc95)