### PR TITLE
test(git): cover intent helper boundaries

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -16,7 +16,10 @@
 - Closed #1403/#1404/#1405/#1406 as superseded or declined by #1559.
 - Merged #1564: synthesized keeper for browser GitHub ingest cache partitioning. Added a token-derived auth partition to in-memory cache keys without storing raw token text and proved token-specific misses plus same-token cache reuse. Gates: `npm --prefix web/runner run check`; `npm --prefix web/runner test`; `node --test web/runner/ingest.test.mjs`; `node --check web/runner/ingest.js`; `git diff --check`; GitHub CI.
 - Closed #1411/#1413/#1415/#1417 as superseded by #1564.
-- Next cluster: Unit coverage (#1478, #1479, #1480).
+- Merged #1565: synthesized keeper for `tokmd-types` optional-field serde omission coverage. Added source-local tests for omitted `CapabilityStatus.reason` and `ArtifactEntry.hash`. Gates: `cargo test -p tokmd-types omits_`; `cargo test -p tokmd-types`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1479 as superseded by #1565.
+- Closed #1480 as duplicate coverage: current main already has all-variant cockpit enum serde coverage in integration/contract tests and snapshots.
+- Next cluster: Unit coverage follow-up (#1478).
 
 ## Operating decisions
 

--- a/crates/tokmd-git/src/lib.rs
+++ b/crates/tokmd-git/src/lib.rs
@@ -547,6 +547,61 @@ mod tests {
     }
 
     #[test]
+    fn classify_intent_prefers_conventional_commit_prefix() {
+        assert_eq!(
+            classify_intent("feat(parser): add support"),
+            CommitIntentKind::Feat
+        );
+        assert_eq!(
+            classify_intent("fix!: breaking hotfix"),
+            CommitIntentKind::Fix
+        );
+        assert_eq!(
+            classify_intent("docs(readme): update usage"),
+            CommitIntentKind::Docs
+        );
+        assert_eq!(
+            classify_intent("test: add regression"),
+            CommitIntentKind::Test
+        );
+    }
+
+    #[test]
+    fn classify_intent_uses_keyword_heuristics() {
+        assert_eq!(classify_intent("Add caching layer"), CommitIntentKind::Feat);
+        assert_eq!(
+            classify_intent("optimize parser allocations"),
+            CommitIntentKind::Perf
+        );
+        assert_eq!(classify_intent("lint workspace"), CommitIntentKind::Style);
+        assert_eq!(
+            classify_intent("pipeline: update checks"),
+            CommitIntentKind::Ci
+        );
+    }
+
+    #[test]
+    fn classify_intent_handles_revert_and_empty_subjects() {
+        assert_eq!(
+            classify_intent("Revert \"bad commit\""),
+            CommitIntentKind::Revert
+        );
+        assert_eq!(
+            classify_intent("revert: undo change"),
+            CommitIntentKind::Revert
+        );
+        assert_eq!(classify_intent("   \t"), CommitIntentKind::Other);
+    }
+
+    #[test]
+    fn contains_word_respects_word_boundaries() {
+        assert!(contains_word("fix parser", "fix"));
+        assert!(contains_word("fix-parser", "fix"));
+        assert!(!contains_word("prefix parser", "fix"));
+        assert!(!contains_word("fixture", "fix"));
+    }
+
+    #[test]
     fn resolve_base_ref_returns_none_when_nothing_resolves() {
         if !git_available() {
             return;


### PR DESCRIPTION
## Summary
- add source-local `tokmd-git` coverage for conventional commit intent classification
- add keyword/revert/empty-subject intent assertions
- cover the private `contains_word` helper's word-boundary behavior directly
- update `PR_DRAIN.md` with #1565 and the #1480 duplicate-coverage closure

## Gates
- `cargo test -p tokmd-git classify_intent_`
- `cargo test -p tokmd-git contains_word_respects_word_boundaries`
- `cargo test -p tokmd-git`
- `cargo fmt-check`
- `git diff --check`

Supersedes #1478.