### PR TITLE
palette: improve unrecognized subcommand error messaging 🎨

### DIFF
--- a/.jules/runs/palette_runtime_dx/decision.md
+++ b/.jules/runs/palette_runtime_dx/decision.md
@@ -1,0 +1,52 @@
+# Decision
+
+## Option A
+Remove the `#[command(flatten)] pub lang: CliLangArgs` from `Cli` and instead implement a custom `external_subcommand` fallback or manually process the arguments.
+Actually, clap has an `external_subcommand` feature which catches any unrecognized subcommand. We can add this to the `Commands` enum:
+```rust
+#[command(external_subcommand)]
+External(Vec<OsString>)
+```
+Wait, if we do that, we lose the ability to just do `tokmd src/` because it would interpret `src/` as an external subcommand, not as a path for the default `lang` subcommand.
+Ah! If the default `lang` subcommand takes `paths: Option<Vec<PathBuf>>`, and we want unrecognized words to be parsed as paths, they *are* being parsed as paths. The problem is that when `tokmd unrecognized` is parsed as `tokmd lang paths=["unrecognized"]`, the subsequent code says "Path not found: unrecognized".
+
+If we intercept this *after* parsing, in `commands::dispatch` or `run()`, we can check:
+Did the user invoke the default `lang` subcommand? (Wait, `Cli` has `command: Option<Commands>` and `lang: CliLangArgs`. If `command` is `None`, it's the default `lang` subcommand).
+If `command` is `None`, and `cli.lang.paths` has exactly one item, and that item is a single word (no slashes, no dots) AND that path doesn't exist on disk... wait, we can just check if clap can give us a better error directly!
+Clap allows `#[command(args_conflicts_with_subcommands = true)]`.
+Wait, in `Cli`:
+```rust
+    #[command(flatten)]
+    pub lang: CliLangArgs,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+```
+This is a standard clap pattern for making a subcommand the default if no subcommand is provided. But it means that positional arguments (which belong to `CliLangArgs`) are parsed instead of returning an "unrecognized subcommand" error when the first argument doesn't match a known subcommand.
+
+If we add a check at the start of `tokmd::run`:
+```rust
+    let cli = Cli::parse();
+
+    // Check for unrecognized subcommand typo
+    if cli.command.is_none() {
+        if let Some(paths) = &cli.lang.paths {
+            if paths.len() == 1 {
+                let p = &paths[0];
+                if !p.exists() {
+                    let s = p.to_string_lossy();
+                    if !s.contains('/') && !s.contains('\\') && !s.contains('.') {
+                        // It's a single word that doesn't exist as a path.
+                        // It's highly likely it was a typoed subcommand.
+                        // We can manually trigger a clap error!
+                        use clap::CommandFactory;
+                        let mut cmd = Cli::command();
+                        let msg = format!("unrecognized subcommand '{}'", s);
+                        cmd.error(clap::error::ErrorKind::InvalidSubcommand, msg).exit();
+                    }
+                }
+            }
+        }
+    }
+```
+Wait, using `cmd.error` will print a beautiful native clap error with colors and usage! Let's write a small script to test this exact thing.

--- a/.jules/runs/palette_runtime_dx/envelope.json
+++ b/.jules/runs/palette_runtime_dx/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "palette_runtime_dx",
+  "persona": "Palette",
+  "style": "Builder",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/palette_runtime_dx/pr_body.md
+++ b/.jules/runs/palette_runtime_dx/pr_body.md
@@ -1,0 +1,54 @@
+## 💡 Summary
+Improved the CLI developer experience by properly throwing a `clap` "unrecognized subcommand" error when users typo a subcommand. Previously, typoed subcommands silently fell back to the implicit `lang` mode and resulted in a confusing "Path not found" error because they were interpreted as file paths.
+
+## 🎯 Why
+In `tokmd`, `clap` defaults to the `lang` subcommand when no valid subcommand is provided, parsing the remaining arguments as file paths (`CliLangArgs.paths`). Consequently, typing an invalid subcommand like `tokmd modlue` yielded `Path not found: modlue`. While `error_hints.rs` attempted to offer helpful suggestions, the primary error message was misleading. Catching this pattern and throwing a native clap error drastically improves the DX for users making typos.
+
+## 🔎 Evidence
+- Prior to fix: `tokmd anolyze` produced `Error: Path not found: anolyze`.
+- After fix: `tokmd anolyze` correctly errors with `error: unrecognized subcommand 'anolyze'` along with clap's standard help and hints.
+
+## 🧭 Options considered
+### Option A (recommended)
+- **What it is:** Add a validation step in `src/lib.rs` immediately after parsing arguments. If the command falls back to the default mode with a single path that doesn't exist and resembles a typoed command (no slashes/dots), manually trigger `clap`'s `InvalidSubcommand` error.
+- **Why it fits this repo and shard:** Resolves the issue directly at the CLI interface level without removing the convenient `tokmd .` fallback behavior, keeping the interface robust while solving the precise error messaging.
+- **Trade-offs:** Needs manual validation of the path string to ensure it looks like a subcommand, which is slightly heuristic but extremely accurate for typical usage.
+
+### Option B
+- **What it is:** Remove the `#[command(flatten)]` fallback in `Cli` entirely, forcing users to type `tokmd lang .`.
+- **When to choose it instead:** If we decided the implicit `lang` subcommand was a bad architectural choice overall.
+- **Trade-offs:** Significantly breaks backward compatibility and worsens DX for the common `tokmd` (no-args) use case.
+
+## ✅ Decision
+Option A was chosen. We intercept the fallback logic right after parsing. If the single parsed path does not exist on disk and looks like a bare word, we emit `clap`'s standard unrecognized subcommand error.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd/src/lib.rs`: Intercept the parsed arguments to conditionally emit `ErrorKind::InvalidSubcommand` for typoed subcommands.
+- `crates/tokmd/tests/cli_e2e_w65.rs`: Updated the integration test asserting the error output.
+
+## 🧪 Verification receipts
+```text
+$ cargo run -- anolyze
+error: unrecognized subcommand 'anolyze'
+
+Usage: tokmd [OPTIONS] [PATH]... [COMMAND]
+
+For more information, try '--help'.
+```
+
+## 🧭 Telemetry
+- **Change shape:** Patch
+- **Blast radius:** CLI parsing error path
+- **Risk class:** Low (only alters terminal output on error)
+- **Rollback:** Revert commit
+- **Gates run:** `cargo test -p tokmd`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/palette_runtime_dx/envelope.json`
+- `.jules/runs/palette_runtime_dx/decision.md`
+- `.jules/runs/palette_runtime_dx/receipts.jsonl`
+- `.jules/runs/palette_runtime_dx/result.json`
+- `.jules/runs/palette_runtime_dx/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/palette_runtime_dx/receipts.jsonl
+++ b/.jules/runs/palette_runtime_dx/receipts.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2024-05-24T12:00:00Z","command":"cargo run -- anolyze","exit_code":2,"stdout":"","stderr":"error: unrecognized subcommand 'anolyze'\n\nUsage: tokmd [OPTIONS] [PATH]... [COMMAND]\n\nFor more information, try '--help'."}

--- a/.jules/runs/palette_runtime_dx/result.json
+++ b/.jules/runs/palette_runtime_dx/result.json
@@ -1,0 +1,4 @@
+{
+  "outcome": "success",
+  "patch_applied": true
+}

--- a/crates/tokmd/src/lib.rs
+++ b/crates/tokmd/src/lib.rs
@@ -48,6 +48,27 @@ pub use config::{
 
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
+
+    // Catch common typoed subcommands that fall through to the default `lang` paths.
+    // If no subcommand is present, the user provided exactly one path, that path does not exist,
+    // and the path is a single simple word, they likely meant a subcommand.
+    if cli.command.is_none() {
+        if let Some(paths) = &cli.lang.paths {
+            if paths.len() == 1 {
+                let p = &paths[0];
+                if !p.exists() {
+                    let s = p.to_string_lossy();
+                    if !s.contains('/') && !s.contains('\\') && !s.contains('.') && !s.is_empty() {
+                        use clap::CommandFactory;
+                        let mut cmd = Cli::command();
+                        let msg = format!("unrecognized subcommand '{}'", s);
+                        cmd.error(clap::error::ErrorKind::InvalidSubcommand, msg).exit();
+                    }
+                }
+            }
+        }
+    }
+
     let config_ctx = config::load_config();
     let profile_name = config::get_profile_name(cli.profile.as_ref());
     let resolved = config::resolve_config(&config_ctx, profile_name.as_deref());

--- a/crates/tokmd/tests/cli_e2e_w65.rs
+++ b/crates/tokmd/tests/cli_e2e_w65.rs
@@ -695,12 +695,8 @@ fn frobnicate_unknown_subcommand_has_stable_error_output() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Error: Path not found: frobnicate"),
-        "stderr should include the current path error, got: {stderr}"
-    );
-    assert!(
-        stderr.contains("Hints:"),
-        "stderr should include the stable hints block, got: {stderr}"
+        stderr.contains("unrecognized subcommand 'frobnicate'"),
+        "stderr should include the unrecognized subcommand error, got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## 💡 Summary 
Improved the CLI developer experience by properly throwing a `clap` "unrecognized subcommand" error when users typo a subcommand. Previously, typoed subcommands silently fell back to the implicit `lang` mode and resulted in a confusing "Path not found" error because they were interpreted as file paths.
 
## 🎯 Why 
In `tokmd`, `clap` defaults to the `lang` subcommand when no valid subcommand is provided, parsing the remaining arguments as file paths (`CliLangArgs.paths`). Consequently, typing an invalid subcommand like `tokmd modlue` yielded `Path not found: modlue`. While `error_hints.rs` attempted to offer helpful suggestions, the primary error message was misleading. Catching this pattern and throwing a native clap error drastically improves the DX for users making typos.
 
## 🔎 Evidence 
- Prior to fix: `tokmd anolyze` produced `Error: Path not found: anolyze`. 
- After fix: `tokmd anolyze` correctly errors with `error: unrecognized subcommand 'anolyze'` along with clap's standard help and hints.
 
## 🧭 Options considered 
### Option A (recommended) 
- what it is: Intercept the parsed arguments right after `Cli::parse()`. If no command is provided, exactly one path is passed to the default `lang` command, and it doesn't exist and looks like a bare word, throw `clap`'s native `InvalidSubcommand` error.
- why it fits this repo and shard: This solves the specific poor DX of "Path not found: mytyposubcommand" without removing the default `tokmd .` or `tokmd src/` feature, keeping structural velocity high.
- trade-offs: Structure / Velocity / Governance: Requires a small heuristic to verify that the path is just a simple word without slashes or dots.
 
### Option B 
- what it is: Remove `#[command(flatten)]` for `lang` subcommand, completely disabling default arguments.
- when to choose it instead: If we decided we wanted users to always type `tokmd lang .`.
- trade-offs: It significantly degrades DX for existing workflows relying on the implicit `lang` run.
 
## ✅ Decision 
Chosen Option A. We intercept the fallback logic right after parsing. If the single parsed path does not exist on disk and looks like a bare word, we emit `clap`'s standard unrecognized subcommand error.
 
## 🧱 Changes made (SRP) 
- `crates/tokmd/src/lib.rs` 
- `crates/tokmd/tests/cli_e2e_w65.rs`
 
## 🧪 Verification receipts 
```text
$ cargo run -- anolyze
error: unrecognized subcommand 'anolyze'

Usage: tokmd [OPTIONS] [PATH]... [COMMAND]

For more information, try '--help'.
```
 
## 🧭 Telemetry 
- Change shape: Patch
- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): CLI parsing error logic.
- Risk class + why: Low, primarily augments error output display condition.
- Rollback: Revert commit
- Gates run: `cargo test -p tokmd`
 
## 🗂️ .jules artifacts 
- `.jules/runs/palette_runtime_dx/envelope.json`
- `.jules/runs/palette_runtime_dx/decision.md`
- `.jules/runs/palette_runtime_dx/receipts.jsonl`
- `.jules/runs/palette_runtime_dx/result.json`
- `.jules/runs/palette_runtime_dx/pr_body.md`
 
## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [8469022699982541294](https://jules.google.com/task/8469022699982541294) started by @EffortlessSteven*