### PR TITLE
feat(wasm): expose data-only JSON helper

### DIFF
--- a/crates/tokmd-wasm/src/lib.rs
+++ b/crates/tokmd-wasm/src/lib.rs
@@ -115,6 +115,13 @@ pub fn run_json(mode: &str, args_json: &str) -> String {
     tokmd_core::ffi::run_json(mode, args_json)
 }
 
+
+/// Run a tokmd mode with raw JSON args and return only the extracted data JSON payload.
+#[wasm_bindgen(js_name = runDataJson)]
+pub fn run_data_json(mode: &str, args_json: &str) -> Result<String, JsValue> {
+    extract_mode_data_json(mode, args_json).map_err(to_js_error)
+}
+
 /// Run a tokmd mode with a plain JavaScript object and return the extracted data payload.
 #[wasm_bindgen(js_name = run)]
 pub fn run(mode: &str, args: JsValue) -> Result<JsValue, JsValue> {
@@ -180,6 +187,17 @@ mod tests {
 
         assert_eq!(envelope["ok"], true);
         assert_eq!(envelope["data"]["version"], env!("CARGO_PKG_VERSION"));
+    }
+
+
+    #[test]
+    fn run_data_json_returns_payload_without_envelope() {
+        let payload = run_data_json("version", "{}")
+            .expect("version payload");
+        let value: Value = serde_json::from_str(&payload).expect("valid payload json");
+
+        assert_eq!(value["version"], env!("CARGO_PKG_VERSION"));
+        assert!(value.get("schema_version").is_some());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide a small ergonomic wasm API for callers that already handle JSON so they can get the `data` payload directly without decoding the full envelope or doing an extra JS parse/stringify roundtrip.

### Description
- Added a new `wasm-bindgen` export `runDataJson(mode, argsJson)` in `crates/tokmd-wasm/src/lib.rs` which returns the extracted `data` JSON string and preserved the existing `runJson` and object-based `run` APIs, and added a unit test `run_data_json_returns_payload_without_envelope` to verify the payload contains expected `version`/`schema_version` fields.

### Testing
- Ran `cargo test -p tokmd-wasm --verbose` and the wasm crate tests passed (`13` tests passed; `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209587af483339427850b9ac15e01)