### PR TITLE
docs: refresh NOW.md for 1.10.0-rc.1 prerelease cleanup

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,18 +1,18 @@
 # NOW / NEXT / LATER
 
-> One-screen operational truth. Updated after the `1.9.0` release.
+> One-screen operational truth. Updated after the `1.10.0-rc.1` release candidate on 2026-04-29.
 
 ## NOW (active)
 
-- **Release aftermath is closed**: `1.9.0` is out, the release pipeline proved green end-to-end, and `main` is back to the normal development lane.
-- **Main must stay boring**: keep CI green, keep `--no-default-features` builds honest, and avoid reintroducing release-only branch noise or operator caveats.
-- **Docs and operator surfaces should match reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what actually shipped in `1.9.0`.
+- **RC proof lane is active**: `1.10.0-rc.1` shipped and `main` is focused on release-candidate proof, regression triage, and stable-promotion readiness.
+- **Keep `main` boring under RC constraints**: keep CI green, keep `--no-default-features` builds honest, and avoid scope creep that widens the release surface before `1.10.0`.
+- **Docs and operator surfaces must match shipped RC reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what shipped in `1.10.0-rc.1`.
 
 ## NEXT (short horizon)
 
-- **WASM-ready continuation**: keep wiring `tokmd-io-port` through scan and walk paths so the in-memory substrate stops being just a seam and becomes a real execution path.
-- **Define the next WASM proof bar**: add explicit wasm CI/parity goals for the next milestone instead of leaving the work implied.
-- **Low-blast-radius follow-ons**: prefer narrow docs, compat, and workflow fixes that preserve the newly boring release path and the new effort-estimation surfaces.
+- **Stable promotion prep**: close only high-signal follow-ons needed to promote `1.10.0-rc.1` to `1.10.0`.
+- **Browser runtime polish planning**: stage low-risk work for the `1.11.0` lane (cache behavior, progress events, retry/rate-limit UX, authenticated fetch).
+- **Low-blast-radius follow-ons**: prefer narrow docs, compat, and workflow fixes that preserve the RC proof chain and release boringness.
 
 ## LATER (roadmap)
 


### PR DESCRIPTION
### Motivation
- Update the one-page operational guidance to reflect that `v1.10.0-rc.1` shipped (2026-04-29) and shift priorities to RC proof, regression triage, and stable-promotion readiness.

### Description
- Edit `docs/NOW.md` to update the header timestamp and replace the NOW/NEXT bullets to emphasize the RC proof lane, stable-promotion prep for `1.10.0`, and staging browser-runtime polish for the `1.11.0` lane.

### Testing
- Documentation-only change; no automated tests were required or run for this edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3d934ac8333ad03c447cf6ad6a4)