### PR TITLE
Improve retry and rate-limit UX for FFI envelope errors

### DIFF
--- a/crates/tokmd-envelope/src/ffi.rs
+++ b/crates/tokmd-envelope/src/ffi.rs
@@ -86,11 +86,23 @@ pub fn format_error_message(error_obj: Option<&Value>) -> String {
         .and_then(Value::as_str)
         .unwrap_or("Unknown error");
 
-    if let Some(details) = error_obj.get("details").and_then(Value::as_str) {
+    let mut formatted = if let Some(details) = error_obj.get("details").and_then(Value::as_str) {
         format!("[{code}] {message}: {details}")
     } else {
         format!("[{code}] {message}")
+    };
+
+    if matches!(code, "rate_limit" | "rate_limited" | "too_many_requests") {
+        if let Some(retry_after) = error_obj.get("retry_after_seconds").and_then(Value::as_u64) {
+            formatted.push_str(&format!(" Retry after about {retry_after}s."));
+        } else if let Some(retry_after) = error_obj.get("retry_after").and_then(Value::as_str) {
+            formatted.push_str(&format!(" Retry after {retry_after}."));
+        } else {
+            formatted.push_str(" Retry after a short delay and reduce request concurrency.");
+        }
     }
+
+    formatted
 }
 
 /// Extract `data` from an already-parsed envelope.
@@ -238,6 +250,34 @@ mod tests {
         assert_eq!(
             format_error_message(Some(&err)),
             "[invalid_settings] Invalid value for 'from': expected a string: Check the spelling."
+        );
+    }
+
+
+    #[test]
+    fn format_error_message_adds_rate_limit_guidance_without_retry_after() {
+        let err = json!({
+            "code": "rate_limit",
+            "message": "Too many requests"
+        });
+
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[rate_limit] Too many requests Retry after a short delay and reduce request concurrency."
+        );
+    }
+
+    #[test]
+    fn format_error_message_adds_retry_after_seconds_for_rate_limit() {
+        let err = json!({
+            "code": "too_many_requests",
+            "message": "Quota exceeded",
+            "retry_after_seconds": 42
+        });
+
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[too_many_requests] Quota exceeded Retry after about 42s."
         );
     }
 


### PR DESCRIPTION
### Motivation
- Upstream rate-limit error payloads were echoed verbatim which provided little actionable guidance to callers when requests should be retried or concurrency reduced. 
- Surface deterministic, human-friendly retry instructions from the FFI envelope so callers and UIs can show immediate next steps.

### Description
- Update `tokmd-envelope::ffi::format_error_message` (`crates/tokmd-envelope/src/ffi.rs`) to append guidance when the error `code` is one of `rate_limit`, `rate_limited`, or `too_many_requests`.
- When present, use `retry_after_seconds` (numeric) to produce `Retry after about Ns.` or `retry_after` (string) to produce `Retry after <value>.`, otherwise append a generic `Retry after a short delay and reduce request concurrency.` hint.
- Add unit tests covering the generic rate-limit guidance and the `retry_after_seconds` case to lock the UX behaviour.

### Testing
- Ran the package tests with `cargo test -p tokmd-envelope --quiet` and the test suite completed successfully with the new tests passing.
- New unit tests are included in `crates/tokmd-envelope/src/ffi.rs` and verify both fallback guidance and explicit retry-after handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20982598083339fbb42a224cab387)