### PR TITLE
test(model): cover mutation boundary helpers

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -35,7 +35,9 @@
 - Closed #1459/#1461 as superseded by #1579.
 - Merged #1580: synthesized keeper for snapshot testing docs. Added current authoring and review workflow guidance while allowing table-driven helpers when snapshot names stay stable and failures remain localized. Gates: `cargo xtask docs --check`; `cargo insta test -p tokmd --help`; `git diff --check`; GitHub CI.
 - Closed #1460 as superseded by #1580.
-- Next cluster: Snapshot harness/docs (#1462).
+- Merged #1582: synthesized keeper for analysis-explain snapshot helper cleanup. Table-drove lookup snapshot checks while preserving the existing per-metric snapshot names. Gates: `cargo test -p tokmd snapshot_lookup_metrics --verbose`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1462 as superseded by #1582.
+- Next cluster: Mutation/unit coverage (#1165, #1519, #1535).
 
 ## Operating decisions
 

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -1114,6 +1114,23 @@ mod tests {
     }
 
     #[test]
+    fn avg_handles_boundaries_and_rounding() {
+        assert_eq!(avg(100, 0), 0);
+        assert_eq!(avg(10, 2), 5);
+        assert_eq!(avg(9, 3), 3);
+        assert_eq!(avg(10, 3), 3);
+        assert_eq!(avg(11, 3), 4);
+    }
+
+    #[test]
+    fn byte_metrics_use_floor_token_estimate() {
+        assert_eq!(metrics_from_byte_len(0), (0, 0));
+        assert_eq!(metrics_from_byte_len(12), (12, 3));
+        assert_eq!(metrics_from_byte_len(15), (15, 3));
+        assert_eq!(metrics_from_bytes(b"hello world!"), (12, 3));
+    }
+
+    #[test]
     fn test_env_interpreter_token() {
         // Simple case
         assert_eq!(


### PR DESCRIPTION
## Summary
- add focused `tokmd-model` unit coverage for `avg` boundary/rounding behavior
- add focused byte/token metric helper coverage for floor token estimates
- record the prior #1582/#1462 drain disposition

## Validation
- cargo test -p tokmd-model avg_handles_boundaries_and_rounding
- cargo test -p tokmd-model byte_metrics_use_floor_token_estimate
- cargo test -p tokmd-model
- cargo fmt-check
- git diff --check

Synthesizes the useful non-duplicated assertions from #1519 and #1535. #1165 is already covered on current `main`.