### PR TITLE
Improve derived COCOMO mode selection by project size

### DIFF
--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -118,7 +118,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         None
     } else {
         let kloc = totals.code as f64 / 1000.0;
-        let (a, b, c, d) = (2.4, 1.05, 2.5, 0.38);
+        let (mode, a, b, c, d) = cocomo_coefficients(kloc);
         let effort = a * kloc.powf(b);
         let duration = c * effort.powf(d);
         let staff = if duration == 0.0 {
@@ -127,7 +127,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
             effort / duration
         };
         Some(CocomoReport {
-            mode: "organic".to_string(),
+            mode: mode.to_string(),
             kloc: round_f64(kloc, 4),
             effort_pm: round_f64(effort, 2),
             duration_months: round_f64(duration, 2),
@@ -161,6 +161,16 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         cocomo,
         todo: None,
         integrity,
+    }
+}
+
+fn cocomo_coefficients(kloc: f64) -> (&'static str, f64, f64, f64, f64) {
+    if kloc <= 50.0 {
+        ("organic", 2.4, 1.05, 2.5, 0.38)
+    } else if kloc <= 300.0 {
+        ("semi-detached", 3.0, 1.12, 2.5, 0.35)
+    } else {
+        ("embedded", 3.6, 1.20, 2.5, 0.32)
     }
 }
 

--- a/crates/tokmd-analysis/src/derived/tests/deep.rs
+++ b/crates/tokmd-analysis/src/derived/tests/deep.rs
@@ -272,6 +272,28 @@ mod cocomo {
     }
 
     #[test]
+    fn cocomo_mode_switches_to_semi_detached_above_50kloc() {
+        let rows = vec![make_simple_row("src/a.rs", "Rust", 60_000)];
+        let report = derive_report(&export(rows), None);
+        let c = report.cocomo.unwrap();
+        assert_eq!(c.mode, "semi-detached");
+        assert!((c.a - 3.0).abs() < 0.001);
+        assert!((c.b - 1.12).abs() < 0.001);
+        assert!((c.d - 0.35).abs() < 0.001);
+    }
+
+    #[test]
+    fn cocomo_mode_switches_to_embedded_above_300kloc() {
+        let rows = vec![make_simple_row("src/a.rs", "Rust", 400_000)];
+        let report = derive_report(&export(rows), None);
+        let c = report.cocomo.unwrap();
+        assert_eq!(c.mode, "embedded");
+        assert!((c.a - 3.6).abs() < 0.001);
+        assert!((c.b - 1.20).abs() < 0.001);
+        assert!((c.d - 0.32).abs() < 0.001);
+    }
+
+    #[test]
     fn cocomo_scales_with_kloc() {
         let small = derive_report(&export(vec![make_simple_row("a.rs", "Rust", 1000)]), None);
         let large = derive_report(


### PR DESCRIPTION
### Motivation
- The derived COCOMO calculation always used the "organic" coefficients which underestimates effort/schedule for medium and large codebases.
- Select mode and coefficients by project size (KLOC tiers) to produce more realistic effort and duration estimates while keeping the existing report schema.

### Description
- Introduce `cocomo_coefficients(kloc: f64) -> (&'static str, f64, f64, f64, f64)` and use it from `derive_report` to pick mode and coefficients by KLOC tier instead of hardcoding organic parameters.
- Tiering rule: `<= 50.0 KLOC` => `organic` (2.4, 1.05, 2.5, 0.38); `> 50.0 and <= 300.0 KLOC` => `semi-detached` (3.0, 1.12, 2.5, 0.35); `> 300.0 KLOC` => `embedded` (3.6, 1.20, 2.5, 0.32).
- Preserve output fields and rounding; only `mode`, `a`, `b`, and `d` vary by tier so the `CocomoReport` schema remains unchanged.
- Add targeted unit tests asserting mode/coefficient selection for semi-detached and embedded thresholds in `crates/tokmd-analysis/src/derived/tests/deep.rs`.
- Files modified: `crates/tokmd-analysis/src/derived/mod.rs` and `crates/tokmd-analysis/src/derived/tests/deep.rs`.

### Testing
- Ran `cargo test -p tokmd-analysis cocomo_mode_switches --verbose` and it completed successfully (COCOMO-related tests passed).
- Ran `cargo test -p tokmd-analysis --lib derived::tests::deep::cocomo::cocomo_mode_switches_to_semi_detached_above_50kloc --verbose` and the specific test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209588794833393535516821c6183)