### PR TITLE
test: add owner-crate fuzz-derived proptests

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -49,7 +49,9 @@
 - Closed #1543/#1526/#1516/#1492 as superseded by #1588; closed #1501 in favor of #1588 because `tokmd tools` is shipped tool-schema generation but `tokmd serve` / MCP server resources remain future work.
 - Merged #1589: synthesized keeper for advisory coverage telemetry. Added a standalone `Coverage` workflow, LCOV artifact upload, Codecov upload, informational Codecov project/patch statuses, and docs that keep coverage advisory until maintainers intentionally make it a gate. Gates: YAML syntax check with Python; Codecov config validator; `cargo llvm-cov --version`; `cargo xtask docs --check`; `cargo fmt-check`; `git diff --check`; GitHub CI including `Rust coverage` and informational `codecov/patch`.
 - Closed #1555/#1556/#1557/#1558/#1569/#1570/#1571/#1572 as superseded by #1589.
-- Next cluster: proof/fuzz conversion candidates (#1574, #1581).
+- Merged #1590: synthesized keeper for fuzz-derived deterministic proptests. Moved the useful #1574 scan-args and context-policy invariants into their owner crates while leaving duplicate no-panic wrappers and stale `.jules` run payloads behind. Gates: `cargo test -p tokmd-format scan_args_preserves_redaction_and_ignore_invariants --verbose`; `cargo test -p tokmd-core context_policy_invariants_hold_for_arbitrary_inputs --verbose`; `cargo clippy -p tokmd-format -p tokmd-core --all-targets -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1574 as superseded by #1590.
+- Next cluster: analysis path root boundary invariant (#1581).
 
 ## Operating decisions
 

--- a/crates/tokmd-core/src/context_policy/mod.rs
+++ b/crates/tokmd-core/src/context_policy/mod.rs
@@ -233,6 +233,7 @@ fn classification_name(classification: &FileClassification) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn smart_exclude_reason_detects_lockfiles_and_sourcemaps() {
@@ -260,5 +261,46 @@ mod tests {
         let (policy, reason) = assign_policy(20_000, 16_000, &[FileClassification::Generated]);
         assert_eq!(policy, InclusionPolicy::Skip);
         assert!(reason.unwrap_or_default().contains("generated"));
+    }
+
+    proptest! {
+        #[test]
+        fn context_policy_invariants_hold_for_arbitrary_inputs(
+            path in "\\PC+",
+            tokens in 0usize..1_000_000,
+            lines in 0usize..1_000_000,
+            budget in 0usize..1_000_000,
+        ) {
+            let _ = is_spine_file(path.as_ref());
+
+            if let Some(reason) = smart_exclude_reason(path.as_ref()) {
+                prop_assert!(matches!(reason, "lockfile" | "minified" | "sourcemap"));
+            }
+
+            let classes = classify_file(path.as_ref(), tokens, lines, DEFAULT_DENSE_THRESHOLD);
+            let mut sorted = classes.clone();
+            sorted.sort();
+            sorted.dedup();
+            prop_assert_eq!(&classes, &sorted);
+
+            let cap_default = compute_file_cap(budget, DEFAULT_MAX_FILE_PCT, None);
+            let cap_hard = compute_file_cap(budget, DEFAULT_MAX_FILE_PCT, Some(4_000));
+            prop_assert!(cap_hard <= 4_000 || cap_hard == usize::MAX);
+
+            let (policy, reason) = assign_policy(tokens, cap_default, &classes);
+            match policy {
+                InclusionPolicy::Full => {
+                    prop_assert!(tokens <= cap_default);
+                    prop_assert!(reason.is_none());
+                }
+                InclusionPolicy::HeadTail | InclusionPolicy::Skip => {
+                    if cap_default != usize::MAX {
+                        prop_assert!(tokens > cap_default);
+                        prop_assert!(reason.is_some());
+                    }
+                }
+                InclusionPolicy::Summary => {}
+            }
+        }
     }
 }

--- a/crates/tokmd-format/src/scan_args/mod.rs
+++ b/crates/tokmd-format/src/scan_args/mod.rs
@@ -74,6 +74,7 @@ pub fn scan_args(paths: &[PathBuf], global: &ScanOptions, redact: Option<RedactM
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn normalize_scan_input_strips_repeated_dot_slash() {
@@ -116,5 +117,91 @@ mod tests {
         assert!(args.no_ignore_parent);
         assert!(args.no_ignore_dot);
         assert!(args.no_ignore_vcs);
+    }
+
+    proptest! {
+        #[test]
+        fn scan_args_preserves_redaction_and_ignore_invariants(
+            paths in prop::collection::vec("[a-zA-Z0-9_\\-\\./\\\\]+", 1..10),
+            excluded in prop::collection::vec("[a-zA-Z0-9_\\-\\.*]+", 0..5),
+            redact_mode in prop::sample::select(vec![
+                None,
+                Some(RedactMode::None),
+                Some(RedactMode::Paths),
+                Some(RedactMode::All),
+            ]),
+            hidden in any::<bool>(),
+            no_ignore in any::<bool>(),
+            no_ignore_parent in any::<bool>(),
+            no_ignore_dot in any::<bool>(),
+            no_ignore_vcs in any::<bool>(),
+            treat_doc_strings_as_comments in any::<bool>(),
+        ) {
+            let path_bufs: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
+            let scan_options = ScanOptions {
+                excluded: excluded.clone(),
+                hidden,
+                no_ignore,
+                no_ignore_parent,
+                no_ignore_dot,
+                no_ignore_vcs,
+                treat_doc_strings_as_comments,
+                ..Default::default()
+            };
+
+            let args = scan_args(&path_bufs, &scan_options, redact_mode);
+            let repeat = scan_args(&path_bufs, &scan_options, redact_mode);
+
+            prop_assert_eq!(&args.paths, &repeat.paths);
+            prop_assert_eq!(&args.excluded, &repeat.excluded);
+            prop_assert_eq!(args.excluded_redacted, repeat.excluded_redacted);
+            prop_assert_eq!(args.config, repeat.config);
+            prop_assert_eq!(args.hidden, repeat.hidden);
+            prop_assert_eq!(args.no_ignore, repeat.no_ignore);
+            prop_assert_eq!(args.no_ignore_parent, repeat.no_ignore_parent);
+            prop_assert_eq!(args.no_ignore_dot, repeat.no_ignore_dot);
+            prop_assert_eq!(args.no_ignore_vcs, repeat.no_ignore_vcs);
+            prop_assert_eq!(
+                args.treat_doc_strings_as_comments,
+                repeat.treat_doc_strings_as_comments
+            );
+            prop_assert_eq!(args.paths.len(), paths.len());
+            prop_assert_eq!(args.hidden, hidden);
+            prop_assert_eq!(args.no_ignore, no_ignore);
+            prop_assert_eq!(args.treat_doc_strings_as_comments, treat_doc_strings_as_comments);
+
+            let should_redact = matches!(redact_mode, Some(RedactMode::Paths | RedactMode::All));
+            prop_assert_eq!(args.excluded_redacted, should_redact && !excluded.is_empty());
+
+            if should_redact {
+                prop_assert_eq!(args.excluded.len(), excluded.len());
+                for value in &args.excluded {
+                    prop_assert_eq!(value.len(), 16);
+                    prop_assert!(value.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+                }
+                for path in &args.paths {
+                    prop_assert!(!path.contains('/'));
+                    prop_assert!(!path.contains('\\'));
+                }
+            } else {
+                let expected_paths: Vec<String> =
+                    path_bufs.iter().map(|p| normalize_scan_input(p)).collect();
+                prop_assert_eq!(&args.paths, &expected_paths);
+                prop_assert_eq!(&args.excluded, &excluded);
+                for path in &args.paths {
+                    prop_assert!(!path.contains('\\'));
+                }
+            }
+
+            if no_ignore {
+                prop_assert!(args.no_ignore_parent);
+                prop_assert!(args.no_ignore_dot);
+                prop_assert!(args.no_ignore_vcs);
+            } else {
+                prop_assert_eq!(args.no_ignore_parent, no_ignore_parent);
+                prop_assert_eq!(args.no_ignore_dot, no_ignore_dot);
+                prop_assert_eq!(args.no_ignore_vcs, no_ignore_vcs);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- synthesize the useful fuzz-derived invariants from #1574 into their owner crates
- add property coverage for scan argument redaction/ignore flag determinism in `tokmd-format`
- add property coverage for context policy classification/cap invariants in `tokmd-core`

## Cluster disposition
- Supersedes #1574 once merged.
- Drops stale `.jules` run payloads and low-signal duplicate fuzz wrappers from the draft branch.
- Keeps the generated branch's high-signal contract checks without adding CLI-level private-module test coupling.

## Validation
- `cargo test -p tokmd-format scan_args_preserves_redaction_and_ignore_invariants --verbose`
- `cargo test -p tokmd-core context_policy_invariants_hold_for_arbitrary_inputs --verbose`
- `cargo clippy -p tokmd-format -p tokmd-core --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`