### PR TITLE
feat(cli): add discoverable aliases for common subcommands

### DIFF
--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -106,15 +106,19 @@ pub struct GlobalArgs {
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
     /// Language summary (default).
+    #[command(visible_alias = "languages")]
     Lang(CliLangArgs),
 
     /// Module summary (group by path prefixes like `crates/<name>` or `packages/<name>`).
+    #[command(visible_alias = "mod")]
     Module(CliModuleArgs),
 
     /// Export a file-level dataset (CSV / JSONL / JSON).
+    #[command(visible_alias = "exp")]
     Export(CliExportArgs),
 
     /// Analyze receipts or paths to produce derived metrics.
+    #[command(visible_alias = "ana")]
     Analyze(CliAnalyzeArgs),
 
     /// Render a simple SVG badge for a metric.
@@ -124,6 +128,7 @@ pub enum Commands {
     Init(InitArgs),
 
     /// Generate shell completions.
+    #[command(visible_alias = "completion")]
     Completions(CompletionsArgs),
 
     /// Run a full scan and save receipts to a state directory.
@@ -136,6 +141,7 @@ pub enum Commands {
     Context(CliContextArgs),
 
     /// Check why a file is being ignored (for troubleshooting).
+    #[command(visible_alias = "why-ignore")]
     CheckIgnore(CliCheckIgnoreArgs),
 
     /// Output CLI schema as JSON for AI agents.


### PR DESCRIPTION
### Motivation
- Improve CLI ergonomics and discoverability by making frequently used subcommands appear under additional visible alias names in `tokmd --help` so users can find and type them more easily.

### Description
- Add `#[command(visible_alias = "...")]` attributes to several `Commands` enum variants in `crates/tokmd/src/cli/parser.rs` to expose alternative names: `lang` -> `languages`, `module` -> `mod`, `export` -> `exp`, `analyze` -> `ana`, `completions` -> `completion`, and `check-ignore` -> `why-ignore`.

### Testing
- Ran `cargo fmt-check` successfully and executed the help/docs sync test `cargo test -p tokmd --test docs_sync_w72 -- --nocapture`, which passed (16 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2095863288333972fb2659f37dc58)