### PR TITLE
docs: tighten publish=false policy, update publish-surface, add ADR/spec skeletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 
 - Collapsed the previous support-crate sprawl into owner crates and SRP module families, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
 - Public crate surface is now enforced around product, contract, workflow, and capability crates.
-- Internal crates are marked `publish = false`, while publish-surface verification and package-list proof treat the 16 published crates as the intentional crates.io boundary.
+- `publish = false` is limited to dev/tooling/fuzz packages outside the production and crates.io dependency closure.
+- Node/Python binding crates require an ADR-backed binding-surface decision: publish them to crates.io as production Rust packages, or move them out of production Cargo package status before stable release.
 - GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
 - No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.

--- a/docs/adr/ADR-binding-surfaces.md
+++ b/docs/adr/ADR-binding-surfaces.md
@@ -1,0 +1,19 @@
+# ADR: Binding Surfaces (Node/Python/WASM)
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+
+`tokmd-node` and `tokmd-python` are production binding surfaces currently marked `publish = false`.
+
+## Decision to record
+
+Document whether each binding crate is:
+1. A crates.io-published production Rust package, or
+2. An external packaging wrapper moved outside production Cargo package status.
+
+## Required outcomes
+
+- No ambiguous production binding package remains `publish = false` without an ADR waiver.
+- Versioning/release expectations are explicit for npm/PyPI/WASM surfaces.

--- a/docs/adr/ADR-crate-vs-module-boundary.md
+++ b/docs/adr/ADR-crate-vs-module-boundary.md
@@ -1,0 +1,24 @@
+# ADR: Crate vs Module Boundary
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+
+The repo needs durable criteria for when to keep a Cargo crate versus collapsing into owner modules.
+
+## Decision
+
+Create a crate only when it carries an independent public/support boundary (contract, workflow, capability, dependency isolation, or semver promise). Keep implementation shards as module folders.
+
+## Criteria
+
+### Keep as crate
+- Independent semver/API support promise.
+- External consumer contract.
+- Load-bearing capability/workflow boundary.
+
+### Collapse to module
+- Internal helper shard.
+- Single-owner implementation detail.
+- Not useful as a standalone published unit.

--- a/docs/adr/ADR-production-package-publishability.md
+++ b/docs/adr/ADR-production-package-publishability.md
@@ -1,0 +1,24 @@
+# ADR: Production Package Publishability
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+
+Workspace policy needs an explicit production/package boundary for `publish = false` usage.
+
+## Decision
+
+Any Rust package used for a production deliverable must be publishable. `publish = false` is allowed only for dev-only/tooling/fuzz/test packages outside production and crates.io dependency closure.
+
+## Rules
+
+If a package participates in a production build chain, it must either:
+1. Publish to crates.io, or
+2. Be collapsed into owner modules under a published crate, or
+3. Move outside production Cargo package status as external packaging glue.
+
+## Consequences
+
+- `tokmd-node` and `tokmd-python` require explicit binding-surface disposition.
+- Publish-surface checks remain dependency-closure proof, not package-count proof.

--- a/docs/adr/ADR-release-train-and-rc-semantics.md
+++ b/docs/adr/ADR-release-train-and-rc-semantics.md
@@ -1,0 +1,19 @@
+# ADR: Release Train and RC Semantics
+
+- Status: Proposed
+- Date: 2026-04-29
+
+## Context
+
+Release automation needs durable rules for RC safety and stable tag behavior.
+
+## Decision (target)
+
+Define stable vs RC semantics for tags, prerelease assets, package publishing, and channel aliases.
+
+## Required RC safeguards
+
+- RC must not move `v1`.
+- RC must not become latest.
+- RC must not publish stable Docker aliases.
+- RC crates.io publication must be explicit/opt-in.

--- a/docs/publish-surface.md
+++ b/docs/publish-surface.md
@@ -16,6 +16,17 @@ The packaging direction is explicit:
 
 This is the hard rule: publishing correctness is defined by dependency closure, not by a broad `publish = false` pass.
 
+## Production package taxonomy
+
+- **Production Rust package**: a Cargo package used to produce a user-facing or supported deliverable (CLI, library, binding, runtime artifact, or release pipeline output).
+- **Dev/tooling package**: a package used only for repository maintenance, developer workflows, or CI tooling.
+- **Fuzz/test package**: a package used only for fuzzing, property testing, fixture generation, or validation harnesses.
+- **Binding package**: a package that builds language bindings (for example npm or PyPI extension artifacts). Binding packages are production packages unless explicitly reclassified as external packaging wrappers outside production Cargo package status.
+
+### Hard invariant
+
+**No production Rust package may be `publish = false`.** Unpublished workspace packages are limited to dev/tooling/fuzz-only classes outside production and crates.io dependency closure.
+
 A published crate is a support promise. A module folder is an architecture seam.
 
 ## Publication model
@@ -107,7 +118,7 @@ compatibility target, but it is not the final product/contract/capability model.
 Support is now a compatibility classification for existing automation. It is
 not the final desired category.
 
-## Non-crates.io packages (intentional exceptions) (4)
+## Non-crates.io packages (intentional exceptions pending binding ADRs) (4)
 
 - `tokmd-fuzz`
 - `tokmd-node`
@@ -115,6 +126,8 @@ not the final desired category.
 - `xtask`
 
 **Count:** 4 non-crates.io packages.
+
+Under the strict production-publishability rule, `xtask` and `tokmd-fuzz` remain valid dev/tooling/fuzz exceptions. `tokmd-node` and `tokmd-python` require an explicit binding-surface ADR decision if they remain `publish = false`; absent that waiver, they are release blockers for stable.
 
 ## Compatibility target surface
 
@@ -160,6 +173,7 @@ decisions remain future work.
 
 ## Hard rule
 
+- No production Rust package may be `publish = false`.
 - Do not leave non-published internal crates on the production path as `publish = false` placeholders.
 - Absorb non-essential packaging noise crates into SRP module folders under the owning public crate.
 

--- a/docs/specs/browser-wasm-capability-runner-protocol.md
+++ b/docs/specs/browser-wasm-capability-runner-protocol.md
@@ -1,0 +1,14 @@
+# Spec: Browser/WASM Capability + Runner Protocol
+
+Status: Draft
+
+## Scope
+
+Defines capability matrix semantics and worker protocol expectations.
+
+## Required coverage
+
+- `browser_safe`/`rootless_safe` meanings.
+- Allowed modes/payload shapes.
+- Runner message schema (`protocolVersion`, `mode`, `args`, error shape).
+- Change-control invariant for payload widening.

--- a/docs/specs/determinism-timestamp-policy.md
+++ b/docs/specs/determinism-timestamp-policy.md
@@ -1,0 +1,13 @@
+# Spec: Determinism and Timestamp Policy
+
+Status: Draft
+
+## Scope
+
+Defines deterministic output expectations across receipts and runtime surfaces.
+
+## Required rules
+
+- Identify byte-stable outputs and allowed variability fields.
+- Prohibit silent `generated_at_ms = 0`.
+- Define snapshot normalization and version-stamping policy.

--- a/docs/specs/github-action-contract.md
+++ b/docs/specs/github-action-contract.md
@@ -1,0 +1,14 @@
+# Spec: GitHub Action Contract
+
+Status: Draft
+
+## Scope
+
+Define `action.yml` contract: inputs, outputs, modes, artifacts, permissions, and failure behavior.
+
+## Required sections
+
+- Default mode behavior.
+- Explicit mode matrix (`module`, `export`, `gate`, `cockpit`, `sensor`, `baseline`).
+- Artifact naming and retention expectations.
+- External smoke-test requirements.

--- a/docs/specs/jules-provenance-policy.md
+++ b/docs/specs/jules-provenance-policy.md
@@ -1,0 +1,13 @@
+# Spec: Jules Provenance Policy
+
+Status: Draft
+
+## Scope
+
+Defines when `.jules/**` provenance updates are expected, allowed, or disallowed.
+
+## Required rules
+
+- Intentional provenance updates are not auto-rejection grounds.
+- Accidental run-log churn in unrelated patch PRs is disallowed.
+- Migration plan required before any hard block on legacy provenance paths.

--- a/docs/specs/path-trust-model.md
+++ b/docs/specs/path-trust-model.md
@@ -1,0 +1,13 @@
+# Spec: Path Trust Model
+
+Status: Draft
+
+## Scope
+
+Defines accepted/rejected path forms and trust boundaries for native, MemFs, and FFI inputs.
+
+## Required rules
+
+- Reject absolute and parent-traversal paths.
+- Define root/rootless semantics for empty and dot paths.
+- Define diagnostics for missing and dirty-index path states.

--- a/docs/specs/publish-surface-spec.md
+++ b/docs/specs/publish-surface-spec.md
@@ -1,0 +1,22 @@
+# Spec: Publish Surface Classification
+
+Status: Draft
+
+## Purpose
+
+Machine-checkable classification for workspace package publication boundaries.
+
+## Classes
+
+- `published_crates_io`
+- `production_crates_io`
+- `production_non_crates_io`
+- `dev_tooling_only`
+- `fuzz_test_only`
+- `external_packaging_only`
+- `removed_collapsed_module`
+
+## Invariants
+
+- `production_non_crates_io` must be empty unless an ADR waiver exists.
+- Publish correctness is verified by non-dev dependency closure.


### PR DESCRIPTION
### Motivation
- Clarify and tighten workspace policy so `publish = false` cannot be used as a shortcut for production crates and to call out ambiguous binding crates that need explicit decisions.
- Fix misleading RC changelog wording that implied internal production crates can be unpublished by default.
- Provide a lightweight governance/decision skeleton so binding, publish-surface, and release semantics can be resolved with concrete ADRs/specs.

### Description
- Reworded `CHANGELOG.md` to replace the blanket "Internal crates are marked `publish = false`" line with strict production-publishability language and an explicit Node/Python binding disposition note. 
- Strengthened `docs/publish-surface.md` by adding a production package taxonomy and the hard invariant: `No production Rust package may be publish = false`, and updated non-crates.io exception wording for `tokmd-node`/`tokmd-python`.
- Added ADR skeletons under `docs/adr/` for production package publishability, crate-vs-module boundary, binding surfaces (Node/Python/WASM), and release-train/RC semantics. 
- Added spec skeletons under `docs/specs/` for publish-surface classification, GitHub Action contract, browser/WASM capability & runner protocol, path trust model, determinism/timestamp policy, and Jules provenance policy.

### Testing
- Ran `cargo xtask docs --check` which reported "Documentation is up to date." and passed. 
- Ran `cargo xtask version-consistency` which passed and confirmed workspace version alignment. 
- Ran `cargo xtask publish-surface --json` which produced a JSON audit report with an empty `violations` list. 
- Ran `git diff --check` which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2112c7f108333ad68bb1d997b171c)