### PR TITLE
ci: guard release pipeline behavior for rc tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,11 @@ jobs:
         with:
           files: artifacts/**/*
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'rc') }}
+          make_latest: ${{ contains(github.ref_name, 'rc') && 'false' || 'true' }}
 
       - name: Update major version tag
+        if: ${{ !contains(github.ref_name, 'rc') }}
         run: |
           # Extract major version from tag (v1.2.3 -> v1)
           TAG="${GITHUB_REF#refs/tags/}"
@@ -176,6 +179,7 @@ jobs:
           git push origin "$MAJOR" --force
 
   publish-crates:
+    if: ${{ !contains(github.ref_name, 'rc') }}
     name: Publish to crates.io
     needs: create-release
     runs-on: ubuntu-latest
@@ -191,6 +195,7 @@ jobs:
         run: cargo xtask publish --yes --skip-tests --verbose
 
   docker:
+    if: ${{ !contains(github.ref_name, 'rc') }}
     name: Build and Push Docker Image
     needs: create-release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Notes:
 - `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. If `base` is omitted, the action infers a repository-aware base from `origin/$GITHUB_BASE_REF` on pull requests or `origin/HEAD` on other events; if no base can be resolved, set `base` explicitly.
 - `mode: sensor` runs `tokmd sensor --format json` and writes `tokmd-sensor-report.json`, `comment.md`, and the `extras/` sidecar directory. The `summary` output points to `comment.md`. It uses the same inferred `base` behavior as cockpit mode.
 - `mode: baseline` runs `tokmd baseline --force` and writes `tokmd-baseline.json`. It accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd baseline` runs.
+- For external pull request workflows using `mode: cockpit` or `mode: sensor`, use full history checkout to make base-ref behavior predictable:
+
+  ```yaml
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+  ```
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
 - To scan multiple paths, pass whitespace-separated values (for example, `paths: "src crates"`), or use a multiline input:
@@ -91,6 +98,29 @@ Notes:
     src
     packages
   ```
+
+Release-candidate example (`v1.10.0rc1`):
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1.10.0rc1
+  with:
+    version: '1.10.0rc1'
+    paths: .
+    artifact: 'true'
+    comment: 'false'
+```
+
+Stable examples:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    version: '1.10.0'
+
+- uses: EffortlessMetrics/tokmd@v1.10.0
+  with:
+    version: '1.10.0'
+```
 
 Gate mode:
 


### PR DESCRIPTION
### Motivation
- Prevent release-candidate tags (containing `rc`) from being treated as stable releases that update the major `vN` tag or become the repository `latest` release.
- Avoid accidentally publishing RCs to crates.io or promoting RC images as stable Docker tags.
- Provide clear README examples and guidance for external consumers to use RC action refs and to avoid base-ref surprises in `cockpit`/`sensor` workflows.

### Description
- Update `.github/workflows/release.yml` to mark GitHub Releases as prerelease when the tag name contains `rc` by adding `prerelease: ${{ contains(github.ref_name, 'rc') }}` and prevent making RCs the latest with `make_latest: ${{ contains(github.ref_name, 'rc') && 'false' || 'true' }}`.
- Add an RC guard to the major-tag retarget step so the `vN` tag update only runs when the tag does not contain `rc` by adding `if: ${{ !contains(github.ref_name, 'rc') }}`.
- Skip crates publishing and Docker publishing for RC tags by adding `if: ${{ !contains(github.ref_name, 'rc') }}` on the `publish-crates` and `docker` jobs.
- Update `README.md` Action docs to include a release-candidate consumer example (`uses: EffortlessMetrics/tokmd@v1.10.0rc1` with `version: '1.10.0rc1'`), stable examples, and explicit checkout guidance using `fetch-depth: 0` for external `cockpit`/`sensor` PR workflows.

### Testing
- Ran `cargo fmt-check` and it passed.
- Ran `cargo xtask docs --check` and it reported "Documentation is up to date.".
- Ran `cargo xtask version-consistency` and it passed version checks.
- Ran `cargo xtask publish-surface --json` to validate publishable crates and surface and it completed successfully with a JSON summary.
- Verified workspace diffs with `git diff --check` (no whitespace errors) and confirmed the two files changed: `.github/workflows/release.yml` and `README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20a8fc0488333b8c016c169eb4f83)