### PR TITLE
Partition GitHub ingest cache by token identity

### DIFF
--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -179,12 +179,26 @@ function normalizeToken(value) {
     return trimmed ? trimmed : null;
 }
 
-function buildCacheKey({ owner, repo, ref, limits, authMode }) {
+function tokenCachePartition(token) {
+    if (!token) {
+        return "anonymous";
+    }
+
+    let hash = 2166136261;
+    for (const char of token) {
+        hash ^= char.codePointAt(0) ?? 0;
+        hash = Math.imul(hash, 16777619);
+    }
+
+    return `token:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function buildCacheKey({ owner, repo, ref, limits, authPartition }) {
     return JSON.stringify({
         owner,
         repo,
         ref,
-        auth: authMode ?? "anonymous",
+        auth: authPartition ?? "anonymous",
         ...limits,
     });
 }
@@ -579,7 +593,8 @@ export async function fetchGitHubRepoInputs(options = {}) {
     const signal = options.signal;
     const onProgress = options.onProgress;
     const authMode = token ? "token" : "anonymous";
-    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authMode });
+    const authPartition = tokenCachePartition(token);
+    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authPartition });
 
     throwIfAborted(signal);
 

--- a/web/runner/ingest.test.mjs
+++ b/web/runner/ingest.test.mjs
@@ -286,6 +286,51 @@ test("fetchGitHubRepoInputs forwards token auth and tracks auth mode", async () 
     );
 });
 
+test("fetchGitHubRepoInputs partitions cache entries by token", async () => {
+    clearGitHubRepoCache();
+
+    let treeCalls = 0;
+    const fetchImpl = async (url, options = {}) => {
+        if (url.includes("/git/trees/")) {
+            treeCalls += 1;
+            return jsonResponse({
+                tree: [{ path: "README.md", size: 32, type: "blob" }],
+            });
+        }
+
+        if (url.includes("/contents/README.md")) {
+            const token = options.headers?.Authorization ?? "anonymous";
+            return textResponse(`# ${token}\n`);
+        }
+
+        throw new Error(`unexpected fetch url: ${url}`);
+    };
+
+    const tokenAFirst = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "secret-a",
+        fetchImpl,
+    });
+    const tokenASecond = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "secret-a",
+        fetchImpl,
+    });
+    const tokenB = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "secret-b",
+        fetchImpl,
+    });
+
+    assert.equal(tokenAFirst.ingest.cache.hit, false);
+    assert.equal(tokenASecond.ingest.cache.hit, true);
+    assert.equal(tokenB.ingest.cache.hit, false);
+    assert.equal(treeCalls, 2);
+});
+
 test("fetchGitHubRepoInputs surfaces auth and private-repo access errors", async () => {
     clearGitHubRepoCache();
 


### PR DESCRIPTION
### Motivation
- Prevent authenticated cache entries from being reused across different credentials by partitioning the in-memory cache per token rather than using a coarse `token`/`anonymous` mode.
- Keep anonymous behavior unchanged while ensuring authenticated loads for different tokens perform separate fetches to avoid leaking private repo data or stale auth-scoped responses.
- Provide deterministic, testable behavior for same-token cache hits and different-token cache misses.

### Description
- Added `tokenCachePartition(token)` which generates a stable partition id for a token using an FNV-1a style hash and returns `anonymous` for no token. (`web/runner/ingest.js`)
- Switched `buildCacheKey` to accept an `authPartition` and made `fetchGitHubRepoInputs` compute `authPartition` via `tokenCachePartition(token)` when creating the cache key. (`web/runner/ingest.js`)
- Added a regression test `fetchGitHubRepoInputs partitions cache entries by token` that asserts same-token requests hit the cache while different tokens trigger fresh tree fetches. (`web/runner/ingest.test.mjs`)

### Testing
- Ran the repository tests for the modified module with `node --test web/runner/ingest.test.mjs`. 
- All tests passed: `15` tests executed, `0` failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209857eac8333a427b7eeee1a6b61)