### PR TITLE
Improve retry and rate-limit UX

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -59,7 +59,9 @@
 - Closed #1545/#1536/#1538/#1522/#1506/#1204/#1143 as superseded or stale after #1593.
 - Merged #1594: synthesized keeper for browser runner `args.scan.inputs` parity. Accepts in-memory browser payloads from either `args.inputs` or `args.scan.inputs`, rejects duplicate root+nested inputs, keeps `scan` strict to `scan.inputs`, and proves posted-worker handling through the stub runner. Gates: `npm --prefix web/runner test`; `npm --prefix web/runner run check`; `cargo test -p tokmd-wasm`; `git diff --check`; GitHub CI.
 - Closed #1534/#1525/#1517/#1515/#1379 as superseded by #1594.
-- Next cluster: retry/rate-limit UX (#1419/#1421/#1423/#1425) or progress events (#1426/#1428/#1430/#1431).
+- Merged #1595: synthesized keeper for retry/rate-limit UX. Added CLI hints for upstream rate limits and transient network/service failures, added rate-limit-only retry guidance to FFI envelope formatting, and preserved existing generic timeout/network envelope formatting semantics.
+- Closed #1419/#1421/#1423/#1425 as superseded by #1595.
+- Next cluster: progress events (#1426/#1428/#1430/#1431).
 
 ## Operating decisions
 

--- a/crates/tokmd-envelope/src/ffi.rs
+++ b/crates/tokmd-envelope/src/ffi.rs
@@ -86,11 +86,48 @@ pub fn format_error_message(error_obj: Option<&Value>) -> String {
         .and_then(Value::as_str)
         .unwrap_or("Unknown error");
 
-    if let Some(details) = error_obj.get("details").and_then(Value::as_str) {
+    let mut formatted = if let Some(details) = error_obj.get("details").and_then(Value::as_str) {
         format!("[{code}] {message}: {details}")
     } else {
         format!("[{code}] {message}")
+    };
+
+    if is_rate_limit_code(code) {
+        if let Some(seconds) = retry_after_seconds(error_obj) {
+            formatted.push_str(&format!(
+                " Retry after {seconds}s, then retry with backoff."
+            ));
+        } else if let Some(retry_after) = error_obj.get("retry_after").and_then(Value::as_str) {
+            formatted.push_str(&format!(
+                " Retry after {retry_after}, then retry with backoff."
+            ));
+        } else {
+            formatted.push_str(
+                " Retry after a short delay and reduce request concurrency when possible.",
+            );
+        }
     }
+
+    formatted
+}
+
+fn is_rate_limit_code(code: &str) -> bool {
+    matches!(
+        code,
+        "rate_limit"
+            | "rate_limited"
+            | "rate_limit_exceeded"
+            | "too_many_requests"
+            | "github_primary_rate_limit"
+            | "github_secondary_rate_limit"
+    )
+}
+
+fn retry_after_seconds(error_obj: &serde_json::Map<String, Value>) -> Option<u64> {
+    error_obj
+        .get("retry_after_seconds")
+        .or_else(|| error_obj.get("retryAfterSeconds"))
+        .and_then(Value::as_u64)
 }
 
 /// Extract `data` from an already-parsed envelope.
@@ -238,6 +275,47 @@ mod tests {
         assert_eq!(
             format_error_message(Some(&err)),
             "[invalid_settings] Invalid value for 'from': expected a string: Check the spelling."
+        );
+    }
+
+    #[test]
+    fn format_error_message_adds_rate_limit_guidance_without_retry_after() {
+        let err = json!({
+            "code": "rate_limit",
+            "message": "Too many requests"
+        });
+
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[rate_limit] Too many requests Retry after a short delay and reduce request concurrency when possible."
+        );
+    }
+
+    #[test]
+    fn format_error_message_adds_retry_after_seconds_for_rate_limit() {
+        let err = json!({
+            "code": "too_many_requests",
+            "message": "Quota exceeded",
+            "retry_after_seconds": 42
+        });
+
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[too_many_requests] Quota exceeded Retry after 42s, then retry with backoff."
+        );
+    }
+
+    #[test]
+    fn format_error_message_adds_retry_after_string_for_github_rate_limit() {
+        let err = json!({
+            "code": "github_secondary_rate_limit",
+            "message": "Secondary rate limit",
+            "retry_after": "2026-05-05T16:00:00Z"
+        });
+
+        assert_eq!(
+            format_error_message(Some(&err)),
+            "[github_secondary_rate_limit] Secondary rate limit Retry after 2026-05-05T16:00:00Z, then retry with backoff."
         );
     }
 

--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -74,6 +74,49 @@ fn suggestions(err: &Error) -> Vec<String> {
         push_hint(&mut out, "Initialize git first if needed: `git init`.");
     }
 
+    if haystack.contains("rate limit")
+        || haystack.contains("rate_limit")
+        || haystack.contains("too many requests")
+        || haystack.contains("http 429")
+        || haystack.contains("status 429")
+    {
+        push_hint(
+            &mut out,
+            "The upstream service is limiting requests. Wait briefly, then retry.",
+        );
+        push_hint(
+            &mut out,
+            "Honor provider retry windows such as `Retry-After` when available.",
+        );
+        push_hint(
+            &mut out,
+            "Use a smaller input scope if this command contacts a remote service.",
+        );
+    }
+
+    if haystack.contains("timed out")
+        || haystack.contains("timeout")
+        || haystack.contains("temporary")
+        || haystack.contains("temporarily")
+        || haystack.contains("connection reset")
+        || haystack.contains("connection refused")
+        || haystack.contains("broken pipe")
+        || haystack.contains("dns")
+        || haystack.contains("network error")
+        || haystack.contains("service unavailable")
+        || haystack.contains("http 503")
+        || haystack.contains("status 503")
+    {
+        push_hint(
+            &mut out,
+            "This looks transient. Retry with backoff after network or service health recovers.",
+        );
+        push_hint(
+            &mut out,
+            "Check network, VPN, or proxy settings if retries keep failing.",
+        );
+    }
+
     if haystack.contains("parent traversal")
         || haystack.contains("must be relative")
         || haystack.contains("escapes scan root")
@@ -387,5 +430,22 @@ mod tests {
         let rendered = format(&err);
         assert!(rendered.contains("Error:"));
         assert!(rendered.contains("Hints:"));
+    }
+
+    #[test]
+    fn suggests_for_rate_limit_errors() {
+        let err = anyhow!("GitHub returned HTTP 429 Too Many Requests");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("limiting requests")));
+        assert!(hints.iter().any(|h| h.contains("Retry-After")));
+        assert!(hints.iter().any(|h| h.contains("smaller input scope")));
+    }
+
+    #[test]
+    fn suggests_for_transient_network_errors() {
+        let err = anyhow!("request timed out while contacting remote service");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("looks transient")));
+        assert!(hints.iter().any(|h| h.contains("VPN, or proxy")));
     }
 }


### PR DESCRIPTION
## Summary

- add CLI error hints for upstream rate limits and transient network/service failures
- add rate-limit-only retry guidance to FFI envelope error formatting
- preserve existing timeout/network envelope formatting semantics

Supersedes #1419, #1421, #1423, and #1425.

## Validation

- cargo test -p tokmd error_hints --lib --verbose
- cargo test -p tokmd-envelope format_error_message --verbose
- cargo test -p tokmd-envelope --verbose
- node --test web/runner/ingest.test.mjs
- cargo test -p xtask publish_rate_limit --verbose
- cargo clippy -p tokmd -p tokmd-envelope --all-targets -- -D warnings
- cargo fmt-check
- typos crates/tokmd/src/error_hints.rs crates/tokmd-envelope/src/ffi.rs PR_DRAIN.md
- git diff --check