### PR TITLE
fix: clarify unknown subcommand errors

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -55,7 +55,9 @@
 - Closed #1581 as superseded by #1591.
 - Merged #1592: synthesized keeper for executable docs and handoff example drift. Aligned the handoff reference example with the shipped `128k` default, added executable handoff recipe coverage, and salvaged focused config/core doctests from the draft librarian PRs without copying stale run payloads or root scratch files. Gates: `cargo test -p tokmd --test docs recipe_handoff --verbose`; `cargo test -p tokmd --doc`; `cargo test -p tokmd-core --doc --all-features`; `cargo xtask docs --check`; `cargo fmt-check`; `cargo clippy -p tokmd -p tokmd-core --all-targets -- -D warnings`; `git diff --check`; GitHub CI.
 - Closed #1528/#1563/#1529 as superseded by #1592.
-- Next cluster: unknown subcommand UX (#1545/#1536/#1538/#1522/#1506/#1204/#1143).
+- Merged #1593: synthesized keeper for unknown subcommand UX. Rewrites bare missing-path fallback errors as `Unrecognized subcommand` while preserving path-shaped missing path errors and implicit `tokmd <existing-path>` language-summary behavior. Gates: `cargo test -p tokmd error_hints --lib --verbose`; `cargo test -p tokmd --test cli_error_paths_w51 unknown_subcommand_fails --verbose`; `cargo test -p tokmd --test cli_error_paths_w51 typo_subcommand_suggests_correction --verbose`; `cargo test -p tokmd --test cli_e2e_w65 err_typo_subcommand_fails --verbose`; `cargo test -p tokmd --test cli_e2e_w65 frobnicate_unknown_subcommand_has_stable_error_output --verbose`; `cargo test -p tokmd --test cli_e2e_w65 existing_bare_path_keeps_implicit_lang_mode --verbose`; `target\debug\tokmd.exe anolyze`; `target\debug\tokmd.exe frobnicate`; `target\debug\tokmd.exe crates/tokmd --format json`; `cargo fmt-check`; `cargo clippy -p tokmd --all-targets -- -D warnings`; `git diff --check`; GitHub CI.
+- Closed #1545/#1536/#1538/#1522/#1506/#1204/#1143 as superseded or stale after #1593.
+- Next cluster: browser runner `args.scan.inputs` parity (#1534/#1525/#1517/#1515/#1379).
 
 ## Operating decisions
 

--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -1,8 +1,18 @@
 use anyhow::Error;
 
 pub(crate) fn format(err: &Error) -> String {
-    let mut out = format!("Error: {err:#}");
-    let hints = suggestions(err);
+    let mut out = if let Some(token) = missing_path_as_unrecognized_subcommand(err) {
+        format!("Error: Unrecognized subcommand '{token}'")
+    } else {
+        format!("Error: {err:#}")
+    };
+    let mut hints = suggestions(err);
+    if out.starts_with("Error: Unrecognized subcommand ") {
+        hints.retain(|h| {
+            !h.contains("was intended as a subcommand")
+                && !h.contains("was meant to be a subcommand")
+        });
+    }
     if !hints.is_empty() {
         out.push_str("\n\nHints:\n");
         for hint in hints {
@@ -12,6 +22,33 @@ pub(crate) fn format(err: &Error) -> String {
         }
     }
     out
+}
+
+fn missing_path_as_unrecognized_subcommand(err: &Error) -> Option<String> {
+    for entry in err.chain() {
+        let message = entry.to_string();
+        let token = message
+            .strip_prefix("Path not found: ")
+            .or_else(|| message.strip_prefix("Input path does not exist: "));
+
+        if let Some(token) = token {
+            let token = token.trim();
+            if looks_like_bare_subcommand_token(token) {
+                return Some(token.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+fn looks_like_bare_subcommand_token(token: &str) -> bool {
+    !token.is_empty()
+        && !token.starts_with('-')
+        && !token.contains('/')
+        && !token.contains('\\')
+        && !token.contains('.')
+        && !token.contains(':')
 }
 
 fn suggestions(err: &Error) -> Vec<String> {
@@ -256,6 +293,24 @@ mod tests {
                 .iter()
                 .any(|h| h.contains("subcommand, it is not recognized"))
         );
+    }
+
+    #[test]
+    fn format_rewrites_bare_missing_path_as_unrecognized_subcommand() {
+        let err = anyhow!("Path not found: frobnicate");
+        let rendered = format(&err);
+        assert!(rendered.contains("Error: Unrecognized subcommand 'frobnicate'"));
+        assert!(!rendered.contains("Error: Path not found: frobnicate"));
+        assert!(!rendered.contains("was intended as a subcommand"));
+        assert!(rendered.contains("Verify the input path exists and is readable."));
+    }
+
+    #[test]
+    fn format_preserves_path_shaped_missing_path_errors() {
+        let err = anyhow!("Path not found: missing/file.rs");
+        let rendered = format(&err);
+        assert!(rendered.contains("Error: Path not found: missing/file.rs"));
+        assert!(!rendered.contains("Unrecognized subcommand"));
     }
 
     #[test]

--- a/crates/tokmd/tests/cli_e2e_w65.rs
+++ b/crates/tokmd/tests/cli_e2e_w65.rs
@@ -543,7 +543,12 @@ fn err_typo_subcommand_fails() {
         .arg("lnag")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "Error: Unrecognized subcommand 'lnag'",
+        ))
+        .stderr(predicate::str::contains(
+            "Did you mean the subcommand `lang`?",
+        ));
 }
 
 #[test]
@@ -695,13 +700,26 @@ fn frobnicate_unknown_subcommand_has_stable_error_output() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Error: Path not found: frobnicate"),
-        "stderr should include the current path error, got: {stderr}"
+        stderr.contains("Error: Unrecognized subcommand 'frobnicate'"),
+        "stderr should include the unrecognized subcommand error, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Error: Path not found: frobnicate"),
+        "stderr should not report a bare unknown token as only a path error, got: {stderr}"
     );
     assert!(
         stderr.contains("Hints:"),
         "stderr should include the stable hints block, got: {stderr}"
     );
+}
+
+#[test]
+fn existing_bare_path_keeps_implicit_lang_mode() {
+    tokmd_cmd()
+        .arg("src")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -224,7 +224,23 @@ fn unknown_subcommand_fails() {
         .arg("nonexistent-subcommand")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "Error: Unrecognized subcommand 'nonexistent-subcommand'",
+        ));
+}
+
+#[test]
+fn typo_subcommand_suggests_correction() {
+    tokmd_cmd()
+        .arg("anolyze")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Error: Unrecognized subcommand 'anolyze'",
+        ))
+        .stderr(predicate::str::contains(
+            "Did you mean the subcommand `analyze`?",
+        ));
 }
 
 /// Verify that every expected subcommand responds to --help without error.


### PR DESCRIPTION
## Summary

Synthesizes the unknown-subcommand UX cluster (#1545/#1536/#1538/#1522/#1506/#1204/#1143) on current main.

- rewrites bare missing-path fallback errors as `Error: Unrecognized subcommand '<token>'`
- keeps path-shaped missing paths as path errors
- preserves implicit `tokmd <existing-path>` language-summary behavior
- tightens focused CLI assertions without broad duplicate test churn

## Gates

- `cargo test -p tokmd error_hints --lib --verbose`
- `cargo test -p tokmd --test cli_error_paths_w51 unknown_subcommand_fails --verbose`
- `cargo test -p tokmd --test cli_error_paths_w51 typo_subcommand_suggests_correction --verbose`
- `cargo test -p tokmd --test cli_e2e_w65 err_typo_subcommand_fails --verbose`
- `cargo test -p tokmd --test cli_e2e_w65 frobnicate_unknown_subcommand_has_stable_error_output --verbose`
- `cargo test -p tokmd --test cli_e2e_w65 existing_bare_path_keeps_implicit_lang_mode --verbose`
- `target\debug\tokmd.exe anolyze`
- `target\debug\tokmd.exe frobnicate`
- `target\debug\tokmd.exe crates/tokmd --format json`
- `cargo fmt-check`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `git diff --check`