### PR TITLE
docs: add release-critical ADR skeletons and fix publish=false changelog wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 
 - Collapsed the previous support-crate sprawl into owner crates and SRP module families, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
 - Public crate surface is now enforced around product, contract, workflow, and capability crates.
-- Internal crates are marked `publish = false`, while publish-surface verification and package-list proof treat the 16 published crates as the intentional crates.io boundary.
+- Release documentation now treats the crate-surface collapse and publish-surface/package-list proof as the boundary evidence; production-path crates are not justified by `publish = false` placeholders.
 - GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
 - No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.

--- a/docs/adr/0000-adr-process.md
+++ b/docs/adr/0000-adr-process.md
@@ -1,0 +1,39 @@
+# ADR-0000: ADR and Spec Governance
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd currently carries architectural rationale, contract details, and release notes across multiple docs. This makes it hard to tell whether a statement is a durable decision (`why`) or a testable interface (`what`).
+
+## Decision
+
+- ADRs record **why** a durable boundary, policy, or release rule was chosen.
+- Specs record the **testable contract** and exact behavior.
+- Release notes, changelog entries, and roadmap notes summarize outcomes but do not replace ADRs/specs.
+
+ADR house style in this repository:
+
+- **Status:** `proposed | accepted | superseded | retired`
+- **Sections:** `context`, `decision`, `consequences`, `alternatives`, `enforcement`, `related specs`
+
+## Consequences
+
+- Architecture intent becomes discoverable without reading changelog prose.
+- Specs can stay implementation-facing and test-oriented.
+- Future architectural changes must include rationale updates.
+
+## Alternatives
+
+- Keep a single mixed architecture document for rationale + behavior + release narrative.
+- Encode rationale only in commit history and PR discussions.
+
+## Enforcement
+
+- New durable architecture policies should ship with a corresponding ADR.
+- Contract changes should update specs and tests, not ADRs alone.
+
+## Related Specs
+
+- `docs/specs/*` (to be introduced/maintained for behavior contracts)

--- a/docs/adr/0001-production-package-publishability.md
+++ b/docs/adr/0001-production-package-publishability.md
@@ -1,0 +1,50 @@
+# ADR-0001: Production Package Publishability
+
+- **Status:** proposed
+- **Date:** 2026-04-29
+
+## Context
+
+`docs/publish-surface.md` establishes that `publish = false` is valid only for crates truly outside the crates.io dependency closure. The release/changelog wording must not imply production packages can remain unpublished placeholders on the production path.
+
+## Decision
+
+**Hard rule:** no production Rust package may be `publish = false`.
+
+Allowed `publish = false` categories:
+
+- dev-only tooling
+- fuzz targets
+- test harness packages
+- repo-local xtask/build helpers not shipped as product
+- external packaging glue outside the production Cargo package closure
+
+Not allowed for `publish = false`:
+
+- production library crates
+- production binding crates
+- build-chain crates required for shipped product artifacts
+- normal/build dependencies of published crates
+
+`tokmd-node` and `tokmd-python` are production binding packages today and require explicit binding-surface resolution (see ADR-0004) if they remain `publish = false`.
+
+## Consequences
+
+- Publish-surface checks become policy enforcement, not documentation only.
+- Production package boundaries must be explicit and auditable.
+- Binding packaging decisions become release-governance decisions.
+
+## Alternatives
+
+- Allow internal production crates to remain `publish = false` if release automation can still produce artifacts.
+- Keep publishability as a best-effort convention with no hard fail conditions.
+
+## Enforcement
+
+- `cargo xtask publish-surface --json` and package-list proof remain required release evidence.
+- Production closure audits must fail if unpublished crates are required on production paths.
+
+## Related Specs
+
+- `docs/publish-surface.md`
+- `docs/specs/publish-surface.md` (planned)

--- a/docs/adr/0002-crate-vs-module-boundaries.md
+++ b/docs/adr/0002-crate-vs-module-boundaries.md
@@ -1,0 +1,54 @@
+# ADR-0002: Crate vs Module Boundaries
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd intentionally collapsed support-crate sprawl into owner crates with SRP-oriented internal modules. Boundary drift can re-introduce microcrate overhead unless the crate/module distinction is explicit.
+
+## Decision
+
+- A **crate** is a public support promise.
+- A **module** is an internal SRP architecture seam.
+
+A crate boundary is justified when one or more apply:
+
+- independent semver contract
+- external consumer API
+- product surface
+- contract/type boundary
+- workflow boundary
+- capability boundary
+- load-bearing dependency isolation
+- published dependency-closure need
+
+A module boundary is preferred for:
+
+- single-owner implementation details
+- renderer/helper/parser/adapter internals
+- analysis leaves
+- test support
+- internal SRP seams
+- code not meant as independent public promise
+
+## Consequences
+
+- Crate count remains intentional rather than incidental.
+- Internal architecture can evolve quickly without creating new support promises.
+- Release documentation can reference crate classes consistently.
+
+## Alternatives
+
+- Keep adding microcrates for local separation-of-concerns only.
+- Merge all crates aggressively into a monolith regardless of external contract boundaries.
+
+## Enforcement
+
+- New crate proposals must state contract/consumer/dependency-closure reasons.
+- Refactors default to modules unless crate-level criteria are met.
+
+## Related Specs
+
+- `docs/publish-surface.md`
+- `docs/architecture.md`

--- a/docs/adr/0003-publish-surface-taxonomy.md
+++ b/docs/adr/0003-publish-surface-taxonomy.md
@@ -1,0 +1,42 @@
+# ADR-0003: Publish-Surface Taxonomy
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+
+## Context
+
+tokmd publishes an intentional crates.io surface and keeps non-crates.io packages outside that closure. A stable taxonomy is needed so public surface planning and verification stay aligned.
+
+## Decision
+
+tokmd public crates are classified as:
+
+- **product**
+- **contract**
+- **workflow**
+- **capability**
+
+Current intentional boundary: **16 published crates** (+ 4 non-crates.io packages tracked separately).
+
+`support crate` is retired as a forward-facing category and retained only as a compatibility label for legacy automation.
+
+## Consequences
+
+- Release audits can verify category coverage and closure intent.
+- Stakeholders can reason about boundary changes by class.
+- Historical “support crate” naming no longer drives new design decisions.
+
+## Alternatives
+
+- Keep an untyped published crate list.
+- Continue using “support crate” as a primary architecture bucket.
+
+## Enforcement
+
+- Publish-surface verification requires closure proof plus package-list proof.
+- Taxonomy updates require documentation updates in publish-surface references.
+
+## Related Specs
+
+- `docs/publish-surface.md`
+- `docs/specs/publish-surface.md` (planned)

--- a/docs/adr/0004-binding-surfaces.md
+++ b/docs/adr/0004-binding-surfaces.md
@@ -1,0 +1,41 @@
+# ADR-0004: Binding Surfaces (Node, Python, WASM)
+
+- **Status:** proposed
+- **Date:** 2026-04-29
+
+## Context
+
+`tokmd-wasm`, `tokmd-node`, and `tokmd-python` are production binding surfaces, but Node/Python Cargo packages are currently `publish = false`. The repository needs a durable rule for binding-package ownership and release classification.
+
+## Decision
+
+- `tokmd-wasm` is a published product crate.
+- Node and Python are production binding packages.
+- Production Rust implementation used by bindings must be published or owned by a published crate.
+- npm/PyPI packaging glue may stay outside crates.io **only** when it is not a production Rust package boundary.
+
+Required outcome for Node/Python binding surfaces:
+
+1. publish `tokmd-node` / `tokmd-python` to crates.io, or
+2. reclassify them as external packaging wrappers outside production Cargo closure, or
+3. move production Rust implementation into an owning published crate and keep only packaging glue external.
+
+## Consequences
+
+- Eliminates ambiguous “production but unpublished” binding-package state.
+- Makes RC/stable release planning for bindings explicit.
+- Tightens closure guarantees for language-ecosystem bindings.
+
+## Alternatives
+
+- Keep current state where production binding packages stay `publish = false` with informal exceptions.
+
+## Enforcement
+
+- Binding release plan must identify Cargo closure class and publishability outcome.
+- Publish-surface checks and release documentation must agree on classification.
+
+## Related Specs
+
+- `docs/publish-surface.md`
+- `docs/specs/publish-surface.md` (planned)

--- a/docs/adr/0005-release-train-and-rc-semantics.md
+++ b/docs/adr/0005-release-train-and-rc-semantics.md
@@ -1,0 +1,46 @@
+# ADR-0005: Release Train and RC Semantics
+
+- **Status:** proposed
+- **Date:** 2026-04-29
+
+## Context
+
+`v1.10.0rc1` surfaced ambiguity around prerelease tagging, channel aliases, and publication rules. tokmd needs explicit RC/stable semantics to prevent accidental promotion.
+
+## Decision
+
+- Package metadata uses semver prerelease format (example: `1.10.0-rc.1`).
+- Human-facing Git tags may use `v1.10.0rc1` only when release automation/docs map it consistently.
+
+RC rules:
+
+- mark as prerelease
+- do not mark as latest
+- do not move `v1`
+- do not publish stable Docker aliases
+- skip crates.io publishing unless explicitly approved
+
+Stable rules:
+
+- may move `v1`
+- may publish crates.io
+- may publish Docker semver/latest aliases
+
+## Consequences
+
+- Prevents RC consumption through stable alias paths.
+- Reduces accidental downstream breakage from prerelease promotion.
+- Aligns Cargo/package semantics and release automation behavior.
+
+## Alternatives
+
+- Treat RC and stable tags identically in channel movement and alias publication.
+
+## Enforcement
+
+- Release workflow guards must enforce RC/stable policy divergence.
+- Release checklist must record alias/tag/publish decisions explicitly.
+
+## Related Specs
+
+- `docs/specs/release-train.md` (planned)


### PR DESCRIPTION
### Motivation

- Separate durable architectural decisions (ADRs) from testable interface specs to avoid mixing rationale, contracts, and release prose. 
- Make publish-surface policy explicit so `publish = false` cannot be used to hide production-path crates without an ADR-level decision. 
- Capture binding, crate/module, and RC semantics decisions exposed by recent release work and the `v1.10.0rc1` ambiguity. 

### Description

- Add ADR governance and initial ADR skeletons under `docs/adr/`: `0000-adr-process.md`, `0001-production-package-publishability.md`, `0002-crate-vs-module-boundaries.md`, `0003-publish-surface-taxonomy.md`, `0004-binding-surfaces.md`, and `0005-release-train-and-rc-semantics.md`. 
- Make a hard-rule draft in `ADR-0001` that no production Rust package may be `publish = false` and call out `tokmd-node` and `tokmd-python` as binding-surface decision points pending ADR-0004. 
- Update `CHANGELOG.md` wording to remove the implication that production-path crates are justified by `publish = false` and instead describe the crate-surface collapse and publish-surface/package-list proof as the boundary evidence. 
- No runtime code changes or behavioral changes were made. 

### Testing

- Ran `cargo xtask docs --check` and it reported "Documentation is up to date." (success). 
- Ran `cargo xtask version-consistency` and it passed version checks against workspace version `1.10.0-rc.1` (success). 
- Ran `cargo xtask publish-surface --json` and the produced JSON reported the public/support/non-crates-io surfaces with no violations (success). 
- Ran `git diff --check` to validate whitespace/checks and it completed with no issues (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f212cd23cc83338bf4a575cf21d518)