### PR TITLE
librarian: add missing docs drift test for CONTEXT_BUNDLE_SCHEMA_VERSION 📚

### DIFF
--- a/.jules/runs/librarian_docs_examples_1/decision.md
+++ b/.jules/runs/librarian_docs_examples_1/decision.md
@@ -1,0 +1,25 @@
+# Decision
+
+## Inspected
+- `xtask/tests/docs_w43.rs` checks for schema documentation sync.
+- `crates/tokmd-types/src/lib.rs` contains `CONTEXT_BUNDLE_SCHEMA_VERSION`.
+- `docs/SCHEMA.md` documents `CONTEXT_BUNDLE_SCHEMA_VERSION` (version 2).
+- The test file `xtask/tests/docs_w43.rs` lacks a test for `CONTEXT_BUNDLE_SCHEMA_VERSION` drift, even though it tests `SCHEMA_VERSION`, `ANALYSIS_SCHEMA_VERSION`, `COCKPIT_SCHEMA_VERSION`, `CONTEXT_SCHEMA_VERSION`, and `HANDOFF_SCHEMA_VERSION`.
+
+## Options
+
+### Option A (recommended)
+- Add a test `schema_md_context_bundle_version_matches_source` to `xtask/tests/docs_w43.rs` to assert that `CONTEXT_BUNDLE_SCHEMA_VERSION` in `crates/tokmd-types/src/lib.rs` matches the documented value in `docs/SCHEMA.md`.
+- Why it fits: It closes a gap in documentation drift prevention. The test suite has similar tests for every other schema version constant, but missed `CONTEXT_BUNDLE_SCHEMA_VERSION`. By adding the missing test, we prevent silent drift for this schema constant. This squarely fits the Librarian persona's mission of improving factual docs quality and executable coverage.
+- Trade-offs:
+  - Structure: Improves test suite structural completeness (all schema versions checked).
+  - Velocity: Negligible test execution cost.
+  - Governance: Strengthens the anti-drift gating.
+
+### Option B
+- Add a learning PR explaining the missing test, but don't add the test itself.
+- When to choose it: Only if there's an insurmountable reason we can't implement the test.
+- Trade-offs: Leaves a clear gap in documentation verification.
+
+## Decision
+Option A. The missing test for `CONTEXT_BUNDLE_SCHEMA_VERSION` is an obvious omission in `xtask/tests/docs_w43.rs` when looking at `schema_md_context_version_matches_source`, `schema_md_handoff_version_matches_source`, etc. Adding this executable test directly serves the Librarian persona's mission to improve executable coverage to prevent silent doc drift.

--- a/.jules/runs/librarian_docs_examples_1/envelope.json
+++ b/.jules/runs/librarian_docs_examples_1/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "librarian_docs_examples",
+  "persona": "Librarian",
+  "style": "Builder",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": ["pr_ready_patch", "learning_pr"]
+}

--- a/.jules/runs/librarian_docs_examples_1/pr_body.md
+++ b/.jules/runs/librarian_docs_examples_1/pr_body.md
@@ -1,0 +1,56 @@
+## 💡 Summary
+Added a missing test to `xtask/tests/docs_w43.rs` to ensure `CONTEXT_BUNDLE_SCHEMA_VERSION` in `crates/tokmd-types/src/lib.rs` matches `docs/SCHEMA.md`. This closes a test coverage gap where all other schema versions were verified for docs drift except this one.
+
+## 🎯 Why
+`xtask/tests/docs_w43.rs` checks for schema documentation sync. It tests `SCHEMA_VERSION`, `ANALYSIS_SCHEMA_VERSION`, `COCKPIT_SCHEMA_VERSION`, `CONTEXT_SCHEMA_VERSION`, and `HANDOFF_SCHEMA_VERSION`, but it completely missed `CONTEXT_BUNDLE_SCHEMA_VERSION` which is also documented in `docs/SCHEMA.md`. This omission could lead to silent documentation drift if the context bundle schema version is updated.
+
+## 🔎 Evidence
+- Path: `xtask/tests/docs_w43.rs`
+- Finding: Missing test `schema_md_context_bundle_version_matches_source`
+- Receipt: `cargo test -p xtask` passes after adding the test.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add a test `schema_md_context_bundle_version_matches_source` to `xtask/tests/docs_w43.rs`.
+- Why it fits: It closes a gap in documentation drift prevention, aligning with the Librarian persona.
+- Trade-offs:
+  - Structure: Improves test suite structural completeness.
+  - Velocity: Negligible test execution cost.
+  - Governance: Strengthens the anti-drift gating.
+
+### Option B
+- Document the gap as a learning PR.
+- When to choose it: If we cannot easily write the test.
+- Trade-offs: Leaves a clear gap in documentation verification.
+
+## ✅ Decision
+Option A was chosen. Adding this executable test directly serves the Librarian persona`s mission to improve executable coverage to prevent silent doc drift.
+
+## 🧱 Changes made (SRP)
+- `xtask/tests/docs_w43.rs`: Added `schema_md_context_bundle_version_matches_source` test.
+
+## 🧪 Verification receipts
+```text
+$ cargo test -p xtask
+...
+test schema_md_context_bundle_version_matches_source ... ok
+...
+test result: ok.
+```
+
+## 🧭 Telemetry
+- Change shape: Test addition
+- Blast radius: Testing (No production code changes)
+- Risk class: Low - Test only
+- Rollback: Revert the commit touching `xtask/tests/docs_w43.rs`.
+- Gates run: cargo test -p xtask, cargo check, cargo fmt, cargo clippy, cargo xtask docs --check
+
+## 🗂️ .jules artifacts
+- `.jules/runs/librarian_docs_examples_1/envelope.json`
+- `.jules/runs/librarian_docs_examples_1/decision.md`
+- `.jules/runs/librarian_docs_examples_1/receipts.jsonl`
+- `.jules/runs/librarian_docs_examples_1/result.json`
+- `.jules/runs/librarian_docs_examples_1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/librarian_docs_examples_1/receipts.jsonl
+++ b/.jules/runs/librarian_docs_examples_1/receipts.jsonl
@@ -1,0 +1,6 @@
+{"cmd":"grep -rn \"CONTEXT_BUNDLE_SCHEMA_VERSION\" crates/","status":"success"}
+{"cmd":"cargo test -p xtask","status":"success","summary":"All 148 tests passed after injecting missing schema test."}
+{"cmd":"cargo check","status":"success"}
+{"cmd":"cargo fmt -- --check","status":"success"}
+{"cmd":"cargo clippy -- -D warnings","status":"success"}
+{"cmd":"cargo xtask docs --check","status":"success"}

--- a/.jules/runs/librarian_docs_examples_1/result.json
+++ b/.jules/runs/librarian_docs_examples_1/result.json
@@ -1,0 +1,20 @@
+{
+  "outcome_type": "patch",
+  "title": "librarian: add missing docs drift test for CONTEXT_BUNDLE_SCHEMA_VERSION \ud83d\udcda",
+  "summary": "Added a missing test to `xtask/tests/docs_w43.rs` to ensure `CONTEXT_BUNDLE_SCHEMA_VERSION` in `crates/tokmd-types/src/lib.rs` matches `docs/SCHEMA.md`. This closes a test coverage gap where all other schema versions were verified for docs drift except this one.",
+  "target_paths": [
+    "xtask/tests/docs_w43.rs"
+  ],
+  "proof_summary": "Added the executable test and verified it passes, ensuring future drift of `CONTEXT_BUNDLE_SCHEMA_VERSION` will be caught.",
+  "gates_run": [
+    "cargo test -p xtask",
+    "cargo check",
+    "cargo fmt",
+    "cargo clippy",
+    "cargo xtask docs --check"
+  ],
+  "friction_items_created": [],
+  "persona_notes_created": [],
+  "rollback": "Revert the commit touching `xtask/tests/docs_w43.rs`.",
+  "follow_ups": []
+}

--- a/xtask/tests/docs_w43.rs
+++ b/xtask/tests/docs_w43.rs
@@ -262,6 +262,22 @@ fn schema_md_context_version_matches_source() {
 }
 
 #[test]
+fn schema_md_context_bundle_version_matches_source() {
+    let source_version = read_schema_constant(
+        "crates/tokmd-types/src/lib.rs",
+        "CONTEXT_BUNDLE_SCHEMA_VERSION",
+    )
+    .expect("CONTEXT_BUNDLE_SCHEMA_VERSION not found in source");
+    let schema_md = std::fs::read_to_string(workspace_root().join("docs/SCHEMA.md")).unwrap();
+    let doc_version = extract_schema_md_version(&schema_md, "`CONTEXT_BUNDLE_SCHEMA_VERSION`")
+        .expect("CONTEXT_BUNDLE_SCHEMA_VERSION not found in SCHEMA.md");
+    assert_eq!(
+        source_version, doc_version,
+        "CONTEXT_BUNDLE_SCHEMA_VERSION mismatch: source={source_version}, SCHEMA.md={doc_version}"
+    );
+}
+
+#[test]
 fn schema_md_handoff_version_matches_source() {
     let source_version =
         read_schema_constant("crates/tokmd-types/src/lib.rs", "HANDOFF_SCHEMA_VERSION")


### PR DESCRIPTION
## 💡 Summary
Added a missing test to `xtask/tests/docs_w43.rs` to ensure `CONTEXT_BUNDLE_SCHEMA_VERSION` in `crates/tokmd-types/src/lib.rs` matches `docs/SCHEMA.md`. This closes a test coverage gap where all other schema versions were verified for docs drift except this one.

## 🎯 Why
`xtask/tests/docs_w43.rs` checks for schema documentation sync. It tests `SCHEMA_VERSION`, `ANALYSIS_SCHEMA_VERSION`, `COCKPIT_SCHEMA_VERSION`, `CONTEXT_SCHEMA_VERSION`, and `HANDOFF_SCHEMA_VERSION`, but it completely missed `CONTEXT_BUNDLE_SCHEMA_VERSION` which is also documented in `docs/SCHEMA.md`. This omission could lead to silent documentation drift if the context bundle schema version is updated.

## 🔎 Evidence
- Path: `xtask/tests/docs_w43.rs`
- Finding: Missing test `schema_md_context_bundle_version_matches_source`
- Receipt: `cargo test -p xtask` passes after adding the test.

## 🧭 Options considered
### Option A (recommended)
- Add a test `schema_md_context_bundle_version_matches_source` to `xtask/tests/docs_w43.rs`.
- Why it fits: It closes a gap in documentation drift prevention, aligning with the Librarian persona.
- Trade-offs:
  - Structure: Improves test suite structural completeness.
  - Velocity: Negligible test execution cost.
  - Governance: Strengthens the anti-drift gating.

### Option B
- Document the gap as a learning PR.
- When to choose it: If we cannot easily write the test.
- Trade-offs: Leaves a clear gap in documentation verification.

## ✅ Decision
Option A was chosen. Adding this executable test directly serves the Librarian persona`s mission to improve executable coverage to prevent silent doc drift.

## 🧱 Changes made (SRP)
- `xtask/tests/docs_w43.rs`: Added `schema_md_context_bundle_version_matches_source` test.

## 🧪 Verification receipts
```text
$ cargo test -p xtask
...
test schema_md_context_bundle_version_matches_source ... ok
...
test result: ok.
```

## 🧭 Telemetry
- Change shape: Test addition
- Blast radius: Testing (No production code changes)
- Risk class: Low - Test only
- Rollback: Revert the commit touching `xtask/tests/docs_w43.rs`.
- Gates run: cargo test -p xtask, cargo check, cargo fmt, cargo clippy, cargo xtask docs --check

## 🗂️ .jules artifacts
- `.jules/runs/librarian_docs_examples_1/envelope.json`
- `.jules/runs/librarian_docs_examples_1/decision.md`
- `.jules/runs/librarian_docs_examples_1/receipts.jsonl`
- `.jules/runs/librarian_docs_examples_1/result.json`
- `.jules/runs/librarian_docs_examples_1/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [9962838196237482045](https://jules.google.com/task/9962838196237482045) started by @EffortlessSteven*