### PR TITLE
fix: restrict redacted path extension preservation

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -6,7 +6,9 @@
 - Closed #1546/#1540/#1523 as superseded by #1549.
 - Merged #1551: synthesized keeper for JS deterministic sorting. Replaced `localeCompare` with explicit Unicode code point comparison and added a browser-runner regression test. Gates: `npm --prefix web/runner run check`; `npm --prefix web/runner test`; `git diff --check`; GitHub CI.
 - Closed #1542/#1512 as superseded by #1551.
-- Next cluster: `export_bundle` no-default-features warning (#1530, #1510, #1502).
+- Merged #1552: synthesized keeper for `export_bundle` no-default-features warning. Gated the module behind `analysis` instead of suppressing dead-code warnings. Gates: `cargo clippy -p tokmd --no-default-features -- -D warnings`; `cargo clippy -p tokmd --no-default-features --features analysis -- -D warnings`; `cargo test -p tokmd --no-default-features`; `git diff --check`; GitHub CI.
+- Closed #1530/#1510/#1502 as superseded by #1552.
+- Next cluster: redaction hardening (#1521, #1507, #1497).
 
 ## Operating decisions
 

--- a/crates/tokmd-format/src/lib.rs
+++ b/crates/tokmd-format/src/lib.rs
@@ -1704,7 +1704,7 @@ mod tests {
         }
 
         #[test]
-        fn redact_rows_paths_end_with_extension(ext in "[a-z]{1,4}") {
+        fn redact_rows_paths_preserve_allowlisted_extensions(ext in "rs|js|ts|json|md|toml|gz") {
             let path = format!("some/path/file.{}", ext);
             let rows = vec![FileRow {
                 path: path.clone(),
@@ -1722,6 +1722,28 @@ mod tests {
             let redacted: Vec<_> = redact_rows(&rows, RedactMode::Paths).collect();
             prop_assert!(redacted[0].path.ends_with(&format!(".{}", ext)),
                 "Redacted path '{}' should end with .{}", redacted[0].path, ext);
+        }
+
+        #[test]
+        fn redact_rows_paths_strip_untrusted_extensions(ext in "passwd|secret|pass1234|token") {
+            let path = format!("some/path/file.{}", ext);
+            let rows = vec![FileRow {
+                path: path.clone(),
+                module: "some".to_string(),
+                lang: "Test".to_string(),
+                kind: FileKind::Parent,
+                code: 100,
+                comments: 10,
+                blanks: 5,
+                lines: 115,
+                bytes: 1000,
+                tokens: 250,
+            }];
+
+            let redacted: Vec<_> = redact_rows(&rows, RedactMode::Paths).collect();
+            prop_assert_eq!(redacted[0].path.len(), 16);
+            prop_assert!(!redacted[0].path.contains('.'));
+            prop_assert!(!redacted[0].path.contains(&ext));
         }
     }
 

--- a/crates/tokmd-format/src/redact/mod.rs
+++ b/crates/tokmd-format/src/redact/mod.rs
@@ -16,6 +16,15 @@
 
 use std::path::Path;
 
+const SAFE_PATH_EXTENSIONS: &[&str] = &[
+    "astro", "bash", "c", "cc", "cjs", "clj", "cljs", "cpp", "cs", "css", "csv", "cxx", "dart",
+    "erl", "ex", "exs", "fish", "fs", "fsx", "gif", "go", "gz", "h", "hpp", "hrl", "htm", "html",
+    "java", "jpeg", "jpg", "js", "json", "jsonl", "jsx", "kt", "kts", "lock", "lua", "mjs", "md",
+    "otf", "pdf", "php", "pl", "pm", "png", "ps1", "py", "pyi", "r", "rb", "rs", "scala", "scss",
+    "sh", "sql", "svg", "svelte", "swift", "toml", "ts", "tsv", "tsx", "ttf", "txt", "vue", "wasm",
+    "webp", "woff", "woff2", "xml", "yaml", "yml", "zsh",
+];
+
 /// Clean a path by normalizing separators and resolving `.` and `./` segments.
 ///
 /// This ensures that logically identical paths produce the same hash.
@@ -35,6 +44,14 @@ fn clean_path(s: &str) -> String {
         normalized.truncate(normalized.len() - 2);
     }
     normalized
+}
+
+fn safe_path_extension(ext: &str) -> Option<&str> {
+    let lower = ext.to_ascii_lowercase();
+    SAFE_PATH_EXTENSIONS
+        .binary_search(&lower.as_str())
+        .ok()
+        .map(|_| ext)
 }
 
 /// Compute a short (16-character) BLAKE3 hash of a string.
@@ -80,10 +97,11 @@ pub fn short_hash(s: &str) -> String {
     hex
 }
 
-/// Redact a path by hashing it while preserving the file extension.
+/// Redact a path by hashing it while preserving a safe file extension.
 ///
 /// This allows redacted paths to still be recognizable by file type
-/// while hiding the actual path structure.
+/// while hiding the actual path structure. Extensions are only preserved
+/// when they are in a small allowlist of common file types.
 ///
 /// Path separators are normalized to forward slashes before hashing
 /// to ensure consistent hashes across operating systems.
@@ -120,11 +138,7 @@ pub fn redact_path(path: &str) -> String {
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("");
-    let ext = if ext.len() <= 8 && ext.chars().all(|c| c.is_ascii_alphanumeric()) {
-        ext
-    } else {
-        ""
-    };
+    let ext = safe_path_extension(ext).unwrap_or("");
     let mut out = short_hash(&cleaned);
     if !ext.is_empty() {
         out.push('.');
@@ -161,6 +175,15 @@ mod tests {
     fn test_redact_path_preserves_extension() {
         let redacted = redact_path("src/lib.rs");
         assert!(redacted.ends_with(".rs"));
+    }
+
+    #[test]
+    fn test_redact_path_strips_untrusted_short_extensions() {
+        for path in ["file.secret", "file.passwd", "file.pass1234"] {
+            let redacted = redact_path(path);
+            assert_eq!(redacted.len(), 16);
+            assert!(!redacted.contains('.'));
+        }
     }
 
     #[test]

--- a/crates/tokmd-format/tests/test_redaction_leak.rs
+++ b/crates/tokmd-format/tests/test_redaction_leak.rs
@@ -2,11 +2,12 @@ use tokmd_format::redact_path;
 
 #[test]
 fn test_redact_path_leak() {
-    let leaked_data = "super_secret_password_123";
-    let path = format!("file.{}", leaked_data);
-    let redacted = redact_path(&path);
-    assert!(
-        !redacted.contains(leaked_data),
-        "Path redaction leaked the extension!"
-    );
+    for leaked_data in ["super_secret_password_123", "passwd", "secret", "pass1234"] {
+        let path = format!("file.{}", leaked_data);
+        let redacted = redact_path(&path);
+        assert!(
+            !redacted.contains(leaked_data),
+            "Path redaction leaked extension {leaked_data:?}: {redacted}"
+        );
+    }
 }

--- a/crates/tokmd-types/tests/determinism_proptest.rs
+++ b/crates/tokmd-types/tests/determinism_proptest.rs
@@ -275,15 +275,28 @@ proptest! {
     }
 
     #[test]
-    fn redact_path_preserves_extension(
+    fn redact_path_preserves_allowlisted_extension(
         stem in "[a-z]{1,5}(/[a-z]{1,5}){0,3}",
-        ext in "[a-z]{1,4}"
+        ext in "rs|js|ts|json|md|toml|gz"
     ) {
         let path = format!("{stem}/file.{ext}");
         let redacted = redact_path(&path);
         prop_assert!(
             redacted.ends_with(&format!(".{ext}")),
             "extension not preserved: input={} redacted={}", path, redacted
+        );
+    }
+
+    #[test]
+    fn redact_path_strips_untrusted_short_extension(
+        stem in "[a-z]{1,5}(/[a-z]{1,5}){0,3}",
+        ext in "passwd|secret|pass1234|token"
+    ) {
+        let path = format!("{stem}/file.{ext}");
+        let redacted = redact_path(&path);
+        prop_assert!(
+            !redacted.ends_with(&format!(".{ext}")),
+            "untrusted extension preserved: input={} redacted={}", path, redacted
         );
     }
 


### PR DESCRIPTION
## Summary
- replaces length-only redacted path extension preservation with an explicit safe-extension allowlist
- strips short secret-like extensions such as .passwd, .secret, and .pass1234
- keeps allowlisted file-type signal for common source, doc, data, and asset extensions
- updates PR_DRAIN.md with the completed export-bundle cluster

## Validation
- cargo test -p tokmd-format test_redact_path_leak
- cargo test -p tokmd-format redact
- cargo fmt-check
- git diff --check

Supersedes #1521, #1507, and #1497 after merge.