### PR TITLE
Improve fuzz coverage for `run_json` FFI target

### DIFF
--- a/fuzz/fuzz_targets/fuzz_run_json.rs
+++ b/fuzz/fuzz_targets/fuzz_run_json.rs
@@ -1,39 +1,99 @@
 //! Fuzz target for the FFI `run_json` entrypoint.
 //!
-//! Feeds arbitrary mode strings and JSON argument payloads into the
-//! single-entrypoint FFI function to verify it never panics and always
-//! returns a well-formed JSON envelope.
+//! Uses a structured input model to improve mode and payload coverage for the
+//! single-entrypoint FFI function while preserving adversarial noise inputs.
 
 #![no_main]
-use libfuzzer_sys::fuzz_target;
+
+use libfuzzer_sys::{arbitrary, arbitrary::Arbitrary, fuzz_target};
 use serde_json::Value;
 use tokmd_core::ffi::run_json;
 
-/// Cap input size to keep iterations fast.
-const MAX_INPUT_SIZE: usize = 64 * 1024; // 64 KB
+/// Cap generated payload size to keep iterations fast.
+const MAX_ARGS_SIZE: usize = 64 * 1024; // 64 KB
 
-fuzz_target!(|data: &[u8]| {
-    if data.is_empty() || data.len() > MAX_INPUT_SIZE {
-        return;
+#[derive(Arbitrary, Debug)]
+enum ModeHint {
+    Lang,
+    Module,
+    Export,
+    Analyze,
+    Diff,
+    Version,
+    RandomAscii,
+    Empty,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    mode: ModeHint,
+    suffix: String,
+    args_template: ArgsTemplate,
+    noise: Vec<u8>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum ArgsTemplate {
+    EmptyObject,
+    EmptyArray,
+    Null,
+    MinimalPath,
+    MinimalDiff,
+    InvalidJsonLike,
+    NoiseOnly,
+}
+
+fn mode_string(mode: ModeHint, suffix: String) -> String {
+    let base = match mode {
+        ModeHint::Lang => "lang",
+        ModeHint::Module => "module",
+        ModeHint::Export => "export",
+        ModeHint::Analyze => "analyze",
+        ModeHint::Diff => "diff",
+        ModeHint::Version => "version",
+        ModeHint::RandomAscii => "tokmd",
+        ModeHint::Empty => "",
+    };
+
+    if suffix.is_empty() {
+        base.to_owned()
+    } else {
+        format!("{base}{suffix}")
     }
-    let Ok(input) = std::str::from_utf8(data) else {
-        return;
-    };
+}
 
-    // Split on first newline: mode\nargs_json
-    let (mode, args_json) = match input.find('\n') {
-        Some(pos) => (&input[..pos], &input[pos + 1..]),
-        None => (input, "{}"),
-    };
+fn args_json(template: ArgsTemplate, noise: Vec<u8>) -> String {
+    match template {
+        ArgsTemplate::EmptyObject => "{}".to_owned(),
+        ArgsTemplate::EmptyArray => "[]".to_owned(),
+        ArgsTemplate::Null => "null".to_owned(),
+        ArgsTemplate::MinimalPath => {
+            r#"{"path":".","format":"json","children":"collapse"}"#.to_owned()
+        }
+        ArgsTemplate::MinimalDiff => {
+            r#"{"left":"./a.json","right":"./b.json"}"#.to_owned()
+        }
+        ArgsTemplate::InvalidJsonLike => "{\"path\":\".\",\"format\":".to_owned(),
+        ArgsTemplate::NoiseOnly => {
+            let mut payload = noise;
+            payload.truncate(MAX_ARGS_SIZE);
+            String::from_utf8_lossy(&payload).to_string()
+        }
+    }
+}
 
-    // Call the FFI entrypoint — must never panic
-    let result = run_json(mode, args_json);
+fuzz_target!(|input: Input| {
+    let mode = mode_string(input.mode, input.suffix);
+    let args_json = args_json(input.args_template, input.noise);
 
-    // Invariant: result is always valid JSON
+    // Call the FFI entrypoint — must never panic.
+    let result = run_json(&mode, &args_json);
+
+    // Invariant: result is always valid JSON.
     let envelope: Value =
         serde_json::from_str(&result).expect("run_json must always return valid JSON");
 
-    // Invariant: envelope always contains an "ok" boolean field
+    // Invariant: envelope always contains an "ok" boolean field.
     assert!(
         envelope.get("ok").and_then(Value::as_bool).is_some(),
         "envelope must have boolean 'ok' field, got: {}",


### PR DESCRIPTION
### Motivation
- Increase fuzzing coverage of the single-entrypoint FFI `run_json` by exercising mode dispatch and argument parsing branches more systematically.
- Replace ad-hoc newline-splitting of raw bytes with a structured generator to hit meaningful combinations of mode strings, suffixes, and payload shapes.
- Keep iteration cost bounded while allowing both well-formed minimal inputs and adversarial noisy/partial-JSON payloads to reveal robustness issues.

### Description
- Reworked `fuzz/fuzz_targets/fuzz_run_json.rs` to use an `Arbitrary` structured input model with `Input`, `ModeHint`, and `ArgsTemplate` instead of raw byte-to-string splitting.
- Added `mode_string` and `args_json` helpers that generate known FFI modes (`lang`, `module`, `export`, `analyze`, `diff`, `version`) plus malformed/empty variants and a capped noisy payload path using `MAX_ARGS_SIZE`.
- Implemented a variety of argument templates including `{}`, `[]`, `null`, minimal valid JSON for common commands, partially invalid JSON, and raw noise to broaden parser coverage while preserving the existing invariants.
- Preserved invariants that `run_json` must never panic, must return valid JSON, and the returned envelope must contain an `ok` boolean.

### Testing
- `cargo check -p tokmd-fuzz --bin fuzz_run_json` failed as expected without enabling the required feature set.
- `cargo check -p tokmd-fuzz --bin fuzz_run_json --features core` completed successfully and the fuzz target compiles.
- The modified target was validated locally by compiling the `tokmd-fuzz` crate, confirming no compilation errors for the new `Arbitrary`-based model.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c40f6488333b7578658ee4efb6c)