### PR TITLE
feat: add `tokmd review` PR review cockpit and GitHub Action `mode: review`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   mode:
-    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit, sensor, baseline.'
+    description: 'tokmd mode to run. Omit for the existing module + export flow. Supported values: module, export, gate, cockpit, sensor, baseline, review.'
     default: ''
   version:
     description: 'Version of tokmd to install. Defaults to the latest release.'
@@ -37,6 +37,16 @@ inputs:
     description: 'Whether to post the generated Markdown summary as a pull request comment'
     default: 'true'
 
+  out-dir:
+    description: 'Output directory for mode: review artifacts'
+    default: '.tokmd/review'
+  config:
+    description: 'Config path for mode: review'
+    default: ''
+  gate:
+    description: 'Gate mode for mode: review (off, advisory, blocking)'
+    default: 'advisory'
+
 outputs:
   receipt:
     description: 'Path to the generated receipt file'
@@ -56,6 +66,9 @@ outputs:
   baseline-report:
     description: 'Path to the generated baseline JSON file'
     value: ${{ steps.generate.outputs['baseline-report'] }}
+  review-manifest:
+    description: 'Path to review manifest JSON when mode: review'
+    value: ${{ steps.generate.outputs['review-manifest'] }}
 
 runs:
   using: "composite"
@@ -167,6 +180,9 @@ runs:
         TOKMD_ACTION_MODULE_ROOTS: ${{ inputs.module-roots }}
         TOKMD_ACTION_PATHS: ${{ inputs.paths }}
         TOKMD_ACTION_TOP: ${{ inputs.top }}
+        TOKMD_ACTION_OUT_DIR: ${{ inputs.out-dir }}
+        TOKMD_ACTION_CONFIG: ${{ inputs.config }}
+        TOKMD_ACTION_GATE: ${{ inputs.gate }}
       run: |
         set -euo pipefail
         echo "Generating receipts..."
@@ -201,6 +217,7 @@ runs:
         cockpit_report_file=""
         sensor_report_file=""
         baseline_report_file=""
+        review_manifest_file=""
         command_status=0
 
         ensure_git_ref() {
@@ -311,6 +328,16 @@ runs:
               --output "$sensor_report_file" \
               --format json > /dev/null
             ;;
+          review)
+            summary_file="${TOKMD_ACTION_OUT_DIR}/comment.md"
+            review_manifest_file="${TOKMD_ACTION_OUT_DIR}/manifest.json"
+            compare_base="$(resolve_base_ref review)"
+            cmd=(tokmd review --base "$compare_base" --head "$TOKMD_ACTION_HEAD" --out-dir "$TOKMD_ACTION_OUT_DIR" --gate "$TOKMD_ACTION_GATE")
+            if [ -n "${TOKMD_ACTION_CONFIG:-}" ]; then
+              cmd+=(--config "$TOKMD_ACTION_CONFIG")
+            fi
+            "${cmd[@]}"
+            ;;
           baseline)
             if [ ${#scan_paths[@]} -ne 1 ]; then
               echo "::error::mode=baseline accepts exactly one input path; received ${#scan_paths[@]} paths"
@@ -325,7 +352,7 @@ runs:
               --no-progress
             ;;
           *)
-            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit, sensor, baseline. Omit mode for the default module + export flow."
+            echo "::error::Unsupported tokmd action mode '$mode'. Supported values: module, export, gate, cockpit, sensor, baseline, review. Omit mode for the default module + export flow."
             exit 1
             ;;
         esac
@@ -337,6 +364,7 @@ runs:
           echo "cockpit-report=$cockpit_report_file"
           echo "sensor-report=$sensor_report_file"
           echo "baseline-report=$baseline_report_file"
+          echo "review-manifest=$review_manifest_file"
           echo "command-status=$command_status"
         } >> "$GITHUB_OUTPUT"
 
@@ -352,6 +380,7 @@ runs:
           ${{ steps.generate.outputs['cockpit-report'] }}
           ${{ steps.generate.outputs['sensor-report'] }}
           ${{ steps.generate.outputs['baseline-report'] }}
+          ${{ steps.generate.outputs['review-manifest'] }}
           extras/
 
     - name: Comment on PR

--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -155,6 +155,9 @@ pub enum Commands {
 
     /// Run as a conforming sensor, producing a SensorReport.
     Sensor(SensorArgs),
+
+    /// Build a PR review cockpit packet (cockpit + analysis + review map).
+    Review(ReviewArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -1023,6 +1026,34 @@ impl From<GlobalArgs> for tokmd_settings::ScanOptions {
     }
 }
 
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReviewGateMode {
+    #[default]
+    Off,
+    Advisory,
+    Blocking,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ReviewArgs {
+    #[arg(long, default_value = "origin/main")]
+    pub base: String,
+    #[arg(long, default_value = "HEAD")]
+    pub head: String,
+    #[arg(long)]
+    pub out_dir: Option<PathBuf>,
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+    #[arg(long, value_enum, default_value_t = ReviewGateMode::Off)]
+    pub gate: ReviewGateMode,
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    pub near_dup: bool,
+    #[arg(long)]
+    pub detail_functions: bool,
+    #[arg(long, default_value_t = 12)]
+    pub max_review_items: usize,
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tokmd/src/commands/mod.rs
+++ b/crates/tokmd/src/commands/mod.rs
@@ -17,6 +17,8 @@ pub(crate) mod init;
 pub(crate) mod lang;
 pub(crate) mod module;
 #[cfg(feature = "analysis")]
+pub(crate) mod review;
+#[cfg(feature = "analysis")]
 pub(crate) mod run;
 pub(crate) mod sensor;
 pub(crate) mod tools;
@@ -51,6 +53,8 @@ pub(crate) fn dispatch(cli: cli::Cli, resolved: &ResolvedConfig) -> Result<()> {
         cli::Commands::Baseline(args) => baseline::handle(args, global),
         cli::Commands::Handoff(args) => handoff::handle(args, global),
         cli::Commands::Sensor(args) => sensor::handle(args, global),
+        #[cfg(feature = "analysis")]
+        cli::Commands::Review(args) => review::handle(args, global),
         #[cfg(not(feature = "analysis"))]
         _ => anyhow::bail!("analysis feature is not enabled"),
     }

--- a/crates/tokmd/src/commands/review.rs
+++ b/crates/tokmd/src/commands/review.rs
@@ -1,0 +1,219 @@
+use crate::cli;
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+pub(crate) fn handle(args: cli::ReviewArgs, _global: &cli::GlobalArgs) -> Result<()> {
+    let out_dir = args
+        .out_dir.clone()
+        .unwrap_or_else(|| PathBuf::from(".tokmd/review"));
+    fs::create_dir_all(&out_dir)?;
+
+    let cockpit_path = out_dir.join("cockpit.json");
+    run_tokmd(
+        &[
+            "cockpit", "--base", &args.base, "--head", &args.head, "--format", "json",
+        ],
+        Some(&cockpit_path),
+    )?;
+
+    let analysis_path = out_dir.join("analysis-risk.json");
+    let mut analyze_args = vec!["analyze", ".", "--preset", "risk", "--format", "json"];
+    if args.near_dup {
+        analyze_args.push("--near-dup");
+    }
+    if args.detail_functions {
+        analyze_args.push("--detail-functions");
+    }
+    run_tokmd(&analyze_args, Some(&analysis_path))?;
+
+    let cockpit: Value = serde_json::from_str(&fs::read_to_string(&cockpit_path)?)?;
+    let analysis: Value = serde_json::from_str(&fs::read_to_string(&analysis_path)?)?;
+
+    let review_map = build_review_map(&cockpit, &analysis, &args);
+    fs::write(
+        out_dir.join("review-map.json"),
+        serde_json::to_string_pretty(&review_map)?,
+    )?;
+    fs::write(
+        out_dir.join("review-map.md"),
+        render_review_map_md(&review_map),
+    )?;
+
+    let evidence = cockpit
+        .get("evidence")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    fs::write(
+        out_dir.join("evidence.json"),
+        serde_json::to_string_pretty(&evidence)?,
+    )?;
+
+    let comment = render_comment(&cockpit, &review_map);
+    fs::write(out_dir.join("comment.md"), comment)?;
+
+    let manifest = json!({
+        "base": args.base,
+        "head": args.head,
+        "artifacts": {
+            "cockpit": "cockpit.json",
+            "analysis": "analysis-risk.json",
+            "review_map": "review-map.json",
+            "review_map_md": "review-map.md",
+            "comment": "comment.md",
+            "evidence": "evidence.json"
+        }
+    });
+    fs::write(
+        out_dir.join("manifest.json"),
+        serde_json::to_string_pretty(&manifest)?,
+    )?;
+
+    if args.gate != cli::ReviewGateMode::Off {
+        let packet_path = out_dir.join("review-packet.json");
+        let packet = json!({"review_map": review_map, "cockpit": cockpit, "analysis": analysis});
+        fs::write(&packet_path, serde_json::to_string_pretty(&packet)?)?;
+        let gate_out = out_dir.join("gate-verdict.json");
+        let status = run_tokmd(
+            &["gate", packet_path.to_str().unwrap(), "--format", "json"],
+            Some(&gate_out),
+        );
+        if args.gate == cli::ReviewGateMode::Blocking {
+            status?;
+        }
+    }
+
+    Ok(())
+}
+
+fn run_tokmd(args: &[&str], output: Option<&PathBuf>) -> Result<()> {
+    let exe = std::env::current_exe().context("resolve current tokmd binary")?;
+    let mut cmd = Command::new(exe);
+    cmd.args(args);
+    if let Some(path) = output {
+        let out = cmd.output().context("failed to run tokmd subcommand")?;
+        if !out.status.success() {
+            bail!("tokmd {:?} failed", args);
+        }
+        fs::write(path, out.stdout)?;
+    } else {
+        let status = cmd.status()?;
+        if !status.success() {
+            bail!("tokmd {:?} failed", args);
+        }
+    }
+    Ok(())
+}
+
+fn build_review_map(cockpit: &Value, analysis: &Value, args: &cli::ReviewArgs) -> Value {
+    let review_plan = cockpit
+        .get("review_plan")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut path = Vec::new();
+    for (idx, item) in review_plan
+        .into_iter()
+        .take(args.max_review_items)
+        .enumerate()
+    {
+        let p = item
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let mut reasons = Vec::new();
+        if let Some(r) = item.get("reason").and_then(Value::as_str) {
+            reasons.push(r.to_string());
+        }
+        path.push(
+            json!({"priority": idx+1, "path": p, "score": 100-(idx as i32*10), "reasons": reasons}),
+        );
+    }
+    let dup_findings = analysis
+        .pointer("/dup/pairs")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let cx_findings = analysis
+        .pointer("/complexity/high_risk_files")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let evidence_gaps = cockpit
+        .pointer("/evidence/mutation/survivors")
+        .and_then(Value::as_array)
+        .map(|a| if a.is_empty() { 0 } else { 1 })
+        .unwrap_or(0);
+    json!({
+      "schema_version":"tokmd.review_map.v1",
+      "base_ref": args.base,
+      "head_ref": args.head,
+      "overall": {
+        "risk_level": cockpit.pointer("/risk/level").and_then(Value::as_str).unwrap_or("unknown"),
+        "risk_score": cockpit.pointer("/risk/score").and_then(Value::as_u64).unwrap_or(0),
+        "health_score": cockpit.pointer("/code_health/score").and_then(Value::as_u64).unwrap_or(0),
+        "health_grade": cockpit.pointer("/code_health/grade").and_then(Value::as_str).unwrap_or("N/A"),
+        "priority_items": path.len(),
+        "complexity_findings": cx_findings,
+        "duplication_findings": dup_findings,
+        "evidence_gaps": evidence_gaps
+      },
+      "review_path": path
+    })
+}
+
+fn render_review_map_md(review_map: &Value) -> String {
+    let mut out = String::from("## Review map\n\n| Priority | File | Why |\n|---:|---|---|\n");
+    if let Some(items) = review_map.get("review_path").and_then(Value::as_array) {
+        for item in items {
+            let reasons = item
+                .get("reasons")
+                .and_then(Value::as_array)
+                .map(|r| {
+                    r.iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+            out.push_str(&format!(
+                "| P{} | {} | {} |\n",
+                item.get("priority").and_then(Value::as_u64).unwrap_or(0),
+                item.get("path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown"),
+                reasons
+            ));
+        }
+    }
+    out
+}
+
+fn render_comment(_cockpit: &Value, review_map: &Value) -> String {
+    format!(
+        "## tokmd Review Cockpit\n\nRisk: {}\nHealth: {} ({})\nComplexity: {} high-complexity files touched\nDuplication: {} near-duplicate pairs\n\n{}",
+        review_map
+            .pointer("/overall/risk_level")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+        review_map
+            .pointer("/overall/health_score")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        review_map
+            .pointer("/overall/health_grade")
+            .and_then(Value::as_str)
+            .unwrap_or("N/A"),
+        review_map
+            .pointer("/overall/complexity_findings")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        review_map
+            .pointer("/overall/duplication_findings")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        render_review_map_md(review_map)
+    )
+}


### PR DESCRIPTION
### Motivation

- Provide a first-class PR Review Cockpit that composes cockpit + deep analysis into a stable review packet and reviewer map so maintainers know where to focus attention. 
- Avoid making users manually stitch `cockpit` + `analyze` + `gate` together by exposing a single `tokmd review` workflow and CI integration. 

### Description

- Add a new `Review` CLI subcommand and `ReviewArgs` with `--base`, `--head`, `--out-dir`, `--config`, `--gate`, `--near-dup`, `--detail-functions`, and `--max-review-items` options in `crates/tokmd/src/cli/parser.rs`. 
- Implement `crates/tokmd/src/commands/review.rs` which orchestrates `tokmd cockpit` and `tokmd analyze` (preset `risk`), merges outputs into a `review-packet`, generates artifacts (`cockpit.json`, `analysis-risk.json`, `review-map.json`, `review-map.md`, `comment.md`, `evidence.json`, `manifest.json`), and optionally runs `tokmd gate` in `advisory` or `blocking` mode. 
- Wire the new command into dispatch in `crates/tokmd/src/commands/mod.rs` guarded by the `analysis` feature. 
- Extend the composite `action.yml` to support `mode: review` with new inputs (`out-dir`, `config`, `gate`) and output `review-manifest`, and add the step that runs `tokmd review` and uploads the review artifacts. 

### Testing

- Ran formatter and lint-fix with `cargo fmt-fix`, which completed successfully. 
- Built and type-checked the CLI with `cargo check -p tokmd`, which finished successfully. 
- The change is feature-gated behind `analysis` (the new review module is included only when the `analysis` feature is enabled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3362f993c83339dde3b45f4e7c40c)