### PR TITLE
ci: guard release workflow for rc tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,11 @@ jobs:
         with:
           files: artifacts/**/*
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'rc') }}
+          make_latest: ${{ contains(github.ref_name, 'rc') && 'false' || 'true' }}
 
       - name: Update major version tag
+        if: ${{ !contains(github.ref_name, 'rc') }}
         run: |
           # Extract major version from tag (v1.2.3 -> v1)
           TAG="${GITHUB_REF#refs/tags/}"
@@ -178,6 +181,7 @@ jobs:
   publish-crates:
     name: Publish to crates.io
     needs: create-release
+    if: ${{ !contains(github.ref_name, 'rc') }}
     runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -193,6 +197,7 @@ jobs:
   docker:
     name: Build and Push Docker Image
     needs: create-release
+    if: ${{ !contains(github.ref_name, 'rc') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
 
       - uses: EffortlessMetrics/tokmd@v1
         with:
-          version: 'x.y.z'
+          version: '1.10.0'
           paths: .
           module-roots: crates,packages
           top: '20'
@@ -92,6 +92,17 @@ Notes:
     packages
   ```
 
+Release candidate example (`v1.10.0rc1`):
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1.10.0rc1
+  with:
+    version: '1.10.0rc1'
+    paths: .
+    artifact: 'true'
+    comment: 'false'
+```
+
 Gate mode:
 
 ```yaml
@@ -106,8 +117,13 @@ Gate mode:
 Cockpit mode:
 
 ```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
 - uses: EffortlessMetrics/tokmd@v1
   with:
+    version: '1.10.0'
     mode: cockpit
     base: origin/main
     head: HEAD
@@ -118,8 +134,13 @@ Cockpit mode:
 Sensor mode:
 
 ```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
 - uses: EffortlessMetrics/tokmd@v1
   with:
+    version: '1.10.0'
     mode: sensor
     base: origin/main
     head: HEAD


### PR DESCRIPTION
### Motivation

- Prevent release-candidate tags from being treated as stable releases to avoid moving the floating major tag (e.g. `v1`) to an RC. 
- Avoid publishing crates or updating broad Docker tags for RCs so downstream `@v1` consumers do not accidentally start using pre-release artifacts. 
- Provide clear README guidance and an RC consumer example so external repos can smoke-test the action without moving stable channels.

### Description

- Make the GitHub Release step mark tags containing `rc` as a prerelease and set `make_latest: false` for RC tags by using `prerelease: ${{ contains(github.ref_name, 'rc') }}` and `make_latest: ${{ contains(github.ref_name, 'rc') && 'false' || 'true' }}`. 
- Guard the floating-major tag update so it runs only for non-RC tags with `if: ${{ !contains(github.ref_name, 'rc') }}`. 
- Skip stable publishing lanes for RCs by adding `if: ${{ !contains(github.ref_name, 'rc') }}` to the `publish-crates` and `docker` jobs. 
- Update README examples: pin the default example to a concrete stable `version: '1.10.0'`, add an RC consumer example using `EffortlessMetrics/tokmd@v1.10.0rc1` with `version: '1.10.0rc1'`, and add `actions/checkout@v4` with `fetch-depth: 0` guidance for cockpit/sensor snippets.

### Testing

- Ran `cargo fmt-check` and the formatter check passed. 
- Ran `cargo xtask docs --check` and documentation checks passed. 
- Ran `cargo xtask version-consistency` and workspace version consistency checks passed. 
- Ran `cargo xtask publish-surface --json` and `git diff --check` to validate packaging surface and workspace diffs, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20a8fc0488333b8c016c169eb4f83)