### PR TITLE
Add standalone Coverage workflow and Codecov configuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,72 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  # Override the repo-level CI debuginfo optimization for coverage.
+  # cargo-llvm-cov will set the instrumentation flags it needs.
+  RUSTFLAGS: ""
+
+jobs:
+  rust-coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Use larger writable target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: ${{ runner.temp }}/target
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          CI: true
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: error
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        if_ci_failed: success
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "fuzz/**"
+  - "xtask/**"
+  - "target/**"
+  - "vendor/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -270,6 +270,21 @@ JSON outputs are sorted deterministically:
 fn test_git_analysis() { ... }
 ```
 
+## Coverage
+
+Rust coverage is generated in CI with `cargo-llvm-cov` and uploaded to Codecov as LCOV.
+
+Local run:
+
+```bash
+cargo llvm-cov clean --workspace
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+```
+
+The first implementation tracks default product crates with all features enabled. It intentionally excludes `fuzz/`, `xtask/`, `target/`, and vendored code from Codecov reporting.
+
+Coverage is advisory at first. Once the baseline is stable, the Codecov project and patch checks can be made required through branch protection.
+
 ## CI Gates
 
 Minimum requirements for merging:


### PR DESCRIPTION
### Motivation
- Add Rust coverage reporting to observe coverage trends before making it a merge gate by keeping it as a separate, non-blocking workflow. 
- Use `cargo-llvm-cov` to produce LCOV artifacts and upload them to Codecov while retaining an artifact on GitHub for inspection. 
- Exclude non-default product paths like `fuzz/` and `xtask/` to avoid polluting the initial baseline and keep the rollout conservative.

### Description
- Add a new GitHub Actions workflow at `.github/workflows/coverage.yml` that runs on `push`/`pull_request` to `main` and `workflow_dispatch`, generates `lcov.info` with `cargo llvm-cov --all-features`, uploads the artifact, and posts to Codecov with `fail_ci_if_error: false`.
- Add `codecov.yml` with conservative thresholds and sane defaults including `project.target: auto`, `project.threshold: 2%`, `patch.target: 60%`, disabled check annotations, and ignored globs for `fuzz/**`, `xtask/**`, `target/**`, and `vendor/**`.
- Document the operator path in `docs/testing.md` by adding a `## Coverage` section with the local `cargo llvm-cov` commands and an advisory-first rollout note.

### Testing
- Verified the new files and key content with repository checks using `rg` and `sed` to confirm the presence of `cargo llvm-cov` commands and the Codecov action lines, and these checks succeeded. 
- Inspected the created workflow and config with `nl` to review the final content, and the inspection showed the expected sections and settings. 
- No automated test-suite runs (e.g., `cargo test`) were executed as part of this change; coverage reporting will be exercised by the new workflow once it runs on `main` and on PRs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da857d90833382dead4b51401344)