### PR TITLE
Emit explicit CLI progress events

### DIFF
--- a/crates/tokmd/src/progress.rs
+++ b/crates/tokmd/src/progress.rs
@@ -26,7 +26,22 @@ fn is_interactive() -> bool {
 mod ui_impl {
     use super::is_interactive;
     use indicatif::{ProgressBar, ProgressStyle};
+    use std::io::Write;
     use std::time::{Duration, Instant};
+
+    fn emit_progress_event(stage: &str, message: &str) {
+        let emit_explicit = std::env::var("TOKMD_PROGRESS_EVENTS").is_ok();
+        if !emit_explicit {
+            return;
+        }
+
+        let _ = writeln!(
+            std::io::stderr(),
+            "tokmd.progress.{}\t{}",
+            stage,
+            message
+        );
+    }
 
     /// A progress indicator that wraps indicatif.
     pub struct Progress {
@@ -62,13 +77,16 @@ mod ui_impl {
 
         /// Set the progress message.
         pub fn set_message(&self, msg: impl Into<String>) {
+            let msg = msg.into();
+            emit_progress_event("update", &msg);
             if let Some(bar) = &self.bar {
-                bar.set_message(msg.into());
+                bar.set_message(msg);
             }
         }
 
         /// Finish and clear the spinner.
         pub fn finish_and_clear(&self) {
+            emit_progress_event("finish", "done");
             if let Some(bar) = &self.bar {
                 bar.finish_and_clear();
             }
@@ -137,6 +155,7 @@ mod ui_impl {
 
         /// Set the progress message.
         pub fn set_message(&self, msg: &str) {
+            emit_progress_event("update", msg);
             if let Some(bar) = &self.bar {
                 bar.set_message(msg.to_string());
             }
@@ -151,6 +170,7 @@ mod ui_impl {
 
         /// Finish the progress bar with a message.
         pub fn finish_with_message(&self, msg: &str) {
+            emit_progress_event("finish", msg);
             if let Some(bar) = &self.bar {
                 bar.finish_with_message(msg.to_string());
             }
@@ -158,6 +178,7 @@ mod ui_impl {
 
         /// Finish and clear the progress bar.
         pub fn finish_and_clear(&self) {
+            emit_progress_event("finish", "done");
             if let Some(bar) = &self.bar {
                 bar.finish_and_clear();
             }


### PR DESCRIPTION
### Motivation
- Provide an explicit, machine-readable progress event stream from the CLI so external tools/CI can observe progress without parsing spinner output. 
- Ensure all existing command flows that use the shared progress helpers emit consistent events without changing per-command code.

### Description
- Add a centralized `emit_progress_event(stage, message)` helper in `crates/tokmd/src/progress.rs` that writes tab-delimited events to stderr in the form `tokmd.progress.<stage>\t<message>`.
- Gate event emission behind the `TOKMD_PROGRESS_EVENTS` environment variable so behavior is opt-in and non-disruptive to existing users.
- Emit `update` events from `set_message` and `finish` events from `finish_with_message` / `finish_and_clear` for both the spinner-style `Progress` and ETA-style `ProgressBarWithEta` helpers.
- Preserve existing `indicatif` spinner/bar behavior and only add the explicit event writes when the env var is set.

### Testing
- Ran `cargo test -p tokmd progress_methods_do_not_panic_when_disabled --quiet` which passed.
- Ran `cargo test -p tokmd progress_bar_methods_do_not_panic_when_disabled --quiet` which passed.
- The changes were limited to `crates/tokmd/src/progress.rs` and unit tests covering no-op behavior when UI is disabled were used to validate no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2097bdf70833384e48e7633c70bcf)