### PR TITLE
ci: add contributor-oriented CI failure guide summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,3 +352,56 @@ jobs:
             exit 1
           fi
           echo "All required jobs passed (or were skipped)."
+
+  contributor-help:
+    name: Contributor Failure Guide
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - msrv
+      - build
+      - build-macos
+      - feature-boundaries
+      - wasm-compile
+      - gate
+      - deny
+      - typos
+      - proptest-smoke
+      - publish-plan
+      - version-consistency
+      - docs-check
+      - nix-pr
+      - mutation
+    steps:
+      - name: Summarize CI results for contributors
+        env:
+          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          {
+            echo "## CI guide for contributors"
+            echo
+            echo "- Full run: ${GH_RUN_URL}"
+            echo
+            echo "### Job results"
+            python - <<'PY_SUMMARY'
+import json
+import os
+
+needs = json.loads(os.environ["NEEDS_JSON"])
+for name in sorted(needs):
+    result = needs[name].get("result", "unknown")
+    icon = {"success": "✅", "failure": "❌", "cancelled": "⚠️", "skipped": "⏭️"}.get(result, "❔")
+    print(f"- {icon} `{name}`: **{result}**")
+PY_SUMMARY
+            echo
+            echo "### Quick local repro commands"
+            echo '```bash'
+            echo "cargo xtask gate --check"
+            echo "cargo test --all-features --verbose"
+            echo "cargo xtask docs --check"
+            echo '```'
+            echo
+            echo "If the failing job is platform-specific, run the matching workflow commands from .github/workflows/ci.yml."
+          } >> "$GITHUB_STEP_SUMMARY"
+


### PR DESCRIPTION
### Motivation
- Provide a single, human-friendly summary for pull-request authors so they don't need to click through many jobs to understand what failed and how to reproduce it locally.
- Reduce contributor friction by surfacing a quick link to the run and concise repro instructions directly in the GitHub Actions UI.

### Description
- Add a new `contributor-help` job to `.github/workflows/ci.yml` that runs for pull requests after the core CI jobs complete and aggregates the `needs` results. 
- The job writes a GitHub Actions step summary including a link to the full run, a per-job pass/fail/skipped list with icons, and quick local repro commands (`cargo xtask gate --check`, `cargo test --all-features --verbose`, `cargo xtask docs --check`).

### Testing
- No CI test suites were executed as part of this change; the update is a workflow YAML edit only. 
- Per-file verification was performed with `rg -n "contributor-help|Quick local repro" .github/workflows/ci.yml` which located the new job, and the change was committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c1603908333a3e06ff6d2edc842)