### PR TITLE
docs: document snapshot testing workflow

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -31,7 +31,9 @@
 - Closed #1464 as superseded by #1577.
 - Merged #1578: synthesized keeper for analysis Health TODO pipeline coverage. Added a content+walk analyzer test with a real temp file and exact TODO/FIXME count and density assertions. Gates: `cargo test -p tokmd-analysis --features content,walk --test analysis_deep_w64 health_preset_populates_todo_metrics_from_real_files`; `cargo test -p tokmd-analysis --features content,walk --test analysis_deep_w64`; `cargo test -p tokmd-analysis`; `cargo test -p tokmd-analysis --all-features --test analysis_deep_w64 health_preset_populates_todo_metrics_from_real_files`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1537 as superseded by #1578; closed #1533/#1496 as duplicate or weaker analysis-proof coverage.
-- Next cluster: Snapshot harness/docs (#1459, #1461, #1460, #1462).
+- Merged #1579: synthesized keeper for CLI snapshot harness cleanup. Replaced repeated command boilerplate with a shared helper that preserves command-aware stderr failure output and shared normalized snapshot assertions. Gates: `cargo test -p tokmd --test cli_snapshot_golden --verbose`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1459/#1461 as superseded by #1579.
+- Next cluster: Snapshot harness/docs (#1460, #1462).
 
 ## Operating decisions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -115,6 +115,38 @@ Snapshots normalize non-deterministic values:
 
 Snapshot files: `<crate>/tests/snapshots/*.snap`
 
+### Snapshot Authoring Guidelines
+
+When adding or updating snapshot tests:
+
+- Prefer structured JSON snapshots for structured output so field ordering and diffs stay readable.
+- Normalize dynamic values before asserting snapshots, including timestamps, versions, absolute paths, and temp directories.
+- Keep snapshot names stable and descriptive, such as `<surface>_<scenario>`.
+- Keep failures localized and reviewable. One scenario per test is the default; table-driven helpers are fine when each case has a stable snapshot name and a clear failing command or scenario.
+- Use inline snapshots only for very small outputs; prefer `.snap` files for larger outputs.
+
+Recommended helper patterns:
+
+- Normalization helpers for JSON, Markdown, SVG, and HTML snapshots with dynamic fields.
+- Command helpers that include the invoked CLI arguments and stderr in failure messages.
+- Path redaction helpers that convert platform-specific or temp paths to stable placeholders.
+
+### Snapshot Review Workflow
+
+Use this workflow to reduce accidental snapshot churn:
+
+```bash
+cargo test -p <crate> <snapshot_test_name> --verbose
+cargo insta test -p <crate>
+cargo insta review
+```
+
+Guidance:
+
+- Review each hunk for semantic intent, not just textual differences.
+- If a change is intentional, accept only the relevant snapshots.
+- If a diff is unexpected, fix normalization or logic and rerun tests.
+
 ## Property-Based Tests
 
 The workspace pins `proptest` 1.11.0. Property suites cover active workspace


### PR DESCRIPTION
## Summary
- add current snapshot authoring guidance to `docs/testing.md`
- document normalization, stable names, command-aware helpers, and review workflow
- allow table-driven helpers when snapshot names remain stable and failures stay localized
- record the #1579 CLI snapshot harness merge in the drain log

## Validation
- `cargo xtask docs --check`
- `cargo insta test -p tokmd --help`
- `git diff --check`

Supersedes #1460.