### PR TITLE
docs: tighten publish=false policy and add ADR/spec backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+### Changed
+
+- Release publishability wording now states that `publish = false` is limited to non-production dev/tooling/fuzz packages outside the production crates.io closure.
+- Added a release-blocker note: `tokmd-node` and `tokmd-python` require an explicit binding-surface ADR decision (publish to crates.io or move out of production Cargo package status) before stable release.
+
 ## [1.9.0] - 2026-03-27
 
 ### Added

--- a/docs/adr/adr-binding-surfaces.md
+++ b/docs/adr/adr-binding-surfaces.md
@@ -1,0 +1,16 @@
+# ADR: Binding surfaces (Node/Python/WASM)
+
+Status: Proposed
+
+## Scope
+Classify Rust binding packages (`tokmd-node`, `tokmd-python`, `tokmd-wasm`) as crates.io products or external packaging wrappers.
+
+## Questions
+- Are Node/Python binding crates first-class production Rust packages?
+- Must they publish on crates.io?
+- Are they only npm/PyPI packaging wrappers?
+- What release/versioning and RC semantics apply?
+- What dependency-closure guarantees are required?
+
+## Required outcome
+Document explicit classification and release policy for each binding surface.

--- a/docs/adr/adr-crate-vs-module-boundary.md
+++ b/docs/adr/adr-crate-vs-module-boundary.md
@@ -1,0 +1,20 @@
+# ADR: Crate vs module boundary
+
+Status: Proposed
+
+## Decision scope
+Define when functionality should remain an independent crate versus an owner-module implementation seam.
+
+## Crate-worthy boundary signals
+- independent semver contract
+- external consumer API
+- public capability/workflow boundary
+- contract/type boundary
+- load-bearing dependency isolation
+
+## Module-worthy boundary signals
+- implementation shard
+- single-owner helper
+- renderer/parser/internal adapter variants
+- test support leaf
+- no independent support promise

--- a/docs/adr/adr-production-package-publishability.md
+++ b/docs/adr/adr-production-package-publishability.md
@@ -1,0 +1,24 @@
+# ADR: Production package publishability
+
+Status: Proposed
+
+## Decision
+Any Rust package used for a production deliverable must be publishable.
+`publish = false` is limited to dev-only tooling, fuzzing, and test-only packages outside the production/build dependency closure.
+
+## Definitions
+- production package
+- published crate
+- production non-crates.io package
+- dev/tooling package
+- fuzz/test package
+- build-chain package
+
+## Required rule
+If a package participates in a production build chain, it must either:
+1. publish to crates.io, or
+2. be collapsed into an owner module under a published crate, or
+3. move outside Cargo workspace production package status as external packaging glue.
+
+## Open questions
+- Classification outcome for `tokmd-node` and `tokmd-python`.

--- a/docs/adr/adr-release-train-rc-semantics.md
+++ b/docs/adr/adr-release-train-rc-semantics.md
@@ -1,0 +1,18 @@
+# ADR: Release train and RC semantics
+
+Status: Proposed
+
+## Scope
+Define stable vs RC tagging, publish lanes, and alias behavior across Cargo/npm/PyPI/GitHub releases and Docker surfaces.
+
+## Required rules
+- RC must not move stable aliases (including `v1`).
+- RC must not become `latest` by default.
+- RC must not publish stable Docker aliases.
+- RC crates.io publication requires explicit intent.
+
+## To define
+- tag format
+- prerelease metadata rules
+- release asset expectations
+- rollback/abort behavior

--- a/docs/publish-surface.md
+++ b/docs/publish-surface.md
@@ -20,7 +20,16 @@ A published crate is a support promise. A module folder is an architecture seam.
 
 ## Publication model
 
-`publish = false` is policy-only and valid only for crates that are truly outside the crates.io closure.
+### Package definitions
+
+- **Production package**: a Rust package used to build or ship a production deliverable (CLI, library, binding, wasm artifact, or release workflow artifact).
+- **Dev/tooling package**: a Rust package used only for local developer workflows, repository automation, or CI helper utilities.
+- **Fuzz/test package**: a Rust package used only for fuzzing, fixtures, property tests, or non-production validation harnesses.
+- **Binding package**: a Rust package that produces language/runtime bindings (for example npm or PyPI artifacts) and must be explicitly classified as production or external packaging glue.
+
+`publish = false` is policy-only and valid only for packages truly outside the production crates.io dependency closure.
+
+**Hard rule:** No production Rust package may be `publish = false`.
 
 For publishability, every intended public crate must have a full non-dev workspace dependency closure that references only:
 - classified published crates
@@ -107,12 +116,15 @@ compatibility target, but it is not the final product/contract/capability model.
 Support is now a compatibility classification for existing automation. It is
 not the final desired category.
 
-## Non-crates.io packages (intentional exceptions) (4)
+## Non-crates.io packages (intentional exceptions, pending binding-surface ADR) (4)
 
 - `tokmd-fuzz`
 - `tokmd-node`
 - `tokmd-python`
 - `xtask`
+
+`tokmd-fuzz` and `xtask` are classified as fuzz/dev tooling-only packages.
+`tokmd-node` and `tokmd-python` are binding packages and require an explicit ADR decision if they remain `publish = false` (publish to crates.io or move out of production Cargo package status).
 
 **Count:** 4 non-crates.io packages.
 

--- a/docs/specs/browser-wasm-capability-runner-protocol.md
+++ b/docs/specs/browser-wasm-capability-runner-protocol.md
@@ -1,0 +1,9 @@
+# Spec: Browser/WASM capability + runner protocol
+
+Status: Draft
+
+## Capability contract
+Define browser-safe/rootless-safe mode and preset matrix, payload restrictions, and approval/testing requirements for capability changes.
+
+## Runner protocol
+Define RunMessage schema, protocolVersion, error envelope, request/response semantics, lifecycle events, and unsupported-mode behavior.

--- a/docs/specs/determinism-timestamp-policy.md
+++ b/docs/specs/determinism-timestamp-policy.md
@@ -1,0 +1,9 @@
+# Spec: Determinism and timestamp policy
+
+Status: Draft
+
+## Scope
+Byte-stability requirements, allowed variable fields, snapshot normalization, and run/diff determinism constraints.
+
+## Invariant
+No silent `generated_at_ms = 0` behavior.

--- a/docs/specs/github-action-contract.md
+++ b/docs/specs/github-action-contract.md
@@ -1,0 +1,12 @@
+# Spec: GitHub Action contract
+
+Status: Draft
+
+## Contract sections
+- inputs/outputs
+- mode matrix and defaults
+- artifact names
+- failure/comment behavior
+- permissions and checkout depth
+- release asset/checksum expectations
+- external smoke workflow expectations

--- a/docs/specs/jules-provenance-policy.md
+++ b/docs/specs/jules-provenance-policy.md
@@ -1,0 +1,11 @@
+# Spec: Jules provenance policy
+
+Status: Draft
+
+## Scope
+Policy for `.jules/**` provenance artifacts in PRs and release-prep workflows.
+
+## Core rules
+- Preserve intentional provenance updates.
+- Do not reject solely for `.jules/**` presence.
+- Distinguish accidental run logs from intentional learning/provenance changes.

--- a/docs/specs/path-trust-model.md
+++ b/docs/specs/path-trust-model.md
@@ -1,0 +1,11 @@
+# Spec: Path trust model
+
+Status: Draft
+
+## Scope
+Native and in-memory path validation, root bounding, traversal rejection, and diagnostics contract.
+
+## Examples
+- "" and "." => root/rootless
+- "src" => bounded subtree
+- "../x", "/src", "/" => reject

--- a/docs/specs/publish-surface-spec.md
+++ b/docs/specs/publish-surface-spec.md
@@ -1,0 +1,15 @@
+# Spec: Publish surface classification
+
+Status: Draft
+
+## Classes
+- published_crates_io
+- production_crates_io
+- production_non_crates_io
+- dev_tooling_only
+- fuzz_test_only
+- external_packaging_only
+- removed_collapsed_module
+
+## Invariant
+`production_non_crates_io` must be empty unless an ADR waiver exists.


### PR DESCRIPTION
### Motivation

- The existing release wording around `publish = false` was ambiguous and could be misused to hide production crates from the crates.io dependency closure. 
- `tokmd-node` and `tokmd-python` are currently non-crates.io workspace members and need an explicit classification decision to avoid a production-surface gap. 
- The repository lacks a formal ADR/spec backlog to record publishability and related release/surface contracts for future enforcement. 

### Description

- Updated `CHANGELOG.md` (Unreleased) to replace the ambiguous publish-surface wording with strict production publishability guidance and an explicit blocker note for Node/Python binding-surface decisions. 
- Strengthened `docs/publish-surface.md` by adding package definitions (production/dev-tooling/fuzz/binding), a hard invariant that production Rust packages may not use `publish = false`, and explicit language flagging `tokmd-node` and `tokmd-python` as requiring an ADR if left unpublished. 
- Added ADR skeletons under `docs/adr/` for production package publishability, crate vs module boundary, binding surfaces, and release-train/RC semantics. 
- Added spec skeletons under `docs/specs/` covering publish-surface classification, GitHub Action contract, browser/WASM capability + runner protocol, path trust model, determinism/timestamp policy, and Jules provenance policy. 

### Testing

- Ran `cargo xtask docs --check` and it passed. 
- Ran `cargo xtask version-consistency` and it passed. 
- Ran `cargo xtask publish-surface --json` and the report completed with no violations. 
- Ran `git diff --check` for whitespace/patch issues and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2112c7f108333ad68bb1d997b171c)