### PR TITLE
docs(runner): document GitHub ingest cache key and invalidation semantics

### DIFF
--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -44,6 +44,38 @@ tokmd-wasm-<tag>.tar.gz
 
 `v1.9.0` becomes `tokmd-wasm-v1.9.0.tar.gz`. Extracting this archive into `vendor/tokmd-wasm` gives the exact layout expected by `web/runner/worker.js` without rebuilding from source.
 
+## GitHub ingest cache semantics
+
+`fetchGitHubRepoInputs()` keeps an in-memory cache (`repoCache`) of in-flight and
+completed loads keyed by a stable JSON key.
+
+### Cache key
+
+The key is built from:
+
+- `owner`
+- `repo`
+- `ref`
+- `authMode` (`"token"` or `"anonymous"`)
+- effective limits (`maxFiles`, `maxBytes`, `maxFileBytes`)
+
+Equivalent requests with the same normalized values share the same cache entry
+for the lifetime of the page.
+
+### Invalidation and lifecycle
+
+- **Success path:** the resolved result remains in memory and is reused.
+- **Failure path:** rejected loads are evicted immediately to allow retries.
+- **Manual invalidation:** call `clearGitHubRepoCache()` to drop all entries.
+- **Process boundary:** cache is not persisted; page refresh/new worker starts
+  with an empty cache.
+
+### Concurrency behavior
+
+The cache stores the in-flight promise, not only final values. Concurrent
+callers for the same key coalesce onto a single network fetch and each waiter
+can still cancel independently through its own `AbortSignal`.
+
 ## Go deeper
 
 Tutorial: [Root README](../../README.md)


### PR DESCRIPTION
### Motivation
- Make the browser runner's GitHub ingest caching explicit so callers understand what dimensions are keyed, how entries are invalidated, and how concurrent callers and aborts behave.

### Description
- Added a `GitHub ingest cache semantics` section to `web/runner/README.md` that documents the cache key components (`owner`, `repo`, `ref`, `authMode`, `maxFiles`, `maxBytes`, `maxFileBytes`), lifecycle/invalidation rules (reuse on success, eviction on failure, `clearGitHubRepoCache()` for manual invalidation, and no persistence across page/worker lifetimes), and concurrency behavior (the cache stores the in-flight `Promise`, coalesces concurrent fetches for the same key, and allows independent cancellation via `AbortSignal`).

### Testing
- Ran the browser-runner unit tests with `npm --prefix web/runner test -- ingest.test.mjs` and the suite completed with all applicable tests passing (48 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20976c528833382c712821e4bd1c3)