### PR TITLE
fuzzer: extract unrunnable fuzz targets to deterministic proptests 🌪️

### DIFF
--- a/.jules/runs/run-fuzzer-input-hardening-1/decision.md
+++ b/.jules/runs/run-fuzzer-input-hardening-1/decision.md
@@ -1,0 +1,11 @@
+# Decision
+
+## Option A
+Since the standard `cargo fuzz` toolchain requires nightly features that are not natively available or fail locally in this sandbox (due to missing nightly compiler options in the default CI/execution environment), I will extract the core logic from one of the un-runnable fuzz targets (`fuzz_toml_config.rs` or `fuzz_json_types.rs`) and convert it into a set of deterministic property tests using `proptest`. The `fuzz_toml_config.rs` target validates critical invariants on TOML configuration parsing that we can test via property testing instead.
+- **Why it fits:** It honors the primary objective (improving proof surfaces in interfaces/parser/config) without relying on broken tools. We can port `fuzz_toml_config` logic to a `config_proptests.rs` file within `crates/tokmd/tests/` (which is within the allowed paths).
+
+## Option B
+Attempt to install nightly Rust to run `cargo fuzz`. This introduces environment-mutating friction, and might not succeed depending on the environment's network/permissions.
+
+## Decision
+I will proceed with **Option A**, extracting the TOML fuzz target into a deterministic property test suite.

--- a/.jules/runs/run-fuzzer-input-hardening-1/envelope.json
+++ b/.jules/runs/run-fuzzer-input-hardening-1/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "fuzzer_input_hardening",
+  "persona": "Fuzzer",
+  "style": "Prover",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "fuzz",
+  "allowed_outcomes": [
+    "proof-improvement patch",
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/run-fuzzer-input-hardening-1/pr_body.md
+++ b/.jules/runs/run-fuzzer-input-hardening-1/pr_body.md
@@ -1,0 +1,76 @@
+## 💡 Summary
+Replaced unrunnable fuzz targets with deterministic `proptest` suites for core interfaces and parser invariants.
+
+## 🎯 Why
+The `cargo fuzz` toolchain requires nightly compiler features (`-Zsanitizer=address`) that fail to build in standard sandbox environments. Since the `fuzz` tests inside `fuzz/fuzz_targets` contained highly valuable property invariants for path normalization, redaction, JSON extraction, and import parsing, converting them to `proptest` suites allows us to lock in this determinism without relying on broken fuzz environments.
+
+## 🔎 Evidence
+Minimal proof:
+- Attempting to run the existing fuzz tests (e.g. `cargo fuzz run fuzz_toml_config`) fails locally with: `error: the option 'Z' is only accepted on the nightly compiler`.
+- Migrated 6 major target domains to `proptest`:
+  - `cargo test -p tokmd --test fuzz_toml_config_proptests`
+  - `cargo test -p tokmd --test fuzz_json_types_proptests`
+  - `cargo test -p tokmd --test fuzz_scan_args_proptests`
+  - `cargo test -p tokmd --test fuzz_context_policy_proptests`
+  - `cargo test -p tokmd --test fuzz_import_parser_proptests`
+  - `cargo test -p tokmd --test fuzz_run_json_proptests`
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Extracting the core `fuzz_target` closures and moving them into isolated deterministic `proptest!` suites inside `crates/tokmd/tests/`.
+- why it fits this repo and shard: Fulfills the Fuzzer mission of input hardening around parsers and configs while sidestepping broken dependencies.
+- trade-offs: Structure / Velocity / Governance: Loses the automated mutation exploration of a true fuzzer, but guarantees that the invariants are run reliably on every standard test suite invocation.
+
+### Option B
+- what it is: Attempt to upgrade or force nightly installation.
+- when to choose it instead: If true fuzzing is an absolute requirement that justifies environmental mutability risk.
+- trade-offs: Introduces high environment-mutating friction and might break standard CI pipelines.
+
+## ✅ Decision
+Option A was chosen to maximize deterministic proof surfaces with the current environmental constraints.
+
+## 🧱 Changes made (SRP)
+- Created `crates/tokmd/tests/fuzz_toml_config_proptests.rs`
+- Created `crates/tokmd/tests/fuzz_json_types_proptests.rs`
+- Created `crates/tokmd/tests/fuzz_scan_args_proptests.rs`
+- Created `crates/tokmd/tests/fuzz_context_policy_proptests.rs`
+- Created `crates/tokmd/tests/fuzz_import_parser_proptests.rs`
+- Created `crates/tokmd/tests/fuzz_run_json_proptests.rs`
+
+## 🧪 Verification receipts
+```text
+$ cargo test -p tokmd --test fuzz_toml_config_proptests
+ok. 3 passed
+
+$ cargo test -p tokmd --test fuzz_json_types_proptests
+ok. 8 passed
+
+$ cargo test -p tokmd --test fuzz_scan_args_proptests
+ok. 1 passed
+
+$ cargo test -p tokmd --test fuzz_context_policy_proptests
+ok. 1 passed
+
+$ cargo test -p tokmd --test fuzz_import_parser_proptests
+ok. 28 passed
+
+$ cargo test -p tokmd --test fuzz_run_json_proptests
+ok. 1 passed
+```
+
+## 🧭 Telemetry
+- Change shape: Test Addition
+- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): No production changes.
+- Risk class + why: Very low. It purely expands deterministic testing.
+- Rollback: Revert the new test files.
+- Gates run: `cargo test`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-fuzzer-input-hardening-1/envelope.json`
+- `.jules/runs/run-fuzzer-input-hardening-1/decision.md`
+- `.jules/runs/run-fuzzer-input-hardening-1/receipts.jsonl`
+- `.jules/runs/run-fuzzer-input-hardening-1/result.json`
+- `.jules/runs/run-fuzzer-input-hardening-1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-fuzzer-input-hardening-1/receipts.jsonl
+++ b/.jules/runs/run-fuzzer-input-hardening-1/receipts.jsonl
@@ -1,0 +1,6 @@
+{"command": "cargo test -p tokmd --test fuzz_toml_config_proptests", "output": "ok. 3 passed"}
+{"command": "cargo test -p tokmd --test fuzz_json_types_proptests", "output": "ok. 8 passed"}
+{"command": "cargo test -p tokmd --test fuzz_scan_args_proptests", "output": "ok. 1 passed"}
+{"command": "cargo test -p tokmd --test fuzz_context_policy_proptests", "output": "ok. 1 passed"}
+{"command": "cargo test -p tokmd --test fuzz_import_parser_proptests", "output": "ok. 28 passed"}
+{"command": "cargo test -p tokmd --test fuzz_run_json_proptests", "output": "ok. 1 passed"}

--- a/.jules/runs/run-fuzzer-input-hardening-1/result.json
+++ b/.jules/runs/run-fuzzer-input-hardening-1/result.json
@@ -1,0 +1,12 @@
+{
+  "outcome": "proof-improvement patch",
+  "files_changed": [
+    "crates/tokmd/tests/fuzz_toml_config_proptests.rs",
+    "crates/tokmd/tests/fuzz_json_types_proptests.rs",
+    "crates/tokmd/tests/fuzz_scan_args_proptests.rs",
+    "crates/tokmd/tests/fuzz_context_policy_proptests.rs",
+    "crates/tokmd/tests/fuzz_import_parser_proptests.rs",
+    "crates/tokmd/tests/fuzz_run_json_proptests.rs"
+  ],
+  "reasoning": "Since `cargo fuzz` requires a nightly Rust toolchain which fails locally (`-Zsanitizer=address` is unsupported), we extracted the deterministic logic from the broken fuzz targets and converted them into comprehensive `proptest` suites inside `crates/tokmd/tests`. This locks in the fuzzable invariant coverage (such as path normalization, JSON extraction, and parser rules) without depending on unrunnable CI tools."
+}

--- a/crates/tokmd/tests/fuzz_context_policy_proptests.rs
+++ b/crates/tokmd/tests/fuzz_context_policy_proptests.rs
@@ -1,0 +1,54 @@
+//! Deterministic property tests extracted from `fuzz_context_policy`.
+//!
+//! Validates invariants for:
+//! - File classification
+//! - File cap computations
+//! - Policy assignments
+
+use proptest::prelude::*;
+use tokmd_core::context_policy::{
+    DEFAULT_DENSE_THRESHOLD, DEFAULT_MAX_FILE_PCT, assign_policy, classify_file, compute_file_cap,
+    is_spine_file, smart_exclude_reason,
+};
+use tokmd_types::InclusionPolicy;
+
+proptest! {
+    #[test]
+    fn context_policy_invariants(
+        path in "\\PC+",
+        tokens in 0usize..1_000_000,
+        lines in 0usize..1_000_000,
+        budget in 0usize..1_000_000,
+    ) {
+        let _ = is_spine_file(path.as_ref());
+
+        if let Some(reason) = smart_exclude_reason(path.as_ref()) {
+            prop_assert!(matches!(reason, "lockfile" | "minified" | "sourcemap"));
+        }
+
+        let classes = classify_file(path.as_ref(), tokens, lines, DEFAULT_DENSE_THRESHOLD);
+        let mut sorted = classes.clone();
+        sorted.sort();
+        sorted.dedup();
+        prop_assert_eq!(&classes, &sorted);
+
+        let cap_default = compute_file_cap(budget, DEFAULT_MAX_FILE_PCT, None);
+        let cap_hard = compute_file_cap(budget, DEFAULT_MAX_FILE_PCT, Some(4_000));
+        prop_assert!(cap_hard <= 4_000 || cap_hard == usize::MAX);
+
+        let (policy_default, reason_default) = assign_policy(tokens, cap_default, &classes);
+        match policy_default {
+            InclusionPolicy::Full => {
+                prop_assert!(tokens <= cap_default);
+                prop_assert!(reason_default.is_none());
+            }
+            InclusionPolicy::HeadTail | InclusionPolicy::Skip => {
+                if cap_default != usize::MAX {
+                    prop_assert!(tokens > cap_default);
+                    prop_assert!(reason_default.is_some());
+                }
+            }
+            InclusionPolicy::Summary => {}
+        }
+    }
+}

--- a/crates/tokmd/tests/fuzz_import_parser_proptests.rs
+++ b/crates/tokmd/tests/fuzz_import_parser_proptests.rs
@@ -1,0 +1,30 @@
+//! Deterministic property tests extracted from `fuzz_import_parser`.
+//!
+//! Validates invariants for:
+//! - Import parsing limits and stability
+
+use proptest::prelude::*;
+
+// We use relative path from tests directory
+#[path = "../../tokmd-analysis/src/imports/parser.rs"]
+mod imports;
+
+use imports::{normalize_import_target, parse_imports, supports_language};
+
+proptest! {
+    #[test]
+    fn import_parser_invariants(
+        lang in "\\PC+",
+        body in "\\PC*"
+    ) {
+        let lines: Vec<&str> = body.lines().take(512).collect();
+        let imports = parse_imports(&lang, &lines);
+
+        let _ = supports_language(&lang);
+        for import in imports {
+            let normalized = normalize_import_target(&import);
+            let double_normalized = normalize_import_target(&normalized);
+            prop_assert_eq!(&normalized, &double_normalized);
+        }
+    }
+}

--- a/crates/tokmd/tests/fuzz_json_types_proptests.rs
+++ b/crates/tokmd/tests/fuzz_json_types_proptests.rs
@@ -1,0 +1,107 @@
+//! Deterministic property tests extracted from `fuzz_json_types`.
+//!
+//! Tests JSON deserialization invariants for model types without requiring a fuzzer.
+
+use proptest::prelude::*;
+use tokmd_types::{
+    ExportData, FileRow, LangReport, LangRow, ModuleReport, ModuleRow, RunReceipt, Totals,
+};
+
+proptest! {
+    #[test]
+    fn file_row_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(file_row) = serde_json::from_str::<FileRow>(&s) {
+            let _ = file_row.path.len();
+            let _ = file_row.module.len();
+            let _ = file_row.lang.len();
+            let _ = file_row.code;
+            let _ = file_row.comments;
+            let _ = file_row.blanks;
+            let _ = file_row.lines;
+            let _ = file_row.bytes;
+            let _ = file_row.tokens;
+        }
+    }
+
+    #[test]
+    fn totals_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(totals) = serde_json::from_str::<Totals>(&s) {
+            let _ = totals.code;
+            let _ = totals.lines;
+            let _ = totals.files;
+            let _ = totals.bytes;
+            let _ = totals.tokens;
+            let _ = totals.avg_lines;
+        }
+    }
+
+    #[test]
+    fn lang_row_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(lang_row) = serde_json::from_str::<LangRow>(&s) {
+            let _ = lang_row.lang.len();
+            let _ = lang_row.code;
+            let _ = lang_row.files;
+        }
+    }
+
+    #[test]
+    fn module_row_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(module_row) = serde_json::from_str::<ModuleRow>(&s) {
+            let _ = module_row.module.len();
+            let _ = module_row.code;
+            let _ = module_row.files;
+        }
+    }
+
+    #[test]
+    fn run_receipt_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(receipt) = serde_json::from_str::<RunReceipt>(&s) {
+            let _ = receipt.schema_version;
+            let _ = receipt.lang_file.len();
+            let _ = receipt.module_file.len();
+            let _ = receipt.export_file.len();
+        }
+    }
+
+    #[test]
+    fn export_data_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(export) = serde_json::from_str::<ExportData>(&s) {
+            for row in &export.rows {
+                let _ = row.path.len();
+                let _ = row.module.len();
+                let _ = row.lang.len();
+                let _ = row.code;
+                let _ = row.lines;
+            }
+
+            for root in &export.module_roots {
+                let _ = root.len();
+            }
+            let _ = export.module_depth;
+        }
+    }
+
+    #[test]
+    fn lang_report_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(report) = serde_json::from_str::<LangReport>(&s) {
+            for row in &report.rows {
+                let _ = row.lang.len();
+                let _ = row.code;
+            }
+            let _ = report.total.code;
+            let _ = report.total.files;
+        }
+    }
+
+    #[test]
+    fn module_report_does_not_crash_on_random_utf8(s in "\\PC*") {
+        if let Ok(report) = serde_json::from_str::<ModuleReport>(&s) {
+            for row in &report.rows {
+                let _ = row.module.len();
+                let _ = row.code;
+            }
+            let _ = report.total.code;
+            let _ = report.module_depth;
+        }
+    }
+}

--- a/crates/tokmd/tests/fuzz_run_json_proptests.rs
+++ b/crates/tokmd/tests/fuzz_run_json_proptests.rs
@@ -1,0 +1,29 @@
+//! Deterministic property tests extracted from `fuzz_run_json`.
+//!
+//! Validates invariants for:
+//! - Run json FFI entrypoint never panics
+
+use proptest::prelude::*;
+use serde_json::Value;
+use tokmd_core::ffi::run_json;
+
+proptest! {
+    #[test]
+    fn run_json_invariants(
+        mode in "\\PC*",
+        args_json in "\\PC*"
+    ) {
+        let result = run_json(&mode, &args_json);
+
+        // Invariant: result is always valid JSON
+        let envelope: Value =
+            serde_json::from_str(&result).expect("run_json must always return valid JSON");
+
+        // Invariant: envelope always contains an "ok" boolean field
+        prop_assert!(
+            envelope.get("ok").and_then(Value::as_bool).is_some(),
+            "envelope must have boolean 'ok' field, got: {}",
+            result
+        );
+    }
+}

--- a/crates/tokmd/tests/fuzz_scan_args_proptests.rs
+++ b/crates/tokmd/tests/fuzz_scan_args_proptests.rs
@@ -1,0 +1,93 @@
+//! Deterministic property tests extracted from `fuzz_scan_args`.
+//!
+//! Validates invariants for:
+//! - Path normalization
+//! - Redaction mode toggles
+//! - Deterministic output
+//! - Ignore-flag fan-out behavior
+
+use proptest::prelude::*;
+use std::path::PathBuf;
+use tokmd_format::scan_args::{normalize_scan_input, scan_args};
+use tokmd_settings::ScanOptions;
+use tokmd_types::RedactMode;
+
+proptest! {
+    #[test]
+    fn scan_args_invariants(
+        paths in prop::collection::vec("[a-zA-Z0-9_\\-\\./\\\\]+", 1..10),
+        excluded in prop::collection::vec("[a-zA-Z0-9_\\-\\.*]+", 0..5),
+        redact_mode in prop::sample::select(vec![None, Some(RedactMode::None), Some(RedactMode::Paths), Some(RedactMode::All)]),
+        hidden in any::<bool>(),
+        no_ignore in any::<bool>(),
+        no_ignore_parent in any::<bool>(),
+        no_ignore_dot in any::<bool>(),
+        no_ignore_vcs in any::<bool>(),
+        treat_doc_strings_as_comments in any::<bool>()
+    ) {
+        let path_bufs: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
+
+        let scan_options = ScanOptions {
+            excluded: excluded.clone(),
+            config: tokmd_settings::ConfigMode::Auto,
+            hidden,
+            no_ignore,
+            no_ignore_parent,
+            no_ignore_dot,
+            no_ignore_vcs,
+            treat_doc_strings_as_comments,
+        };
+
+        let args = scan_args(&path_bufs, &scan_options, redact_mode);
+        let args2 = scan_args(&path_bufs, &scan_options, redact_mode);
+
+        // Determinism: same input must produce same output.
+        prop_assert_eq!(&args.paths, &args2.paths);
+        prop_assert_eq!(&args.excluded, &args2.excluded);
+        prop_assert_eq!(args.excluded_redacted, args2.excluded_redacted);
+        prop_assert_eq!(args.no_ignore_parent, args2.no_ignore_parent);
+        prop_assert_eq!(args.no_ignore_dot, args2.no_ignore_dot);
+        prop_assert_eq!(args.no_ignore_vcs, args2.no_ignore_vcs);
+
+        // Paths are always one-to-one with input paths.
+        prop_assert_eq!(args.paths.len(), paths.len());
+
+        // Normalization invariant: output paths never contain backslashes.
+        for p in &args.paths {
+            prop_assert!(!p.contains('\\'));
+        }
+
+        let should_redact = matches!(redact_mode, Some(RedactMode::Paths | RedactMode::All));
+        let expected_excluded_redacted = should_redact && !excluded.is_empty();
+        prop_assert_eq!(args.excluded_redacted, expected_excluded_redacted);
+
+        if should_redact {
+            // Redacted paths are hash-based and should not include separators.
+            for p in &args.paths {
+                prop_assert!(!p.contains('/'));
+                prop_assert!(!p.contains('\\'));
+            }
+
+            // Excluded patterns are short hashes (16 lowercase hex chars).
+            prop_assert_eq!(args.excluded.len(), excluded.len());
+            for value in &args.excluded {
+                prop_assert_eq!(value.len(), 16);
+                for c in value.chars() {
+                    prop_assert!(c.is_ascii_hexdigit());
+                    prop_assert!(!c.is_ascii_uppercase());
+                }
+            }
+        } else {
+            let expected_paths: Vec<String> = path_bufs.iter().map(|p| normalize_scan_input(p)).collect();
+            prop_assert_eq!(&args.paths, &expected_paths);
+            prop_assert_eq!(&args.excluded, &excluded);
+        }
+
+        // no_ignore should force sub-flags true.
+        if no_ignore {
+            prop_assert!(args.no_ignore_parent);
+            prop_assert!(args.no_ignore_dot);
+            prop_assert!(args.no_ignore_vcs);
+        }
+    }
+}

--- a/crates/tokmd/tests/fuzz_toml_config_proptests.rs
+++ b/crates/tokmd/tests/fuzz_toml_config_proptests.rs
@@ -1,0 +1,79 @@
+//! Deterministic property tests extracted from `fuzz_toml_config`.
+//!
+//! Tests `TomlConfig::parse()` and serialization round-trip behavior.
+
+use proptest::prelude::*;
+use tokmd_settings::{TomlConfig};
+
+proptest! {
+    #[test]
+    fn toml_config_does_not_crash_on_random_utf8(s in "\\PC*") {
+        let _ = TomlConfig::parse(&s);
+    }
+}
+
+// We use basic explicit tests for serde roundtrips because it avoids
+// exhaustively hand-rolling an exact proptest strategy for every new optional field.
+#[test]
+fn toml_config_json_roundtrip() {
+    let toml_str = r#"
+[scan]
+paths = ["src", "lib"]
+
+[module]
+roots = ["src"]
+depth = 2
+
+[export]
+format = "json"
+
+[analyze]
+preset = "health"
+
+[view.default]
+format = "md"
+top = 10
+"#;
+    let config = TomlConfig::parse(toml_str).expect("should parse");
+    let json = serde_json::to_string(&config).expect("should serialize json");
+    let roundtrip: TomlConfig = serde_json::from_str(&json).expect("should parse json");
+
+    assert_eq!(config.scan.paths, roundtrip.scan.paths);
+    assert_eq!(config.module.roots, roundtrip.module.roots);
+    assert_eq!(config.module.depth, roundtrip.module.depth);
+    assert_eq!(config.export.format, roundtrip.export.format);
+    assert_eq!(config.analyze.preset, roundtrip.analyze.preset);
+    assert_eq!(config.view.len(), roundtrip.view.len());
+}
+
+#[test]
+fn toml_config_toml_roundtrip() {
+    let toml_str = r#"
+[scan]
+paths = ["src", "lib"]
+
+[module]
+roots = ["src"]
+depth = 2
+
+[export]
+format = "json"
+
+[analyze]
+preset = "health"
+
+[view.default]
+format = "md"
+top = 10
+"#;
+    let config = TomlConfig::parse(toml_str).expect("should parse");
+    let serialized = toml::to_string(&config).expect("should serialize toml");
+    let roundtrip = TomlConfig::parse(&serialized).expect("should parse serialized toml");
+
+    assert_eq!(config.scan.paths, roundtrip.scan.paths);
+    assert_eq!(config.module.roots, roundtrip.module.roots);
+    assert_eq!(config.module.depth, roundtrip.module.depth);
+    assert_eq!(config.export.format, roundtrip.export.format);
+    assert_eq!(config.analyze.preset, roundtrip.analyze.preset);
+    assert_eq!(config.view.len(), roundtrip.view.len());
+}


### PR DESCRIPTION
Extracts core invariant checks from `fuzz/fuzz_targets/*` into standalone `proptest` suites within `crates/tokmd/tests/` to guarantee execution in standard environments without relying on nightly compiler features (`-Zsanitizer=address`).

---
*PR created automatically by Jules for task [11291239683762621160](https://jules.google.com/task/11291239683762621160) started by @EffortlessSteven*