### PR TITLE
Add standalone Coverage workflow and Codecov baseline config

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,72 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  # Override the repo-level CI debuginfo optimization for coverage.
+  # cargo-llvm-cov will set the instrumentation flags it needs.
+  RUSTFLAGS: ""
+
+jobs:
+  rust-coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Use larger writable target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: ${{ runner.temp }}/target
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          CI: true
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: error
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        if_ci_failed: success
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "fuzz/**"
+  - "xtask/**"
+  - "target/**"
+  - "vendor/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -289,3 +289,18 @@ For repeated local rebuilds, `cargo with-sccache test --workspace --all-features
 
 - Mutation testing: Weekly or on-demand
 - Extended fuzz runs: Nightly
+
+## Coverage
+
+Rust coverage is generated in CI with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
+
+Local run:
+
+```bash
+cargo llvm-cov clean --workspace
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+```
+
+The first implementation tracks default product crates with all features enabled. It intentionally excludes `fuzz/`, `xtask/`, `target/`, and vendored code from Codecov reporting.
+
+Coverage is advisory at first. Once the baseline is stable, the Codecov project and patch checks can be made required through branch protection.


### PR DESCRIPTION
### Motivation

- Add coverage collection and a conservative Codecov baseline without making third-party uploads part of the required CI gate. 
- Keep `fuzz` and `xtask` out of the initial baseline and observe results for a few PRs before hardening the check. 
- Provide an auditable LCOV artifact for debugging upload/permission edge cases while leaving the Codecov upload non-blocking initially.

### Description

- Add `.github/workflows/coverage.yml` that runs on `push`/`pull_request` to `main` and `workflow_dispatch`, sets up Rust with `llvm-tools-preview`, runs `cargo llvm-cov --all-features --lcov`, saves `lcov.info` as a 14-day artifact, and uploads to Codecov with `fail_ci_if_error: false`.
- Add `codecov.yml` with conservative project/patch targets, a 2% project threshold, 60% patch target, layout/comment settings, and ignore globs for `fuzz/**`, `xtask/**`, `target/**`, and `vendor/**`.
- Update `docs/testing.md` with a new **Coverage** section documenting the local `cargo llvm-cov` commands, the initial scope/exclusions, and the advisory rollout posture.

### Testing

- Ran `cargo fmt-check` (via the repository `xtask lint-fix --check --no-clippy` path) and it completed successfully.
- Verified the new files were added and committed; no new failing automated checks were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b821c38083338c265345f5352815)