### PR TITLE
Improve COCOMO'81 calculations with size-based modes

### DIFF
--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -16,6 +16,16 @@ const TOP_N: usize = 10;
 const MIN_DOC_LINES: usize = 50;
 const MIN_DENSE_LINES: usize = 10;
 
+fn cocomo81_mode(kloc: f64) -> (&'static str, f64, f64, f64, f64) {
+    if kloc <= 50.0 {
+        ("organic", 2.4, 1.05, 2.5, 0.38)
+    } else if kloc <= 300.0 {
+        ("semi-detached", 3.0, 1.12, 2.5, 0.35)
+    } else {
+        ("embedded", 3.6, 1.20, 2.5, 0.32)
+    }
+}
+
 pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> DerivedReport {
     let parents: Vec<&FileRow> = export
         .rows
@@ -118,7 +128,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         None
     } else {
         let kloc = totals.code as f64 / 1000.0;
-        let (a, b, c, d) = (2.4, 1.05, 2.5, 0.38);
+        let (mode, a, b, c, d) = cocomo81_mode(kloc);
         let effort = a * kloc.powf(b);
         let duration = c * effort.powf(d);
         let staff = if duration == 0.0 {
@@ -127,7 +137,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
             effort / duration
         };
         Some(CocomoReport {
-            mode: "organic".to_string(),
+            mode: mode.to_string(),
             kloc: round_f64(kloc, 4),
             effort_pm: round_f64(effort, 2),
             duration_months: round_f64(duration, 2),

--- a/crates/tokmd-analysis/src/effort/cocomo81.rs
+++ b/crates/tokmd-analysis/src/effort/cocomo81.rs
@@ -1,20 +1,28 @@
 use tokmd_analysis_types::EffortResults;
 
-const A: f64 = 2.4;
-const B: f64 = 1.05;
-const C: f64 = 2.5;
-const D: f64 = 0.38;
+fn cocomo81_coefficients(kloc: f64) -> (f64, f64, f64, f64) {
+    // COCOMO'81 basic model switches mode by project size (KLOC).
+    // Organic: <= 50 KLOC, Semi-detached: <= 300 KLOC, Embedded: > 300 KLOC.
+    if kloc <= 50.0 {
+        (2.4, 1.05, 2.5, 0.38)
+    } else if kloc <= 300.0 {
+        (3.0, 1.12, 2.5, 0.35)
+    } else {
+        (3.6, 1.20, 2.5, 0.32)
+    }
+}
 
 pub fn cocomo81_effort_pm(kloc: f64) -> (f64, f64, f64, f64) {
     if kloc <= 0.0 {
         return (0.0, 0.0, 0.0, 0.0);
     }
 
-    let effort_pm = A * kloc.powf(B);
+    let (a, b, c, d) = cocomo81_coefficients(kloc);
+    let effort_pm = a * kloc.powf(b);
     let schedule_months = if effort_pm <= 0.0 {
         0.0
     } else {
-        C * effort_pm.powf(D)
+        c * effort_pm.powf(d)
     };
     let staff = if schedule_months > 0.0 {
         effort_pm / schedule_months


### PR DESCRIPTION
### Motivation
- Make COCOMO estimates more realistic by selecting COCOMO'81 coefficients based on project size (KLOC) instead of always using the organic coefficients. 
- Surface the selected mode in the derived `CocomoReport` so outputs indicate `organic`, `semi-detached`, or `embedded` as appropriate. 
- Preserve existing behavior for zero or non-positive KLOC (COCOMO remains absent/zero). 

### Description
- Add `cocomo81_coefficients` in `crates/tokmd-analysis/src/effort/cocomo81.rs` to choose `(a,b,c,d)` by KLOC bands (<=50, <=300, >300) and use those when computing effort/schedule/staff. 
- Update `cocomo81_effort_pm` to use the size-selected coefficients. 
- Add `cocomo81_mode` and update `crates/tokmd-analysis/src/derived/mod.rs` to use the same sizing logic and emit the chosen `mode` and coefficients in the `CocomoReport`. 

### Testing
- Ran `cargo test -p tokmd-analysis cocomo_100k_loc`, which passed. 
- Ran formatting commands `cargo fmt-fix` and `cargo fmt-check`, both succeeded. 
- Executed filtered/targeted test runs during development to validate COCOMO behavior; no test failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209588794833393535516821c6183)