### PR TITLE
docs: add specification baseline and core ADRs

### DIFF
--- a/docs/adr/0001-tiered-architecture.md
+++ b/docs/adr/0001-tiered-architecture.md
@@ -1,0 +1,33 @@
+# ADR-0001: Tiered microcrate architecture and dependency direction
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd spans scanning, modeling, formatting, analysis orchestration, and multiple product surfaces (CLI + bindings). Unconstrained dependencies create coupling and make evolution/runtimes harder to manage.
+
+## Decision
+
+Adopt and preserve a strict tiered architecture:
+
+`types -> scan -> model -> format -> analysis -> cli/products`
+
+Rules:
+
+1. Lower tiers never depend on higher tiers.
+2. Cross-cutting helpers live in owner modules at the lowest valid tier.
+3. Public contracts originate in type/settings crates and are consumed upward.
+
+## Consequences
+
+### Positive
+
+- Clear dependency direction and simpler review criteria.
+- Better compile-time isolation and cache reuse.
+- Safer embedding story via `tokmd-core` facade.
+
+### Trade-offs
+
+- More crate boundaries and explicit API shaping work.
+- Refactors may require moving utilities down-tier before reuse.

--- a/docs/adr/0002-deterministic-output.md
+++ b/docs/adr/0002-deterministic-output.md
@@ -1,0 +1,31 @@
+# ADR-0002: Deterministic output as a product invariant
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd is used in CI, policy gates, and LLM pipelines where non-deterministic ordering causes noisy diffs, flaky snapshots, and unreliable automation.
+
+## Decision
+
+Make deterministic output a hard invariant for all receipt and renderer surfaces.
+
+Implementation constraints:
+
+1. Stable key ordering in emitted structures.
+2. Stable sort order for ranked outputs (descending code lines, then name).
+3. Path normalization before output and key derivation.
+
+## Consequences
+
+### Positive
+
+- Reproducible outputs and reliable golden tests.
+- Cleaner PR diffs and downstream policy comparisons.
+- Predictable behavior for external integrators.
+
+### Trade-offs
+
+- Slightly higher implementation discipline for any new aggregation path.
+- Some data structures optimized for speed cannot be used directly in output paths.

--- a/docs/adr/0003-schema-family-versioning.md
+++ b/docs/adr/0003-schema-family-versioning.md
@@ -1,0 +1,25 @@
+# ADR-0003: Independent receipt schema family versioning
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd emits multiple receipt families (core, analysis, cockpit, handoff, context). A single global schema version would force unrelated consumers to react to irrelevant changes.
+
+## Decision
+
+Use independent schema version constants per receipt family, and require family-local version bumps when breaking structure changes occur.
+
+## Consequences
+
+### Positive
+
+- Reduces unnecessary migrations for consumers of unaffected families.
+- Enables faster evolution in active areas (e.g., analysis) without destabilizing core flows.
+- Improves compatibility signaling in multi-surface ecosystems.
+
+### Trade-offs
+
+- Slightly more governance overhead to track several version constants.
+- Documentation must stay synchronized across multiple schema references.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records (ADRs)
+
+This directory stores major architecture and product-contract decisions.
+
+## Status legend
+
+- **Accepted**: approved and currently active.
+- **Superseded**: replaced by a newer ADR.
+- **Proposed**: drafted but not yet accepted.
+
+## ADR index
+
+- [ADR-0001: Tiered microcrate architecture and dependency direction](./0001-tiered-architecture.md) — Accepted
+- [ADR-0002: Deterministic output as a product invariant](./0002-deterministic-output.md) — Accepted
+- [ADR-0003: Independent receipt schema family versioning](./0003-schema-family-versioning.md) — Accepted

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,127 @@
+# tokmd Specification
+
+## Purpose
+
+This document defines the normative behavior of tokmd across its CLI, library facade, and receipt outputs. It is intended to be stable enough for implementers, integrators, and binding maintainers.
+
+Normative keywords **MUST**, **SHOULD**, and **MAY** follow RFC 2119 semantics.
+
+## 1. Product Scope
+
+`tokmd` is a deterministic repository inventory and analysis system with:
+
+- CLI workflows (`tokmd`, `tokmd lang`, `module`, `export`, `run`, `analyze`, `diff`, `cockpit`, `gate`, etc.)
+- Library workflows (`tokmd-core`) for embedding.
+- FFI/SDK bindings (Python and Node) with receipt-compatible output.
+
+The system MUST produce machine-readable receipts and human-readable summaries from the same canonical scan/model pipeline.
+
+## 2. Layering and Dependency Rules
+
+The crate architecture is tiered:
+
+`types -> scan -> model -> format -> analysis -> cli`
+
+Requirements:
+
+1. Lower tiers MUST NOT depend on higher tiers.
+2. Tier-0 contracts MUST remain serialization-stable unless the relevant schema version is incremented.
+3. Tier-4 (`tokmd-core`) MUST provide clap-free embedding APIs.
+4. Tier-5 product crates MAY add UX-specific behavior but MUST preserve receipt semantics.
+
+## 3. Determinism
+
+tokmd outputs are deterministic by contract.
+
+Requirements:
+
+1. Keyed collections in receipt emission paths MUST preserve stable order (e.g., `BTreeMap`-style ordering).
+2. Ranked rows MUST sort by descending code lines, then by name for tie-breaking.
+3. Equal input corpus + equal options + equal version MUST yield byte-stable JSON/JSONL/CSV/Markdown outputs (excluding explicitly timestamped metadata fields where applicable).
+
+## 4. Path Semantics
+
+Requirements:
+
+1. Output paths MUST be normalized to forward slashes (`/`) on all operating systems.
+2. Module key computation MUST use normalized paths.
+3. Ignore/exclude decisions SHOULD report normalized paths in diagnostics.
+
+## 5. Embedded-Language Semantics
+
+tokmd supports two children modes:
+
+- `Collapse`: embedded languages are merged into the parent language totals.
+- `Separate`: embedded rows are emitted explicitly as embedded language entries.
+
+Requirements:
+
+1. Children-mode behavior MUST be consistent across `lang`, `module`, `export`, and `run` flows.
+2. Mode selection SHOULD be reflected in human-readable renderers to avoid ambiguity.
+
+## 6. Receipt Contracts and Schema Versioning
+
+Receipt families version independently.
+
+Current schema constants:
+
+- Core receipts: `SCHEMA_VERSION = 2`
+- Analysis receipts: `ANALYSIS_SCHEMA_VERSION = 9`
+- Cockpit receipts: `COCKPIT_SCHEMA_VERSION = 3`
+- Handoff manifests: `HANDOFF_SCHEMA_VERSION = 5`
+- Context receipts: `CONTEXT_SCHEMA_VERSION = 4`
+- Context bundles: `CONTEXT_BUNDLE_SCHEMA_VERSION = 2`
+
+Requirements:
+
+1. Any breaking JSON structure change MUST increment the matching family schema version.
+2. Schema changes MUST update formal schema documentation (`docs/schema.json` and family-specific schema docs/files).
+3. Receipts MUST include envelope metadata sufficient for consumers to detect schema family and version.
+
+## 7. Git Range Semantics
+
+Requirements:
+
+1. `A..B` MUST be used for release/tag comparison style flows (e.g., cockpit/diff release deltas).
+2. `A...B` SHOULD be reserved for CI branch-divergence workflows.
+3. Commands MUST document the active interpretation when accepting user-provided ranges.
+
+## 8. Library and Binding Contracts
+
+### 8.1 `tokmd-core`
+
+- Must expose clap-free workflow functions for lang/module/export/diff semantics.
+- Must provide JSON FFI entrypoint behavior compatible with receipt envelopes.
+
+### 8.2 Python Binding
+
+- Must return Python-native structures.
+- Should release GIL during long-running scans.
+
+### 8.3 Node Binding
+
+- Must expose async APIs (Promises).
+- Should move blocking work off event loop threads.
+
+## 9. Quality Gates
+
+Minimum validation before merge SHOULD include:
+
+1. Formatting check.
+2. Workspace tests relevant to touched receipt surfaces.
+3. Snapshot updates/reviews where deterministic outputs changed.
+4. Clippy/lint checks for touched crates.
+
+## 10. Backward Compatibility Guidance
+
+1. New optional fields SHOULD be additive and default-safe.
+2. Existing fields SHOULD NOT change type/meaning without schema bump.
+3. Deprecated fields MAY remain for one minor release cycle with explicit migration notes.
+
+## 11. References
+
+- `docs/architecture.md`
+- `docs/design.md`
+- `docs/requirements.md`
+- `docs/SCHEMA.md`
+- `docs/schema.json`


### PR DESCRIPTION
### Motivation

- Establish a normative implementation specification that documents tokmd product contracts for CLI, library, and bindings including determinism, path semantics, embedded-language modes, schema versioning, and git range semantics. 
- Create durable Architecture Decision Records to capture and communicate key, accepted decisions about layering, determinism, and independent schema-family versioning.

### Description

- Add `docs/specification.md` with the canonical, RFC-2119-style normative requirements covering scope, layering, determinism, path normalization, children-mode behavior, receipt schema/version rules, git-range semantics, binding contracts, and compatibility guidance. 
- Add ADR infrastructure `docs/adr/README.md` plus three accepted ADRs: `docs/adr/0001-tiered-architecture.md`, `docs/adr/0002-deterministic-output.md`, and `docs/adr/0003-schema-family-versioning.md`. 
- These are documentation-only additions and do not modify any code, schemas, or runtime behavior.

### Testing

- No automated tests were executed for this documentation-only change; standard CI/test suites will run as part of the normal pipeline when this PR is processed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c6265a0833382c23366a21d5a50)