### PR TITLE
docs: add implementation specification and ADRs

### DIFF
--- a/docs/adr/ADR-001-facade-boundary-for-tier5-products.md
+++ b/docs/adr/ADR-001-facade-boundary-for-tier5-products.md
@@ -1,0 +1,40 @@
+# ADR-001: Tier-5 products must use `tokmd-core` facade for orchestration
+
+- Status: Accepted
+- Date: 2026-04-29
+- Deciders: tokmd maintainers
+
+## Context
+
+`tokmd` ships multiple Tier-5 products (CLI, Python, Node, WASM) while orchestration logic lives in Tier-3 crates (`tokmd-analysis`, `tokmd-cockpit`, `tokmd-gate`). Direct product-to-orchestration wiring creates unstable coupling, duplicated argument translation, and boundary drift.
+
+The architecture already declares a facade tier (`tokmd-core`) and references this decision from dependency rules.
+
+## Decision
+
+Tier-5 products MUST access orchestration behavior via Tier-4 facade APIs in `tokmd-core` (including dedicated facade modules such as `analysis_facade`) instead of importing Tier-3 crates directly.
+
+## Consequences
+
+### Positive
+
+- Single clap-free embedding contract for products and bindings.
+- Reduced dependency churn in CLI/Python/Node/WASM surfaces.
+- Clear ownership of translation between settings, workflows, and FFI envelopes.
+- Easier policy enforcement for tier boundaries.
+
+### Trade-offs
+
+- Additional facade maintenance when Tier-3 capabilities expand.
+- Some duplicate type reshaping may exist at facade edges by design.
+
+## Implementation notes
+
+- Add new orchestration entrypoints in `tokmd-core` first.
+- Keep product-side wiring thin and focused on UX concerns.
+- Validate no upward dependency leaks during review.
+
+## Related
+
+- `docs/architecture.md` (tier model and dependency rules)
+- `docs/specification.md` (implementation contract)

--- a/docs/adr/ADR-002-receipt-first-and-deterministic-output.md
+++ b/docs/adr/ADR-002-receipt-first-and-deterministic-output.md
@@ -1,0 +1,54 @@
+# ADR-002: Receipt-first contract with deterministic output invariants
+
+- Status: Accepted
+- Date: 2026-04-29
+- Deciders: tokmd maintainers
+
+## Context
+
+tokmd outputs are consumed by automation pipelines, code-review tooling, snapshot tests, and AI workflows. Non-deterministic ordering or unstable schemas creates noisy diffs and breaks downstream consumers.
+
+## Decision
+
+tokmd adopts a receipt-first contract:
+
+1. Receipts are the primary machine contract.
+2. Every receipt family owns an independent schema-version line.
+3. Output determinism is a non-negotiable invariant.
+
+## Determinism invariants
+
+Implementations MUST ensure:
+
+- ordered containers (`BTreeMap`/`BTreeSet`) at output boundaries
+- stable row sorting (descending code lines, ascending name tie-break)
+- forward-slash path normalization
+- reproducible snapshot behavior (normalized timestamps in tests)
+
+## Schema governance
+
+When structure changes for any receipt family:
+
+- increment the matching family schema version
+- update formal schema and documentation
+- refresh snapshots/tests that encode the contract
+
+## Consequences
+
+### Positive
+
+- Predictable diffs for receipts and PR commentary.
+- Safer library/FFI evolution for polyglot callers.
+- Stronger confidence for policy gates and historical comparisons.
+
+### Trade-offs
+
+- Slightly slower adoption speed for output changes due to schema governance.
+- More review overhead for seemingly small serialization modifications.
+
+## Related
+
+- `docs/SCHEMA.md`
+- `docs/schema.json`
+- `docs/specification.md`
+- `docs/architecture.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records (ADRs)
+
+This directory captures durable architectural decisions for tokmd.
+
+## Index
+
+- [ADR-001: Tier-5 products must use `tokmd-core` facade for orchestration](ADR-001-facade-boundary-for-tier5-products.md)
+- [ADR-002: Receipt-first contract with deterministic output invariants](ADR-002-receipt-first-and-deterministic-output.md)
+
+## Writing guidance
+
+Create a new ADR when a decision changes any of:
+
+- crate-tier boundaries or dependency direction
+- receipt schema governance or compatibility policy
+- determinism guarantees and output invariants
+- embedding/FFI contract semantics

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ CLI/config/progress/tool-schema/explain wiring in `tokmd`.
 
 | Crate | Purpose |
 |-------|---------|
-| `tokmd-core` | Library facade with FFI layer; exposes analysis formatting via `analysis_facade` module (see ADR-001) |
+| `tokmd-core` | Library facade with FFI layer; exposes analysis formatting via `analysis_facade` module (see [ADR-001](adr/ADR-001-facade-boundary-for-tier5-products.md)) |
 
 ### Tier 5: Products
 
@@ -100,7 +100,7 @@ CLI/config/progress/tool-schema/explain wiring in `tokmd`.
 
 1. **Contracts MUST NOT depend on clap** — Keep `tokmd-types` and `tokmd-analysis-types` pure
 2. **Lower tiers MUST NOT depend on higher tiers** — No upward dependencies
-3. **Tier boundary compliance via facade** — Tier 5 products access Tier 3 orchestration only through Tier 4 facades (e.g., `tokmd-core::analysis_facade`). See ADR-001.
+3. **Tier boundary compliance via facade** — Tier 5 products access Tier 3 orchestration only through Tier 4 facades (e.g., `tokmd-core::analysis_facade`). See [ADR-001](adr/ADR-001-facade-boundary-for-tier5-products.md).
 4. **Feature flags control optional adapters** — `git`, `walk`, `content` features
 5. **IO adapters depend on domain/contracts, never reverse**
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,144 @@
+# tokmd Specification
+
+## Purpose
+
+This specification defines the implementation contract for `tokmd` as both a CLI and an embeddable analysis engine. It is intended to be implementation-facing (what the system **must** do) and pairs with architecture and schema docs.
+
+## Scope
+
+This document covers:
+
+- repository scan and inventory behavior
+- receipt families and schema compatibility
+- determinism and reproducibility requirements
+- command behavior and artifact guarantees
+- embedding contracts (Rust, FFI, Python, Node)
+
+This document does not replace user-focused tutorials or CLI flag reference.
+
+## Normative language
+
+The keywords **MUST**, **SHOULD**, and **MAY** are normative.
+
+## 1) System model
+
+`tokmd` is a single-scan, multi-view system:
+
+1. Collect source inventory from repository paths.
+2. Aggregate into normalized receipt models.
+3. Render outputs in human and machine formats.
+4. Optionally enrich with analysis presets and adapters.
+
+Implementations MUST preserve the tiered crate boundaries documented in `docs/architecture.md`.
+
+## 2) Receipt-first contract
+
+### 2.1 Receipt families
+
+Implementations MUST maintain separate schema-version lines for independent receipt families:
+
+- Core receipts (`lang`, `module`, `export`, `diff`, `run`)
+- Analysis receipts
+- Cockpit receipts
+- Handoff manifests
+- Context receipts
+- Context bundle receipts
+
+### 2.2 Schema change policy
+
+When the JSON structure of a receipt family changes:
+
+1. The corresponding schema version constant MUST be incremented.
+2. `docs/schema.json` and/or family-specific schema docs MUST be updated.
+3. Golden snapshots and integration tests MUST be refreshed.
+
+## 3) Determinism requirements
+
+For identical input trees and settings, implementations MUST produce byte-stable machine outputs.
+
+Determinism depends on:
+
+- ordered map/set usage (`BTree*`) at output boundaries
+- stable sorting (descending by code lines, ascending by name tie-break)
+- normalized slash-separated paths
+- normalized test timestamps where snapshots are used
+
+Any new feature that emits rows or keys MUST explicitly define stable ordering.
+
+## 4) Scan and aggregation behavior
+
+### 4.1 Scan pass
+
+A single inventory scan SHOULD be reused across downstream views where possible.
+
+### 4.2 Embedded language policy
+
+Implementations MUST support both children modes:
+
+- Collapse: embedded children roll into parent totals
+- Separate: embedded children appear as explicit rows
+
+The selected mode MUST be applied consistently across all relevant commands.
+
+### 4.3 Path behavior
+
+All outward-facing paths MUST be normalized to `/` regardless of host OS.
+
+## 5) Command-level guarantees
+
+### 5.1 Inventory commands
+
+- `tokmd lang` MUST produce language totals and totals metadata.
+- `tokmd module` MUST group by normalized module key.
+- `tokmd export` MUST emit file-level inventory in requested format.
+
+### 5.2 Orchestration commands
+
+- `tokmd run` MUST support artifact output for repeatable workflows.
+- `tokmd analyze` MUST support preset-driven enrichment and explicit feature gating.
+- `tokmd diff` MUST compare receipts/runs with explicit range inputs.
+- `tokmd cockpit` and `tokmd gate` MUST return policy-relevant evidence in machine-readable form.
+
+## 6) Embedding and FFI
+
+### 6.1 Rust facade
+
+`tokmd-core` workflow functions MUST remain clap-free and settings-driven.
+
+### 6.2 JSON FFI envelope
+
+`ffi::run_json(mode, args_json)` MUST return an envelope with:
+
+- `ok: bool`
+- `data` on success
+- `error` on failure
+
+Binding layers (Python/Node/WASM) SHOULD map this envelope without lossy transformations.
+
+## 7) Optional adapters and feature flags
+
+Adapters that require external context (Git history, file content inspection, filesystem walk variants) MUST remain behind explicit feature flags and degrade gracefully when disabled.
+
+## 8) Error and exit semantics
+
+CLI implementations MUST preserve distinct outcome classes:
+
+- success with full receipt
+- runtime/tooling error
+- policy gate failure
+- skip/missing optional input where applicable
+
+Exit-code semantics MUST remain stable across minor releases unless explicitly versioned and documented.
+
+## 9) Verification requirements
+
+Before merging behavior changes, contributors SHOULD run:
+
+- formatting checks
+- unit/integration tests
+- snapshot verification for changed receipts
+- strict linting when practical (`clippy -D warnings`)
+
+## 10) Traceability to ADRs
+
+Major architectural decisions that alter boundaries, contracts, or determinism MUST be captured under `docs/adr/` and referenced from architecture/specification docs.


### PR DESCRIPTION
### Motivation

- Provide a formal, implementation-facing specification that declares normative behavior for scanning, receipts, determinism, command guarantees, and embedding contracts.
- Capture durable architectural decisions about tier boundaries and output determinism so future changes are traceable and reviewed (facade boundary and receipt-first policy).
- Improve documentation traceability between architecture guidance and decision records to reduce boundary drift and schema churn.

### Description

- Add `docs/specification.md` with a normative implementation contract covering receipts, determinism, scan behavior, commands, FFI, and verification requirements.
- Add `docs/adr/README.md` as an index and guidance for creating ADRs.
- Add `docs/adr/ADR-001-facade-boundary-for-tier5-products.md` formalizing that Tier-5 products must use the `tokmd-core` facade for orchestration.
- Add `docs/adr/ADR-002-receipt-first-and-deterministic-output.md` defining the receipt-first contract and determinism/schema governance rules, and update `docs/architecture.md` to link to ADR-001 for traceability.

### Testing

- Documentation-only change; no automated tests were required or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c6265a0833382c23366a21d5a50)