### PR TITLE
Improve tokmd-wasm JS argument handling

### DIFF
--- a/crates/tokmd-wasm/src/lib.rs
+++ b/crates/tokmd-wasm/src/lib.rs
@@ -42,6 +42,12 @@ fn js_args_to_json(args: JsValue) -> Result<String, JsValue> {
         return Ok("{}".to_string());
     }
 
+    if let Some(raw_json) = args.as_string() {
+        serde_json::from_str::<serde_json::Value>(&raw_json)
+            .map_err(|err| to_js_error(format!("failed to parse JSON string arguments: {err}")))?;
+        return Ok(raw_json);
+    }
+
     JSON::stringify(&args)
         .map_err(|_| to_js_error("failed to serialize JS arguments"))?
         .as_string()


### PR DESCRIPTION
### Motivation
- Allow wasm entrypoints to accept pre-serialized JSON string arguments from JS so callers are not forced into double-quoting when they already have JSON text. 
- Surface a clear parse error when a malformed JSON string is passed so integration bugs are easier to diagnose.

### Description
- Updated `js_args_to_json` in `crates/tokmd-wasm/src/lib.rs` to detect when the incoming `JsValue` is a string, validate it with `serde_json::from_str`, and return the raw string if valid. 
- Preserved the existing behavior for non-string JS values by continuing to call `JSON::stringify` and returning the produced string. 
- No changes to exported wasm entrypoints; this is an input-handling improvement that returns clearer JS errors on invalid input.

### Testing
- Ran `cargo fmt-check`, which completed successfully. 
- Ran `cargo test -p tokmd-wasm --verbose`, which built and executed the wasm crate tests successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209587af483339427850b9ac15e01)