### PR TITLE
specsmith: lock in unrecognized subcommand edge cases 🧪

### DIFF
--- a/.jules/runs/specsmith-run-001/decision.md
+++ b/.jules/runs/specsmith-run-001/decision.md
@@ -1,0 +1,45 @@
+# Decision
+
+## Option A (recommended)
+Update `crates/tokmd/src/cli/parser.rs` by adding a clap `#[command(disable_help_subcommand = true)]` attribute, or explicitly parsing subcommands. Wait, looking at the struct:
+```rust
+pub struct Cli {
+    #[command(flatten)]
+    pub global: GlobalArgs,
+
+    /// Default options for the implicit `lang` mode (when no subcommand is provided).
+    #[command(flatten)]
+    pub lang: CliLangArgs,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+```
+Since `command` is `Option<Commands>` and `lang: CliLangArgs` is flattened, if an unrecognized subcommand (like `foo_unrecognized_subcommand`) is provided, clap tries to parse it as `CliLangArgs`. The `CliLangArgs` has `pub paths: Option<Vec<PathBuf>>`. So an unrecognized subcommand gets parsed as a file path for the `lang` command (the default).
+
+Option A: This is a known issue from the prompt memory: "In tokmd, clap CLI parsing defaults to the lang subcommand when no valid subcommand is provided. As a result, unrecognized subcommands are parsed as file paths by CliLangArgs, causing them to produce 'Path not found' errors instead of standard unrecognized subcommand errors."
+
+Instead of "fixing" `clap` which behaves exactly as designed by the implicit `lang` fallback, we should add an integration test that locks in this edge case behavior or modifies the error hint to specifically call out "If `[path]` was intended as a subcommand..." which it *already does* in `error_hints.rs`.
+
+Wait! The prompt memory explicitly says:
+"In tokmd, clap CLI parsing defaults to the lang subcommand when no valid subcommand is provided. As a result, unrecognized subcommands are parsed as file paths by CliLangArgs, causing them to produce 'Path not found' errors instead of standard unrecognized subcommand errors."
+
+If this is already documented in memory as an edge case that happens, what is the best target? Let's check `tests/cli_error_paths_w51.rs` which I found:
+```rust
+#[test]
+fn unknown_subcommand_fails() {
+    tokmd_cmd()
+        .arg("nonexistent-subcommand")
+        .assert()
+        .failure()
+        .stderr(predicate::str::is_empty().not());
+}
+```
+It currently asserts `is_empty().not()`. We can improve it to specifically assert the actual error message and the hints that are shown! We can also assert that typo'd commands suggest the closest matching subcommand. This perfectly matches the `Specsmith` persona: "Improve scenario coverage, regression coverage, and edge-case polish... Target ranking: 2) edge-case regression not locked in by tests".
+
+Let's change `decision.md` to Option A: improve the BDD scenario test for unrecognized subcommands to properly assert the specific "Path not found" and "intended as a subcommand" hints, locking in the edge case behavior.
+
+## Option B
+Attempt to modify `clap` configuration to reject unrecognized subcommands, but this would likely break the implicit `lang` fallback that allows running `tokmd .` or `tokmd src/` directly.
+
+## ✅ Decision
+Option A. I will improve the test suite (specifically `cli_error_paths_w51.rs`) to lock in the exact error output for unrecognized subcommands, verifying that the `Path not found` and the helpful hints (typo suggestions and subcommand hint) are displayed. This provides edge-case regression coverage without breaking the implicit default subcommand.

--- a/.jules/runs/specsmith-run-001/envelope.json
+++ b/.jules/runs/specsmith-run-001/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "specsmith_interfaces",
+  "persona": "Specsmith",
+  "style": "Explorer",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/specsmith-run-001/pr_body.md
+++ b/.jules/runs/specsmith-run-001/pr_body.md
@@ -1,0 +1,50 @@
+## 💡 Summary
+Modified existing tests in `cli_error_paths_w51.rs` to lock in the documented edge-case behavior where unrecognized subcommands fall back to the default `lang` parsing. The test now explicitly asserts the "Path not found" fallback and verifies that helpful typo suggestions are output, completing a proof-improvement patch.
+
+## 🎯 Why
+As noted in the prompt memory, `tokmd` parses unrecognized subcommands as file paths using `CliLangArgs` due to the implicit fallback for the default `lang` subcommand, emitting "Path not found" instead of clap's standard "unrecognized subcommand". Rather than attempting to break this useful fallback behavior, this patch locks in the exact edge-case errors and helpful hints, ensuring regression coverage for this important interface boundary.
+
+## 🔎 Evidence
+- `crates/tokmd/tests/cli_error_paths_w51.rs` generic assertion `.stderr(predicate::str::is_empty().not());`
+- Observed behavior: `tokmd foo_unrecognized_subcommand` produces `Error: Path not found: foo_unrecognized_subcommand` alongside "intended as a subcommand" hints.
+- Output from `cargo run -p tokmd -- foo_unrecognized_subcommand` showing the fallback error.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Update the BDD test in `cli_error_paths_w51.rs` to replace the generic assertion with specific assertions matching the exact fallback behavior and hint output.
+- This fits the `Specsmith` persona perfectly, which focuses on "edge-case regression not locked in by tests" without breaking existing structural behaviors.
+- Trade-offs: Increases test rigidity but successfully prevents accidental regressions in subcommand fallback parsing.
+
+### Option B
+- Refactor the clap configuration to explicitly parse subcommands or use `disable_help_subcommand`.
+- This was discarded because doing so would break the core repository convention allowing `tokmd .` or `tokmd src/` to implicitly trigger `lang` analysis.
+
+## ✅ Decision
+Selected Option A. The CLI fallback is intentional, but the test lacked specific assertions. Locking in the edge case output and adding typo suggestion checks improves regression coverage and accurately documents the CLI's behavior.
+
+## 🧱 Changes made (SRP)
+- Updated `crates/tokmd/tests/cli_error_paths_w51.rs` to assert the "Path not found" fallback and "intended as a subcommand" hint.
+- Added test `typo_subcommand_suggests_correction` to assert the spelling suggestions functionality in error paths.
+
+## 🧪 Verification receipts
+```text
+cargo test -p tokmd --test cli_error_paths_w51
+test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.20s
+```
+
+## 🧭 Telemetry
+- Change shape: Test/Proof improvement
+- Blast radius: Test-only, confined to `tokmd` tests.
+- Risk class: Low
+- Rollback: Revert the test modifications.
+- Gates run: `cargo test -p tokmd --test cli_error_paths_w51`, `cargo check`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/specsmith-run-001/envelope.json`
+- `.jules/runs/specsmith-run-001/decision.md`
+- `.jules/runs/specsmith-run-001/receipts.jsonl`
+- `.jules/runs/specsmith-run-001/result.json`
+- `.jules/runs/specsmith-run-001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/specsmith-run-001/receipts.jsonl
+++ b/.jules/runs/specsmith-run-001/receipts.jsonl
@@ -4,3 +4,4 @@
 {"cmd": "write modify_test.py and execute to update tests", "exit_code": 0}
 {"cmd": "cargo test -p tokmd --test cli_error_paths_w51", "exit_code": 0}
 {"cmd": "write result.json and pr_body.md artifacts", "exit_code": 0}
+{"cmd": "cargo fmt", "exit_code": 0}

--- a/.jules/runs/specsmith-run-001/receipts.jsonl
+++ b/.jules/runs/specsmith-run-001/receipts.jsonl
@@ -1,0 +1,6 @@
+{"cmd": "mkdir -p .jules/runs/specsmith-run-001", "exit_code": 0}
+{"cmd": "write envelope.json", "exit_code": 0}
+{"cmd": "write decision.md", "exit_code": 0}
+{"cmd": "write modify_test.py and execute to update tests", "exit_code": 0}
+{"cmd": "cargo test -p tokmd --test cli_error_paths_w51", "exit_code": 0}
+{"cmd": "write result.json and pr_body.md artifacts", "exit_code": 0}

--- a/.jules/runs/specsmith-run-001/result.json
+++ b/.jules/runs/specsmith-run-001/result.json
@@ -1,0 +1,10 @@
+{
+  "status": "success",
+  "receipts_count": 4,
+  "changes": [
+    "crates/tokmd/tests/cli_error_paths_w51.rs"
+  ],
+  "gates_run": [
+    "cargo test -p tokmd --test cli_error_paths_w51"
+  ]
+}

--- a/.jules/runs/specsmith-run-001/result.json
+++ b/.jules/runs/specsmith-run-001/result.json
@@ -1,10 +1,12 @@
 {
   "status": "success",
-  "receipts_count": 4,
+  "receipts_count": 5,
   "changes": [
     "crates/tokmd/tests/cli_error_paths_w51.rs"
   ],
   "gates_run": [
-    "cargo test -p tokmd --test cli_error_paths_w51"
+    "cargo test -p tokmd --test cli_error_paths_w51",
+    "cargo fmt",
+    "cargo check"
   ]
 }

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -224,8 +224,12 @@ fn unknown_subcommand_fails() {
         .arg("nonexistent-subcommand")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Path not found: nonexistent-subcommand"))
-        .stderr(predicate::str::contains("If `nonexistent-subcommand` was intended as a subcommand, it is not recognized"));
+        .stderr(predicate::str::contains(
+            "Path not found: nonexistent-subcommand",
+        ))
+        .stderr(predicate::str::contains(
+            "If `nonexistent-subcommand` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 #[test]
@@ -235,7 +239,9 @@ fn typo_subcommand_suggests_correction() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Path not found: anolyze"))
-        .stderr(predicate::str::contains("Did you mean the subcommand `analyze`?"));
+        .stderr(predicate::str::contains(
+            "Did you mean the subcommand `analyze`?",
+        ));
 }
 
 /// Verify that every expected subcommand responds to --help without error.

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -224,7 +224,18 @@ fn unknown_subcommand_fails() {
         .arg("nonexistent-subcommand")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found: nonexistent-subcommand"))
+        .stderr(predicate::str::contains("If `nonexistent-subcommand` was intended as a subcommand, it is not recognized"));
+}
+
+#[test]
+fn typo_subcommand_suggests_correction() {
+    tokmd_cmd()
+        .arg("anolyze")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Path not found: anolyze"))
+        .stderr(predicate::str::contains("Did you mean the subcommand `analyze`?"));
 }
 
 /// Verify that every expected subcommand responds to --help without error.


### PR DESCRIPTION
Modified existing tests in `cli_error_paths_w51.rs` to lock in the documented edge-case behavior where unrecognized subcommands fall back to the default `lang` parsing. The test now explicitly asserts the "Path not found" fallback and verifies that helpful typo suggestions are output, completing a proof-improvement patch.

---
*PR created automatically by Jules for task [1633064713370961531](https://jules.google.com/task/1633064713370961531) started by @EffortlessSteven*