### PR TITLE
chore: remove stale cargo deny advisory ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,8 +12,6 @@ all-features = true
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    # rsa crate is brought in by uselesskey which is only used in tests
-    { id = "RUSTSEC-2023-0071", reason = "vulnerable rsa crate used only in test dependencies via uselesskey" },
     # term_size is transitive via tokei; no patched version available upstream
     { id = "RUSTSEC-2020-0163", reason = "transitive via tokei; revisit when upstream removes it" },
 ]


### PR DESCRIPTION
## Summary
- removes the stale RUSTSEC-2023-0071 ignore from deny.toml
- keeps the deny cluster scoped to the actual cargo-deny warning without duplicate .jules run artifacts

## Validation
- cargo deny --all-features check
- git diff --check

Supersedes #1546, #1540, and #1523 after merge.