### PR TITLE
docs: add release-train execution status checkpoint

### DIFF
--- a/docs/release-train-status-2026-04-30.md
+++ b/docs/release-train-status-2026-04-30.md
@@ -1,0 +1,35 @@
+# Release Train Status (2026-04-30)
+
+This checkpoint records why the automated release-train execution could not proceed in this environment.
+
+## Blocking environment issue
+
+`git fetch origin` fails because the repository has no configured `origin` remote in this container.
+
+Without `origin`, the following release-train steps cannot be executed here:
+
+- Rebaseline against `origin/main`
+- Restack and inspect PR branches (`gh pr checkout 1457`, `gh pr checkout 1449`)
+- Merge or close PRs
+- Open or merge a stable release PR
+- Push stable tags
+- Observe GitHub Actions release workflows
+
+## Commands attempted
+
+```bash
+git fetch origin
+git switch --detach origin/main
+cargo xtask docs --check
+cargo xtask version-consistency
+cargo xtask publish-surface --json
+git diff --check
+cargo test -p tokmd --no-default-features
+cargo test -p tokmd --all-features
+```
+
+## Next action once remote is available
+
+1. Configure/fix `origin` and re-run `git fetch origin`.
+2. Start from detached `origin/main`.
+3. Execute blocker flow in order: #1457, #1449, then stable `v1.10.0` prep.


### PR DESCRIPTION
### Motivation
- Record why the automated release-train steps could not run in this environment due to a missing `origin` remote so future runs can resume from a known checkpoint.

### Description
- Add `docs/release-train-status-2026-04-30.md` which documents the blocking issue, the exact commands attempted (rebaseline, PR restack, tests, and validations), and the next actions required once remote access is available, then commit the docs-only change.

### Testing
- `git fetch origin` was run and failed because the repository has no configured `origin` remote in this container.  
- `cargo xtask docs --check`, `cargo xtask version-consistency`, and `cargo xtask publish-surface --json` were invoked but could not complete reliably due to environment/build locks.  
- `cargo test -p tokmd --no-default-features` and `cargo test -p tokmd --all-features` were attempted but did not complete in this environment.  
- The docs-only file was added and committed successfully as `docs/release-train-status-2026-04-30.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d7d6e2848333a5f9cc7707084dac)