### PR TITLE
ci: add contributor-friendly required-check summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,31 @@ jobs:
       - mutation
       - feature-boundaries
     steps:
+      - name: Summarize CI results for contributors
+        run: |
+          {
+            echo "## CI Required Check Summary"
+            echo
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "| MSRV Check | ${{ needs.msrv.result }} |"
+            echo "| Build & Test | ${{ needs.build.result }} |"
+            echo "| Build & Test (macOS) | ${{ needs.build-macos.result }} |"
+            echo "| Feature Boundaries | ${{ needs.feature-boundaries.result }} |"
+            echo "| Wasm Compile & Test | ${{ needs.wasm-compile.result }} |"
+            echo "| Quality Gate | ${{ needs.gate.result }} |"
+            echo "| Cargo Deny | ${{ needs.deny.result }} |"
+            echo "| Typos | ${{ needs.typos.result }} |"
+            echo "| Proptest Smoke | ${{ needs.proptest-smoke.result }} |"
+            echo "| Publish Surface | ${{ needs.publish-plan.result }} |"
+            echo "| Version consistency | ${{ needs.version-consistency.result }} |"
+            echo "| Docs Check | ${{ needs.docs-check.result }} |"
+            echo "| Nix PR Package Gate | ${{ needs.nix-pr.result }} |"
+            echo "| Mutation Testing (Required) | ${{ needs.mutation.result }} |"
+            echo
+            echo "If a job failed, open that job's logs for the exact failing command and copy-paste it locally (for example, \\`cargo xtask gate --check\\`)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check overall status
         run: |
           # If any needed job failed or was cancelled, fail this job


### PR DESCRIPTION
### Motivation

- Surface a concise, human-readable summary of required CI job results so contributors can quickly identify which job failed without immediately opening each job log.

### Description

- Add a `Summarize CI results for contributors` step to the `ci-required` job that writes a Markdown table of per-job results into `GITHUB_STEP_SUMMARY` using `${{ needs.<job>.result }}`.
- Include a short hint telling contributors to open the failing job logs to copy the exact failing command and run it locally (example: `cargo xtask gate --check`).
- Preserve existing gating behavior so the `Check overall status` step still fails the job if any required job failed or was cancelled.

### Testing

- No automated tests were modified for this PR; the change is limited to the CI workflow and will be validated by the existing CI jobs when the PR is run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c1603908333a3e06ff6d2edc842)