### PR TITLE
ci: guard RC tags in release workflow and action docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,11 @@ jobs:
         with:
           files: artifacts/**/*
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'rc') }}
+          make_latest: ${{ contains(github.ref_name, 'rc') && 'false' || 'true' }}
 
       - name: Update major version tag
+        if: ${{ !contains(github.ref_name, 'rc') }}
         run: |
           # Extract major version from tag (v1.2.3 -> v1)
           TAG="${GITHUB_REF#refs/tags/}"
@@ -176,6 +179,7 @@ jobs:
           git push origin "$MAJOR" --force
 
   publish-crates:
+    if: ${{ !contains(github.ref_name, 'rc') }}
     name: Publish to crates.io
     needs: create-release
     runs-on: ubuntu-latest
@@ -191,6 +195,7 @@ jobs:
         run: cargo xtask publish --yes --skip-tests --verbose
 
   docker:
+    if: ${{ !contains(github.ref_name, 'rc') }}
     name: Build and Push Docker Image
     needs: create-release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ jobs:
           comment: 'true'
 ```
 
+RC consumer example (pins both action ref and release asset version):
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1.10.0rc1
+  with:
+    version: '1.10.0rc1'
+    paths: .
+    artifact: 'true'
+    comment: 'false'
+```
+
+Stable consumers can keep using `@v1` or pin a stable tag such as `@v1.10.0` with `version: '1.10.0'`.
+
 Inputs:
 
 | Input | Required | Default | Purpose |
@@ -103,9 +116,13 @@ Gate mode:
     comment: 'false'
 ```
 
-Cockpit mode:
+Cockpit mode (recommended checkout for external PR workflows):
 
 ```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
 - uses: EffortlessMetrics/tokmd@v1
   with:
     mode: cockpit
@@ -115,9 +132,13 @@ Cockpit mode:
     comment: 'false'
 ```
 
-Sensor mode:
+Sensor mode (recommended checkout for external PR workflows):
 
 ```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
 - uses: EffortlessMetrics/tokmd@v1
   with:
     mode: sensor


### PR DESCRIPTION
### Motivation

- Prevent release-candidate tags from being treated as stable releases so an RC cannot move the major `v1` tag or become the repo `latest`.
- Avoid publishing stable crates or mutating broad Docker tags for RCs to stop external consumers from accidentally using release candidates.
- Provide clear guidance for external consumers on how to pin and test RC action releases without surprising behavior.

### Description

- Patch `.github/workflows/release.yml` to mark tag names containing `rc` as prereleases by setting `prerelease` and `make_latest` dynamically from `github.ref_name` in the Release step. 
- Guard the major-tag retarget step with `if: ${{ !contains(github.ref_name, 'rc') }}` so RCs do not move `v1`. 
- Add job-level RC guards so `publish-crates` and `docker` jobs are skipped for RC tags via `if: ${{ !contains(github.ref_name, 'rc') }}`. 
- Update `README.md` Action docs with an RC consumer example that pins the action ref and `version` (example: `EffortlessMetrics/tokmd@v1.10.0rc1` with `version: '1.10.0rc1'`) and add `actions/checkout@v4` with `fetch-depth: 0` guidance for `cockpit`/`sensor` external PR workflows.

### Testing

- Ran `cargo fmt-check` and it succeeded. 
- Ran `cargo xtask docs --check` and documentation is up to date. 
- Ran `cargo xtask version-consistency` and version checks passed. 
- Ran `cargo xtask publish-surface --json` and the publish surface was inspected with no violations. 
- Ran `git diff --check` and repository changes pass the check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20a8fc0488333b8c016c169eb4f83)