### PR TITLE
test: tighten schema drift checks

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -77,7 +77,9 @@
 - Closed #1387/#1388/#1389/#1390/#1467/#1468/#1469 as superseded by #1602.
 - Merged #1603: synthesized docs-only keeper for the missing global `--profile <PROFILE>` reference. Added the shipped `--profile` flag and visible `--view` alias to the handwritten global arguments table without carrying draft run-packet churn. Gates: `cargo xtask docs --check`; `typos docs/reference-cli.md`; `git diff --check`; GitHub CI.
 - Closed #1576 as superseded by #1603.
-- Next cluster after #1603: choose the next proof/docs/control-plane cluster from the remaining open queue after refreshing `origin/main`.
+- Merged #1604: synthesized keeper for schema docs drift checks. Corrected the ecosystem envelope constant names in `docs/SCHEMA.md`, added the missing W43 `CONTEXT_BUNDLE_SCHEMA_VERSION` check, and covered `BASELINE_VERSION` across `docs/SCHEMA.md` and `docs/baseline.schema.json`. Gates: `cargo test -p xtask schema_md_ --verbose`; `cargo test -p xtask baseline_schema_json_version_matches_source --verbose`; `cargo fmt-check`; `cargo xtask docs --check`; `typos docs/SCHEMA.md xtask/tests/docs_w43.rs xtask/tests/docs_schema_w72.rs`; `git diff --check`; GitHub CI.
+- Closed #1518/#1494/#1508 as superseded by #1604.
+- Next cluster after #1604: choose the next proof/docs/control-plane cluster from the remaining open queue after refreshing `origin/main`.
 
 ## Operating decisions
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -94,10 +94,10 @@ tokmd uses **separate schema versions** for different receipt families. Each rec
 
 ### Canonical vs Backward Compatibility
 
-The `tokmd-analysis-types` crate provides `ENVELOPE_SCHEMA_VERSION` as a **backward compatibility alias** for the sensor report schema. The canonical constant is now `tokmd-envelope::SENSOR_REPORT_SCHEMA_VERSION`.
+The `tokmd-analysis-types` crate provides `ENVELOPE_SCHEMA` as a **backward compatibility alias** for the sensor report schema. The canonical constant is now `tokmd-envelope::SENSOR_REPORT_SCHEMA`.
 
-**New code should use**: `tokmd-envelope::SENSOR_REPORT_SCHEMA_VERSION` (canonical)
-**Legacy code continues to use**: `tokmd-analysis-types::ENVELOPE_SCHEMA_VERSION` (alias)
+**New code should use**: `tokmd-envelope::SENSOR_REPORT_SCHEMA` (canonical)
+**Legacy code continues to use**: `tokmd-analysis-types::ENVELOPE_SCHEMA` (alias)
 
 This alias is maintained for compatibility with existing code that imports from `tokmd-analysis-types`.
 

--- a/xtask/tests/docs_schema_w72.rs
+++ b/xtask/tests/docs_schema_w72.rs
@@ -226,6 +226,18 @@ fn schema_md_context_bundle_version_matches_source() {
     );
 }
 
+#[test]
+fn schema_md_baseline_version_matches_source() {
+    let src = read_const_u32("crates/tokmd-analysis-types/src/lib.rs", "BASELINE_VERSION")
+        .expect("BASELINE_VERSION not found in source");
+    let doc = schema_md_version(&schema_md(), "`BASELINE_VERSION`")
+        .expect("BASELINE_VERSION not found in SCHEMA.md");
+    assert_eq!(
+        src, doc,
+        "BASELINE_VERSION: source={src} != SCHEMA.md={doc}"
+    );
+}
+
 // ===========================================================================
 // 3. schema.json structure alignment
 // ===========================================================================
@@ -257,6 +269,27 @@ fn schema_json_has_required_receipt_definitions() {
             "docs/schema.json missing definition for {name}"
         );
     }
+}
+
+fn baseline_schema_json() -> serde_json::Value {
+    let raw = std::fs::read_to_string(workspace_root().join("docs/baseline.schema.json"))
+        .expect("docs/baseline.schema.json must exist");
+    serde_json::from_str(&raw).expect("docs/baseline.schema.json must be valid JSON")
+}
+
+#[test]
+fn baseline_schema_json_version_matches_source() {
+    let json = baseline_schema_json();
+    let src = read_const_u32("crates/tokmd-analysis-types/src/lib.rs", "BASELINE_VERSION")
+        .expect("BASELINE_VERSION not found in source");
+    let json_ver = json["properties"]["baseline_version"]["const"]
+        .as_u64()
+        .expect("baseline_version const must be a number");
+
+    assert_eq!(
+        json_ver as u32, src,
+        "baseline.schema.json baseline_version ({json_ver}) != BASELINE_VERSION ({src})"
+    );
 }
 
 #[test]

--- a/xtask/tests/docs_w43.rs
+++ b/xtask/tests/docs_w43.rs
@@ -262,6 +262,22 @@ fn schema_md_context_version_matches_source() {
 }
 
 #[test]
+fn schema_md_context_bundle_version_matches_source() {
+    let source_version = read_schema_constant(
+        "crates/tokmd-types/src/lib.rs",
+        "CONTEXT_BUNDLE_SCHEMA_VERSION",
+    )
+    .expect("CONTEXT_BUNDLE_SCHEMA_VERSION not found in source");
+    let schema_md = std::fs::read_to_string(workspace_root().join("docs/SCHEMA.md")).unwrap();
+    let doc_version = extract_schema_md_version(&schema_md, "`CONTEXT_BUNDLE_SCHEMA_VERSION`")
+        .expect("CONTEXT_BUNDLE_SCHEMA_VERSION not found in SCHEMA.md");
+    assert_eq!(
+        source_version, doc_version,
+        "CONTEXT_BUNDLE_SCHEMA_VERSION mismatch: source={source_version}, SCHEMA.md={doc_version}"
+    );
+}
+
+#[test]
 fn schema_md_handoff_version_matches_source() {
     let source_version =
         read_schema_constant("crates/tokmd-types/src/lib.rs", "HANDOFF_SCHEMA_VERSION")
@@ -272,6 +288,20 @@ fn schema_md_handoff_version_matches_source() {
     assert_eq!(
         source_version, doc_version,
         "HANDOFF_SCHEMA_VERSION mismatch: source={source_version}, SCHEMA.md={doc_version}"
+    );
+}
+
+#[test]
+fn schema_md_baseline_version_matches_source() {
+    let source_version =
+        read_schema_constant("crates/tokmd-analysis-types/src/lib.rs", "BASELINE_VERSION")
+            .expect("BASELINE_VERSION not found in source");
+    let schema_md = std::fs::read_to_string(workspace_root().join("docs/SCHEMA.md")).unwrap();
+    let doc_version = extract_schema_md_version(&schema_md, "`BASELINE_VERSION`")
+        .expect("BASELINE_VERSION not found in SCHEMA.md");
+    assert_eq!(
+        source_version, doc_version,
+        "BASELINE_VERSION mismatch: source={source_version}, SCHEMA.md={doc_version}"
     );
 }
 


### PR DESCRIPTION
## Summary
- fix `docs/SCHEMA.md` to use the real string schema constants `SENSOR_REPORT_SCHEMA` and `ENVELOPE_SCHEMA`
- add missing W43 `CONTEXT_BUNDLE_SCHEMA_VERSION` drift coverage
- add baseline-version sync checks for `docs/SCHEMA.md` and `docs/baseline.schema.json`

## Supersedes
- #1518
- #1494
- #1508

## Validation
- `cargo test -p xtask schema_md_ --verbose`
- `cargo test -p xtask baseline_schema_json_version_matches_source --verbose`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `typos docs/SCHEMA.md xtask/tests/docs_w43.rs xtask/tests/docs_schema_w72.rs`
- `git diff --check`