### PR TITLE
Add standalone Rust coverage workflow and Codecov config

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,72 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  # Override the repo-level CI debuginfo optimization for coverage.
+  # cargo-llvm-cov will set the instrumentation flags it needs.
+  RUSTFLAGS: ""
+
+jobs:
+  rust-coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Use larger writable target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: ${{ runner.temp }}/target
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          CI: true
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: error
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        if_ci_failed: success
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "fuzz/**"
+  - "xtask/**"
+  - "target/**"
+  - "vendor/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -289,3 +289,18 @@ For repeated local rebuilds, `cargo with-sccache test --workspace --all-features
 
 - Mutation testing: Weekly or on-demand
 - Extended fuzz runs: Nightly
+
+## Coverage
+
+Rust coverage is generated in CI with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
+
+Local run:
+
+```bash
+cargo llvm-cov clean --workspace
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+```
+
+The first implementation tracks default product crates with all features enabled. It intentionally excludes `fuzz/`, `xtask/`, `target/`, and vendored code from Codecov reporting.
+
+Coverage is advisory at first. Once the baseline is stable, the Codecov project and patch checks can be made required through branch protection.


### PR DESCRIPTION
### Motivation

- Add coverage reporting without making a third-party upload path part of the existing required CI fan-in. 
- Use `cargo-llvm-cov` → LCOV to produce a reproducible Rust coverage artifact and observe Codecov behavior before enforcing gates. 
- Exclude non-default workspace members (`fuzz`, `xtask`) and vendor/target paths from the initial baseline and document the operator path.

### Description

- Create `.github/workflows/coverage.yml` which runs on `push`/`pull_request` to `main` and `workflow_dispatch`, sets up Rust with `llvm-tools-preview`, runs `cargo llvm-cov --all-features --lcov --output-path lcov.info`, uploads `lcov.info` as a GitHub artifact, and uploads to Codecov with `fail_ci_if_error: false` and flag `rust`.
- Add top-level `codecov.yml` with conservative defaults including `project.target: auto`, `project.threshold: 2%`, `patch.target: 60%`, disabled annotations, and ignore rules for `fuzz/**`, `xtask/**`, `target/**`, and `vendor/**`.
- Append a `## Coverage` section to `docs/testing.md` documenting the local run commands and the advisory rollout plan.
- Configure the workflow to use a larger writable target directory (`CARGO_TARGET_DIR=${RUNNER_TEMP}/target`) and a cache for the target directory to avoid polluting default product builds.

### Testing

- Validated the new workflow and config file contents with `nl -ba .github/workflows/coverage.yml`, `nl -ba codecov.yml`, and `nl -ba docs/testing.md | tail -n 40`, and observed the expected coverage job, Codecov settings, and docs section. 
- Confirmed repository scan for guidance files succeeded with `find .. -name AGENTS.md -o -name CLAUDE.md` to ensure AGENTS/CLAUDE guidance is intact. 
- No crate-level or CI test suite (e.g., `cargo test`, `insta`, or property/fuzz runs) was executed as part of this change; the change adds CI workflow and documentation only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da857d90833382dead4b51401344)