### PR TITLE
Strengthen tokmd-cockpit property testing invariants

### DIFF
--- a/crates/tokmd-cockpit/tests/properties.rs
+++ b/crates/tokmd-cockpit/tests/properties.rs
@@ -125,6 +125,38 @@ proptest! {
             health.grade
         );
     }
+
+    #[test]
+    fn prop_health_is_monotonic_for_breaking_indicators(
+        stats in prop::collection::vec(file_stat_strategy(), 0..20),
+        breaking_a in 0..5usize,
+        breaking_b in 0..5usize,
+    ) {
+        let (low, high) = if breaking_a <= breaking_b {
+            (breaking_a, breaking_b)
+        } else {
+            (breaking_b, breaking_a)
+        };
+        let base = Contracts {
+            api_changed: false,
+            cli_changed: false,
+            schema_changed: false,
+            breaking_indicators: low,
+        };
+        let stricter = Contracts {
+            breaking_indicators: high,
+            ..base
+        };
+
+        let health_base = compute_code_health(&stats, &base);
+        let health_stricter = compute_code_health(&stats, &stricter);
+        prop_assert!(
+            health_stricter.score <= health_base.score,
+            "more breaking indicators should not improve score: {} -> {}",
+            health_base.score,
+            health_stricter.score
+        );
+    }
 }
 
 // ===========================================================================
@@ -433,12 +465,6 @@ proptest! {
     // NEW property tests
 
     #[test]
-    fn sparkline_length(values in prop::collection::vec(0.0f64..100.0, 1..20)) {
-        let s = sparkline(&values);
-        prop_assert_eq!(s.chars().count(), values.len());
-    }
-
-    #[test]
     fn round_pct_bounded(val in 0.0f64..100.0) {
         let r = round_pct(val);
         prop_assert!((0.0..=100.0).contains(&r));
@@ -459,10 +485,12 @@ proptest! {
     #[test]
     fn composition_percentages(files in prop::collection::vec(file_path_strategy(), 1..20)) {
         let comp = compute_composition(&files);
-        prop_assert!((0.0..=100.0).contains(&comp.code_pct));
-        prop_assert!((0.0..=100.0).contains(&comp.test_pct));
-        prop_assert!((0.0..=100.0).contains(&comp.docs_pct));
-        prop_assert!((0.0..=100.0).contains(&comp.config_pct));
+        let sum = comp.code_pct + comp.test_pct + comp.docs_pct + comp.config_pct;
+        prop_assert!((0.0..=1.0).contains(&comp.code_pct));
+        prop_assert!((0.0..=1.0).contains(&comp.test_pct));
+        prop_assert!((0.0..=1.0).contains(&comp.docs_pct));
+        prop_assert!((0.0..=1.0).contains(&comp.config_pct));
+        prop_assert!(sum <= 1.001, "sum was {}", sum);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve the signal quality and correctness coverage of property-based tests in the cockpit crate by adding a monotonicity invariant and tightening ambiguous percentage checks.
- Ensure tests reflect the internal normalized percentage model and catch regressions where increased breaking indicators could incorrectly raise health scores.

### Description
- Added a new property test `prop_health_is_monotonic_for_breaking_indicators` to assert that increasing `breaking_indicators` does not increase the result of `compute_code_health`.
- Tightened the composition assertions in `compute_composition` tests to validate normalized bounds `0..=1` and assert the summed share is capped (`sum <= 1.001`).
- Removed a redundant duplicate sparkline-length property from the “NEW property tests” block to avoid repetition while preserving coverage via the existing sparkline test.
- Changed file: `crates/tokmd-cockpit/tests/properties.rs`; no production code was modified.

### Testing
- Ran `cargo test -p tokmd-cockpit properties --verbose` and the focused property suites completed successfully with relevant property checks passing.
- Ran `cargo test -p tokmd-cockpit --test properties --verbose` and the targeted test binary ran 23 tests which all passed (`23 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3a245c88333bc67e6976ac14e68)