### PR TITLE
specsmith: add BDD test scenarios for analysis presets 🧪

### DIFF
--- a/.jules/runs/run-specsmith-001/decision.md
+++ b/.jules/runs/run-specsmith-001/decision.md
@@ -1,0 +1,20 @@
+# Decision
+
+The task calls for improving BDD/integration coverage or edge-case polish in the analysis-stack. I noticed `bdd_analyze_scenarios_w50.rs` in `crates/tokmd/tests/` uses the term "w50" and tests core analysis scenarios like JSON outputs, schema version presence, and effort reports.
+
+However, `tokmd/tests/bdd_diff_scenarios_w50.rs` and `tokmd/tests/bdd_export_scenarios_w50.rs` and `tokmd/tests/bdd_lang_scenarios_w50.rs` and `bdd_module_scenarios_w50.rs` are present.
+Wait, let's look at `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs` - the file ends with a scenario `given_project_when_analyze_estimate_then_effort_model_present` testing the "estimate" preset.
+I can add more BDD scenarios to `bdd_analyze_scenarios_w50.rs` to cover things like the `risk`, `supply`, and `health` presets, and feature flags.
+
+Wait, looking at `crates/tokmd-analysis/tests/deep_analysis_w48.rs` vs `crates/tokmd-analysis/tests/analysis_depth_w62.rs` - these cover analysis logic deep tests.
+
+Let's look at missing BDD scenarios in `bdd_analyze_scenarios_w50.rs`:
+- Scenario testing `supply` preset: dependencies should be present.
+- Scenario testing `risk` preset: git/complexity should be present.
+- Scenario testing `health` preset: todo/complexity should be present.
+
+Option A: Add BDD scenario tests for the missing analysis presets (`supply`, `risk`, `health`) in `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`. This directly fulfills the specsmith target "missing BDD/integration coverage for an important path".
+
+Option B: Add tests for missing edge-cases around Git integration errors in analysis.
+
+I'll choose Option A. It's safe, straight-forward, and provides direct BDD coverage for user-facing presets.

--- a/.jules/runs/run-specsmith-001/envelope.json
+++ b/.jules/runs/run-specsmith-001/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "specsmith_analysis_stack",
+  "persona": "specsmith",
+  "style": "Builder",
+  "primary_shard": "analysis-stack",
+  "allowed_paths": [
+    "crates/tokmd-analysis*/**",
+    "crates/tokmd-fun/**",
+    "crates/tokmd-gate/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/tests/**",
+    "docs/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/run-specsmith-001/pr_body.md
+++ b/.jules/runs/run-specsmith-001/pr_body.md
@@ -1,0 +1,65 @@
+## 💡 Summary
+Added missing BDD scenario tests in `tokmd/tests/bdd_analyze_scenarios_w50.rs` to cover analysis presets: `risk`, `supply`, and `health`.
+
+## 🎯 Why
+While the `receipt`, `estimate`, and `fun` presets were covered in integration scenarios, the other analysis-focused presets (`risk`, `supply`, `health`) were missing behavior-level edge-case coverage to ensure their derived metrics (e.g. `complexity`, `assets`, `deps`) correctly appear in the output artifacts when requested.
+
+## 🔎 Evidence
+- `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs` lacked tests for `risk`, `supply`, and `health` presets.
+- By running `cargo test -p tokmd --test bdd_analyze_scenarios_w50`, it was verified that the new scenarios run successfully and accurately capture expected output behavior.
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Add BDD scenario tests for the missing analysis presets (`supply`, `risk`, `health`) in `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`.
+- why it fits this repo and shard: Directly fulfills the Specsmith target for "missing BDD/integration coverage for an important path" without altering product-level analysis contracts.
+- trade-offs: Structure / Velocity / Governance: Safest, focused change.
+
+### Option B
+- what it is: Add deep tests in `tokmd-analysis` checking specific git and complexity edge cases.
+- when to choose it instead: If the `preset` parsing itself was flaky or core computation was failing under unique workloads.
+- trade-offs: More invasive, changes analysis internal tests rather than pure user-facing behavior tests.
+
+## ✅ Decision
+Chose Option A to add scenario coverage. It's clean, improves our regression suite, and directly matches the Specsmith mission constraint.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd/tests/bdd_analyze_scenarios_w50.rs`
+  - Added `given_project_when_analyze_risk_then_risk_data_present`
+  - Added `given_project_when_analyze_supply_then_supply_data_present`
+  - Added `given_project_when_analyze_health_then_health_data_present`
+
+## 🧪 Verification receipts
+```text
+$ cargo test -p tokmd --test bdd_analyze_scenarios_w50
+running 11 tests
+test given_project_when_analyze_fun_then_eco_label_present ... ok
+test given_project_when_analyze_health_then_health_data_present ... ok
+test given_project_when_analyze_json_then_has_args_metadata ... ok
+test given_project_when_analyze_estimate_then_effort_model_present ... ok
+test given_project_when_analyze_json_then_has_schema_version ... ok
+test given_project_when_analyze_md_then_markdown_table ... ok
+test given_project_when_analyze_receipt_then_derived_metrics_present ... ok
+test given_project_when_analyze_supply_then_supply_data_present ... ok
+test given_project_when_analyze_risk_then_risk_data_present ... ok
+test given_project_when_analyze_with_output_dir_then_file_created ... ok
+test given_project_when_analyze_xml_then_valid_xml_structure ... ok
+
+test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s
+```
+
+## 🧭 Telemetry
+- Change shape: Tests only.
+- Blast radius: Testing layer only.
+- Risk class: Low risk. Pure addition of tests.
+- Rollback: Revert the test additions.
+- Gates run: `cargo clippy`, `cargo fmt`, `cargo test -p tokmd --test bdd_analyze_scenarios_w50`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-specsmith-001/envelope.json`
+- `.jules/runs/run-specsmith-001/decision.md`
+- `.jules/runs/run-specsmith-001/receipts.jsonl`
+- `.jules/runs/run-specsmith-001/result.json`
+- `.jules/runs/run-specsmith-001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-specsmith-001/receipts.jsonl
+++ b/.jules/runs/run-specsmith-001/receipts.jsonl
@@ -1,0 +1,4 @@
+{"command": "cargo test -p tokmd --test bdd_analyze_scenarios_w50", "result": "11 passed; 0 failed"}
+{"command": "cargo clippy -- -D warnings", "result": "passed"}
+{"command": "cargo fmt -- --check", "result": "passed"}
+{"command": "cargo check", "result": "passed"}

--- a/.jules/runs/run-specsmith-001/result.json
+++ b/.jules/runs/run-specsmith-001/result.json
@@ -1,0 +1,6 @@
+{
+  "outcome": "PR-ready patch",
+  "files_touched": ["crates/tokmd/tests/bdd_analyze_scenarios_w50.rs"],
+  "test_results": "11 passed; 0 failed",
+  "lint_results": "no warnings"
+}

--- a/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
@@ -239,3 +239,64 @@ fn given_project_when_analyze_estimate_then_effort_model_present() {
         .expect("effort drivers should be an array");
     assert!(!drivers.is_empty(), "effort should have drivers");
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 9: Risk preset returns git and complexity data
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_analyze_risk_then_risk_data_present() {
+    let output = tokmd_cmd()
+        .args(["analyze", ".", "--preset", "risk", "--format", "json"])
+        .output()
+        .expect("failed to execute tokmd analyze --preset risk");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let json: Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert!(
+        json.get("complexity").is_some(),
+        "risk should include complexity"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 10: Supply preset returns assets and deps data
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_analyze_supply_then_supply_data_present() {
+    let output = tokmd_cmd()
+        .args(["analyze", ".", "--preset", "supply", "--format", "json"])
+        .output()
+        .expect("failed to execute tokmd analyze --preset supply");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let json: Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert!(json.get("assets").is_some(), "supply should include assets");
+    assert!(json.get("deps").is_some(), "supply should include deps");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 11: Health preset returns todo and complexity data
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_analyze_health_then_health_data_present() {
+    let output = tokmd_cmd()
+        .args(["analyze", ".", "--preset", "health", "--format", "json"])
+        .output()
+        .expect("failed to execute tokmd analyze --preset health");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let json: Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert!(
+        json.get("complexity").is_some(),
+        "health should include complexity"
+    );
+}


### PR DESCRIPTION
Added missing BDD scenario tests in `tokmd/tests/bdd_analyze_scenarios_w50.rs` to cover analysis presets: `risk`, `supply`, and `health`. 

While the `receipt`, `estimate`, and `fun` presets were covered in integration scenarios, the other analysis-focused presets (`risk`, `supply`, `health`) were missing behavior-level edge-case coverage to ensure their derived metrics (e.g. `complexity`, `assets`, `deps`) correctly appear in the output artifacts when requested.

---
*PR created automatically by Jules for task [2888400207640475347](https://jules.google.com/task/2888400207640475347) started by @EffortlessSteven*