### PR TITLE
fix: sanitize ffi and config string boundaries

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -10,7 +10,9 @@
 - Closed #1530/#1510/#1502 as superseded by #1552.
 - Merged #1553: synthesized keeper for redaction hardening. Preserved only allowlisted path extensions and stripped short untrusted tokens such as `passwd`, `secret`, `pass1234`, and `token`. Gates: `cargo test -p tokmd-format test_redact_path_leak`; `cargo test -p tokmd-format redact`; `cargo test -p tokmd-types --test determinism_proptest`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1521/#1507/#1497 as superseded by #1553.
-- Next cluster: Git subprocess hardening (#1503).
+- Merged #1554: synthesized keeper for Git subprocess hardening. Added an explicit `--end-of-options` boundary to revision verification and validated fallback base refs without stripping legitimate alternate-index or object-store Git environment variables. Gates: `cargo test -p tokmd-git --verbose`; `cargo test -p tokmd --verbose`; `cargo clippy -p tokmd-git -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1503 as superseded by #1554.
+- Next cluster: FFI/env/path sanitization (#1403, #1404, #1405, #1406).
 
 ## Operating decisions
 

--- a/crates/tokmd-core/src/ffi.rs
+++ b/crates/tokmd-core/src/ffi.rs
@@ -30,6 +30,8 @@ use crate::{
     lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
 };
 
+const MAX_IN_MEMORY_INPUT_PATH_BYTES: usize = 4096;
+
 /// Run a tokmd operation with JSON arguments, returning JSON output.
 ///
 /// This is the primary entrypoint for language bindings (Python, Node.js).
@@ -382,6 +384,20 @@ fn validate_in_memory_input_path(path: &str, idx: usize) -> Result<(), TokmdErro
         return Err(TokmdError::invalid_field(
             &field,
             "a non-empty relative file path",
+        ));
+    }
+
+    if path.len() > MAX_IN_MEMORY_INPUT_PATH_BYTES {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a relative file path no longer than 4096 bytes",
+        ));
+    }
+
+    if path.chars().any(char::is_control) {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a relative path without control characters",
         ));
     }
 
@@ -1423,6 +1439,47 @@ mod tests {
                 .as_str()
                 .ok_or_else(|| std::io::Error::other("not a string"))?
                 .contains("non-empty")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn in_memory_inputs_rejects_control_chars_in_path() -> Result<(), Box<dyn std::error::Error>> {
+        let result = run_json(
+            "lang",
+            "{\"inputs\": [{\"path\": \"bad\\npath.rs\", \"text\": \"fn main() {}\"}]}",
+        );
+        let parsed: Value = serde_json::from_str(&result)?;
+        assert_eq!(parsed["ok"], false);
+        assert_eq!(parsed["error"]["code"], "invalid_settings");
+        assert!(
+            parsed["error"]["message"]
+                .as_str()
+                .ok_or_else(|| std::io::Error::other("not a string"))?
+                .contains("control characters")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn in_memory_inputs_rejects_overlong_path() -> Result<(), Box<dyn std::error::Error>> {
+        let long_path = "a".repeat(MAX_IN_MEMORY_INPUT_PATH_BYTES + 1);
+        let args = serde_json::json!({
+            "inputs": [{
+                "path": long_path,
+                "text": "fn main() {}"
+            }]
+        })
+        .to_string();
+        let result = run_json("lang", &args);
+        let parsed: Value = serde_json::from_str(&result)?;
+        assert_eq!(parsed["ok"], false);
+        assert_eq!(parsed["error"]["code"], "invalid_settings");
+        assert!(
+            parsed["error"]["message"]
+                .as_str()
+                .ok_or_else(|| std::io::Error::other("not a string"))?
+                .contains("4096 bytes")
         );
         Ok(())
     }

--- a/crates/tokmd/src/config.rs
+++ b/crates/tokmd/src/config.rs
@@ -48,6 +48,15 @@ pub fn load_config() -> ConfigContext {
     }
 }
 
+fn sanitize_selector(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_control) {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 /// Discover TOML configuration following the precedence chain:
 /// 1. TOKMD_CONFIG env var (explicit path)
 /// 2. ./tokmd.toml (current directory)
@@ -55,7 +64,9 @@ pub fn load_config() -> ConfigContext {
 /// 4. ~/.config/tokmd/tokmd.toml (user config)
 fn discover_toml_config() -> Option<(TomlConfig, PathBuf)> {
     // 1. Check TOKMD_CONFIG environment variable
-    if let Ok(config_path) = std::env::var("TOKMD_CONFIG") {
+    if let Ok(config_path) = std::env::var("TOKMD_CONFIG")
+        && let Some(config_path) = sanitize_selector(&config_path)
+    {
         let path = PathBuf::from(&config_path);
         if let Some(result) = try_load_toml(&path) {
             return Some(result);
@@ -112,14 +123,16 @@ fn load_json_config() -> Option<UserConfig> {
 /// Get the profile name from CLI arg, env var, or default.
 pub fn get_profile_name(cli_profile: Option<&String>) -> Option<String> {
     // CLI argument takes precedence
-    if let Some(name) = cli_profile {
-        return Some(name.clone());
+    if let Some(name) = cli_profile
+        && let Some(name) = sanitize_selector(name)
+    {
+        return Some(name);
     }
 
     // Then check TOKMD_PROFILE environment variable
     std::env::var("TOKMD_PROFILE")
         .ok()
-        .filter(|s| !s.is_empty())
+        .and_then(|name| sanitize_selector(&name))
 }
 
 /// Resolve a JSON profile by name (legacy).
@@ -736,5 +749,37 @@ pub fn resolve_export_with_config(
             .unwrap_or(cli::RedactMode::None),
         meta: cli_args.meta.or(resolved.meta()).unwrap_or(true),
         strip_prefix: cli_args.strip_prefix.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_profile_name, sanitize_selector};
+
+    #[test]
+    fn sanitize_selector_rejects_empty_and_control_values() {
+        assert_eq!(sanitize_selector("   "), None);
+        assert_eq!(sanitize_selector("bad\nvalue"), None);
+        assert_eq!(sanitize_selector("bad\0value"), None);
+    }
+
+    #[test]
+    fn sanitize_selector_trims_safe_values() {
+        assert_eq!(sanitize_selector("  default  ").as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn get_profile_name_sanitizes_cli_value() {
+        let cli_value = "  secure-profile  ".to_string();
+        assert_eq!(
+            get_profile_name(Some(&cli_value)).as_deref(),
+            Some("secure-profile")
+        );
+    }
+
+    #[test]
+    fn get_profile_name_rejects_control_char_cli_value() {
+        let cli_value = "bad\nprofile".to_string();
+        assert_eq!(get_profile_name(Some(&cli_value)), None);
     }
 }


### PR DESCRIPTION
## Summary\n\nSynthesize the conservative parts of the FFI/env/path sanitization cluster (#1403-#1406).\n\n- reject in-memory FFI input paths over 4096 bytes\n- reject control characters in in-memory FFI input paths\n- trim and reject empty/control-character config selectors from TOKMD_CONFIG, TOKMD_PROFILE, and CLI profile values\n- update PR_DRAIN.md with the merged Git subprocess cluster outcome\n\n## Cluster decisions\n\n- #1405 is the primary keeper for in-memory path validation.\n- #1404 is partially kept for config/profile string sanitization, with formatting fixed.\n- #1406's duplicate control-character path direction is covered here, but whitespace-only real scan path rejection is not adopted because it changes path semantics for possible real paths.\n- #1403's case-insensitive FFI mode behavior is rejected to preserve the existing contract that LANG is an unknown mode; its payload cap is left out as a separate behavior decision.\n\n## Gates\n\n- cargo test -p tokmd-core in_memory_inputs_rejects_\n- cargo test -p tokmd-core --test error_boundary\n- cargo test -p tokmd-core parse_scan_settings\n- cargo test -p tokmd sanitize_selector\n- cargo test -p tokmd get_profile_name\n- cargo clippy -p tokmd-core -p tokmd -- -D warnings\n- cargo fmt-check\n- git diff --check\n\nSupersedes #1403, #1404, #1405, and #1406 after merge.