### PR TITLE
docs: align shipped reality examples

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -79,7 +79,9 @@
 - Closed #1576 as superseded by #1603.
 - Merged #1604: synthesized keeper for schema docs drift checks. Corrected the ecosystem envelope constant names in `docs/SCHEMA.md`, added the missing W43 `CONTEXT_BUNDLE_SCHEMA_VERSION` check, and covered `BASELINE_VERSION` across `docs/SCHEMA.md` and `docs/baseline.schema.json`. Gates: `cargo test -p xtask schema_md_ --verbose`; `cargo test -p xtask baseline_schema_json_version_matches_source --verbose`; `cargo fmt-check`; `cargo xtask docs --check`; `typos docs/SCHEMA.md xtask/tests/docs_w43.rs xtask/tests/docs_schema_w72.rs`; `git diff --check`; GitHub CI.
 - Closed #1518/#1494/#1508 as superseded by #1604.
-- Next cluster after #1604: choose the next proof/docs/control-plane cluster from the remaining open queue after refreshing `origin/main`.
+- Merged #1605: synthesized current-truth docs keeper from #1587/#1562. Moved shipped Python/Node FFI bindings from the future v2.0 horizon into the completed v1.4.0 milestone, renumbered the remaining future-horizon subsections, and refreshed schema/sensor-report example tool versions to `1.10.0`. Gates: `cargo xtask docs --check`; `cargo xtask version-consistency`; `typos ROADMAP.md docs/SCHEMA.md docs/sensor-report-v1.md`; `git diff --check`; GitHub CI.
+- Closed #1587/#1562 as superseded by #1605.
+- Next cluster after #1605: choose the next proof/docs/control-plane cluster from the remaining open queue after refreshing `origin/main`.
 
 ## Operating decisions
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -196,6 +196,34 @@ This document outlines the evolution of `tokmd` and the path forward.
 | PR template with trend section       | ✅ Complete | Template with TREND section markers                                |
 | Automatic PR comment injection       | ✅ Complete | Post cockpit metrics via `thollander/actions-comment-pull-request` |
 
+### Language Bindings (FFI)
+
+_Goal: Native integration in CI pipelines and tooling ecosystems._
+
+**Python (PyPI: `tokmd`)** ✅
+
+- Native bindings via PyO3 + maturin
+- Crate: `tokmd-python/`
+- API: `tokmd.lang()`, `tokmd.module()`, `tokmd.export()`, `tokmd.analyze()`, `tokmd.diff()`
+- Returns native Python dicts
+- Wheels for Linux, macOS, Windows (x64 + arm64)
+- JSON API: `tokmd.run_json(mode, args_json)` for low-level access
+
+**Node.js (npm: `@tokmd/core`)** ✅
+
+- Native bindings via napi-rs
+- Crate: `tokmd-node/`
+- API: `lang()`, `module()`, `export()`, `analyze()`, `diff()` returning JS objects
+- Prebuilds for major platforms
+- All functions return Promises (async/non-blocking)
+
+**Shared Infrastructure** ✅
+
+- `tokmd-core` crate expanded with binding-friendly API
+- Pure settings types (no Clap dependencies)
+- JSON-in/JSON-out FFI boundary via `run_json()`
+- Structured error types for FFI
+
 ### Schema Changes
 
 - **Analysis schema version**: 3 → 4
@@ -534,35 +562,7 @@ UX work is explicitly **incremental and non-breaking**:
 
 ### v2.0 — Platform Evolution
 
-#### A. Language Bindings (FFI) ✅ Complete
-
-_Goal: Native integration in CI pipelines and tooling ecosystems._
-
-**Python (PyPI: `tokmd`)** ✅
-
-- Native bindings via PyO3 + maturin
-- Crate: `tokmd-python/`
-- API: `tokmd.lang()`, `tokmd.module()`, `tokmd.export()`, `tokmd.analyze()`, `tokmd.diff()`
-- Returns native Python dicts
-- Wheels for Linux, macOS, Windows (x64 + arm64)
-- JSON API: `tokmd.run_json(mode, args_json)` for low-level access
-
-**Node.js (npm: `@tokmd/core`)** ✅
-
-- Native bindings via napi-rs
-- Crate: `tokmd-node/`
-- API: `lang()`, `module()`, `export()`, `analyze()`, `diff()` returning JS objects
-- Prebuilds for major platforms
-- All functions return Promises (async/non-blocking)
-
-**Shared Infrastructure** ✅
-
-- `tokmd-core` crate expanded with binding-friendly API
-- Pure settings types (no Clap dependencies)
-- JSON-in/JSON-out FFI boundary via `run_json()`
-- Structured error types for FFI
-
-#### B. AI Agent Integration & MCP Server Mode
+#### A. AI Agent Integration & MCP Server Mode
 
 _Goal: Native integration with Claude and other MCP-compatible clients._
 
@@ -572,7 +572,7 @@ _Goal: Native integration with Claude and other MCP-compatible clients._
 - Tools: `scan`, `analyze`, `diff`, `suggest` as MCP tools
 - Streaming: Incremental analysis results
 
-#### C. Streaming Analysis
+#### B. Streaming Analysis
 
 _Goal: Handle massive repositories without memory pressure._
 
@@ -581,7 +581,7 @@ _Goal: Handle massive repositories without memory pressure._
 - Memory-bounded analysis limits
 - Progress reporting via stderr
 
-#### D. Plugin System
+#### C. Plugin System
 
 _Goal: Extensible enrichers without core changes._
 
@@ -591,7 +591,7 @@ _Goal: Extensible enrichers without core changes._
 
 ### v2.1 — Intelligence Features
 
-#### E. Smart Suggestions
+#### D. Smart Suggestions
 
 _Goal: Actionable recommendations, not just metrics._
 
@@ -599,7 +599,7 @@ _Goal: Actionable recommendations, not just metrics._
 - `tokmd suggest --review` — Files likely to need attention
 - `tokmd suggest --test` — Untested code paths
 
-#### F. Diff Intelligence
+#### E. Diff Intelligence
 
 _Goal: Semantic diff beyond structural changes._
 
@@ -607,7 +607,7 @@ _Goal: Semantic diff beyond structural changes._
 - Breaking change indicators
 - Migration path suggestions
 
-#### G. Watch Mode
+#### F. Watch Mode
 
 _Goal: Continuous analysis during development._
 
@@ -617,7 +617,7 @@ _Goal: Continuous analysis during development._
 
 ### v2.2 — Ecosystem Integration
 
-#### H. CI/CD Native
+#### G. CI/CD Native
 
 _Goal: First-class CI pipeline support._
 
@@ -626,7 +626,7 @@ _Goal: First-class CI pipeline support._
 - Trend tracking across commits
 - Threshold-based failures (e.g., fail if complexity increases)
 
-#### I. Editor Extensions
+#### H. Editor Extensions
 
 _Goal: Analysis at your fingertips._
 
@@ -634,7 +634,7 @@ _Goal: Analysis at your fingertips._
 - Neovim plugin for buffer analysis
 - JetBrains plugin
 
-#### J. Cloud Dashboard
+#### I. Cloud Dashboard
 
 _Goal: Historical tracking and team insights._
 
@@ -647,7 +647,7 @@ _Goal: Historical tracking and team insights._
 
 _Goal: Accurate parsing for precise metrics. This is a significant undertaking requiring substantial R&D investment and is intentionally deferred well beyond the v2.x roadmap._
 
-#### K. Tree-sitter AST Parsing
+#### J. Tree-sitter AST Parsing
 
 - `tokmd-treesitter` crate with multi-language AST parsing
 - Language-specific complexity rules (Rust, TypeScript, Python, Go, etc.)

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -113,7 +113,7 @@ Every receipt includes:
 | `generated_at_ms` | `integer` | Unix timestamp (milliseconds) when the scan ran. |
 | `tool` | `object` | Information about the tool version. |
 | `tool.name` | `string` | Always `"tokmd"`. |
-| `tool.version` | `string` | The version of tokmd used (e.g., `"1.9.0"`). |
+| `tool.version` | `string` | The version of tokmd used (e.g., `"1.10.0"`). |
 | `mode` | `string` | One of `"lang"`, `"module"`, `"export"`, `"analysis"`, or `"cockpit"`. |
 | `status` | `string` | Scan status: `"complete"` or `"partial"`. |
 | `warnings` | `array` | Array of warning strings generated during the scan. |
@@ -146,7 +146,7 @@ Produced by `tokmd --format json` or `tokmd lang --format json`.
 {
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.9.0" },
+  "tool": { "name": "tokmd", "version": "1.10.0" },
   "mode": "lang",
   "status": "complete",
   "warnings": [],
@@ -227,7 +227,7 @@ Produced by `tokmd module --format json`.
 {
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.9.0" },
+  "tool": { "name": "tokmd", "version": "1.10.0" },
   "mode": "module",
   "status": "complete",
   "warnings": [],
@@ -310,7 +310,7 @@ JSONL output consists of a **Meta Record** (first line) followed by **Data Rows*
   "type": "meta",
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.9.0" },
+  "tool": { "name": "tokmd", "version": "1.10.0" },
   "mode": "export",
   "status": "complete",
   "warnings": [],
@@ -354,7 +354,7 @@ When using `--format json`, the output is a single JSON object:
 {
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.9.0" },
+  "tool": { "name": "tokmd", "version": "1.10.0" },
   "mode": "export",
   "status": "complete",
   "warnings": [],
@@ -444,7 +444,7 @@ Analysis receipts contain derived metrics and optional enrichments. All sections
 {
   "schema_version": 9,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.9.0" },
+  "tool": { "name": "tokmd", "version": "1.10.0" },
   "mode": "analysis",
   "status": "complete",
   "warnings": [],
@@ -802,7 +802,7 @@ The ecosystem envelope provides a standardized JSON format for multi-sensor inte
   "schema": "sensor.report.v1",
   "tool": {
     "name": "tokmd",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "mode": "cockpit"
   },
   "generated_at": "2024-01-27T10:30:00Z",

--- a/docs/sensor-report-v1.md
+++ b/docs/sensor-report-v1.md
@@ -47,7 +47,7 @@ The formal JSON Schema is available at:
   "schema": "sensor.report.v1",
   "tool": {
     "name": "tokmd",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "mode": "cockpit"
   },
   "generated_at": "2026-02-07T12:00:00Z",
@@ -117,7 +117,7 @@ The formal JSON Schema is available at:
 ```json
 {
   "name": "tokmd",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "mode": "cockpit"
 }
 ```


### PR DESCRIPTION
## Summary
- move shipped Python/Node FFI bindings out of the future v2.0 roadmap section and into the completed v1.4.0 milestone
- renumber the remaining v2.x future-horizon subsections after removing the shipped FFI item
- update schema and sensor-report example tool versions from `1.9.0` to the current shipped `1.10.0`

## Supersedes
- #1587
- #1562

## Validation
- `cargo xtask docs --check`
- `cargo xtask version-consistency`
- `typos ROADMAP.md docs/SCHEMA.md docs/sensor-report-v1.md`
- `git diff --check`