### PR TITLE
docs: add ADR skeletons for publishability, crate boundaries, bindings, and RC semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 
 - Collapsed the previous support-crate sprawl into owner crates and SRP module families, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
 - Public crate surface is now enforced around product, contract, workflow, and capability crates.
-- Internal crates are marked `publish = false`, while publish-surface verification and package-list proof treat the 16 published crates as the intentional crates.io boundary.
+- Crate-surface collapse is complete, and publish-surface verification plus package-list proof treat the 16 published crates as the intentional crates.io boundary.
 - GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
 - No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.

--- a/docs/adr/0000-adr-process.md
+++ b/docs/adr/0000-adr-process.md
@@ -1,0 +1,45 @@
+# ADR-0000: ADR and Spec Governance
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd has durable architectural decisions, policy decisions, and contract-level behavior spread across release notes, roadmap notes, and implementation docs. This mixes decision rationale with executable specification details.
+
+## Decision
+
+- ADRs record **why** durable boundaries, policies, or release rules were chosen.
+- Specs record the **testable contract** and exact behavior.
+- Release docs and roadmap docs summarize outcomes; they do not replace ADRs.
+
+House style for ADRs:
+
+- Status: `proposed | accepted | superseded | retired`
+- Required sections:
+  - context
+  - decision
+  - consequences
+  - alternatives
+  - enforcement
+  - related specs
+
+## Consequences
+
+- Architecture rationale is searchable, durable, and reviewable.
+- Contract details stay in specs and tests instead of ADR prose.
+- Future release notes can reference ADR IDs rather than re-stating policy decisions.
+
+## Alternatives
+
+- Keep policy/rationale in mixed docs (rejected: causes drift and ambiguity).
+- Put all architecture in one large design document (rejected: weak decision history).
+
+## Enforcement
+
+- New durable policy or boundary changes should include ADR updates.
+- PR review checks that behavior contracts are in specs/tests, not only in ADR text.
+
+## Related Specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0001-production-package-publishability.md
+++ b/docs/adr/0001-production-package-publishability.md
@@ -1,0 +1,54 @@
+# ADR-0001: Production Package Publishability
+
+- **Status:** proposed
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd's publish-surface policy requires crates.io closure integrity for production packages. `publish = false` is valid only when a package is truly outside that closure.
+
+## Decision
+
+Hard rule:
+
+- No production Rust package may be `publish = false`.
+
+Allowed `publish = false` categories:
+
+- dev-only tooling packages
+- fuzz targets
+- test harness packages
+- repo-local xtask/build helpers not shipped as product
+- external packaging glue that is outside the production Cargo dependency closure
+
+Not allowed as `publish = false`:
+
+- production library crates
+- production binding crates
+- build-chain crates required for shipped product artifacts
+- normal/build dependencies of published crates
+
+Explicit binding-surface decision required:
+
+- `tokmd-node` and `tokmd-python` currently require explicit classification and policy resolution under ADR-0004.
+
+## Consequences
+
+- Publishability becomes enforceable policy, not release-note interpretation.
+- The workspace must not rely on non-published production Rust packages.
+- Binding packages must be published, reclassified as non-production glue, or refactored so production Rust code is owned by published crates.
+
+## Alternatives
+
+- Broadly allow production packages to remain `publish = false` (rejected: breaks closure guarantees).
+- Treat publishability as best-effort release hygiene (rejected: not reliable for dependency consumers).
+
+## Enforcement
+
+- `cargo xtask publish-surface --json --verify-publish` is release-gate evidence.
+- Changelog/release notes must not claim production internal crates are intentionally non-published placeholders.
+- ADR-0004 must resolve binding-package classification for Node/Python.
+
+## Related Specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0002-crate-vs-module-boundaries.md
+++ b/docs/adr/0002-crate-vs-module-boundaries.md
@@ -1,0 +1,52 @@
+# ADR-0002: Crate vs Module Boundaries
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd recently collapsed support-crate sprawl into owner crates and module families. To prevent drift back to microcrate proliferation, crate boundaries need explicit policy.
+
+## Decision
+
+- A crate is a public support promise.
+- A module folder is an internal SRP architecture seam.
+
+A crate earns its boundary when it carries one or more of:
+
+- independent semver contract
+- external consumer API
+- product surface
+- contract/type boundary
+- workflow boundary
+- capability boundary
+- load-bearing dependency isolation
+- published dependency closure need
+
+A module seam is preferred for:
+
+- single-owner implementation details
+- renderer/helper/parser/adapter internals
+- analysis leaves
+- test support code
+- internal SRP partitions not intended as external promises
+
+## Consequences
+
+- New crates require explicit justification as support promises.
+- Internal structure can evolve via modules without expanding publish-surface scope.
+- The 16 published-crate boundary remains intentional rather than accidental.
+
+## Alternatives
+
+- Keep creating microcrates for internal SRP splits (rejected: increases surface and release burden).
+- Collapse all crates into one package (rejected: loses useful boundary contracts).
+
+## Enforcement
+
+- New crate proposals should document boundary reason and external contract.
+- Publish-surface verification and package list review must reflect intentional crate taxonomy.
+
+## Related Specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0003-publish-surface-taxonomy.md
+++ b/docs/adr/0003-publish-surface-taxonomy.md
@@ -1,0 +1,46 @@
+# ADR-0003: Publish Surface Taxonomy
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd's crates.io boundary is now intentionally structured and must be preserved as a stable public package surface.
+
+## Decision
+
+Public crates are classified as:
+
+- product
+- contract
+- workflow
+- capability
+
+Current intentional crates.io boundary is 16 published crates:
+
+- product: `tokmd`, `tokmd-core`, `tokmd-wasm`
+- contract: `tokmd-analysis-types`, `tokmd-envelope`, `tokmd-io-port`, `tokmd-settings`, `tokmd-types`
+- workflow: `tokmd-cockpit`, `tokmd-gate`, `tokmd-sensor`
+- capability: `tokmd-analysis`, `tokmd-format`, `tokmd-git`, `tokmd-model`, `tokmd-scan`
+
+`support crate` is retired as a forward-looking category and may remain only as a compatibility label for legacy automation.
+
+## Consequences
+
+- Crate classification is explicit and reviewable.
+- Boundary changes require deliberate policy updates.
+- Closure proof and package-list proof become the source of truth for release readiness.
+
+## Alternatives
+
+- Keep informal category naming in release notes only (rejected: ambiguous enforcement).
+- Keep `support crate` as an active category (rejected: revives sprawl framing).
+
+## Enforcement
+
+- `cargo xtask publish-surface --json` and package-list proof are release evidence.
+- Taxonomy changes require ADR/spec updates in the same change set.
+
+## Related Specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0004-binding-surfaces.md
+++ b/docs/adr/0004-binding-surfaces.md
@@ -1,0 +1,38 @@
+# ADR-0004: Binding Surfaces (Node, Python, WASM)
+
+- **Status:** proposed
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd ships multiple binding surfaces with different packaging ecosystems. Rust package publishability policy must remain consistent with production-boundary rules.
+
+## Decision
+
+- `tokmd-wasm` is a published product crate.
+- Node/Python bindings are production binding surfaces.
+- Production Rust implementation used by bindings must be published or owned by a published crate.
+- npm/PyPI packaging glue may remain outside crates.io only when it is not a production Rust package boundary.
+
+Open policy resolution tracked by this ADR:
+
+- classify `tokmd-node` and `tokmd-python` as crates.io-published production Rust packages, **or**
+- reclassify them as ecosystem packaging glue outside the production Cargo closure while moving production Rust implementation behind published crate boundaries.
+
+## Consequences
+
+- Binding packaging is explicit instead of a `publish = false` gray zone.
+- Release train can reason consistently about production surfaces across Cargo, npm, and PyPI.
+
+## Alternatives
+
+- Keep Node/Python production Rust crates non-published without formal exception (rejected).
+
+## Enforcement
+
+- Binding package classification must be documented and reflected in publish-surface verification.
+- Release readiness requires closure-safe binding surface decisions.
+
+## Related Specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0005-release-train-and-rc-semantics.md
+++ b/docs/adr/0005-release-train-and-rc-semantics.md
@@ -1,0 +1,45 @@
+# ADR-0005: Release Train and RC Semantics
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+Release-candidate handling must not blur stable-channel guarantees. RC tags and artifact publication semantics need explicit rules.
+
+## Decision
+
+- Package metadata uses semver prerelease for RCs (for example `1.10.0-rc.1`).
+- If a human-facing Git tag form is used (for example `v1.10.0rc1`), automation and docs must match it exactly.
+
+RC releases:
+
+- are prereleases
+- are not latest
+- do not move `v1`
+- do not publish stable Docker aliases
+- skip crates.io publication unless explicitly approved
+
+Stable releases:
+
+- may update `v1`
+- may publish crates.io
+- may publish stable Docker aliases
+
+## Consequences
+
+- External consumers do not accidentally consume RC content as stable.
+- Release artifacts have predictable channel semantics.
+
+## Alternatives
+
+- Treat RC tags as stable aliases (rejected: high risk of accidental promotion).
+
+## Enforcement
+
+- Release automation must gate alias movement and prerelease flags by channel.
+- Release review verifies RC/stable behavior before promotion.
+
+## Related Specs
+
+- `docs/publish-surface.md`


### PR DESCRIPTION
### Motivation
- Provide a concise ADR set to separate durable architectural decisions from specs and release notes.
- Make the publish-surface rule explicit so `publish = false` is not used for production Rust packages.
- Surface unresolved binding packaging decisions (Node/Python) so they are resolved by policy rather than release wording.

### Description
- Add ADR skeletons under `docs/adr/`: `0000-adr-process.md`, `0001-production-package-publishability.md`, `0002-crate-vs-module-boundaries.md`, `0003-publish-surface-taxonomy.md`, `0004-binding-surfaces.md`, and `0005-release-train-and-rc-semantics.md` documenting governance, publishability, crate/module policy, taxonomy, binding-surface policy, and RC semantics.
- Update `CHANGELOG.md` to remove wording that implied production internal crates can remain `publish = false` and instead state the crate-surface collapse and publish-surface/package-list proof as the intentional boundary.
- Mark `tokmd-node` and `tokmd-python` as open policy items in ADR-0001/ADR-0004 requiring classification (publish or reclassify as packaging glue) without changing runtime behavior.
- No code or runtime behavior was modified; this change is documentation and policy only.

### Testing
- Ran `cargo xtask docs --check` which reported "Documentation is up to date." and succeeded.
- Ran `cargo xtask version-consistency` which passed all workspace version checks.
- Ran `cargo xtask publish-surface --json` which produced a publish-surface report with no violations.
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f212cd23cc83338bf4a575cf21d518)