### PR TITLE
Improve retry and rate-limit error hints

### DIFF
--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -175,6 +175,46 @@ fn suggestions(err: &Error) -> Vec<String> {
         );
     }
 
+    if haystack.contains("rate limit")
+        || haystack.contains("rate_limit")
+        || haystack.contains("too many requests")
+        || haystack.contains("http 429")
+        || haystack.contains("status 429")
+    {
+        push_hint(
+            &mut out,
+            "The upstream service is throttling requests. Wait briefly, then retry.",
+        );
+        push_hint(
+            &mut out,
+            "Reduce request burstiness (smaller batches, less parallelism) to avoid repeated 429s.",
+        );
+        push_hint(
+            &mut out,
+            "If available in your environment, honor provider retry windows such as `Retry-After`.",
+        );
+    }
+
+    if haystack.contains("timed out")
+        || haystack.contains("timeout")
+        || haystack.contains("temporar")
+        || haystack.contains("connection reset")
+        || haystack.contains("broken pipe")
+        || haystack.contains("dns")
+        || haystack.contains("service unavailable")
+        || haystack.contains("http 503")
+        || haystack.contains("status 503")
+    {
+        push_hint(
+            &mut out,
+            "This looks transient. Retry with exponential backoff and jitter.",
+        );
+        push_hint(
+            &mut out,
+            "Check network stability/VPN/proxy settings if retries keep failing.",
+        );
+    }
+
     if haystack.contains("toml") && (haystack.contains("parse") || haystack.contains("invalid")) {
         push_hint(
             &mut out,
@@ -332,5 +372,30 @@ mod tests {
         let rendered = format(&err);
         assert!(rendered.contains("Error:"));
         assert!(rendered.contains("Hints:"));
+    }
+
+    #[test]
+    fn suggests_for_rate_limit_errors() {
+        let err = anyhow!("HTTP 429 Too Many Requests");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("throttling requests")));
+        assert!(hints.iter().any(|h| h.contains("Reduce request burstiness")));
+        assert!(hints.iter().any(|h| h.contains("Retry-After")));
+    }
+
+    #[test]
+    fn suggests_for_transient_retry_errors() {
+        let err = anyhow!("request timed out while contacting remote service");
+        let hints = suggestions(&err);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("Retry with exponential backoff and jitter"))
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("network stability/VPN/proxy settings"))
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Provide clearer, actionable UX when upstream services throttle requests or transient transport failures occur so users know how to recover (retry/backoff, respect `Retry-After`, reduce burstiness, check network). 

### Description
- Expanded `suggestions` matcher in `crates/tokmd/src/error_hints.rs` to detect rate-limit patterns (`rate limit`, `rate_limit`, `429`, `Too Many Requests`) and add user-facing hints about waiting, reducing burstiness, and honoring `Retry-After`.
- Added transient/transport failure detection (timeouts, connection reset, DNS, 503/service unavailable, broken pipe) with hints recommending exponential backoff with jitter and checking network/VPN/proxy stability.
- Added unit tests `suggests_for_rate_limit_errors` and `suggests_for_transient_retry_errors` to lock behavior.

### Testing
- Ran the new tests with `cargo test -p tokmd error_hints::tests::suggests_for_rate_limit_errors -- --nocapture` and `cargo test -p tokmd error_hints::tests::suggests_for_transient_retry_errors -- --nocapture` and both tests passed.
- The crate compiled and unit test suite for the `tokmd` crate ran as part of the test commands with no failures for the exercised tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20982598083339fbb42a224cab387)