### PR TITLE
compat: fix feature gate for analyze tests 📎

### DIFF
--- a/crates/tokmd/tests/cli_snapshot_golden.rs
+++ b/crates/tokmd/tests/cli_snapshot_golden.rs
@@ -210,6 +210,7 @@ fn snapshot_export_csv() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[cfg(feature = "analysis")]
 fn snapshot_analyze_json() {
     let output = tokmd_cmd()
         .args([
@@ -224,6 +225,7 @@ fn snapshot_analyze_json() {
 }
 
 #[test]
+#[cfg(feature = "analysis")]
 fn snapshot_analyze_markdown() {
     let output = tokmd_cmd()
         .args([

--- a/crates/tokmd/tests/determinism.rs
+++ b/crates/tokmd/tests/determinism.rs
@@ -636,6 +636,7 @@ fn export_csv_consistent_column_count() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[cfg(feature = "analysis")]
 fn run_receipt_is_deterministic_across_runs() {
     let temp1 = tempfile::tempdir().unwrap();
     let temp2 = tempfile::tempdir().unwrap();
@@ -662,6 +663,7 @@ fn run_receipt_is_deterministic_across_runs() {
 }
 
 #[test]
+#[cfg(feature = "analysis")]
 fn diff_receipt_is_deterministic_across_runs() {
     let temp = tempfile::tempdir().unwrap();
     let run1_dir = temp.path().join("run1");


### PR DESCRIPTION
## 💡 Summary 
Fixed a compatibility issue in integration tests where tests reliant on the `analyze` subcommand would panic and fail when run with `--no-default-features`. I added the `#[cfg(feature = "analysis")]` feature-gate at the individual test function level to properly conditionally compile only the tests that need it in `cli_snapshot_golden.rs` and `determinism.rs`.

## 🎯 Why 
During cross-toolchain and compatibility matrix testing, `cargo test -p tokmd --no-default-features` was reporting false-negative failures because standard integration tests executing CLI subcommands (like `analyze`) require the `analysis` optional feature. Adding the `#[cfg(feature = "analysis")]` conditionally prevents these specific tests from attempting to test omitted subcommands while allowing the rest of the test suite to verify core functionality correctly.

## 🔎 Evidence 
- `crates/tokmd/tests/cli_snapshot_golden.rs`
- `crates/tokmd/tests/determinism.rs`
- Observed `cargo test -p tokmd --no-default-features` failed on tests like `snapshot_analyze_json` and `run_receipt_is_deterministic_across_runs` (which invokes `analyze` via `tokmd run`).

## 🧭 Options considered 
### Option A (recommended) 
- Use function-level `#[cfg(feature = "analysis")]` in the affected integration tests.
- Why it fits this repo and shard: It stops testing logic that specifically depends on optional features not present, addressing the false-positive integration failures for standard matrix runs while preserving the test suite's efficacy for the rest of the crate's logic.
- Trade-offs: Structure / Velocity / Governance: Excellent. Standard Rust idiom for dealing with optional features.

### Option B 
- Refactor the tests to skip or ignore dynamically during test execution when subcommands error with "Error: analysis feature is not enabled".
- When to choose it instead: If the test harness must always run but conditionally warn.
- Trade-offs: Much more complex and unnecessary given `#[cfg]` exists precisely for this.

## ✅ Decision 
Option A. It's the standard, concise, and clean way to handle optional features in integration tests.

## 🧱 Changes made (SRP) 
- `crates/tokmd/tests/cli_snapshot_golden.rs`
- `crates/tokmd/tests/determinism.rs`

## 🧪 Verification receipts 
```text
cargo test -p tokmd --no-default-features
cargo test -p tokmd --all-features
```

## 🧭 Telemetry 
- Change shape: Test compatibility fix
- Blast radius: Only test code.
- Risk class: Low
- Rollback: Revert the PR
- Gates run: `cargo test -p tokmd --no-default-features` and `cargo test -p tokmd --all-features`

## 🗂️ .jules artifacts 
- `.jules/runs/compat_interfaces_matrix/envelope.json`
- `.jules/runs/compat_interfaces_matrix/decision.md`
- `.jules/runs/compat_interfaces_matrix/receipts.jsonl`
- `.jules/runs/compat_interfaces_matrix/result.json`
- `.jules/runs/compat_interfaces_matrix/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [3285148049457265421](https://jules.google.com/task/3285148049457265421) started by @EffortlessSteven*