### PR TITLE
release: make crates publish resume-safe

### DIFF
--- a/crates/tokmd-analysis-types/Cargo.toml
+++ b/crates/tokmd-analysis-types/Cargo.toml
@@ -23,4 +23,4 @@ js-sys = "0.3.91"
 [dev-dependencies]
 chrono = "0.4.44"
 proptest.workspace = true
-tokmd-scan.workspace = true
+tokmd-scan = { path = "../tokmd-scan", version = ">=1.9, <2" }

--- a/crates/tokmd-envelope/Cargo.toml
+++ b/crates/tokmd-envelope/Cargo.toml
@@ -18,4 +18,4 @@ serde_json.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-tokmd-core.workspace = true
+tokmd-core = { path = "../tokmd-core", version = ">=1.9, <2" }

--- a/crates/tokmd-scan/Cargo.toml
+++ b/crates/tokmd-scan/Cargo.toml
@@ -22,4 +22,4 @@ tokmd-types.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-tokmd-model.workspace = true
+tokmd-model = { path = "../tokmd-model", version = ">=1.9, <2" }

--- a/crates/tokmd-types/Cargo.toml
+++ b/crates/tokmd-types/Cargo.toml
@@ -22,6 +22,6 @@ clap = { version = "4.6.0", features = ["derive"], optional = true }
 proptest.workspace = true
 serde_json.workspace = true
 insta = { workspace = true }
-tokmd-scan = { workspace = true }
-tokmd-format = { workspace = true }
-tokmd-model = { workspace = true }
+tokmd-scan = { path = "../tokmd-scan", version = ">=1.9, <2" }
+tokmd-format = { path = "../tokmd-format", version = ">=1.9, <2" }
+tokmd-model = { path = "../tokmd-model", version = ">=1.9, <2" }

--- a/crates/tokmd-wasm/Cargo.toml
+++ b/crates/tokmd-wasm/Cargo.toml
@@ -26,7 +26,7 @@ tokmd-envelope.workspace = true
 wasm-bindgen = "0.2.114"
 
 [dev-dependencies]
-tokmd-types.workspace = true
+tokmd-types = { path = "../tokmd-types", version = ">=1.9, <2" }
 wasm-bindgen-test = "0.3.64"
 
 [package.metadata.wasm-pack.profile.release]

--- a/xtask/tests/publish_w71.rs
+++ b/xtask/tests/publish_w71.rs
@@ -248,6 +248,103 @@ fn publish_order_every_crate_after_its_deps() {
     }
 }
 
+#[test]
+fn publishable_internal_dev_dependencies_use_loose_versions() {
+    let crates_dir = workspace_root().join("crates");
+    let mut violations = Vec::new();
+
+    for entry in std::fs::read_dir(&crates_dir).expect("crates directory should be readable") {
+        let entry = entry.expect("crate directory entry should be readable");
+        if !entry
+            .file_type()
+            .expect("file type should be readable")
+            .is_dir()
+        {
+            continue;
+        }
+
+        let manifest_path = entry.path().join("Cargo.toml");
+        if !manifest_path.exists() {
+            continue;
+        }
+
+        let manifest = std::fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|err| panic!("{} should be readable: {err}", manifest_path.display()));
+        let table: toml::Table = toml::from_str(&manifest).unwrap_or_else(|err| {
+            panic!("{} should parse as TOML: {err}", manifest_path.display())
+        });
+
+        let Some(package) = table.get("package").and_then(toml::Value::as_table) else {
+            continue;
+        };
+
+        let publishable = match package.get("publish") {
+            Some(toml::Value::Boolean(false)) => false,
+            Some(toml::Value::Array(allow_list)) if allow_list.is_empty() => false,
+            _ => true,
+        };
+        if !publishable {
+            continue;
+        }
+
+        let crate_name = package
+            .get("name")
+            .and_then(toml::Value::as_str)
+            .unwrap_or("<unknown>");
+        let Some(dev_deps) = table
+            .get("dev-dependencies")
+            .and_then(toml::Value::as_table)
+        else {
+            continue;
+        };
+
+        for (dep_name, dep_value) in dev_deps {
+            if !dep_name.starts_with("tokmd-") {
+                continue;
+            }
+
+            let Some(dep_table) = dep_value.as_table() else {
+                violations.push(format!(
+                    "{crate_name} dev-dependency {dep_name} must use table form with path and loose version"
+                ));
+                continue;
+            };
+
+            if dep_table
+                .get("workspace")
+                .and_then(toml::Value::as_bool)
+                .unwrap_or(false)
+            {
+                violations.push(format!(
+                    "{crate_name} dev-dependency {dep_name} must not use workspace = true"
+                ));
+            }
+
+            if !dep_table.contains_key("path") {
+                violations.push(format!(
+                    "{crate_name} dev-dependency {dep_name} must keep a local path"
+                ));
+            }
+
+            match dep_table.get("version").and_then(toml::Value::as_str) {
+                Some(">=1.9, <2") => {}
+                Some(version) => violations.push(format!(
+                    "{crate_name} dev-dependency {dep_name} uses {version:?}; expected \">=1.9, <2\""
+                )),
+                None => violations.push(format!(
+                    "{crate_name} dev-dependency {dep_name} must declare loose version \">=1.9, <2\""
+                )),
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "publishable internal dev-dependencies must not require unpublished same-version crates:\n  - {}",
+        violations.join("\n  - ")
+    );
+}
+
 // ===========================================================================
 // 2. Rate limit detection (429 codes)
 // ===========================================================================


### PR DESCRIPTION
## Summary
- relax internal tokmd dev-dependency version requirements in publishable crates while keeping local path dependencies
- add an xtask regression test so publishable internal dev-dependencies cannot go back to `workspace = true`
- keep runtime dependency graph and publish order unchanged

## Why
The v1.10.0 crates.io job partially published `tokmd-gate` and `tokmd-io-port`, then failed when `tokmd-types` tried to resolve same-version internal dev-dependencies that had not been published yet. These were dev-dependencies only, but Cargo still resolves them during publish packaging.

## Validation
- `cargo fmt-check`
- `cargo test -p xtask --test publish_w71`
- `cargo xtask version-consistency`
- `cargo xtask publish --plan --verbose`
- `cargo xtask publish --dry-run --skip-tests --skip-git-check --verbose`
- `cargo publish -p tokmd-types --locked --dry-run --no-verify --allow-dirty`
- `cargo publish -p tokmd-envelope --locked --dry-run --no-verify --allow-dirty`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check HEAD~1..HEAD`

## Resume after merge
From merged `origin/main`, resume the partial v1.10.0 crates.io publish with:

```bash
cargo xtask publish --yes --skip-tests --verbose --from tokmd-types
```

`tokmd-gate` and `tokmd-io-port` are already published at 1.10.0. Starting from `tokmd-types` avoids reattempting them while preserving the corrected dependency order for the remaining crates.