### PR TITLE
docs: add ADR skeletons for publish-surface and release semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 
 - Collapsed the previous support-crate sprawl into owner crates and SRP module families, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
 - Public crate surface is now enforced around product, contract, workflow, and capability crates.
-- Internal crates are marked `publish = false`, while publish-surface verification and package-list proof treat the 16 published crates as the intentional crates.io boundary.
+- Release governance now centers on crate-surface collapse and publish-surface proof; the intentional crates.io boundary is the 16 published crates, and production-path crates are not justified by blanket `publish = false` wording.
 - GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
 - No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.

--- a/docs/adr/0000-adr-process.md
+++ b/docs/adr/0000-adr-process.md
@@ -1,0 +1,45 @@
+# ADR-0000: ADR and spec governance
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd currently records durable decisions, behavioral contracts, and release summaries across multiple documents. Some documents mix architecture rationale (why) with contract details (what/how), which makes it harder to track long-lived decisions and enforceable behavior separately.
+
+## Decision
+
+- ADRs record why a durable boundary, policy, or release rule exists.
+- Specs record the exact, testable contract and behavior.
+- Release notes, changelog entries, and roadmap material summarize delivery; they do not replace ADRs.
+
+House style for ADRs:
+
+- **Status:** `proposed` | `accepted` | `superseded` | `retired`
+- Required sections:
+  - context
+  - decision
+  - consequences
+  - alternatives
+  - enforcement
+  - related specs
+
+## Consequences
+
+- Architectural intent and policy rationale stay stable and auditable.
+- Behavioral contracts can evolve in spec docs without rewriting decision history.
+- Release communication becomes easier to verify against ADR intent and spec behavior.
+
+## Alternatives
+
+- Keep mixed ADR/spec/policy content in single docs. Rejected because it obscures rationale versus contract and makes policy drift harder to detect.
+
+## Enforcement
+
+- New durable boundary/policy decisions should be captured as ADRs under `docs/adr/`.
+- New externally consumed behavior should be captured or updated in a spec document.
+- Documentation reviews should reject major architecture or policy changes that do not include ADR/spec updates.
+
+## Related specs
+
+- `docs/publish-surface.md` (current mixed policy/spec source to progressively split).

--- a/docs/adr/0001-production-package-publishability.md
+++ b/docs/adr/0001-production-package-publishability.md
@@ -1,0 +1,51 @@
+# ADR-0001: Production package publishability
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd's publish-surface governance requires proving the intentional crates.io closure for production artifacts. Historically, release wording implied internal production crates could remain `publish = false`, which conflicts with the explicit boundary rule that non-published crates must be truly outside the production crates.io closure.
+
+## Decision
+
+Hard rule:
+
+- No production Rust package may be `publish = false`.
+
+Allowed `publish = false` exceptions:
+
+- dev-only tooling packages
+- fuzz targets
+- test harness packages
+- repo-local build/automation helpers not shipped as product artifacts
+- packaging glue that is outside the production Cargo package closure
+
+Not allowed as `publish = false`:
+
+- production library crates
+- production binding crates
+- build-chain crates required for shipped product artifacts
+- normal/build dependencies in the closure of published production crates
+
+`tokmd-node` and `tokmd-python` are explicitly in scope for binding-surface policy resolution and must be treated by ADR-0004 rather than assumed compliant by default.
+
+## Consequences
+
+- Release documentation must not imply production packages can hide behind `publish = false`.
+- Any production-package exception claim must prove that the crate is packaging glue outside production Cargo closure.
+- Binding surfaces that are production-facing require explicit architecture classification.
+
+## Alternatives
+
+- Permit production internal crates to remain unpublished indefinitely. Rejected because it weakens closure proof and breaks publish-surface policy clarity.
+
+## Enforcement
+
+- Publish-surface verification must fail if a production Rust package is `publish = false` without an ADR-backed exception model.
+- Release/changelog wording must reflect closure proof and taxonomy outcomes, not unpublished-production shorthand.
+- Binding surfaces (`tokmd-node`, `tokmd-python`) remain release-governance follow-up until ADR-0004 outcomes are implemented.
+
+## Related specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0002-crate-vs-module-boundaries.md
+++ b/docs/adr/0002-crate-vs-module-boundaries.md
@@ -1,0 +1,53 @@
+# ADR-0002: Crate vs module boundaries
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd reduced support-crate sprawl by collapsing helper crates into owner crates and SRP module families. To prevent drift back to microcrate proliferation, the project needs a durable boundary rule for when code should be a crate versus an internal module.
+
+## Decision
+
+- A crate is a public support promise.
+- A module is an internal SRP seam.
+
+A crate boundary is justified when one or more applies:
+
+- independent semver contract
+- external consumer API
+- product surface boundary
+- contract/type boundary
+- workflow boundary
+- capability boundary
+- load-bearing dependency isolation
+- published dependency-closure need
+
+A module boundary is preferred when code is:
+
+- single-owner implementation detail
+- renderer/helper/parser/adapter
+- analysis leaf logic
+- test support
+- internal SRP partition not useful independently
+
+## Consequences
+
+- Fewer crates with clearer support obligations.
+- Better internal refactoring freedom via module seams.
+- More explicit review standards for introducing new workspace crates.
+
+## Alternatives
+
+- Keep creating crates for most implementation partitions. Rejected due to governance, release, and maintenance overhead.
+
+## Enforcement
+
+- New crate proposals should include rationale mapped to crate-qualification criteria above.
+- Refactors should default to module seams unless a public support promise is required.
+- Publish-surface proof should remain aligned with intentional crate boundaries.
+
+## Related specs
+
+- `docs/architecture.md`
+- `docs/publish-surface.md`

--- a/docs/adr/0003-publish-surface-taxonomy.md
+++ b/docs/adr/0003-publish-surface-taxonomy.md
@@ -1,0 +1,46 @@
+# ADR-0003: Publish surface taxonomy
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd's crates.io boundary is now intentionally organized around product and support roles rather than legacy support-crate sprawl. A durable taxonomy is required to keep package classification, closure proof, and release governance aligned.
+
+## Decision
+
+tokmd public crates are classified as:
+
+- product
+- contract
+- workflow
+- capability
+
+Current intentional boundary includes 16 published crates:
+
+- **product:** `tokmd`, `tokmd-core`, `tokmd-wasm`
+- **contract:** `tokmd-analysis-types`, `tokmd-envelope`, `tokmd-io-port`, `tokmd-settings`, `tokmd-types`
+- **workflow:** `tokmd-cockpit`, `tokmd-gate`, `tokmd-sensor`
+- **capability:** `tokmd-analysis`, `tokmd-format`, `tokmd-git`, `tokmd-model`, `tokmd-scan`
+
+The phrase "support crate" is retired as a forward taxonomy label and retained only as compatibility wording for historical automation/migration references.
+
+## Consequences
+
+- Package purpose becomes explicit and reviewable.
+- Release closure proof is easier to audit and communicate.
+- Taxonomy drift can be detected through package-list and closure checks.
+
+## Alternatives
+
+- Keep only a flat published/unpublished package list with no role taxonomy. Rejected because it weakens architectural intent and governance clarity.
+
+## Enforcement
+
+- Publish-surface checks must verify both dependency closure and package-list membership.
+- New published crates must declare taxonomy classification at introduction time.
+- Release notes should reference boundary proof outcomes, not ad hoc labeling.
+
+## Related specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0004-binding-surfaces.md
+++ b/docs/adr/0004-binding-surfaces.md
@@ -1,0 +1,42 @@
+# ADR-0004: Binding surfaces (Node, Python, WASM)
+
+- **Status:** proposed
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd includes Rust-based bindings for Node and Python plus WASM/browser delivery. `tokmd-wasm` is in the published product set, while `tokmd-node` and `tokmd-python` currently use `publish = false`. The project needs an explicit policy distinguishing production Rust package boundaries from ecosystem packaging glue.
+
+## Decision
+
+- `tokmd-wasm` is a published product crate.
+- `tokmd-node` and `tokmd-python` are production binding packages.
+- Production Rust implementation used by bindings must be published or owned by a published crate.
+- npm/PyPI packaging glue may remain outside crates.io only when it is not a production Rust package boundary.
+
+Resolution paths for `tokmd-node`/`tokmd-python`:
+
+1. Publish binding crates to crates.io.
+2. Reclassify them as external packaging wrappers outside production Cargo closure.
+3. Move Rust implementation into an owning published crate and keep only thin packaging glue outside crates.io.
+
+## Consequences
+
+- Binding packaging decisions become explicit release-governance items.
+- Production publishability policy (ADR-0001) is applied consistently across language surfaces.
+- Current `publish = false` state for production binding packages remains an explicit follow-up until final classification is accepted and implemented.
+
+## Alternatives
+
+- Leave Node/Python binding status implicit. Rejected due to unresolved compliance with production publishability policy.
+
+## Enforcement
+
+- Release readiness requires an accepted binding-surface classification and matching package configuration.
+- Publish-surface proof must include binding closure and classification evidence.
+- Documentation and changelog language must avoid implying unresolved policy is already compliant.
+
+## Related specs
+
+- `docs/publish-surface.md`
+- `docs/capabilities/WASM.md`

--- a/docs/adr/0005-release-train-and-rc-semantics.md
+++ b/docs/adr/0005-release-train-and-rc-semantics.md
@@ -1,0 +1,48 @@
+# ADR-0005: Release train and RC semantics
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+RC release handling must prevent prerelease artifacts from being promoted as stable by tag alias movement, latest markers, or stable distribution aliases.
+
+## Decision
+
+- Package metadata uses semver prerelease notation for RCs (example: `1.10.0-rc.1`).
+- Human-facing Git tags may use forms like `v1.10.0rc1` only when action/version docs and automation are explicitly aligned to that shape.
+
+RC semantics:
+
+- RCs are prereleases.
+- RCs are not latest.
+- RCs must not move `v1` stable alias.
+- RCs must not publish stable Docker aliases.
+- RC crates.io publication is skipped unless explicitly approved.
+
+Stable release semantics:
+
+- Stable may update `v1` alias.
+- Stable may publish crates.io artifacts.
+- Stable may publish semver/latest Docker aliases.
+
+## Consequences
+
+- Consumers using stable aliases avoid accidental RC uptake.
+- Release automation behavior is consistent with documented semver and channel intent.
+- RC execution requires explicit approval for any exceptional publication behavior.
+
+## Alternatives
+
+- Treat RC and stable pipelines identically with only label changes. Rejected because it risks unstable artifacts being consumed as stable.
+
+## Enforcement
+
+- Release workflows must enforce alias and publication guards by channel.
+- Release checklists must include RC/stable channel assertions.
+- Version and docs consistency checks must validate tag/package semantics.
+
+## Related specs
+
+- `docs/reference-cli.md`
+- `CHANGELOG.md`


### PR DESCRIPTION
### Motivation
- Establish a short ADR set to record durable boundary and release decisions so rationale (ADRs) is separate from testable contracts (specs). 
- Make publish-surface policy explicit — production Rust packages must not rely on `publish = false` — and call out unresolved binding-surface decisions for Node/Python bindings. 
- Capture release/RC semantics and crate vs module boundaries as release-critical governance items so release wording and automation match policy.

### Description
- Added ADR skeletons under `docs/adr/`: `0000-adr-process.md` (ADR governance), `0001-production-package-publishability.md`, `0002-crate-vs-module-boundaries.md`, `0003-publish-surface-taxonomy.md`, `0004-binding-surfaces.md` (proposed), and `0005-release-train-and-rc-semantics.md`.
- Updated `CHANGELOG.md` to remove wording that suggested production-path crates could be justified by blanket `publish = false` and replaced it with crate-surface collapse + publish-surface proof language.
- No runtime or behavioral code changes were made; these are documentation and governance artifacts only.

### Testing
- Ran `cargo xtask docs --check` and it reported documentation is up to date (passed).
- Ran `cargo xtask version-consistency` and all version consistency checks passed (passed).
- Ran `cargo xtask publish-surface --json` which produced the publish-surface summary with no violations (passed).
- Ran `git diff --check` and repository checks returned clean (no whitespace/trailing-diff issues) (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f212cd23cc83338bf4a575cf21d518)