### PR TITLE
mutant: Extract inline sort closures to fix test gaps 🧬

### DIFF
--- a/.jules/runs/mutant_high_value/decision.md
+++ b/.jules/runs/mutant_high_value/decision.md
@@ -1,0 +1,13 @@
+# Decision
+
+## Option A (Extract duplicate test sorting functions to the core API)
+Extract `sort_lang_rows`, `sort_module_rows`, and `sort_file_rows` into public standalone functions in `tokmd-model`.
+Currently, the `determinism_w66.rs` test suite defines its own versions of these sorting functions, which means it tests its own sorting logic rather than the *actual* inline sorting closures used in `build_model` and `create_export_data_from_rows`.
+By centralizing these functions, we ensure that a mutation in the actual library sorting logic is properly caught by the test suite, effectively closing a massive mutation gap.
+
+## Option B (Add e2e determinism tests via CLI)
+We could leave the inline sorting closures as they are and instead add a full end-to-end test that calls the `build_model` function and compares the full output with differently ordered inputs.
+This works but is a heavier and slower test. It also doesn't fix the fact that `determinism_w66.rs` has dummy sorting functions that could give a false sense of security.
+
+## Decision
+Option A. It's cleaner, removes duplicated test logic that causes false mutation test coverage, and fulfills the Mutant persona's goal of improving tests around a high-value production surface (deterministic sorting).

--- a/.jules/runs/mutant_high_value/envelope.json
+++ b/.jules/runs/mutant_high_value/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "mutant_high_value",
+  "persona": "Mutant \ud83e\uddec",
+  "style": "Prover",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "mutation",
+  "allowed_outcomes": [
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/mutant_high_value/pr_body.md
+++ b/.jules/runs/mutant_high_value/pr_body.md
@@ -1,0 +1,53 @@
+## 💡 Summary
+Extracted the inline sorting logic from `tokmd-model`'s core into public deterministic sort functions and updated `determinism_w66.rs` to use them directly. This closes a large testing gap where `determinism_w66.rs` was testing its own duplicated sorting functions rather than the actual sorting logic used in production.
+
+## 🎯 Why
+The `determinism_w66.rs` test suite previously redefined `sort_lang_rows`, `sort_module_rows`, and `sort_file_rows`. This means the test suite was asserting determinism against its *own* logic, rather than the library's actual behavior. Any mutation in the production library's inline sorting closures would go unnoticed. By centralizing these, we close a massive mutation coverage gap around deterministic sorting.
+
+## 🔎 Evidence
+- File: `crates/tokmd-model/tests/determinism_w66.rs`
+- Finding: The test defined duplicate sort functions (e.g., `fn sort_lang_rows(rows: &mut [LangRow]) { ... }`) that exactly mirrored the inline closures in `build_model`.
+- Receipt: Tests passing successfully using the actual public API (`tokmd_model::sort_lang_rows`) after extraction.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Extract duplicate test sorting functions into the `tokmd-model` public API and call them both from the library and the tests.
+- Fits the `core-pipeline` shard and fulfills the Mutant goal of improving mutation-style test assertions.
+- Trade-offs: Increases the public API surface slightly, but massively improves test confidence.
+
+### Option B
+- Add heavy end-to-end integration tests that call `build_model` and `create_export_data_from_rows` with permuted inputs to test determinism through the public interface without extracting sort methods.
+- Slower tests, and doesn't remove the misleading duplicated test functions that give false security.
+- Trade-offs: Lower velocity, higher complexity.
+
+## ✅ Decision
+Option A. It's cleaner, removes duplicated test logic, and effectively closes the mutation gap in `determinism_w66.rs`.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-model/src/lib.rs`
+- `crates/tokmd-model/tests/determinism_w66.rs`
+
+## 🧪 Verification receipts
+```text
+cargo build
+cargo test -p tokmd-model
+cargo clippy -p tokmd-model -- -D warnings
+cargo fmt -- --check
+```
+
+## 🧭 Telemetry
+- Change shape: Extract function, test cleanup
+- Blast radius: API (added 3 new functions to `tokmd-model`), Tests
+- Risk class: Low, pure extraction of existing inline logic.
+- Rollback: Revert the PR.
+- Gates run: build, test, clippy, fmt
+
+## 🗂️ .jules artifacts
+- `.jules/runs/mutant_high_value/envelope.json`
+- `.jules/runs/mutant_high_value/decision.md`
+- `.jules/runs/mutant_high_value/receipts.jsonl`
+- `.jules/runs/mutant_high_value/result.json`
+- `.jules/runs/mutant_high_value/pr_body.md`
+
+## 🔜 Follow-ups
+None

--- a/.jules/runs/mutant_high_value/receipts.jsonl
+++ b/.jules/runs/mutant_high_value/receipts.jsonl
@@ -1,0 +1,4 @@
+{"command": "cargo build", "exit_code": 0}
+{"command": "cargo test -p tokmd-model", "exit_code": 0}
+{"command": "cargo clippy -p tokmd-model -- -D warnings", "exit_code": 0}
+{"command": "cargo fmt -- --check", "exit_code": 0}

--- a/.jules/runs/mutant_high_value/result.json
+++ b/.jules/runs/mutant_high_value/result.json
@@ -1,0 +1,8 @@
+{
+  "outcome": "proof-improvement patch",
+  "files_changed": [
+    "crates/tokmd-model/src/lib.rs",
+    "crates/tokmd-model/tests/determinism_w66.rs"
+  ],
+  "gates_run": ["cargo build", "cargo test -p tokmd-model", "cargo clippy -p tokmd-model -- -D warnings", "cargo fmt -- --check"]
+}

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -413,7 +413,7 @@ pub fn create_lang_report_from_rows(
         });
     }
 
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+    sort_lang_rows(&mut rows);
 
     let total_code: usize = rows.iter().map(|r| r.code).sum();
     let total_lines: usize = rows.iter().map(|r| r.lines).sum();
@@ -537,7 +537,7 @@ pub fn create_module_report_from_rows(
     }
 
     // Sort descending by code, then by module name for determinism.
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+    sort_module_rows(&mut rows);
 
     if top > 0 && rows.len() > top {
         let other = fold_other_module(&rows[top..]);
@@ -630,7 +630,7 @@ pub fn create_export_data_from_rows(
     if min_code > 0 {
         rows.retain(|r| r.code >= min_code);
     }
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.path.cmp(&b.path)));
+    sort_file_rows(&mut rows);
 
     if max_rows > 0 && rows.len() > max_rows {
         rows.truncate(max_rows);
@@ -642,6 +642,21 @@ pub fn create_export_data_from_rows(
         module_depth,
         children,
     }
+}
+
+/// Sort `LangRow`s deterministically by code descending, then by lang name ascending.
+pub fn sort_lang_rows(rows: &mut [LangRow]) {
+    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+}
+
+/// Sort `ModuleRow`s deterministically by code descending, then by module name ascending.
+pub fn sort_module_rows(rows: &mut [ModuleRow]) {
+    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+}
+
+/// Sort `FileRow`s deterministically by code descending, then by path ascending.
+pub fn sort_file_rows(rows: &mut [FileRow]) {
+    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.path.cmp(&b.path)));
 }
 
 /// Collect per-file contributions, optionally including embedded language reports.

--- a/crates/tokmd-model/tests/determinism_w66.rs
+++ b/crates/tokmd-model/tests/determinism_w66.rs
@@ -63,18 +63,6 @@ fn totals_from_rows(rows: &[LangRow]) -> Totals {
     }
 }
 
-fn sort_lang_rows(rows: &mut [LangRow]) {
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
-}
-
-fn sort_module_rows(rows: &mut [ModuleRow]) {
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
-}
-
-fn sort_file_rows(rows: &mut [FileRow]) {
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.path.cmp(&b.path)));
-}
-
 // -- 1. Lang rows: different insertion order -> same sorted output --
 
 #[test]
@@ -94,9 +82,9 @@ fn lang_rows_insertion_order_does_not_affect_sorted_output() {
         make_lang_row("Go", 100),
         make_lang_row("Rust", 500),
     ];
-    sort_lang_rows(&mut order_a);
-    sort_lang_rows(&mut order_b);
-    sort_lang_rows(&mut order_c);
+    tokmd_model::sort_lang_rows(&mut order_a);
+    tokmd_model::sort_lang_rows(&mut order_b);
+    tokmd_model::sort_lang_rows(&mut order_c);
     let json_a = serde_json::to_string(&order_a).unwrap();
     let json_b = serde_json::to_string(&order_b).unwrap();
     let json_c = serde_json::to_string(&order_c).unwrap();
@@ -118,8 +106,8 @@ fn module_rows_insertion_order_does_not_affect_sorted_output() {
         make_module_row("crates/tokmd", 800),
         make_module_row("src", 200),
     ];
-    sort_module_rows(&mut order_a);
-    sort_module_rows(&mut order_b);
+    tokmd_model::sort_module_rows(&mut order_a);
+    tokmd_model::sort_module_rows(&mut order_b);
     let json_a = serde_json::to_string(&order_a).unwrap();
     let json_b = serde_json::to_string(&order_b).unwrap();
     assert_eq!(json_a, json_b);
@@ -139,8 +127,8 @@ fn file_rows_insertion_order_does_not_affect_sorted_output() {
         make_file_row("src/lib.rs", "Rust", "src", 80),
         make_file_row("src/main.rs", "Rust", "src", 120),
     ];
-    sort_file_rows(&mut order_a);
-    sort_file_rows(&mut order_b);
+    tokmd_model::sort_file_rows(&mut order_a);
+    tokmd_model::sort_file_rows(&mut order_b);
     let json_a = serde_json::to_string(&order_a).unwrap();
     let json_b = serde_json::to_string(&order_b).unwrap();
     assert_eq!(json_a, json_b);
@@ -314,7 +302,7 @@ fn export_data_sort_code_desc_then_path_asc() {
         make_file_row("src/a.rs", "Rust", "src", 100),
         make_file_row("src/c.rs", "Rust", "src", 200),
     ];
-    sort_file_rows(&mut rows);
+    tokmd_model::sort_file_rows(&mut rows);
     assert_eq!(rows[0].path, "src/c.rs");
     assert_eq!(rows[1].path, "src/a.rs");
     assert_eq!(rows[2].path, "src/b.rs");
@@ -330,7 +318,7 @@ fn top_n_folding_is_deterministic() {
         make_lang_row("Go", 100),
         make_lang_row("Java", 50),
     ];
-    sort_lang_rows(&mut rows);
+    tokmd_model::sort_lang_rows(&mut rows);
     let top = 2;
     let other_code: usize = rows[top..].iter().map(|r| r.code).sum();
     let other_lines: usize = rows[top..].iter().map(|r| r.lines).sum();
@@ -353,7 +341,7 @@ fn top_n_folding_is_deterministic() {
         make_lang_row("Python", 300),
         make_lang_row("Rust", 500),
     ];
-    sort_lang_rows(&mut rows2);
+    tokmd_model::sort_lang_rows(&mut rows2);
     let other_code2: usize = rows2[top..].iter().map(|r| r.code).sum();
     let other_lines2: usize = rows2[top..].iter().map(|r| r.lines).sum();
     let other_files2: usize = rows2[top..].iter().map(|r| r.files).sum();
@@ -409,7 +397,7 @@ fn tie_breaking_by_name_is_deterministic() {
         make_lang_row("Alpha", 100),
         make_lang_row("Mid", 100),
     ];
-    sort_lang_rows(&mut rows);
+    tokmd_model::sort_lang_rows(&mut rows);
     assert_eq!(rows[0].lang, "Alpha");
     assert_eq!(rows[1].lang, "Mid");
     assert_eq!(rows[2].lang, "Zeta");
@@ -433,8 +421,8 @@ proptest! {
         ];
         let mut fwd = raw.clone();
         let mut rev = raw.into_iter().rev().collect::<Vec<_>>();
-        sort_lang_rows(&mut fwd);
-        sort_lang_rows(&mut rev);
+        tokmd_model::sort_lang_rows(&mut fwd);
+        tokmd_model::sort_lang_rows(&mut rev);
         let json_fwd = serde_json::to_string(&fwd).unwrap();
         let json_rev = serde_json::to_string(&rev).unwrap();
         prop_assert_eq!(json_fwd, json_rev);
@@ -453,8 +441,8 @@ proptest! {
         ];
         let mut fwd = raw.clone();
         let mut rev = raw.into_iter().rev().collect::<Vec<_>>();
-        sort_module_rows(&mut fwd);
-        sort_module_rows(&mut rev);
+        tokmd_model::sort_module_rows(&mut fwd);
+        tokmd_model::sort_module_rows(&mut rev);
         let json_fwd = serde_json::to_string(&fwd).unwrap();
         let json_rev = serde_json::to_string(&rev).unwrap();
         prop_assert_eq!(json_fwd, json_rev);
@@ -471,8 +459,8 @@ proptest! {
         ];
         let mut fwd = raw.clone();
         let mut rev = raw.into_iter().rev().collect::<Vec<_>>();
-        sort_file_rows(&mut fwd);
-        sort_file_rows(&mut rev);
+        tokmd_model::sort_file_rows(&mut fwd);
+        tokmd_model::sort_file_rows(&mut rev);
         let json_fwd = serde_json::to_string(&fwd).unwrap();
         let json_rev = serde_json::to_string(&rev).unwrap();
         prop_assert_eq!(json_fwd, json_rev);


### PR DESCRIPTION
## 💡 Summary
Extracted the inline sorting logic from `tokmd-model`'s core into public deterministic sort functions and updated `determinism_w66.rs` to use them directly. This closes a large testing gap where `determinism_w66.rs` was testing its own duplicated sorting functions rather than the actual sorting logic used in production.

## 🎯 Why
The `determinism_w66.rs` test suite previously redefined `sort_lang_rows`, `sort_module_rows`, and `sort_file_rows`. This means the test suite was asserting determinism against its *own* logic, rather than the library's actual behavior. Any mutation in the production library's inline sorting closures would go unnoticed. By centralizing these, we close a massive mutation coverage gap around deterministic sorting.

## 🔎 Evidence
- File: `crates/tokmd-model/tests/determinism_w66.rs`
- Finding: The test defined duplicate sort functions (e.g., `fn sort_lang_rows(rows: &mut [LangRow]) { ... }`) that exactly mirrored the inline closures in `build_model`.
- Receipt: Tests passing successfully using the actual public API (`tokmd_model::sort_lang_rows`) after extraction.

## 🧭 Options considered
### Option A (recommended)
- Extract duplicate test sorting functions into the `tokmd-model` public API and call them both from the library and the tests.
- Fits the `core-pipeline` shard and fulfills the Mutant goal of improving mutation-style test assertions.
- Trade-offs: Increases the public API surface slightly, but massively improves test confidence.

### Option B
- Add heavy end-to-end integration tests that call `build_model` and `create_export_data_from_rows` with permuted inputs to test determinism through the public interface without extracting sort methods.
- Slower tests, and doesn't remove the misleading duplicated test functions that give false security.
- Trade-offs: Lower velocity, higher complexity.

## ✅ Decision
Option A. It's cleaner, removes duplicated test logic, and effectively closes the mutation gap in `determinism_w66.rs`.

## 🧱 Changes made (SRP)
- `crates/tokmd-model/src/lib.rs`
- `crates/tokmd-model/tests/determinism_w66.rs`

## 🧪 Verification receipts
```text
cargo build
cargo test -p tokmd-model
cargo clippy -p tokmd-model -- -D warnings
cargo fmt -- --check
```

## 🧭 Telemetry
- Change shape: Extract function, test cleanup
- Blast radius: API (added 3 new functions to `tokmd-model`), Tests
- Risk class: Low, pure extraction of existing inline logic.
- Rollback: Revert the PR.
- Gates run: build, test, clippy, fmt

## 🗂️ .jules artifacts
- `.jules/runs/mutant_high_value/envelope.json`
- `.jules/runs/mutant_high_value/decision.md`
- `.jules/runs/mutant_high_value/receipts.jsonl`
- `.jules/runs/mutant_high_value/result.json`
- `.jules/runs/mutant_high_value/pr_body.md`

## 🔜 Follow-ups
None

---
*PR created automatically by Jules for task [9081594594353998550](https://jules.google.com/task/9081594594353998550) started by @EffortlessSteven*