### PR TITLE
palette: align browser runner validation schema with core FFI interface 🎨

### DIFF
--- a/.jules/runs/run-palette-binding-dx/decision.md
+++ b/.jules/runs/run-palette-binding-dx/decision.md
@@ -1,0 +1,22 @@
+# Decision Record: Browser Runner Memory Input Schema Alignment
+
+## Context
+The core `tokmd` FFI API supports in-memory inputs either at the root level (`args.inputs`) or nested within a scan object (`args.scan.inputs`). However, the JavaScript `web/runner/messages.js` implementation for validating run messages was strictly enforcing `inputs` only at the root level (`args.inputs`). This caused interface drift between the Rust core and the browser runner, where runner messages mimicking valid core FFI payloads containing `scan: { inputs: [...] }` were silently rejected.
+
+## Options Considered
+
+### Option A: Align runner validation to match core Rust API interface
+- **What it is:** Update `isRunArgsForMode` in `web/runner/messages.js` to correctly accept in-memory inputs under `args.scan.inputs` in addition to `args.inputs`, while explicitly rejecting cases where both are provided (matching core FFI constraints).
+- **Why it fits this repo and shard:** Resolves documented memory friction ("In `tokmd`, the core API (`tokmd-core` FFI) accepts in-memory inputs either at the root level... Bindings and runners (like `web/runner`) must support both input locations identically to prevent interface drift").
+- **Trade-offs:**
+  - *Structure:* Better alignment between the WASM boundary and the JS protocol layer.
+  - *Velocity:* Small targeted patch.
+  - *Governance:* Closes a gap where valid protocol schemas were dropped without diagnostics.
+
+### Option B: Forbid `scan.inputs` entirely in the JS runner
+- **What it is:** Maintain the current JS runner validation logic but add a specific runtime error indicating `scan.inputs` is unsupported via the runner.
+- **When to choose it instead:** If `scan.inputs` caused significant unresolvable architectural problems inside the JS runtime or WASM worker.
+- **Trade-offs:** Worsens interface drift; forces callers to manually transform payloads between standard `tokmd` FFI configurations and runner configurations.
+
+## Decision
+**Option A** is the best path. It resolves a clear developer experience friction point by preventing valid API payloads from being rejected as invalid protocol messages due to missing `scan.inputs` validation. It completely adheres to the `Palette` persona's objective of reducing confusion and fixing public API ergonomics across code-facing surfaces in the JS runner layer.

--- a/.jules/runs/run-palette-binding-dx/envelope.json
+++ b/.jules/runs/run-palette-binding-dx/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "palette_binding_dx",
+  "persona": "Palette",
+  "style": "Prover",
+  "primary_shard": "bindings-targets",
+  "allowed_paths": [
+    "crates/tokmd-python/**",
+    "crates/tokmd-node/**",
+    "crates/tokmd-wasm/**",
+    "web/runner/**",
+    "crates/tokmd-core/**",
+    "docs/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": [
+    "proof-improvement patch",
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/run-palette-binding-dx/pr_body.md
+++ b/.jules/runs/run-palette-binding-dx/pr_body.md
@@ -1,0 +1,62 @@
+## 💡 Summary
+Updated the browser runner protocol validation to accept in-memory inputs within the `scan` object (`args.scan.inputs`). This eliminates an interface drift where the JS runner was incorrectly rejecting valid core FFI payloads.
+
+## 🎯 Why
+The core `tokmd` FFI API supports providing in-memory inputs either at the root level (`args.inputs`) or nested within a scan object (`args.scan.inputs`). The browser runner's FFI validation (`web/runner/messages.js`) was overly restrictive, enforcing that inputs could *only* be at the root level. This caused valid payloads configured specifically with `scan: { inputs: [...] }` to be silently rejected with confusing validation errors, damaging runtime DX.
+
+## 🔎 Evidence
+- `web/runner/messages.js`
+- `web/runner/messages.test.mjs`
+- The `isRunArgsForMode` function was previously checking `!Array.isArray(args.inputs)`, forcing root inputs.
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Align runner validation to match the core Rust API interface by allowing inputs under `args.scan.inputs` or `args.inputs`, while explicitly rejecting cases where both are provided.
+- why it fits this repo and shard: Directly resolves memory friction regarding "in-memory inputs either at the root level... or nested within a scan object... Bindings and runners (like `web/runner`) must support both input locations identically to prevent interface drift".
+- trade-offs: Structure is improved by ensuring JS boundaries align with WASM FFI core expectations. Velocity is high as the patch is isolated to validation logic. Governance is satisfied by adhering to cross-target consistency constraints.
+
+### Option B
+- what it is: Forbid `scan.inputs` entirely in the JS runner but provide a clearer error message.
+- when to choose it instead: If supporting nested inputs caused major architectural conflicts in the JS runner or worker processing.
+- trade-offs: Suboptimal as it worsens interface drift and forces users to manually reshape compliant standard payloads just for the browser runner.
+
+## ✅ Decision
+Option A was chosen to directly eliminate the interface drift and allow uniform API usage across bindings.
+
+## 🧱 Changes made (SRP)
+- `web/runner/messages.js`: Updated `isRunArgsForMode` to accept either root inputs or scan inputs. Added checks to enforce mutual exclusivity.
+- `web/runner/messages.test.mjs`: Updated assertions to expect `isRunMessage` to pass for valid `scan.inputs` structures.
+
+## 🧪 Verification receipts
+```text
+$ npm --prefix web/runner test
+# Subtest: run messages require explicit in-memory inputs
+ok 20 - run messages require explicit in-memory inputs
+...
+# pass 48
+# fail 0
+# skipped 1
+
+$ CI=true cargo test -p tokmd-core --verbose
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.18s
+
+$ CI=true cargo test -p tokmd-wasm --verbose
+test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+```
+
+## 🧭 Telemetry
+- Change shape: Logic alignment / bug fix
+- Blast radius: API schema validation boundary
+- Risk class + why: Low risk. Corrects an existing over-restriction in the JS protocol.
+- Rollback: Revert `messages.js` changes.
+- Gates run: `npm --prefix web/runner test`, `cargo test -p tokmd-core`, `cargo test -p tokmd-wasm`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-palette-binding-dx/envelope.json`
+- `.jules/runs/run-palette-binding-dx/decision.md`
+- `.jules/runs/run-palette-binding-dx/receipts.jsonl`
+- `.jules/runs/run-palette-binding-dx/result.json`
+- `.jules/runs/run-palette-binding-dx/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-palette-binding-dx/receipts.jsonl
+++ b/.jules/runs/run-palette-binding-dx/receipts.jsonl
@@ -1,0 +1,3 @@
+{"command": "npm --prefix web/runner test", "outcome": "Passed 48/49 tests (1 skipped via expected behavior for unbuilt WASM binary)"}
+{"command": "CI=true cargo test -p tokmd-core --verbose", "outcome": "All tests passed (3 suites, ~120 tests run)"}
+{"command": "CI=true cargo test -p tokmd-wasm --verbose", "outcome": "All tests passed (12 tests run)"}

--- a/.jules/runs/run-palette-binding-dx/result.json
+++ b/.jules/runs/run-palette-binding-dx/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "outcome_type": "PR-ready patch",
+  "patch_description": "Aligned JS runner validation to accept in-memory inputs within the `scan` object, matching core FFI interface requirements."
+}

--- a/web/runner/messages.js
+++ b/web/runner/messages.js
@@ -117,26 +117,43 @@ function isRunArgsForMode(mode, args) {
         return false;
     }
 
-    if (!Array.isArray(args.inputs) || !args.inputs.every(isInMemoryInput)) {
+    const hasRootInputs = Array.isArray(args.inputs);
+    const hasNestedInputs = args.scan && Array.isArray(args.scan.inputs);
+
+    if (hasRootInputs && hasNestedInputs) {
         return false;
     }
 
+    if (!hasRootInputs && !hasNestedInputs) {
+        return false;
+    }
+
+    const inputsToValidate = hasRootInputs ? args.inputs : args.scan.inputs;
+
+    if (!inputsToValidate.every(isInMemoryInput)) {
+        return false;
+    }
+
+    const scanIsValid = args.scan === undefined || hasOnlyKeys(args.scan, ["inputs"]);
+
     if (mode === "analyze") {
         return Boolean(
-            hasOnlyKeys(args, ["inputs", "preset", "analyze"]) &&
+            hasOnlyKeys(args, ["inputs", "scan", "preset", "analyze"]) &&
                 (args.preset === undefined || typeof args.preset === "string") &&
-                (args.analyze === undefined || isAnalyzeOptions(args.analyze))
+                (args.analyze === undefined || isAnalyzeOptions(args.analyze)) &&
+                scanIsValid
         );
     }
 
     if (mode === "lang") {
         return Boolean(
-            hasOnlyKeys(args, ["inputs", "files"]) &&
-                (args.files === undefined || typeof args.files === "boolean")
+            hasOnlyKeys(args, ["inputs", "scan", "files"]) &&
+                (args.files === undefined || typeof args.files === "boolean") &&
+                scanIsValid
         );
     }
 
-    return hasOnlyKeys(args, ["inputs"]);
+    return Boolean(hasOnlyKeys(args, ["inputs", "scan"]) && scanIsValid);
 }
 
 export function isRunMessage(value) {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -192,7 +192,7 @@ test("run messages require explicit in-memory inputs", () => {
                 },
             },
         }),
-        false
+        true
     );
     assert.equal(
         isRunMessage({


### PR DESCRIPTION
This aligns the browser runner's implementation of `isRunArgsForMode` in `messages.js` with the core Rust interface. It now permits `args.scan.inputs` alongside `args.inputs`, strictly enforcing that both cannot be specified together, fixing a clear DX friction point in the JS SDK payload validation boundaries.

---
*PR created automatically by Jules for task [13625500627376442589](https://jules.google.com/task/13625500627376442589) started by @EffortlessSteven*