### PR TITLE
Improve retry and rate-limit error hint UX

### DIFF
--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -168,6 +168,40 @@ fn suggestions(err: &Error) -> Vec<String> {
         );
     }
 
+
+    if haystack.contains("rate limit")
+        || haystack.contains("rate-limit")
+        || haystack.contains("rate_limit")
+        || haystack.contains("too many requests")
+        || haystack.contains("http 429")
+        || haystack.contains("status 429")
+    {
+        push_hint(
+            &mut out,
+            "The upstream service is throttling requests; wait briefly, then retry.",
+        );
+        push_hint(
+            &mut out,
+            "If available, lower request concurrency or scan a narrower scope to reduce burst traffic.",
+        );
+    }
+
+    if haystack.contains("retry")
+        || haystack.contains("timed out")
+        || haystack.contains("timeout")
+        || haystack.contains("temporar")
+        || haystack.contains("connection reset")
+        || haystack.contains("connection refused")
+    {
+        push_hint(
+            &mut out,
+            "This appears transient; retry the command once network/service health recovers.",
+        );
+        push_hint(
+            &mut out,
+            "For flaky environments, re-run with fewer optional enrichers (for example `--no-git`) to reduce external calls.",
+        );
+    }
     if haystack.contains("unknown metric/finding key") {
         push_hint(
             &mut out,
@@ -326,6 +360,22 @@ mod tests {
         );
     }
 
+
+    #[test]
+    fn suggests_for_rate_limit_errors() {
+        let err = anyhow!("[rate_limit] Too many requests (HTTP 429)");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("throttling requests")));
+        assert!(hints.iter().any(|h| h.contains("lower request concurrency")));
+    }
+
+    #[test]
+    fn suggests_for_transient_retry_errors() {
+        let err = anyhow!("request timed out; retry later");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("appears transient")));
+        assert!(hints.iter().any(|h| h.contains("fewer optional enrichers")));
+    }
     #[test]
     fn format_includes_hints_section() {
         let err = anyhow!("Path not found: no-file");


### PR DESCRIPTION
### Motivation
- Surface clearer, actionable CLI guidance when upstream services throttle requests (HTTP 429 / rate_limit) so users know to wait or reduce request pressure.
- Help users recognize and recover from transient network/service failures by recommending simple retry and optional flag adjustments to avoid noisy enrichers.

### Description
- Add pattern detection in `crates/tokmd/src/error_hints.rs` for rate-limit signals (`rate limit`, `rate-limit`, `rate_limit`, `too many requests`, `http 429`, `status 429`) and push targeted hints recommending a brief wait and reduced concurrency or narrower scans.
- Add detection for transient failures (`retry`, `timed out`, `timeout`, `temporar`, `connection reset`, `connection refused`) and push hints recommending retry after recovery and running with fewer optional enrichers (for example `--no-git`).
- Add two focused unit tests in the same file: `suggests_for_rate_limit_errors` and `suggests_for_transient_retry_errors` to verify the new hint families.

### Testing
- Added unit tests `suggests_for_rate_limit_errors` and `suggests_for_transient_retry_errors` under `crates/tokmd/src/error_hints.rs` to validate hint content.
- Attempted to run `cargo test -p tokmd error_hints --verbose`, but the workspace build in this environment expanded into a very large compile and the test run did not complete during the session.
- Recommend running `cargo test -p tokmd error_hints` or `cargo test -p tokmd --lib error_hints` locally or in CI to confirm the new tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20982598083339fbb42a224cab387)