### PR TITLE
cli: add friendly subcommand aliases

### DIFF
--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -115,6 +115,7 @@ pub enum Commands {
     Export(CliExportArgs),
 
     /// Analyze receipts or paths to produce derived metrics.
+    #[command(visible_alias = "analyse")]
     Analyze(CliAnalyzeArgs),
 
     /// Render a simple SVG badge for a metric.
@@ -124,6 +125,7 @@ pub enum Commands {
     Init(InitArgs),
 
     /// Generate shell completions.
+    #[command(visible_alias = "completion")]
     Completions(CompletionsArgs),
 
     /// Run a full scan and save receipts to a state directory.

--- a/crates/tokmd/tests/cli_comprehensive.rs
+++ b/crates/tokmd/tests/cli_comprehensive.rs
@@ -440,6 +440,18 @@ fn analyze_health_preset_json() {
     assert!(json["derived"].is_object());
 }
 
+#[test]
+fn analyse_alias_works_like_analyze() {
+    let output = tokmd_cmd()
+        .args(["analyse", "--preset", "receipt", "--format", "json"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["schema_version"].is_number());
+}
+
 // ===========================================================================
 // 8. badge subcommand
 // ===========================================================================
@@ -711,6 +723,15 @@ fn completions_powershell_produces_script() {
 fn completions_elvish_produces_script() {
     tokmd_cmd()
         .args(["completions", "elvish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn completion_alias_produces_script() {
+    tokmd_cmd()
+        .args(["completion", "bash"])
         .assert()
         .success()
         .stdout(predicate::str::is_empty().not());


### PR DESCRIPTION
### Motivation
- Improve CLI ergonomics by accepting a common UK spelling for the analysis subcommand and a more intuitive singular form for completion generation so users can run commands with either spelling/form without friction.

### Description
- Add a visible alias `analyse` for the `analyze` subcommand by annotating `Commands::Analyze` with `#[command(visible_alias = "analyse")]` in `crates/tokmd/src/cli/parser.rs`.
- Add a visible alias `completion` for the `completions` subcommand by annotating `Commands::Completions` with `#[command(visible_alias = "completion")]` in `crates/tokmd/src/cli/parser.rs`.
- Add two integration tests in `crates/tokmd/tests/cli_comprehensive.rs` named `analyse_alias_works_like_analyze` and `completion_alias_produces_script` to exercise the new aliases end-to-end.

### Testing
- Run the analyze-alias test with `cargo test -p tokmd analyse_alias_works_like_analyze -- --exact` and the test passed (`ok`).
- Run the completion-alias test with `cargo test -p tokmd completion_alias_produces_script -- --exact` and the test passed (`ok`).
- The changes were committed with message `cli: add friendly subcommand aliases` and the two modified files are `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/tests/cli_comprehensive.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2095863288333972fb2659f37dc58)