### PR TITLE
Emit explicit progress events

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -61,7 +61,9 @@
 - Closed #1534/#1525/#1517/#1515/#1379 as superseded by #1594.
 - Merged #1595: synthesized keeper for retry/rate-limit UX. Added CLI hints for upstream rate limits and transient network/service failures, added rate-limit-only retry guidance to FFI envelope formatting, and preserved existing generic timeout/network envelope formatting semantics.
 - Closed #1419/#1421/#1423/#1425 as superseded by #1595.
-- Next cluster: progress events (#1426/#1428/#1430/#1431).
+- Merged #1596: synthesized keeper for progress events. Added opt-in newline-delimited JSON progress events on stderr behind `TOKMD_PROGRESS_EVENTS`, covered `update` and `finish` events across UI and no-UI builds, and documented the CLI grammar while leaving browser worker progress as remaining v1.11 scope. Gates: `cargo test -p tokmd progress --lib --verbose`; `cargo check -p tokmd --no-default-features --all-targets`; `cargo check -p tokmd --all-targets`; `cargo xtask docs --check`; `cargo build -p tokmd`; `TOKMD_PROGRESS_EVENTS=1 target/debug/tokmd run --no-progress --output-dir target/tokmd-progress-smoke crates/tokmd`; `cargo clippy -p tokmd --all-targets -- -D warnings`; `cargo fmt-check`; `typos crates/tokmd/src/progress.rs docs/progress-events.md docs/implementation-plan.md PR_DRAIN.md`; `git diff --check`; GitHub CI.
+- Closed #1426/#1428/#1430/#1431 as superseded by #1596.
+- Next cluster: cockpit PR output (#1399/#1401/#1402/#1400) or WASM ergonomics (#1420/#1422/#1424/#1427).
 
 ## Operating decisions
 

--- a/crates/tokmd/src/progress.rs
+++ b/crates/tokmd/src/progress.rs
@@ -3,6 +3,29 @@
 #[cfg(feature = "ui")]
 use std::io::IsTerminal;
 
+const PROGRESS_EVENT_NAME: &str = "tokmd.progress";
+const PROGRESS_EVENT_SCHEMA_VERSION: u8 = 1;
+
+fn progress_events_enabled() -> bool {
+    std::env::var_os("TOKMD_PROGRESS_EVENTS").is_some()
+}
+
+fn progress_event_json(kind: &str, message: &str) -> String {
+    serde_json::json!({
+        "event": PROGRESS_EVENT_NAME,
+        "schema_version": PROGRESS_EVENT_SCHEMA_VERSION,
+        "kind": kind,
+        "message": message,
+    })
+    .to_string()
+}
+
+fn emit_progress_event(kind: &str, message: &str) {
+    if progress_events_enabled() {
+        eprintln!("{}", progress_event_json(kind, message));
+    }
+}
+
 /// Check if we should show interactive output.
 #[cfg(feature = "ui")]
 fn is_interactive() -> bool {
@@ -24,7 +47,7 @@ fn is_interactive() -> bool {
 
 #[cfg(feature = "ui")]
 mod ui_impl {
-    use super::is_interactive;
+    use super::{emit_progress_event, is_interactive};
     use indicatif::{ProgressBar, ProgressStyle};
     use std::time::{Duration, Instant};
 
@@ -62,13 +85,16 @@ mod ui_impl {
 
         /// Set the progress message.
         pub fn set_message(&self, msg: impl Into<String>) {
+            let msg = msg.into();
+            emit_progress_event("update", &msg);
             if let Some(bar) = &self.bar {
-                bar.set_message(msg.into());
+                bar.set_message(msg);
             }
         }
 
         /// Finish and clear the spinner.
         pub fn finish_and_clear(&self) {
+            emit_progress_event("finish", "done");
             if let Some(bar) = &self.bar {
                 bar.finish_and_clear();
             }
@@ -137,6 +163,7 @@ mod ui_impl {
 
         /// Set the progress message.
         pub fn set_message(&self, msg: &str) {
+            emit_progress_event("update", msg);
             if let Some(bar) = &self.bar {
                 bar.set_message(msg.to_string());
             }
@@ -151,6 +178,7 @@ mod ui_impl {
 
         /// Finish the progress bar with a message.
         pub fn finish_with_message(&self, msg: &str) {
+            emit_progress_event("finish", msg);
             if let Some(bar) = &self.bar {
                 bar.finish_with_message(msg.to_string());
             }
@@ -158,6 +186,7 @@ mod ui_impl {
 
         /// Finish and clear the progress bar.
         pub fn finish_and_clear(&self) {
+            emit_progress_event("finish", "done");
             if let Some(bar) = &self.bar {
                 bar.finish_and_clear();
             }
@@ -181,6 +210,8 @@ mod ui_impl {
 
 #[cfg(not(feature = "ui"))]
 mod ui_impl {
+    use super::emit_progress_event;
+
     /// A no-op progress indicator when the `ui` feature is disabled.
     pub struct Progress;
 
@@ -191,10 +222,15 @@ mod ui_impl {
         }
 
         /// Set the progress message (no-op without `ui` feature).
-        pub fn set_message(&self, _msg: impl Into<String>) {}
+        pub fn set_message(&self, msg: impl Into<String>) {
+            let msg = msg.into();
+            emit_progress_event("update", &msg);
+        }
 
         /// Finish and clear the spinner (no-op without `ui` feature).
-        pub fn finish_and_clear(&self) {}
+        pub fn finish_and_clear(&self) {
+            emit_progress_event("finish", "done");
+        }
     }
 
     /// A no-op progress bar when `ui` feature is disabled.
@@ -218,16 +254,22 @@ mod ui_impl {
         pub fn set_position(&self, _pos: u64) {}
 
         /// Set the progress message (no-op without `ui` feature).
-        pub fn set_message(&self, _msg: &str) {}
+        pub fn set_message(&self, msg: &str) {
+            emit_progress_event("update", msg);
+        }
 
         /// Update the total length (no-op without `ui` feature).
         pub fn set_length(&self, _len: u64) {}
 
         /// Finish the progress bar (no-op without `ui` feature).
-        pub fn finish_with_message(&self, _msg: &str) {}
+        pub fn finish_with_message(&self, msg: &str) {
+            emit_progress_event("finish", msg);
+        }
 
         /// Finish and clear the progress bar (no-op without `ui` feature).
-        pub fn finish_and_clear(&self) {}
+        pub fn finish_and_clear(&self) {
+            emit_progress_event("finish", "done");
+        }
     }
 }
 
@@ -256,5 +298,23 @@ mod tests {
         progress.set_length(20);
         progress.finish_with_message("done");
         progress.finish_and_clear();
+    }
+
+    #[test]
+    fn progress_event_json_is_stable_and_parseable() {
+        let line = progress_event_json("update", "Scanning codebase...");
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["event"], "tokmd.progress");
+        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["kind"], "update");
+        assert_eq!(parsed["message"], "Scanning codebase...");
+    }
+
+    #[test]
+    fn progress_event_json_escapes_control_characters() {
+        let line = progress_event_json("update", "line one\nline two");
+        assert!(!line.contains('\n'));
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["message"], "line one\nline two");
     }
 }

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -375,7 +375,8 @@ authenticated fetch.
 ### Work Items
 
 - [ ] Define cache key and invalidation semantics
-- [ ] Emit explicit progress events
+- [ ] Emit explicit progress events (CLI grammar documented in
+      `docs/progress-events.md`; browser worker progress remains in scope)
 - [ ] Improve retry and rate-limit UX
 - [ ] Partition authenticated fetch/cache behavior safely
 

--- a/docs/progress-events.md
+++ b/docs/progress-events.md
@@ -1,0 +1,34 @@
+# Progress Events
+
+`tokmd` keeps normal command output on stdout. Progress output is stderr-only.
+
+When `TOKMD_PROGRESS_EVENTS` is set, the CLI progress helper emits one
+newline-delimited JSON object per progress event to stderr. For machine
+readers, combine it with `--no-progress` to suppress spinner output while
+keeping explicit events enabled.
+
+## Grammar
+
+Each event is a single JSON object:
+
+```json
+{"event":"tokmd.progress","schema_version":1,"kind":"update","message":"Scanning codebase..."}
+```
+
+Fields:
+
+- `event`: always `tokmd.progress`.
+- `schema_version`: progress event grammar version, currently `1`.
+- `kind`: event phase. Current values are `update` and `finish`.
+- `message`: human-readable progress message from the active command.
+
+Events are informational. They do not change command stdout, receipt schemas, or
+exit-code policy.
+
+## Example
+
+```console
+$ TOKMD_PROGRESS_EVENTS=1 tokmd run --no-progress --output-dir target/tokmd
+{"event":"tokmd.progress","schema_version":1,"kind":"update","message":"Scanning codebase..."}
+{"event":"tokmd.progress","schema_version":1,"kind":"finish","message":"done"}
+```


### PR DESCRIPTION
## Summary

- add opt-in newline-delimited JSON progress events on stderr behind TOKMD_PROGRESS_EVENTS
- emit update and finish events from the shared CLI progress helpers, including no-default-features/no-ui builds
- document the progress event grammar and keep browser worker progress listed as remaining v1.11 scope

Supersedes #1426, #1428, #1430, and #1431.

## Validation

- cargo test -p tokmd progress --lib --verbose
- cargo check -p tokmd --no-default-features --all-targets
- cargo check -p tokmd --all-targets
- cargo xtask docs --check
- cargo build -p tokmd
- TOKMD_PROGRESS_EVENTS=1 target/debug/tokmd run --no-progress --output-dir target/tokmd-progress-smoke crates/tokmd
- cargo clippy -p tokmd --all-targets -- -D warnings
- cargo fmt-check
- typos crates/tokmd/src/progress.rs docs/progress-events.md docs/implementation-plan.md PR_DRAIN.md
- git diff --check