### PR TITLE
docs: clarify and modernize proptest guidance

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -117,7 +117,7 @@ Snapshot files: `<crate>/tests/snapshots/*.snap`
 
 ## Property-Based Tests
 
-Using `proptest` (1.9.0) across 17 crates:
+Using `proptest` (1.11.0) across 17 crates:
 
 | Crate | Properties Tested |
 |-------|-------------------|
@@ -138,7 +138,8 @@ Using `proptest` (1.9.0) across 17 crates:
 
 `proptest.toml`:
 ```toml
-[proptest]
+[default]
+# Default local/CI profile used by this repo
 cases = 256
 max_shrink_iters = 1000
 timeout = 10000
@@ -149,6 +150,8 @@ timeout = 10000
 ```bash
 cargo test -p tokmd-scan properties
 cargo test properties    # All property tests
+# Increase exploration depth temporarily without editing files
+PROPTEST_CASES=1024 cargo test -p tokmd-scan properties
 ```
 
 ### Regression Seeds


### PR DESCRIPTION
### Motivation
- Update the repository property-testing guidance to match current tooling and make it easier to run deeper exploration locally without editing files.

### Description
- Updated `docs/testing.md` to bump the documented `proptest` version to `1.11.0`, corrected the sample `proptest.toml` section header to `[default]`, and added a short example showing how to temporarily increase exploration depth via `PROPTEST_CASES`.

### Testing
- Ran the property-focused test command `cargo test -p tokmd-scan properties -- --nocapture`, which completed successfully (tests that matched the selector passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3a245c88333bc67e6976ac14e68)