### PR TITLE
test: broaden cockpit enum serde unit coverage

### DIFF
--- a/crates/tokmd-types/src/cockpit.rs
+++ b/crates/tokmd-types/src/cockpit.rs
@@ -562,19 +562,33 @@ mod tests {
     }
 
     #[test]
-    fn gate_status_serde() {
-        let json = serde_json::to_string(&GateStatus::Pass).unwrap();
-        assert_eq!(json, "\"pass\"");
-        let back: GateStatus = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, GateStatus::Pass);
+    fn gate_status_serde_all_variants() {
+        for (status, expected) in [
+            (GateStatus::Pass, "\"pass\""),
+            (GateStatus::Warn, "\"warn\""),
+            (GateStatus::Fail, "\"fail\""),
+            (GateStatus::Skipped, "\"skipped\""),
+            (GateStatus::Pending, "\"pending\""),
+        ] {
+            let json = serde_json::to_string(&status).unwrap();
+            assert_eq!(json, expected);
+            let back: GateStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, status);
+        }
     }
 
     #[test]
-    fn trend_direction_serde() {
-        let json = serde_json::to_string(&TrendDirection::Improving).unwrap();
-        assert_eq!(json, "\"improving\"");
-        let back: TrendDirection = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, TrendDirection::Improving);
+    fn trend_direction_serde_all_variants() {
+        for (direction, expected) in [
+            (TrendDirection::Improving, "\"improving\""),
+            (TrendDirection::Stable, "\"stable\""),
+            (TrendDirection::Degrading, "\"degrading\""),
+        ] {
+            let json = serde_json::to_string(&direction).unwrap();
+            assert_eq!(json, expected);
+            let back: TrendDirection = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, direction);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve unit test coverage to detect regressions in Serde JSON mappings for cockpit enums by exercising every enum variant instead of a single happy-path case.
- Make tests validate both serialization output strings and deserialization roundtrips so naming drift is caught early.

### Description
- Expanded tests in `crates/tokmd-types/src/cockpit.rs` to iterate and assert Serde JSON string mappings for all `GateStatus` variants (`Pass`, `Warn`, `Fail`, `Skipped`, `Pending`) and to roundtrip-deserialize each one.
- Expanded the `TrendDirection` test to validate serialized names and deserialization for `Improving`, `Stable`, and `Degrading` variants.
- No production/library API changes; this PR only updates unit tests and expected serialized strings in the test code.

### Testing
- Ran `cargo test -p tokmd-types --verbose` and the tokmd-types test suite completed successfully with all tests passing.
- The updated tests exercise the enum serde roundtrips and passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dc8aa2b4833397d4300038eb00ab)