### PR TITLE
docs: record no-default-features release-fence recheck

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -366,6 +366,7 @@ fetch.
 - [x] Enforce publish-surface classification and verify package-list proof for the 16 published crates
 - [x] Replace manual CLI reference tables with checked HELP markers
 - [x] Add determinism, snapshot, and property-test proof coverage for release-critical paths
+- [x] Re-verify release fence checks on main (`cargo test -p tokmd --no-default-features` and `--all-features`) before stable tagging; no-default-features currently passes without extra test gating patches.
 - [x] Clarify Jules provenance policy without blanket-blocking intentional `.jules/**` history
 
 ### Follow-Up: v1.11.0 Browser Runtime Polish


### PR DESCRIPTION
### Motivation
- Make the release-train checklist explicit by requiring a final re-run of the `tokmd` no-default-features and all-features tests before tagging stable, and record that `--no-default-features` currently passes on main.

### Description
- Add a single checklist item to `docs/implementation-plan.md` under the v1.10.0 release-train hardening section that instructs maintainers to re-run `cargo test -p tokmd --no-default-features` and `cargo test -p tokmd --all-features` before stable tagging.

### Testing
- Ran `cargo xtask docs --check`, `cargo xtask version-consistency`, `cargo xtask publish-surface --json`, `cargo test -p tokmd --no-default-features`, `cargo test -p tokmd --all-features`, and `git diff --check`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d7d6e2848333a5f9cc7707084dac)