### PR TITLE
docs: align roadmap with shipped reality

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -43,7 +43,9 @@
 - Closed #1513/#1504/#1493/#1453 as superseded by #1584.
 - Merged #1585: synthesized keeper for `tokmd-config` retirement. Deleted the stale non-workspace compatibility shim, retargeted the interface shard to active owners, and kept the retired dependency name as a boundary guard. Gates: `cargo metadata --format-version 1 --no-deps`; `cargo xtask docs --check`; `cargo xtask version-consistency`; `cargo xtask publish-surface --json`; `cargo fmt-check`; `cargo test -p xtask boundaries --verbose`; `cargo check -p tokmd-settings -p tokmd-core -p tokmd --all-targets`; `cargo test -p tokmd-settings`; `cargo test -p tokmd-types`; `cargo test -p tokmd --lib`; `git diff --check`; `cargo xtask publish-surface --json --verify-publish`; GitHub CI.
 - Closed #1544/#1520/#1532/#1481 as superseded by #1585.
-- Next cluster: COCOMO estimate consolidation (#1429, #1432, #1434, #1436).
+- Merged #1586: synthesized keeper for COCOMO estimate consolidation. Reused one private COCOMO'81 core helper for derived receipts and effort estimates without switching receipt mode semantics. Gates: `cargo fmt-check`; `cargo test -p tokmd-analysis cocomo_receipt_matches_shared_cocomo81_model --verbose`; `cargo test -p tokmd-analysis cocomo --verbose`; `cargo test -p tokmd-analysis`; `cargo clippy -p tokmd-analysis -- -D warnings`; `cargo test -p tokmd-analysis --all-features --verbose`; `cargo test -p tokmd-analysis --no-default-features --verbose`; `cargo xtask boundaries-check`; `git diff --check`; GitHub CI.
+- Closed #1429/#1432/#1434/#1436 as superseded or declined by #1586; size-based COCOMO mode switching still needs an explicit estimation-semantics decision.
+- Next cluster: shipped v1.10/v1.11 docs reality (#1543, #1526, #1516, #1492, #1501).
 
 ## Operating decisions
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,7 +475,7 @@ UX work is explicitly **incremental and non-breaking**:
 
 - The full in-memory scan path and wasm CI parity work did not fully land in `1.8.0`; that continuation is now the next milestone instead of implicit spillover.
 
-## v1.9.0 — Browser/WASM Productization
+## Completed: v1.9.0 — Browser/WASM Productization
 
 **Goal:** Finish the browser/WASM product surface around the already-landed in-memory execution path and make the supported browser workflow explicit, repeatable, and capability-honest.
 
@@ -506,7 +506,7 @@ UX work is explicitly **incremental and non-breaking**:
 - No browser zipball ingestion as the primary supported path for `v1.9.0`; tree+contents is the supported browser acquisition strategy.
 - No mutation testing or other heavy tooling in-browser.
 
-## v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability
+## Completed: v1.10.0 — CI Control Plane, Trust Hardening, and Proof Stability
 
 **Goal:** Ship the stable release after the Action, path-trust, WASM, publish-surface, and proof-hardening work landed and the release candidate was validated.
 
@@ -519,7 +519,11 @@ UX work is explicitly **incremental and non-breaking**:
 - [x] Determinism and proof coverage for analyze snapshots, run/diff receipts, effort serde, and core CLI behavior.
 - [x] CLI reference docs generated through checked HELP markers.
 
-### Deferred to v1.11.0
+## v1.11.0 — Browser Runtime Polish
+
+**Goal:** Deliver the browser runtime polish deferred from the v1.10 release fence: explicit cache semantics, visible progress, resilient fetch UX, and safe authenticated-fetch boundaries.
+
+### What is planned for v1.11.0
 
 - Browser cache key/invalidation semantics.
 - Browser progress events.
@@ -563,7 +567,7 @@ _Goal: Native integration in CI pipelines and tooling ecosystems._
 _Goal: Native integration with Claude and other MCP-compatible clients._
 
 - **Tool definitions** ✅: `tokmd tools` already emits OpenAI, Anthropic, and JSON Schema definitions for agent/tool consumers.
-- `tokmd serve` — Start MCP server for tool-based interaction
+- **Future server**: `tokmd serve` remains planned for MCP server interaction.
 - Resources: Expose receipts as MCP resources
 - Tools: `scan`, `analyze`, `diff`, `suggest` as MCP tools
 - Streaming: Incremental analysis results

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,21 +1,20 @@
 # NOW / NEXT / LATER
 
-> One-screen operational truth. Updated after the `1.9.0` release.
+> One-screen operational truth. Updated after the `1.10.0` release.
 
 ## NOW (active)
 
-- **Release aftermath is closed**: `1.9.0` is out, the release pipeline proved green end-to-end, and `main` is back to the normal development lane.
+- **Release aftermath is closed**: `1.10.0` is out, the release pipeline proved green end-to-end with the CI control plane, trust hardening, WASM truth, and proof stability work complete. `main` is back to the normal development lane.
 - **Main must stay boring**: keep CI green, keep `--no-default-features` builds honest, and avoid reintroducing release-only branch noise or operator caveats.
-- **Docs and operator surfaces should match reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what actually shipped in `1.9.0`.
+- **Docs and operator surfaces should match reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what actually shipped in `1.10.0`.
 
 ## NEXT (short horizon)
 
-- **WASM-ready continuation**: keep wiring `tokmd-io-port` through scan and walk paths so the in-memory substrate stops being just a seam and becomes a real execution path.
-- **Define the next WASM proof bar**: add explicit wasm CI/parity goals for the next milestone instead of leaving the work implied.
+- **Browser runtime polish (v1.11.0)**: define cache key and invalidation semantics, emit progress events, improve retry and rate-limit UX, and partition authenticated fetch/cache behavior safely.
 - **Low-blast-radius follow-ons**: prefer narrow docs, compat, and workflow fixes that preserve the newly boring release path and the new effort-estimation surfaces.
 
 ## LATER (roadmap)
 
-- **Browser runner**: zipball ingestion + in-browser receipt generation.
+- **Browser runner**: zipball ingestion remains later; in-browser receipt generation shipped in `1.9.0`.
 - **MCP/server mode**: streaming analysis, plugin system, and server surfaces.
 - **AST depth**: higher-resolution syntax/AST integration on a later horizon.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -114,7 +114,7 @@ Analysis provides information, not judgments:
 
 ## Future Direction
 
-*   **MCP Server**: Native integration with Claude and MCP-compatible tools
+*   **MCP Server**: Future server/resource integration with Claude and MCP-compatible tools; `tokmd tools` already covers tool schema generation
 *   **Watch Mode**: Continuous analysis during development
 *   **Plugin System**: WASM-based extensible enrichers
 *   **Smart Suggestions**: Context-aware file recommendations for LLM workflows

--- a/docs/design.md
+++ b/docs/design.md
@@ -28,6 +28,9 @@ Run the scan once. Derive all views (lang, module, export, analysis) from that s
 - Deep analysis is opt-in via presets
 - Feature flags control compilation footprint
 
+### 7. No Green By Omission
+The `capabilities` field explicitly reports which checks were available, unavailable, or skipped. This lets directors distinguish "all checks passed" from "nothing ran" instead of treating unavailable evidence as success.
+
 ## System Context
 
 ### Standalone Mode
@@ -69,7 +72,7 @@ Every JSON receipt includes:
 {
   "schema_version": 2,
   "tool": "tokmd",
-  "tool_version": "1.9.0",
+  "tool_version": "1.10.0",
   "generated_at_ms": 1706886000000,
   "mode": "lang",
   "scan": { ... },
@@ -141,10 +144,10 @@ Respects .gitignore, .tokeignore
 
 ### I/O Port Contract (tokmd-io-port)
 
-Host-abstracted file access for future in-memory and WASM execution:
+Host-abstracted file access for in-memory and WASM execution:
 ```
 ReadFs trait → HostFs (native std::fs)
-             → MemFs (tests / future in-memory substrates)
+             → MemFs (tests / in-memory substrates)
 ```
 
 ## Analysis Architecture

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -342,9 +342,9 @@ pub fn cockpit_workflow(settings: &CockpitSettings) -> Result<CockpitReceipt>;
 - Integration tests: in-memory scan path using `MemFs`
 - Browser smoke tests: worker execution and tree + contents ingestion
 
-Runtime hardening beyond the v1.9.0 browser baseline remains follow-up work:
-cache behavior, progress events, retry/rate-limit UX, and optional authenticated
-fetch.
+Runtime hardening beyond the v1.9.0 browser baseline is tracked below as
+Phase 5c: cache behavior, progress events, retry/rate-limit UX, and optional
+authenticated fetch.
 
 ---
 
@@ -368,12 +368,22 @@ fetch.
 - [x] Add determinism, snapshot, and property-test proof coverage for release-critical paths
 - [x] Clarify Jules provenance policy without blanket-blocking intentional `.jules/**` history
 
-### Follow-Up: v1.11.0 Browser Runtime Polish
+## Phase 5c: Browser Runtime Polish (v1.11.0)
+
+**Goal**: Deliver browser runtime polish for cache semantics, long-running analysis visibility, fetch resilience, and authenticated-fetch boundaries.
+
+### Work Items
 
 - [ ] Define cache key and invalidation semantics
 - [ ] Emit explicit progress events
 - [ ] Improve retry and rate-limit UX
 - [ ] Partition authenticated fetch/cache behavior safely
+
+### Tests
+
+- Unit tests: cache key and invalidation behavior
+- Worker tests: progress event emission during long scans
+- Runner tests: retry/rate-limit and authenticated-cache partition behavior
 
 ---
 
@@ -382,6 +392,8 @@ fetch.
 **Goal**: Native integration with Claude and MCP clients.
 
 ### Server Implementation
+
+`tokmd tools` already ships tool schema generation for agent consumers. This phase is the future server/resource layer on top of that shipped schema surface.
 
 1. **Command**: `tokmd serve`
 2. **Protocol**: MCP (Model Context Protocol)


### PR DESCRIPTION
## Summary
- updates NOW/design/roadmap docs from post-1.9 wording to shipped 1.10 reality
- promotes v1.11 browser runtime polish into an explicit roadmap/implementation-plan section
- documents capability honesty as "No Green By Omission" and keeps MCP server work future while noting shipped `tokmd tools`
- records the prior COCOMO drain progress in `PR_DRAIN.md`

## Cluster disposition
- synthesizes the useful docs corrections from #1492, #1526, #1543, and #1516
- does not merge #1501 as written because `tokmd tools` is shipped, but `tokmd serve` / MCP server resources remain future work
- avoids importing duplicate `.jules/runs/cartographer_roadmap_design` paths from the draft PRs

## Gates
- `cargo xtask docs --check`
- `cargo xtask version-consistency`
- `cargo fmt-check`
- `git diff --check`