### PR TITLE
docs: tighten publish=false policy and add ADR/spec skeletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Tier Boundary Compliance**: Fixed architectural violation where `tokmd` CLI (Tier 5) directly depended on the analysis renderer, bypassing the `tokmd-core` facade (Tier 4) ([#996](https://github.com/EffortlessMetrics/tokmd/issues/996))
+- Clarified release policy wording: `publish = false` is limited to dev/tooling/fuzz packages outside production and crates.io dependency closure.
+- Added release-blocker note: `tokmd-node` and `tokmd-python` require a binding-surface ADR decision (publish to crates.io or move outside production Cargo package status) before stable release under strict policy.
   - Added `analysis_facade` module in `tokmd-core` with renderer re-exports
   - Removed the direct analysis-renderer dependency from `tokmd` crate
   - Restored proper tier hierarchy: Tier 5 → Tier 4 → Tier 3

--- a/docs/adr/0001-production-package-publishability.md
+++ b/docs/adr/0001-production-package-publishability.md
@@ -1,0 +1,25 @@
+# ADR 0001: Production Package Publishability
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+Define when `publish = false` is acceptable and how production Rust package
+closure is enforced.
+
+## Decision
+Any Rust package used for a production deliverable must be publishable.
+`publish = false` is allowed only for dev-only tooling, fuzzing, test harnesses,
+or packages outside production/build dependency closure.
+
+## Required terms
+- production package
+- published crate
+- production non-crates.io package
+- dev/tooling package
+- fuzz/test package
+- build-chain package
+
+## Consequences
+Production-chain packages must publish, collapse into owner modules, or move out
+of production Cargo workspace status.

--- a/docs/adr/0002-crate-vs-module-boundary.md
+++ b/docs/adr/0002-crate-vs-module-boundary.md
@@ -1,0 +1,15 @@
+# ADR 0002: Crate vs Module Boundary
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+Prevent microcrate sprawl while preserving intentional public boundaries.
+
+## Decision draft
+Use crates for independent semver/API/capability/contract/workflow boundaries.
+Use modules for implementation shards, owner-local helpers, and internal
+adapters not meant to carry independent support promises.
+
+## Follow-up
+Document evaluative checklist and required migration path for crate collapse.

--- a/docs/adr/0003-binding-surfaces-node-python-wasm.md
+++ b/docs/adr/0003-binding-surfaces-node-python-wasm.md
@@ -1,0 +1,19 @@
+# ADR 0003: Binding Surfaces (Node/Python/WASM)
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+`tokmd-node` and `tokmd-python` are binding packages and currently
+`publish = false`; production publishability policy requires explicit treatment.
+
+## Decision scope
+- binding package classification
+- crates.io publishability expectations
+- packaging-only exception criteria
+- release and version alignment requirements
+
+## Open questions
+- Are Node/Python bindings first-class production Rust packages?
+- Must they publish to crates.io under strict policy?
+- If not, what waiver criteria prove they are outside production closure?

--- a/docs/adr/0004-release-train-and-rc-semantics.md
+++ b/docs/adr/0004-release-train-and-rc-semantics.md
@@ -1,0 +1,16 @@
+# ADR 0004: Release Train and RC Semantics
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+RC behavior needs a durable policy contract beyond workflow YAML.
+
+## Decision scope
+Define stable vs RC tag semantics, prerelease metadata behavior, `latest`/`v1`
+movement, crates.io and Docker publish behavior, and rollback controls.
+
+## Baseline guardrails
+- RC must not move `v1`.
+- RC must not become latest.
+- RC must not publish stable Docker aliases.

--- a/docs/publish-surface.md
+++ b/docs/publish-surface.md
@@ -249,3 +249,43 @@ Violations include:
 - workspace packages not classified in the forward policy model
 - stale forward policy entries after a package is removed
 - Cargo packaging validation failures
+
+## Production package classification additions
+
+To make the publish-surface policy machine-checkable and release-safe, use the
+following package classes in addition to the current forward policy classes.
+
+### Definitions
+
+- **production package**: a Rust package used to produce a shipped deliverable
+  (CLI/library artifact, wasm/browser artifact, or language binding artifact) or
+  participating in the non-dev build chain for one.
+- **dev/tooling package**: workspace-only helper used for development,
+  automation, release tooling, or repository maintenance; not in any production
+  non-dev dependency closure.
+- **fuzz/test package**: package used only for fuzzing, synthetic fixtures, or
+  dedicated test harnesses; not in any production non-dev dependency closure.
+- **binding package**: package that produces language binding deliverables
+  (e.g., npm/PyPI native extension outputs) and may or may not be a crates.io
+  product.
+
+### Hard production rule
+
+- **No production Rust package may be `publish = false`.**
+- `publish = false` is limited to dev/tooling/fuzz packages outside the
+  production and crates.io dependency closure.
+
+If a package participates in the production build chain, it must either:
+1. publish to crates.io,
+2. be collapsed into owner modules under a published crate, or
+3. be moved outside workspace Cargo production package status as external
+   packaging glue.
+
+### Binding decision note (current workspace)
+
+- `tokmd-node` and `tokmd-python` are currently binding packages with
+  `publish = false` and therefore require an explicit binding-surface ADR
+  decision if they remain unpublished.
+- Under strict production publishability policy, this is a release blocker until
+  they are either crates.io-publishable production crates or no longer treated as
+  production Rust workspace packages.

--- a/docs/specs/browser-wasm-capability-and-runner-protocol.md
+++ b/docs/specs/browser-wasm-capability-and-runner-protocol.md
@@ -1,0 +1,19 @@
+# Spec: Browser/WASM Capability and Runner Protocol
+
+Status: Draft
+Date: 2026-04-29
+
+## Purpose
+Define capability boundaries and browser runner protocol semantics.
+
+## Capability contract
+- browser_safe/rootless_safe definitions
+- allowed mode/payload matrix
+- native-only exclusions
+- capability-change approval rule
+
+## Runner protocol contract
+- RunMessage schema and protocolVersion
+- request/response/error shape
+- unsupported-mode behavior
+- worker lifecycle and version payload semantics

--- a/docs/specs/determinism-and-timestamp-policy.md
+++ b/docs/specs/determinism-and-timestamp-policy.md
@@ -1,0 +1,12 @@
+# Spec: Determinism and Timestamp Policy
+
+Status: Draft
+Date: 2026-04-29
+
+## Purpose
+Define deterministic output guarantees and timestamp handling rules.
+
+## Core rules
+- byte-stable output scope and accepted variability
+- generated_at_ms behavior and normalization
+- explicit prohibition of silent timestamp `0`

--- a/docs/specs/github-action-contract.md
+++ b/docs/specs/github-action-contract.md
@@ -1,0 +1,15 @@
+# Spec: GitHub Action Contract
+
+Status: Draft
+Date: 2026-04-29
+
+## Purpose
+Define durable action inputs/outputs/modes/artifacts and failure semantics.
+
+## Required sections
+- input contract
+- mode matrix
+- artifact contract
+- permissions and checkout requirements
+- failure and comment behavior
+- external smoke expectations

--- a/docs/specs/jules-provenance-policy.md
+++ b/docs/specs/jules-provenance-policy.md
@@ -1,0 +1,12 @@
+# Spec: Jules Provenance Policy
+
+Status: Draft
+Date: 2026-04-29
+
+## Purpose
+Define governance rules for intentional `.jules/**` provenance artifacts.
+
+## Contract areas
+- intentional provenance inclusion criteria
+- patch PR vs provenance/learning PR expectations
+- ledger/runbook historical integrity and migration constraints

--- a/docs/specs/path-trust-model.md
+++ b/docs/specs/path-trust-model.md
@@ -1,0 +1,14 @@
+# Spec: Path Trust Model
+
+Status: Draft
+Date: 2026-04-29
+
+## Purpose
+Define trusted path constraints for native and in-memory execution.
+
+## Contract areas
+- root/path bounding
+- absolute/parent traversal rejection
+- dirty-index and missing-path handling
+- MemFs and FFI in-memory path behavior
+- diagnostic metadata expectations

--- a/docs/specs/publish-surface-spec.md
+++ b/docs/specs/publish-surface-spec.md
@@ -1,0 +1,19 @@
+# Spec: Publish Surface Classification
+
+Status: Draft
+Date: 2026-04-29
+
+## Purpose
+Machine-checkable classification and invariants for publish-surface policy.
+
+## Required classes
+- published_crates_io
+- production_crates_io
+- production_non_crates_io
+- dev_tooling_only
+- fuzz_test_only
+- external_packaging_only
+- removed_collapsed_module
+
+## Invariant
+`production_non_crates_io` must be empty unless an ADR waiver exists.


### PR DESCRIPTION
### Motivation

- Clarify the intended policy that `publish = false` must not be used to hide production Rust packages and to prevent production artifacts from depending on unpublished workspace crates.
- Surface a clear release-blocker requirement for binding packages (Node/Python) that currently live as unpublished workspace members.
- Provide a minimal ADR/spec backlog and skeletons to make publish-surface and release behavior machine-checkable and reviewable.

### Description

- Reworded the Unreleased changelog to remove ambiguous publish-surface language and add a release-blocker note for `tokmd-node` and `tokmd-python` in `CHANGELOG.md`.
- Extended `docs/publish-surface.md` with a `Production package classification additions` section that defines `production`, `dev/tooling`, `fuzz/test`, and `binding` package classes and states the hard rule `No production Rust package may be \\`publish = false\\`.
- Added ADR skeletons under `docs/adr/` for production-package publishability, crate-vs-module boundary, binding surfaces (Node/Python/WASM), and release-train/RC semantics (`docs/adr/0001-0004-*.md`).
- Added spec skeletons under `docs/specs/` for publish-surface classification, GitHub Action contract, browser/WASM capability & runner protocol, path trust model, determinism/timestamp policy, and Jules provenance policy (`docs/specs/*.md`).
- Recorded an explicit binding decision note calling out `tokmd-node` and `tokmd-python` as needing an ADR if they remain unpublished.

### Testing

- Ran `cargo xtask docs --check` and it completed successfully.
- Ran `cargo xtask version-consistency` and it completed successfully.
- Ran `cargo xtask publish-surface --json` and the report emitted a `violations: []` result indicating no publish-surface violations in the updated classification.
- Ran `git diff --check` as part of validation and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2112c7f108333ad68bb1d997b171c)