### PR TITLE
Refactor derived COCOMO to reuse shared cocomo81 effort model

### DIFF
--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -11,6 +11,8 @@ use tokmd_format::render_analysis_tree;
 use tokmd_scan::{gini_coefficient, percentile, round_f64, safe_ratio};
 use tokmd_types::{ExportData, FileKind, FileRow};
 
+use crate::effort::cocomo81::{cocomo81_effort_pm, COCOMO81_COEFFICIENTS};
+
 const LINES_PER_MINUTE: usize = 20;
 const TOP_N: usize = 10;
 const MIN_DOC_LINES: usize = 50;
@@ -118,14 +120,8 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         None
     } else {
         let kloc = totals.code as f64 / 1000.0;
-        let (a, b, c, d) = (2.4, 1.05, 2.5, 0.38);
-        let effort = a * kloc.powf(b);
-        let duration = c * effort.powf(d);
-        let staff = if duration == 0.0 {
-            0.0
-        } else {
-            effort / duration
-        };
+        let (a, b, c, d) = COCOMO81_COEFFICIENTS;
+        let (effort, duration, staff, _) = cocomo81_effort_pm(kloc);
         Some(CocomoReport {
             mode: "organic".to_string(),
             kloc: round_f64(kloc, 4),

--- a/crates/tokmd-analysis/src/effort/cocomo81.rs
+++ b/crates/tokmd-analysis/src/effort/cocomo81.rs
@@ -1,9 +1,11 @@
 use tokmd_analysis_types::EffortResults;
 
-const A: f64 = 2.4;
-const B: f64 = 1.05;
-const C: f64 = 2.5;
-const D: f64 = 0.38;
+pub const COCOMO81_COEFFICIENTS: (f64, f64, f64, f64) = (2.4, 1.05, 2.5, 0.38);
+
+const A: f64 = COCOMO81_COEFFICIENTS.0;
+const B: f64 = COCOMO81_COEFFICIENTS.1;
+const C: f64 = COCOMO81_COEFFICIENTS.2;
+const D: f64 = COCOMO81_COEFFICIENTS.3;
 
 pub fn cocomo81_effort_pm(kloc: f64) -> (f64, f64, f64, f64) {
     if kloc <= 0.0 {


### PR DESCRIPTION
### Motivation
- Prevent duplicated COCOMO math and keep legacy `derived.cocomo` output aligned with the canonical effort engine to avoid formula drift.

### Description
- Replace inline COCOMO formula in `derive_report` with a call to `cocomo81_effort_pm` and import `COCOMO81_COEFFICIENTS` from the effort module.
- Add a public `COCOMO81_COEFFICIENTS` tuple in `crates/tokmd-analysis/src/effort/cocomo81.rs` and wire existing local constants to reference it so both code paths share the same coefficients.
- Update `CocomoReport` construction to use the shared `effort`, `duration`, and `staff` returned by the effort helper.

### Testing
- Ran `cargo check -p tokmd-analysis --quiet`, which completed successfully in this environment.
- Attempted the targeted unit test `cargo test -p tokmd-analysis derived::tests::derived_depth_w56::cocomo_formula_verification` and `cargo test -p tokmd-analysis cocomo_formula_verification`, but the full test execution did not complete within the interactive session window.
- Changes were committed after local validation (`git add`/`git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209588794833393535516821c6183)