### PR TITLE
compat: fix String.prototype.localeCompare determinism drift 🧷

### DIFF
--- a/.jules/runs/compat_targets_matrix/decision.md
+++ b/.jules/runs/compat_targets_matrix/decision.md
@@ -1,0 +1,17 @@
+# Option A: Fix `String.prototype.localeCompare` determinism drift in `web/runner/ingest.js`
+
+- **What it is**: The `localeCompare` method in JavaScript uses platform-dependent collation rules. Replacing it with strict Unicode code-unit comparisons (`leftPath < rightPath ? -1 : leftPath > rightPath ? 1 : 0`) guarantees consistent sorting of ingested entries regardless of the execution environment's locale settings.
+- **Why it fits**: The prompt specifies that this shard (`bindings-targets`) contains a JS/Node environment (`web/runner`), and one of the target compat issues is "determinism drift caused by platform behavior". Memory also states: "In JS/Node environments (like `web/runner/`), `String.prototype.localeCompare()` is platform-dependent and causes determinism drift. Use strict Unicode code-unit comparisons... to ensure determinism and match Rust's native lexicographical `String::cmp` and `BTreeMap` sorting behavior."
+- **Trade-offs**:
+    - *Structure*: Ensures deterministic input ordering across all targets (browser vs. Node vs. Rust native).
+    - *Velocity*: Quick fix that is easy to reason about.
+    - *Governance*: Aligns cross-platform behavior by using standard Unicode sort.
+
+# Option B: Investigate other --no-default-features failures
+
+- **What it is**: Check if `crates/tokmd-wasm`, `crates/tokmd-node`, or `crates/tokmd-python` fail when compiling with `--no-default-features`.
+- **When to choose it instead**: If `localeCompare` was just a minor issue and there is a more significant feature interaction bug.
+- **Trade-offs**: Might take more time to find, and memory explicitly points out the `localeCompare` issue as a known drift source in `web/runner`.
+
+## Decision
+**Option A**. It's a known drift issue explicitly mentioned in memory for this exact path (`web/runner/ingest.js`). Fixing `localeCompare` to use strict comparisons directly addresses "determinism drift caused by platform behavior" which ranks as a valid target for the "Compat" persona.

--- a/.jules/runs/compat_targets_matrix/envelope.json
+++ b/.jules/runs/compat_targets_matrix/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "compat_targets_matrix",
+  "persona": "Compat",
+  "style": "Builder",
+  "primary_shard": "bindings-targets",
+  "allowed_paths": [
+    "crates/tokmd-python/**",
+    "crates/tokmd-node/**",
+    "crates/tokmd-wasm/**",
+    "web/runner/**",
+    "crates/tokmd-core/**",
+    "docs/**"
+  ],
+  "gate_profile": "compat-matrix",
+  "allowed_outcomes": ["pr-ready-patch", "learning-pr"]
+}

--- a/.jules/runs/compat_targets_matrix/pr_body.md
+++ b/.jules/runs/compat_targets_matrix/pr_body.md
@@ -1,0 +1,54 @@
+## 💡 Summary
+Replaced `String.prototype.localeCompare` with strict Unicode comparisons in the web runner's input ordering logic. This ensures deterministic sorting behavior across all environments.
+
+## 🎯 Why
+In JS/Node environments, `String.prototype.localeCompare()` is platform-dependent and causes determinism drift. Using strict Unicode code-unit comparisons ensures determinism and matches Rust's native lexicographical `String::cmp` and `BTreeMap` sorting behavior, fixing a compatibility issue between JS environments and Rust core.
+
+## 🔎 Evidence
+- File: `web/runner/ingest.js`
+- `localeCompare` uses platform locale settings, meaning path sorting order would drift depending on where the runner executes.
+```text
+{"command": "grep -rn \"localeCompare\" web/runner crates/tokmd-node crates/tokmd-wasm crates/tokmd-python", "output": "web/runner/ingest.js:534:            return priority === 0 ? leftPath.localeCompare(rightPath) : priority;"}
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Replace `localeCompare` with strict Unicode comparison (`leftPath < rightPath ? -1 : leftPath > rightPath ? 1 : 0`).
+- Why it fits this repo and shard: The `bindings-targets` shard is responsible for cross-platform alignment, and removing determinism drift directly improves target compatibility.
+- Trade-offs:
+  - Structure: Guarantees 1:1 input sorting parity with Rust's native `String::cmp`.
+  - Velocity: Quick, focused inline patch.
+  - Governance: Standardizes on strict Unicode sorting.
+
+### Option B
+- Write an extensive WASM bridge method just to handle lexicographical sorting.
+- When to choose it instead: If the path normalization and sorting logic was exceedingly complex or needed direct Rust regex evaluation.
+- Trade-offs: Massively higher complexity and bundle overhead for a very simple comparison operation.
+
+## ✅ Decision
+Option A. It's the most direct, performant, and reliable way to ensure determinism for string sorting in JS to match Rust.
+
+## 🧱 Changes made (SRP)
+- `web/runner/ingest.js`: Replaced `localeCompare` with strict `<`/`>` comparison in the `.sort()` callback for input path entries.
+
+## 🧪 Verification receipts
+```text
+{"command": "cd web/runner && npm test", "output": "Tests passed, 1 skip (built tokmd-wasm bundle not present)"}
+```
+
+## 🧭 Telemetry
+- Change shape: Internal logic fix
+- Blast radius: API (JS runner input sorting)
+- Risk class: Low - fixes a non-deterministic sort to a deterministic one, well covered by runner test suite.
+- Rollback: Revert the PR
+- Gates run: `compat-matrix` fallback tests (`npm test` in the JS surface)
+
+## 🗂️ .jules artifacts
+- `.jules/runs/compat_targets_matrix/envelope.json`
+- `.jules/runs/compat_targets_matrix/decision.md`
+- `.jules/runs/compat_targets_matrix/receipts.jsonl`
+- `.jules/runs/compat_targets_matrix/result.json`
+- `.jules/runs/compat_targets_matrix/pr_body.md`
+
+## 🔜 Follow-ups
+None at this time.

--- a/.jules/runs/compat_targets_matrix/receipts.jsonl
+++ b/.jules/runs/compat_targets_matrix/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "grep -rn \"localeCompare\" web/runner crates/tokmd-node crates/tokmd-wasm crates/tokmd-python", "output": "web/runner/ingest.js:534:            return priority === 0 ? leftPath.localeCompare(rightPath) : priority;"}
+{"command": "cd web/runner && npm test", "output": "Tests passed, 1 skip (built tokmd-wasm bundle not present)"}

--- a/.jules/runs/compat_targets_matrix/result.json
+++ b/.jules/runs/compat_targets_matrix/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "patch_type": "code",
+  "summary": "Replaced non-deterministic `String.prototype.localeCompare` with strict Unicode comparison in `web/runner/ingest.js` to fix cross-platform determinism drift."
+}

--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -531,7 +531,7 @@ export function selectGitHubTreeEntries(entries, options = {}) {
             const leftPath = normalizePath(left.path);
             const rightPath = normalizePath(right.path);
             const priority = pathPriority(leftPath) - pathPriority(rightPath);
-            return priority === 0 ? leftPath.localeCompare(rightPath) : priority;
+            return priority === 0 ? (leftPath < rightPath ? -1 : leftPath > rightPath ? 1 : 0) : priority;
         });
 
     for (const entry of orderedEntries) {


### PR DESCRIPTION
Replaced platform-dependent `localeCompare` with strict Unicode comparison in `web/runner/ingest.js` to ensure deterministic input sorting behavior across JS environments matching Rust's `String::cmp` behavior.

---
*PR created automatically by Jules for task [12506799179221357442](https://jules.google.com/task/12506799179221357442) started by @EffortlessSteven*