### PR TITLE
test(config): add unit coverage for CLI enum behavior

### DIFF
--- a/crates/tokmd-config/src/cli_enums.rs
+++ b/crates/tokmd-config/src/cli_enums.rs
@@ -163,3 +163,60 @@ impl From<CliAnalysisFormat> for tokmd_types::AnalysisFormat {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_config_mode_defaults_to_auto() {
+        assert_eq!(CliConfigMode::default(), CliConfigMode::Auto);
+    }
+
+    #[test]
+    fn cli_table_format_maps_to_core_type() {
+        assert_eq!(tokmd_types::TableFormat::from(CliTableFormat::Md), tokmd_types::TableFormat::Md);
+        assert_eq!(tokmd_types::TableFormat::from(CliTableFormat::Tsv), tokmd_types::TableFormat::Tsv);
+        assert_eq!(tokmd_types::TableFormat::from(CliTableFormat::Json), tokmd_types::TableFormat::Json);
+    }
+
+    #[test]
+    fn cli_export_format_maps_to_core_type() {
+        assert_eq!(
+            tokmd_types::ExportFormat::from(CliExportFormat::Cyclonedx),
+            tokmd_types::ExportFormat::Cyclonedx
+        );
+        assert_eq!(tokmd_types::ExportFormat::from(CliExportFormat::Csv), tokmd_types::ExportFormat::Csv);
+    }
+
+    #[test]
+    fn cli_analysis_format_maps_to_core_type() {
+        assert_eq!(tokmd_types::AnalysisFormat::from(CliAnalysisFormat::Md), tokmd_types::AnalysisFormat::Md);
+        assert_eq!(tokmd_types::AnalysisFormat::from(CliAnalysisFormat::Html), tokmd_types::AnalysisFormat::Html);
+        assert_eq!(
+            tokmd_types::AnalysisFormat::from(CliAnalysisFormat::Mermaid),
+            tokmd_types::AnalysisFormat::Mermaid
+        );
+    }
+
+    #[test]
+    fn cli_enum_serialization_uses_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&CliChildIncludeMode::ParentsOnly).expect("serializes"),
+            "\"parents-only\""
+        );
+        assert_eq!(serde_json::to_string(&CliConfigMode::Auto).expect("serializes"), "\"auto\"");
+    }
+
+    #[test]
+    fn cli_enum_deserialization_accepts_kebab_case() {
+        assert_eq!(
+            serde_json::from_str::<CliRedactMode>("\"paths\"").expect("deserializes"),
+            CliRedactMode::Paths
+        );
+        assert_eq!(
+            serde_json::from_str::<CliAnalysisFormat>("\"jsonld\"").expect("deserializes"),
+            CliAnalysisFormat::Jsonld
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve regression safety for the CLI surface by adding unit tests that lock down enum defaults, mappings, and serde behavior.

### Description
- Add a `#[cfg(test)]` test module to `crates/tokmd-config/src/cli_enums.rs` containing focused unit tests for CLI enums.
- Add tests that assert `CliConfigMode::default()` is `Auto`, verify representative `From<...>` mappings into `tokmd_types` enums, and check `serde` kebab-case serialization and deserialization for CLI-facing enums.

### Testing
- Ran `cargo test -p tokmd-config --verbose` from the workspace root which failed because the package was not found in the workspace members (failed).
- Ran `cargo test --verbose` from `crates/tokmd-config` which failed because the crate expects to be executed as part of the workspace (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dc8aa2b4833397d4300038eb00ab)