### PR TITLE
fix: gate export bundle behind analysis feature

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -4,7 +4,9 @@
 - Held #1541: external Factory Droid review workflow requires maintainer approval and secret/API-key policy.
 - Merged #1549: synthesized keeper for stale `deny.toml` advisory cleanup. Removed only the obsolete `RUSTSEC-2023-0071` ignore. Gates: `cargo deny --all-features check`; `git diff --check`; GitHub CI.
 - Closed #1546/#1540/#1523 as superseded by #1549.
-- Next cluster: JS deterministic sorting (#1542, #1512).
+- Merged #1551: synthesized keeper for JS deterministic sorting. Replaced `localeCompare` with explicit Unicode code point comparison and added a browser-runner regression test. Gates: `npm --prefix web/runner run check`; `npm --prefix web/runner test`; `git diff --check`; GitHub CI.
+- Closed #1542/#1512 as superseded by #1551.
+- Next cluster: `export_bundle` no-default-features warning (#1530, #1510, #1502).
 
 ## Operating decisions
 

--- a/crates/tokmd/src/lib.rs
+++ b/crates/tokmd/src/lib.rs
@@ -29,6 +29,7 @@ mod commands;
 pub mod config;
 mod context_pack;
 mod error_hints;
+#[cfg(feature = "analysis")]
 mod export_bundle;
 mod git_support;
 #[cfg(feature = "ui")]


### PR DESCRIPTION
## Summary
- gates the CLI export_bundle module behind the analysis feature
- fixes the tokmd no-default-features dead-code warning without suppressing warnings
- updates PR_DRAIN.md with the completed JS sorting cluster

## Validation
- cargo clippy -p tokmd --no-default-features -- -D warnings
- cargo clippy -p tokmd --no-default-features --features analysis -- -D warnings
- cargo test -p tokmd --no-default-features
- git diff --check

Supersedes #1530, #1510, and #1502 after merge.