### PR TITLE
librarian: add missing doctests to config profile resolution functions 📚

### DIFF
--- a/.jules/runs/run-librarian_api_doctests/decision.md
+++ b/.jules/runs/run-librarian_api_doctests/decision.md
@@ -1,0 +1,17 @@
+# Decision
+
+## Option A (recommended)
+Add doctests directly to `resolve_profile` and `get_profile_name` in `crates/tokmd/src/config.rs`.
+- **Why it fits:** The Librarian persona aims to improve executable coverage for common usage, preventing docs/schemas/help text mismatch. Adding these examples explicitly verifies the fallback resolution path.
+- **Trade-offs:**
+  - **Structure**: Increases documentation surface slightly in `config.rs`.
+  - **Velocity**: Fast implementation.
+  - **Governance**: Complies with the `docs-executable` gate profile.
+
+## Option B
+Do not add doctests to these particular config functions as they are less likely to be called externally compared to the higher-level CLI interfaces.
+- **When to choose it instead:** If `tokmd-settings` or higher-level structs were explicitly tested instead.
+- **Trade-offs:** Lower confidence in the underlying resolution logic directly from the doc level.
+
+## Decision
+Chose Option A to ensure the `get_profile_name` and `resolve_profile` APIs remain demonstrably working, satisfying the Librarian persona's mission to improve missing doctest or example coverage for common usage.

--- a/.jules/runs/run-librarian_api_doctests/envelope.json
+++ b/.jules/runs/run-librarian_api_doctests/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "librarian_api_doctests",
+  "persona": "Librarian \ud83d\udcda",
+  "style": "Prover",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": ["proof-improvement patch", "learning PR"]
+}

--- a/.jules/runs/run-librarian_api_doctests/pr_body.md
+++ b/.jules/runs/run-librarian_api_doctests/pr_body.md
@@ -1,0 +1,51 @@
+## 💡 Summary
+Added missing doctests to the `get_profile_name` and `resolve_profile` functions in the config interface. This improves executable documentation coverage for configuration resolution logic.
+
+## 🎯 Why
+The `config.rs` facade in `tokmd` parses and resolves CLI configurations with fallbacks (CLI args -> environment variables -> config files). Explicit doctests were missing for `get_profile_name` and `resolve_profile`, risking silent factual drift. These doctests lock down and prove the expected behaviors.
+
+## 🔎 Evidence
+- File path: `crates/tokmd/src/config.rs`
+- Observed behavior: `get_profile_name` and `resolve_profile` lacked doctests.
+- Receipt: `cargo test --doc -p tokmd` now shows 11 passed tests instead of 9.
+
+## 🧭 Options considered
+### Option A (recommended)
+- What it is: Add doctests directly to `resolve_profile` and `get_profile_name` in `crates/tokmd/src/config.rs`.
+- Why it fits this repo and shard: Directly aligns with the Librarian persona's mission to add missing doctests to public interfaces in the `interfaces` shard.
+- Trade-offs: Structure (minor increase in doc length), Velocity (quick addition), Governance (aligns with `docs-executable`).
+
+### Option B
+- What it is: Ignore unit-level doctests and only rely on higher-level integration tests for CLI resolution.
+- When to choose it instead: If the internal functions were strictly private and tested solely through the CLI facade.
+- Trade-offs: Docs could drift silently if behaviors changed since there's no executable proof.
+
+## ✅ Decision
+Option A was chosen. Adding targeted doctests locks in the specific fallback logic directly within the code documentation.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd/src/config.rs`: Added comprehensive doctests for `get_profile_name` and `resolve_profile`.
+
+## 🧪 Verification receipts
+```text
+cargo test --doc -p tokmd
+...
+test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+```
+
+## 🧭 Telemetry
+- Change shape: Documentation addition
+- Blast radius: API docs only
+- Risk class: Low (doctest additions only)
+- Rollback: Revert documentation strings
+- Gates run: `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test --doc -p tokmd`, `cargo test -p tokmd`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-librarian_api_doctests/envelope.json`
+- `.jules/runs/run-librarian_api_doctests/decision.md`
+- `.jules/runs/run-librarian_api_doctests/receipts.jsonl`
+- `.jules/runs/run-librarian_api_doctests/result.json`
+- `.jules/runs/run-librarian_api_doctests/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-librarian_api_doctests/receipts.jsonl
+++ b/.jules/runs/run-librarian_api_doctests/receipts.jsonl
@@ -1,0 +1,1 @@
+{"command": "cargo test --doc -p tokmd", "output": "all doctests ran in 1.12s; merged doctests compilation took 1.09s\ntest result: ok. 11 passed; 0 failed", "status": "success"}

--- a/.jules/runs/run-librarian_api_doctests/result.json
+++ b/.jules/runs/run-librarian_api_doctests/result.json
@@ -1,0 +1,12 @@
+{
+  "outcome": "proof-improvement patch",
+  "files_changed": [
+    "crates/tokmd/src/config.rs"
+  ],
+  "gates_run": [
+    "cargo fmt -- --check",
+    "cargo clippy -- -D warnings",
+    "cargo test --doc -p tokmd",
+    "cargo test -p tokmd"
+  ]
+}

--- a/crates/tokmd/src/config.rs
+++ b/crates/tokmd/src/config.rs
@@ -110,6 +110,22 @@ fn load_json_config() -> Option<UserConfig> {
 }
 
 /// Get the profile name from CLI arg, env var, or default.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd::config::get_profile_name;
+///
+/// // CLI argument takes precedence
+/// let cli_name = String::from("cli-profile");
+/// assert_eq!(get_profile_name(Some(&cli_name)), Some("cli-profile".to_string()));
+///
+/// // None is returned if neither CLI arg nor TOKMD_PROFILE env var is provided
+/// // (assuming TOKMD_PROFILE is not set in the test environment)
+/// if std::env::var("TOKMD_PROFILE").is_err() {
+///     assert_eq!(get_profile_name(None), None);
+/// }
+/// ```
 pub fn get_profile_name(cli_profile: Option<&String>) -> Option<String> {
     // CLI argument takes precedence
     if let Some(name) = cli_profile {
@@ -123,6 +139,30 @@ pub fn get_profile_name(cli_profile: Option<&String>) -> Option<String> {
 }
 
 /// Resolve a JSON profile by name (legacy).
+///
+/// # Examples
+///
+/// ```
+/// use tokmd_settings::{UserConfig, Profile};
+/// use tokmd::config::resolve_profile;
+/// use std::collections::BTreeMap;
+///
+/// let mut profiles = BTreeMap::new();
+/// let mut default_profile = Profile::default();
+/// default_profile.top = Some(10);
+/// profiles.insert("default".to_string(), default_profile);
+///
+/// let user_config = Some(UserConfig { profiles, repos: BTreeMap::new() });
+///
+/// // Resolve default profile implicitly
+/// let profile1 = resolve_profile(&user_config, None);
+/// assert_eq!(profile1.unwrap().top, Some(10));
+///
+/// // Resolve missing profile explicitly
+/// let name = String::from("missing");
+/// let profile2 = resolve_profile(&user_config, Some(&name));
+/// assert!(profile2.is_none());
+/// ```
 pub fn resolve_profile<'a>(
     config: &'a Option<UserConfig>,
     name: Option<&String>,


### PR DESCRIPTION
## 💡 Summary
Added missing doctests to the `get_profile_name` and `resolve_profile` functions in the config interface. This improves executable documentation coverage for configuration resolution logic.

## 🎯 Why
The `config.rs` facade in `tokmd` parses and resolves CLI configurations with fallbacks (CLI args -> environment variables -> config files). Explicit doctests were missing for `get_profile_name` and `resolve_profile`, risking silent factual drift. These doctests lock down and prove the expected behaviors.

## 🔎 Evidence
- File path: `crates/tokmd/src/config.rs`
- Observed behavior: `get_profile_name` and `resolve_profile` lacked doctests.
- Receipt: `cargo test --doc -p tokmd` now shows 11 passed tests instead of 9.

## 🧭 Options considered
### Option A (recommended)
- What it is: Add doctests directly to `resolve_profile` and `get_profile_name` in `crates/tokmd/src/config.rs`.
- Why it fits this repo and shard: Directly aligns with the Librarian persona's mission to add missing doctests to public interfaces in the `interfaces` shard.
- Trade-offs: Structure (minor increase in doc length), Velocity (quick addition), Governance (aligns with `docs-executable`).

### Option B
- What it is: Ignore unit-level doctests and only rely on higher-level integration tests for CLI resolution.
- When to choose it instead: If the internal functions were strictly private and tested solely through the CLI facade.
- Trade-offs: Docs could drift silently if behaviors changed since there's no executable proof.

## ✅ Decision
Option A was chosen. Adding targeted doctests locks in the specific fallback logic directly within the code documentation.

## 🧱 Changes made (SRP)
- `crates/tokmd/src/config.rs`: Added comprehensive doctests for `get_profile_name` and `resolve_profile`.

## 🧪 Verification receipts
```text
cargo test --doc -p tokmd
...
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

## 🧭 Telemetry
- Change shape: Documentation addition
- Blast radius: API docs only
- Risk class: Low (doctest additions only)
- Rollback: Revert documentation strings
- Gates run: `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test --doc -p tokmd`, `cargo test -p tokmd`

## 🗂️ .jules artifacts
- `.jules/runs/run-librarian_api_doctests/envelope.json`
- `.jules/runs/run-librarian_api_doctests/decision.md`
- `.jules/runs/run-librarian_api_doctests/receipts.jsonl`
- `.jules/runs/run-librarian_api_doctests/result.json`
- `.jules/runs/run-librarian_api_doctests/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [17741202674285693299](https://jules.google.com/task/17741202674285693299) started by @EffortlessSteven*