### PR TITLE
docs: add executable handoff and config examples

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -53,7 +53,9 @@
 - Closed #1574 as superseded by #1590.
 - Merged #1591: synthesized keeper for analysis test-path root boundary classification. Detects root `test`, `tests`, `spec`, and `specs` directories as path segments and adds case-insensitive root-directory property coverage while preserving existing `__tests__` behavior. Gates: `cargo test -p tokmd-analysis-types is_test_path_known_root_dirs_always_detected --verbose`; `cargo test -p tokmd-analysis-types is_test_path --verbose`; `cargo test -p tokmd-analysis-types --verbose`; `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`; `cargo fmt-check`; `git diff --check`; GitHub CI.
 - Closed #1581 as superseded by #1591.
-- Next cluster: doctests/executable docs (#1528/#1563/#1529).
+- Merged #1592: synthesized keeper for executable docs and handoff example drift. Aligned the handoff reference example with the shipped `128k` default, added executable handoff recipe coverage, and salvaged focused config/core doctests from the draft librarian PRs without copying stale run payloads or root scratch files. Gates: `cargo test -p tokmd --test docs recipe_handoff --verbose`; `cargo test -p tokmd --doc`; `cargo test -p tokmd-core --doc --all-features`; `cargo xtask docs --check`; `cargo fmt-check`; `cargo clippy -p tokmd -p tokmd-core --all-targets -- -D warnings`; `git diff --check`; GitHub CI.
+- Closed #1528/#1563/#1529 as superseded by #1592.
+- Next cluster: unknown subcommand UX (#1545/#1536/#1538/#1522/#1506/#1204/#1143).
 
 ## Operating decisions
 

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -107,6 +107,26 @@ fn now_ms() -> u128 {
 /// # Returns
 ///
 /// A `LangReceipt` containing the language summary.
+///
+/// # Example
+///
+/// ```rust
+/// use std::fs;
+///
+/// use tokmd_core::{
+///     lang_workflow,
+///     settings::{LangSettings, ScanSettings},
+/// };
+///
+/// let tmp = tempfile::tempdir().expect("tempdir");
+/// fs::write(tmp.path().join("main.rs"), "fn main() {}").expect("write fixture");
+///
+/// let scan = ScanSettings::for_paths(vec![tmp.path().to_string_lossy().into_owned()]);
+/// let lang = LangSettings::default();
+///
+/// let receipt = lang_workflow(&scan, &lang).expect("language scan");
+/// assert_eq!(receipt.report.rows.len(), 1);
+/// ```
 pub fn lang_workflow(scan: &ScanSettings, lang: &LangSettings) -> Result<LangReceipt> {
     let scan_opts = settings_to_scan_options(scan);
     let paths = scan_paths_or_current_dir(scan);

--- a/crates/tokmd/src/config.rs
+++ b/crates/tokmd/src/config.rs
@@ -121,6 +121,18 @@ fn load_json_config() -> Option<UserConfig> {
 }
 
 /// Get the profile name from CLI arg, env var, or default.
+///
+/// # Examples
+///
+/// ```
+/// use tokmd::config::get_profile_name;
+///
+/// let cli_profile = "  ci-profile  ".to_string();
+/// assert_eq!(
+///     get_profile_name(Some(&cli_profile)).as_deref(),
+///     Some("ci-profile")
+/// );
+/// ```
 pub fn get_profile_name(cli_profile: Option<&String>) -> Option<String> {
     // CLI argument takes precedence
     if let Some(name) = cli_profile
@@ -136,6 +148,30 @@ pub fn get_profile_name(cli_profile: Option<&String>) -> Option<String> {
 }
 
 /// Resolve a JSON profile by name (legacy).
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::BTreeMap;
+///
+/// use tokmd::config::resolve_profile;
+/// use tokmd_settings::{Profile, UserConfig};
+///
+/// let mut profiles = BTreeMap::new();
+/// let profile = Profile {
+///     top: Some(10),
+///     ..Default::default()
+/// };
+/// profiles.insert("default".to_string(), profile);
+///
+/// let config = Some(UserConfig {
+///     profiles,
+///     repos: BTreeMap::new(),
+/// });
+///
+/// let resolved = resolve_profile(&config, None).expect("default profile");
+/// assert_eq!(resolved.top, Some(10));
+/// ```
 pub fn resolve_profile<'a>(
     config: &'a Option<UserConfig>,
     name: Option<&String>,

--- a/crates/tokmd/tests/docs.rs
+++ b/crates/tokmd/tests/docs.rs
@@ -426,13 +426,57 @@ fn recipe_generate_baseline() {
 
 #[test]
 fn recipe_handoff_bundle() {
-    // "tokmd handoff --out-dir .handoff"
+    // "tokmd handoff"
     let tmp = tempfile::tempdir().unwrap();
     let handoff_dir = tmp.path().join(".handoff");
     tokmd()
+        .current_dir(tmp.path())
+        .arg("handoff")
+        .assert()
+        .success();
+    assert!(handoff_dir.exists());
+    assert!(handoff_dir.join("manifest.json").exists());
+
+    // "tokmd handoff --out-dir ./artifacts/handoff"
+    let out_dir = tmp.path().join("artifacts").join("handoff");
+    tokmd()
+        .current_dir(tmp.path())
         .arg("handoff")
         .arg("--out-dir")
-        .arg(&handoff_dir)
+        .arg("./artifacts/handoff")
+        .assert()
+        .success();
+    assert!(out_dir.exists());
+    assert!(out_dir.join("manifest.json").exists());
+}
+
+#[test]
+fn recipe_handoff_budget_spread() {
+    // "tokmd handoff --budget 128k --strategy spread"
+    let tmp = tempfile::tempdir().unwrap();
+    let handoff_dir = tmp.path().join(".handoff");
+    tokmd()
+        .current_dir(tmp.path())
+        .arg("handoff")
+        .arg("--budget")
+        .arg("128k")
+        .arg("--strategy")
+        .arg("spread")
+        .assert()
+        .success();
+    assert!(handoff_dir.exists());
+    assert!(handoff_dir.join("manifest.json").exists());
+}
+
+#[test]
+fn recipe_handoff_no_git() {
+    // "tokmd handoff --no-git"
+    let tmp = tempfile::tempdir().unwrap();
+    let handoff_dir = tmp.path().join(".handoff");
+    tokmd()
+        .current_dir(tmp.path())
+        .arg("handoff")
+        .arg("--no-git")
         .assert()
         .success();
     assert!(handoff_dir.exists());

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -1071,8 +1071,8 @@ tokmd handoff
 # Custom output directory
 tokmd handoff --out-dir ./artifacts/handoff
 
-# Smaller budget and spread strategy
-tokmd handoff --budget 64k --strategy spread
+# Control token budget and strategy
+tokmd handoff --budget 128k --strategy spread
 
 # Disable git enrichment
 tokmd handoff --no-git


### PR DESCRIPTION
## Summary
- synthesize the executable-docs cluster from #1528/#1563/#1529 with #1529 as the spine
- align the handoff reference example with the shipped `128k` default and add executable handoff recipe coverage
- add focused config resolution doctests and a fixture-backed `tokmd-core::lang_workflow` doctest

## Cluster disposition
- Supersedes #1528/#1563/#1529 once merged.
- Keeps #1529's handoff docs/test fix, salvages #1563's useful config examples against current sanitization behavior, and only keeps #1528's still-missing `lang_workflow` doctest.
- Drops stale generated `.jules` run payloads, root scratch cleanup/deletions, and broad generated-reference churn.

## Validation
- `cargo test -p tokmd --test docs recipe_handoff --verbose`
- `cargo test -p tokmd --doc`
- `cargo test -p tokmd-core --doc --all-features`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo clippy -p tokmd -p tokmd-core --all-targets -- -D warnings`
- `git diff --check`