### PR TITLE
test(types): cover optional serde omissions

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -14,7 +14,9 @@
 - Closed #1503 as superseded by #1554.
 - Merged #1559: synthesized keeper for FFI/env/path sanitization. Added in-memory input path length/control-character validation and config/profile selector trim/control-character sanitization while preserving case-sensitive FFI modes and existing path semantics. Gates: `cargo test -p tokmd-core in_memory_inputs_rejects_`; `cargo test -p tokmd-core --test error_boundary`; `cargo test -p tokmd-core parse_scan_settings`; `cargo test -p tokmd sanitize_selector`; `cargo test -p tokmd get_profile_name`; `cargo clippy -p tokmd-core -p tokmd -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1403/#1404/#1405/#1406 as superseded or declined by #1559.
-- Next cluster: Browser GitHub ingest cache partition (#1411, #1413, #1415, #1417).
+- Merged #1564: synthesized keeper for browser GitHub ingest cache partitioning. Added a token-derived auth partition to in-memory cache keys without storing raw token text and proved token-specific misses plus same-token cache reuse. Gates: `npm --prefix web/runner run check`; `npm --prefix web/runner test`; `node --test web/runner/ingest.test.mjs`; `node --check web/runner/ingest.js`; `git diff --check`; GitHub CI.
+- Closed #1411/#1413/#1415/#1417 as superseded by #1564.
+- Next cluster: Unit coverage (#1478, #1479, #1480).
 
 ## Operating decisions
 

--- a/crates/tokmd-types/src/lib.rs
+++ b/crates/tokmd-types/src/lib.rs
@@ -1242,6 +1242,36 @@ mod tests {
     }
 
     #[test]
+    fn capability_status_omits_reason_when_none() {
+        let status = CapabilityStatus {
+            name: "git".into(),
+            status: CapabilityState::Available,
+            reason: None,
+        };
+
+        let value = serde_json::to_value(&status).unwrap();
+        assert_eq!(value["name"], "git");
+        assert_eq!(value["status"], "available");
+        assert!(value.get("reason").is_none());
+    }
+
+    #[test]
+    fn artifact_entry_omits_hash_when_none() {
+        let artifact = ArtifactEntry {
+            name: "summary.md".into(),
+            path: "out/summary.md".into(),
+            description: "Markdown summary".into(),
+            bytes: 128,
+            hash: None,
+        };
+
+        let value = serde_json::to_value(&artifact).unwrap();
+        assert_eq!(value["name"], "summary.md");
+        assert_eq!(value["bytes"], 128);
+        assert!(value.get("hash").is_none());
+    }
+
+    #[test]
     fn analysis_format_serde_roundtrip() {
         for variant in [
             AnalysisFormat::Md,


### PR DESCRIPTION
## Summary
- add `tokmd-types` unit coverage proving `CapabilityStatus.reason` is omitted when absent
- add unit coverage proving `ArtifactEntry.hash` is omitted when absent
- update `PR_DRAIN.md` with the completed browser ingest cache partition cluster

## Gates
- `cargo test -p tokmd-types omits_`
- `cargo test -p tokmd-types`
- `cargo fmt-check`
- `git diff --check`

Supersedes #1479.