### PR TITLE
ci: add standalone Coverage workflow and Codecov config

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,72 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  # Override the repo-level CI debuginfo optimization for coverage.
+  # cargo-llvm-cov will set the instrumentation flags it needs.
+  RUSTFLAGS: ""
+
+jobs:
+  rust-coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Use larger writable target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: ${{ runner.temp }}/target
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          CI: true
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: error
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        if_ci_failed: success
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "fuzz/**"
+  - "xtask/**"
+  - "target/**"
+  - "vendor/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -289,3 +289,18 @@ For repeated local rebuilds, `cargo with-sccache test --workspace --all-features
 
 - Mutation testing: Weekly or on-demand
 - Extended fuzz runs: Nightly
+
+## Coverage
+
+Rust coverage is generated in CI with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
+
+Local run:
+
+```bash
+cargo llvm-cov clean --workspace
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+```
+
+The first implementation tracks default product crates with all features enabled. It intentionally excludes `fuzz/`, `xtask/`, `target/`, and vendored code from Codecov reporting.
+
+Coverage is advisory at first. Once the baseline is stable, the Codecov project and patch checks can be made required through branch protection.


### PR DESCRIPTION
### Motivation

- Add a separate coverage pipeline so Codecov uploads are observed before making them a required merge gate. 
- Produce Rust LCOV coverage via `cargo-llvm-cov` without expanding the existing required CI fan-in and while excluding non-default members like `fuzz` and `xtask` from the baseline. 
- Keep the first rollout non-blocking and inspectable so the Codecov signal can be tuned before enforcing policy.

### Description

- Add a new GitHub Actions workflow at `/.github/workflows/coverage.yml` that sets up Rust, runs `cargo llvm-cov --all-features --lcov --output-path lcov.info`, uploads `lcov.info` as a GitHub artifact, and calls `codecov/codecov-action@v5` with `fail_ci_if_error: false` and the `rust` flag. 
- Add a repository-level `codecov.yml` with conservative defaults including `project.target: auto`, `project.threshold: 2%`, `patch.target: 60%`, `ignore` entries for `fuzz/**`, `xtask/**`, `target/**`, and `vendor/**`, and disabled annotation noise for GitHub checks. 
- Document local reproduction and the advisory rollout in `docs/testing.md` under a new `## Coverage` section with the `cargo llvm-cov` commands. 
- Use a larger writable `CARGO_TARGET_DIR` in the workflow, cache the target dir, and install `cargo-llvm-cov` via an action to mirror CI shape used elsewhere in the repo.

### Testing

- Performed repository sanity checks including `git status --short` which showed the new files, and file inspections via `nl`/`sed` to verify contents of `/.github/workflows/coverage.yml`, `codecov.yml`, and `docs/testing.md`, and committed the changes successfully. 
- Created the PR and verified the diff contains the three added/updated files. 
- No runtime CI coverage jobs were executed locally; the workflow will run on `push`/`pull_request` events and should be validated by observing the first runs on `main` and a follow-up PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da857d90833382dead4b51401344)