### PR TITLE
Partition authenticated repo cache entries by token

### DIFF
--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -179,12 +179,26 @@ function normalizeToken(value) {
     return trimmed ? trimmed : null;
 }
 
-function buildCacheKey({ owner, repo, ref, limits, authMode }) {
+function tokenPartition(token) {
+    if (!token) {
+        return "none";
+    }
+
+    let hash = 0;
+    for (const char of token) {
+        hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+    }
+
+    return hash.toString(16).padStart(8, "0");
+}
+
+function buildCacheKey({ owner, repo, ref, limits, authMode, tokenPartitionId }) {
     return JSON.stringify({
         owner,
         repo,
         ref,
         auth: authMode ?? "anonymous",
+        tokenPartition: tokenPartitionId ?? "none",
         ...limits,
     });
 }
@@ -579,7 +593,14 @@ export async function fetchGitHubRepoInputs(options = {}) {
     const signal = options.signal;
     const onProgress = options.onProgress;
     const authMode = token ? "token" : "anonymous";
-    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authMode });
+    const cacheKey = buildCacheKey({
+        owner,
+        repo,
+        ref,
+        limits,
+        authMode,
+        tokenPartitionId: tokenPartition(token),
+    });
 
     throwIfAborted(signal);
 

--- a/web/runner/ingest.test.mjs
+++ b/web/runner/ingest.test.mjs
@@ -286,6 +286,49 @@ test("fetchGitHubRepoInputs forwards token auth and tracks auth mode", async () 
     );
 });
 
+test("fetchGitHubRepoInputs partitions token-auth cache by token identity", async () => {
+    clearGitHubRepoCache();
+
+    const calls = [];
+    const fetchImpl = async (url, options = {}) => {
+        calls.push(options.headers?.Authorization ?? "none");
+
+        if (url.includes("/git/trees/")) {
+            return jsonResponse({
+                tree: [{ path: "README.md", size: 32, type: "blob" }],
+            });
+        }
+
+        if (url.includes("/contents/README.md")) {
+            return textResponse("# tokmd\n");
+        }
+
+        throw new Error(`unexpected fetch url: ${url}`);
+    };
+
+    await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "secret-token-1",
+        fetchImpl,
+    });
+
+    const second = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "secret-token-2",
+        fetchImpl,
+    });
+
+    assert.equal(second.ingest.cache.hit, false);
+    assert.deepEqual(calls, [
+        "token secret-token-1",
+        "token secret-token-1",
+        "token secret-token-2",
+        "token secret-token-2",
+    ]);
+});
+
 test("fetchGitHubRepoInputs surfaces auth and private-repo access errors", async () => {
     clearGitHubRepoCache();
 


### PR DESCRIPTION
### Motivation
- Prevent different authenticated fetches from sharing the same in-memory cache entry by separating cache keys for token-auth requests without storing raw tokens.

### Description
- Add `tokenPartition(token)` which produces a stable non-reversible hex partition id derived from the token and return `"none"` for anonymous mode.
- Include the partition id as `tokenPartition` in `buildCacheKey` and wire `tokenPartitionId: tokenPartition(token)` into `fetchGitHubRepoInputs` cache-key construction so cache entries are isolated per token identity.
- Keep `auth` semantics (`anonymous` vs `token`) intact while adding token-level partitioning to the key to avoid accidental cache sharing.
- Add a regression test `fetchGitHubRepoInputs partitions token-auth cache by token identity` in `web/runner/ingest.test.mjs` to validate two different tokens do not hit the same in-memory cache.

### Testing
- Ran the JavaScript unit tests with `node --test web/runner/ingest.test.mjs` and all tests passed (`15/15` subtests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209857eac8333a427b7eeee1a6b61)