### PR TITLE
Define cockpit mutation cache key and invalidation semantics

### DIFF
--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -1726,18 +1726,33 @@ fn try_load_cached(
     head_commit: &str,
     relevant_files: &[String],
 ) -> Result<Option<MutationGate>> {
+    // Cache key semantics:
+    // - Namespace: ".tokmd/cache/mutants"
+    // - Primary key: git HEAD commit OID at evaluation time
+    // - Physical key encoding: "<head_commit>.json"
+    //
+    // Invalidation semantics:
+    // 1) If the cache namespace or keyed file is missing => cache miss.
+    // 2) If the stored evidence commit disagrees with the requested HEAD commit
+    //    (unless the field is absent for back-compat) => invalidate.
+    // 3) If the stored tested-file scope does not fully cover current relevant files
+    //    => invalidate as partial/stale scope.
     let cache_dir = repo_root.join(".tokmd/cache/mutants");
     if !cache_dir.exists() {
         return Ok(None);
     }
 
-    let cache_file = cache_dir.join(format!("{}.json", head_commit));
+    let cache_file = cache_dir.join(cache_file_name_for_head(head_commit));
     if !cache_file.exists() {
         return Ok(None);
     }
 
     let content = std::fs::read_to_string(&cache_file)?;
     let gate: MutationGate = serde_json::from_str(&content)?;
+
+    if cached_commit_mismatch(&gate, head_commit) {
+        return Ok(None);
+    }
 
     // Verify scope hasn't changed significantly
     let tested = &gate.meta.scope.tested;
@@ -1752,6 +1767,19 @@ fn try_load_cached(
     }
 
     Ok(Some(gate))
+}
+
+#[cfg(feature = "git")]
+fn cache_file_name_for_head(head_commit: &str) -> String {
+    format!("{head_commit}.json")
+}
+
+#[cfg(feature = "git")]
+fn cached_commit_mismatch(gate: &MutationGate, head_commit: &str) -> bool {
+    gate.meta
+        .evidence_commit
+        .as_deref()
+        .is_some_and(|cached| cached != head_commit)
 }
 
 /// Run mutations locally.


### PR DESCRIPTION
### Motivation
- Make mutation-result caching for the cockpit gate explicit and deterministic by documenting the cache key, physical layout, and when a cached result should be considered stale or invalid.

### Description
- Documented cache key and invalidation semantics inside `try_load_cached` (namespace `.tokmd/cache/mutants`, primary key = HEAD commit OID, physical file = `<head_commit>.json`).
- Replaced inline filename construction with `cache_file_name_for_head` and factored commit-consistency check into `cached_commit_mismatch` for clearer policy boundaries.
- Enforce invalidation when `meta.evidence_commit` is present but does not match the requested HEAD commit while preserving backward compatibility when the field is absent.
- Kept existing scope-coverage invalidation behavior that rejects caches which do not fully cover the current `relevant_files`.

### Testing
- Ran `cargo fmt-check` which passed successfully.
- Ran `cargo test -p tokmd-cockpit --lib --quiet` which completed with all tests passing (`55 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20976c528833382c712821e4bd1c3)