### PR TITLE
Partition browser ingest cache by auth token

### DIFF
--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -179,12 +179,27 @@ function normalizeToken(value) {
     return trimmed ? trimmed : null;
 }
 
-function buildCacheKey({ owner, repo, ref, limits, authMode }) {
+function authCachePartition(token) {
+    if (!token) {
+        return "anonymous";
+    }
+
+    let hash = 2166136261;
+    for (let index = 0; index < token.length; index += 1) {
+        hash ^= token.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+
+    return `token:${(hash >>> 0).toString(16)}`;
+}
+
+function buildCacheKey({ owner, repo, ref, limits, authMode, authPartition }) {
     return JSON.stringify({
         owner,
         repo,
         ref,
         auth: authMode ?? "anonymous",
+        authPartition: authPartition ?? "anonymous",
         ...limits,
     });
 }
@@ -579,7 +594,14 @@ export async function fetchGitHubRepoInputs(options = {}) {
     const signal = options.signal;
     const onProgress = options.onProgress;
     const authMode = token ? "token" : "anonymous";
-    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authMode });
+    const cacheKey = buildCacheKey({
+        owner,
+        repo,
+        ref,
+        limits,
+        authMode,
+        authPartition: authCachePartition(token),
+    });
 
     throwIfAborted(signal);
 

--- a/web/runner/ingest.test.mjs
+++ b/web/runner/ingest.test.mjs
@@ -286,6 +286,58 @@ test("fetchGitHubRepoInputs forwards token auth and tracks auth mode", async () 
     );
 });
 
+test("fetchGitHubRepoInputs partitions cache entries by auth token", async () => {
+    clearGitHubRepoCache();
+
+    const calls = [];
+    const fetchImpl = async (url, options = {}) => {
+        calls.push(options.headers?.Authorization ?? null);
+
+        if (url.includes("/git/trees/")) {
+            return jsonResponse({
+                tree: [{ path: "README.md", size: 32, type: "blob" }],
+            });
+        }
+
+        if (url.includes("/contents/README.md")) {
+            const suffix = options.headers?.Authorization?.includes("second")
+                ? "second"
+                : "first";
+            return textResponse(`# ${suffix}\n`);
+        }
+
+        throw new Error(`unexpected fetch url: ${url}`);
+    };
+
+    const first = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "first-token",
+        fetchImpl,
+    });
+
+    const second = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "second-token",
+        fetchImpl,
+    });
+
+    const third = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "first-token",
+        fetchImpl,
+    });
+
+    assert.equal(first.ingest.cache.hit, false);
+    assert.equal(second.ingest.cache.hit, false);
+    assert.equal(third.ingest.cache.hit, true);
+    assert.equal(first.inputs[0].text, "# first\n");
+    assert.equal(second.inputs[0].text, "# second\n");
+    assert.equal(calls.length, 4);
+});
+
 test("fetchGitHubRepoInputs surfaces auth and private-repo access errors", async () => {
     clearGitHubRepoCache();
 


### PR DESCRIPTION
### Motivation
- Prevent different authenticated fetches from colliding in the in-memory repo cache so each token's view of a repository is cached separately.
- Keep cache keys free of raw secrets by deriving a small non-reversible partition marker from the token rather than storing tokens verbatim.

### Description
- Added `authCachePartition(token)` which computes a compact FNV-1a-based partition string for a token and returns `anonymous` for no token.
- Extended `buildCacheKey` to include an `authPartition` field and wired `authCachePartition(token)` into `fetchGitHubRepoInputs` so cache entries are partitioned by auth marker.
- Added a regression test `fetchGitHubRepoInputs partitions cache entries by auth token` to `web/runner/ingest.test.mjs` that verifies different tokens produce separate cold loads while repeating a token yields a cache hit.

### Testing
- Ran the web runner tests with `npm --prefix web/runner test -- ingest.test.mjs` which executed the ingest test suite including the new partition test and completed successfully (all relevant subtests passed; one unrelated worker bootstrap test was skipped).
- The new regression test confirms: first-token = cache miss, second different-token = separate cache miss, third same-as-first = cache hit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209857eac8333a427b7eeee1a6b61)