### PR TITLE
ci: set read-only workflow permissions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
### Motivation
- Limit the default `GITHUB_TOKEN` capabilities by adding an explicit `permissions` block so CI jobs run with least-privilege (only `contents: read`).

### Description
- Add a top-level `permissions:` block with `contents: read` to `.github/workflows/ci.yml` to scope workflow token access to repository read-only for all jobs.

### Testing
- No automated tests were executed for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c00e33883339c790ac7370978d3)