### PR TITLE
fix: harden git ref boundary handling

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -8,7 +8,9 @@
 - Closed #1542/#1512 as superseded by #1551.
 - Merged #1552: synthesized keeper for `export_bundle` no-default-features warning. Gated the module behind `analysis` instead of suppressing dead-code warnings. Gates: `cargo clippy -p tokmd --no-default-features -- -D warnings`; `cargo clippy -p tokmd --no-default-features --features analysis -- -D warnings`; `cargo test -p tokmd --no-default-features`; `git diff --check`; GitHub CI.
 - Closed #1530/#1510/#1502 as superseded by #1552.
-- Next cluster: redaction hardening (#1521, #1507, #1497).
+- Merged #1553: synthesized keeper for redaction hardening. Preserved only allowlisted path extensions and stripped short untrusted tokens such as `passwd`, `secret`, `pass1234`, and `token`. Gates: `cargo test -p tokmd-format test_redact_path_leak`; `cargo test -p tokmd-format redact`; `cargo test -p tokmd-types --test determinism_proptest`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1521/#1507/#1497 as superseded by #1553.
+- Next cluster: Git subprocess hardening (#1503).
 
 ## Operating decisions
 

--- a/crates/tokmd-git/src/lib.rs
+++ b/crates/tokmd-git/src/lib.rs
@@ -238,7 +238,7 @@ pub fn rev_exists(repo_root: &Path, rev: &str) -> bool {
     git_cmd()
         .arg("-C")
         .arg(repo_root)
-        .args(["rev-parse", "--verify", "--quiet"])
+        .args(["rev-parse", "--verify", "--quiet", "--end-of-options"])
         .arg(format!("{rev}^{{commit}}"))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -271,7 +271,7 @@ pub fn resolve_base_ref(repo_root: &Path, requested: &str) -> Option<String> {
 
     // TOKMD_GIT_BASE_REF env override
     if let Ok(env_ref) = std::env::var("TOKMD_GIT_BASE_REF")
-        && !env_ref.is_empty()
+        && env_base_ref_is_safe(&env_ref)
         && rev_exists(repo_root, &env_ref)
     {
         return Some(env_ref);
@@ -279,7 +279,7 @@ pub fn resolve_base_ref(repo_root: &Path, requested: &str) -> Option<String> {
 
     // GitHub Actions: origin/$GITHUB_BASE_REF
     if let Ok(gh_base) = std::env::var("GITHUB_BASE_REF")
-        && !gh_base.is_empty()
+        && env_base_ref_is_safe(&gh_base)
     {
         let candidate = format!("origin/{gh_base}");
         if rev_exists(repo_root, &candidate) {
@@ -303,6 +303,14 @@ pub fn resolve_base_ref(repo_root: &Path, requested: &str) -> Option<String> {
     }
 
     None
+}
+
+fn env_base_ref_is_safe(ref_name: &str) -> bool {
+    !ref_name.is_empty()
+        && !ref_name.starts_with('-')
+        && !ref_name
+            .chars()
+            .any(|c| c.is_whitespace() || c.is_control() || c == '\\')
 }
 
 // -----------------------
@@ -478,6 +486,35 @@ mod tests {
     }
 
     #[test]
+    fn rev_exists_treats_option_like_ref_as_missing() {
+        if !git_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+
+        test_git(dir.path())
+            .args(["init", "-b", "main"])
+            .output()
+            .unwrap();
+        test_git(dir.path())
+            .args(["config", "user.email", "test@test.com"])
+            .output()
+            .unwrap();
+        test_git(dir.path())
+            .args(["config", "user.name", "Test"])
+            .output()
+            .unwrap();
+        std::fs::write(dir.path().join("f.txt"), "hello").unwrap();
+        test_git(dir.path()).args(["add", "."]).output().unwrap();
+        test_git(dir.path())
+            .args(["commit", "-m", "init"])
+            .output()
+            .unwrap();
+
+        assert!(!rev_exists(dir.path(), "--help"));
+    }
+
+    #[test]
     fn resolve_base_ref_returns_requested_when_valid() {
         if !git_available() {
             return;
@@ -524,5 +561,41 @@ mod tests {
 
         // No commits exist, so even "trunk" won't resolve to a commit
         assert_eq!(resolve_base_ref(dir.path(), "nonexistent"), None);
+    }
+
+    #[test]
+    fn env_base_ref_accepts_common_refs() {
+        for ref_name in [
+            "HEAD",
+            "HEAD~1",
+            "feature/foo",
+            "release/v1.2.3",
+            "dependabot/cargo/foo-1.2.3",
+            "origin/main",
+            "af6004c",
+        ] {
+            assert!(
+                env_base_ref_is_safe(ref_name),
+                "expected env base ref to be safe: {ref_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn env_base_ref_rejects_ambiguous_or_malformed_refs() {
+        for ref_name in [
+            "",
+            "-bad",
+            "--help",
+            "feature foo",
+            "main\nnext",
+            "main\0next",
+            r"feature\foo",
+        ] {
+            assert!(
+                !env_base_ref_is_safe(ref_name),
+                "expected env base ref to be rejected: {ref_name:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary\n\nSynthesize the useful part of #1503 into a smaller Git boundary hardening patch.\n\n- pass --end-of-options to git rev-parse --verify so revision-like inputs cannot be interpreted as options\n- validate TOKMD_GIT_BASE_REF and GITHUB_BASE_REF fallback values before using them\n- keep legitimate Git environment behavior intact by not stripping GIT_INDEX_FILE, object directory, alternate object directory, or ceiling directory variables\n- update PR_DRAIN.md with the merged redaction cluster outcome\n\n## Why this shape\n\n#1503 had a valid security signal, but it was draft, deleted unrelated plan.md, carried generated run artifacts, and proposed broad Git env stripping that can break alternate-index or shared-object-store workflows. This keeper keeps the ref/option boundary hardening while avoiding that compatibility risk.\n\n## Gates\n\n- cargo test -p tokmd-git --verbose\n- cargo test -p tokmd --verbose\n- cargo clippy -p tokmd-git -- -D warnings\n- cargo fmt-check\n- git diff --check\n\nSupersedes #1503 after merge.