### PR TITLE
release: guard RC-tag behavior and document RC action pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,11 @@ jobs:
         with:
           files: artifacts/**/*
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'rc') }}
+          make_latest: ${{ contains(github.ref_name, 'rc') && 'false' || 'true' }}
 
       - name: Update major version tag
+        if: ${{ !contains(github.ref_name, 'rc') }}
         run: |
           # Extract major version from tag (v1.2.3 -> v1)
           TAG="${GITHUB_REF#refs/tags/}"
@@ -176,6 +179,7 @@ jobs:
           git push origin "$MAJOR" --force
 
   publish-crates:
+    if: ${{ !contains(github.ref_name, 'rc') }}
     name: Publish to crates.io
     needs: create-release
     runs-on: ubuntu-latest
@@ -191,6 +195,7 @@ jobs:
         run: cargo xtask publish --yes --skip-tests --verbose
 
   docker:
+    if: ${{ !contains(github.ref_name, 'rc') }}
     name: Build and Push Docker Image
     needs: create-release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Notes:
 - `mode: gate` accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd gate` runs.
 - `mode: cockpit` runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`. If `base` is omitted, the action infers a repository-aware base from `origin/$GITHUB_BASE_REF` on pull requests or `origin/HEAD` on other events; if no base can be resolved, set `base` explicitly.
 - `mode: sensor` runs `tokmd sensor --format json` and writes `tokmd-sensor-report.json`, `comment.md`, and the `extras/` sidecar directory. The `summary` output points to `comment.md`. It uses the same inferred `base` behavior as cockpit mode.
+- For `mode: cockpit` and `mode: sensor` in external PR workflows, prefer `actions/checkout@v4` with `fetch-depth: 0` so base/head inference has complete history.
 - `mode: baseline` runs `tokmd baseline --force` and writes `tokmd-baseline.json`. It accepts exactly one path; same-line or multiline multi-path inputs fail before `tokmd baseline` runs.
 - The action currently installs the latest `tokmd` release by default. If you publish the action under `@v1` and want a specific binary version, set `with: version: 'x.y.z'` explicitly.
 - Release asset support is Linux/macOS `amd64` and `arm64`, plus Windows `amd64`.
@@ -91,6 +92,31 @@ Notes:
     src
     packages
   ```
+
+RC pin (release-candidate smoke in external repos):
+
+```yaml
+- uses: actions/checkout@v4
+
+- uses: EffortlessMetrics/tokmd@v1.10.0rc1
+  with:
+    version: '1.10.0rc1'
+    paths: .
+    artifact: 'true'
+    comment: 'false'
+```
+
+Stable pins:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    version: '1.10.0'
+
+- uses: EffortlessMetrics/tokmd@v1.10.0
+  with:
+    version: '1.10.0'
+```
 
 Gate mode:
 


### PR DESCRIPTION
### Motivation
- Prevent release-candidate tags (containing `rc`) from being treated as stable releases so an RC cannot inadvertently move the floating major tag (e.g. `v1`) or become the repo `latest`.
- Avoid publishing stable artifacts for RCs by skipping crates.io and broad Docker tag updates on RC pushes.
- Provide clear README guidance and an external-consumer example for how to pin and smoke-test RC Action releases.

### Description
- Update `.github/workflows/release.yml` to mark tag releases containing `rc` as prerelease via the `softprops/action-gh-release` input and set `make_latest: false` for RCs.
- Add an `if: ${{ !contains(github.ref_name, 'rc') }}` guard to the major-floating-tag update step so RC tags do not move `v1` (or other major tags).
- Guard the `publish-crates` and `docker` jobs with `if: ${{ !contains(github.ref_name, 'rc') }}` so crates.io publishing and broad Docker tagging are skipped for RCs.
- Update `README.md` to add an RC consumer example (`uses: EffortlessMetrics/tokmd@v1.10.0rc1` with `version: '1.10.0rc1'`), stable pin examples (`@v1` and `@v1.10.0`), and a note to prefer `actions/checkout@v4` with `fetch-depth: 0` for `cockpit`/`sensor` external PR workflows.

### Testing
- Ran `cargo fmt-check` and it completed successfully.
- Ran `cargo xtask docs --check` and documentation checks passed.
- Ran `cargo xtask version-consistency` and `cargo xtask publish-surface --json` and both succeeded with no packaging violations.
- Ran `git diff --check` and workspace diffs/format checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20a8fc0488333b8c016c169eb4f83)