### PR TITLE
docs: add ADR skeletons for publish-surface, bindings, and release semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 
 - Collapsed the previous support-crate sprawl into owner crates and SRP module families, including analysis leaf crates, rendering helpers, content/walk/fun/substrate helpers, and tool-schema helpers.
 - Public crate surface is now enforced around product, contract, workflow, and capability crates.
-- Internal crates are marked `publish = false`, while publish-surface verification and package-list proof treat the 16 published crates as the intentional crates.io boundary.
+- Release work completed crate-surface collapse and publish-surface verification, with package-list proof treating the 16 published crates as the intentional crates.io boundary (without treating production crates as `publish = false` placeholders).
 - GitHub Action omitted mode continues the legacy module + export behavior, while explicit modes run one surface at a time.
 - CLI reference docs are generated through checked `HELP` markers instead of manually maintained flag tables.
 - No-default-features integration tests are feature-gated so the CLI test matrix respects optional analysis-dependent commands.

--- a/docs/adr/0000-adr-process.md
+++ b/docs/adr/0000-adr-process.md
@@ -1,0 +1,47 @@
+# ADR-0000: ADR and specification governance
+
+- Status: accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd documentation has mixed architectural rationale with behavior-level specification text. This makes it hard to distinguish durable decision intent from testable contract details.
+
+## Decision
+
+- ADRs record why a durable architecture, boundary, policy, or release decision was made.
+- Specs record exact, testable contract behavior and validation rules.
+- Release notes, changelogs, and roadmaps summarize outcomes but do not replace ADRs.
+
+House style for ADRs in this repository:
+
+- Status: `proposed | accepted | superseded | retired`
+- Sections:
+  - context
+  - decision
+  - consequences
+  - alternatives
+  - enforcement
+  - related specs
+
+## Consequences
+
+- Architecture rationale remains concise and discoverable.
+- Contract details move to dedicated specs where they can be tested and versioned.
+- Mixed “policy/spec/changelog” documents are reduced over time.
+
+## Alternatives
+
+- Keep mixed narrative docs for all architecture and behavior guidance.
+- Keep decisions only in release notes.
+
+Both alternatives were rejected because they obscure decision provenance and testability.
+
+## Enforcement
+
+- New durable architecture or release-governance decisions must land as ADRs.
+- Behavior-level details referenced by ADRs should be documented in specs and validated by checks/tests where applicable.
+
+## Related specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0001-production-package-publishability.md
+++ b/docs/adr/0001-production-package-publishability.md
@@ -1,0 +1,51 @@
+# ADR-0001: Production package publishability
+
+- Status: accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd maintains a publish-surface policy that defines crates.io closure correctness by dependency closure and package-list proof. The repository must avoid treating `publish = false` as a blanket mechanism for production package boundaries.
+
+## Decision
+
+Hard rule: **no production Rust package may be `publish = false`**.
+
+Allowed `publish = false` classes:
+
+- dev-only tooling packages
+- fuzz targets and fuzz harness packages
+- test harness-only packages
+- repository-local build/automation helpers (for example `xtask`) that are not production product artifacts
+- external packaging glue that is outside the production Cargo dependency closure
+
+Not allowed `publish = false` classes:
+
+- production library crates
+- production binding crates
+- build-chain crates required for shipped product artifacts
+- normal/build dependencies in the closure of published crates
+
+`tokmd-node` and `tokmd-python` are treated as production binding surfaces and require explicit treatment under binding-surface policy (ADR-0004).
+
+## Consequences
+
+- Publishability governance is explicit and enforceable.
+- `publish = false` remains a narrow exception mechanism, not a production placeholder.
+- Binding surfaces that remain non-crates.io must be justified as packaging glue outside production Cargo closure.
+
+## Alternatives
+
+- Allow production internal crates to remain `publish = false` indefinitely.
+- Use category labels alone without closure verification.
+
+Both alternatives were rejected because they allow policy drift and ambiguous production boundaries.
+
+## Enforcement
+
+- Keep publish-surface closure verification and package-list proof in release checks.
+- Reject new production packages that use `publish = false` without explicit ADR-backed exception handling.
+
+## Related specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0002-crate-vs-module-boundaries.md
+++ b/docs/adr/0002-crate-vs-module-boundaries.md
@@ -1,0 +1,54 @@
+# ADR-0002: Crate vs module boundaries
+
+- Status: accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd historically reduced support-crate sprawl by collapsing helper microcrates into owner crates and SRP-focused module families. The project needs a durable rule for when code should be a crate versus a module seam.
+
+## Decision
+
+- A crate is a public support promise boundary.
+- A module is an internal SRP implementation seam.
+
+A crate boundary is warranted when one or more of the following are true:
+
+- independent semver contract
+- external consumer API
+- product surface boundary
+- contract/type boundary
+- workflow boundary
+- capability boundary
+- load-bearing dependency isolation
+- published dependency closure requirement
+
+A module boundary is preferred when code is:
+
+- single-owner implementation detail
+- renderer/helper/parser/adapter logic
+- analysis leaf implementation
+- test support
+- internal SRP seam not meant as public support promise
+
+## Consequences
+
+- Crate proliferation is constrained.
+- Internal architecture remains modular without increasing public package surface.
+- The 16-crate published boundary remains deliberate rather than incidental.
+
+## Alternatives
+
+- Keep creating microcrates for most SRP seams.
+- Collapse most seams into large monolithic crates.
+
+Both alternatives were rejected in favor of deliberate crate boundaries plus internal SRP modules.
+
+## Enforcement
+
+- New crates require justification against crate criteria.
+- Refactors should prefer internal module seams unless external/public boundary value is clear.
+
+## Related specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0003-publish-surface-taxonomy.md
+++ b/docs/adr/0003-publish-surface-taxonomy.md
@@ -1,0 +1,50 @@
+# ADR-0003: Publish-surface taxonomy
+
+- Status: accepted
+- Date: 2026-04-29
+
+## Context
+
+tokmd’s public crates.io footprint is intentionally classified and validated. The repository currently treats 16 published crates as the deliberate crates.io boundary, with additional non-crates.io packages outside that closure.
+
+## Decision
+
+tokmd public crates are classified as:
+
+- product
+- contract
+- workflow
+- capability
+
+Current intentional taxonomy:
+
+- product: `tokmd`, `tokmd-core`, `tokmd-wasm`
+- contract: `tokmd-analysis-types`, `tokmd-envelope`, `tokmd-io-port`, `tokmd-settings`, `tokmd-types`
+- workflow: `tokmd-cockpit`, `tokmd-gate`, `tokmd-sensor`
+- capability: `tokmd-analysis`, `tokmd-format`, `tokmd-git`, `tokmd-model`, `tokmd-scan`
+
+The 16 published crates are the current intentional crates.io boundary.
+
+The “support crate” label is retained only as a compatibility term for historical automation and not as a forward architecture category.
+
+## Consequences
+
+- Public package intent is explicit.
+- Surface governance can be validated by closure proof and package-list proof.
+- Category drift is reduced.
+
+## Alternatives
+
+- Treat all crates as a flat category.
+- Keep “support crate” as a primary forward taxonomy bucket.
+
+Both alternatives were rejected because they blur release intent and governance.
+
+## Enforcement
+
+- Maintain publish-surface verification in release gates.
+- Require taxonomy updates when adding/removing public crates.
+
+## Related specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0004-binding-surfaces.md
+++ b/docs/adr/0004-binding-surfaces.md
@@ -1,0 +1,43 @@
+# ADR-0004: Binding surfaces (Node, Python, WASM)
+
+- Status: proposed
+- Date: 2026-04-29
+
+## Context
+
+tokmd includes Node, Python, and WASM binding surfaces with differing packaging and distribution mechanics. Current `publish = false` state for Node/Python Cargo packages requires explicit production-boundary policy.
+
+## Decision
+
+- `tokmd-wasm` is a published product crate.
+- Node and Python bindings are production binding surfaces.
+- Production Rust implementation used by bindings must be published on crates.io or owned by a published crate.
+- npm/PyPI packaging glue may remain outside crates.io only if it is not a production Rust package boundary in the production Cargo closure.
+
+Required resolution for Node/Python surfaces:
+
+1. publish `tokmd-node`/`tokmd-python` crates, or
+2. reclassify them as packaging wrappers outside production Cargo closure, or
+3. move production Rust implementation into owning published crates and keep only packaging glue outside crates.io.
+
+## Consequences
+
+- Eliminates ambiguity for binding publishability.
+- Aligns bindings with ADR-0001 publishability policy.
+- May require packaging refactors before stable release closure.
+
+## Alternatives
+
+- Keep binding package status implicit and unresolved.
+- Allow production binding crates to remain non-published by default.
+
+Both alternatives were rejected due to policy ambiguity.
+
+## Enforcement
+
+- Binding releases must document which resolution path is used.
+- Publish-surface checks and release notes must reflect binding policy status.
+
+## Related specs
+
+- `docs/publish-surface.md`

--- a/docs/adr/0005-release-train-and-rc-semantics.md
+++ b/docs/adr/0005-release-train-and-rc-semantics.md
@@ -1,0 +1,50 @@
+# ADR-0005: Release train and RC semantics
+
+- Status: accepted
+- Date: 2026-04-29
+
+## Context
+
+`v1.10.0-rc.1` surfaced risk around prerelease tags, moving major aliases, and stable-channel publication behavior. Release train semantics need explicit durable policy.
+
+## Decision
+
+- Package metadata uses semver prerelease format for release candidates (example: `1.10.0-rc.1`).
+- Git tags use the matching hyphenated prerelease form (example: `v1.10.0-rc.1`).
+- Non-hyphenated RC tags such as `v1.10.0rc1` are not release-train tags unless automation is explicitly updated to classify them as prereleases.
+
+RC releases:
+
+- are prereleases
+- are not latest
+- do not move `v1`
+- do not publish stable Docker aliases
+- skip crates.io publication unless explicitly approved
+
+Stable releases:
+
+- may move `v1`
+- may publish crates.io artifacts
+- may publish stable Docker aliases (including semver/latest rules)
+
+## Consequences
+
+- Prevents RC channel leakage into stable consumption paths.
+- Makes alias/tag behavior predictable across GitHub and Docker ecosystems.
+- Reduces accidental prerelease promotion risk.
+
+## Alternatives
+
+- Treat RC and stable release trains identically.
+- Allow RC tags to update stable aliases by default.
+
+Both alternatives were rejected due to high distribution risk.
+
+## Enforcement
+
+- Release automation must enforce RC/stable behavior differences.
+- Version and release docs must match tag and package semantics.
+
+## Related specs
+
+- `docs/publish-surface.md`


### PR DESCRIPTION
### Motivation

- Provide a short, discoverable ADR set so architecture decisions (why) are separated from specs (what/testable behavior). 
- Make publishability policy explicit because `publish = false` must not be used as a blanket placeholder for production crates. 
- Clarify binding and release semantics because `tokmd-node` / `tokmd-python` publish status is ambiguous and RC behavior previously risked leaking into stable channels.

### Description

- Add ADR skeleton files `docs/adr/0000-adr-process.md` through `docs/adr/0005-release-train-and-rc-semantics.md` implementing ADR governance and the first release-blocking decisions. 
- `ADR-0001` enforces the hard rule that no production Rust package may be `publish = false` and enumerates allowed exceptions; `ADR-0004` records the required resolution paths for Node/Python bindings. 
- `ADR-0002` and `ADR-0003` codify crate-vs-module boundaries and the publish-surface taxonomy, and `ADR-0005` establishes RC vs stable release semantics. 
- Update `CHANGELOG.md` wording to remove the implication that production internal crates can remain `publish = false` placeholders and reflect the crate-surface collapse and publish-surface verification.

### Testing

- Ran `cargo xtask docs --check` which completed and reported “Documentation is up to date.”
- Ran `cargo xtask version-consistency` which passed the workspace version checks. 
- Ran `cargo xtask publish-surface --json` which produced a publish-surface summary and reported no violations. 
- Ran `git diff --check` (and repository validation steps) with no blocking issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f212cd23cc83338bf4a575cf21d518)