### PR TITLE
docs: refresh proptest testing guidance

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -23,7 +23,9 @@
 - Closed #1478 as superseded by #1566.
 - Merged #1568: synthesized keeper for `tokmd-io-port` `MemFs` property tests. Added properties for byte-length file size reporting and sorted unique path listing. Gates: `cargo test -p tokmd-io-port --test properties`; `cargo test -p tokmd-io-port`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1463 as superseded by #1568.
-- Next cluster: Property/proptest improvements (#1464, #1465, #1466).
+- Merged #1573: synthesized keeper for `tokmd-scan` config property tests. Added real-helper properties proving monotonic opt-in flag behavior and the `no_ignore` implication across scan config mapping. Gates: `cargo test -p tokmd-scan --test properties`; `cargo test -p tokmd-scan`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1466 as superseded by #1573.
+- Next cluster: Property/proptest improvements (#1464, #1465).
 
 ## Operating decisions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,7 +15,7 @@ This document describes the testing infrastructure and strategy for tokmd.
                └────────────────────────┘
           ┌──────────────────────────────────┐
           │    Property-Based Testing        │  proptest
-          │    (invariant verification)      │  17 crates
+          │    (invariant verification)      │  workspace surfaces
           └──────────────────────────────────┘
      ┌────────────────────────────────────────────┐
      │    Integration Tests (CLI contract)        │  assert_cmd
@@ -117,28 +117,31 @@ Snapshot files: `<crate>/tests/snapshots/*.snap`
 
 ## Property-Based Tests
 
-Using `proptest` (1.9.0) across 17 crates:
+The workspace pins `proptest` 1.11.0. Property suites cover active workspace
+crates and owner modules rather than retired helper microcrates:
 
-| Crate | Properties Tested |
-|-------|-------------------|
-| `tokmd-model` | Path normalization, aggregation invariants |
-| `tokmd-format` | Table formatting, redaction, scan metadata, badge/tree rendering determinism |
-| `tokmd-scan` | Scanning options, exclude/path/tokeignore helpers, numeric invariants |
-| `tokmd-types` | DTO serialization roundtrips |
-| `tokmd-analysis-types` | Analysis receipt types |
-| `tokmd-analysis::imports` | Import parsing and normalization invariants |
-| `tokmd-gate` | Policy evaluation invariants |
-| `tokmd-git` | Git history collection |
-| `tokmd-analysis::content` | Entropy calculation, tag counting |
-| `tokmd-scan::walk` | File listing, traversal |
-| `tokmd-format::fun` | Novelty output generation |
-| `tokmd` | CLI output properties |
+| Surface | Properties Tested |
+|---------|-------------------|
+| `tokmd-analysis` | Analysis enrichers, imports, content, metrics, topics, and deterministic derived values |
+| `tokmd-analysis-types` | Analysis DTO serialization and numeric helper invariants |
+| `tokmd-cockpit` | Review metrics, gate status, trend, composition, and health invariants |
+| `tokmd-envelope` | Ecosystem envelope roundtrips and error-shape invariants |
+| `tokmd-format` | Table formatting, redaction, scan metadata, badge/tree rendering, and analysis renderer determinism |
+| `tokmd-gate` | Policy parsing and evaluation invariants |
+| `tokmd-git` | Git history collection and commit intent classification |
+| `tokmd-io-port` | In-memory filesystem contracts and sorted path listing |
+| `tokmd-model` | Path normalization and aggregation invariants |
+| `tokmd-scan` | Scan option mapping, exclude/path helpers, and numeric invariants |
+| `tokmd-sensor` | Substrate and trait analysis invariants |
+| `tokmd-settings` | Settings DTO roundtrips and defaults |
+| `tokmd-types` | Core receipt DTO serialization and schema invariants |
+| `tokmd` | CLI output and command-contract properties |
 
 ### Configuration
 
 `proptest.toml`:
 ```toml
-[proptest]
+[default]
 cases = 256
 max_shrink_iters = 1000
 timeout = 10000
@@ -147,7 +150,8 @@ timeout = 10000
 ### Running Property Tests
 
 ```bash
-cargo test -p tokmd-scan properties
+cargo test -p tokmd-scan --test properties
+PROPTEST_CASES=1024 cargo test -p tokmd-scan --test properties
 cargo test properties    # All property tests
 ```
 


### PR DESCRIPTION
## Summary
- refresh the property-test documentation to match the current proptest 1.11 workspace setup
- replace retired helper microcrate entries with active workspace surfaces and owner modules
- update the documented `proptest.toml` section to `[default]` and record the prior #1573 drain progress

## Validation
- `cargo xtask docs --check`
- `git diff --check`

Supersedes #1465.