### PR TITLE
test(git): expand unit coverage for intent classification

### DIFF
--- a/crates/tokmd-git/src/lib.rs
+++ b/crates/tokmd-git/src/lib.rs
@@ -509,6 +509,37 @@ mod tests {
         );
     }
 
+
+    #[test]
+    fn classify_intent_prefers_conventional_commit_prefix() {
+        assert_eq!(classify_intent("feat(parser): add support"), CommitIntentKind::Feat);
+        assert_eq!(classify_intent("fix!: breaking hotfix"), CommitIntentKind::Fix);
+        assert_eq!(classify_intent("docs(readme): update usage"), CommitIntentKind::Docs);
+        assert_eq!(classify_intent("test: add regression"), CommitIntentKind::Test);
+    }
+
+    #[test]
+    fn classify_intent_uses_keyword_heuristics() {
+        assert_eq!(classify_intent("Add caching layer"), CommitIntentKind::Feat);
+        assert_eq!(classify_intent("optimize parser allocations"), CommitIntentKind::Perf);
+        assert_eq!(classify_intent("lint workspace"), CommitIntentKind::Style);
+        assert_eq!(classify_intent("pipeline: update checks"), CommitIntentKind::Ci);
+    }
+
+    #[test]
+    fn classify_intent_handles_revert_and_empty_subjects() {
+        assert_eq!(classify_intent("Revert \"bad commit\""), CommitIntentKind::Revert);
+        assert_eq!(classify_intent("revert: undo change"), CommitIntentKind::Revert);
+        assert_eq!(classify_intent("   	"), CommitIntentKind::Other);
+    }
+
+    #[test]
+    fn contains_word_respects_word_boundaries() {
+        assert!(contains_word("fix parser", "fix"));
+        assert!(contains_word("fix-parser", "fix"));
+        assert!(!contains_word("prefix parser", "fix"));
+        assert!(!contains_word("fixture", "fix"));
+    }
     #[test]
     fn resolve_base_ref_returns_none_when_nothing_resolves() {
         if !git_available() {


### PR DESCRIPTION
### Motivation
- Improve unit test coverage around commit intent classification to catch regressions in conventional-prefix parsing and keyword heuristics.
- Validate edge cases such as revert formatting, whitespace-only subjects, and word-boundary matching for `contains_word`.

### Description
- Add targeted unit tests to `crates/tokmd-git/src/lib.rs` that assert conventional commit prefix mapping with `classify_intent` (e.g. `feat(...):`, `fix!:`).
- Add tests that verify keyword-based heuristics produce expected `CommitIntentKind` outcomes for natural language subjects.
- Add tests for revert detection, whitespace-only subjects, and `contains_word` word-boundary behavior to prevent false positives.

### Testing
- Ran `cargo test -p tokmd-git` and all tests passed successfully (existing and new tests executed without failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dc8aa2b4833397d4300038eb00ab)