### PR TITLE
fix: accept nested scan inputs in browser runner

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -57,7 +57,9 @@
 - Closed #1528/#1563/#1529 as superseded by #1592.
 - Merged #1593: synthesized keeper for unknown subcommand UX. Rewrites bare missing-path fallback errors as `Unrecognized subcommand` while preserving path-shaped missing path errors and implicit `tokmd <existing-path>` language-summary behavior. Gates: `cargo test -p tokmd error_hints --lib --verbose`; `cargo test -p tokmd --test cli_error_paths_w51 unknown_subcommand_fails --verbose`; `cargo test -p tokmd --test cli_error_paths_w51 typo_subcommand_suggests_correction --verbose`; `cargo test -p tokmd --test cli_e2e_w65 err_typo_subcommand_fails --verbose`; `cargo test -p tokmd --test cli_e2e_w65 frobnicate_unknown_subcommand_has_stable_error_output --verbose`; `cargo test -p tokmd --test cli_e2e_w65 existing_bare_path_keeps_implicit_lang_mode --verbose`; `target\debug\tokmd.exe anolyze`; `target\debug\tokmd.exe frobnicate`; `target\debug\tokmd.exe crates/tokmd --format json`; `cargo fmt-check`; `cargo clippy -p tokmd --all-targets -- -D warnings`; `git diff --check`; GitHub CI.
 - Closed #1545/#1536/#1538/#1522/#1506/#1204/#1143 as superseded or stale after #1593.
-- Next cluster: browser runner `args.scan.inputs` parity (#1534/#1525/#1517/#1515/#1379).
+- Merged #1594: synthesized keeper for browser runner `args.scan.inputs` parity. Accepts in-memory browser payloads from either `args.inputs` or `args.scan.inputs`, rejects duplicate root+nested inputs, keeps `scan` strict to `scan.inputs`, and proves posted-worker handling through the stub runner. Gates: `npm --prefix web/runner test`; `npm --prefix web/runner run check`; `cargo test -p tokmd-wasm`; `git diff --check`; GitHub CI.
+- Closed #1534/#1525/#1517/#1515/#1379 as superseded by #1594.
+- Next cluster: retry/rate-limit UX (#1419/#1421/#1423/#1425) or progress events (#1426/#1428/#1430/#1431).
 
 ## Operating decisions
 

--- a/web/runner/messages.js
+++ b/web/runner/messages.js
@@ -112,18 +112,57 @@ function isAnalyzeOptions(value) {
     );
 }
 
+function isPlainObject(value) {
+    return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function resolveRunInputs(args) {
+    if (!isPlainObject(args)) {
+        return null;
+    }
+
+    const hasRootInputs = args.inputs !== undefined;
+    const hasScan = args.scan !== undefined;
+
+    if (hasScan && !isPlainObject(args.scan)) {
+        return null;
+    }
+
+    const hasScanInputs = hasScan && args.scan.inputs !== undefined;
+
+    if (hasRootInputs && hasScanInputs) {
+        return null;
+    }
+
+    if (hasRootInputs) {
+        return Array.isArray(args.inputs) ? args.inputs : null;
+    }
+
+    if (hasScanInputs) {
+        return Array.isArray(args.scan.inputs) ? args.scan.inputs : null;
+    }
+
+    return null;
+}
+
+function isScanOptions(value) {
+    return value === undefined || (isPlainObject(value) && hasOnlyKeys(value, ["inputs"]));
+}
+
 function isRunArgsForMode(mode, args) {
-    if (!args || typeof args !== "object" || Array.isArray(args)) {
+    if (!isPlainObject(args)) {
         return false;
     }
 
-    if (!Array.isArray(args.inputs) || !args.inputs.every(isInMemoryInput)) {
+    const inputs = resolveRunInputs(args);
+
+    if (!inputs || !inputs.every(isInMemoryInput) || !isScanOptions(args.scan)) {
         return false;
     }
 
     if (mode === "analyze") {
         return Boolean(
-            hasOnlyKeys(args, ["inputs", "preset", "analyze"]) &&
+            hasOnlyKeys(args, ["inputs", "scan", "preset", "analyze"]) &&
                 (args.preset === undefined || typeof args.preset === "string") &&
                 (args.analyze === undefined || isAnalyzeOptions(args.analyze))
         );
@@ -131,12 +170,12 @@ function isRunArgsForMode(mode, args) {
 
     if (mode === "lang") {
         return Boolean(
-            hasOnlyKeys(args, ["inputs", "files"]) &&
+            hasOnlyKeys(args, ["inputs", "scan", "files"]) &&
                 (args.files === undefined || typeof args.files === "boolean")
         );
     }
 
-    return hasOnlyKeys(args, ["inputs"]);
+    return hasOnlyKeys(args, ["inputs", "scan"]);
 }
 
 export function isRunMessage(value) {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -192,6 +192,45 @@ test("run messages require explicit in-memory inputs", () => {
                 },
             },
         }),
+        true
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: {
+                inputs: [{ path: "root.rs", text: "pub fn root() {}\n" }],
+                scan: {
+                    inputs: [{ path: "nested.rs", text: "pub fn nested() {}\n" }],
+                },
+            },
+        }),
+        false
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: {
+                scan: null,
+            },
+        }),
+        false
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "x",
+            mode: "lang",
+            args: {
+                scan: {
+                    inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+                    paths: ["src/lib.rs"],
+                },
+            },
+        }),
         false
     );
     assert.equal(
@@ -235,6 +274,15 @@ test("analyze run messages allow only explicit preset options with inputs", () =
             requestId: "analyze-2",
             mode: "analyze",
             args: { inputs, analyze: { preset: "receipt" } },
+        }),
+        true
+    );
+    assert.equal(
+        isRunMessage({
+            type: "run",
+            requestId: "analyze-scan",
+            mode: "analyze",
+            args: { scan: { inputs }, preset: "estimate" },
         }),
         true
     );

--- a/web/runner/worker.js
+++ b/web/runner/worker.js
@@ -35,39 +35,47 @@ if (
     };
 }
 
+function resolveRunnerInputs(args) {
+    return args.inputs ?? args.scan?.inputs ?? [];
+}
+
 function createStubRunner() {
     const supportedModes = [...SUPPORTED_MODES];
 
     return {
         runLang(args) {
+            const inputs = resolveRunnerInputs(args);
             return {
                 mode: "lang",
                 scan: {
-                    paths: args.inputs.map((input) => input.path),
+                    paths: inputs.map((input) => input.path),
                 },
                 total: {
-                    files: args.inputs.length,
+                    files: inputs.length,
                 },
             };
         },
         runModule(args) {
+            const inputs = resolveRunnerInputs(args);
             return {
                 mode: "module",
-                rows: args.inputs.map((input) => ({ module: input.path })),
+                rows: inputs.map((input) => ({ module: input.path })),
             };
         },
         runExport(args) {
+            const inputs = resolveRunnerInputs(args);
             return {
                 mode: "export",
-                rows: args.inputs.map((input) => ({ path: input.path })),
+                rows: inputs.map((input) => ({ path: input.path })),
             };
         },
         runAnalyze(args) {
+            const inputs = resolveRunnerInputs(args);
             return {
                 mode: "analysis",
                 preset: normalizeAnalyzePreset(args),
                 source: {
-                    inputs: args.inputs.map((input) => input.path),
+                    inputs: inputs.map((input) => input.path),
                 },
             };
         },

--- a/web/runner/worker.test.mjs
+++ b/web/runner/worker.test.mjs
@@ -140,6 +140,39 @@ test("worker publishes ready on boot", async () => {
     }
 });
 
+test("worker forwards nested scan inputs through the stub runner", async () => {
+    const worker = new Worker(new URL("./worker.js", import.meta.url), {
+        type: "module",
+        workerData: {
+            runnerMode: "stub",
+        },
+    });
+
+    try {
+        await onceMessage(worker);
+
+        worker.postMessage({
+            type: "run",
+            requestId: "stub-scan-inputs",
+            mode: "analyze",
+            args: {
+                scan: {
+                    inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+                },
+                preset: "estimate",
+            },
+        });
+
+        const result = await onceMessage(worker);
+        assert.equal(result.type, MESSAGE_TYPES.RESULT);
+        assert.equal(result.requestId, "stub-scan-inputs");
+        assert.equal(result.data.mode, "analysis");
+        assert.deepEqual(result.data.source.inputs, ["src/lib.rs"]);
+    } finally {
+        await worker.terminate();
+    }
+});
+
 test("worker advertises only supported modes from a minimal wasm module", async () => {
     const { worker, cleanup } = createWorkerForMockWasm({
         includeRunLang: true,


### PR DESCRIPTION
## Summary

Synthesizes the browser runner `args.scan.inputs` parity cluster (#1534/#1525/#1517/#1515/#1379) on current main.

- accepts in-memory inputs from either `args.inputs` or `args.scan.inputs`
- rejects root+nested duplicate inputs
- keeps `scan` strict to `scan.inputs` and continues rejecting `paths` with in-memory browser payloads
- updates the worker stub to normalize inputs once for all browser-supported modes
- adds message validation and posted-worker coverage for nested scan inputs

## Gates

- `npm --prefix web/runner test`
- `npm --prefix web/runner run check`
- `cargo test -p tokmd-wasm`
- `git diff --check`