### PR TITLE
docs: refresh NOW for 1.10 prerelease stabilization

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,18 +1,18 @@
 # NOW / NEXT / LATER
 
-> One-screen operational truth. Updated after the `1.9.0` release.
+> One-screen operational truth. Updated after the `1.10.0-rc.1` release candidate.
 
 ## NOW (active)
 
-- **Release aftermath is closed**: `1.9.0` is out, the release pipeline proved green end-to-end, and `main` is back to the normal development lane.
-- **Main must stay boring**: keep CI green, keep `--no-default-features` builds honest, and avoid reintroducing release-only branch noise or operator caveats.
-- **Docs and operator surfaces should match reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what actually shipped in `1.9.0`.
+- **RC aftermath is closed**: `1.10.0-rc.1` shipped on April 29, 2026, the prerelease lane proved green end-to-end, and `main` is in stabilization mode for `1.10.0`.
+- **Main must stay boring**: keep CI green, keep `--no-default-features` and browser-capability checks honest, and avoid reintroducing release-only branch noise or operator caveats.
+- **Docs and operator surfaces should match reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what actually shipped in `1.10.0-rc.1`.
 
 ## NEXT (short horizon)
 
+- **Stable cut readiness**: finish low-blast-radius polish so `1.10.0` promotion is a metadata/tagging event, not a late code shuffle.
 - **WASM-ready continuation**: keep wiring `tokmd-io-port` through scan and walk paths so the in-memory substrate stops being just a seam and becomes a real execution path.
-- **Define the next WASM proof bar**: add explicit wasm CI/parity goals for the next milestone instead of leaving the work implied.
-- **Low-blast-radius follow-ons**: prefer narrow docs, compat, and workflow fixes that preserve the newly boring release path and the new effort-estimation surfaces.
+- **Define the next WASM proof bar**: add explicit wasm CI/parity goals for the post-`1.10.0` milestone instead of leaving the work implied.
 
 ## LATER (roadmap)
 


### PR DESCRIPTION
### Motivation
- Update the one-page operational status to reflect that `1.10.0-rc.1` shipped and the tree is in `1.10.0` prerelease/stabilization mode.

### Description
- Replace outdated `1.9.0` references and tighten short-horizon priorities by updating `docs/NOW.md` to mention `1.10.0-rc.1`, add an explicit date, and emphasize stable-cut readiness and post-`1.10.0` WASM proof goals.

### Testing
- No automated tests were required for this docs-only change; the edit was locally verified with `git diff -- docs/NOW.md`, `git status`, and committed as `docs: refresh NOW for 1.10 prerelease stabilization`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3d934ac8333ad03c447cf6ad6a4)