### PR TITLE
Refactor analysis_explain snapshot tests to table-driven test

### DIFF
--- a/crates/tokmd/src/analysis_explain/tests/snapshots.rs
+++ b/crates/tokmd/src/analysis_explain/tests/snapshots.rs
@@ -2,6 +2,12 @@
 
 use crate::analysis_explain::{catalog, lookup};
 
+fn assert_lookup_snapshot(metric: &str) {
+    let snapshot_name = format!("lookup_{metric}");
+    let text = lookup(metric).unwrap_or_else(|| panic!("missing metric: {metric}"));
+    insta::assert_snapshot!(snapshot_name, text);
+}
+
 #[test]
 fn snapshot_catalog_full() {
     let text = catalog();
@@ -9,176 +15,41 @@ fn snapshot_catalog_full() {
 }
 
 #[test]
-fn snapshot_lookup_doc_density() {
-    insta::assert_snapshot!("lookup_doc_density", lookup("doc_density").unwrap());
-}
+fn snapshot_lookup_metrics() {
+    let metrics = [
+        "doc_density",
+        "whitespace_ratio",
+        "verbosity",
+        "test_density",
+        "todo_density",
+        "polyglot_entropy",
+        "gini",
+        "avg_cyclomatic",
+        "max_cyclomatic",
+        "avg_cognitive",
+        "max_nesting_depth",
+        "maintainability_index",
+        "technical_debt_ratio",
+        "halstead",
+        "complexity_histogram",
+        "hotspots",
+        "bus_factor",
+        "freshness",
+        "code_age_distribution",
+        "coupling",
+        "predictive_churn",
+        "duplicate_waste",
+        "duplication_density",
+        "imports",
+        "entropy_suspects",
+        "license_radar",
+        "archetype",
+        "context_window_fit",
+    ];
 
-#[test]
-fn snapshot_lookup_whitespace_ratio() {
-    insta::assert_snapshot!(
-        "lookup_whitespace_ratio",
-        lookup("whitespace_ratio").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_verbosity() {
-    insta::assert_snapshot!("lookup_verbosity", lookup("verbosity").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_test_density() {
-    insta::assert_snapshot!("lookup_test_density", lookup("test_density").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_todo_density() {
-    insta::assert_snapshot!("lookup_todo_density", lookup("todo_density").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_polyglot_entropy() {
-    insta::assert_snapshot!(
-        "lookup_polyglot_entropy",
-        lookup("polyglot_entropy").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_gini() {
-    insta::assert_snapshot!("lookup_gini", lookup("gini").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_avg_cyclomatic() {
-    insta::assert_snapshot!("lookup_avg_cyclomatic", lookup("avg_cyclomatic").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_max_cyclomatic() {
-    insta::assert_snapshot!("lookup_max_cyclomatic", lookup("max_cyclomatic").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_avg_cognitive() {
-    insta::assert_snapshot!("lookup_avg_cognitive", lookup("avg_cognitive").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_max_nesting_depth() {
-    insta::assert_snapshot!(
-        "lookup_max_nesting_depth",
-        lookup("max_nesting_depth").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_maintainability_index() {
-    insta::assert_snapshot!(
-        "lookup_maintainability_index",
-        lookup("maintainability_index").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_technical_debt_ratio() {
-    insta::assert_snapshot!(
-        "lookup_technical_debt_ratio",
-        lookup("technical_debt_ratio").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_halstead() {
-    insta::assert_snapshot!("lookup_halstead", lookup("halstead").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_complexity_histogram() {
-    insta::assert_snapshot!(
-        "lookup_complexity_histogram",
-        lookup("complexity_histogram").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_hotspots() {
-    insta::assert_snapshot!("lookup_hotspots", lookup("hotspots").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_bus_factor() {
-    insta::assert_snapshot!("lookup_bus_factor", lookup("bus_factor").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_freshness() {
-    insta::assert_snapshot!("lookup_freshness", lookup("freshness").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_code_age_distribution() {
-    insta::assert_snapshot!(
-        "lookup_code_age_distribution",
-        lookup("code_age_distribution").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_coupling() {
-    insta::assert_snapshot!("lookup_coupling", lookup("coupling").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_predictive_churn() {
-    insta::assert_snapshot!(
-        "lookup_predictive_churn",
-        lookup("predictive_churn").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_duplicate_waste() {
-    insta::assert_snapshot!("lookup_duplicate_waste", lookup("duplicate_waste").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_duplication_density() {
-    insta::assert_snapshot!(
-        "lookup_duplication_density",
-        lookup("duplication_density").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_imports() {
-    insta::assert_snapshot!("lookup_imports", lookup("imports").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_entropy_suspects() {
-    insta::assert_snapshot!(
-        "lookup_entropy_suspects",
-        lookup("entropy_suspects").unwrap()
-    );
-}
-
-#[test]
-fn snapshot_lookup_license_radar() {
-    insta::assert_snapshot!("lookup_license_radar", lookup("license_radar").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_archetype() {
-    insta::assert_snapshot!("lookup_archetype", lookup("archetype").unwrap());
-}
-
-#[test]
-fn snapshot_lookup_context_window_fit() {
-    insta::assert_snapshot!(
-        "lookup_context_window_fit",
-        lookup("context_window_fit").unwrap()
-    );
+    for metric in metrics {
+        assert_lookup_snapshot(metric);
+    }
 }
 
 // Alias lookups should produce identical output to canonical lookups


### PR DESCRIPTION
### Motivation
- Remove repetitive per-metric snapshot test boilerplate to improve maintainability of the test suite.
- Make it easier to add or remove explainable metrics in one central place.
- Improve failure clarity when a metric key is missing by providing an explicit helper that panics with a clear message.

### Description
- Reworked `crates/tokmd/src/analysis_explain/tests/snapshots.rs` to replace many near-identical `insta::assert_snapshot!` functions with a single table-driven test `snapshot_lookup_metrics` that iterates a metrics list.
- Added helper `assert_lookup_snapshot(metric: &str)` which builds stable snapshot names (`lookup_<metric>`), looks up the metric via `lookup(metric)`, and fails with a clear panic when the metric is missing.
- Kept the `snapshot_catalog_full` snapshot and the alias-equivalence assertions intact so existing behavioral checks remain covered.

### Testing
- Ran `cargo test -p tokmd snapshot_lookup_metrics --verbose` and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3bbd61c8333a6a3b524ddf45238)