### PR TITLE
test: improve tokmd CLI snapshot test harness ergonomics

### DIFF
--- a/crates/tokmd/tests/cli_snapshot_golden.rs
+++ b/crates/tokmd/tests/cli_snapshot_golden.rs
@@ -14,6 +14,23 @@ fn tokmd_cmd() -> Command {
     cmd
 }
 
+fn run_cli(args: &[&str]) -> String {
+    let output = tokmd_cmd()
+        .args(args)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run tokmd {}: {err}", args.join(" ")));
+
+    assert!(
+        output.status.success(),
+        "tokmd {} failed with status {}\nstderr:\n{}",
+        args.join(" "),
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).expect("CLI output should be valid UTF-8")
+}
+
 /// Replace dynamic values (timestamps, versions, absolute paths) with stable
 /// placeholders so snapshots are deterministic across machines and runs.
 fn normalize(output: &str) -> String {
@@ -64,25 +81,13 @@ fn normalize(output: &str) -> String {
 
 #[test]
 fn snapshot_lang_json() {
-    let output = tokmd_cmd()
-        .args(["lang", "--format", "json"])
-        .output()
-        .expect("failed to run tokmd lang --format json");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["lang", "--format", "json"]);
     insta::assert_snapshot!("lang_json", normalize(&stdout));
 }
 
 #[test]
 fn snapshot_lang_json_structure() {
-    let output = tokmd_cmd()
-        .args(["lang", "--format", "json"])
-        .output()
-        .expect("failed to run tokmd lang --format json");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["lang", "--format", "json"]);
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
 
     // Verify structural keys are present — the snapshot captures exact values
@@ -99,13 +104,7 @@ fn snapshot_lang_json_structure() {
 
 #[test]
 fn snapshot_lang_markdown() {
-    let output = tokmd_cmd()
-        .args(["lang"])
-        .output()
-        .expect("failed to run tokmd lang");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["lang"]);
     insta::assert_snapshot!("lang_markdown", stdout);
 }
 
@@ -115,13 +114,7 @@ fn snapshot_lang_markdown() {
 
 #[test]
 fn snapshot_lang_tsv() {
-    let output = tokmd_cmd()
-        .args(["lang", "--format", "tsv"])
-        .output()
-        .expect("failed to run tokmd lang --format tsv");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["lang", "--format", "tsv"]);
     insta::assert_snapshot!("lang_tsv", stdout);
 }
 
@@ -131,37 +124,19 @@ fn snapshot_lang_tsv() {
 
 #[test]
 fn snapshot_module_json() {
-    let output = tokmd_cmd()
-        .args(["module", "--format", "json"])
-        .output()
-        .expect("failed to run tokmd module --format json");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["module", "--format", "json"]);
     insta::assert_snapshot!("module_json", normalize(&stdout));
 }
 
 #[test]
 fn snapshot_module_markdown() {
-    let output = tokmd_cmd()
-        .args(["module"])
-        .output()
-        .expect("failed to run tokmd module");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["module"]);
     insta::assert_snapshot!("module_markdown", stdout);
 }
 
 #[test]
 fn snapshot_module_tsv() {
-    let output = tokmd_cmd()
-        .args(["module", "--format", "tsv"])
-        .output()
-        .expect("failed to run tokmd module --format tsv");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["module", "--format", "tsv"]);
     insta::assert_snapshot!("module_tsv", stdout);
 }
 
@@ -171,37 +146,19 @@ fn snapshot_module_tsv() {
 
 #[test]
 fn snapshot_export_json() {
-    let output = tokmd_cmd()
-        .args(["export", "--format", "json"])
-        .output()
-        .expect("failed to run tokmd export --format json");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["export", "--format", "json"]);
     insta::assert_snapshot!("export_json", normalize(&stdout));
 }
 
 #[test]
 fn snapshot_export_jsonl() {
-    let output = tokmd_cmd()
-        .args(["export", "--format", "jsonl"])
-        .output()
-        .expect("failed to run tokmd export --format jsonl");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["export", "--format", "jsonl"]);
     insta::assert_snapshot!("export_jsonl", normalize(&stdout));
 }
 
 #[test]
 fn snapshot_export_csv() {
-    let output = tokmd_cmd()
-        .args(["export", "--format", "csv"])
-        .output()
-        .expect("failed to run tokmd export --format csv");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["export", "--format", "csv"]);
     insta::assert_snapshot!("export_csv", stdout);
 }
 
@@ -212,30 +169,18 @@ fn snapshot_export_csv() {
 #[test]
 #[cfg(feature = "analysis")]
 fn snapshot_analyze_json() {
-    let output = tokmd_cmd()
-        .args([
-            "analyze", ".", "--preset", "receipt", "--format", "json", "--no-git",
-        ])
-        .output()
-        .expect("failed to run tokmd analyze --format json");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&[
+        "analyze", ".", "--preset", "receipt", "--format", "json", "--no-git",
+    ]);
     insta::assert_snapshot!("analyze_json", normalize(&stdout));
 }
 
 #[test]
 #[cfg(feature = "analysis")]
 fn snapshot_analyze_markdown() {
-    let output = tokmd_cmd()
-        .args([
-            "analyze", ".", "--preset", "receipt", "--format", "md", "--no-git",
-        ])
-        .output()
-        .expect("failed to run tokmd analyze --format md");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&[
+        "analyze", ".", "--preset", "receipt", "--format", "md", "--no-git",
+    ]);
     insta::assert_snapshot!("analyze_markdown", normalize(&stdout));
 }
 
@@ -245,13 +190,7 @@ fn snapshot_analyze_markdown() {
 
 #[test]
 fn snapshot_version() {
-    let output = tokmd_cmd()
-        .arg("--version")
-        .output()
-        .expect("failed to run tokmd --version");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["--version"]);
     insta::assert_snapshot!("version", normalize(&stdout));
 }
 
@@ -261,13 +200,7 @@ fn snapshot_version() {
 
 #[test]
 fn snapshot_help() {
-    let output = tokmd_cmd()
-        .arg("--help")
-        .output()
-        .expect("failed to run tokmd --help");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = run_cli(&["--help"]);
     // Normalize the version in the help header
     insta::assert_snapshot!("help", normalize(&stdout));
 }


### PR DESCRIPTION
### Motivation

- Reduce boilerplate and harden CLI snapshot tests so failures are easier to diagnose in CI.
- Ensure snapshot determinism is preserved while improving assertion diagnostics for command failures.

### Description

- Introduce a shared `run_cli(args: &[&str]) -> String` helper in `crates/tokmd/tests/cli_snapshot_golden.rs` that centralizes command execution, UTF-8 decoding, and success assertions.
- Replace repetitive `assert!(output.status.success())` + `String::from_utf8(...)` blocks with `run_cli(...)` across all snapshot tests in the file.
- Improve failure diagnostics by including the full command, exit status, and captured `stderr` in the test assertion message.
- Preserve existing normalization logic for timestamps, versions, paths, and hashes so snapshots remain deterministic.

### Testing

- Ran `cargo fmt-fix` to apply formatting fixes and the formatter passed successfully.
- Ran `cargo test -p tokmd --test cli_snapshot_golden` and all snapshot tests passed (`14 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3bbd61c8333a6a3b524ddf45238)