### PR TITLE
docs(adr): clarify binding-surface publish=false context wording

### DIFF
--- a/docs/adr/0004-binding-surfaces.md
+++ b/docs/adr/0004-binding-surfaces.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-tokmd includes Node, Python, and WASM binding surfaces with differing packaging and distribution mechanics. Current `publish = false` state for Node/Python Cargo packages requires explicit production-boundary policy.
+tokmd includes Node, Python, and WASM binding surfaces with differing packaging and distribution mechanics. Historical use of `publish = false` for Node/Python Cargo packages requires explicit production-boundary policy and release-time verification.
 
 ## Decision
 


### PR DESCRIPTION
### Motivation
- Clarify ADR language that currently implied `publish = false` was an active policy for Node/Python binding crates and instead frame prior `publish = false` usage as historical and requiring release-time verification to match the repository publishability rules.

### Description
- Update `docs/adr/0004-binding-surfaces.md` to replace the sentence about the "Current `publish = false` state" with wording that references the "Historical use of `publish = false`" and adds an explicit note about release-time verification to remove ambiguity.

### Testing
- Ran `cargo xtask docs --check`, `cargo xtask version-consistency`, `cargo xtask publish-surface --json`, `cargo fmt-check`, `cargo test -p tokmd --no-default-features`, and `cargo test -p tokmd --all-features`, and `git diff --check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d7d6e2848333a5f9cc7707084dac)