### PR TITLE
gatekeeper: enforce baseline schema version sync ✅

### DIFF
--- a/.jules/runs/gatekeeper_contracts/decision.md
+++ b/.jules/runs/gatekeeper_contracts/decision.md
@@ -1,17 +1,19 @@
-# Option A (recommended)
-Use the `xtask docs --update` tool logic by replacing hardcoded command parameter tables in `docs/reference-cli.md` with auto-updating `<!-- HELP: <command> -->` markers. The xtask command automatically pulls the current `tokmd` help text.
-
-- **Structure**: Automatically synchronizes docs with command changes, removing drift.
-- **Velocity**: Speeds up doc updates since CLI parameters will always stay in sync.
-- **Governance**: Ensures reference documentation acts as a deterministically correct reflection of the program options. Fits well within the 'Gatekeeper' persona and the `tooling-governance` shard.
-
-# Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand, matching them against `cargo run --bin tokmd -- <cmd> --help`.
-
-- **When to choose it**: Only if you strictly want specialized tables with custom columns or manually edited parameter groups that rust `clap` output does not provide.
-- **Trade-offs**: Extreme risk of drift and maintenance burden. Requires a developer to manually verify changes on every new parameter addition.
-
 # Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables (from `.jules/policy/shards.json` or general run memory). The final restack replaces the remaining manual command tables with `<!-- HELP: <command> -->` markers, then makes `cargo xtask docs --check` fail if any expected marker pair is missing. This keeps the deterministic docs path inside `cargo xtask docs --update` / `cargo xtask docs --check` instead of relying on ad hoc post-processing scripts.
 
-The restack also aligns the xtask gate regression test with the current repository rule that Jules provenance under `.jules/**` may be intentional PR state. Gate still blocks cache/transcript/runtime/tmp paths, but it does not blanket-block `.jules/runs/**` provenance packets.
+## Target
+The baseline complexity schema `docs/baseline.schema.json` defines a contract version but lacks a test ensuring its constants align with truth in `crates/tokmd-analysis-types/src/lib.rs` and `docs/SCHEMA.md`. Adding tests prevents drift in these areas, fitting the Gatekeeper persona.
+
+## Option A (recommended)
+Add tests to `xtask/tests/docs_w43.rs` and `xtask/tests/docs_schema_w72.rs` to enforce that `BASELINE_VERSION` from `crates/tokmd-analysis-types/src/lib.rs` matches `BASELINE_VERSION` in `docs/SCHEMA.md`.
+- What it is: A test-only change to tighten invariants.
+- Why it fits: Matches Gatekeeper target 1 (schema/version drift) and 2 (snapshot/golden drift or weak coverage).
+- Trade-offs: Minor test time increase; improves governance.
+
+## Option B
+Also try to validate `docs/baseline.schema.json` version.
+- What it is: Extract the version from `baseline.schema.json` and verify it matches.
+- When to choose: If we want to guarantee the schema's internal version matches the source of truth.
+- Trade-offs: Slightly more complex test logic parsing JSON schema `$id` or `baseline_version` const.
+
+## Decision
+Choosing **Option A**. The tests have already been successfully prototyped and added, covering the basic alignment between source code and SCHEMA.md. Option B is also valuable and we can easily add it to `schema_json_receipt_versions_match_source` or a separate check. We will implement Option B as well (extending `schema_json_receipt_versions_match_source` for the baseline). Wait, `baseline.schema.json` is a separate file from `schema.json`. So we'll just add tests for `docs/SCHEMA.md` alignment. Option A is sufficient to close the gap.

--- a/.jules/runs/gatekeeper_contracts/envelope.json
+++ b/.jules/runs/gatekeeper_contracts/envelope.json
@@ -17,7 +17,6 @@
   "gate_profile": "contracts-determinism",
   "allowed_outcomes": [
     "PR-ready patch",
-    "proof-improvement patch",
     "learning PR"
   ]
 }

--- a/.jules/runs/gatekeeper_contracts/pr_body.md
+++ b/.jules/runs/gatekeeper_contracts/pr_body.md
@@ -1,58 +1,61 @@
 ## 💡 Summary
-Removed manual markdown parameter tables from `docs/reference-cli.md` and replaced them with `<!-- HELP: <command> -->` markers. This delegates documentation generation to `cargo xtask docs`, locks in deterministic CLI usage tracking, and closes the silent-skip case where a missing marker pair could make docs checks pass without checking a command.
-
-The restack also updates the xtask gate regression test to match the current queue policy: Jules provenance under `.jules/**` can be intentional PR state, so gate should not blanket-block `.jules/runs/**` while still guarding actual runtime/cache/transcript directories.
+Added baseline schema tests to prevent version drift. The `BASELINE_VERSION` constant was defined in `crates/tokmd-analysis-types/src/lib.rs`, `docs/SCHEMA.md`, and `docs/baseline.schema.json`, but no automated gate ensured they stayed perfectly synchronized.
 
 ## 🎯 Why
-Manual parameter tables in documentation frequently become outdated when CLI arguments change. `tokmd` provides `cargo xtask docs --update` which relies on `<!-- HELP: <command> -->` markers. Several commands were still using hand-maintained markdown tables, meaning updates to CLI args could easily be missed by the xtask check. The final patch also makes missing marker pairs an explicit docs-check failure.
+Schema or contract definitions can easily drift when versions are manually bumped in some places but forgotten in others. As a Gatekeeper, implementing automated enforcement across these truth sources prevents inconsistencies and ensures deterministic outputs remain sound across code and docs.
 
 ## 🔎 Evidence
-- File: `docs/reference-cli.md`
-- Observation: Many subcommands like `module`, `export`, `run`, `handoff` did not have `<!-- HELP: <command> -->` markers and used manual `| Argument | Description |` tables.
-- Verification: Running `cargo xtask docs --check` before the change ignored drift in these subcommands because they had no markers.
+- `crates/tokmd-analysis-types/src/lib.rs` defines `pub const BASELINE_VERSION: u32 = 1;`
+- `docs/SCHEMA.md` documents `BASELINE_VERSION`
+- `docs/baseline.schema.json` requires `baseline_version: 1`
+- `cargo test -p xtask` passed with the newly added tests guarding these relationships.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-Replace manual parameter tables with `<!-- HELP: <command> -->` markers for all commands, letting `cargo xtask docs --update` populate them correctly from the clap help output. Also fail `cargo xtask docs --check` when an expected marker pair is absent.
-- Trade-offs:
-  - **Structure**: Eliminates duplication of parameter details.
-  - **Velocity**: Developers no longer have to manually edit markdown tables when updating CLI parameters.
-  - **Governance**: Fits perfectly within the `tooling-governance` shard.
+- Add verification steps to `xtask/tests/docs_w43.rs` and `xtask/tests/docs_schema_w72.rs` to validate `BASELINE_VERSION` sync between source, documentation, and the JSON schema.
+- This perfectly matches the Gatekeeper role by adding missing schema invariants without excessive abstractions.
+- Trade-offs: Minor execution overhead in tests, high confidence in version alignment.
 
 ### Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand.
-- When to choose it: Only if custom columns are needed that clap does not output.
-- Trade-offs: Extreme risk of drift and maintenance burden.
+- Add a dedicated integration test binary specifically for `baseline.schema.json`.
+- When to choose it instead: If the JSON schema validation is extremely expensive or requires massive fixtures.
+- Trade-offs: Increases integration test scaffolding overhead when it's much simpler to bolt on to the existing robust `xtask` docs testing suite.
 
 ## ✅ Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables. The final patch keeps all synchronization in `cargo xtask docs --update` / `cargo xtask docs --check` and verifies that every expected command marker exists.
+Chose Option A to centralize doc and schema assertions inside the existing xtask tests designed for this exact purpose.
 
 ## 🧱 Changes made (SRP)
-- `docs/reference-cli.md`: Removed manual parameter tables for the CLI command surface and replaced them with `<!-- HELP: <command> -->` markers.
-- `xtask/src/tasks/docs.rs`: Treats missing marker pairs as documentation drift instead of silently skipping those commands.
-- `xtask/src/tasks/gate.rs`, `xtask/tests/xtask_deep_w74.rs`: Document and test that `.jules/runs/**` is not treated as forbidden runtime state because it may be intentional PR provenance.
+- `xtask/tests/docs_w43.rs`: Added `schema_md_baseline_version_matches_source`.
+- `xtask/tests/docs_schema_w72.rs`: Added `schema_md_baseline_version_matches_source` and `baseline_schema_json_version_matches_source`.
 
 ## 🧪 Verification receipts
 ```text
-$ cargo xtask docs --update
-Updated docs/reference-cli.md
+running 28 tests
+test changelog_follows_keepachangelog ... ok
+test changelog_mentions_latest_version ... ok
+test changelog_has_unreleased_section ... ok
+test reference_cli_commands_section_exists ... ok
+test baseline_schema_json_version_matches_source ... ok
+...
+test schema_md_baseline_version_matches_source ... ok
+...
+test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
 
-$ cargo xtask docs --check
-Documentation is up to date.
-
-$ cargo test -p tokmd --test docs
-test result: ok
-
-$ cargo test -p xtask
-test result: ok
+running 15 tests
+test baseline_schema_json_is_valid ... ok
+test docs_all_md_files_are_nonempty ... ok
+...
+test schema_md_baseline_version_matches_source ... ok
+...
+test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
 ```
 
 ## 🧭 Telemetry
-- Change shape: Replacement of manual documentation content with auto-generated sync blocks plus docs-check and provenance-policy guardrails.
-- Blast radius: Docs and xtask validation only.
-- Risk class: Low - Does not change application runtime behavior.
-- Rollback: Revert the commit.
-- Gates run: `cargo xtask docs --update`, `cargo xtask docs --check`, `cargo test -p xtask`, `cargo test -p tokmd --test docs`, `cargo fmt-check`, `git diff --check`
+- Change shape: Test enhancement
+- Blast radius: Restricted strictly to test scaffolding; no runtime logic affected.
+- Risk class + why: Low risk. Failing test on drift provides immediate feedback before merge.
+- Rollback: Revert the added test functions.
+- Gates run: `cargo test -p xtask` (verified sync logic passes on valid inputs).
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/gatekeeper_contracts/envelope.json`
@@ -62,4 +65,4 @@ test result: ok
 - `.jules/runs/gatekeeper_contracts/pr_body.md`
 
 ## 🔜 Follow-ups
-None. All CLI references are now correctly managed via xtask.
+None identified.

--- a/.jules/runs/gatekeeper_contracts/receipts.jsonl
+++ b/.jules/runs/gatekeeper_contracts/receipts.jsonl
@@ -1,4 +1,1 @@
-{"command": "cargo xtask docs --update", "result": "updated docs/reference-cli.md from tokmd help markers"}
-{"command": "cargo xtask docs --check", "result": "documentation is up to date and all expected marker pairs exist"}
-{"command": "cargo test -p xtask", "result": "xtask docs guard covered by task tests"}
-{"command": "cargo test -p tokmd --test docs", "result": "CLI docs integration tests passed"}
+{"command": "cargo test -p xtask", "status": "success"}

--- a/.jules/runs/gatekeeper_contracts/result.json
+++ b/.jules/runs/gatekeeper_contracts/result.json
@@ -1,17 +1,7 @@
 {
-  "summary": "Fixed documentation drift by replacing manual parameter tables with `<!-- HELP: <command> -->` markers and failing docs checks when expected marker pairs are missing",
-  "files_changed": [
-    "docs/reference-cli.md",
-    "xtask/src/tasks/docs.rs",
-    "xtask/src/tasks/gate.rs",
-    "xtask/tests/xtask_deep_w74.rs"
-  ],
-  "gates_run": [
-    "cargo xtask docs --update",
-    "cargo xtask docs --check",
-    "cargo test -p xtask",
-    "cargo test -p tokmd --test docs",
-    "cargo fmt-check",
-    "git diff --check"
+  "status": "success",
+  "files_modified": [
+    "xtask/tests/docs_w43.rs",
+    "xtask/tests/docs_schema_w72.rs"
   ]
 }

--- a/xtask/tests/docs_schema_w72.rs
+++ b/xtask/tests/docs_schema_w72.rs
@@ -211,7 +211,6 @@ fn schema_md_baseline_version_matches_source() {
     );
 }
 
-
 #[test]
 fn schema_md_context_version_matches_source() {
     let src = read_const_u32("crates/tokmd-types/src/lib.rs", "CONTEXT_SCHEMA_VERSION")
@@ -271,7 +270,6 @@ fn schema_json_has_required_receipt_definitions() {
         );
     }
 }
-
 
 fn baseline_schema_json() -> serde_json::Value {
     let raw = std::fs::read_to_string(workspace_root().join("docs/baseline.schema.json"))

--- a/xtask/tests/docs_schema_w72.rs
+++ b/xtask/tests/docs_schema_w72.rs
@@ -200,6 +200,19 @@ fn schema_md_handoff_version_matches_source() {
 }
 
 #[test]
+fn schema_md_baseline_version_matches_source() {
+    let src = read_const_u32("crates/tokmd-analysis-types/src/lib.rs", "BASELINE_VERSION")
+        .expect("BASELINE_VERSION not found in source");
+    let doc = schema_md_version(&schema_md(), "`BASELINE_VERSION`")
+        .expect("BASELINE_VERSION not found in SCHEMA.md");
+    assert_eq!(
+        src, doc,
+        "BASELINE_VERSION: source={src} != SCHEMA.md={doc}"
+    );
+}
+
+
+#[test]
 fn schema_md_context_version_matches_source() {
     let src = read_const_u32("crates/tokmd-types/src/lib.rs", "CONTEXT_SCHEMA_VERSION")
         .expect("CONTEXT_SCHEMA_VERSION not found in source");
@@ -257,6 +270,29 @@ fn schema_json_has_required_receipt_definitions() {
             "docs/schema.json missing definition for {name}"
         );
     }
+}
+
+
+fn baseline_schema_json() -> serde_json::Value {
+    let raw = std::fs::read_to_string(workspace_root().join("docs/baseline.schema.json"))
+        .expect("docs/baseline.schema.json must exist");
+    serde_json::from_str(&raw).expect("docs/baseline.schema.json must be valid JSON")
+}
+
+#[test]
+fn baseline_schema_json_version_matches_source() {
+    let json = baseline_schema_json();
+    let src = read_const_u32("crates/tokmd-analysis-types/src/lib.rs", "BASELINE_VERSION")
+        .expect("BASELINE_VERSION not found in source");
+
+    let json_ver = json["properties"]["baseline_version"]["const"]
+        .as_u64()
+        .expect("baseline_version const must be a number");
+
+    assert_eq!(
+        json_ver as u32, src,
+        "baseline.schema.json baseline_version ({json_ver}) != BASELINE_VERSION ({src})"
+    );
 }
 
 #[test]

--- a/xtask/tests/docs_w43.rs
+++ b/xtask/tests/docs_w43.rs
@@ -277,11 +277,9 @@ fn schema_md_handoff_version_matches_source() {
 
 #[test]
 fn schema_md_baseline_version_matches_source() {
-    let source_version = read_schema_constant(
-        "crates/tokmd-analysis-types/src/lib.rs",
-        "BASELINE_VERSION",
-    )
-    .expect("BASELINE_VERSION not found in source");
+    let source_version =
+        read_schema_constant("crates/tokmd-analysis-types/src/lib.rs", "BASELINE_VERSION")
+            .expect("BASELINE_VERSION not found in source");
     let schema_md = std::fs::read_to_string(workspace_root().join("docs/SCHEMA.md")).unwrap();
     let doc_version = extract_schema_md_version(&schema_md, "`BASELINE_VERSION`")
         .expect("BASELINE_VERSION not found in SCHEMA.md");
@@ -290,7 +288,6 @@ fn schema_md_baseline_version_matches_source() {
         "BASELINE_VERSION mismatch: source={source_version}, SCHEMA.md={doc_version}"
     );
 }
-
 
 // ── Reference-CLI doc markers ───────────────────────────────────────────
 

--- a/xtask/tests/docs_w43.rs
+++ b/xtask/tests/docs_w43.rs
@@ -275,6 +275,23 @@ fn schema_md_handoff_version_matches_source() {
     );
 }
 
+#[test]
+fn schema_md_baseline_version_matches_source() {
+    let source_version = read_schema_constant(
+        "crates/tokmd-analysis-types/src/lib.rs",
+        "BASELINE_VERSION",
+    )
+    .expect("BASELINE_VERSION not found in source");
+    let schema_md = std::fs::read_to_string(workspace_root().join("docs/SCHEMA.md")).unwrap();
+    let doc_version = extract_schema_md_version(&schema_md, "`BASELINE_VERSION`")
+        .expect("BASELINE_VERSION not found in SCHEMA.md");
+    assert_eq!(
+        source_version, doc_version,
+        "BASELINE_VERSION mismatch: source={source_version}, SCHEMA.md={doc_version}"
+    );
+}
+
+
 // ── Reference-CLI doc markers ───────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
See PR body for full details. Added schema version tracking tests for the new `baseline.schema.json` contract logic.

---
*PR created automatically by Jules for task [6903002921207323377](https://jules.google.com/task/6903002921207323377) started by @EffortlessSteven*