### PR TITLE
feat(cockpit): add comment format for PR output

### DIFF
--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -851,6 +851,8 @@ pub enum CockpitFormat {
     Md,
     /// Section-based output for PR template filling.
     Sections,
+    /// Compact PR comment markdown.
+    Comment,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/tokmd/src/commands/cockpit.rs
+++ b/crates/tokmd/src/commands/cockpit.rs
@@ -94,6 +94,7 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
             cli::CockpitFormat::Json => tokmd_cockpit::render::render_json(&receipt)?,
             cli::CockpitFormat::Md => tokmd_cockpit::render::render_markdown(&receipt),
             cli::CockpitFormat::Sections => tokmd_cockpit::render::render_sections(&receipt),
+            cli::CockpitFormat::Comment => tokmd_cockpit::render::render_comment_md(&receipt),
         };
 
         if let Some(artifacts_dir) = &args.artifacts_dir {


### PR DESCRIPTION
### Motivation
- Let users print the compact PR-comment markdown directly from the CLI so PR authors/reviewers can get the same concise comment content without writing artifact files or opening `artifacts_dir/comment.md`.

### Description
- Add a new `CockpitFormat::Comment` value and wire `--format comment` in the `tokmd cockpit` handler to call `tokmd_cockpit::render::render_comment_md(&receipt)`.

### Testing
- Ran `cargo test -p tokmd cockpit_format_default_is_json -q` and the test passed (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20bfb388083339f2536806d292359)