### PR TITLE
cartographer: align roadmap and implementation plan drift 🗺️

### DIFF
--- a/.jules/runs/cartographer_roadmap_design/decision.md
+++ b/.jules/runs/cartographer_roadmap_design/decision.md
@@ -1,0 +1,36 @@
+## Options Considered
+
+### Option A: Clean up v1.10.0 roadmap/implementation-plan drift and outline missing v1.11.0 sections
+- **What it is**:
+  - Since v1.10.0 was completed in RC and stable, update ROADMAP.md and implementation-plan.md to reflect v1.10.0 completion properly in sections not just the status table.
+  - v1.11.0 section in ROADMAP.md is missing in detailed phase mapping.
+  - Outline Phase 5c for Browser Runtime Polish (v1.11.0) in implementation-plan.md, which is currently just listed as "Follow-up" or missing in some roadmap parts.
+  - The status table has `v1.10.0-rc.1` and `v1.10.0` but the detailed milestones below don't have the final v1.10.0.
+  - Wait, let me check ROADMAP.md detailed milestones for v1.10.0.
+- **Why it fits**: Directly addresses roadmap and implementation plan drift and clarity.
+
+Let's look at `ROADMAP.md` detailed milestones.
+
+Looking at `ROADMAP.md` and `docs/implementation-plan.md`, `v1.10.0` is marked as "Completed" in `ROADMAP.md` status table (`v1.10.0-rc.1` and `v1.10.0`).
+However, in `ROADMAP.md` detailed sections, it says:
+`## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability`
+but does not have `✅ Complete` in the header, while earlier ones (like `## Completed: v1.8.0 ...`) do.
+Wait, looking closely at `get_sections.py` output:
+`## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability` is not prefixed with `Completed: ` like `v1.8.0`, nor does it have `✅ Complete`.
+Also `v1.9.0` says `## v1.9.0 — Browser/WASM Productization` (missing `Completed: ` or `✅ Complete`). Wait, in the status table v1.9.0 is ✅ Complete.
+
+In `docs/implementation-plan.md`:
+`## Phase 5b: Release Train Hardening (v1.10.0) ✅ Complete` -> It actually does have `✅ Complete`.
+But `Phase 5c: Browser Runtime Polish (v1.11.0)` is missing as a proper phase section in `implementation-plan.md` - it's just listed as a "Follow-Up".
+
+Also, there is no detailed milestone for `v1.11.0` in `ROADMAP.md`. It just lists "Deferred to v1.11.0" under v1.10.0, and "v1.11.0" is in the table as `🔭 Planned`.
+Wait, looking at `ROADMAP.md` for `v1.9.0`: `What shipped in v1.9.0` implies it's complete.
+
+Let's do Option A: Align the headers in `ROADMAP.md` to reflect `v1.9.0` and `v1.10.0` as completed (they shipped), and add a formal `v1.11.0` section to `ROADMAP.md` and `docs/implementation-plan.md` outlining the planned work so future reviewers have a clear target, removing the "Deferred to v1.11.0" from v1.10.0 and moving it to its own heading.
+
+### Option B: Create a Learning PR indicating that there are no significant design drifts to fix.
+- **What it is**: No code changes. Just create a run packet and open a learning PR.
+- **Why**: Maybe the drift is too small to warrant a change.
+
+### Decision
+Option A. The `ROADMAP.md` and `docs/implementation-plan.md` are actively read to understand what the next major efforts are. A `v1.11.0` section doesn't exist yet, but it's the immediate next planned milestone. Leaving it hidden as "Deferred to v1.11.0" inside the `v1.10.0` section makes the roadmap confusing, and `v1.9.0`/`v1.10.0` are structurally missing the `Completed: ` header prefix that `v1.8.0` and earlier have. This is exactly what the `Cartographer` persona should fix.

--- a/.jules/runs/cartographer_roadmap_design/envelope.json
+++ b/.jules/runs/cartographer_roadmap_design/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "cartographer_roadmap_design",
+  "persona": "cartographer",
+  "style": "builder",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/**/Cargo.toml",
+    ".cargo/**"
+  ],
+  "gate_profile": "governance-release",
+  "allowed_outcomes": ["pr-ready patch", "learning pr"]
+}

--- a/.jules/runs/cartographer_roadmap_design/pr_body.md
+++ b/.jules/runs/cartographer_roadmap_design/pr_body.md
@@ -1,0 +1,53 @@
+## 💡 Summary
+Updated `ROADMAP.md` and `docs/implementation-plan.md` to formally reflect the completion of the `v1.9.0` and `v1.10.0` milestones. Added a formal `v1.11.0` section to structure the planned browser runtime polish work that was previously buried as a deferred item or follow-up note.
+
+## 🎯 Why
+The roadmap and implementation plan exhibited factual drift from the shipped reality of `v1.10.0`. While the status table noted these releases as complete, their detailed sections were missing the "Completed" prefix and proper headings. Furthermore, the `v1.11.0` work was hidden as "Deferred to v1.11.0" inside the `v1.10.0` block, which makes the roadmap misleading and obscures the concrete targets for the upcoming release.
+
+## 🔎 Evidence
+- `ROADMAP.md` status table listed `v1.10.0` as `✅ Complete`, but `## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability` lacked completion indicators.
+- `docs/implementation-plan.md` had `### Follow-Up: v1.11.0 Browser Runtime Polish` rather than treating it as a formal buildout phase matching the roadmap.
+- Run receipt: `cargo xtask docs --check` completed successfully, ensuring the documentation edits did not break generation or anchors.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Make the completed `v1.9.0` and `v1.10.0` milestones uniform with older versions. Extract the `v1.11.0` scope into its own major section in both files.
+- Fits the `tooling-governance` shard by correcting factual drift in roadmap design references.
+- Trade-offs: Minor documentation update but improves future visibility and coherence.
+
+### Option B
+- Ignore the mismatch and consider the status table sufficient.
+- Leaves the `v1.11.0` targets buried and makes future implementation planning harder.
+
+## ✅ Decision
+Chose Option A to cleanly align the roadmap's detailed sections with the shipped status and properly frame the incoming `v1.11.0` milestone, eliminating the contradictory "deferred" state.
+
+## 🧱 Changes made (SRP)
+- `ROADMAP.md`
+- `docs/implementation-plan.md`
+
+## 🧪 Verification receipts
+```text
+cargo xtask docs --check -> Documentation is up to date.
+cargo xtask publish --plan --verbose -> Workspace version: 1.10.0
+cargo xtask version-consistency -> Version consistency checks passed.
+cargo fmt -- --check -> success
+cargo check -> Finished `dev` profile
+```
+
+## 🧭 Telemetry
+- Change shape: Docs structure fix.
+- Blast radius: `docs` / `ROADMAP.md` (no functional changes).
+- Risk class: Low, pure markdown updates without contract changes.
+- Rollback: `git checkout -- ROADMAP.md docs/implementation-plan.md`
+- Gates run: `xtask docs --check`, `xtask publish --plan`, `xtask version-consistency`, `cargo check`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/cartographer_roadmap_design/envelope.json`
+- `.jules/runs/cartographer_roadmap_design/decision.md`
+- `.jules/runs/cartographer_roadmap_design/receipts.jsonl`
+- `.jules/runs/cartographer_roadmap_design/result.json`
+- `.jules/runs/cartographer_roadmap_design/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/cartographer_roadmap_design/receipts.jsonl
+++ b/.jules/runs/cartographer_roadmap_design/receipts.jsonl
@@ -1,0 +1,7 @@
+{"command": "cargo xtask docs --check", "status": "success", "output": "Documentation is up to date."}
+{"command": "cargo xtask publish --plan --verbose", "status": "success", "output": "Workspace version: 1.10.0"}
+{"command": "cargo xtask version-consistency", "status": "success", "output": "Version consistency checks passed."}
+{"command": "cargo fmt -- --check", "status": "success", "output": ""}
+{"command": "cargo check", "status": "success", "output": "Finished `dev` profile [unoptimized + debuginfo]"}
+{"command": "python3 update_roadmap.py", "status": "success", "output": ""}
+{"command": "python3 update_implementation_plan.py", "status": "success", "output": ""}

--- a/.jules/runs/cartographer_roadmap_design/result.json
+++ b/.jules/runs/cartographer_roadmap_design/result.json
@@ -1,0 +1,11 @@
+{
+  "outcome": "pr-ready patch",
+  "files_changed": ["ROADMAP.md", "docs/implementation-plan.md"],
+  "gates_run": [
+    "cargo xtask docs --check",
+    "cargo xtask publish --plan",
+    "cargo xtask version-consistency",
+    "cargo fmt -- --check",
+    "cargo check"
+  ]
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -476,7 +476,7 @@ UX work is explicitly **incremental and non-breaking**:
 
 - The full in-memory scan path and wasm CI parity work did not fully land in `1.8.0`; that continuation is now the next milestone instead of implicit spillover.
 
-## v1.9.0 — Browser/WASM Productization
+## Completed: v1.9.0 — Browser/WASM Productization
 
 **Goal:** Finish the browser/WASM product surface around the already-landed in-memory execution path and make the supported browser workflow explicit, repeatable, and capability-honest.
 
@@ -507,7 +507,7 @@ UX work is explicitly **incremental and non-breaking**:
 - No browser zipball ingestion as the primary supported path for `v1.9.0`; tree+contents is the supported browser acquisition strategy.
 - No mutation testing or other heavy tooling in-browser.
 
-## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability
+## Completed: v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability
 
 **Goal:** Ship the stable release after the Action, path-trust, WASM, publish-surface, and proof-hardening work landed and the release candidate was validated.
 
@@ -520,7 +520,11 @@ UX work is explicitly **incremental and non-breaking**:
 - [x] Determinism and proof coverage for analyze snapshots, run/diff receipts, effort serde, and core CLI behavior.
 - [x] CLI reference docs generated through checked HELP markers.
 
-### Deferred to v1.11.0
+## v1.11.0 — Browser Runtime Polish
+
+**Goal:** Deliver polish for the browser runtime environment, handling edge cases, UX for long-running analyses, and fetch boundaries.
+
+### What is planned for v1.11.0
 
 - Browser cache key/invalidation semantics.
 - Browser progress events.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -368,12 +368,21 @@ fetch.
 - [x] Add determinism, snapshot, and property-test proof coverage for release-critical paths
 - [x] Clarify Jules provenance policy without blanket-blocking intentional `.jules/**` history
 
-### Follow-Up: v1.11.0 Browser Runtime Polish
+## Phase 5c: Browser Runtime Polish (v1.11.0)
+
+**Goal**: Deliver polish for the browser runtime environment, handling edge cases, UX for long-running analyses, and fetch boundaries.
+
+### Work Items
 
 - [ ] Define cache key and invalidation semantics
 - [ ] Emit explicit progress events
 - [ ] Improve retry and rate-limit UX
 - [ ] Partition authenticated fetch/cache behavior safely
+
+### Tests
+
+- Unit tests: Cache invalidation logic
+- E2E tests: Progress event emission during long scans
 
 ---
 


### PR DESCRIPTION
cartographer: align roadmap and implementation plan drift 🗺️

Updated ROADMAP.md and docs/implementation-plan.md to reflect the shipped completion of the v1.9.0 and v1.10.0 milestones. Also extracted the v1.11.0 browser runtime polish effort into proper sections rather than obscuring it as a deferred item inside v1.10.0. Includes corresponding per-run artifacts.

---
*PR created automatically by Jules for task [906878359967537284](https://jules.google.com/task/906878359967537284) started by @EffortlessSteven*