### PR TITLE
Improve cockpit PR comment next-step guidance

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use tokmd_envelope::{SensorReport, ToolMeta, Verdict};
 
 use crate::{
-    CockpitReceipt, GateStatus, format_signed_f64, now_iso8601, sparkline, trend_direction_label,
+    CockpitReceipt, GateStatus, RiskLevel, format_signed_f64, now_iso8601, sparkline, trend_direction_label,
 };
 
 /// Render receipt as JSON.
@@ -514,6 +514,23 @@ pub fn render_comment_md(receipt: &CockpitReceipt) -> String {
             "- Complexity: threshold exceeded (max cyclomatic: {})",
             cx.max_cyclomatic
         );
+    }
+    let _ = writeln!(s);
+
+    // Suggested next steps for PR authors/reviewers
+    let _ = writeln!(s, "**Next steps**:");
+    if matches!(receipt.evidence.overall_status, GateStatus::Fail) {
+        let _ = writeln!(s, "- [ ] Address failing evidence gates before merge");
+    } else if matches!(receipt.evidence.overall_status, GateStatus::Warn) {
+        let _ = writeln!(s, "- [ ] Review warning evidence gates and capture risk acceptance");
+    } else {
+        let _ = writeln!(s, "- [ ] Proceed with reviewer sign-off");
+    }
+    if receipt.contracts.breaking_indicators > 0 {
+        let _ = writeln!(s, "- [ ] Confirm breaking changes are documented in release notes");
+    }
+    if matches!(receipt.risk.level, RiskLevel::High | RiskLevel::Critical) {
+        let _ = writeln!(s, "- [ ] Add at least one domain reviewer for high-risk files");
     }
     let _ = writeln!(s);
 


### PR DESCRIPTION
### Motivation
- Make the generated `comment.md` from the `cockpit` command more actionable for PR authors and reviewers by adding explicit, status-aware next steps. 
- Reduce ambiguity and speed decision-making by surfacing recommended checklist items based on evidence gates, contract break indicators, and risk level.

### Description
- Add a **Next steps** checklist to `render_comment_md` in `crates/tokmd-cockpit/src/render.rs` that is printed between evidence summary and the review plan. 
- Checklist items are selected by gate status using `GateStatus` (`Fail`/`Warn`/other), by `receipt.contracts.breaking_indicators`, and by `receipt.risk.level` matching `RiskLevel::High` or `RiskLevel::Critical`.
- Import `RiskLevel` into the `use crate::{ ... }` list to enable risk-level checks.
- No changes to JSON outputs, schemas, or receipt shape; only markdown comment rendering is modified.

### Testing
- Ran `cargo test -p tokmd-cockpit integration_comment_md --quiet`, which executed the cockpit integration comment tests and passed (relevant tests ran and succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20bfb388083339f2536806d292359)