### PR TITLE
release: prepare v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.10.0-rc.1] - 2026-04-29
+## [1.10.0] - 2026-04-30
 
-Release candidate for `v1.10.0` (`v1.10.0rc1`).
+Stable release following `v1.10.0-rc.1` validation.
 
 ### Added
 
@@ -81,7 +81,7 @@ Release candidate for `v1.10.0` (`v1.10.0rc1`).
 - Jules provenance policy was clarified: intentional `.jules/**` provenance is allowed, while normal patch PRs should not carry accidental run packets.
 - Consolidated Jules persona guidance and run/provenance indexing so intentional learning packets are distinguishable from runtime debris.
 - Added/updated the Jules run index builder to aggregate historical ledgers without rewriting provenance history.
-- Closed duplicate/stale PR families for pyo3 cleanup, no-default-features tests, analyze snapshots, browser-runner dynamic payloads, docs-marker drift, and stale architecture-doc updates.
+- Resolved duplicate release-prep PR families for pyo3 cleanup, no-default-features tests, analyze snapshots, browser-runner dynamic payloads, docs-marker drift, RC workflow guards, and ADR publishability policy.
 
 ## [1.9.2] - 2026-04-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "clap",
  "insta",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3534,7 +3534,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.10.0-rc.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.10.0-rc.1"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -56,22 +56,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.10.0-rc.1" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.10.0-rc.1" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.10.0-rc.1" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.10.0-rc.1" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.10.0-rc.1" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.10.0-rc.1" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.10.0-rc.1" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.10.0-rc.1" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.10.0-rc.1" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.10.0-rc.1" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.10.0-rc.1" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.10.0-rc.1" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.10.0-rc.1" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.10.0-rc.1" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.10.0-rc.1" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.10.0-rc.1" }
+tokmd = { path = "crates/tokmd", version = "1.10.0" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.10.0" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.10.0" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.10.0" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.10.0" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.10.0" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.10.0" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.10.0" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.10.0" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.10.0" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.10.0" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.10.0" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.10.0" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.10.0" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.10.0" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.10.0" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,8 +33,8 @@ This document outlines the evolution of `tokmd` and the path forward.
 | **v1.7.x** | ✅ Complete | Deep test expansion across the workspace, sensor determinism, and the first `tokmd-io-port` seam. |
 | **v1.8.0** | ✅ Complete | Effort estimation, estimate preset/reporting, `tokmd-io-port` seam work, and release/devex hardening. |
 | **v1.9.0** | ✅ Complete | Browser/WASM productization: parity-covered wasm entrypoints, browser runner MVP, and public repo ingestion via tree+contents |
-| **v1.10.0-rc.1** | 🚢 RC | CI control plane, bounded trust hardening, WASM truth, and proof stability release candidate. |
-| **v1.10.0** | 🔜 Planned | Stable promotion after release-candidate proof. |
+| **v1.10.0-rc.1** | ✅ Complete | Release-candidate proof for CI control plane, bounded trust hardening, WASM truth, and proof stability. |
+| **v1.10.0** | ✅ Complete | Stable CI control plane, trust hardening, WASM truth, Action release, and proof stability. |
 | **v1.11.0** | 🔭 Planned | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
 | **v3.0.0** | 🔭 Long-term | Tree-sitter AST integration (requires significant R&D).      |
@@ -507,11 +507,11 @@ UX work is explicitly **incremental and non-breaking**:
 - No browser zipball ingestion as the primary supported path for `v1.9.0`; tree+contents is the supported browser acquisition strategy.
 - No mutation testing or other heavy tooling in-browser.
 
-## v1.10.0-rc.1 — CI Control Plane, Trust Hardening, and Proof Stability
+## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability
 
-**Goal:** Cut a release candidate after the Action, path-trust, WASM, publish-surface, and proof-hardening work landed.
+**Goal:** Ship the stable release after the Action, path-trust, WASM, publish-surface, and proof-hardening work landed and the release candidate was validated.
 
-### What is in v1.10.0-rc.1
+### What is in v1.10.0
 
 - [x] GitHub Action explicit modes for `module`, `export`, `gate`, `cockpit`, `sensor`, and `baseline`.
 - [x] Bounded path/root handling across native, Git, and in-memory flows.

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.10.0-rc.1"
+        "version": "1.10.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.10.0-rc.1"
+        "version": "1.10.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.10.0-rc.1"
+        "version": "1.10.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.10.0-rc.1"
+        "version": "1.10.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.10.0-rc.1"
+        "version": "1.10.0"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.10.0-rc.1",
+  "version": "1.10.0",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.10.0-rc.1",
-    "@tokmd/core-darwin-x64": "1.10.0-rc.1",
-    "@tokmd/core-linux-arm64-gnu": "1.10.0-rc.1",
-    "@tokmd/core-linux-x64-gnu": "1.10.0-rc.1",
-    "@tokmd/core-win32-x64-msvc": "1.10.0-rc.1"
+    "@tokmd/core-darwin-arm64": "1.10.0",
+    "@tokmd/core-darwin-x64": "1.10.0",
+    "@tokmd/core-linux-arm64-gnu": "1.10.0",
+    "@tokmd/core-linux-x64-gnu": "1.10.0",
+    "@tokmd/core-win32-x64-msvc": "1.10.0"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.10.0-rc.1",
+  "version": "1.10.0",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.0.0-alpha.66"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.10.0-rc.1",
-    "@tokmd/core-darwin-x64": "1.10.0-rc.1",
-    "@tokmd/core-darwin-arm64": "1.10.0-rc.1",
-    "@tokmd/core-linux-x64-gnu": "1.10.0-rc.1",
-    "@tokmd/core-linux-x64-musl": "1.10.0-rc.1",
-    "@tokmd/core-linux-arm64-gnu": "1.10.0-rc.1",
-    "@tokmd/core-linux-arm64-musl": "1.10.0-rc.1",
-    "@tokmd/core-win32-arm64-msvc": "1.10.0-rc.1"
+    "@tokmd/core-win32-x64-msvc": "1.10.0",
+    "@tokmd/core-darwin-x64": "1.10.0",
+    "@tokmd/core-darwin-arm64": "1.10.0",
+    "@tokmd/core-linux-x64-gnu": "1.10.0",
+    "@tokmd/core-linux-x64-musl": "1.10.0",
+    "@tokmd/core-linux-arm64-gnu": "1.10.0",
+    "@tokmd/core-linux-arm64-musl": "1.10.0",
+    "@tokmd/core-win32-arm64-msvc": "1.10.0"
   }
 }

--- a/docs/adr/0004-binding-surfaces.md
+++ b/docs/adr/0004-binding-surfaces.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-tokmd includes Node, Python, and WASM binding surfaces with differing packaging and distribution mechanics. Current `publish = false` state for Node/Python Cargo packages requires explicit production-boundary policy.
+tokmd includes Node, Python, and WASM binding surfaces with differing packaging and distribution mechanics. Historical use of `publish = false` for Node/Python Cargo packages requires explicit production-boundary policy and release-time verification.
 
 ## Decision
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # tokmd Implementation Plan
 
-This document records completed implementation phases through `1.10.0-rc.1` and the next active buildout aligned with the roadmap.
+This document records completed implementation phases through `1.10.0` and the next active buildout aligned with the roadmap.
 
 ## Phase 1: Baseline & Ratchet System (v1.5.0) ✅ Complete
 
@@ -348,9 +348,9 @@ fetch.
 
 ---
 
-## Phase 5b: Release Train Hardening (v1.10.0-rc.1) 🚢 RC
+## Phase 5b: Release Train Hardening (v1.10.0) ✅ Complete
 
-**Goal**: Stabilize the shipped control-plane and browser/WASM surfaces in a release candidate without widening product scope.
+**Goal**: Stabilize the shipped control-plane and browser/WASM surfaces without widening product scope.
 
 ### Release Fence
 


### PR DESCRIPTION
## Summary

Prepare the stable `v1.10.0` release after the `v1.10.0-rc.1` validation pass.

- Bump workspace and Node package metadata from `1.10.0-rc.1` to `1.10.0`.
- Promote the changelog section from RC framing to stable release framing.
- Mark `v1.10.0` as shipped in the roadmap and implementation plan while keeping browser cache/progress/retry/auth in `v1.11.0` follow-up scope.
- Preserve the CLI/product-first README from #1458.

## Queue notes

- #1457 landed the release-blocking no-default-features test gating fix.
- #1449 landed the release-critical ADR/publishability keeper.
- The broad spec/BDD branches that were closed for release-fence reasons were reopened for merits-based review; they are not treated as release blockers by this PR.

## Validation

- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask version-consistency`
- `cargo xtask publish-surface --json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask gate --check`
- `cargo deny --all-features check`
- `npm test --prefix web/runner`
- `cargo test -p tokmd --no-default-features`
- `cargo test -p tokmd --all-features`
- `git diff --check`