### PR TITLE
test(io-port): strengthen MemFs properties

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -19,7 +19,9 @@
 - Merged #1565: synthesized keeper for `tokmd-types` optional-field serde omission coverage. Added source-local tests for omitted `CapabilityStatus.reason` and `ArtifactEntry.hash`. Gates: `cargo test -p tokmd-types omits_`; `cargo test -p tokmd-types`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1479 as superseded by #1565.
 - Closed #1480 as duplicate coverage: current main already has all-variant cockpit enum serde coverage in integration/contract tests and snapshots.
-- Next cluster: Unit coverage follow-up (#1478).
+- Merged #1566: synthesized keeper for `tokmd-git` intent helper coverage. Added source-local intent classification tests and direct private word-boundary helper assertions after fixing the stale branch formatting issue. Gates: `cargo test -p tokmd-git classify_intent_`; `cargo test -p tokmd-git contains_word_respects_word_boundaries`; `cargo test -p tokmd-git`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1478 as superseded by #1566.
+- Next cluster: Property/proptest improvements (#1463, #1464, #1465, #1466).
 
 ## Operating decisions
 

--- a/crates/tokmd-io-port/tests/properties.rs
+++ b/crates/tokmd-io-port/tests/properties.rs
@@ -144,6 +144,42 @@ proptest! {
 }
 
 proptest! {
+    #[test]
+    fn prop_file_size_matches_bytes_len(
+        path in forward_slash_path(),
+        content in pvec(any::<u8>(), 0..2048),
+    ) {
+        let mut fs = MemFs::new();
+        fs.add_bytes(&path, content.clone());
+        let size = fs.file_size(Path::new(&path)).unwrap();
+        prop_assert_eq!(size as usize, content.len());
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+    #[test]
+    fn prop_file_paths_are_sorted_and_unique(
+        entries in pvec((forward_slash_path(), pvec(any::<u8>(), 0..64)), 1..30),
+    ) {
+        let mut fs = MemFs::new();
+        for (path, content) in &entries {
+            fs.add_bytes(path, content.clone());
+        }
+
+        let listed = fs
+            .file_paths()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        prop_assert!(listed.windows(2).all(|window| window[0] < window[1]));
+
+        let unique = listed.iter().collect::<std::collections::BTreeSet<_>>();
+        prop_assert_eq!(listed.len(), unique.len());
+    }
+}
+
+proptest! {
     #![proptest_config(ProptestConfig::with_cases(32))]
     #[test]
     fn prop_bulk_insert_all_retrievable(


### PR DESCRIPTION
## Summary
- add property coverage that `MemFs::file_size` matches inserted byte lengths
- add property coverage that `MemFs::file_paths` returns sorted unique paths
- update `PR_DRAIN.md` with the completed #1566 unit-coverage follow-up

## Gates
- `cargo test -p tokmd-io-port --test properties`
- `cargo test -p tokmd-io-port`
- `cargo fmt-check`
- `git diff --check`

Supersedes #1463.