### PR TITLE
fuzz: broaden run_json mode dispatch coverage

### DIFF
--- a/fuzz/fuzz_targets/fuzz_run_json.rs
+++ b/fuzz/fuzz_targets/fuzz_run_json.rs
@@ -12,6 +12,25 @@ use tokmd_core::ffi::run_json;
 /// Cap input size to keep iterations fast.
 const MAX_INPUT_SIZE: usize = 64 * 1024; // 64 KB
 
+/// High-value mode names to exercise successful dispatch paths.
+const KNOWN_MODES: &[&str] = &["lang", "module", "export", "analyze", "diff", "version"];
+
+fn assert_envelope_shape(mode: &str, args_json: &str) {
+    // Call the FFI entrypoint — must never panic.
+    let result = run_json(mode, args_json);
+
+    // Invariant: result is always valid JSON.
+    let envelope: Value =
+        serde_json::from_str(&result).expect("run_json must always return valid JSON");
+
+    // Invariant: envelope always contains an "ok" boolean field.
+    assert!(
+        envelope.get("ok").and_then(Value::as_bool).is_some(),
+        "envelope must have boolean 'ok' field, got: {}",
+        result
+    );
+}
+
 fuzz_target!(|data: &[u8]| {
     if data.is_empty() || data.len() > MAX_INPUT_SIZE {
         return;
@@ -26,17 +45,15 @@ fuzz_target!(|data: &[u8]| {
         None => (input, "{}"),
     };
 
-    // Call the FFI entrypoint — must never panic
-    let result = run_json(mode, args_json);
+    // Explore arbitrary user inputs.
+    assert_envelope_shape(mode, args_json);
 
-    // Invariant: result is always valid JSON
-    let envelope: Value =
-        serde_json::from_str(&result).expect("run_json must always return valid JSON");
+    // Also replay arguments through canonical modes to improve branch coverage
+    // of mode dispatch and per-mode argument decoding.
+    for known_mode in KNOWN_MODES {
+        assert_envelope_shape(known_mode, args_json);
+    }
 
-    // Invariant: envelope always contains an "ok" boolean field
-    assert!(
-        envelope.get("ok").and_then(Value::as_bool).is_some(),
-        "envelope must have boolean 'ok' field, got: {}",
-        result
-    );
+    // Exercise unknown-mode behavior with a stable sentinel.
+    assert_envelope_shape("__unknown_mode__", args_json);
 });


### PR DESCRIPTION
### Motivation
- Improve fuzzing depth for the FFI `run_json` entrypoint by driving per-mode argument decoding and dispatch branches rather than only fuzzing arbitrary mode strings.
- Centralize envelope invariants to reduce duplicated assertion logic and make checks clearer and more maintainable.

### Description
- Updated `fuzz/fuzz_targets/fuzz_run_json.rs` to add a `KNOWN_MODES` list of canonical modes (`lang`, `module`, `export`, `analyze`, `diff`, `version`).
- Introduced `assert_envelope_shape(mode, args_json)` helper that calls `run_json`, parses the returned envelope with `serde_json`, and asserts the presence of the boolean `ok` field.
- Modified the fuzz target to: 1) validate the envelope for the incoming fuzzed `mode`/`args_json`, 2) replay the same `args_json` through each `KNOWN_MODES` to exercise per-mode code paths, and 3) invoke a stable unknown-mode sentinel (`"__unknown_mode__"`) to continuously exercise error-envelope behavior.

### Testing
- Ran `cargo check -p tokmd-fuzz --bin fuzz_run_json --features core` which completed successfully and produced a finished `dev` profile build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c40f6488333b7578658ee4efb6c)