### PR TITLE
Partition browser ingest cache by auth token

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -12,7 +12,9 @@
 - Closed #1521/#1507/#1497 as superseded by #1553.
 - Merged #1554: synthesized keeper for Git subprocess hardening. Added an explicit `--end-of-options` boundary to revision verification and validated fallback base refs without stripping legitimate alternate-index or object-store Git environment variables. Gates: `cargo test -p tokmd-git --verbose`; `cargo test -p tokmd --verbose`; `cargo clippy -p tokmd-git -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1503 as superseded by #1554.
-- Next cluster: FFI/env/path sanitization (#1403, #1404, #1405, #1406).
+- Merged #1559: synthesized keeper for FFI/env/path sanitization. Added in-memory input path length/control-character validation and config/profile selector trim/control-character sanitization while preserving case-sensitive FFI modes and existing path semantics. Gates: `cargo test -p tokmd-core in_memory_inputs_rejects_`; `cargo test -p tokmd-core --test error_boundary`; `cargo test -p tokmd-core parse_scan_settings`; `cargo test -p tokmd sanitize_selector`; `cargo test -p tokmd get_profile_name`; `cargo clippy -p tokmd-core -p tokmd -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1403/#1404/#1405/#1406 as superseded or declined by #1559.
+- Next cluster: Browser GitHub ingest cache partition (#1411, #1413, #1415, #1417).
 
 ## Operating decisions
 

--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -202,12 +202,49 @@ function normalizeToken(value) {
     return trimmed ? trimmed : null;
 }
 
-function buildCacheKey({ owner, repo, ref, limits, authMode }) {
+function bytesToHex(bytes) {
+    return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function fallbackTokenPartition(token) {
+    let hash = 0xcbf29ce484222325n;
+    const prime = 0x100000001b3n;
+    const mask = 0xffffffffffffffffn;
+
+    for (const byte of new TextEncoder().encode(token)) {
+        hash ^= BigInt(byte);
+        hash = (hash * prime) & mask;
+    }
+
+    return `token:fnv1a64:${hash.toString(16).padStart(16, "0")}`;
+}
+
+async function tokenCachePartition(token) {
+    if (!token) {
+        return "anonymous";
+    }
+
+    const encoded = new TextEncoder().encode(token);
+    const digest = globalThis.crypto?.subtle?.digest;
+    if (typeof digest === "function") {
+        try {
+            const hash = await digest.call(globalThis.crypto.subtle, "SHA-256", encoded);
+            return `token:sha256:${bytesToHex(new Uint8Array(hash))}`;
+        } catch {
+            // Fall back to a non-secret in-memory partition if Web Crypto is unavailable.
+        }
+    }
+
+    return fallbackTokenPartition(token);
+}
+
+function buildCacheKey({ owner, repo, ref, limits, authMode, authPartition }) {
     return JSON.stringify({
         owner,
         repo,
         ref,
         auth: authMode ?? "anonymous",
+        authPartition: authPartition ?? "anonymous",
         ...limits,
     });
 }
@@ -602,9 +639,11 @@ export async function fetchGitHubRepoInputs(options = {}) {
     const signal = options.signal;
     const onProgress = options.onProgress;
     const authMode = token ? "token" : "anonymous";
-    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authMode });
 
     throwIfAborted(signal);
+    const authPartition = await tokenCachePartition(token);
+    throwIfAborted(signal);
+    const cacheKey = buildCacheKey({ owner, repo, ref, limits, authMode, authPartition });
 
     if (repoCache.has(cacheKey)) {
         const cached = withCacheHit(await withAbortSignal(repoCache.get(cacheKey), signal));

--- a/web/runner/ingest.test.mjs
+++ b/web/runner/ingest.test.mjs
@@ -302,6 +302,66 @@ test("fetchGitHubRepoInputs forwards token auth and tracks auth mode", async () 
     );
 });
 
+test("fetchGitHubRepoInputs partitions cache entries by auth token", async () => {
+    clearGitHubRepoCache();
+
+    const calls = [];
+    const fetchImpl = async (url, options = {}) => {
+        const authorization = options.headers?.Authorization ?? null;
+        calls.push({ url, authorization });
+
+        if (url.includes("/git/trees/")) {
+            return jsonResponse({
+                tree: [{ path: "README.md", size: 32, type: "blob" }],
+            });
+        }
+
+        if (url.includes("/contents/README.md")) {
+            const suffix = authorization?.includes("second") ? "second" : "first";
+            return textResponse(`# ${suffix}\n`);
+        }
+
+        throw new Error(`unexpected fetch url: ${url}`);
+    };
+
+    const first = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "first-token",
+        fetchImpl,
+    });
+
+    const second = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "second-token",
+        fetchImpl,
+    });
+
+    const firstAgain = await fetchGitHubRepoInputs({
+        repo: "EffortlessMetrics/tokmd",
+        ref: "main",
+        token: "first-token",
+        fetchImpl,
+    });
+
+    assert.equal(first.ingest.cache.hit, false);
+    assert.equal(second.ingest.cache.hit, false);
+    assert.equal(firstAgain.ingest.cache.hit, true);
+    assert.equal(first.inputs[0].text, "# first\n");
+    assert.equal(second.inputs[0].text, "# second\n");
+    assert.equal(firstAgain.inputs[0].text, "# first\n");
+    assert.deepEqual(
+        calls.map((call) => call.authorization),
+        [
+            "token first-token",
+            "token first-token",
+            "token second-token",
+            "token second-token",
+        ]
+    );
+});
+
 test("fetchGitHubRepoInputs surfaces auth and private-repo access errors", async () => {
     clearGitHubRepoCache();
 


### PR DESCRIPTION
## Summary
- partition browser GitHub ingest cache entries by a token-derived auth partition instead of only anonymous/token mode
- avoid embedding raw token text in cache keys while preserving anonymous/token mode in the key
- add an ingest regression test proving token-specific cache hits and misses
- update `PR_DRAIN.md` with the completed FFI/env/path cluster result

## Gates
- `npm --prefix web/runner run check`
- `npm --prefix web/runner test` (exits 0; existing real-WASM skipped test still prints its known missing-bundle assertion detail)
- `node --test web/runner/ingest.test.mjs`
- `node --check web/runner/ingest.js`
- `git diff --check`

Supersedes #1411, #1413, #1415, and #1417.