### PR TITLE
specsmith: tighten CLI unknown subcommand assertions 🧪

### DIFF
--- a/.jules/runs/specsmith_interfaces_01/decision.md
+++ b/.jules/runs/specsmith_interfaces_01/decision.md
@@ -1,0 +1,17 @@
+# Decision Record
+
+## Option A (recommended)
+Update all integration and BDD test suites that assert for `.stderr(predicate::str::is_empty().not())` when asserting a bad or misspelled subcommand to correctly verify the exact suggestion stderr message produced by `tokmd`. This directly ties down the error suggestion features tested in CLI test suites (fixing the edge-case regression / loose assertions issue for `tokmd_config::error_hints`).
+
+- Fits repo: Yes, directly addresses "Specsmith" mission of improving regression coverage and test suite assertions, specifically closing mutation testing gaps and loose assertion gaps around the CLI interface behavior.
+- Structure: Replaces vague `.is_empty().not()` assertions with strict `.contains(...)` checks matching what the `error_hints::suggestions` engine returns.
+- Velocity: Prevents future regressions in CLI parser hints.
+- Governance: Improves strictness.
+
+## Option B
+Modify CLI test suites to test all combinations of flag configurations for unknown subcommands.
+- When to choose: If the current test suites lack sufficient coverage over CLI error output shapes (but they already do, they just lack precise assertions).
+- Trade-offs: Bloats the test suite without actually tightening the assertions on the specific `error_hints` output.
+
+## Decision
+Choosing Option A because it specifically targets the vague test assertions in the `interfaces` shard (CLI testing suites) and tightens them to verify the concrete suggestion string returned by `tokmd-config/src/error_hints.rs`.

--- a/.jules/runs/specsmith_interfaces_01/envelope.json
+++ b/.jules/runs/specsmith_interfaces_01/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "specsmith_interfaces",
+  "persona": "Specsmith",
+  "style": "Explorer",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": ["pr-ready patch", "proof-improvement patch", "learning pr"]
+}

--- a/.jules/runs/specsmith_interfaces_01/mutants.log
+++ b/.jules/runs/specsmith_interfaces_01/mutants.log
@@ -1,0 +1,894 @@
+crates/tokmd/src/bin/tok.rs:4:5: replace main with ()
+crates/tokmd/src/bin/tokmd.rs:4:5: replace main with ()
+crates/tokmd/src/lib.rs:50:5: replace run -> Result<()> with Ok(())
+crates/tokmd/src/lib.rs:58:5: replace format_error -> String with String::new()
+crates/tokmd/src/lib.rs:58:5: replace format_error -> String with "xyzzy".into()
+crates/tokmd/src/analysis_explain/mod.rs:153:5: replace normalize -> String with String::new()
+crates/tokmd/src/analysis_explain/mod.rs:153:5: replace normalize -> String with "xyzzy".into()
+crates/tokmd/src/analysis_explain/mod.rs:159:5: replace lookup -> Option<String> with None
+crates/tokmd/src/analysis_explain/mod.rs:159:5: replace lookup -> Option<String> with Some(String::new())
+crates/tokmd/src/analysis_explain/mod.rs:159:5: replace lookup -> Option<String> with Some("xyzzy".into())
+crates/tokmd/src/analysis_explain/mod.rs:161:39: replace == with != in lookup
+crates/tokmd/src/analysis_explain/mod.rs:164:54: replace == with != in lookup
+crates/tokmd/src/analysis_explain/mod.rs:172:5: replace catalog -> String with String::new()
+crates/tokmd/src/analysis_explain/mod.rs:172:5: replace catalog -> String with "xyzzy".into()
+crates/tokmd/src/analysis_utils.rs:25:5: replace child_include_to_string -> String with String::new()
+crates/tokmd/src/analysis_utils.rs:25:5: replace child_include_to_string -> String with "xyzzy".into()
+crates/tokmd/src/analysis_utils.rs:32:5: replace preset_to_string -> String with String::new()
+crates/tokmd/src/analysis_utils.rs:32:5: replace preset_to_string -> String with "xyzzy".into()
+crates/tokmd/src/analysis_utils.rs:39:5: replace format_to_string -> String with String::new()
+crates/tokmd/src/analysis_utils.rs:39:5: replace format_to_string -> String with "xyzzy".into()
+crates/tokmd/src/analysis_utils.rs:54:5: replace granularity_to_string -> String with String::new()
+crates/tokmd/src/analysis_utils.rs:54:5: replace granularity_to_string -> String with "xyzzy".into()
+crates/tokmd/src/analysis_utils.rs:61:5: replace map_preset -> analysis::AnalysisPreset with Default::default()
+crates/tokmd/src/analysis_utils.rs:78:5: replace map_granularity -> analysis::ImportGranularity with Default::default()
+crates/tokmd/src/analysis_utils.rs:85:5: replace analysis_output_filename -> &'static str with ""
+crates/tokmd/src/analysis_utils.rs:85:5: replace analysis_output_filename -> &'static str with "xyzzy"
+crates/tokmd/src/analysis_utils.rs:104:5: replace write_analysis_output -> Result<()> with Ok(())
+crates/tokmd/src/analysis_utils.rs:121:5: replace write_analysis_stdout -> Result<()> with Ok(())
+crates/tokmd/src/commands/mod.rs:30:5: replace dispatch -> Result<()> with Ok(())
+crates/tokmd/src/commands/mod.rs:32:9: delete match arm cli::Commands::Completions(args) in dispatch
+crates/tokmd/src/commands/mod.rs:33:9: delete match arm cli::Commands::Run(args) in dispatch
+crates/tokmd/src/commands/mod.rs:35:9: delete match arm cli::Commands::Diff(args) in dispatch
+crates/tokmd/src/commands/mod.rs:36:9: delete match arm cli::Commands::Lang(args) in dispatch
+crates/tokmd/src/commands/mod.rs:37:9: delete match arm cli::Commands::Module(args) in dispatch
+crates/tokmd/src/commands/mod.rs:38:9: delete match arm cli::Commands::Export(args) in dispatch
+crates/tokmd/src/commands/mod.rs:39:9: delete match arm cli::Commands::Analyze(args) in dispatch
+crates/tokmd/src/commands/mod.rs:41:9: delete match arm cli::Commands::Badge(args) in dispatch
+crates/tokmd/src/commands/mod.rs:43:9: delete match arm cli::Commands::Init(args) in dispatch
+crates/tokmd/src/commands/mod.rs:44:9: delete match arm cli::Commands::Context(args) in dispatch
+crates/tokmd/src/commands/mod.rs:45:9: delete match arm cli::Commands::CheckIgnore(args) in dispatch
+crates/tokmd/src/commands/mod.rs:46:9: delete match arm cli::Commands::Tools(args) in dispatch
+crates/tokmd/src/commands/mod.rs:47:9: delete match arm cli::Commands::Gate(args) in dispatch
+crates/tokmd/src/commands/mod.rs:49:9: delete match arm cli::Commands::Cockpit(args) in dispatch
+crates/tokmd/src/commands/mod.rs:50:9: delete match arm cli::Commands::Baseline(args) in dispatch
+crates/tokmd/src/commands/mod.rs:52:9: delete match arm cli::Commands::Handoff(args) in dispatch
+crates/tokmd/src/commands/mod.rs:53:9: delete match arm cli::Commands::Sensor(args) in dispatch
+crates/tokmd/src/config.rs:30:9: replace ConfigContext::get_toml_view -> Option<&ViewProfile> with None
+crates/tokmd/src/config.rs:30:9: replace ConfigContext::get_toml_view -> Option<&ViewProfile> with Some(Box::leak(Box::new(Default::default())))
+crates/tokmd/src/config.rs:35:9: replace ConfigContext::get_json_profile -> Option<&Profile> with None
+crates/tokmd/src/config.rs:35:9: replace ConfigContext::get_json_profile -> Option<&Profile> with Some(Box::leak(Box::new(Default::default())))
+crates/tokmd/src/config.rs:41:5: replace load_config -> ConfigContext with Default::default()
+crates/tokmd/src/config.rs:58:5: replace discover_toml_config -> Option<(TomlConfig, PathBuf)> with None
+crates/tokmd/src/config.rs:58:5: replace discover_toml_config -> Option<(TomlConfig, PathBuf)> with Some((Default::default(), Default::default()))
+crates/tokmd/src/config.rs:90:5: replace try_load_toml -> Option<(TomlConfig, PathBuf)> with None
+crates/tokmd/src/config.rs:90:5: replace try_load_toml -> Option<(TomlConfig, PathBuf)> with Some((Default::default(), Default::default()))
+crates/tokmd/src/config.rs:101:5: replace load_json_config -> Option<UserConfig> with None
+crates/tokmd/src/config.rs:101:5: replace load_json_config -> Option<UserConfig> with Some(Default::default())
+crates/tokmd/src/config.rs:115:5: replace get_profile_name -> Option<String> with None
+crates/tokmd/src/config.rs:115:5: replace get_profile_name -> Option<String> with Some(String::new())
+crates/tokmd/src/config.rs:115:5: replace get_profile_name -> Option<String> with Some("xyzzy".into())
+crates/tokmd/src/config.rs:122:21: delete ! in get_profile_name
+crates/tokmd/src/config.rs:130:5: replace resolve_profile -> Option<&'a Profile> with None
+crates/tokmd/src/config.rs:130:5: replace resolve_profile -> Option<&'a Profile> with Some(Box::leak(Box::new(Default::default())))
+crates/tokmd/src/config.rs:165:9: replace ResolvedConfig<'_>::format -> Option<&str> with None
+crates/tokmd/src/config.rs:165:9: replace ResolvedConfig<'_>::format -> Option<&str> with Some("")
+crates/tokmd/src/config.rs:165:9: replace ResolvedConfig<'_>::format -> Option<&str> with Some("xyzzy")
+crates/tokmd/src/config.rs:172:9: replace ResolvedConfig<'_>::top -> Option<usize> with None
+crates/tokmd/src/config.rs:172:9: replace ResolvedConfig<'_>::top -> Option<usize> with Some(0)
+crates/tokmd/src/config.rs:172:9: replace ResolvedConfig<'_>::top -> Option<usize> with Some(1)
+crates/tokmd/src/config.rs:179:9: replace ResolvedConfig<'_>::files -> Option<bool> with None
+crates/tokmd/src/config.rs:179:9: replace ResolvedConfig<'_>::files -> Option<bool> with Some(true)
+crates/tokmd/src/config.rs:179:9: replace ResolvedConfig<'_>::files -> Option<bool> with Some(false)
+crates/tokmd/src/config.rs:186:9: replace ResolvedConfig<'_>::module_roots -> Option<Vec<String>> with None
+crates/tokmd/src/config.rs:186:9: replace ResolvedConfig<'_>::module_roots -> Option<Vec<String>> with Some(vec![])
+crates/tokmd/src/config.rs:186:9: replace ResolvedConfig<'_>::module_roots -> Option<Vec<String>> with Some(vec![String::new()])
+crates/tokmd/src/config.rs:186:9: replace ResolvedConfig<'_>::module_roots -> Option<Vec<String>> with Some(vec!["xyzzy".into()])
+crates/tokmd/src/config.rs:194:9: replace ResolvedConfig<'_>::module_depth -> Option<usize> with None
+crates/tokmd/src/config.rs:194:9: replace ResolvedConfig<'_>::module_depth -> Option<usize> with Some(0)
+crates/tokmd/src/config.rs:194:9: replace ResolvedConfig<'_>::module_depth -> Option<usize> with Some(1)
+crates/tokmd/src/config.rs:202:9: replace ResolvedConfig<'_>::children -> Option<&str> with None
+crates/tokmd/src/config.rs:202:9: replace ResolvedConfig<'_>::children -> Option<&str> with Some("")
+crates/tokmd/src/config.rs:202:9: replace ResolvedConfig<'_>::children -> Option<&str> with Some("xyzzy")
+crates/tokmd/src/config.rs:210:9: replace ResolvedConfig<'_>::min_code -> Option<usize> with None
+crates/tokmd/src/config.rs:210:9: replace ResolvedConfig<'_>::min_code -> Option<usize> with Some(0)
+crates/tokmd/src/config.rs:210:9: replace ResolvedConfig<'_>::min_code -> Option<usize> with Some(1)
+crates/tokmd/src/config.rs:218:9: replace ResolvedConfig<'_>::max_rows -> Option<usize> with None
+crates/tokmd/src/config.rs:218:9: replace ResolvedConfig<'_>::max_rows -> Option<usize> with Some(0)
+crates/tokmd/src/config.rs:218:9: replace ResolvedConfig<'_>::max_rows -> Option<usize> with Some(1)
+crates/tokmd/src/config.rs:226:9: replace ResolvedConfig<'_>::redact -> Option<&str> with None
+crates/tokmd/src/config.rs:226:9: replace ResolvedConfig<'_>::redact -> Option<&str> with Some("")
+crates/tokmd/src/config.rs:226:9: replace ResolvedConfig<'_>::redact -> Option<&str> with Some("xyzzy")
+crates/tokmd/src/config.rs:233:9: replace ResolvedConfig<'_>::meta -> Option<bool> with None
+crates/tokmd/src/config.rs:233:9: replace ResolvedConfig<'_>::meta -> Option<bool> with Some(true)
+crates/tokmd/src/config.rs:233:9: replace ResolvedConfig<'_>::meta -> Option<bool> with Some(false)
+crates/tokmd/src/config.rs:256:5: replace resolve_config -> ResolvedConfig<'a> with Default::default()
+crates/tokmd/src/config.rs:294:5: replace resolve_lang -> tokmd_types::LangArgs with Default::default()
+crates/tokmd/src/config.rs:311:31: replace || with && in resolve_lang
+crates/tokmd/src/config.rs:367:5: replace resolve_lang_with_config -> tokmd_types::LangArgs with Default::default()
+crates/tokmd/src/config.rs:381:31: replace || with && in resolve_lang_with_config
+crates/tokmd/src/config.rs:424:5: replace resolve_module -> tokmd_types::ModuleArgs with Default::default()
+crates/tokmd/src/config.rs:511:5: replace resolve_module_with_config -> tokmd_types::ModuleArgs with Default::default()
+crates/tokmd/src/config.rs:577:5: replace resolve_export -> tokmd_types::ExportArgs with Default::default()
+crates/tokmd/src/config.rs:684:5: replace resolve_export_with_config -> tokmd_types::ExportArgs with Default::default()
+crates/tokmd/src/context_pack.rs:23:5: replace is_smart_excluded -> Option<&'static str> with None
+crates/tokmd/src/context_pack.rs:23:5: replace is_smart_excluded -> Option<&'static str> with Some("")
+crates/tokmd/src/context_pack.rs:23:5: replace is_smart_excluded -> Option<&'static str> with Some("xyzzy")
+crates/tokmd/src/context_pack.rs:36:5: replace is_spine_file -> bool with true
+crates/tokmd/src/context_pack.rs:36:5: replace is_spine_file -> bool with false
+crates/tokmd/src/context_pack.rs:86:5: replace parse_budget -> anyhow::Result<usize> with Ok(0)
+crates/tokmd/src/context_pack.rs:86:5: replace parse_budget -> anyhow::Result<usize> with Ok(1)
+crates/tokmd/src/context_pack.rs:88:29: replace || with && in parse_budget
+crates/tokmd/src/context_pack.rs:88:14: replace == with != in parse_budget
+crates/tokmd/src/context_pack.rs:88:38: replace == with != in parse_budget
+crates/tokmd/src/context_pack.rs:109:20: replace * with + in parse_budget
+crates/tokmd/src/context_pack.rs:109:20: replace * with / in parse_budget
+crates/tokmd/src/context_pack.rs:110:28: replace || with && in parse_budget
+crates/tokmd/src/context_pack.rs:110:8: delete ! in parse_budget
+crates/tokmd/src/context_pack.rs:110:38: replace < with == in parse_budget
+crates/tokmd/src/context_pack.rs:110:38: replace < with > in parse_budget
+crates/tokmd/src/context_pack.rs:110:38: replace < with <= in parse_budget
+crates/tokmd/src/context_pack.rs:116:15: replace > with == in parse_budget
+crates/tokmd/src/context_pack.rs:116:15: replace > with < in parse_budget
+crates/tokmd/src/context_pack.rs:116:15: replace > with >= in parse_budget
+crates/tokmd/src/context_pack.rs:129:5: replace get_value -> usize with 0
+crates/tokmd/src/context_pack.rs:129:5: replace get_value -> usize with 1
+crates/tokmd/src/context_pack.rs:140:47: replace + with - in get_value
+crates/tokmd/src/context_pack.rs:140:47: replace + with * in get_value
+crates/tokmd/src/context_pack.rs:140:40: replace * with + in get_value
+crates/tokmd/src/context_pack.rs:140:40: replace * with / in get_value
+crates/tokmd/src/context_pack.rs:157:5: replace classify_file -> Vec<FileClassification> with vec![]
+crates/tokmd/src/context_pack.rs:157:5: replace classify_file -> Vec<FileClassification> with vec![Default::default()]
+crates/tokmd/src/context_pack.rs:172:5: replace resolve_metric -> ResolvedMetric with Default::default()
+crates/tokmd/src/context_pack.rs:173:33: replace match guard git_scores.is_none() with true in resolve_metric
+crates/tokmd/src/context_pack.rs:173:33: replace match guard git_scores.is_none() with false in resolve_metric
+crates/tokmd/src/context_pack.rs:179:31: replace match guard git_scores.is_none() with true in resolve_metric
+crates/tokmd/src/context_pack.rs:179:31: replace match guard git_scores.is_none() with false in resolve_metric
+crates/tokmd/src/context_pack.rs:198:5: replace compute_file_cap -> usize with 0
+crates/tokmd/src/context_pack.rs:198:5: replace compute_file_cap -> usize with 1
+crates/tokmd/src/context_pack.rs:207:5: replace assign_policy -> (InclusionPolicy, Option<String>) with (Default::default(), None)
+crates/tokmd/src/context_pack.rs:207:5: replace assign_policy -> (InclusionPolicy, Option<String>) with (Default::default(), Some(String::new()))
+crates/tokmd/src/context_pack.rs:207:5: replace assign_policy -> (InclusionPolicy, Option<String>) with (Default::default(), Some("xyzzy".into()))
+crates/tokmd/src/context_pack.rs:224:5: replace write_head_tail -> anyhow::Result<()> with Ok(())
+crates/tokmd/src/context_pack.rs:230:20: replace == with != in write_head_tail
+crates/tokmd/src/context_pack.rs:236:34: replace / with % in write_head_tail
+crates/tokmd/src/context_pack.rs:236:34: replace / with * in write_head_tail
+crates/tokmd/src/context_pack.rs:237:31: replace > with == in write_head_tail
+crates/tokmd/src/context_pack.rs:237:31: replace > with < in write_head_tail
+crates/tokmd/src/context_pack.rs:237:31: replace > with >= in write_head_tail
+crates/tokmd/src/context_pack.rs:238:21: replace / with % in write_head_tail
+crates/tokmd/src/context_pack.rs:238:21: replace / with * in write_head_tail
+crates/tokmd/src/context_pack.rs:243:21: replace >= with < in write_head_tail
+crates/tokmd/src/context_pack.rs:246:25: replace && with || in write_head_tail
+crates/tokmd/src/context_pack.rs:254:43: replace * with + in write_head_tail
+crates/tokmd/src/context_pack.rs:254:43: replace * with / in write_head_tail
+crates/tokmd/src/context_pack.rs:256:57: replace + with - in write_head_tail
+crates/tokmd/src/context_pack.rs:256:57: replace + with * in write_head_tail
+crates/tokmd/src/context_pack.rs:260:21: replace && with || in write_head_tail
+crates/tokmd/src/context_pack.rs:267:16: replace > with == in write_head_tail
+crates/tokmd/src/context_pack.rs:267:16: replace > with < in write_head_tail
+crates/tokmd/src/context_pack.rs:267:16: replace > with >= in write_head_tail
+crates/tokmd/src/context_pack.rs:274:21: replace && with || in write_head_tail
+crates/tokmd/src/context_pack.rs:291:5: replace pack_greedy -> Vec<ContextFileRow> with vec![]
+crates/tokmd/src/context_pack.rs:291:5: replace pack_greedy -> Vec<ContextFileRow> with vec![Default::default()]
+crates/tokmd/src/context_pack.rs:291:64: replace == with != in pack_greedy
+crates/tokmd/src/context_pack.rs:303:37: replace <= with > in pack_greedy
+crates/tokmd/src/context_pack.rs:303:24: replace + with - in pack_greedy
+crates/tokmd/src/context_pack.rs:303:24: replace + with * in pack_greedy
+crates/tokmd/src/context_pack.rs:304:25: replace += with -= in pack_greedy
+crates/tokmd/src/context_pack.rs:304:25: replace += with *= in pack_greedy
+crates/tokmd/src/context_pack.rs:320:5: replace pack_spread -> Vec<ContextFileRow> with vec![]
+crates/tokmd/src/context_pack.rs:320:5: replace pack_spread -> Vec<ContextFileRow> with vec![Default::default()]
+crates/tokmd/src/context_pack.rs:320:57: replace == with != in pack_spread
+crates/tokmd/src/context_pack.rs:340:40: replace * with + in pack_spread
+crates/tokmd/src/context_pack.rs:340:40: replace * with / in pack_spread
+crates/tokmd/src/context_pack.rs:346:25: replace && with || in pack_spread
+crates/tokmd/src/context_pack.rs:346:40: replace < with == in pack_spread
+crates/tokmd/src/context_pack.rs:346:40: replace < with > in pack_spread
+crates/tokmd/src/context_pack.rs:346:40: replace < with <= in pack_spread
+crates/tokmd/src/context_pack.rs:350:21: replace < with == in pack_spread
+crates/tokmd/src/context_pack.rs:350:21: replace < with > in pack_spread
+crates/tokmd/src/context_pack.rs:350:21: replace < with <= in pack_spread
+crates/tokmd/src/context_pack.rs:352:45: replace <= with > in pack_spread
+crates/tokmd/src/context_pack.rs:352:32: replace + with - in pack_spread
+crates/tokmd/src/context_pack.rs:352:32: replace + with * in pack_spread
+crates/tokmd/src/context_pack.rs:353:33: replace += with -= in pack_spread
+crates/tokmd/src/context_pack.rs:353:33: replace += with *= in pack_spread
+crates/tokmd/src/context_pack.rs:355:26: replace += with -= in pack_spread
+crates/tokmd/src/context_pack.rs:355:26: replace += with *= in pack_spread
+crates/tokmd/src/context_pack.rs:358:26: replace += with -= in pack_spread
+crates/tokmd/src/context_pack.rs:358:26: replace += with *= in pack_spread
+crates/tokmd/src/context_pack.rs:367:21: delete ! in pack_spread
+crates/tokmd/src/context_pack.rs:367:53: replace == with != in pack_spread
+crates/tokmd/src/context_pack.rs:377:37: replace <= with > in pack_spread
+crates/tokmd/src/context_pack.rs:377:24: replace + with - in pack_spread
+crates/tokmd/src/context_pack.rs:377:24: replace + with * in pack_spread
+crates/tokmd/src/context_pack.rs:378:25: replace += with -= in pack_spread
+crates/tokmd/src/context_pack.rs:378:25: replace += with *= in pack_spread
+crates/tokmd/src/context_pack.rs:395:5: replace select_files -> Vec<ContextFileRow> with vec![]
+crates/tokmd/src/context_pack.rs:395:5: replace select_files -> Vec<ContextFileRow> with vec![Default::default()]
+crates/tokmd/src/context_pack.rs:402:13: delete field no_smart_exclude from struct SelectOptions expression in select_files
+crates/tokmd/src/context_pack.rs:419:5: replace select_files_with_options -> SelectResult with Default::default()
+crates/tokmd/src/context_pack.rs:439:29: replace != with == in select_files_with_options
+crates/tokmd/src/context_pack.rs:472:56: replace == with != in select_files_with_options
+crates/tokmd/src/context_pack.rs:506:23: replace != with == in select_files_with_options
+crates/tokmd/src/context_pack.rs:510:13: delete ! in select_files_with_options
+crates/tokmd/src/context_pack.rs:515:17: replace && with || in select_files_with_options
+crates/tokmd/src/context_pack.rs:515:32: replace == with != in select_files_with_options
+crates/tokmd/src/context_pack.rs:520:21: delete field tokens from struct FileRow expression in select_files_with_options
+crates/tokmd/src/context_pack.rs:530:24: replace * with + in select_files_with_options
+crates/tokmd/src/context_pack.rs:530:24: replace * with / in select_files_with_options
+crates/tokmd/src/context_pack.rs:536:28: replace == with != in select_files_with_options
+crates/tokmd/src/context_pack.rs:551:36: replace <= with > in select_files_with_options
+crates/tokmd/src/context_pack.rs:551:23: replace + with - in select_files_with_options
+crates/tokmd/src/context_pack.rs:551:23: replace + with * in select_files_with_options
+crates/tokmd/src/context_pack.rs:552:24: replace += with -= in select_files_with_options
+crates/tokmd/src/context_pack.rs:552:24: replace += with *= in select_files_with_options
+crates/tokmd/src/context_pack.rs:567:21: delete ! in select_files_with_options
+crates/tokmd/src/context_pack.rs:604:28: replace == with != in select_files_with_options
+crates/tokmd/src/context_pack.rs:627:5: replace to_context_row -> ContextFileRow with Default::default()
+crates/tokmd/src/context_pack.rs:636:5: replace to_context_row_with_reason -> ContextFileRow with Default::default()
+crates/tokmd/src/error_hints.rs:4:5: replace format -> String with String::new()
+crates/tokmd/src/error_hints.rs:4:5: replace format -> String with "xyzzy".into()
+crates/tokmd/src/error_hints.rs:6:8: delete ! in format
+crates/tokmd/src/error_hints.rs:18:5: replace suggestions -> Vec<String> with vec![]
+crates/tokmd/src/error_hints.rs:18:5: replace suggestions -> Vec<String> with vec![String::new()]
+crates/tokmd/src/error_hints.rs:18:5: replace suggestions -> Vec<String> with vec!["xyzzy".into()]
+crates/tokmd/src/error_hints.rs:23:9: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:44:9: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:43:9: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:42:9: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:41:9: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:65:9: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:64:9: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:79:75: replace && with || in suggestions
+crates/tokmd/src/error_hints.rs:79:48: replace && with || in suggestions
+crates/tokmd/src/error_hints.rs:79:24: delete ! in suggestions
+crates/tokmd/src/error_hints.rs:79:51: delete ! in suggestions
+crates/tokmd/src/error_hints.rs:79:78: delete ! in suggestions
+crates/tokmd/src/error_hints.rs:105:34: replace < with == in suggestions
+crates/tokmd/src/error_hints.rs:105:34: replace < with > in suggestions
+crates/tokmd/src/error_hints.rs:105:34: replace < with <= in suggestions
+crates/tokmd/src/error_hints.rs:113:70: replace / with % in suggestions
+crates/tokmd/src/error_hints.rs:113:70: replace / with * in suggestions
+crates/tokmd/src/error_hints.rs:114:55: replace && with || in suggestions
+crates/tokmd/src/error_hints.rs:114:42: replace <= with > in suggestions
+crates/tokmd/src/error_hints.rs:114:68: replace > with == in suggestions
+crates/tokmd/src/error_hints.rs:114:68: replace > with < in suggestions
+crates/tokmd/src/error_hints.rs:114:68: replace > with >= in suggestions
+crates/tokmd/src/error_hints.rs:125:12: delete ! in suggestions
+crates/tokmd/src/error_hints.rs:127:59: replace && with || in suggestions
+crates/tokmd/src/error_hints.rs:127:38: replace && with || in suggestions
+crates/tokmd/src/error_hints.rs:127:20: delete ! in suggestions
+crates/tokmd/src/error_hints.rs:127:41: delete ! in suggestions
+crates/tokmd/src/error_hints.rs:127:62: delete ! in suggestions
+crates/tokmd/src/error_hints.rs:149:38: replace && with || in suggestions
+crates/tokmd/src/error_hints.rs:160:56: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:178:34: replace && with || in suggestions
+crates/tokmd/src/error_hints.rs:178:65: replace || with && in suggestions
+crates/tokmd/src/error_hints.rs:189:5: replace push_hint with ()
+crates/tokmd/src/error_hints.rs:189:8: delete ! in push_hint
+crates/tokmd/src/error_hints.rs:189:30: replace == with != in push_hint
+crates/tokmd/src/error_hints.rs:195:5: replace levenshtein -> usize with 0
+crates/tokmd/src/error_hints.rs:195:5: replace levenshtein -> usize with 1
+crates/tokmd/src/error_hints.rs:207:65: replace + with - in levenshtein
+crates/tokmd/src/error_hints.rs:207:65: replace + with * in levenshtein
+crates/tokmd/src/error_hints.rs:210:69: replace + with - in levenshtein
+crates/tokmd/src/error_hints.rs:210:69: replace + with * in levenshtein
+crates/tokmd/src/error_hints.rs:216:42: replace == with != in levenshtein
+crates/tokmd/src/error_hints.rs:216:37: replace - with + in levenshtein
+crates/tokmd/src/error_hints.rs:216:37: replace - with / in levenshtein
+crates/tokmd/src/error_hints.rs:216:55: replace - with + in levenshtein
+crates/tokmd/src/error_hints.rs:216:55: replace - with / in levenshtein
+crates/tokmd/src/error_hints.rs:222:43: replace + with - in levenshtein
+crates/tokmd/src/error_hints.rs:222:43: replace + with * in levenshtein
+crates/tokmd/src/error_hints.rs:222:35: replace - with + in levenshtein
+crates/tokmd/src/error_hints.rs:222:35: replace - with / in levenshtein
+crates/tokmd/src/error_hints.rs:222:60: replace + with - in levenshtein
+crates/tokmd/src/error_hints.rs:222:60: replace + with * in levenshtein
+crates/tokmd/src/error_hints.rs:222:55: replace - with + in levenshtein
+crates/tokmd/src/error_hints.rs:222:55: replace - with / in levenshtein
+crates/tokmd/src/error_hints.rs:223:33: replace + with - in levenshtein
+crates/tokmd/src/error_hints.rs:223:33: replace + with * in levenshtein
+crates/tokmd/src/error_hints.rs:223:21: replace - with + in levenshtein
+crates/tokmd/src/error_hints.rs:223:21: replace - with / in levenshtein
+crates/tokmd/src/error_hints.rs:223:28: replace - with + in levenshtein
+crates/tokmd/src/error_hints.rs:223:28: replace - with / in levenshtein
+crates/tokmd/src/export_bundle.rs:45:5: replace load_export_from_inputs -> Result<ExportBundle> with Ok(Default::default())
+crates/tokmd/src/export_bundle.rs:45:21: replace > with == in load_export_from_inputs
+crates/tokmd/src/export_bundle.rs:45:21: replace > with < in load_export_from_inputs
+crates/tokmd/src/export_bundle.rs:45:21: replace > with >= in load_export_from_inputs
+crates/tokmd/src/export_bundle.rs:84:5: replace scan_export_from_paths -> Result<ExportBundle> with Ok(Default::default())
+crates/tokmd/src/export_bundle.rs:110:5: replace load_export_from_receipt -> Result<ExportBundle> with Ok(Default::default())
+crates/tokmd/src/export_bundle.rs:131:5: replace load_export_from_file -> Result<ExportBundle> with Ok(Default::default())
+crates/tokmd/src/export_bundle.rs:138:22: replace && with || in load_export_from_file
+crates/tokmd/src/export_bundle.rs:138:12: replace != with == in load_export_from_file
+crates/tokmd/src/export_bundle.rs:138:29: replace != with == in load_export_from_file
+crates/tokmd/src/export_bundle.rs:148:9: replace && with || in load_export_from_file
+crates/tokmd/src/export_bundle.rs:147:12: replace == with != in load_export_from_file
+crates/tokmd/src/export_bundle.rs:161:37: replace == with != in load_export_from_file
+crates/tokmd/src/export_bundle.rs:182:5: replace load_export_jsonl_content -> Result<(tokmd_types::ExportData, ExportMetaLite)> with Ok((Default::default(), Default::default()))
+crates/tokmd/src/export_bundle.rs:192:15: replace == with != in load_export_jsonl_content
+crates/tokmd/src/export_bundle.rs:225:5: replace load_export_json_content -> Result<(tokmd_types::ExportData, ExportMetaLite)> with Ok((Default::default(), Default::default()))
+crates/tokmd/src/git_support.rs:5:5: replace git_cmd -> Command with Default::default()
+crates/tokmd/src/progress.rs:10:5: replace is_interactive -> bool with true
+crates/tokmd/src/progress.rs:10:5: replace is_interactive -> bool with false
+crates/tokmd/src/progress.rs:10:8: delete ! in is_interactive
+crates/tokmd/src/progress.rs:65:13: replace ui_impl::Progress::set_message with ()
+crates/tokmd/src/progress.rs:72:13: replace ui_impl::Progress::finish_and_clear with ()
+crates/tokmd/src/progress.rs:80:13: replace ui_impl::<impl Drop for Progress>::drop with ()
+crates/tokmd/src/progress.rs:119:13: replace ui_impl::ProgressBarWithEta::inc with ()
+crates/tokmd/src/progress.rs:126:13: replace ui_impl::ProgressBarWithEta::inc_by with ()
+crates/tokmd/src/progress.rs:133:13: replace ui_impl::ProgressBarWithEta::set_position with ()
+crates/tokmd/src/progress.rs:140:13: replace ui_impl::ProgressBarWithEta::set_message with ()
+crates/tokmd/src/progress.rs:147:13: replace ui_impl::ProgressBarWithEta::set_length with ()
+crates/tokmd/src/progress.rs:154:13: replace ui_impl::ProgressBarWithEta::finish_with_message with ()
+crates/tokmd/src/progress.rs:161:13: replace ui_impl::ProgressBarWithEta::finish_and_clear with ()
+crates/tokmd/src/progress.rs:169:13: replace ui_impl::ProgressBarWithEta::elapsed -> Option<Duration> with None
+crates/tokmd/src/progress.rs:169:13: replace ui_impl::ProgressBarWithEta::elapsed -> Option<Duration> with Some(Default::default())
+crates/tokmd/src/progress.rs:175:13: replace ui_impl::<impl Drop for ProgressBarWithEta>::drop with ()
+crates/tokmd/src/tool_schema.rs:90:5: replace build_tool_schema -> ToolSchemaOutput with Default::default()
+crates/tokmd/src/tool_schema.rs:99:17: replace == with != in build_tool_schema
+crates/tokmd/src/tool_schema.rs:116:5: replace build_tool_definition -> ToolDefinition with Default::default()
+crates/tokmd/src/tool_schema.rs:124:35: replace || with && in build_tool_definition
+crates/tokmd/src/tool_schema.rs:124:25: replace == with != in build_tool_definition
+crates/tokmd/src/tool_schema.rs:124:51: replace == with != in build_tool_definition
+crates/tokmd/src/tool_schema.rs:139:5: replace build_parameter_schema -> ParameterSchema with Default::default()
+crates/tokmd/src/tool_schema.rs:178:5: replace determine_param_type -> String with String::new()
+crates/tokmd/src/tool_schema.rs:178:5: replace determine_param_type -> String with "xyzzy".into()
+crates/tokmd/src/tool_schema.rs:179:9: delete match arm ArgAction::SetTrue | ArgAction::SetFalse in determine_param_type
+crates/tokmd/src/tool_schema.rs:180:9: delete match arm ArgAction::Count in determine_param_type
+crates/tokmd/src/tool_schema.rs:181:9: delete match arm ArgAction::Append in determine_param_type
+crates/tokmd/src/tool_schema.rs:192:5: replace render_output -> Result<String> with Ok(String::new())
+crates/tokmd/src/tool_schema.rs:192:5: replace render_output -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/tool_schema.rs:202:5: replace render_jsonschema -> Result<String> with Ok(String::new())
+crates/tokmd/src/tool_schema.rs:202:5: replace render_jsonschema -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/tool_schema.rs:265:5: replace render_openai -> Result<String> with Ok(String::new())
+crates/tokmd/src/tool_schema.rs:265:5: replace render_openai -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/tool_schema.rs:320:5: replace render_anthropic -> Result<String> with Ok(String::new())
+crates/tokmd/src/tool_schema.rs:320:5: replace render_anthropic -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/tool_schema.rs:375:5: replace render_clap -> Result<String> with Ok(String::new())
+crates/tokmd/src/tool_schema.rs:375:5: replace render_clap -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/cli/parser.rs:1007:9: replace <impl From<&GlobalArgs> for tokmd_settings::ScanOptions>::from -> Self with Default::default()
+crates/tokmd/src/cli/parser.rs:1022:9: replace <impl From<GlobalArgs> for tokmd_settings::ScanOptions>::from -> Self with Default::default()
+crates/tokmd/src/commands/analyze.rs:12:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/analyze.rs:14:56: replace || with && in handle
+crates/tokmd/src/commands/analyze.rs:14:33: replace || with && in handle
+crates/tokmd/src/commands/analyze.rs:14:23: replace == with != in handle
+crates/tokmd/src/commands/analyze.rs:14:47: replace == with != in handle
+crates/tokmd/src/commands/analyze.rs:14:70: replace == with != in handle
+crates/tokmd/src/commands/analyze.rs:30:34: delete ! in handle
+crates/tokmd/src/commands/analyze.rs:77:53: replace == with != in handle
+crates/tokmd/src/commands/analyze.rs:126:5: replace parse_effort_request -> Result<Option<analysis::EffortRequest>> with Ok(None)
+crates/tokmd/src/commands/analyze.rs:126:5: replace parse_effort_request -> Result<Option<analysis::EffortRequest>> with Ok(Some(Default::default()))
+crates/tokmd/src/commands/analyze.rs:128:51: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:128:28: replace && with || in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:128:74: replace && with || in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:139:9: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:138:9: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:137:9: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:136:9: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:135:9: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:134:9: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:133:9: replace || with && in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:140:8: delete ! in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:156:22: replace == with != in parse_effort_request
+crates/tokmd/src/commands/analyze.rs:172:5: replace map_effort_model -> Result<analysis::EffortModelKind> with Ok(Default::default())
+crates/tokmd/src/commands/analyze.rs:181:5: replace map_effort_layer -> analysis::EffortLayer with Default::default()
+crates/tokmd/src/commands/badge.rs:10:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/badge.rs:12:44: replace && with || in handle
+crates/tokmd/src/commands/badge.rs:12:15: replace == with != in handle
+crates/tokmd/src/commands/badge.rs:19:22: replace == with != in handle
+crates/tokmd/src/commands/badge.rs:129:5: replace badge_metric_label -> &'static str with ""
+crates/tokmd/src/commands/badge.rs:129:5: replace badge_metric_label -> &'static str with "xyzzy"
+crates/tokmd/src/commands/baseline.rs:21:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/baseline.rs:21:34: delete ! in handle
+crates/tokmd/src/commands/baseline.rs:24:29: replace && with || in handle
+crates/tokmd/src/commands/baseline.rs:24:32: delete ! in handle
+crates/tokmd/src/commands/baseline.rs:120:9: replace && with || in handle
+crates/tokmd/src/commands/baseline.rs:119:9: replace && with || in handle
+crates/tokmd/src/commands/baseline.rs:119:12: delete ! in handle
+crates/tokmd/src/commands/baseline.rs:120:12: delete ! in handle
+crates/tokmd/src/commands/baseline.rs:167:5: replace compute_determinism_baseline -> Result<DeterminismBaseline> with Ok(Default::default())
+crates/tokmd/src/commands/baseline.rs:190:5: replace capture_git_commit -> Option<String> with None
+crates/tokmd/src/commands/baseline.rs:190:5: replace capture_git_commit -> Option<String> with Some(String::new())
+crates/tokmd/src/commands/baseline.rs:190:5: replace capture_git_commit -> Option<String> with Some("xyzzy".into())
+crates/tokmd/src/commands/baseline.rs:200:12: delete ! in capture_git_commit
+crates/tokmd/src/commands/baseline.rs:210:5: replace capture_git_commit -> Option<String> with Some(String::new())
+crates/tokmd/src/commands/baseline.rs:210:5: replace capture_git_commit -> Option<String> with Some("xyzzy".into())
+crates/tokmd/src/commands/check_ignore.rs:17:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/check_ignore.rs:63:5: replace check_path -> Result<CheckResult> with Ok(Default::default())
+crates/tokmd/src/commands/check_ignore.rs:103:17: replace && with || in check_path
+crates/tokmd/src/commands/check_ignore.rs:103:8: delete ! in check_path
+crates/tokmd/src/commands/check_ignore.rs:124:5: replace check_git_ignore -> Option<IgnoreReason> with None
+crates/tokmd/src/commands/check_ignore.rs:124:5: replace check_git_ignore -> Option<IgnoreReason> with Some(Default::default())
+crates/tokmd/src/commands/check_ignore.rs:141:54: replace + with - in check_git_ignore
+crates/tokmd/src/commands/check_ignore.rs:141:54: replace + with * in check_git_ignore
+crates/tokmd/src/commands/check_ignore.rs:146:41: replace + with - in check_git_ignore
+crates/tokmd/src/commands/check_ignore.rs:146:41: replace + with * in check_git_ignore
+crates/tokmd/src/commands/check_ignore.rs:180:5: replace is_git_tracked -> bool with true
+crates/tokmd/src/commands/check_ignore.rs:180:5: replace is_git_tracked -> bool with false
+crates/tokmd/src/commands/check_ignore.rs:192:5: replace check_tokeignore -> Option<IgnoreReason> with None
+crates/tokmd/src/commands/check_ignore.rs:192:5: replace check_tokeignore -> Option<IgnoreReason> with Some(Default::default())
+crates/tokmd/src/commands/check_ignore.rs:198:36: replace || with && in check_tokeignore
+crates/tokmd/src/commands/check_ignore.rs:216:32: replace || with && in check_tokeignore
+crates/tokmd/src/commands/check_ignore.rs:235:5: replace matches_glob -> bool with true
+crates/tokmd/src/commands/check_ignore.rs:235:5: replace matches_glob -> bool with false
+crates/tokmd/src/commands/check_ignore.rs:248:24: replace == with != in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:252:52: replace || with && in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:253:52: replace || with && in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:254:28: replace && with || in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:261:24: replace == with != in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:262:40: replace && with || in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:271:13: replace || with && in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:270:13: replace || with && in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:269:14: replace == with != in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:274:18: delete ! in matches_glob
+crates/tokmd/src/commands/check_ignore.rs:278:5: replace print_result with ()
+crates/tokmd/src/commands/cockpit.rs:26:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/cockpit.rs:34:12: delete ! in handle
+crates/tokmd/src/commands/completions.rs:6:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/context.rs:22:9: replace CountingWriter<W>::bytes -> u64 with 0
+crates/tokmd/src/commands/context.rs:22:9: replace CountingWriter<W>::bytes -> u64 with 1
+crates/tokmd/src/commands/context.rs:28:9: replace <impl Write for CountingWriter<W>>::write -> std::io::Result<usize> with Ok(0)
+crates/tokmd/src/commands/context.rs:28:9: replace <impl Write for CountingWriter<W>>::write -> std::io::Result<usize> with Ok(1)
+crates/tokmd/src/commands/context.rs:29:20: replace += with -= in <impl Write for CountingWriter<W>>::write
+crates/tokmd/src/commands/context.rs:29:20: replace += with *= in <impl Write for CountingWriter<W>>::write
+crates/tokmd/src/commands/context.rs:34:9: replace <impl Write for CountingWriter<W>>::flush -> std::io::Result<()> with Ok(())
+crates/tokmd/src/commands/context.rs:50:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/context.rs:50:34: delete ! in handle
+crates/tokmd/src/commands/context.rs:109:35: replace && with || in handle
+crates/tokmd/src/commands/context.rs:109:38: delete ! in handle
+crates/tokmd/src/commands/context.rs:118:47: replace && with || in handle
+crates/tokmd/src/commands/context.rs:143:13: delete field no_smart_exclude from struct context_pack::SelectOptions expression in handle
+crates/tokmd/src/commands/context.rs:144:13: delete field max_file_pct from struct context_pack::SelectOptions expression in handle
+crates/tokmd/src/commands/context.rs:145:13: delete field max_file_tokens from struct context_pack::SelectOptions expression in handle
+crates/tokmd/src/commands/context.rs:146:13: delete field require_git_scores from struct context_pack::SelectOptions expression in handle
+crates/tokmd/src/commands/context.rs:152:32: replace && with || in handle
+crates/tokmd/src/commands/context.rs:168:33: replace > with == in handle
+crates/tokmd/src/commands/context.rs:168:33: replace > with < in handle
+crates/tokmd/src/commands/context.rs:168:33: replace > with >= in handle
+crates/tokmd/src/commands/context.rs:169:46: replace * with + in handle
+crates/tokmd/src/commands/context.rs:169:46: replace * with / in handle
+crates/tokmd/src/commands/context.rs:169:29: replace / with % in handle
+crates/tokmd/src/commands/context.rs:169:29: replace / with * in handle
+crates/tokmd/src/commands/context.rs:209:22: replace && with || in handle
+crates/tokmd/src/commands/context.rs:209:18: replace > with == in handle
+crates/tokmd/src/commands/context.rs:209:18: replace > with < in handle
+crates/tokmd/src/commands/context.rs:209:18: replace > with >= in handle
+crates/tokmd/src/commands/context.rs:209:44: replace > with == in handle
+crates/tokmd/src/commands/context.rs:209:44: replace > with < in handle
+crates/tokmd/src/commands/context.rs:209:44: replace > with >= in handle
+crates/tokmd/src/commands/context.rs:242:5: replace determine_output_destination -> String with String::new()
+crates/tokmd/src/commands/context.rs:242:5: replace determine_output_destination -> String with "xyzzy".into()
+crates/tokmd/src/commands/context.rs:262:5: replace write_to_destination -> Result<usize> with Ok(0)
+crates/tokmd/src/commands/context.rs:262:5: replace write_to_destination -> Result<usize> with Ok(1)
+crates/tokmd/src/commands/context.rs:302:5: replace write_bundle_to_destination -> Result<usize> with Ok(0)
+crates/tokmd/src/commands/context.rs:302:5: replace write_bundle_to_destination -> Result<usize> with Ok(1)
+crates/tokmd/src/commands/context.rs:317:28: replace && with || in write_bundle_to_destination
+crates/tokmd/src/commands/context.rs:317:16: delete ! in write_bundle_to_destination
+crates/tokmd/src/commands/context.rs:352:5: replace format_list_output -> String with String::new()
+crates/tokmd/src/commands/context.rs:352:5: replace format_list_output -> String with "xyzzy".into()
+crates/tokmd/src/commands/context.rs:380:5: replace write_bundle_output -> Result<()> with Ok(())
+crates/tokmd/src/commands/context.rs:382:12: delete ! in write_bundle_output
+crates/tokmd/src/commands/context.rs:397:28: delete ! in write_bundle_output
+crates/tokmd/src/commands/context.rs:405:44: replace * with + in write_bundle_output
+crates/tokmd/src/commands/context.rs:405:44: replace * with / in write_bundle_output
+crates/tokmd/src/commands/context.rs:409:30: replace == with != in write_bundle_output
+crates/tokmd/src/commands/context.rs:412:43: replace - with + in write_bundle_output
+crates/tokmd/src/commands/context.rs:412:43: replace - with / in write_bundle_output
+crates/tokmd/src/commands/context.rs:415:29: replace != with == in write_bundle_output
+crates/tokmd/src/commands/context.rs:449:5: replace format_json_output -> Result<String> with Ok(String::new())
+crates/tokmd/src/commands/context.rs:449:5: replace format_json_output -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/commands/context.rs:483:5: replace write_output_file -> Result<()> with Ok(())
+crates/tokmd/src/commands/context.rs:493:19: replace && with || in write_output_file
+crates/tokmd/src/commands/context.rs:493:12: delete ! in write_output_file
+crates/tokmd/src/commands/context.rs:526:5: replace write_bundle_directory -> Result<usize> with Ok(0)
+crates/tokmd/src/commands/context.rs:526:5: replace write_bundle_directory -> Result<usize> with Ok(1)
+crates/tokmd/src/commands/context.rs:531:22: replace && with || in write_bundle_directory
+crates/tokmd/src/commands/context.rs:531:12: delete ! in write_bundle_directory
+crates/tokmd/src/commands/context.rs:531:25: delete ! in write_bundle_directory
+crates/tokmd/src/commands/context.rs:678:5: replace add_excluded_path with ()
+crates/tokmd/src/commands/context.rs:686:8: delete ! in add_excluded_path
+crates/tokmd/src/commands/context.rs:686:46: replace == with != in add_excluded_path
+crates/tokmd/src/commands/context.rs:695:5: replace hash_file -> Result<String> with Ok(String::new())
+crates/tokmd/src/commands/context.rs:695:5: replace hash_file -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/commands/context.rs:698:27: replace * with + in hash_file
+crates/tokmd/src/commands/context.rs:698:27: replace * with / in hash_file
+crates/tokmd/src/commands/context.rs:701:14: replace == with != in hash_file
+crates/tokmd/src/commands/context.rs:711:5: replace append_log_record -> Result<()> with Ok(())
+crates/tokmd/src/commands/diff.rs:19:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/diff.rs:50:5: replace resolve_color_mode -> DiffColorMode with Default::default()
+crates/tokmd/src/commands/diff.rs:58:5: replace should_use_color -> bool with true
+crates/tokmd/src/commands/diff.rs:58:5: replace should_use_color -> bool with false
+crates/tokmd/src/commands/diff.rs:66:5: replace auto_color_enabled -> bool with true
+crates/tokmd/src/commands/diff.rs:66:5: replace auto_color_enabled -> bool with false
+crates/tokmd/src/commands/diff.rs:71:9: replace && with || in auto_color_enabled
+crates/tokmd/src/commands/diff.rs:71:12: delete ! in auto_color_enabled
+crates/tokmd/src/commands/diff.rs:73:22: replace != with == in auto_color_enabled
+crates/tokmd/src/commands/diff.rs:77:9: replace && with || in auto_color_enabled
+crates/tokmd/src/commands/diff.rs:77:22: replace == with != in auto_color_enabled
+crates/tokmd/src/commands/diff.rs:86:5: replace resolve_targets -> Result<(String, String)> with Ok((String::new(), String::new()))
+crates/tokmd/src/commands/diff.rs:86:5: replace resolve_targets -> Result<(String, String)> with Ok((String::new(), "xyzzy".into()))
+crates/tokmd/src/commands/diff.rs:86:5: replace resolve_targets -> Result<(String, String)> with Ok(("xyzzy".into(), String::new()))
+crates/tokmd/src/commands/diff.rs:86:5: replace resolve_targets -> Result<(String, String)> with Ok(("xyzzy".into(), "xyzzy".into()))
+crates/tokmd/src/commands/diff.rs:86:8: delete ! in resolve_targets
+crates/tokmd/src/commands/diff.rs:87:32: replace || with && in resolve_targets
+crates/tokmd/src/commands/diff.rs:90:28: replace != with == in resolve_targets
+crates/tokmd/src/commands/diff.rs:97:9: delete match arm (Some(from), Some(to)) in resolve_targets
+crates/tokmd/src/commands/diff.rs:103:5: replace resolve_lang_report -> Result<LangReport> with Ok(Default::default())
+crates/tokmd/src/commands/diff.rs:112:5: replace load_lang_report_from_path -> Result<LangReport> with Ok(Default::default())
+crates/tokmd/src/commands/diff.rs:116:26: replace == with != in load_lang_report_from_path
+crates/tokmd/src/commands/diff.rs:133:5: replace lang_report_from_git_ref -> Result<LangReport> with Ok(Default::default())
+crates/tokmd/src/commands/diff.rs:138:5: replace lang_report_from_git_ref -> Result<LangReport> with Ok(Default::default())
+crates/tokmd/src/commands/diff.rs:138:8: delete ! in lang_report_from_git_ref
+crates/tokmd/src/commands/diff.rs:178:9: replace <impl Drop for ScopedCwd>::drop with ()
+crates/tokmd/src/commands/diff.rs:219:9: replace <impl Drop for GitWorktree>::drop with ()
+crates/tokmd/src/commands/diff.rs:233:5: replace make_temp_dir -> Result<PathBuf> with Ok(Default::default())
+crates/tokmd/src/commands/diff.rs:242:12: delete ! in make_temp_dir
+crates/tokmd/src/commands/export.rs:15:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/gate.rs:43:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/gate.rs:59:25: replace && with || in handle
+crates/tokmd/src/commands/gate.rs:92:9: delete match arm (Some(baseline_value), Some(ratchet)) in handle
+crates/tokmd/src/commands/gate.rs:108:8: delete ! in handle
+crates/tokmd/src/commands/gate.rs:120:5: replace combine_results -> CombinedGateResult with Default::default()
+crates/tokmd/src/commands/gate.rs:125:38: replace + with - in combine_results
+crates/tokmd/src/commands/gate.rs:125:38: replace + with * in combine_results
+crates/tokmd/src/commands/gate.rs:126:42: replace + with - in combine_results
+crates/tokmd/src/commands/gate.rs:126:42: replace + with * in combine_results
+crates/tokmd/src/commands/gate.rs:127:31: replace == with != in combine_results
+crates/tokmd/src/commands/gate.rs:141:5: replace load_policy -> Result<PolicyConfig> with Ok(Default::default())
+crates/tokmd/src/commands/gate.rs:159:13: replace && with || in load_policy
+crates/tokmd/src/commands/gate.rs:159:16: delete ! in load_policy
+crates/tokmd/src/commands/gate.rs:184:5: replace load_baseline -> Result<Option<serde_json::Value>> with Ok(None)
+crates/tokmd/src/commands/gate.rs:184:5: replace load_baseline -> Result<Option<serde_json::Value>> with Ok(Some(Default::default()))
+crates/tokmd/src/commands/gate.rs:198:9: replace && with || in load_baseline
+crates/tokmd/src/commands/gate.rs:218:5: replace load_ratchet_config -> Result<Option<RatchetConfig>> with Ok(None)
+crates/tokmd/src/commands/gate.rs:218:5: replace load_ratchet_config -> Result<Option<RatchetConfig>> with Ok(Some(Default::default()))
+crates/tokmd/src/commands/gate.rs:233:13: replace && with || in load_ratchet_config
+crates/tokmd/src/commands/gate.rs:233:16: delete ! in load_ratchet_config
+crates/tokmd/src/commands/gate.rs:252:5: replace convert_ratchet_rule -> RatchetRule with Default::default()
+crates/tokmd/src/commands/gate.rs:263:5: replace convert_gate_rule -> Result<PolicyRule> with Ok(Default::default())
+crates/tokmd/src/commands/gate.rs:279:5: replace parse_operator -> Result<RuleOperator> with Ok(Default::default())
+crates/tokmd/src/commands/gate.rs:280:9: delete match arm "gt" | ">" in parse_operator
+crates/tokmd/src/commands/gate.rs:281:9: delete match arm "gte" | ">=" in parse_operator
+crates/tokmd/src/commands/gate.rs:282:9: delete match arm "lt" | "<" in parse_operator
+crates/tokmd/src/commands/gate.rs:283:9: delete match arm "lte" | "<=" in parse_operator
+crates/tokmd/src/commands/gate.rs:284:9: delete match arm "eq" | "==" | "=" in parse_operator
+crates/tokmd/src/commands/gate.rs:285:9: delete match arm "ne" | "!=" in parse_operator
+crates/tokmd/src/commands/gate.rs:286:9: delete match arm "in" in parse_operator
+crates/tokmd/src/commands/gate.rs:287:9: delete match arm "contains" in parse_operator
+crates/tokmd/src/commands/gate.rs:288:9: delete match arm "exists" in parse_operator
+crates/tokmd/src/commands/gate.rs:298:5: replace parse_level -> RuleLevel with Default::default()
+crates/tokmd/src/commands/gate.rs:299:9: delete match arm Some("warn") | Some("warning") in parse_level
+crates/tokmd/src/commands/gate.rs:309:5: replace load_or_compute_receipt -> Result<serde_json::Value> with Ok(Default::default())
+crates/tokmd/src/commands/gate.rs:312:64: replace && with || in load_or_compute_receipt
+crates/tokmd/src/commands/gate.rs:312:36: replace == with != in load_or_compute_receipt
+crates/tokmd/src/commands/gate.rs:338:5: replace compute_receipt -> Result<serde_json::Value> with Ok(Default::default())
+crates/tokmd/src/commands/gate.rs:397:5: replace print_text_result with ()
+crates/tokmd/src/commands/gate.rs:407:36: replace + with - in print_text_result
+crates/tokmd/src/commands/gate.rs:407:36: replace + with * in print_text_result
+crates/tokmd/src/commands/gate.rs:422:9: replace && with || in print_text_result
+crates/tokmd/src/commands/gate.rs:422:12: delete ! in print_text_result
+crates/tokmd/src/commands/gate.rs:450:9: replace && with || in print_text_result
+crates/tokmd/src/commands/gate.rs:450:12: delete ! in print_text_result
+crates/tokmd/src/commands/gate.rs:488:16: delete ! in print_text_result
+crates/tokmd/src/commands/gate.rs:497:5: replace print_json_result -> Result<()> with Ok(())
+crates/tokmd/src/commands/handoff.rs:36:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/handoff.rs:36:34: delete ! in handle
+crates/tokmd/src/commands/handoff.rs:50:22: replace && with || in handle
+crates/tokmd/src/commands/handoff.rs:50:12: delete ! in handle
+crates/tokmd/src/commands/handoff.rs:50:25: delete ! in handle
+crates/tokmd/src/commands/handoff.rs:109:13: delete field no_smart_exclude from struct context_pack::SelectOptions expression in handle
+crates/tokmd/src/commands/handoff.rs:110:13: delete field max_file_pct from struct context_pack::SelectOptions expression in handle
+crates/tokmd/src/commands/handoff.rs:111:13: delete field max_file_tokens from struct context_pack::SelectOptions expression in handle
+crates/tokmd/src/commands/handoff.rs:122:33: replace > with == in handle
+crates/tokmd/src/commands/handoff.rs:122:33: replace > with < in handle
+crates/tokmd/src/commands/handoff.rs:122:33: replace > with >= in handle
+crates/tokmd/src/commands/handoff.rs:123:46: replace * with + in handle
+crates/tokmd/src/commands/handoff.rs:123:46: replace * with / in handle
+crates/tokmd/src/commands/handoff.rs:123:29: replace / with % in handle
+crates/tokmd/src/commands/handoff.rs:123:29: replace / with * in handle
+crates/tokmd/src/commands/handoff.rs:233:32: replace == with != in handle
+crates/tokmd/src/commands/handoff.rs:276:5: replace detect_capabilities -> Vec<CapabilityStatus> with vec![]
+crates/tokmd/src/commands/handoff.rs:276:5: replace detect_capabilities -> Vec<CapabilityStatus> with vec![Default::default()]
+crates/tokmd/src/commands/handoff.rs:291:15: delete ! in detect_capabilities
+crates/tokmd/src/commands/handoff.rs:322:15: delete ! in detect_capabilities
+crates/tokmd/src/commands/handoff.rs:341:60: replace == with != in detect_capabilities
+crates/tokmd/src/commands/handoff.rs:344:20: replace || with && in detect_capabilities
+crates/tokmd/src/commands/handoff.rs:344:23: delete ! in detect_capabilities
+crates/tokmd/src/commands/handoff.rs:373:5: replace capability_state -> Option<CapabilityState> with None
+crates/tokmd/src/commands/handoff.rs:373:5: replace capability_state -> Option<CapabilityState> with Some(Default::default())
+crates/tokmd/src/commands/handoff.rs:375:26: replace == with != in capability_state
+crates/tokmd/src/commands/handoff.rs:380:5: replace capability_reason -> Option<String> with None
+crates/tokmd/src/commands/handoff.rs:380:5: replace capability_reason -> Option<String> with Some(String::new())
+crates/tokmd/src/commands/handoff.rs:380:5: replace capability_reason -> Option<String> with Some("xyzzy".into())
+crates/tokmd/src/commands/handoff.rs:382:26: replace == with != in capability_reason
+crates/tokmd/src/commands/handoff.rs:387:5: replace should_compute_git -> bool with true
+crates/tokmd/src/commands/handoff.rs:387:5: replace should_compute_git -> bool with false
+crates/tokmd/src/commands/handoff.rs:387:51: replace == with != in should_compute_git
+crates/tokmd/src/commands/handoff.rs:397:5: replace build_intelligence -> HandoffIntelligence with Default::default()
+crates/tokmd/src/commands/handoff.rs:413:29: replace match guard !scores.hotspots.is_empty() with true in build_intelligence
+crates/tokmd/src/commands/handoff.rs:413:29: replace match guard !scores.hotspots.is_empty() with false in build_intelligence
+crates/tokmd/src/commands/handoff.rs:413:29: delete ! in build_intelligence
+crates/tokmd/src/commands/handoff.rs:422:63: replace == with != in build_intelligence
+crates/tokmd/src/commands/handoff.rs:507:41: replace * with +
+crates/tokmd/src/commands/handoff.rs:507:41: replace * with /
+crates/tokmd/src/commands/handoff.rs:511:5: replace build_simple_complexity -> HandoffComplexity with Default::default()
+crates/tokmd/src/commands/handoff.rs:514:28: replace == with != in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:550:25: replace += with -= in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:550:25: replace += with *= in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:551:23: replace > with == in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:551:23: replace > with < in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:551:23: replace > with >= in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:559:28: replace || with && in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:559:23: replace > with == in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:559:23: replace > with < in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:559:23: replace > with >= in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:559:42: replace > with == in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:559:42: replace > with < in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:559:42: replace > with >= in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:560:29: replace += with -= in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:560:29: replace += with *= in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:564:50: replace == with != in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:568:26: replace / with % in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:568:26: replace / with * in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:575:22: replace / with % in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:575:22: replace / with * in build_simple_complexity
+crates/tokmd/src/commands/handoff.rs:590:5: replace is_analyzable_lang -> bool with true
+crates/tokmd/src/commands/handoff.rs:590:5: replace is_analyzable_lang -> bool with false
+crates/tokmd/src/commands/handoff.rs:608:5: replace read_file_capped -> Option<String> with None
+crates/tokmd/src/commands/handoff.rs:608:5: replace read_file_capped -> Option<String> with Some(String::new())
+crates/tokmd/src/commands/handoff.rs:608:5: replace read_file_capped -> Option<String> with Some("xyzzy".into())
+crates/tokmd/src/commands/handoff.rs:618:5: replace count_functions_simple -> (usize, usize) with (0, 0)
+crates/tokmd/src/commands/handoff.rs:618:5: replace count_functions_simple -> (usize, usize) with (0, 1)
+crates/tokmd/src/commands/handoff.rs:618:5: replace count_functions_simple -> (usize, usize) with (1, 0)
+crates/tokmd/src/commands/handoff.rs:618:5: replace count_functions_simple -> (usize, usize) with (1, 1)
+crates/tokmd/src/commands/handoff.rs:620:9: delete match arm "rust" in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:621:9: delete match arm "go" in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:622:9: delete match arm "javascript" | "typescript" in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:629:9: delete match arm "c" | "c++" | "java" | "c#" | "php" in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:640:9: delete match arm "python" in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:641:9: delete match arm "ruby" in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:627:17: replace || with && in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:626:17: replace || with && in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:625:17: replace || with && in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:624:17: replace || with && in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:627:40: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:627:43: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:638:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:637:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:636:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:635:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:634:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:633:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:632:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:631:17: replace && with || in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:630:33: replace || with && in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:631:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:632:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:633:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:634:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:635:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:636:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:637:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:638:20: delete ! in count_functions_simple
+crates/tokmd/src/commands/handoff.rs:649:5: replace is_rust_fn_start_simple -> bool with true
+crates/tokmd/src/commands/handoff.rs:649:5: replace is_rust_fn_start_simple -> bool with false
+crates/tokmd/src/commands/handoff.rs:657:11: delete ! in is_rust_fn_start_simple
+crates/tokmd/src/commands/handoff.rs:664:36: replace + with - in is_rust_fn_start_simple
+crates/tokmd/src/commands/handoff.rs:664:36: replace + with * in is_rust_fn_start_simple
+crates/tokmd/src/commands/handoff.rs:680:40: replace + with - in is_rust_fn_start_simple
+crates/tokmd/src/commands/handoff.rs:680:40: replace + with * in is_rust_fn_start_simple
+crates/tokmd/src/commands/handoff.rs:694:5: replace count_brace_functions -> (usize, usize) with (0, 0)
+crates/tokmd/src/commands/handoff.rs:694:5: replace count_brace_functions -> (usize, usize) with (0, 1)
+crates/tokmd/src/commands/handoff.rs:694:5: replace count_brace_functions -> (usize, usize) with (1, 0)
+crates/tokmd/src/commands/handoff.rs:694:5: replace count_brace_functions -> (usize, usize) with (1, 1)
+crates/tokmd/src/commands/handoff.rs:702:19: replace && with || in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:702:12: delete ! in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:703:19: replace += with -= in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:703:19: replace += with *= in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:709:25: replace += with -= in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:709:25: replace += with *= in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:709:55: replace == with != in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:710:81: replace == with != in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:711:33: replace && with || in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:711:28: replace == with != in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:712:43: replace + with - in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:712:43: replace + with * in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:712:32: replace - with + in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:712:32: replace - with / in count_brace_functions
+crates/tokmd/src/commands/handoff.rs:724:5: replace count_python_functions_simple -> (usize, usize) with (0, 0)
+crates/tokmd/src/commands/handoff.rs:724:5: replace count_python_functions_simple -> (usize, usize) with (0, 1)
+crates/tokmd/src/commands/handoff.rs:724:5: replace count_python_functions_simple -> (usize, usize) with (1, 0)
+crates/tokmd/src/commands/handoff.rs:724:5: replace count_python_functions_simple -> (usize, usize) with (1, 1)
+crates/tokmd/src/commands/handoff.rs:732:40: replace || with && in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:734:41: replace - with + in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:734:41: replace - with / in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:736:19: replace += with -= in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:736:19: replace += with *= in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:739:36: replace - with + in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:739:36: replace - with / in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:740:48: replace && with || in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:740:25: replace && with || in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:740:28: delete ! in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:740:51: delete ! in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:741:37: replace - with + in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:741:37: replace - with / in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:744:17: replace && with || in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:743:17: replace && with || in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:742:23: replace <= with > in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:743:20: delete ! in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:744:20: delete ! in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:746:41: replace - with + in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:746:41: replace - with / in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:752:43: replace - with + in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:752:43: replace - with / in count_python_functions_simple
+crates/tokmd/src/commands/handoff.rs:760:5: replace count_ruby_functions_simple -> (usize, usize) with (0, 0)
+crates/tokmd/src/commands/handoff.rs:760:5: replace count_ruby_functions_simple -> (usize, usize) with (0, 1)
+crates/tokmd/src/commands/handoff.rs:760:5: replace count_ruby_functions_simple -> (usize, usize) with (1, 0)
+crates/tokmd/src/commands/handoff.rs:760:5: replace count_ruby_functions_simple -> (usize, usize) with (1, 1)
+crates/tokmd/src/commands/handoff.rs:769:16: delete ! in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:770:23: replace += with -= in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:770:23: replace += with *= in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:775:23: replace += with -= in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:775:23: replace += with *= in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:784:17: replace || with && in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:783:17: replace || with && in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:782:17: replace || with && in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:781:17: replace || with && in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:780:17: replace || with && in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:779:17: replace || with && in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:786:23: replace += with -= in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:786:23: replace += with *= in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:788:33: replace || with && in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:788:24: replace == with != in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:789:23: replace -= with += in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:789:23: replace -= with /= in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:790:26: replace == with != in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:791:56: replace + with - in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:791:56: replace + with * in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:791:45: replace - with + in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:791:45: replace - with / in count_ruby_functions_simple
+crates/tokmd/src/commands/handoff.rs:803:5: replace estimate_cyclomatic_simple -> usize with 0
+crates/tokmd/src/commands/handoff.rs:803:5: replace estimate_cyclomatic_simple -> usize with 1
+crates/tokmd/src/commands/handoff.rs:806:9: delete match arm "rust" in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:809:9: delete match arm "javascript" | "typescript" in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:812:9: delete match arm "python" in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:813:9: delete match arm "go" in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:816:9: delete match arm "c" | "c++" | "java" | "c#" | "php" in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:819:9: delete match arm "ruby" in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:828:66: replace || with && in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:828:38: replace || with && in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:832:24: replace += with -= in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:832:24: replace += with *= in estimate_cyclomatic_simple
+crates/tokmd/src/commands/handoff.rs:841:5: replace build_simple_derived -> HandoffDerived with Default::default()
+crates/tokmd/src/commands/handoff.rs:844:28: replace == with != in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:855:59: replace += with -= in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:855:59: replace += with *= in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:866:38: replace > with == in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:866:38: replace > with < in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:866:38: replace > with >= in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:867:52: replace * with + in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:867:52: replace * with / in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:867:31: replace / with % in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:867:31: replace / with * in build_simple_derived
+crates/tokmd/src/commands/handoff.rs:885:5: replace write_map_jsonl -> Result<u64> with Ok(0)
+crates/tokmd/src/commands/handoff.rs:885:5: replace write_map_jsonl -> Result<u64> with Ok(1)
+crates/tokmd/src/commands/handoff.rs:890:53: replace == with != in write_map_jsonl
+crates/tokmd/src/commands/handoff.rs:893:15: replace += with -= in write_map_jsonl
+crates/tokmd/src/commands/handoff.rs:893:15: replace += with *= in write_map_jsonl
+crates/tokmd/src/commands/handoff.rs:893:36: replace + with - in write_map_jsonl
+crates/tokmd/src/commands/handoff.rs:893:36: replace + with * in write_map_jsonl
+crates/tokmd/src/commands/handoff.rs:906:5: replace write_code_bundle -> Result<u64> with Ok(0)
+crates/tokmd/src/commands/handoff.rs:906:5: replace write_code_bundle -> Result<u64> with Ok(1)
+crates/tokmd/src/commands/handoff.rs:913:12: delete ! in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:921:23: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:921:23: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:931:28: delete ! in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:933:35: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:933:35: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:933:56: replace + with - in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:933:56: replace + with * in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:937:27: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:937:27: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:942:27: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:942:27: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:943:24: delete ! in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:945:31: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:945:31: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:948:27: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:948:27: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:954:23: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:954:23: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:960:23: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:960:23: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:963:23: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:963:23: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:972:23: replace += with -= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:972:23: replace += with *= in write_code_bundle
+crates/tokmd/src/commands/handoff.rs:986:5: replace exclude_output_dir -> Vec<HandoffExcludedPath> with vec![]
+crates/tokmd/src/commands/handoff.rs:986:5: replace exclude_output_dir -> Vec<HandoffExcludedPath> with vec![Default::default()]
+crates/tokmd/src/commands/handoff.rs:987:8: delete ! in exclude_output_dir
+crates/tokmd/src/commands/handoff.rs:997:5: replace hash_bytes -> String with String::new()
+crates/tokmd/src/commands/handoff.rs:997:5: replace hash_bytes -> String with "xyzzy".into()
+crates/tokmd/src/commands/handoff.rs:1001:5: replace hash_file -> Result<String> with Ok(String::new())
+crates/tokmd/src/commands/handoff.rs:1001:5: replace hash_file -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/commands/handoff.rs:1004:27: replace * with + in hash_file
+crates/tokmd/src/commands/handoff.rs:1004:27: replace * with / in hash_file
+crates/tokmd/src/commands/handoff.rs:1007:14: replace == with != in hash_file
+crates/tokmd/src/commands/handoff.rs:1017:5: replace round_f64 -> f64 with 0.0
+crates/tokmd/src/commands/handoff.rs:1017:5: replace round_f64 -> f64 with 1.0
+crates/tokmd/src/commands/handoff.rs:1017:5: replace round_f64 -> f64 with -1.0
+crates/tokmd/src/commands/handoff.rs:1018:30: replace / with % in round_f64
+crates/tokmd/src/commands/handoff.rs:1018:30: replace / with * in round_f64
+crates/tokmd/src/commands/handoff.rs:1018:12: replace * with + in round_f64
+crates/tokmd/src/commands/handoff.rs:1018:12: replace * with / in round_f64
+crates/tokmd/src/commands/init.rs:14:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/init.rs:18:46: replace && with || in handle
+crates/tokmd/src/commands/init.rs:18:21: replace && with || in handle
+crates/tokmd/src/commands/init.rs:18:9: delete ! in handle
+crates/tokmd/src/commands/init.rs:18:24: delete ! in handle
+crates/tokmd/src/commands/init.rs:20:8: delete ! in handle
+crates/tokmd/src/commands/init.rs:66:45: replace && with || in handle
+crates/tokmd/src/commands/init.rs:66:48: delete ! in handle
+crates/tokmd/src/commands/init.rs:89:5: replace to_tokeignore_args -> tokeignore::InitArgs with Default::default()
+crates/tokmd/src/commands/lang.rs:15:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/module.rs:15:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/run.rs:16:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/run.rs:16:34: delete ! in handle
+crates/tokmd/src/commands/run.rs:134:38: delete ! in handle
+crates/tokmd/src/commands/run.rs:202:5: replace now_ms -> u128 with 0
+crates/tokmd/src/commands/run.rs:202:5: replace now_ms -> u128 with 1
+crates/tokmd/src/commands/sensor.rs:29:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/commands/sensor.rs:39:12: delete ! in handle
+crates/tokmd/src/commands/sensor.rs:94:12: delete ! in handle
+crates/tokmd/src/commands/sensor.rs:159:5: replace build_summary -> String with String::new()
+crates/tokmd/src/commands/sensor.rs:159:5: replace build_summary -> String with "xyzzy".into()
+crates/tokmd/src/commands/sensor.rs:174:5: replace map_verdict -> Verdict with Default::default()
+crates/tokmd/src/commands/sensor.rs:186:5: replace map_gates -> GateResults with Default::default()
+crates/tokmd/src/commands/sensor.rs:206:23: replace > with == in map_gates
+crates/tokmd/src/commands/sensor.rs:206:23: replace > with < in map_gates
+crates/tokmd/src/commands/sensor.rs:206:23: replace > with >= in map_gates
+crates/tokmd/src/commands/sensor.rs:235:5: replace emit_risk_findings with ()
+crates/tokmd/src/commands/sensor.rs:271:5: replace emit_contract_findings with ()
+crates/tokmd/src/commands/sensor.rs:315:5: replace emit_complexity_findings with ()
+crates/tokmd/src/commands/sensor.rs:353:5: replace emit_gate_findings with ()
+crates/tokmd/src/commands/sensor.rs:353:38: replace == with != in emit_gate_findings
+crates/tokmd/src/commands/sensor.rs:371:9: replace && with || in emit_gate_findings
+crates/tokmd/src/commands/sensor.rs:371:27: replace == with != in emit_gate_findings
+crates/tokmd/src/commands/sensor.rs:392:9: replace && with || in emit_gate_findings
+crates/tokmd/src/commands/sensor.rs:392:27: replace == with != in emit_gate_findings
+crates/tokmd/src/commands/sensor.rs:412:5: replace render_sensor_md -> String with String::new()
+crates/tokmd/src/commands/sensor.rs:412:5: replace render_sensor_md -> String with "xyzzy".into()
+crates/tokmd/src/commands/sensor.rs:420:8: delete ! in render_sensor_md
+crates/tokmd/src/commands/sensor.rs:436:9: replace && with || in render_sensor_md
+crates/tokmd/src/commands/sensor.rs:435:9: replace && with || in render_sensor_md
+crates/tokmd/src/commands/sensor.rs:450:5: replace now_iso8601 -> String with String::new()
+crates/tokmd/src/commands/sensor.rs:450:5: replace now_iso8601 -> String with "xyzzy".into()
+crates/tokmd/src/commands/tools.rs:10:5: replace handle -> Result<()> with Ok(())
+crates/tokmd/src/interactive/tty.rs:14:5: replace should_be_interactive_inner -> bool with true
+crates/tokmd/src/interactive/tty.rs:14:5: replace should_be_interactive_inner -> bool with false
+crates/tokmd/src/interactive/tty.rs:14:8: delete ! in should_be_interactive_inner
+crates/tokmd/src/interactive/tty.rs:17:8: delete ! in should_be_interactive_inner
+crates/tokmd/src/interactive/tty.rs:37:5: replace should_be_interactive -> bool with true
+crates/tokmd/src/interactive/tty.rs:37:5: replace should_be_interactive -> bool with false
+crates/tokmd/src/interactive/wizard.rs:45:9: replace ProjectType::as_str -> &'static str with ""
+crates/tokmd/src/interactive/wizard.rs:45:9: replace ProjectType::as_str -> &'static str with "xyzzy"
+crates/tokmd/src/interactive/wizard.rs:58:9: replace ProjectType::default_module_roots -> Vec<String> with vec![]
+crates/tokmd/src/interactive/wizard.rs:58:9: replace ProjectType::default_module_roots -> Vec<String> with vec![String::new()]
+crates/tokmd/src/interactive/wizard.rs:58:9: replace ProjectType::default_module_roots -> Vec<String> with vec!["xyzzy".into()]
+crates/tokmd/src/interactive/wizard.rs:83:5: replace index_to_project_type -> Option<ProjectType> with None
+crates/tokmd/src/interactive/wizard.rs:83:5: replace index_to_project_type -> Option<ProjectType> with Some(Default::default())
+crates/tokmd/src/interactive/wizard.rs:110:5: replace wizard_result_from_answers -> Option<WizardResult> with None
+crates/tokmd/src/interactive/wizard.rs:110:5: replace wizard_result_from_answers -> Option<WizardResult> with Some(Default::default())
+crates/tokmd/src/interactive/wizard.rs:112:22: replace && with || in wizard_result_from_answers
+crates/tokmd/src/interactive/wizard.rs:112:8: delete ! in wizard_result_from_answers
+crates/tokmd/src/interactive/wizard.rs:112:25: delete ! in wizard_result_from_answers
+crates/tokmd/src/interactive/wizard.rs:131:5: replace run_init_wizard -> Result<Option<WizardResult>> with Ok(None)
+crates/tokmd/src/interactive/wizard.rs:131:5: replace run_init_wizard -> Result<Option<WizardResult>> with Ok(Some(Default::default()))
+crates/tokmd/src/interactive/wizard.rs:173:21: delete ! in run_init_wizard
+crates/tokmd/src/interactive/wizard.rs:231:5: replace generate_toml_config -> Result<String> with Ok(String::new())
+crates/tokmd/src/interactive/wizard.rs:231:5: replace generate_toml_config -> Result<String> with Ok("xyzzy".into())
+crates/tokmd/src/interactive/wizard.rs:234:9: delete field module from struct TomlConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:239:9: delete field export from struct TomlConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:244:9: delete field context from struct TomlConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:249:9: delete field analyze from struct TomlConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:235:13: delete field roots from struct ModuleConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:236:13: delete field depth from struct ModuleConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:240:13: delete field format from struct ExportConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:241:13: delete field min_code from struct ExportConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:245:13: delete field budget from struct ContextConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:246:13: delete field strategy from struct ContextConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:250:13: delete field preset from struct AnalyzeConfig expression in generate_toml_config
+crates/tokmd/src/interactive/wizard.rs:268:5: replace project_type_to_profile -> crate::cli::InitProfile with Default::default()

--- a/.jules/runs/specsmith_interfaces_01/pr_body.md
+++ b/.jules/runs/specsmith_interfaces_01/pr_body.md
@@ -1,0 +1,71 @@
+## 💡 Summary
+Tightened CLI assertion logic in integration tests to enforce strict output validation for unrecognized subcommands. Replaces vague `is_empty().not()` assertions with exact matches against `error_hints` suggestions.
+
+## 🎯 Why
+Test assertions for unknown or misspelled subcommands were previously relying on vague `.stderr(predicate::str::is_empty().not())` checks. This failed to lock in the actual CLI output behavior (like "Did you mean the subcommand X?" or "If Y was intended as a subcommand..."). Updating these test assertions locks in the real edge-case behavior and prevents silent regressions in `tokmd`'s CLI parsing feedback.
+
+## 🔎 Evidence
+- `crates/tokmd/tests/cli_e2e_w58.rs`, `crates/tokmd/tests/cli_e2e_w65.rs`, and others.
+- Observed that running an invalid subcommand like `frobnicate` outputs "If `frobnicate` was intended as a subcommand...", but tests were only checking that stderr was not empty.
+- Receipt: `cargo run -p tokmd -- frobnicate` -> `Error: Path not found: frobnicate \n\nHints: ... If \`frobnicate\` was intended as a subcommand, it is not recognized.`
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Update `.is_empty().not()` assertions to strict `.contains(...)` checks matching what the `error_hints::suggestions` engine returns.
+- why it fits this repo and shard: Directly targets the Specsmith mission of improving test assertions and closing gaps around interface behavior (specifically `error_hints` logic).
+- trade-offs:
+  - Structure: Improves exactness and lock-in of error formats.
+  - Velocity: Prevents future regressions in CLI parser hints.
+  - Governance: High. Requires tests to be updated if the hint output shape changes.
+
+### Option B
+- what it is: Add a new suite of parameter exhaustive tests for bad flag and CLI values.
+- when to choose it instead: If the CLI tests had poor code path coverage.
+- trade-offs: Bloats the test suite without necessarily targeting the loose assertions identified in the existing test definitions.
+
+## ✅ Decision
+Chose Option A to strictly lock in the existing `error_hints` behavior without bloating the test suite with new boilerplate tests.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd/tests/cli_comprehensive.rs`: Strict assertion for `invalid_subcommand_fails`
+- `crates/tokmd/tests/cli_e2e_w58.rs`: Strict assertion for `err_invalid_subcommand_shows_suggestion` and `err_completely_unknown_subcommand`
+- `crates/tokmd/tests/cli_e2e_w65.rs`: Strict assertion for `err_typo_subcommand_fails` and `frobnicate_unknown_subcommand_has_stable_error_output`
+- `crates/tokmd/tests/cli_e2e_w69.rs`: Strict assertion for `w69_error_unknown_subcommand`
+- `crates/tokmd/tests/cli_error_paths_w51.rs`: Strict assertion for `unknown_subcommand_fails`
+- `crates/tokmd/tests/cli_errors_w66.rs`: Strict assertion for `unknown_subcommand_produces_helpful_error`
+- `crates/tokmd/tests/cli_pipeline_e2e_w54.rs`: Strict assertion for `invalid_subcommand_fails`
+- `crates/tokmd/tests/e2e_extended.rs`: Strict assertion for `nonexistent_subcommand_fails`
+- `crates/tokmd/tests/error_handling.rs`: Strict assertion for `unknown_subcommand_fails`
+- `crates/tokmd/tests/error_handling_w70.rs`: Strict assertion for `unknown_subcommand_fails_with_stderr`
+- `crates/tokmd/tests/regression_prevention_w55.rs`: Strict assertion for `invalid_subcommand_fails_with_help`
+
+## 🧪 Verification receipts
+```text
+running 1 test
+test err_invalid_subcommand_shows_suggestion ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 62 filtered out; finished in 0.01s
+
+running 1 test
+test invalid_subcommand_fails_with_help ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 44 filtered out; finished in 0.01s
+
+cargo test -p tokmd --tests
+test result: ok. 429 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s
+```
+
+## 🧭 Telemetry
+- Change shape: Test modification (Proof improvement patch)
+- Blast radius: `tests/` boundary only
+- Risk class: Zero risk (no production code changed) + why: Tests were strengthened, not implementation.
+- Rollback: `git revert`
+- Gates run: `cargo clippy`, `cargo fmt`, `cargo test -p tokmd --tests`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/specsmith_interfaces_01/envelope.json`
+- `.jules/runs/specsmith_interfaces_01/decision.md`
+- `.jules/runs/specsmith_interfaces_01/receipts.jsonl`
+- `.jules/runs/specsmith_interfaces_01/result.json`
+- `.jules/runs/specsmith_interfaces_01/pr_body.md`
+
+## 🔜 Follow-ups
+- N/A

--- a/.jules/runs/specsmith_interfaces_01/receipts.jsonl
+++ b/.jules/runs/specsmith_interfaces_01/receipts.jsonl
@@ -1,0 +1,3 @@
+{"timestamp": "2026-05-03T14:36:19Z", "command": "write envelope.json", "outcome": "success"}
+{"timestamp": "2026-05-03T15:01:39Z", "command": "write decision.md", "outcome": "success"}
+{"timestamp": "2026-05-03T15:01:48Z", "command": "write result.json", "outcome": "success"}

--- a/.jules/runs/specsmith_interfaces_01/result.json
+++ b/.jules/runs/specsmith_interfaces_01/result.json
@@ -1,0 +1,9 @@
+{
+  "status": "success",
+  "outcome": "proof-improvement patch",
+  "findings": [
+    "Test suites across the `tokmd/tests` interface used vague `predicate::str::is_empty().not()` assertions when validating unknown or misspelled CLI subcommands.",
+    "This failed to lock in the real behavior provided by `tokmd-config/src/error_hints.rs` (like 'Did you mean the subcommand X?' or 'If Y was intended as a subcommand...').",
+    "Tightened assertions in multiple test files to check for precise error suggestion output."
+  ]
+}

--- a/crates/tokmd/tests/cli_comprehensive.rs
+++ b/crates/tokmd/tests/cli_comprehensive.rs
@@ -827,7 +827,7 @@ fn invalid_subcommand_fails() {
         .arg("this-subcommand-does-not-exist")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("If `this-subcommand-does-not-exist` was intended as a subcommand, it is not recognized"));
 }
 
 #[test]

--- a/crates/tokmd/tests/cli_e2e_w58.rs
+++ b/crates/tokmd/tests/cli_e2e_w58.rs
@@ -36,7 +36,9 @@ fn err_invalid_subcommand_shows_suggestion() {
         .arg("lnag")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "Did you mean the subcommand `lang`?",
+        ));
 }
 
 #[test]
@@ -45,7 +47,9 @@ fn err_completely_unknown_subcommand() {
         .arg("frobnicate")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "If `frobnicate` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cli_e2e_w65.rs
+++ b/crates/tokmd/tests/cli_e2e_w65.rs
@@ -543,7 +543,9 @@ fn err_typo_subcommand_fails() {
         .arg("lnag")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "Did you mean the subcommand `lang`?",
+        ));
 }
 
 #[test]
@@ -698,6 +700,7 @@ fn frobnicate_unknown_subcommand_has_stable_error_output() {
         stderr.contains("Error: Path not found: frobnicate"),
         "stderr should include the current path error, got: {stderr}"
     );
+    assert!(stderr.contains("If `frobnicate` was intended as a subcommand, it is not recognized"));
     assert!(
         stderr.contains("Hints:"),
         "stderr should include the stable hints block, got: {stderr}"

--- a/crates/tokmd/tests/cli_e2e_w69.rs
+++ b/crates/tokmd/tests/cli_e2e_w69.rs
@@ -618,7 +618,9 @@ fn w69_error_unknown_subcommand() {
         .arg("nonexistent_subcommand_xyz")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "If `nonexistent_subcommand_xyz` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -224,7 +224,9 @@ fn unknown_subcommand_fails() {
         .arg("nonexistent-subcommand")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "If `nonexistent-subcommand` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 /// Verify that every expected subcommand responds to --help without error.

--- a/crates/tokmd/tests/cli_errors_w66.rs
+++ b/crates/tokmd/tests/cli_errors_w66.rs
@@ -259,7 +259,9 @@ fn unknown_subcommand_produces_helpful_error() {
         .arg("not-a-real-command")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "If `not-a-real-command` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 #[test]

--- a/crates/tokmd/tests/cli_pipeline_e2e_w54.rs
+++ b/crates/tokmd/tests/cli_pipeline_e2e_w54.rs
@@ -572,7 +572,9 @@ fn invalid_subcommand_fails() {
         .arg("not-a-real-command")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "If `not-a-real-command` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 #[test]

--- a/crates/tokmd/tests/e2e_extended.rs
+++ b/crates/tokmd/tests/e2e_extended.rs
@@ -272,7 +272,8 @@ fn nonexistent_subcommand_fails() {
     tokmd_cmd()
         .arg("this-subcommand-does-not-exist")
         .assert()
-        .failure();
+        .failure()
+        .stderr(predicate::str::contains("If `this-subcommand-does-not-exist` was intended as a subcommand, it is not recognized"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tokmd/tests/error_handling.rs
+++ b/crates/tokmd/tests/error_handling.rs
@@ -107,7 +107,7 @@ fn unknown_subcommand_fails() {
         .arg("this-subcommand-does-not-exist")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("If `this-subcommand-does-not-exist` was intended as a subcommand, it is not recognized"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tokmd/tests/error_handling_w70.rs
+++ b/crates/tokmd/tests/error_handling_w70.rs
@@ -158,7 +158,9 @@ fn unknown_subcommand_fails_with_stderr() {
         .arg("nonexistent_subcommand_w70")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "If `nonexistent_subcommand_w70` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/regression_prevention_w55.rs
+++ b/crates/tokmd/tests/regression_prevention_w55.rs
@@ -305,7 +305,10 @@ fn invalid_subcommand_fails_with_help() {
     Command::new(env!("CARGO_BIN_EXE_tokmd"))
         .arg("nonexistent-subcommand")
         .assert()
-        .failure();
+        .failure()
+        .stderr(predicates::str::contains(
+            "If `nonexistent-subcommand` was intended as a subcommand, it is not recognized",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## 💡 Summary 
Tightened CLI assertion logic in integration tests to enforce strict output validation for unrecognized subcommands. Replaces vague `is_empty().not()` assertions with exact matches against `error_hints` suggestions.

## 🎯 Why 
Test assertions for unknown or misspelled subcommands were previously relying on vague `.stderr(predicate::str::is_empty().not())` checks. This failed to lock in the actual CLI output behavior (like "Did you mean the subcommand X?" or "If Y was intended as a subcommand..."). Updating these test assertions locks in the real edge-case behavior and prevents silent regressions in `tokmd`'s CLI parsing feedback.

## 🔎 Evidence 
- `crates/tokmd/tests/cli_e2e_w58.rs`, `crates/tokmd/tests/cli_e2e_w65.rs`, and others.
- Observed that running an invalid subcommand like `frobnicate` outputs "If `frobnicate` was intended as a subcommand...", but tests were only checking that stderr was not empty.
- Receipt: `cargo run -p tokmd -- frobnicate` -> `Error: Path not found: frobnicate \n\nHints: ... If \`frobnicate\` was intended as a subcommand, it is not recognized.`

## 🧭 Options considered 
### Option A (recommended) 
- what it is: Update `.is_empty().not()` assertions to strict `.contains(...)` checks matching what the `error_hints::suggestions` engine returns.
- why it fits this repo and shard: Directly targets the Specsmith mission of improving test assertions and closing gaps around interface behavior (specifically `error_hints` logic).
- trade-offs: 
  - Structure: Improves exactness and lock-in of error formats.
  - Velocity: Prevents future regressions in CLI parser hints.
  - Governance: High. Requires tests to be updated if the hint output shape changes.

### Option B 
- what it is: Add a new suite of parameter exhaustive tests for bad flag and CLI values.
- when to choose it instead: If the CLI tests had poor code path coverage.
- trade-offs: Bloats the test suite without necessarily targeting the loose assertions identified in the existing test definitions.

## ✅ Decision 
Chose Option A to strictly lock in the existing `error_hints` behavior without bloating the test suite with new boilerplate tests.

## 🧱 Changes made (SRP) 
- `crates/tokmd/tests/cli_comprehensive.rs`: Strict assertion for `invalid_subcommand_fails`
- `crates/tokmd/tests/cli_e2e_w58.rs`: Strict assertion for `err_invalid_subcommand_shows_suggestion` and `err_completely_unknown_subcommand`
- `crates/tokmd/tests/cli_e2e_w65.rs`: Strict assertion for `err_typo_subcommand_fails` and `frobnicate_unknown_subcommand_has_stable_error_output`
- `crates/tokmd/tests/cli_e2e_w69.rs`: Strict assertion for `w69_error_unknown_subcommand`
- `crates/tokmd/tests/cli_error_paths_w51.rs`: Strict assertion for `unknown_subcommand_fails`
- `crates/tokmd/tests/cli_errors_w66.rs`: Strict assertion for `unknown_subcommand_produces_helpful_error`
- `crates/tokmd/tests/cli_pipeline_e2e_w54.rs`: Strict assertion for `invalid_subcommand_fails`
- `crates/tokmd/tests/e2e_extended.rs`: Strict assertion for `nonexistent_subcommand_fails`
- `crates/tokmd/tests/error_handling.rs`: Strict assertion for `unknown_subcommand_fails`
- `crates/tokmd/tests/error_handling_w70.rs`: Strict assertion for `unknown_subcommand_fails_with_stderr`
- `crates/tokmd/tests/regression_prevention_w55.rs`: Strict assertion for `invalid_subcommand_fails_with_help`

## 🧪 Verification receipts 
```text
running 1 test
test err_invalid_subcommand_shows_suggestion ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 62 filtered out; finished in 0.01s

running 1 test
test invalid_subcommand_fails_with_help ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 44 filtered out; finished in 0.01s

cargo test -p tokmd --tests
test result: ok. 429 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s
```

## 🧭 Telemetry 
- Change shape: Test modification (Proof improvement patch)
- Blast radius: `tests/` boundary only
- Risk class: Zero risk (no production code changed) + why: Tests were strengthened, not implementation.
- Rollback: `git revert`
- Gates run: `cargo clippy`, `cargo fmt`, `cargo test -p tokmd --tests`

## 🗂️ .jules artifacts 
- `.jules/runs/specsmith_interfaces_01/envelope.json`
- `.jules/runs/specsmith_interfaces_01/decision.md`
- `.jules/runs/specsmith_interfaces_01/receipts.jsonl`
- `.jules/runs/specsmith_interfaces_01/result.json`
- `.jules/runs/specsmith_interfaces_01/pr_body.md`

## 🔜 Follow-ups 
- N/A

---
*PR created automatically by Jules for task [5556694181396590715](https://jules.google.com/task/5556694181396590715) started by @EffortlessSteven*