### PR TITLE
ci: scope GitHub Actions token permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
### Motivation
- Reduce GITHUB_TOKEN surface by setting an explicit top-level `permissions` block so CI jobs run with least privilege (`contents: read`).

### Description
- Add `permissions:\n  contents: read` to the top of `.github/workflows/ci.yml` to apply a least-privilege default for the workflow.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c00e33883339c790ac7370978d3)