### PR TITLE
test(scan): strengthen config mapping properties

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -21,7 +21,9 @@
 - Closed #1480 as duplicate coverage: current main already has all-variant cockpit enum serde coverage in integration/contract tests and snapshots.
 - Merged #1566: synthesized keeper for `tokmd-git` intent helper coverage. Added source-local intent classification tests and direct private word-boundary helper assertions after fixing the stale branch formatting issue. Gates: `cargo test -p tokmd-git classify_intent_`; `cargo test -p tokmd-git contains_word_respects_word_boundaries`; `cargo test -p tokmd-git`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1478 as superseded by #1566.
-- Next cluster: Property/proptest improvements (#1463, #1464, #1465, #1466).
+- Merged #1568: synthesized keeper for `tokmd-io-port` `MemFs` property tests. Added properties for byte-length file size reporting and sorted unique path listing. Gates: `cargo test -p tokmd-io-port --test properties`; `cargo test -p tokmd-io-port`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1463 as superseded by #1568.
+- Next cluster: Property/proptest improvements (#1464, #1465, #1466).
 
 ## Operating decisions
 

--- a/crates/tokmd-scan/tests/properties.rs
+++ b/crates/tokmd-scan/tests/properties.rs
@@ -12,6 +12,7 @@
 
 use proptest::prelude::*;
 use proptest::string::string_regex;
+use tokmd_scan::config_from_scan_options;
 use tokmd_settings::ScanOptions;
 use tokmd_types::ConfigMode;
 
@@ -129,6 +130,10 @@ fn arb_global_args_many_excludes() -> impl Strategy<Value = ScanOptions> {
             args.excluded = excludes;
             args
         })
+}
+
+fn effective_flag(value: Option<bool>) -> bool {
+    value.unwrap_or(false)
 }
 
 // ============================================================================
@@ -606,6 +611,57 @@ proptest! {
         cfg.no_ignore_dot = Some(true);
         cfg.no_ignore_parent = Some(true);
         cfg.no_ignore_vcs = Some(true);
+
+        prop_assert_eq!(cfg.no_ignore, Some(true));
+        prop_assert_eq!(cfg.no_ignore_dot, Some(true));
+        prop_assert_eq!(cfg.no_ignore_parent, Some(true));
+        prop_assert_eq!(cfg.no_ignore_vcs, Some(true));
+    }
+}
+
+proptest! {
+    /// `config_from_scan_options` preserves monotonic behavior:
+    /// enabling an opt-in flag never disables a previously enabled config field.
+    #[test]
+    fn config_mapping_is_monotonic(
+        args in arb_global_args(),
+        toggle_hidden in any::<bool>(),
+        toggle_no_ignore in any::<bool>(),
+        toggle_dot in any::<bool>(),
+        toggle_parent in any::<bool>(),
+        toggle_vcs in any::<bool>(),
+        toggle_doc in any::<bool>(),
+    ) {
+        let base = config_from_scan_options(&args);
+
+        let mut stronger = args.clone();
+        stronger.hidden |= toggle_hidden;
+        stronger.no_ignore |= toggle_no_ignore;
+        stronger.no_ignore_dot |= toggle_dot;
+        stronger.no_ignore_parent |= toggle_parent;
+        stronger.no_ignore_vcs |= toggle_vcs;
+        stronger.treat_doc_strings_as_comments |= toggle_doc;
+
+        let raised = config_from_scan_options(&stronger);
+
+        prop_assert!(effective_flag(base.hidden) <= effective_flag(raised.hidden));
+        prop_assert!(effective_flag(base.no_ignore) <= effective_flag(raised.no_ignore));
+        prop_assert!(effective_flag(base.no_ignore_dot) <= effective_flag(raised.no_ignore_dot));
+        prop_assert!(
+            effective_flag(base.no_ignore_parent) <= effective_flag(raised.no_ignore_parent)
+        );
+        prop_assert!(effective_flag(base.no_ignore_vcs) <= effective_flag(raised.no_ignore_vcs));
+        prop_assert!(
+            effective_flag(base.treat_doc_strings_as_comments)
+                <= effective_flag(raised.treat_doc_strings_as_comments)
+        );
+    }
+
+    /// `config_from_scan_options` enforces the `no_ignore` implication contract.
+    #[test]
+    fn config_from_scan_options_enforces_no_ignore_implication(mut args in arb_global_args()) {
+        args.no_ignore = true;
+        let cfg = config_from_scan_options(&args);
 
         prop_assert_eq!(cfg.no_ignore, Some(true));
         prop_assert_eq!(cfg.no_ignore_dot, Some(true));


### PR DESCRIPTION
## Summary
- add property tests for real `config_from_scan_options` monotonic flag behavior
- add property coverage for the `no_ignore` implication contract through the public helper
- update `PR_DRAIN.md` with the completed #1568 property-test keeper

## Gates
- `cargo test -p tokmd-scan --test properties`
- `cargo test -p tokmd-scan`
- `cargo fmt-check`
- `git diff --check`

Supersedes #1466.