### PR TITLE
Optimize tokmd-wasm analyze argument validation path

### DIFF
--- a/crates/tokmd-wasm/src/lib.rs
+++ b/crates/tokmd-wasm/src/lib.rs
@@ -25,7 +25,17 @@ fn serialize_args(args: &Value) -> Result<String, String> {
 }
 
 fn extract_mode_data_json(mode: &str, args_json: &str) -> Result<String, String> {
-    validate_mode_args_json(mode, args_json).map_err(|err| err.to_string())?;
+    extract_mode_data_json_with_validation(mode, args_json, true)
+}
+
+fn extract_mode_data_json_with_validation(
+    mode: &str,
+    args_json: &str,
+    validate_args: bool,
+) -> Result<String, String> {
+    if validate_args {
+        validate_mode_args_json(mode, args_json).map_err(|err| err.to_string())?;
+    }
     let result_json = tokmd_core::ffi::run_json(mode, args_json);
     tokmd_envelope::ffi::extract_data_json(&result_json).map_err(|err| err.to_string())
 }
@@ -83,7 +93,8 @@ fn validate_mode_args_json(mode: &str, args_json: &str) -> Result<(), TokmdError
 fn run_analyze_js(args: JsValue) -> Result<JsValue, JsValue> {
     let args_json = js_args_to_json(args)?;
     validate_analyze_args_json(&args_json).map_err(|err| to_js_error(err.to_string()))?;
-    let data_json = extract_mode_data_json("analyze", &args_json).map_err(to_js_error)?;
+    let data_json = extract_mode_data_json_with_validation("analyze", &args_json, false)
+        .map_err(to_js_error)?;
     JSON::parse(&data_json).map_err(|_| to_js_error("failed to parse tokmd result JSON"))
 }
 


### PR DESCRIPTION
### Motivation
- Avoid redundant JSON parsing/validation for the wasm `analyze` pathway to reduce work and improve performance for in-memory analyze calls.
- Preserve existing error and envelope behavior for all other modes while allowing an optimized path for analyze.

### Description
- Add internal helper `extract_mode_data_json_with_validation(mode, args_json, validate_args)` to optionally skip argument validation before calling `tokmd_core::ffi::run_json` and extracting the data payload.
- Replace the original `extract_mode_data_json` with a thin wrapper that calls the new helper with `validate_args = true` so default behavior is unchanged.
- Update `run_analyze_js` to validate once via `validate_analyze_args_json` and then call `extract_mode_data_json_with_validation("analyze", &args_json, false)` to avoid a second parse/validation pass.
- Change is localized to `crates/tokmd-wasm/src/lib.rs` and keeps all other mode paths unchanged.

### Testing
- Ran formatting checks with `cargo fmt-check`, fixed formatting with `cargo fmt-fix` when the check initially reported a diff.
- Ran unit tests for the wasm crate with `cargo test -p tokmd-wasm --verbose` and all tests passed (`12 passed; 0 failed`).
- Doc-tests were executed and completed successfully (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209587af483339427850b9ac15e01)