### PR TITLE
Add advisory Rust coverage workflow and Codecov config

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,72 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  # Override the repo-level CI debuginfo optimization for coverage.
+  # cargo-llvm-cov will set the instrumentation flags it needs.
+  RUSTFLAGS: ""
+
+jobs:
+  rust-coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Use larger writable target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: ${{ runner.temp }}/target
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          CI: true
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: error
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        if_ci_failed: success
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "fuzz/**"
+  - "xtask/**"
+  - "target/**"
+  - "vendor/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -289,3 +289,18 @@ For repeated local rebuilds, `cargo with-sccache test --workspace --all-features
 
 - Mutation testing: Weekly or on-demand
 - Extended fuzz runs: Nightly
+
+## Coverage
+
+Rust coverage is generated in CI with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
+
+Local run:
+
+```bash
+cargo llvm-cov clean --workspace
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+```
+
+The first implementation tracks default product crates with all features enabled. It intentionally excludes `fuzz/`, `xtask/`, `target/`, and vendored code from Codecov reporting.
+
+Coverage is advisory at first. Once the baseline is stable, the Codecov project and patch checks can be made required through branch protection.


### PR DESCRIPTION
### Motivation

- Add a separate, non-blocking coverage pipeline so Codecov is observed before becoming a required merge gate. 
- Use `cargo-llvm-cov`/LCOV to produce a coverage artifact that matches common Rust coverage tooling and keeps `fuzz`/`xtask` out of the initial baseline. 
- Document the local run and rollout expectations to make the coverage signal discoverable and operator-friendly.

### Description

- Add a standalone GitHub Actions workflow at `.github/workflows/coverage.yml` that runs `cargo llvm-cov --all-features --lcov`, emits `lcov.info`, uploads it as a GitHub artifact, and uploads to Codecov with `fail_ci_if_error: false`.
- Add a repository-level `codecov.yml` that sets conservative project and patch status targets, PR comment layout, disables annotations, and ignores `fuzz/**`, `xtask/**`, `target/**`, and `vendor/**` paths.
- Add a `## Coverage` section to `docs/testing.md` documenting the CI command (`cargo llvm-cov ...`) and the advisory rollout plan.

### Testing

- Verified the new files were staged and committed using `git status --short`, and committed with message `Add advisory Codecov coverage workflow and docs` (succeeded).
- Inspected the workflow and config contents with `nl -ba .github/workflows/coverage.yml`, `nl -ba codecov.yml`, and checked the docs insertion with `nl -ba docs/testing.md | tail -n 40` (succeeded).
- No CI coverage run was executed as part of this change; the workflow will run on `push`/`pull_request` to `main` to generate the first baseline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b821c38083338c265345f5352815)