### PR TITLE
ci: add advisory Rust coverage workflow, Codecov config, and docs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,72 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  # Override the repo-level CI debuginfo optimization for coverage.
+  # cargo-llvm-cov will set the instrumentation flags it needs.
+  RUSTFLAGS: ""
+
+jobs:
+  rust-coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Use larger writable target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: ${{ runner.temp }}/target
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          CI: true
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: error
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        if_ci_failed: success
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "fuzz/**"
+  - "xtask/**"
+  - "target/**"
+  - "vendor/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -289,3 +289,18 @@ For repeated local rebuilds, `cargo with-sccache test --workspace --all-features
 
 - Mutation testing: Weekly or on-demand
 - Extended fuzz runs: Nightly
+
+## Coverage
+
+Rust coverage is generated in CI with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
+
+Local run:
+
+```bash
+cargo llvm-cov clean --workspace
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+```
+
+The first implementation tracks default product crates with all features enabled. It intentionally excludes `fuzz/`, `xtask/`, `target/`, and vendored code from Codecov reporting.
+
+Coverage is advisory at first. Once the baseline is stable, the Codecov project and patch checks can be made required through branch protection.


### PR DESCRIPTION
### Motivation

- Introduce Rust coverage reporting without making a third-party upload part of the required CI gate by adding a separate advisory workflow that can be observed for a few PRs first.
- Use LCOV via `cargo-llvm-cov` and avoid polluting the initial baseline by excluding `fuzz/` and `xtask/` from reporting.

### Description

- Add `.github/workflows/coverage.yml` to generate LCOV with `cargo llvm-cov --all-features`, upload `lcov.info` as a GitHub artifact, and upload to Codecov with `fail_ci_if_error: false` so uploads are non-blocking.
- Add `codecov.yml` with conservative project/patch status settings, comment layout, `github_checks.annotations: false`, and ignore patterns for `fuzz/**`, `xtask/**`, `target/**`, and `vendor/**`.
- Update `docs/testing.md` with a new `## Coverage` section that documents local `cargo llvm-cov` commands, the intended scope, and the advisory rollout plan.
- Commit changes to the branch (workflow, Codecov config, and docs).

### Testing

- No automated tests were executed as part of this PR; the new `Coverage` workflow is configured to run on `push`/`pull_request` to `main` and via `workflow_dispatch` and will produce artifacts and a Codecov upload when it runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b821c38083338c265345f5352815)