### PR TITLE
ci: add advisory coverage telemetry

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,71 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  # Coverage instrumentation owns its own debug/instrumentation flags.
+  RUSTFLAGS: ""
+
+jobs:
+  rust-coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Use larger writable target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: ${{ runner.temp }}/target
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+        env:
+          CI: true
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          fail_ci_if_error: false
+          verbose: true

--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -1,11 +1,5 @@
 ## 2026-05-05 PR drain
 
-## Active cluster
-
-| Cluster | Keeper | Status | Duplicates |
-|---|---:|---|---|
-| Coverage telemetry | TBD | synthesis in progress | #1555/#1556/#1557/#1558/#1569/#1570/#1571/#1572 |
-
 - Merged #1548: dependabot rust minor/patch dependency bump for `jsonschema`, `napi`, `napi-derive`, `tokio`, and `wasm-bindgen-test`. Gates: `cargo check --workspace`; `cargo test --workspace`; `cargo deny --all-features check`; `npm --prefix web/runner test`.
 - Held #1541: external Factory Droid review workflow requires maintainer approval and secret/API-key policy.
 - Merged #1549: synthesized keeper for stale `deny.toml` advisory cleanup. Removed only the obsolete `RUSTSEC-2023-0071` ignore. Gates: `cargo deny --all-features check`; `git diff --check`; GitHub CI.
@@ -53,7 +47,9 @@
 - Closed #1429/#1432/#1434/#1436 as superseded or declined by #1586; size-based COCOMO mode switching still needs an explicit estimation-semantics decision.
 - Merged #1588: synthesized keeper for shipped v1.10/v1.11 docs reality. Updated `NOW.md`, `design.md`, `ROADMAP.md`, `docs/implementation-plan.md`, and `docs/PRODUCT.md` to align shipped v1.10 truth, planned v1.11 browser runtime polish, capability honesty, and the current `tokmd tools` vs future MCP server boundary. Gates: `cargo xtask docs --check`; `cargo xtask version-consistency`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1543/#1526/#1516/#1492 as superseded by #1588; closed #1501 in favor of #1588 because `tokmd tools` is shipped tool-schema generation but `tokmd serve` / MCP server resources remain future work.
-- Next cluster: advisory coverage telemetry (#1555, #1556, #1557, #1558, #1569, #1570, #1571, #1572).
+- Merged #1589: synthesized keeper for advisory coverage telemetry. Added a standalone `Coverage` workflow, LCOV artifact upload, Codecov upload, informational Codecov project/patch statuses, and docs that keep coverage advisory until maintainers intentionally make it a gate. Gates: YAML syntax check with Python; Codecov config validator; `cargo llvm-cov --version`; `cargo xtask docs --check`; `cargo fmt-check`; `git diff --check`; GitHub CI including `Rust coverage` and informational `codecov/patch`.
+- Closed #1555/#1556/#1557/#1558/#1569/#1570/#1571/#1572 as superseded by #1589.
+- Next cluster: proof/fuzz conversion candidates (#1574, #1581).
 
 ## Operating decisions
 

--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -1,5 +1,11 @@
 ## 2026-05-05 PR drain
 
+## Active cluster
+
+| Cluster | Keeper | Status | Duplicates |
+|---|---:|---|---|
+| Coverage telemetry | TBD | synthesis in progress | #1555/#1556/#1557/#1558/#1569/#1570/#1571/#1572 |
+
 - Merged #1548: dependabot rust minor/patch dependency bump for `jsonschema`, `napi`, `napi-derive`, `tokio`, and `wasm-bindgen-test`. Gates: `cargo check --workspace`; `cargo test --workspace`; `cargo deny --all-features check`; `npm --prefix web/runner test`.
 - Held #1541: external Factory Droid review workflow requires maintainer approval and secret/API-key policy.
 - Merged #1549: synthesized keeper for stale `deny.toml` advisory cleanup. Removed only the obsolete `RUSTSEC-2023-0071` ignore. Gates: `cargo deny --all-features check`; `git diff --check`; GitHub CI.
@@ -45,7 +51,9 @@
 - Closed #1544/#1520/#1532/#1481 as superseded by #1585.
 - Merged #1586: synthesized keeper for COCOMO estimate consolidation. Reused one private COCOMO'81 core helper for derived receipts and effort estimates without switching receipt mode semantics. Gates: `cargo fmt-check`; `cargo test -p tokmd-analysis cocomo_receipt_matches_shared_cocomo81_model --verbose`; `cargo test -p tokmd-analysis cocomo --verbose`; `cargo test -p tokmd-analysis`; `cargo clippy -p tokmd-analysis -- -D warnings`; `cargo test -p tokmd-analysis --all-features --verbose`; `cargo test -p tokmd-analysis --no-default-features --verbose`; `cargo xtask boundaries-check`; `git diff --check`; GitHub CI.
 - Closed #1429/#1432/#1434/#1436 as superseded or declined by #1586; size-based COCOMO mode switching still needs an explicit estimation-semantics decision.
-- Next cluster: shipped v1.10/v1.11 docs reality (#1543, #1526, #1516, #1492, #1501).
+- Merged #1588: synthesized keeper for shipped v1.10/v1.11 docs reality. Updated `NOW.md`, `design.md`, `ROADMAP.md`, `docs/implementation-plan.md`, and `docs/PRODUCT.md` to align shipped v1.10 truth, planned v1.11 browser runtime polish, capability honesty, and the current `tokmd tools` vs future MCP server boundary. Gates: `cargo xtask docs --check`; `cargo xtask version-consistency`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1543/#1526/#1516/#1492 as superseded by #1588; closed #1501 in favor of #1588 because `tokmd tools` is shipped tool-schema generation but `tokmd serve` / MCP server resources remain future work.
+- Next cluster: advisory coverage telemetry (#1555, #1556, #1557, #1558, #1569, #1570, #1571, #1572).
 
 ## Operating decisions
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        if_ci_failed: success
+        informational: true
+
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+        if_ci_failed: success
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "fuzz/**"
+  - "xtask/**"
+  - "target/**"
+  - "vendor/**"
+  - ".jules/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -321,6 +321,21 @@ On Windows, `cargo fmt-check` avoids the `cargo fmt --all` workspace argv limit.
 For bloated local `target/debug` directories, use `cargo trim-target --check` to inspect reclaimable space and `cargo trim-target` to trim PDB and incremental artifacts.
 For repeated local rebuilds, `cargo with-sccache test --workspace --all-features` enables an opt-in compiler cache wrapper, and `cargo sccache-stats` reports hit rates. For cache reuse across multiple worktrees, use `cargo xtask sccache --basedir <PATH> -- test --workspace --all-features`.
 
+## Coverage Telemetry
+
+Rust coverage is generated in CI with `cargo-llvm-cov`, uploaded as an LCOV artifact, and reported to Codecov.
+
+Local smoke:
+
+```bash
+cargo llvm-cov clean --workspace
+cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+```
+
+Coverage is advisory telemetry in the first pass. The Codecov project and patch statuses are informational, and the upload step uses `fail_ci_if_error: false`; branch protection should not require coverage until the baseline is stable and maintainers explicitly choose a gate.
+
+Codecov ignores fuzz corpora, `xtask` repo tooling, local build output, vendored code, and `.jules` provenance artifacts. Pair coverage trends with mutation and property testing; line coverage alone is not treated as proof quality.
+
 ### Scheduled Jobs
 
 - Mutation testing: Weekly or on-demand


### PR DESCRIPTION
## Summary
- adds a standalone Rust Coverage workflow using `cargo-llvm-cov` and an uploaded `lcov.info` artifact
- adds Codecov configuration with project and patch statuses explicitly marked informational during baseline collection
- documents coverage as advisory telemetry that should not be branch-protection required until maintainers intentionally turn it into a gate
- records #1588 completion and marks the coverage duplicate cluster in `PR_DRAIN.md`

## Cluster disposition
- synthesized from duplicate coverage PRs #1555/#1556/#1557/#1558/#1569/#1570/#1571/#1572
- keeps the shared useful workflow/config/docs shape, with advisory Codecov status hardening before merge
- excludes fuzz corpora, `xtask` tooling, local build output, vendored code, and `.jules` provenance from Codecov reporting

## Gates
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/coverage.yml').read_text()); yaml.safe_load(pathlib.Path('codecov.yml').read_text()); print('yaml ok')"`
- `curl.exe -sS -X POST --data-binary "@codecov.yml" https://codecov.io/validate`
- `cargo llvm-cov --version`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`