### PR TITLE
docs: add v1.10.0 stable release train checklist

### DIFF
--- a/docs/release-v1.10.0-train-checklist.md
+++ b/docs/release-v1.10.0-train-checklist.md
@@ -1,0 +1,98 @@
+# v1.10.0 Stable Release Train Checklist
+
+This checklist captures the minimum-release discipline for promoting `v1.10.0-rc.1` to stable `v1.10.0`.
+
+## Scope fence
+
+Merge only:
+- release blockers
+- release-correctness docs/policy fixes
+- already-clean proof PRs that do not widen product scope
+
+Defer to `v1.11`:
+- browser cache/progress/retry/auth work
+- CLI ergonomics
+- performance and model-behavior expansions
+
+## Phase 0 — rebaseline
+
+- `git fetch origin`
+- `git switch --detach origin/main`
+- `cargo xtask docs --check`
+- `cargo xtask version-consistency`
+- `cargo xtask publish-surface --json`
+- `git diff --check`
+- `cargo test -p tokmd --no-default-features`
+- `cargo test -p tokmd --all-features`
+
+## Phase 1 — blocker `#1457`
+
+- If no-default-features already passes on main, close `#1457` as superseded.
+- Otherwise restack and keep only:
+  - `crates/tokmd/tests/cli_snapshot_golden.rs`
+  - `crates/tokmd/tests/determinism.rs`
+- Remove `.jules/runs/**`, `Cargo.lock` churn, and unrelated artifacts.
+
+## Phase 2 — ADR keeper and publishability wording
+
+Use `#1449` as keeper (if cleanly restacked), with tight scope:
+- `docs/adr/0000-adr-process.md`
+- `docs/adr/0001-production-package-publishability.md`
+- `docs/adr/0002-crate-vs-module-boundaries.md`
+- `docs/adr/0003-publish-surface-taxonomy.md`
+- `docs/adr/0004-binding-surfaces.md`
+- `docs/adr/0005-release-train-and-rc-semantics.md`
+- `CHANGELOG.md` wording fix only if still needed
+
+Policy wording that must remain true:
+- no production Rust package may be `publish = false`
+- `publish = false` is only allowed for dev/tooling/fuzz packages outside production closures
+
+## Phase 3 — close duplicate PR families
+
+After `#1457` and `#1449` resolution:
+- close `#1451` if superseded by `#1457`
+- close `#1442 #1443 #1444 #1445 #1446 #1447 #1448` as superseded by `#1449`
+
+Park (do not close):
+- `#1456 #1214 #1156 #1144`
+
+## Phase 4 — stable prep PR
+
+Create `release/v1.10.0-stable` and run:
+- `cargo xtask bump 1.10.0`
+
+Expected touched files:
+- `Cargo.toml`
+- `Cargo.lock`
+- `crates/tokmd-node/package.json`
+- `crates/tokmd-node/npm/package.json`
+- `CHANGELOG.md`
+- `ROADMAP.md`
+- `docs/implementation-plan.md`
+- `README.md` only if stable-version examples must change
+
+## Phase 5 — pre-merge validation
+
+Run sequentially (gate then deny):
+- `cargo fmt-check`
+- `cargo xtask docs --check`
+- `cargo xtask version-consistency`
+- `cargo xtask publish-surface --json`
+- `cargo xtask publish-surface --json --verify-publish`
+- `cargo xtask gate --check`
+- `cargo deny --all-features check`
+- `npm test --prefix web/runner`
+- `cargo test -p tokmd --no-default-features`
+- `cargo test -p tokmd --all-features`
+- `git diff --check`
+
+## Phase 6 — tag and verify stable
+
+- `git tag -a v1.10.0 -m "v1.10.0"`
+- `git push origin v1.10.0`
+- monitor release workflow and verify:
+  - release is not prerelease and is latest
+  - `v1` tag moves to `v1.10.0`
+  - crates.io + Docker publish complete
+  - assets + checksums exist


### PR DESCRIPTION
### Motivation
- Provide a concise, auditable release-train playbook to promote `v1.10.0-rc.1` to stable `v1.10.0` and enforce a tight scope fence for the release.
- Capture explicit steps for evaluating the first release blockers (`#1457`), selecting an ADR keeper (`#1449`), closing duplicates, and preparing/tagging the stable release to avoid accidental scope expansion.

### Description
- Add `docs/release-v1.10.0-train-checklist.md` which lays out phases (rebaseline, blocker resolution, ADR keeper, duplicate-PR closure, stable prep, validation, tag/verify) and the exact commands to run. 
- The document codifies the scope fence (what to merge vs defer), required file touches for a stable bump, and verification gates; this change is docs-only and does not modify runtime code.

### Testing
- Ran `cargo xtask docs --check` and `cargo xtask version-consistency` and they completed successfully. 
- Ran `cargo xtask publish-surface --json` to verify publish-surface summary and it returned a clean packaging report with no violations. 
- Ran `cargo test -p tokmd --no-default-features` and `cargo test -p tokmd --all-features` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d7d6e2848333a5f9cc7707084dac)