### PR TITLE
docs: add implementation specifications and ADR set

### DIFF
--- a/docs/adrs/0001-facade-tier-boundary.md
+++ b/docs/adrs/0001-facade-tier-boundary.md
@@ -1,0 +1,26 @@
+# ADR-0001: Tier-boundary facade for analysis workflows
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd uses a strict crate tiering model to keep dependencies directional and maintainable.
+Tier 5 products (CLI/bindings) need access to tier 3 analysis orchestration, but direct coupling risks tier violations and larger API surfaces.
+
+## Decision
+
+Tier 5 products access tier 3 analysis behavior through tier 4 facade APIs (for example, `tokmd-core::analysis_facade`) rather than direct imports of orchestration internals.
+
+## Consequences
+
+### Positive
+
+- Preserves dependency layering and crate boundary clarity.
+- Provides a clap-free embedding surface for Rust, Python, and Node adapters.
+- Reduces churn exposure for downstream adapters.
+
+### Tradeoffs
+
+- Facade maintenance overhead when adding new capabilities.
+- Potential lag between internal features and facade exposure if not prioritized.

--- a/docs/adrs/0002-deterministic-receipts.md
+++ b/docs/adrs/0002-deterministic-receipts.md
@@ -1,0 +1,29 @@
+# ADR-0002: Deterministic receipt output as a product invariant
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd outputs are consumed by snapshot tests, automation pipelines, and LLM workflows that depend on stable ordering.
+Non-deterministic map iteration or unstable sorting causes noisy diffs and brittle automation.
+
+## Decision
+
+Deterministic receipt output is a hard invariant:
+
+- Use deterministic key structures (e.g., `BTreeMap`) for emitted aggregation maps.
+- Sort human-readable rows by descending code lines and stable lexical tie-breakers.
+- Treat unstable ordering regressions as correctness bugs.
+
+## Consequences
+
+### Positive
+
+- Stable snapshots and reproducible receipts.
+- Cleaner PR diffs and fewer false-positive pipeline changes.
+- Better downstream cacheability and deterministic LLM context generation.
+
+### Tradeoffs
+
+- Slight additional implementation discipline around data structures and sorting paths.

--- a/docs/adrs/0003-path-normalization-contract.md
+++ b/docs/adrs/0003-path-normalization-contract.md
@@ -1,0 +1,26 @@
+# ADR-0003: Cross-platform path normalization contract
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd runs across operating systems with different path separators.
+Without a normalization contract, outputs can diverge by platform and break tests/consumers.
+
+## Decision
+
+All emitted paths use forward slashes (`/`) regardless of host OS.
+Normalization occurs before formatting/output and before computing module keys.
+
+## Consequences
+
+### Positive
+
+- Cross-platform stable output for tests and integrations.
+- Simplified consumer logic and reduced platform branching.
+
+### Tradeoffs
+
+- Requires strict discipline to normalize at boundaries.
+- Internals must carefully distinguish filesystem-native paths vs output paths.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records (ADRs)
+
+This directory stores architecture decisions that explain *why* tokmd is implemented the way it is.
+
+## ADR Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-0001](./0001-facade-tier-boundary.md) | Tier-boundary facade for analysis workflows | Accepted |
+| [ADR-0002](./0002-deterministic-receipts.md) | Deterministic receipt output as a product invariant | Accepted |
+| [ADR-0003](./0003-path-normalization-contract.md) | Cross-platform path normalization contract | Accepted |
+
+## ADR Lifecycle
+
+- **Proposed**: under review, not yet committed as policy.
+- **Accepted**: active decision; implementation and docs should align.
+- **Superseded**: replaced by a newer ADR; keep for historical context.
+- **Deprecated**: no longer recommended but retained for migration context.

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -1,0 +1,26 @@
+# tokmd Specifications
+
+This directory captures implementation-facing specifications for tokmd's major surfaces.
+Specifications in this folder are intended to be:
+
+- **Normative** where behavior must remain stable for compatibility.
+- **Testable** through existing integration/golden/property tests.
+- **Version-aware** so schema and CLI changes are explicit.
+
+## Specification Index
+
+| Spec | Status | Scope |
+|------|--------|-------|
+| [Core Receipt Contract](./core-receipt-contract.md) | Active | `lang`, `module`, `export`, `diff`, `run` envelope + deterministic ordering |
+
+## Writing Rules
+
+1. Use RFC-2119 style keywords (**MUST**, **SHOULD**, **MAY**) for normative requirements.
+2. Keep examples concise and stable; avoid timestamps unless required.
+3. Every normative section SHOULD map to at least one existing test suite or a test TODO.
+4. Any schema-shape change MUST include:
+   - schema version update in code,
+   - `docs/schema.json` update,
+   - `docs/SCHEMA.md` update,
+   - changelog note.
+5. If a specification introduces a tradeoff or long-lived policy, add/update an ADR in `docs/adrs/`.

--- a/docs/specifications/core-receipt-contract.md
+++ b/docs/specifications/core-receipt-contract.md
@@ -1,0 +1,50 @@
+# Core Receipt Contract Specification
+
+- **Status:** Active
+- **Last updated:** 2026-04-29
+- **Applies to:** core receipts (`lang`, `module`, `export`, `diff`, `run`)
+- **Primary crates:** `tokmd-types`, `tokmd-format`, `tokmd-core`, `tokmd`
+
+## 1. Envelope Requirements
+
+1. Core JSON receipts **MUST** include an envelope containing `schema_version`.
+2. Core receipt schema version **MUST** match `SCHEMA_VERSION = 2` until a breaking shape change is introduced.
+3. Producers **MUST NOT** omit envelope metadata when JSON output mode is selected.
+
+## 2. Deterministic Ordering
+
+1. Aggregation maps exposed in receipts **MUST** be deterministically ordered.
+2. Stable key ordering **MUST** use `BTreeMap`-equivalent behavior, not hash-randomized maps.
+3. Human-readable ordered rows **MUST** sort by:
+   1. descending `code` lines,
+   2. ascending name/path tie-break.
+
+## 3. Path Semantics
+
+1. Paths emitted in machine-readable or human-readable receipts **MUST** be normalized to forward slashes (`/`).
+2. Module keys **MUST** be derived from normalized paths.
+3. Platform-specific separators **MUST NOT** leak into emitted receipt payloads.
+
+## 4. Embedded Language Handling
+
+1. `ChildrenMode::Collapse` **MUST** merge embedded-language counts into parent language totals.
+2. `ChildrenMode::Separate` **MUST** emit separate embedded rows labeled as embedded.
+3. The selected children mode **MUST** be applied consistently for all receipt families where supported.
+
+## 5. Compatibility and Change Management
+
+1. Any JSON shape change in core receipts **MUST** increment the core schema version and update documentation artifacts.
+2. Backward-incompatible CLI output behavior changes **SHOULD** be called out in release notes.
+3. New fields **SHOULD** be additive where possible to preserve consumer compatibility.
+
+## 6. Verification Matrix
+
+- Integration tests in `crates/tokmd/tests/` validate CLI-level receipt behavior.
+- Golden snapshots verify stable ordering and formatting.
+- Crate-level tests in `tokmd-types` and `tokmd-format` validate shape and rendering invariants.
+
+## 7. Non-goals
+
+- Defining analysis receipt semantics (covered by analysis-specific contracts).
+- Defining cockpit gate policy semantics.
+- Defining transport-level API guarantees outside `tokmd-core`/CLI artifacts.


### PR DESCRIPTION
### Motivation

- Capture and publish implementation-facing contracts and decision rationale so invariants (schema, ordering, path semantics, children-mode) are explicit and discoverable.
- Reduce future churn and test brittleness by making normative requirements and ADRs available to implementers and reviewers.

### Description

- Add `docs/specifications/` with a normative specifications index and authoring rules in `docs/specifications/README.md`.
- Add the `Core Receipt Contract` spec in `docs/specifications/core-receipt-contract.md` documenting envelope/schema expectations, deterministic ordering, path normalization, embedded-language semantics, and compatibility/change management rules.
- Add `docs/adrs/` with an ADR index and three accepted ADRs: `0001-facade-tier-boundary.md`, `0002-deterministic-receipts.md`, and `0003-path-normalization-contract.md` capturing tier facades, deterministic output, and cross-platform path normalization decisions.

### Testing

- No automated tests were executed for this change because it is documentation-only, and no code or schema constants were modified.
- The repository's CI will run standard checks (formatting, linters, and test suites) on merge to validate the docs change does not regress tooling or schema alignment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c6265a0833382c23366a21d5a50)