### PR TITLE
Default `tokmd cockpit` output to Markdown for better PR ergonomics

### DIFF
--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -194,7 +194,7 @@ pub struct DiffArgs {
     #[arg(value_name = "REF", num_args = 2)]
     pub refs: Vec<String>,
 
-    /// Output format.
+    /// Output format (default: md).
     #[arg(long, value_enum, default_value_t = DiffFormat::Md)]
     pub format: DiffFormat,
 
@@ -791,7 +791,7 @@ pub struct CockpitArgs {
     pub head: String,
 
     /// Output format.
-    #[arg(long, value_enum, default_value_t = CockpitFormat::Json)]
+    #[arg(long, value_enum, default_value_t = CockpitFormat::Md)]
     pub format: CockpitFormat,
 
     /// Output file (stdout if omitted).
@@ -844,11 +844,12 @@ pub struct BaselineArgs {
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum CockpitFormat {
-    /// JSON output with full metrics.
-    #[default]
-    Json,
     /// Markdown output for human readability.
+    #[default]
     Md,
+    /// JSON output with full metrics.
+    Json,
+    
     /// Section-based output for PR template filling.
     Sections,
 }
@@ -1133,8 +1134,8 @@ mod tests {
     }
 
     #[test]
-    fn cockpit_format_default_is_json() {
-        assert_eq!(CockpitFormat::default(), CockpitFormat::Json);
+    fn cockpit_format_default_is_md() {
+        assert_eq!(CockpitFormat::default(), CockpitFormat::Md);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve the out-of-the-box PR/ reviewer experience by making `tokmd cockpit` produce human-readable output by default instead of machine JSON.

### Description
- Change the CLI default for `CockpitArgs::format` from `CockpitFormat::Json` to `CockpitFormat::Md` by updating the `default_value_t` on the `--format` arg.
- Make the `Md` variant the `#[default]` in the `CockpitFormat` enum while keeping `Json` and `Sections` available as explicit choices.
- Update the unit test to `cockpit_format_default_is_md` and assert `CockpitFormat::default()` is `CockpitFormat::Md`.

### Testing
- Ran the targeted unit test `cargo test -p tokmd cockpit_format_default_is_md -- --exact`, which passed.
- Verified the crate builds and tests in the development run after the change (no remaining compile/test failures encountered).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20bfb388083339f2536806d292359)