### PR TITLE
test(types): add unit tests for optional serde fields

### DIFF
--- a/crates/tokmd-types/src/lib.rs
+++ b/crates/tokmd-types/src/lib.rs
@@ -1242,6 +1242,36 @@ mod tests {
     }
 
     #[test]
+    fn capability_status_omits_reason_when_none() {
+        let status = CapabilityStatus {
+            name: "git".into(),
+            status: CapabilityState::Available,
+            reason: None,
+        };
+
+        let value = serde_json::to_value(&status).unwrap();
+        assert_eq!(value["name"], "git");
+        assert_eq!(value["status"], "available");
+        assert!(value.get("reason").is_none());
+    }
+
+    #[test]
+    fn artifact_entry_omits_hash_when_none() {
+        let artifact = ArtifactEntry {
+            name: "summary.md".into(),
+            path: "out/summary.md".into(),
+            description: "Markdown summary".into(),
+            bytes: 128,
+            hash: None,
+        };
+
+        let value = serde_json::to_value(&artifact).unwrap();
+        assert_eq!(value["name"], "summary.md");
+        assert_eq!(value["bytes"], 128);
+        assert!(value.get("hash").is_none());
+    }
+
+    #[test]
     fn analysis_format_serde_roundtrip() {
         for variant in [
             AnalysisFormat::Md,


### PR DESCRIPTION
### Motivation
- Ensure optional fields serialized with `skip_serializing_if` remain omitted from JSON when `None` to keep envelopes minimal and deterministic.

### Description
- Add two unit tests to `crates/tokmd-types/src/lib.rs` that assert `CapabilityStatus.reason` and `ArtifactEntry.hash` are omitted from the serialized JSON when set to `None`.

### Testing
- Ran `cargo test -p tokmd-types -q` and the test-suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dc8aa2b4833397d4300038eb00ab)