### PR TITLE
jules: record auditor learning on core-pipeline shard 🧾

### DIFF
--- a/.jules/friction/open/auditor_core_manifests_friction.md
+++ b/.jules/friction/open/auditor_core_manifests_friction.md
@@ -1,0 +1,21 @@
+---
+id: auditor_core_manifests_friction
+persona: auditor
+style: builder
+shard: core-pipeline
+status: open
+---
+
+# Friction Item
+
+## Summary
+Unable to find an unused dependency to remove in the `core-pipeline` shard (`tokmd-types`, `tokmd-scan`, `tokmd-model`, `tokmd-format`).
+
+## Detail
+`cargo machete --with-metadata` confirmed there are no unused dependencies in the target crates. While `cargo machete` identified unused dependencies in `tokmd-fuzz` (`anyhow`, `blake3`, `tempfile`) and `tokmd-node` (`napi-build`), these fall outside the assigned primary shard. Following the prompt's instruction to record out-of-shard targets as friction rather than chasing them, this learning PR captures the state and defers the out-of-shard cleanup.
+
+## Impact
+No direct harm, but highlights that the core pipeline crates are currently in a good state regarding direct dependency hygiene.
+
+## Context
+Prompt ID: `auditor_core_manifests`

--- a/.jules/runs/auditor_core_manifests/decision.md
+++ b/.jules/runs/auditor_core_manifests/decision.md
@@ -1,0 +1,23 @@
+## Option A
+Remove unused `midly` feature/dependency from `tokmd-format`
+- *Why it fits*: The `cargo tree` output previously showed `tokmd-format` having a `fun` feature depending on `midly`. But `tokmd-format` actually has multiple files (e.g. `src/fun/mod.rs`, `tests/fun_bdd.rs`, etc) that use `midly` so it's not unused.
+
+## Option B
+Find an unused or redundant dependency using `cargo machete` or manual review. `cargo machete` found nothing in the target crates `tokmd-types`, `tokmd-scan`, `tokmd-model`, `tokmd-format`.
+
+## Option C
+Tighten `serde` features. `tokmd-types` currently depends on `serde` with `features = ["derive"]` (which is often redundant or can be tightened). But it seems we don't have any obvious unneeded dependency in the core-pipeline shard. Let's record a learning PR as instructed.
+
+## Option D
+Wait, I see `tokmd-scan` depends on `anyhow`, `ignore`, `tempfile`, `tokei`, `tokmd-io-port`, `tokmd-settings`, `tokmd-types`. But `tokmd-types` depends on `serde` and `clap` (optional). The `clap` feature is enabled by `tokmd` but it might be cleanly removed if we move the CLI-specific `clap` derives out of `tokmd-types`. But changing contract surface is risky.
+
+Let's double check `tokmd-format` `midly` dependency. It's optional.
+
+Let's double check `tokmd-model`. It depends on `serde`, `tokei`, `tokmd-types`. `tempfile` is a dev-dependency.
+
+Wait, `cargo machete` on `fuzz` found `anyhow`, `blake3`, `tempfile` unused. But `fuzz` is not in the primary shard, though the instruction says "If the strongest target you find is outside the shard, record it as friction instead of chasing it."
+
+I will create a learning PR as I couldn't find a safe, unused direct dependency to remove in the primary shard.
+
+## Decision
+I choose **Option B** (Learning PR). I've thoroughly investigated `tokmd-types`, `tokmd-scan`, `tokmd-model`, and `tokmd-format` for unused dependencies using `cargo machete` and `cargo tree`. `cargo machete` reported "didn't find any unused dependencies" for all four crates. While `cargo machete` found unused dependencies in `tokmd-fuzz` and `tokmd-node` (outside the primary shard), the Auditor instructions explicitly state to "record it as friction instead of chasing it" if the strongest target is outside the shard.

--- a/.jules/runs/auditor_core_manifests/envelope.json
+++ b/.jules/runs/auditor_core_manifests/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "auditor_core_manifests",
+  "persona": "auditor",
+  "style": "builder",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "deps-hygiene",
+  "allowed_outcomes": ["patch", "learning"]
+}

--- a/.jules/runs/auditor_core_manifests/pr_body.md
+++ b/.jules/runs/auditor_core_manifests/pr_body.md
@@ -1,0 +1,61 @@
+## 💡 Summary
+This is a learning PR. I investigated the `core-pipeline` shard (`tokmd-types`, `tokmd-scan`, `tokmd-model`, `tokmd-format`) for unused dependencies or redundant features to remove. I found that the core pipeline crates are currently in a good state regarding direct dependency hygiene.
+
+## 🎯 Why
+The assignment was to land a high-signal dependency hygiene improvement in the `core-pipeline` shard, specifically targeting unused dependencies or redundant declarations. If the strongest target found is outside the shard, the instructions mandate recording it as a friction item instead of chasing it.
+
+## 🔎 Evidence
+- `cargo machete --with-metadata` confirmed no unused dependencies in `crates/tokmd-types`, `crates/tokmd-scan`, `crates/tokmd-model`, and `crates/tokmd-format`.
+- `cargo machete` identified unused dependencies in `tokmd-fuzz` and `tokmd-node`, which fall outside the assigned primary shard.
+
+## 🧭 Options considered
+### Option A
+Remove unused `clap` feature and optional dependency from `tokmd-types`.
+- what it is: Moving CLI-specific enum derivations out of `tokmd-types`.
+- why it fits this repo and shard: The `clap` feature is only used by `tokmd` itself, but `tokmd-types` is a core pipeline crate. It separates CLI vs Core Types.
+- trade-offs: Structure: Better separation of concerns. Velocity: Higher friction, requires moving code and potentially breaking contracts. Governance: Higher risk.
+
+### Option B (recommended)
+Create a learning PR documenting the hygiene gap in `tokmd-fuzz` and `tokmd-node` as friction.
+- what it is: Recording the findings and deferring the out-of-shard cleanup.
+- when to choose it instead: When no safe, unused direct dependency can be removed in the primary shard, and out-of-shard targets are explicitly disallowed by the prompt.
+- trade-offs: Structure: No structural change. Velocity: Fast. Governance: Low risk.
+
+## ✅ Decision
+I chose Option B. I've thoroughly investigated the target crates for unused dependencies using `cargo machete` and `cargo tree`. `cargo machete` reported "didn't find any unused dependencies" for all four core crates. While unused dependencies were found in `tokmd-fuzz` and `tokmd-node`, the instructions explicitly state to "record it as friction instead of chasing it" if the strongest target is outside the shard.
+
+## 🧱 Changes made (SRP)
+- `.jules/friction/open/auditor_core_manifests_friction.md`
+
+## 🧪 Verification receipts
+```text
+cargo machete --with-metadata crates/tokmd-types
+cargo-machete didn't find any unused dependencies in crates/tokmd-types. Good job!
+
+cargo machete --with-metadata crates/tokmd-model
+cargo-machete didn't find any unused dependencies in crates/tokmd-model. Good job!
+
+cargo machete --with-metadata crates/tokmd-format
+cargo-machete didn't find any unused dependencies in crates/tokmd-format. Good job!
+
+cargo machete --with-metadata crates/tokmd-scan
+cargo-machete didn't find any unused dependencies in crates/tokmd-scan. Good job!
+```
+
+## 🧭 Telemetry
+- Change shape: Learning PR / Documentation
+- Blast radius: None (API / IO / docs / schema / concurrency / compatibility / dependencies)
+- Risk class: Low
+- Rollback: N/A
+- Gates run: `cargo machete`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/auditor_core_manifests/envelope.json`
+- `.jules/runs/auditor_core_manifests/decision.md`
+- `.jules/runs/auditor_core_manifests/receipts.jsonl`
+- `.jules/runs/auditor_core_manifests/result.json`
+- `.jules/runs/auditor_core_manifests/pr_body.md`
+- `.jules/friction/open/auditor_core_manifests_friction.md`
+
+## 🔜 Follow-ups
+- Clean up unused dependencies in `tokmd-fuzz` (`anyhow`, `blake3`, `tempfile`) and `tokmd-node` (`napi-build`) (captured in `.jules/friction/open/auditor_core_manifests_friction.md`).

--- a/.jules/runs/auditor_core_manifests/receipts.jsonl
+++ b/.jules/runs/auditor_core_manifests/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "cargo machete --with-metadata", "outcome": "cargo-machete didn't find any unused dependencies in crates/tokmd-types, crates/tokmd-model, crates/tokmd-format, crates/tokmd-scan"}
+{"command": "cargo tree -p tokmd-model", "outcome": "Verified dependencies, all active."}

--- a/.jules/runs/auditor_core_manifests/result.json
+++ b/.jules/runs/auditor_core_manifests/result.json
@@ -1,0 +1,4 @@
+{
+  "status": "learning",
+  "reason": "No unused direct dependencies found in the core-pipeline shard. Unused dependencies in tokmd-fuzz and tokmd-node were recorded as friction per instructions."
+}


### PR DESCRIPTION
Learning PR documenting the dependency hygiene pass on the `core-pipeline` shard (`tokmd-types`, `tokmd-scan`, `tokmd-model`, `tokmd-format`). No unused dependencies were found in the assigned shard, but unused dependencies were identified in `tokmd-fuzz` and `tokmd-node`. As instructed by the prompt, these out-of-shard findings are recorded as a friction item.

---
*PR created automatically by Jules for task [4828168067413399035](https://jules.google.com/task/4828168067413399035) started by @EffortlessSteven*