### PR TITLE
test(analysis): cover health todo pipeline

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -27,7 +27,9 @@
 - Closed #1466 as superseded by #1573.
 - Merged #1575: synthesized keeper for proptest testing docs. Replaced stale retired-helper-crate guidance with current workspace surfaces, updated the pinned `proptest` version, and documented the active `[default]` config section. Gates: `cargo xtask docs --check`; `git diff --check`; GitHub CI.
 - Closed #1465 as superseded by #1575.
-- Next cluster: Property/proptest improvements (#1464).
+- Merged #1577: synthesized keeper for cockpit property invariants. Added monotonic code-health scoring coverage for breaking indicators and tightened composition percentage assertions to the actual 0..1 fraction contract while preserving existing sparkline coverage. Gates: `cargo test -p tokmd-cockpit --test properties`; `cargo test -p tokmd-cockpit`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1464 as superseded by #1577.
+- Next cluster: Analysis invariant tests (#1533, #1537, #1496).
 
 ## Operating decisions
 

--- a/crates/tokmd-analysis/tests/analysis_deep_w64.rs
+++ b/crates/tokmd-analysis/tests/analysis_deep_w64.rs
@@ -974,3 +974,52 @@ fn zero_code_export_valid() {
     assert_eq!(d.totals.code, 0);
     assert_eq!(d.totals.files, 1);
 }
+
+#[cfg(all(feature = "content", feature = "walk"))]
+#[test]
+fn health_preset_populates_todo_metrics_from_real_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("src/main.rs"),
+        "// TODO: tighten parser\n// FIXME: cover edge case\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let export = ExportData {
+        rows: vec![file_row("src/main.rs", "src", "Rust", 20)],
+        module_roots: vec!["src".to_string()],
+        module_depth: 2,
+        children: ChildIncludeMode::Separate,
+    };
+
+    let mut req = make_req(PresetKind::Health);
+    req.git = Some(false);
+    let mut ctx = make_ctx(export);
+    ctx.root = root;
+
+    let receipt = analyze(ctx, req).expect("analyze should not fail");
+    let derived = receipt.derived.as_ref().unwrap();
+    let todo = derived
+        .todo
+        .as_ref()
+        .expect("health preset should populate TODO metrics");
+
+    assert_eq!(todo.total, 2);
+    assert_eq!(todo.density_per_kloc, 100.0);
+    assert_eq!(
+        todo.tags
+            .iter()
+            .find(|row| row.tag == "TODO")
+            .map(|row| row.count),
+        Some(1)
+    );
+    assert_eq!(
+        todo.tags
+            .iter()
+            .find(|row| row.tag == "FIXME")
+            .map(|row| row.count),
+        Some(1)
+    );
+}


### PR DESCRIPTION
## Summary
- add a Health-preset analyzer test that scans a real temp file through the content+walk pipeline
- assert exact TODO/FIXME counts and density in `derived.todo`
- record the #1577 cockpit property merge in the drain log

## Validation
- `cargo test -p tokmd-analysis --features content,walk --test analysis_deep_w64 health_preset_populates_todo_metrics_from_real_files`
- `cargo test -p tokmd-analysis --features content,walk --test analysis_deep_w64`
- `cargo test -p tokmd-analysis`
- `cargo test -p tokmd-analysis --all-features --test analysis_deep_w64 health_preset_populates_todo_metrics_from_real_files`
- `cargo test -p tokmd-analysis --all-features --test enricher_pipeline empty_export_has_complete_status`
- `cargo fmt-check`
- `git diff --check`

Note: probing the nonstandard partial feature set `--features content,walk` for the full `tokmd-analysis` crate currently hits an unrelated existing failure in `enricher_pipeline::empty_export_has_complete_status`; the same status test passes under `--all-features`, and this PR only changes `analysis_deep_w64.rs` plus `PR_DRAIN.md`.

Supersedes #1537. #1533 and #1496 were reviewed as duplicate/broader weaker proof candidates for this cluster.