### PR TITLE
feat(cli): emit explicit progress events

### DIFF
--- a/crates/tokmd/src/progress.rs
+++ b/crates/tokmd/src/progress.rs
@@ -22,15 +22,21 @@ fn is_interactive() -> bool {
     true
 }
 
+/// Check if explicit machine-readable progress events should be emitted.
+fn should_emit_progress_events() -> bool {
+    std::env::var("TOKMD_PROGRESS_EVENTS").is_ok()
+}
+
 #[cfg(feature = "ui")]
 mod ui_impl {
-    use super::is_interactive;
+    use super::{is_interactive, should_emit_progress_events};
     use indicatif::{ProgressBar, ProgressStyle};
     use std::time::{Duration, Instant};
 
     /// A progress indicator that wraps indicatif.
     pub struct Progress {
         bar: Option<ProgressBar>,
+        emit_events: bool,
     }
 
     impl Progress {
@@ -57,13 +63,20 @@ mod ui_impl {
                 None
             };
 
-            Self { bar }
+            Self {
+                bar,
+                emit_events: should_emit_progress_events(),
+            }
         }
 
         /// Set the progress message.
         pub fn set_message(&self, msg: impl Into<String>) {
+            let msg = msg.into();
             if let Some(bar) = &self.bar {
-                bar.set_message(msg.into());
+                bar.set_message(msg.clone());
+            }
+            if self.emit_events {
+                eprintln!("tokmd.progress message={msg}");
             }
         }
 
@@ -181,6 +194,7 @@ mod ui_impl {
 
 #[cfg(not(feature = "ui"))]
 mod ui_impl {
+    use super::should_emit_progress_events;
     /// A no-op progress indicator when the `ui` feature is disabled.
     pub struct Progress;
 
@@ -191,7 +205,11 @@ mod ui_impl {
         }
 
         /// Set the progress message (no-op without `ui` feature).
-        pub fn set_message(&self, _msg: impl Into<String>) {}
+        pub fn set_message(&self, msg: impl Into<String>) {
+            if should_emit_progress_events() {
+                eprintln!("tokmd.progress message={}", msg.into());
+            }
+        }
 
         /// Finish and clear the spinner (no-op without `ui` feature).
         pub fn finish_and_clear(&self) {}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable progress event channel so automation and CI can observe progress even when the interactive spinner is not available. 
- Make progress emission consistent between `ui` and non-`ui` builds so tools see the same `tokmd.progress` lines regardless of feature flags.

### Description
- Add a new environment toggle `TOKMD_PROGRESS_EVENTS` and helper `should_emit_progress_events()` to control explicit event emission. 
- Extend the UI `Progress` implementation with an `emit_events` flag and emit `tokmd.progress message=...` to stderr from `set_message` when enabled. 
- Update the non-`ui` no-op `Progress` to also emit the same `tokmd.progress message=...` line so behavior is consistent across builds. 

### Testing
- Ran `cargo test -p tokmd progress --verbose` which compiled the workspace and exercised the progress tests without failures. 
- The progress-targeted tests completed successfully (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2097bdf70833384e48e7633c70bcf)