### PR TITLE
refactor: share cocomo81 effort calculation

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -41,7 +41,9 @@
 - Closed #1165/#1519/#1535 as superseded or stale after #1583 landed.
 - Merged #1584: synthesized keeper for model row sorting extraction. Shared the row-ordering closures as private helpers, added source-local ordering tests, and avoided expanding the `tokmd-model` public API for tests. Gates: `cargo test -p tokmd-model sort_`; `cargo test -p tokmd-model --test determinism_w66`; `cargo test -p tokmd-model`; `cargo fmt-check`; `cargo clippy -p tokmd-model --all-targets -- -D warnings`; `git diff --check`; GitHub CI.
 - Closed #1513/#1504/#1493/#1453 as superseded by #1584.
-- Next cluster: `tokmd-config` retirement (#1544, #1520, #1532, #1481).
+- Merged #1585: synthesized keeper for `tokmd-config` retirement. Deleted the stale non-workspace compatibility shim, retargeted the interface shard to active owners, and kept the retired dependency name as a boundary guard. Gates: `cargo metadata --format-version 1 --no-deps`; `cargo xtask docs --check`; `cargo xtask version-consistency`; `cargo xtask publish-surface --json`; `cargo fmt-check`; `cargo test -p xtask boundaries --verbose`; `cargo check -p tokmd-settings -p tokmd-core -p tokmd --all-targets`; `cargo test -p tokmd-settings`; `cargo test -p tokmd-types`; `cargo test -p tokmd --lib`; `git diff --check`; `cargo xtask publish-surface --json --verify-publish`; GitHub CI.
+- Closed #1544/#1520/#1532/#1481 as superseded by #1585.
+- Next cluster: COCOMO estimate consolidation (#1429, #1432, #1434, #1436).
 
 ## Operating decisions
 

--- a/crates/tokmd-analysis/src/cocomo81_core.rs
+++ b/crates/tokmd-analysis/src/cocomo81_core.rs
@@ -1,0 +1,22 @@
+pub(crate) const COCOMO81_COEFFICIENTS: (f64, f64, f64, f64) = (2.4, 1.05, 2.5, 0.38);
+
+pub(crate) fn cocomo81_effort_pm(kloc: f64) -> (f64, f64, f64, f64) {
+    if kloc <= 0.0 {
+        return (0.0, 0.0, 0.0, 0.0);
+    }
+
+    let (a, b, c, d) = COCOMO81_COEFFICIENTS;
+    let effort_pm = a * kloc.powf(b);
+    let schedule_months = if effort_pm <= 0.0 {
+        0.0
+    } else {
+        c * effort_pm.powf(d)
+    };
+    let staff = if schedule_months > 0.0 {
+        effort_pm / schedule_months
+    } else {
+        0.0
+    };
+
+    (effort_pm, schedule_months, staff, effort_pm)
+}

--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -11,6 +11,8 @@ use tokmd_format::render_analysis_tree;
 use tokmd_scan::{gini_coefficient, percentile, round_f64, safe_ratio};
 use tokmd_types::{ExportData, FileKind, FileRow};
 
+use crate::cocomo81_core::{COCOMO81_COEFFICIENTS, cocomo81_effort_pm};
+
 const LINES_PER_MINUTE: usize = 20;
 const TOP_N: usize = 10;
 const MIN_DOC_LINES: usize = 50;
@@ -118,14 +120,8 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         None
     } else {
         let kloc = totals.code as f64 / 1000.0;
-        let (a, b, c, d) = (2.4, 1.05, 2.5, 0.38);
-        let effort = a * kloc.powf(b);
-        let duration = c * effort.powf(d);
-        let staff = if duration == 0.0 {
-            0.0
-        } else {
-            effort / duration
-        };
+        let (a, b, c, d) = COCOMO81_COEFFICIENTS;
+        let (effort, duration, staff, _) = cocomo81_effort_pm(kloc);
         Some(CocomoReport {
             mode: "organic".to_string(),
             kloc: round_f64(kloc, 4),

--- a/crates/tokmd-analysis/src/derived/tests/derived_depth_w56.rs
+++ b/crates/tokmd-analysis/src/derived/tests/derived_depth_w56.rs
@@ -1,6 +1,8 @@
 //! Depth tests for derived analytics (COCOMO, density, distribution) (W56).
 
+use crate::cocomo81_core::{COCOMO81_COEFFICIENTS, cocomo81_effort_pm};
 use crate::derived::derive_report;
+use tokmd_scan::round_f64;
 use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
 
 // ───────────────────── helpers ─────────────────────
@@ -137,6 +139,22 @@ fn cocomo_formula_verification() {
     // Allow small rounding difference
     assert!((cocomo.effort_pm - expected_effort).abs() < 0.1);
     assert!((cocomo.duration_months - expected_duration).abs() < 0.1);
+}
+
+#[test]
+fn cocomo_receipt_matches_shared_cocomo81_model() {
+    let export = make_export(vec![make_row("a.rs", "Rust", 12_345, 0, 0)]);
+    let cocomo = derive_report(&export, None).cocomo.unwrap();
+    let kloc = 12.345_f64;
+    let (a, b, c, d) = COCOMO81_COEFFICIENTS;
+    let (effort, duration, staff, _) = cocomo81_effort_pm(kloc);
+
+    assert_eq!(cocomo.mode, "organic");
+    assert_eq!(cocomo.kloc, round_f64(kloc, 4));
+    assert_eq!(cocomo.effort_pm, round_f64(effort, 2));
+    assert_eq!(cocomo.duration_months, round_f64(duration, 2));
+    assert_eq!(cocomo.staff, round_f64(staff, 2));
+    assert_eq!((cocomo.a, cocomo.b, cocomo.c, cocomo.d), (a, b, c, d));
 }
 
 // ───────────────────── doc density ─────────────────────

--- a/crates/tokmd-analysis/src/effort/cocomo81.rs
+++ b/crates/tokmd-analysis/src/effort/cocomo81.rs
@@ -1,28 +1,8 @@
+use crate::cocomo81_core::cocomo81_effort_pm as cocomo81_effort_pm_core;
 use tokmd_analysis_types::EffortResults;
 
-const A: f64 = 2.4;
-const B: f64 = 1.05;
-const C: f64 = 2.5;
-const D: f64 = 0.38;
-
 pub fn cocomo81_effort_pm(kloc: f64) -> (f64, f64, f64, f64) {
-    if kloc <= 0.0 {
-        return (0.0, 0.0, 0.0, 0.0);
-    }
-
-    let effort_pm = A * kloc.powf(B);
-    let schedule_months = if effort_pm <= 0.0 {
-        0.0
-    } else {
-        C * effort_pm.powf(D)
-    };
-    let staff = if schedule_months > 0.0 {
-        effort_pm / schedule_months
-    } else {
-        0.0
-    };
-
-    (effort_pm, schedule_months, staff, effort_pm)
+    cocomo81_effort_pm_core(kloc)
 }
 
 pub fn estimate_with_factors(

--- a/crates/tokmd-analysis/src/lib.rs
+++ b/crates/tokmd-analysis/src/lib.rs
@@ -23,6 +23,7 @@ mod api_surface;
 mod archetype;
 #[cfg(feature = "walk")]
 mod assets;
+mod cocomo81_core;
 #[cfg(all(feature = "content", feature = "walk"))]
 mod complexity;
 #[cfg(feature = "content")]


### PR DESCRIPTION
## Summary
- reuse one always-available private COCOMO'81 core helper when building derived COCOMO receipts and effort estimates
- keep the current organic-mode coefficients and receipt semantics unchanged
- add a regression proving derived receipt values match the shared COCOMO'81 helper after existing rounding
- record #1585 and the `tokmd-config` cluster disposition in `PR_DRAIN.md`

## Cluster disposition
- Does not merge #1429/#1432/#1434 behavior changes that switch COCOMO mode by KLOC; that remains a product/estimation semantics decision.
- Supersedes #1436 with a narrower version that avoids public API expansion and preserves no-default feature boundaries.
- After this lands, #1429/#1432/#1434/#1436 can be closed as superseded or declined by the no-semantics keeper.

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis cocomo_receipt_matches_shared_cocomo81_model --verbose`
- `cargo test -p tokmd-analysis cocomo --verbose`
- `cargo test -p tokmd-analysis`
- `cargo clippy -p tokmd-analysis -- -D warnings`
- `cargo test -p tokmd-analysis --all-features --verbose`
- `cargo test -p tokmd-analysis --no-default-features --verbose`
- `cargo xtask boundaries-check`
- `git diff --check`