### PR TITLE
fix: sort browser ingest paths by code point

### DIFF
--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -88,6 +88,29 @@ function normalizePath(value) {
     return value.replaceAll("\\", "/");
 }
 
+function compareByCodePoint(left, right) {
+    let leftIndex = 0;
+    let rightIndex = 0;
+
+    while (leftIndex < left.length && rightIndex < right.length) {
+        const leftCodePoint = left.codePointAt(leftIndex);
+        const rightCodePoint = right.codePointAt(rightIndex);
+
+        if (leftCodePoint !== rightCodePoint) {
+            return leftCodePoint < rightCodePoint ? -1 : 1;
+        }
+
+        leftIndex += leftCodePoint > 0xffff ? 2 : 1;
+        rightIndex += rightCodePoint > 0xffff ? 2 : 1;
+    }
+
+    if (leftIndex === left.length && rightIndex === right.length) {
+        return 0;
+    }
+
+    return leftIndex === left.length ? -1 : 1;
+}
+
 function pathExtension(path) {
     const lastSegment = path.split("/").at(-1) ?? "";
     const dotIndex = lastSegment.lastIndexOf(".");
@@ -531,7 +554,7 @@ export function selectGitHubTreeEntries(entries, options = {}) {
             const leftPath = normalizePath(left.path);
             const rightPath = normalizePath(right.path);
             const priority = pathPriority(leftPath) - pathPriority(rightPath);
-            return priority === 0 ? leftPath.localeCompare(rightPath) : priority;
+            return priority === 0 ? compareByCodePoint(leftPath, rightPath) : priority;
         });
 
     for (const entry of orderedEntries) {

--- a/web/runner/ingest.test.mjs
+++ b/web/runner/ingest.test.mjs
@@ -82,6 +82,22 @@ test("selectGitHubTreeEntries filters vendor, binary, and oversized files determ
     assert.equal(result.stats.skippedFileLimit, 0);
 });
 
+test("selectGitHubTreeEntries sorts tied paths by Unicode code point", () => {
+    const result = selectGitHubTreeEntries(
+        [
+            { path: "src/\u{1f600}.rs", size: 10, type: "blob" },
+            { path: "src/\ue000.rs", size: 10, type: "blob" },
+            { path: "src/a.rs", size: 10, type: "blob" },
+        ],
+        { maxFiles: 10, maxFileBytes: 512 }
+    );
+
+    assert.deepEqual(
+        result.selected.map((entry) => entry.path),
+        ["src/a.rs", "src/\ue000.rs", "src/\u{1f600}.rs"]
+    );
+});
+
 test("fetchGitHubRepoInputs materializes ordered inputs and reuses the in-memory cache", async () => {
     clearGitHubRepoCache();
 


### PR DESCRIPTION
## Summary
- replaces locale-sensitive browser ingest path ordering with explicit Unicode code point ordering
- adds a focused non-ASCII path ordering regression test that distinguishes code point order from UTF-16 code-unit order

## Validation
- npm --prefix web/runner run check
- npm --prefix web/runner test
- git diff --check

Supersedes #1542 and #1512 after merge.