### PR TITLE
Partition authenticated ingest cache entries by token identity

### DIFF
--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -179,12 +179,27 @@ function normalizeToken(value) {
     return trimmed ? trimmed : null;
 }
 
-function buildCacheKey({ owner, repo, ref, limits, authMode }) {
+function tokenPartition(token) {
+    if (!token) {
+        return "anonymous";
+    }
+
+    let hash = 2166136261;
+    for (let index = 0; index < token.length; index += 1) {
+        hash ^= token.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+
+    return `token:${(hash >>> 0).toString(16)}`;
+}
+
+function buildCacheKey({ owner, repo, ref, limits, authMode, token }) {
     return JSON.stringify({
         owner,
         repo,
         ref,
         auth: authMode ?? "anonymous",
+        authPartition: tokenPartition(token),
         ...limits,
     });
 }
@@ -579,7 +594,7 @@ export async function fetchGitHubRepoInputs(options = {}) {
     const signal = options.signal;
     const onProgress = options.onProgress;
     const authMode = token ? "token" : "anonymous";
-    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authMode });
+    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authMode, token });
 
     throwIfAborted(signal);
 

--- a/web/runner/ingest.test.mjs
+++ b/web/runner/ingest.test.mjs
@@ -286,6 +286,48 @@ test("fetchGitHubRepoInputs forwards token auth and tracks auth mode", async () 
     );
 });
 
+test("fetchGitHubRepoInputs partitions cache by token identity", async () => {
+    clearGitHubRepoCache();
+
+    const calls = [];
+    const fetchImpl = async (url, options = {}) => {
+        calls.push({
+            url,
+            authorization: options.headers?.Authorization ?? null,
+        });
+
+        if (url.includes("/git/trees/")) {
+            return jsonResponse({
+                tree: [{ path: "README.md", size: 32, type: "blob" }],
+            });
+        }
+
+        if (url.includes("/contents/README.md")) {
+            return textResponse("# tokmd\n");
+        }
+
+        throw new Error(`unexpected fetch url: ${url}`);
+    };
+
+    const first = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "token-one",
+        fetchImpl,
+    });
+
+    const second = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "token-two",
+        fetchImpl,
+    });
+
+    assert.equal(first.ingest.cache.hit, false);
+    assert.equal(second.ingest.cache.hit, false);
+    assert.equal(calls.length, 4);
+});
+
 test("fetchGitHubRepoInputs surfaces auth and private-repo access errors", async () => {
     clearGitHubRepoCache();
 


### PR DESCRIPTION
### Motivation

- Prevent authenticated requests from sharing the same in-memory cache entry when different tokens are used while avoiding storing raw tokens in the cache key.

### Description

- Added a `tokenPartition` helper that derives a lightweight, non-reversible fingerprint for a token and returns `"anonymous"` for empty tokens.
- Included `authPartition` (from `tokenPartition(token)`) in the `buildCacheKey` payload and updated the `fetchGitHubRepoInputs` call site to pass `token` when building cache keys.
- Kept existing behavior for request headers by still passing the raw token to `buildGitHubHeaders` while ensuring the cache key does not contain the token itself.
- Added a regression test `fetchGitHubRepoInputs partitions cache by token identity` that performs two authenticated loads with different tokens and asserts they do not reuse the same in-memory cache entry.

### Testing

- Ran `node --test web/runner/ingest.test.mjs` and all tests passed (`15` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209857eac8333a427b7eeee1a6b61)