### PR TITLE
ci: reduce default workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: '1800'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -3,6 +3,9 @@ name: Mutation Testing
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,6 +7,9 @@ on:
       - '.github/labels.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/test-action.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-action:
     name: Test tokmd-receipt Action


### PR DESCRIPTION
### Motivation
- Tighten GitHub Actions token scope by declaring least-privilege defaults for workflows that only require repository read access.
- Make intent explicit and consistent across CI, nightly fuzzing, mutation testing, action self-test, and label-sync workflows.

### Description
- Added a top-level `permissions: contents: read` block to `.github/workflows/ci.yml`, `.github/workflows/fuzz.yml`, `.github/workflows/mutants.yml`, `.github/workflows/test-action.yml`, and `.github/workflows/sync-labels.yml` to reduce default `GITHUB_TOKEN` privileges.
- Preserved any job-level elevated permissions (for example `issues: write` in the label sync job) so steps that need extra rights remain functional.
- Changes are limited to workflow metadata and do not alter job steps, commands, or caching behavior.

### Testing
- Reviewed the diffs of the modified workflow files to confirm only the `permissions` blocks were added and that the YAML structure remains valid.
- Verified the change is present in the branch and that no workflow logic or job-level permissions were unintentionally modified.
- No additional CI test jobs were altered as part of this change and existing job-level permissions remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c00e33883339c790ac7370978d3)