### PR TITLE
Improve COCOMO mode selection by KLOC

### DIFF
--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -16,6 +16,16 @@ const TOP_N: usize = 10;
 const MIN_DOC_LINES: usize = 50;
 const MIN_DENSE_LINES: usize = 10;
 
+fn cocomo81_basic_coefficients(kloc: f64) -> (&'static str, f64, f64, f64, f64) {
+    if kloc <= 50.0 {
+        ("organic", 2.4, 1.05, 2.5, 0.38)
+    } else if kloc <= 300.0 {
+        ("semi-detached", 3.0, 1.12, 2.5, 0.35)
+    } else {
+        ("embedded", 3.6, 1.20, 2.5, 0.32)
+    }
+}
+
 pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> DerivedReport {
     let parents: Vec<&FileRow> = export
         .rows
@@ -118,7 +128,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         None
     } else {
         let kloc = totals.code as f64 / 1000.0;
-        let (a, b, c, d) = (2.4, 1.05, 2.5, 0.38);
+        let (mode, a, b, c, d) = cocomo81_basic_coefficients(kloc);
         let effort = a * kloc.powf(b);
         let duration = c * effort.powf(d);
         let staff = if duration == 0.0 {
@@ -127,7 +137,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
             effort / duration
         };
         Some(CocomoReport {
-            mode: "organic".to_string(),
+            mode: mode.to_string(),
             kloc: round_f64(kloc, 4),
             effort_pm: round_f64(effort, 2),
             duration_months: round_f64(duration, 2),

--- a/crates/tokmd-analysis/src/derived/tests/derived_depth_w56.rs
+++ b/crates/tokmd-analysis/src/derived/tests/derived_depth_w56.rs
@@ -139,6 +139,22 @@ fn cocomo_formula_verification() {
     assert!((cocomo.duration_months - expected_duration).abs() < 0.1);
 }
 
+#[test]
+fn cocomo_mode_switches_to_semi_detached_above_50_kloc() {
+    let export = make_export(vec![make_row("a.rs", "Rust", 51_000, 0, 0)]);
+    let cocomo = derive_report(&export, None).cocomo.unwrap();
+    assert_eq!(cocomo.mode, "semi-detached");
+    assert_eq!((cocomo.a, cocomo.b, cocomo.c, cocomo.d), (3.0, 1.12, 2.5, 0.35));
+}
+
+#[test]
+fn cocomo_mode_switches_to_embedded_above_300_kloc() {
+    let export = make_export(vec![make_row("a.rs", "Rust", 301_000, 0, 0)]);
+    let cocomo = derive_report(&export, None).cocomo.unwrap();
+    assert_eq!(cocomo.mode, "embedded");
+    assert_eq!((cocomo.a, cocomo.b, cocomo.c, cocomo.d), (3.6, 1.2, 2.5, 0.32));
+}
+
 // ───────────────────── doc density ─────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation
- Make the legacy COCOMO-81 basic estimate more realistic across repository sizes by selecting mode-specific coefficients based on total KLOC instead of always using the `organic` coefficients. 
- Preserve the existing output shape (`CocomoReport`) while emitting the selected `mode` and its coefficients so downstream consumers remain compatible.

### Description
- Add `cocomo81_basic_coefficients(kloc: f64)` to choose COCOMO-81 basic coefficients and mode (`organic`, `semi-detached`, `embedded`) by KLOC bands and return `(mode, a, b, c, d)` in `crates/tokmd-analysis/src/derived/mod.rs`.
- Use the new helper in `derive_report` to select `mode`, `a`, `b`, `c`, `d` and populate `CocomoReport.mode` and coefficient fields instead of hardcoding `organic` values. 
- Add focused tests in `crates/tokmd-analysis/src/derived/tests/derived_depth_w56.rs` that validate transitions to `semi-detached` and `embedded` modes for larger KLOC values.

### Testing
- Ran the targeted test subset with `cargo test -p tokmd-analysis cocomo_mode_switches --quiet`, which executed the new tests and returned success. 
- The test run passed (2 tests passed; 0 failed) and the crate compiled during the test run without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209588794833393535516821c6183)