### PR TITLE
test(cockpit): strengthen property invariants

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -25,7 +25,9 @@
 - Closed #1463 as superseded by #1568.
 - Merged #1573: synthesized keeper for `tokmd-scan` config property tests. Added real-helper properties proving monotonic opt-in flag behavior and the `no_ignore` implication across scan config mapping. Gates: `cargo test -p tokmd-scan --test properties`; `cargo test -p tokmd-scan`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1466 as superseded by #1573.
-- Next cluster: Property/proptest improvements (#1464, #1465).
+- Merged #1575: synthesized keeper for proptest testing docs. Replaced stale retired-helper-crate guidance with current workspace surfaces, updated the pinned `proptest` version, and documented the active `[default]` config section. Gates: `cargo xtask docs --check`; `git diff --check`; GitHub CI.
+- Closed #1465 as superseded by #1575.
+- Next cluster: Property/proptest improvements (#1464).
 
 ## Operating decisions
 

--- a/crates/tokmd-cockpit/tests/properties.rs
+++ b/crates/tokmd-cockpit/tests/properties.rs
@@ -125,6 +125,38 @@ proptest! {
             health.grade
         );
     }
+
+    #[test]
+    fn prop_health_is_monotonic_for_breaking_indicators(
+        stats in prop::collection::vec(file_stat_strategy(), 0..20),
+        breaking_a in 0..5usize,
+        breaking_b in 0..5usize,
+    ) {
+        let (low, high) = if breaking_a <= breaking_b {
+            (breaking_a, breaking_b)
+        } else {
+            (breaking_b, breaking_a)
+        };
+        let base = Contracts {
+            api_changed: false,
+            cli_changed: false,
+            schema_changed: false,
+            breaking_indicators: low,
+        };
+        let stricter = Contracts {
+            breaking_indicators: high,
+            ..base
+        };
+
+        let health_base = compute_code_health(&stats, &base);
+        let health_stricter = compute_code_health(&stats, &stricter);
+        prop_assert!(
+            health_stricter.score <= health_base.score,
+            "more breaking indicators should not improve score: {} -> {}",
+            health_base.score,
+            health_stricter.score
+        );
+    }
 }
 
 // ===========================================================================
@@ -459,10 +491,13 @@ proptest! {
     #[test]
     fn composition_percentages(files in prop::collection::vec(file_path_strategy(), 1..20)) {
         let comp = compute_composition(&files);
-        prop_assert!((0.0..=100.0).contains(&comp.code_pct));
-        prop_assert!((0.0..=100.0).contains(&comp.test_pct));
-        prop_assert!((0.0..=100.0).contains(&comp.docs_pct));
-        prop_assert!((0.0..=100.0).contains(&comp.config_pct));
+        let sum = comp.code_pct + comp.test_pct + comp.docs_pct + comp.config_pct;
+
+        prop_assert!((0.0..=1.0).contains(&comp.code_pct));
+        prop_assert!((0.0..=1.0).contains(&comp.test_pct));
+        prop_assert!((0.0..=1.0).contains(&comp.docs_pct));
+        prop_assert!((0.0..=1.0).contains(&comp.config_pct));
+        prop_assert!(sum <= 1.001, "sum was {}", sum);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a cockpit property proving extra breaking indicators cannot improve code-health score
- tighten the stale composition-percentage property from `0..=100` to the actual `0..=1` fraction contract and keep the existing sparkline coverage
- record the #1575 proptest-docs merge in the drain log

## Validation
- `cargo test -p tokmd-cockpit --test properties`
- `cargo test -p tokmd-cockpit`
- `cargo fmt-check`
- `git diff --check`

Supersedes #1464.