### PR TITLE
action: add pr onboarding mode and CI-friendly inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   mode:
-    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit, sensor, baseline.'
+    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: pr, module, export, gate, cockpit, sensor, baseline.'
     default: ''
   version:
     description: 'Version of tokmd to install. Defaults to the latest release.'
@@ -34,8 +34,23 @@ inputs:
     description: 'Whether to upload generated tokmd files as workflow artifacts'
     default: 'true'
   comment:
-    description: 'Whether to post the generated Markdown summary as a pull request comment'
-    default: 'true'
+    description: 'Comment behavior: auto, true, or false'
+    default: 'auto'
+  gate-mode:
+    description: 'Gate behavior for mode=pr: off, advisory, or blocking'
+    default: 'advisory'
+  fail-no-policy:
+    description: 'When true, fail mode=pr if no gate policy is found'
+    default: 'false'
+  output-dir:
+    description: 'Directory where generated files are written'
+    default: '.tokmd/action'
+  artifact-name:
+    description: 'Artifact name used when artifact=true'
+    default: 'tokmd-${{ github.run_id }}'
+  artifact-retention-days:
+    description: 'Artifact retention days'
+    default: '14'
 
 outputs:
   receipt:
@@ -167,6 +182,9 @@ runs:
         TOKMD_ACTION_MODULE_ROOTS: ${{ inputs.module-roots }}
         TOKMD_ACTION_PATHS: ${{ inputs.paths }}
         TOKMD_ACTION_TOP: ${{ inputs.top }}
+        TOKMD_ACTION_GATE_MODE: ${{ inputs.gate-mode }}
+        TOKMD_ACTION_FAIL_NO_POLICY: ${{ inputs.fail-no-policy }}
+        TOKMD_ACTION_OUTPUT_DIR: ${{ inputs.output-dir }}
       run: |
         set -euo pipefail
         echo "Generating receipts..."
@@ -195,6 +213,7 @@ runs:
 
         format="$TOKMD_ACTION_FORMAT"
         mode="$TOKMD_ACTION_MODE"
+        output_dir="$TOKMD_ACTION_OUTPUT_DIR"
         summary_file=""
         receipt_file=""
         gate_verdict_file=""
@@ -202,6 +221,7 @@ runs:
         sensor_report_file=""
         baseline_report_file=""
         command_status=0
+        mkdir -p "$output_dir"
 
         ensure_git_ref() {
           local ref="$1"
@@ -248,8 +268,8 @@ runs:
 
         case "$mode" in
           "")
-            summary_file="tokmd-summary.md"
-            receipt_file="tokmd-receipt.${format}"
+            summary_file="$output_dir/tokmd-summary.md"
+            receipt_file="$output_dir/tokmd-receipt.${format}"
 
             tokmd module \
               "${scan_paths[@]}" \
@@ -263,7 +283,7 @@ runs:
               --format "$format" > "$receipt_file"
             ;;
           module)
-            summary_file="tokmd-summary.md"
+            summary_file="$output_dir/tokmd-summary.md"
 
             tokmd module \
               "${scan_paths[@]}" \
@@ -272,12 +292,45 @@ runs:
               --format md > "$summary_file"
             ;;
           export)
-            receipt_file="tokmd-receipt.${format}"
+            receipt_file="$output_dir/tokmd-receipt.${format}"
 
             tokmd export \
               "${scan_paths[@]}" \
               --module-roots "$TOKMD_ACTION_MODULE_ROOTS" \
               --format "$format" > "$receipt_file"
+            ;;
+          pr)
+            summary_file="$output_dir/tokmd-summary.md"
+            receipt_file="$output_dir/tokmd-receipt.${format}"
+            gate_verdict_file="$output_dir/tokmd-gate-verdict.json"
+            sensor_report_file="$output_dir/tokmd-sensor-report.json"
+            manifest_file="$output_dir/manifest.json"
+
+            tokmd module "${scan_paths[@]}" --module-roots "$TOKMD_ACTION_MODULE_ROOTS" --top "$TOKMD_ACTION_TOP" --format md > "$summary_file"
+            tokmd export "${scan_paths[@]}" --module-roots "$TOKMD_ACTION_MODULE_ROOTS" --format "$format" > "$receipt_file"
+            if [ -n "${GITHUB_BASE_REF:-}" ]; then
+              compare_base="$(resolve_base_ref sensor)"
+              tokmd sensor --base "$compare_base" --head "$TOKMD_ACTION_HEAD" --output "$sensor_report_file" --format json > /dev/null
+            fi
+            if [ "$TOKMD_ACTION_GATE_MODE" != "off" ]; then
+              if [ -f tokmd.toml ]; then
+                set +e
+                tokmd gate "${scan_paths[0]}" --format json > "$gate_verdict_file"
+                gate_status=$?
+                set -e
+                if [ "$TOKMD_ACTION_GATE_MODE" = "blocking" ] && [ $gate_status -ne 0 ]; then
+                  command_status=$gate_status
+                fi
+              elif [ "$TOKMD_ACTION_FAIL_NO_POLICY" = "true" ] || [ "$TOKMD_ACTION_GATE_MODE" = "blocking" ]; then
+                echo "::error::No tokmd gate policy found."
+                command_status=1
+              else
+                echo "::notice::No tokmd gate policy found; skipping gate in advisory mode."
+              fi
+            fi
+            cat > "$manifest_file" <<EOF
+{"schema_version":"tokmd.action.v1","mode":"pr","files":{"summary":"$summary_file","receipt":"$receipt_file","gate_verdict":"$gate_verdict_file","sensor_report":"$sensor_report_file"}}
+EOF
             ;;
           gate)
             if [ ${#scan_paths[@]} -ne 1 ]; then
@@ -285,14 +338,14 @@ runs:
               exit 1
             fi
 
-            gate_verdict_file="tokmd-gate-verdict.json"
+            gate_verdict_file="$output_dir/tokmd-gate-verdict.json"
             set +e
             tokmd gate "${scan_paths[0]}" --format json > "$gate_verdict_file"
             command_status=$?
             set -e
             ;;
           cockpit)
-            cockpit_report_file="tokmd-cockpit-report.json"
+            cockpit_report_file="$output_dir/tokmd-cockpit-report.json"
             compare_base="$(resolve_base_ref cockpit)"
 
             tokmd cockpit \
@@ -301,8 +354,8 @@ runs:
               --format json > "$cockpit_report_file"
             ;;
           sensor)
-            summary_file="comment.md"
-            sensor_report_file="tokmd-sensor-report.json"
+            summary_file="$output_dir/comment.md"
+            sensor_report_file="$output_dir/tokmd-sensor-report.json"
             compare_base="$(resolve_base_ref sensor)"
 
             tokmd sensor \
@@ -317,7 +370,7 @@ runs:
               exit 1
             fi
 
-            baseline_report_file="tokmd-baseline.json"
+            baseline_report_file="$output_dir/tokmd-baseline.json"
 
             tokmd baseline "${scan_paths[0]}" \
               --output "$baseline_report_file" \
@@ -325,7 +378,7 @@ runs:
               --no-progress
             ;;
           *)
-            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit, sensor, baseline. Omit mode for the default module + export flow."
+            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: pr, module, export, gate, cockpit, sensor, baseline. Omit mode for the default module + export flow."
             exit 1
             ;;
         esac
@@ -338,24 +391,19 @@ runs:
           echo "sensor-report=$sensor_report_file"
           echo "baseline-report=$baseline_report_file"
           echo "command-status=$command_status"
+          echo "manifest=$manifest_file"
         } >> "$GITHUB_OUTPUT"
 
     - name: Upload Artifact
       if: inputs.artifact == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: tokmd-receipts
-        path: |
-          ${{ steps.generate.outputs.summary }}
-          ${{ steps.generate.outputs.receipt }}
-          ${{ steps.generate.outputs['gate-verdict'] }}
-          ${{ steps.generate.outputs['cockpit-report'] }}
-          ${{ steps.generate.outputs['sensor-report'] }}
-          ${{ steps.generate.outputs['baseline-report'] }}
-          extras/
+        name: ${{ inputs.artifact-name }}
+        retention-days: ${{ inputs.artifact-retention-days }}
+        path: ${{ inputs.output-dir }}/
 
     - name: Comment on PR
-      if: inputs.comment == 'true' && github.event_name == 'pull_request' && steps.generate.outputs.summary != ''
+      if: (inputs.comment == 'true' || (inputs.comment == 'auto' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) && steps.generate.outputs.summary != ''
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
       with:
         file-path: ${{ steps.generate.outputs.summary }}

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -67,7 +67,7 @@ If `version` does not start with `v`, the Action prepends it before downloading 
 
 | Input | Required | Default | Purpose |
 | :---- | :------- | :------ | :------ |
-| `mode` | no | `(omitted)` | `tokmd` mode to run: `module`, `export`, `gate`, `cockpit`, `sensor`, or `baseline`. Omit it for the default module plus export flow. |
+| `mode` | no | `(omitted)` | `tokmd` mode to run: `pr`, `module`, `export`, `gate`, `cockpit`, `sensor`, or `baseline`. Omit it for the default module plus export flow. |
 | `version` | no | `latest` | `tokmd` release to install. Use an explicit version when you want the Action ref and binary version to stay aligned. |
 | `paths` | no | `.` | Paths to scan. Values are split on whitespace and passed as separate path arguments. |
 | `module-roots` | no | `crates,packages` | Module root prefixes for `module`, `export`, and the default flow. |
@@ -76,7 +76,12 @@ If `version` does not start with `v`, the Action prepends it before downloading 
 | `base` | no | `(inferred)` | Base git ref for `cockpit` and `sensor`. Explicit values are used as provided. When omitted, pull request runs use `origin/$GITHUB_BASE_REF`; other runs use `origin/HEAD` when available. |
 | `head` | no | `HEAD` | Head git ref for `cockpit` and `sensor`. |
 | `artifact` | no | `true` | Upload generated tokmd files as workflow artifacts. |
-| `comment` | no | `true` | Post the generated Markdown summary as a pull request comment when running on `pull_request` events. |
+| `comment` | no | `auto` | Comment behavior: `auto`, `true`, or `false`. |
+| `gate-mode` | no | `advisory` | `mode: pr` gate behavior: `off`, `advisory`, `blocking`. |
+| `fail-no-policy` | no | `false` | Fail `mode: pr` when no gate policy is found. |
+| `output-dir` | no | `.tokmd/action` | Directory for generated files. |
+| `artifact-name` | no | `tokmd-${{ github.run_id }}` | Artifact name when uploads are enabled. |
+| `artifact-retention-days` | no | `14` | Artifact retention period in days. |
 
 ## Outputs
 


### PR DESCRIPTION
### Motivation
- Provide a single, onboarding-friendly GitHub Action mode to make PR/CI integrations simpler and safer by composing sensor, receipt/export, and gate behavior into one invocation (`mode: pr`).
- Reduce workflow friction by centralizing outputs into a stable directory, configurable artifact naming/retention, and safer default commenting behavior for forks.
- Expose gate semantics useful for first-run onboarding via `gate-mode` and `fail-no-policy` so advisory vs blocking behavior is explicit.

### Description
- Added a new `pr` mode and expanded `mode` documentation in `action.yml` so the composite action now supports `pr` alongside existing modes. 
- Introduced new inputs: `comment` (defaults to `auto`), `gate-mode`, `fail-no-policy`, `output-dir`, `artifact-name`, and `artifact-retention-days`, and wired them into the generation step so outputs are written into `output-dir` (default `.tokmd/action`).
- `mode: pr` orchestration now runs `tokmd module` + `tokmd export`, optionally runs `tokmd sensor` when a base ref is available, conditionally runs `tokmd gate` based on policy presence and `gate-mode`, and writes a machine-readable `manifest.json` into the output directory.
- Updated artifact upload to publish the entire `output-dir` under a configurable artifact name/retention, and adjusted the PR comment condition to respect `comment: auto` (same-repo PRs only) while keeping explicit `true`/`false` semantics.
- Updated `docs/github-action.md` to document the new `pr` mode and all added inputs and defaults.

### Testing
- Ran targeted repository checks with `rg` to verify the new inputs/mode and updated docs, which succeeded. 
- Performed file inspection and commits (`git add` / `git commit`) locally to validate applied changes and updated docs, which succeeded. 
- A shell syntax lint (`bash -n action.yml`) was performed during iteration and reported an issue while editing, which was addressed before the final commit; files were inspected to ensure the new logic and outputs (`manifest`, `output-dir`) were written to `action.yml` and `docs/github-action.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f329ac437883339ec83ace1e2686a5)