### PR TITLE
Improve required CI workflow output for human contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,10 +345,49 @@ jobs:
       - feature-boundaries
     steps:
       - name: Check overall status
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
         run: |
-          # If any needed job failed or was cancelled, fail this job
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "One or more required jobs failed or were cancelled."
-            exit 1
-          fi
-          echo "All required jobs passed (or were skipped)."
+          python - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = []
+          cancelled = []
+          lines = ["## Required CI job summary", "", "| Job | Result |", "| --- | --- |"]
+
+          for job, payload in sorted(needs.items()):
+              result = payload.get("result", "unknown")
+              emoji = {
+                  "success": "✅",
+                  "skipped": "⏭️",
+                  "failure": "❌",
+                  "cancelled": "🚫",
+              }.get(result, "❓")
+              lines.append(f"| `{job}` | {emoji} `{result}` |")
+
+              if result == "failure":
+                  failed.append(job)
+              elif result == "cancelled":
+                  cancelled.append(job)
+
+          summary = "\n".join(lines) + "\n"
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fh:
+                  fh.write(summary)
+
+          print(summary)
+
+          if failed or cancelled:
+              if failed:
+                  print(f"::error::Failed jobs: {', '.join(failed)}")
+              if cancelled:
+                  print(f"::error::Cancelled jobs: {', '.join(cancelled)}")
+              sys.exit(1)
+
+          print("All required jobs passed (or were skipped).")
+          PY


### PR DESCRIPTION
### Motivation

- The `CI (Required)` gate previously emitted only a generic pass/fail message which made it hard for contributors to triage which upstream job failed. 
- Providing a readable summary in the job summary UI will reduce context-switching and speed up PR triage. 

### Description

- Replaced the fragile shell-only check with a Python snippet in `.github/workflows/ci.yml` that parses the `needs` payload via `toJson(needs)` and exposes it via the `NEEDS_JSON` environment variable. 
- The script constructs a markdown table with per-job rows and emoji status indicators and appends it to the GitHub step summary using `GITHUB_STEP_SUMMARY`. 
- The workflow still fails the job when any required job has `failure` or `cancelled`, and now emits explicit `::error::` lines naming failed or cancelled jobs. 
- Kept the strict gating behavior while improving human-readable diagnostics for contributors. 

### Testing

- Verified the workflow patch with `git diff -- .github/workflows/ci.yml` and inspected the updated region with `nl -ba .github/workflows/ci.yml | sed -n '340,405p'`, both of which succeeded. 
- Performed an automated in-place replacement of the old step and committed the change, and validated the inserted Python snippet for correct string joining and summary writing by static inspection. 
- No runtime CI execution was performed here; runtime behavior (markdown summary generation and failure propagation) is preserved by the script and will be observed in normal GitHub Actions runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c1603908333a3e06ff6d2edc842)