### PR TITLE
compat: conditionally compile `export_bundle` to fix `--no-default-features` warnings 🧷

### DIFF
--- a/.jules/runs/compat_interfaces_matrix/decision.md
+++ b/.jules/runs/compat_interfaces_matrix/decision.md
@@ -1,0 +1,17 @@
+# Decision
+
+## Option A (recommended)
+- **What it is**: Ensure `ExportBundle` and its associated loading logic in `crates/tokmd/src/export_bundle.rs` isn't entirely dead code when compiling without default features. The issue happens because the only callers to `export_bundle` are inside commands configured behind the `analysis` feature flag (`analyze`, `badge`, `baseline`, `gate`). However, `export_bundle` itself has no feature gating, so rustc warns about unused structs and functions under `--no-default-features`.
+- **Why it fits this repo and shard**: Matches the exact assignment constraint ("--no-default-features failure" and MSRV/feature-boundary compat in config/core/CLI surfaces). By adding `#[cfg(feature = "analysis")]` to the top level of `crates/tokmd/src/export_bundle.rs` or the `mod export_bundle;` declaration in `crates/tokmd/src/lib.rs` (and conditionally compiling any usages like in `tests/`), we respect feature boundaries without degrading velocity.
+- **Trade-offs**:
+  - *Structure*: Follows idiomatic Rust feature flagging structure.
+  - *Velocity*: Minor build speed improvement without default features since we skip compiling unused code.
+  - *Governance*: No changes to public API or runtime behavior.
+
+## Option B
+- **What it is**: Suppress the lint entirely using `#[allow(dead_code)]` on the affected items or the whole file.
+- **When to choose it instead**: If the code is intended to be used by other parts of the workspace even if the local crate doesn't use it.
+- **Trade-offs**: Poor hygiene, masks actual dead code if we ever stop using it in the `analysis` features.
+
+## Decision
+Choose Option A. It's the most correct, idiomatic fix for Rust feature flag warnings (dead code). We'll apply `#[cfg(feature = "analysis")]` to `mod export_bundle;` in `crates/tokmd/src/lib.rs`.

--- a/.jules/runs/compat_interfaces_matrix/envelope.json
+++ b/.jules/runs/compat_interfaces_matrix/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "compat_interfaces_matrix",
+  "persona": "Compat",
+  "style": "Builder",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "compat-matrix",
+  "allowed_outcomes": ["pr_ready_patch", "learning_pr", "proof_improvement_patch"]
+}

--- a/.jules/runs/compat_interfaces_matrix/pr_body.md
+++ b/.jules/runs/compat_interfaces_matrix/pr_body.md
@@ -1,0 +1,53 @@
+## 💡 Summary
+Fixes unused code warnings for `export_bundle` when building `tokmd` with `--no-default-features`.
+
+## 🎯 Why
+When compiling without default features (which excludes the `analysis` feature), the `export_bundle` module is compiled but entirely unused, resulting in dead code warnings (`ExportMetaLite`, `ExportBundle`, `load_export_from_inputs`, etc.). To ensure a clean matrix build, we must conditionally compile this module only when `feature = "analysis"` is active.
+
+## 🔎 Evidence
+- file path: `crates/tokmd/src/lib.rs`
+- observed behavior: `cargo check -p tokmd --no-default-features` produced multiple `dead_code` warnings.
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Conditionally compile `mod export_bundle;` in `lib.rs` using `#[cfg(feature = "analysis")]`.
+- why it fits this repo and shard: It is the most idiomatic Rust approach to dead code feature flag warnings and limits compilation only to the required surfaces.
+- trade-offs:
+  - Structure: Clean feature boundary.
+  - Velocity: Minor improvement to `--no-default-features` build times.
+  - Governance: No behavior change.
+
+### Option B
+- what it is: Use `#[allow(dead_code)]`.
+- when to choose it instead: If the code could conceptually be consumed elsewhere outside of an explicit feature flag.
+- trade-offs: Degrades code hygiene and suppresses legitimate warnings if it truly becomes dead code.
+
+## ✅ Decision
+Chose Option A to maintain strong code hygiene and accurate feature boundary isolation.
+
+## 🧱 Changes made (SRP)
+- Added `#[cfg(feature = "analysis")]` to `mod export_bundle;` in `crates/tokmd/src/lib.rs`.
+
+## 🧪 Verification receipts
+```text
+{"command": "cargo check -p tokmd --no-default-features", "status": "success"}
+{"command": "cargo test -p tokmd --no-default-features", "status": "success"}
+{"command": "cargo test -p tokmd --all-features", "status": "success"}
+```
+
+## 🧭 Telemetry
+- Change shape: Minor conditional compilation fix.
+- Blast radius: Extremely low risk. Internal feature matrix compatibility. No public API/IO changes.
+- Risk class: Low
+- Rollback: Trivial git revert.
+- Gates run: `cargo check/test` across `--no-default-features` and `--all-features`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/compat_interfaces_matrix/envelope.json`
+- `.jules/runs/compat_interfaces_matrix/decision.md`
+- `.jules/runs/compat_interfaces_matrix/receipts.jsonl`
+- `.jules/runs/compat_interfaces_matrix/result.json`
+- `.jules/runs/compat_interfaces_matrix/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/compat_interfaces_matrix/receipts.jsonl
+++ b/.jules/runs/compat_interfaces_matrix/receipts.jsonl
@@ -1,0 +1,3 @@
+{"command": "cargo check -p tokmd --no-default-features", "status": "success"}
+{"command": "cargo test -p tokmd --no-default-features", "status": "success"}
+{"command": "cargo test -p tokmd --all-features", "status": "success"}

--- a/.jules/runs/compat_interfaces_matrix/result.json
+++ b/.jules/runs/compat_interfaces_matrix/result.json
@@ -1,0 +1,5 @@
+{
+  "outcome": "patch_ready",
+  "friction_items": [],
+  "verification_status": "verified"
+}

--- a/crates/tokmd/src/lib.rs
+++ b/crates/tokmd/src/lib.rs
@@ -29,6 +29,7 @@ mod commands;
 pub mod config;
 mod context_pack;
 mod error_hints;
+#[cfg(feature = "analysis")]
 mod export_bundle;
 mod git_support;
 #[cfg(feature = "ui")]


### PR DESCRIPTION
Fixes unused code warnings for `export_bundle` when building `tokmd` with `--no-default-features` by adding `#[cfg(feature = "analysis")]`.

---
*PR created automatically by Jules for task [15879886118843442851](https://jules.google.com/task/15879886118843442851) started by @EffortlessSteven*