### PR TITLE
feat(cli): emit optional explicit progress events

### DIFF
--- a/crates/tokmd/src/progress.rs
+++ b/crates/tokmd/src/progress.rs
@@ -23,6 +23,20 @@ fn is_interactive() -> bool {
 }
 
 #[cfg(feature = "ui")]
+fn emit_progress_event(msg: &str) {
+    if std::env::var("TOKMD_PROGRESS_EVENTS").is_ok() {
+        eprintln!("[progress] {msg}");
+    }
+}
+
+#[cfg(not(feature = "ui"))]
+fn emit_progress_event(msg: &str) {
+    if std::env::var("TOKMD_PROGRESS_EVENTS").is_ok() {
+        eprintln!("[progress] {msg}");
+    }
+}
+
+#[cfg(feature = "ui")]
 mod ui_impl {
     use super::is_interactive;
     use indicatif::{ProgressBar, ProgressStyle};
@@ -62,8 +76,10 @@ mod ui_impl {
 
         /// Set the progress message.
         pub fn set_message(&self, msg: impl Into<String>) {
+            let msg = msg.into();
+            super::emit_progress_event(&msg);
             if let Some(bar) = &self.bar {
-                bar.set_message(msg.into());
+                bar.set_message(msg);
             }
         }
 
@@ -191,7 +207,10 @@ mod ui_impl {
         }
 
         /// Set the progress message (no-op without `ui` feature).
-        pub fn set_message(&self, _msg: impl Into<String>) {}
+        pub fn set_message(&self, msg: impl Into<String>) {
+            let msg = msg.into();
+            super::emit_progress_event(&msg);
+        }
 
         /// Finish and clear the spinner (no-op without `ui` feature).
         pub fn finish_and_clear(&self) {}


### PR DESCRIPTION
### Motivation
- Make progress updates machine-visible for non-interactive and CI consumers by emitting explicit progress events while preserving the existing spinner UI and behavior.

### Description
- Add an `emit_progress_event(msg: &str)` helper (both `cfg(feature = "ui")` and `cfg(not(feature = "ui"))`) that writes `[progress] {msg}` to stderr when the `TOKMD_PROGRESS_EVENTS` environment variable is set.
- Invoke `emit_progress_event` from `Progress::set_message` in the UI spinner implementation before updating the spinner text.
- Implement `Progress::set_message` in the no-`ui` variant to emit events so progress messages are available even when the spinner feature is disabled.

### Testing
- Ran formatting/validation commands `cargo fmt-fix` and `cargo fmt-check`, which completed successfully.
- An initial `cargo fmt-check -p tokmd` invocation failed due to the repository `xtask` wrapper not accepting `-p`, so validation proceeded with the full `cargo fmt-fix`/`cargo fmt-check` run that passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2097bdf70833384e48e7633c70bcf)