### PR TITLE
Harden env/profile input sanitization in config resolution

### DIFF
--- a/crates/tokmd/src/config.rs
+++ b/crates/tokmd/src/config.rs
@@ -48,6 +48,16 @@ pub fn load_config() -> ConfigContext {
     }
 }
 
+
+fn sanitize_env_var(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_control) {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 /// Discover TOML configuration following the precedence chain:
 /// 1. TOKMD_CONFIG env var (explicit path)
 /// 2. ./tokmd.toml (current directory)
@@ -55,7 +65,9 @@ pub fn load_config() -> ConfigContext {
 /// 4. ~/.config/tokmd/tokmd.toml (user config)
 fn discover_toml_config() -> Option<(TomlConfig, PathBuf)> {
     // 1. Check TOKMD_CONFIG environment variable
-    if let Ok(config_path) = std::env::var("TOKMD_CONFIG") {
+    if let Ok(config_path) = std::env::var("TOKMD_CONFIG")
+        && let Some(config_path) = sanitize_env_var(config_path)
+    {
         let path = PathBuf::from(&config_path);
         if let Some(result) = try_load_toml(&path) {
             return Some(result);
@@ -112,14 +124,16 @@ fn load_json_config() -> Option<UserConfig> {
 /// Get the profile name from CLI arg, env var, or default.
 pub fn get_profile_name(cli_profile: Option<&String>) -> Option<String> {
     // CLI argument takes precedence
-    if let Some(name) = cli_profile {
-        return Some(name.clone());
+    if let Some(name) = cli_profile
+        && let Some(name) = sanitize_env_var(name.clone())
+    {
+        return Some(name);
     }
 
     // Then check TOKMD_PROFILE environment variable
     std::env::var("TOKMD_PROFILE")
         .ok()
-        .filter(|s| !s.is_empty())
+        .and_then(sanitize_env_var)
 }
 
 /// Resolve a JSON profile by name (legacy).
@@ -736,5 +750,29 @@ pub fn resolve_export_with_config(
             .unwrap_or(cli::RedactMode::None),
         meta: cli_args.meta.or(resolved.meta()).unwrap_or(true),
         strip_prefix: cli_args.strip_prefix.clone(),
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{get_profile_name, sanitize_env_var};
+
+    #[test]
+    fn sanitize_env_var_rejects_empty_and_control_values() {
+        assert_eq!(sanitize_env_var("   ".to_string()), None);
+        assert_eq!(sanitize_env_var("bad
+value".to_string()), None);
+    }
+
+    #[test]
+    fn sanitize_env_var_trims_safe_values() {
+        assert_eq!(sanitize_env_var("  default  ".to_string()), Some("default".to_string()));
+    }
+
+    #[test]
+    fn get_profile_name_sanitizes_cli_value() {
+        let cli_value = "  secure-profile  ".to_string();
+        assert_eq!(get_profile_name(Some(&cli_value)).as_deref(), Some("secure-profile"));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent malformed or malicious environment and CLI profile inputs from being interpreted as valid configuration paths or names by rejecting empty/whitespace-only values and control-character payloads.
- Reduce risk of unexpected behavior when loading `TOKMD_CONFIG` or resolving profile names from `--profile` / `TOKMD_PROFILE` by normalizing and validating inputs early.

### Description
- Add a shared helper `sanitize_env_var(String) -> Option<String>` that trims input and rejects empty or control-character-containing values.
- Apply `sanitize_env_var` to `discover_toml_config()` so `TOKMD_CONFIG` is validated before being converted to a `PathBuf`.
- Apply `sanitize_env_var` to `get_profile_name()` so CLI-provided profile values and the `TOKMD_PROFILE` env var are normalized and unsafe values are ignored.
- Add focused unit tests in `crates/tokmd/src/config.rs` covering rejection of unsafe inputs, trimming behavior, and sanitized CLI profile handling.

### Testing
- Ran the added unit test `sanitize_env_var_trims_safe_values` with `cargo test -p tokmd --lib sanitize_env_var_trims_safe_values`, which passed.
- The added tests for `sanitize_env_var` and `get_profile_name` were executed locally and validated the new sanitization behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20bf5c3b08333a5edb36d9c508ecf)