### PR TITLE
fix: detect root test path directories

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -51,7 +51,9 @@
 - Closed #1555/#1556/#1557/#1558/#1569/#1570/#1571/#1572 as superseded by #1589.
 - Merged #1590: synthesized keeper for fuzz-derived deterministic proptests. Moved the useful #1574 scan-args and context-policy invariants into their owner crates while leaving duplicate no-panic wrappers and stale `.jules` run payloads behind. Gates: `cargo test -p tokmd-format scan_args_preserves_redaction_and_ignore_invariants --verbose`; `cargo test -p tokmd-core context_policy_invariants_hold_for_arbitrary_inputs --verbose`; `cargo clippy -p tokmd-format -p tokmd-core --all-targets -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1574 as superseded by #1590.
-- Next cluster: analysis path root boundary invariant (#1581).
+- Merged #1591: synthesized keeper for analysis test-path root boundary classification. Detects root `test`, `tests`, `spec`, and `specs` directories as path segments and adds case-insensitive root-directory property coverage while preserving existing `__tests__` behavior. Gates: `cargo test -p tokmd-analysis-types is_test_path_known_root_dirs_always_detected --verbose`; `cargo test -p tokmd-analysis-types is_test_path --verbose`; `cargo test -p tokmd-analysis-types --verbose`; `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
+- Closed #1581 as superseded by #1591.
+- Next cluster: doctests/executable docs (#1528/#1563/#1529).
 
 ## Operating decisions
 

--- a/crates/tokmd-analysis-types/src/util.rs
+++ b/crates/tokmd-analysis-types/src/util.rs
@@ -44,10 +44,11 @@ pub fn path_depth(path: &str) -> usize {
 
 pub fn is_test_path(path: &str) -> bool {
     let lower = path.to_lowercase();
-    if lower.contains("/test/") || lower.contains("/tests/") || lower.contains("__tests__") {
-        return true;
-    }
-    if lower.contains("/spec/") || lower.contains("/specs/") {
+    if lower
+        .split('/')
+        .any(|segment| matches!(segment, "test" | "tests" | "spec" | "specs"))
+        || lower.contains("__tests__")
+    {
         return true;
     }
     let name = lower.rsplit('/').next().unwrap_or(&lower);

--- a/crates/tokmd-analysis-types/src/util/tests/properties.rs
+++ b/crates/tokmd-analysis-types/src/util/tests/properties.rs
@@ -123,6 +123,17 @@ proptest! {
     }
 
     #[test]
+    fn is_test_path_known_root_dirs_always_detected(
+        dir in prop::sample::select(vec!["test", "tests", "__tests__", "spec", "specs"]),
+        file in "[a-zA-Z][a-zA-Z0-9_]*\\.(rs|ts|js|py)"
+    ) {
+        let lower_path = format!("{}/{}", dir, file);
+        let upper_path = format!("{}/{}", dir.to_uppercase(), file);
+        prop_assert!(is_test_path(&lower_path), "Should detect root dir: {}", lower_path);
+        prop_assert!(is_test_path(&upper_path), "Should detect uppercase root dir: {}", upper_path);
+    }
+
+    #[test]
     fn is_test_path_known_file_patterns_always_detected(
         pattern in prop::sample::select(vec![
             "foo_test.rs", "test_foo.rs", "foo.test.js", "foo.spec.ts", "bar_test.rs"


### PR DESCRIPTION
## Summary
- synthesize the useful #1581 root-directory test path fix on current main
- detect `test`, `tests`, `spec`, and `specs` as real path segments, including repository-root directories
- add a property that covers lowercase and uppercase root test/spec directories

## Cluster disposition
- Supersedes #1581 once merged.
- Does not copy stale run payloads from the generated draft branch.
- Fixes the draft's generated rejection-property weakness by avoiding a brittle non-test root property and proving the positive boundary directly.

## Validation
- `cargo test -p tokmd-analysis-types is_test_path_known_root_dirs_always_detected --verbose`
- `cargo test -p tokmd-analysis-types is_test_path --verbose`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`