### PR TITLE
Improve retry and rate-limit UX in FFI envelope errors

### DIFF
--- a/crates/tokmd-envelope/src/ffi.rs
+++ b/crates/tokmd-envelope/src/ffi.rs
@@ -86,11 +86,30 @@ pub fn format_error_message(error_obj: Option<&Value>) -> String {
         .and_then(Value::as_str)
         .unwrap_or("Unknown error");
 
-    if let Some(details) = error_obj.get("details").and_then(Value::as_str) {
+    let mut msg = if let Some(details) = error_obj.get("details").and_then(Value::as_str) {
         format!("[{code}] {message}: {details}")
     } else {
         format!("[{code}] {message}")
+    };
+
+    match code {
+        "rate_limit" => {
+            let retry_after = error_obj.get("retry_after_seconds").and_then(Value::as_u64);
+            if let Some(seconds) = retry_after {
+                msg.push_str(&format!(
+                    " Retry after {seconds}s or lower request concurrency."
+                ));
+            } else {
+                msg.push_str(" Retry with backoff or lower request concurrency.");
+            }
+        }
+        "timeout" | "network_error" | "service_unavailable" => {
+            msg.push_str(" This may be transient; retry with backoff.");
+        }
+        _ => {}
     }
+
+    msg
 }
 
 /// Extract `data` from an already-parsed envelope.
@@ -238,6 +257,31 @@ mod tests {
         assert_eq!(
             format_error_message(Some(&err)),
             "[invalid_settings] Invalid value for 'from': expected a string: Check the spelling."
+        );
+    }
+
+    #[test]
+    fn format_error_message_rate_limit_includes_retry_guidance() {
+        let err = json!({
+            "code": "rate_limit",
+            "message": "Too many requests"
+        });
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[rate_limit] Too many requests Retry with backoff or lower request concurrency."
+        );
+    }
+
+    #[test]
+    fn format_error_message_rate_limit_with_retry_after_seconds() {
+        let err = json!({
+            "code": "rate_limit",
+            "message": "Too many requests",
+            "retry_after_seconds": 12
+        });
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[rate_limit] Too many requests Retry after 12s or lower request concurrency."
         );
     }
 


### PR DESCRIPTION
### Motivation
- Make upstream error messages returned by the FFI more actionable when callers hit transient failures or rate limits.
- Surface `retry_after_seconds` where available and suggest concrete retry/backoff guidance to reduce operator confusion and repetitive retries.

### Description
- Enhance `format_error_message` in `crates/tokmd-envelope/src/ffi.rs` to append contextual guidance for `rate_limit`, including honoring `retry_after_seconds` when present.
- Add retry guidance for transient codes (`timeout`, `network_error`, `service_unavailable`) recommending backoff.
- Preserve existing formatting and defaults when fields are missing; behavior remains stable for non-transient codes.
- Add focused unit tests that assert the new `rate_limit` messaging with and without `retry_after_seconds`.

### Testing
- Ran the focused tests with `cargo test -p tokmd-envelope format_error_message_rate_limit -- --nocapture` and both new tests passed.
- Ran the `tokmd-envelope` crate test suite via `cargo test -p tokmd-envelope` and observed the crate tests complete with the new tests included and no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20982598083339fbb42a224cab387)