### PR TITLE
fuzz: expand tokmd-types JSON deserialization coverage

### DIFF
--- a/fuzz/fuzz_targets/fuzz_json_types.rs
+++ b/fuzz/fuzz_targets/fuzz_json_types.rs
@@ -6,7 +6,10 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use tokmd_types::{
-    ExportData, FileRow, LangReport, LangRow, ModuleReport, ModuleRow, RunReceipt, Totals,
+    ConfigMode, ContextBundleManifest, ContextReceipt, DiffReceipt, ExportData, ExportReceipt,
+    FileRow, HandoffManifest, LangReceipt, LangReport, LangRow, ModuleReceipt, ModuleReport,
+    ModuleRow, RedactMode, RunReceipt, Totals,
+    cockpit::{CockpitReceipt, Evidence, ReviewItem},
 };
 
 /// Max input size to prevent pathological parse times
@@ -129,6 +132,24 @@ fuzz_target!(|data: &[u8]| {
         let _ = receipt.module_file.len();
         let _ = receipt.export_file.len();
     }
+
+    // Higher-level receipt envelopes
+    let _ = serde_json::from_str::<LangReceipt>(s);
+    let _ = serde_json::from_str::<ModuleReceipt>(s);
+    let _ = serde_json::from_str::<ExportReceipt>(s);
+    let _ = serde_json::from_str::<DiffReceipt>(s);
+    let _ = serde_json::from_str::<ContextReceipt>(s);
+    let _ = serde_json::from_str::<HandoffManifest>(s);
+    let _ = serde_json::from_str::<ContextBundleManifest>(s);
+
+    // Cockpit family
+    let _ = serde_json::from_str::<CockpitReceipt>(s);
+    let _ = serde_json::from_str::<Evidence>(s);
+    let _ = serde_json::from_str::<ReviewItem>(s);
+
+    // Config and redaction modes
+    let _ = serde_json::from_str::<ConfigMode>(s);
+    let _ = serde_json::from_str::<RedactMode>(s);
 
     // Also try as generic JSON Value and back
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(s) {


### PR DESCRIPTION
### Motivation
- Increase fuzz surface area for `tokmd-types` JSON handling so libfuzzer exercises more serde deserialization paths and edge-cases.
- Include higher-level receipts, cockpit evidence structures, and config/redact enums to catch schema/enum-related parsing issues without changing stable schemas.

### Description
- Extended `fuzz/fuzz_targets/fuzz_json_types.rs` imports to include additional types such as `LangReceipt`, `ModuleReceipt`, `ExportReceipt`, `DiffReceipt`, `ContextReceipt`, `HandoffManifest`, `ContextBundleManifest`, cockpit types, and `ConfigMode`/`RedactMode` enums.
- Added non-panicking deserialization attempts for those types inside the fuzz loop so arbitrary inputs exercise more serde entry points while preserving existing guards.
- Kept existing iteration guards (`MAX_INPUT_SIZE` and UTF-8 checks) unchanged to maintain fuzz speed and stability.
- No changes to JSON schemas or runtime behavior; this only broadens fuzz coverage.

### Testing
- Ran `cargo fmt-fix` and formatting/lint task completed successfully.
- Ran `cargo check --manifest-path fuzz/Cargo.toml --features types` and the fuzz crate checked successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d39af7f083338cc4121e06557ee0)