### PR TITLE
docs: synthesize specification and ADR baseline

### DIFF
--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -99,6 +99,8 @@
 - Closed #1144 as declined stale steward learning. The 1.9-era tooling-governance note and lockfile churn do not add durable value after the current `cargo xtask` workflow docs and release-train ADR.
 - Closed #1214 as superseded by current `.jules` migration/rollup state. The legacy-ledger migration and gate wording are already represented on main; the draft should not reintroduce old run-packet churn.
 - Closed #1218 as declined for current main. ANSI-colored CLI errors need a fresh product/color-policy pass with `NO_COLOR`/`CLICOLOR` handling and tests, not a conflicting draft that adds a dependency and previously failed the required quality gate.
+- Merged #1613: synthesized keeper for the specification/ADR family. Added the canonical `docs/adr` index, accepted ADRs for deterministic receipts/renderers and independent schema-family versioning, and a current product specification aligned with crate/module consolidation, `tokmd-config` retirement, cockpit as the current review surface, and capability honesty. Gates: `cargo xtask docs --check`; `typos README.md docs/architecture.md docs/specification.md docs/adr`; `git diff --check`; GitHub CI.
+- Closed #1370/#1371/#1372/#1373/#1374/#1375/#1376/#1377/#1378/#1380/#1381/#1382/#1383/#1384/#1385/#1386 as superseded by #1613. The generated variants competed on ADR/spec directory layout, numbering, and stale microcrate framing; #1613 kept the useful deterministic/schema/spec content in the current canonical layout.
 - Next cluster after the cache semantics disposition: choose the next proof/docs/control-plane cluster from the remaining open queue after refreshing `origin/main`.
 
 ## Operating decisions

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The machine-readable capability contract lives in [`docs/capabilities/wasm.json`
 
 - [GitHub Action reference](docs/github-action.md) for Action inputs, outputs, modes, and release assets
 - [CLI Reference](docs/reference-cli.md) for flags, formats, and config
+- [Specification](docs/specification.md) for current product contracts
 - [Schema](docs/SCHEMA.md) for receipt contracts
 - [tokmd responsibilities](tokmd-role.md) for the wider sensor/receipt stack
 
@@ -168,6 +169,7 @@ The machine-readable capability contract lives in [`docs/capabilities/wasm.json`
 
 - [Philosophy](docs/explanation.md) for the design stance
 - [Architecture](docs/architecture.md) for the crate graph and boundaries
+- [ADRs](docs/adr/README.md) for accepted architecture and contract decisions
 - [Design](docs/design.md) for system concepts and invariants
 - [Roadmap](ROADMAP.md) for the active horizon
 

--- a/docs/adr/0006-deterministic-receipts.md
+++ b/docs/adr/0006-deterministic-receipts.md
@@ -1,0 +1,48 @@
+# ADR-0006: Deterministic receipts and renderers
+
+- Status: accepted
+- Date: 2026-05-06
+
+## Context
+
+tokmd receipts are consumed by CI, policy gates, review comments, browser
+workers, FFI bindings, and LLM pipelines. Unstable ordering creates noisy diffs,
+flaky snapshots, cache churn, and misleading review artifacts.
+
+## Decision
+
+Deterministic output is a product invariant for receipt and renderer surfaces.
+
+Implementation paths that emit machine-readable receipts or stable human
+artifacts must use deterministic ordering at the boundary. Ranked rows sort by
+descending code lines and then by a stable name/key tie-break unless a surface
+documents a more specific order. Paths emitted in receipts and diagnostics are
+normalized to forward slashes before output and key derivation.
+
+## Consequences
+
+- Golden snapshots and downstream policy comparisons stay stable.
+- Browser, native, and binding surfaces can share receipt expectations.
+- Internal code can still use faster transient data structures when it sorts or
+  normalizes before emission.
+
+## Alternatives
+
+- Allow data-structure iteration order to leak into outputs.
+- Treat determinism as a best-effort renderer concern only.
+
+Both alternatives were rejected because tokmd outputs are intended to be
+receipt-grade evidence, not transient logs.
+
+## Enforcement
+
+- Prefer `BTreeMap` / `BTreeSet` or explicit sorting for emitted keyed data.
+- Add or update determinism, snapshot, or property tests when output ordering
+  changes.
+- Do not use locale-sensitive ordering in generated browser or HTML artifacts.
+
+## Related specs
+
+- `docs/specification.md`
+- `docs/SCHEMA.md`
+- `docs/testing.md`

--- a/docs/adr/0007-schema-family-versioning.md
+++ b/docs/adr/0007-schema-family-versioning.md
@@ -1,0 +1,47 @@
+# ADR-0007: Independent schema-family versioning
+
+- Status: accepted
+- Date: 2026-05-06
+
+## Context
+
+tokmd emits multiple receipt families: core inventory receipts, analysis
+receipts, cockpit receipts, handoff manifests, context receipts, context bundle
+manifests, sensor reports, and baselines. A single global schema version would
+force unrelated consumers to react to changes in surfaces they do not use.
+
+## Decision
+
+Receipt families version independently. A breaking structure or semantic change
+increments the schema version for the affected family only. Additive optional
+fields may remain within the current family version when existing consumers can
+ignore them safely.
+
+## Consequences
+
+- Consumers can pin the receipt family they actually use.
+- Active surfaces can evolve without forcing unrelated migrations.
+- Documentation and checks must track multiple schema constants instead of one
+  workspace-wide number.
+
+## Alternatives
+
+- Use one global schema version for all tokmd JSON outputs.
+- Avoid version bumps and rely on tool version alone.
+
+Both alternatives were rejected because they either over-notify consumers or
+make compatibility harder to reason about.
+
+## Enforcement
+
+- Keep `docs/SCHEMA.md`, formal schema files, and source constants in sync.
+- Add docs checks for new schema constants or family-specific schema files.
+- Bump the affected family version when changing a required field, field type,
+  field meaning, or envelope shape.
+
+## Related specs
+
+- `docs/specification.md`
+- `docs/SCHEMA.md`
+- `docs/schema.json`
+- `docs/handoff.schema.json`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+This directory stores accepted architecture, packaging, and product-contract
+decisions for tokmd. ADRs explain why a durable decision exists; exact
+behavioral contracts belong in specs such as `docs/specification.md` or
+surface-specific schema documents.
+
+## Index
+
+| ADR | Status | Title |
+|-----|--------|-------|
+| [0000](0000-adr-process.md) | accepted | ADR and specification governance |
+| [0001](0001-production-package-publishability.md) | accepted | Production package publishability |
+| [0002](0002-crate-vs-module-boundaries.md) | accepted | Crate vs module boundaries |
+| [0003](0003-publish-surface-taxonomy.md) | accepted | Publish-surface taxonomy |
+| [0004](0004-binding-surfaces.md) | accepted | Binding surfaces (Node, Python, WASM) |
+| [0005](0005-release-train-and-rc-semantics.md) | accepted | Release train and RC semantics |
+| [0006](0006-deterministic-receipts.md) | accepted | Deterministic receipts and renderers |
+| [0007](0007-schema-family-versioning.md) | accepted | Independent schema-family versioning |
+
+## House Style
+
+Use the structure defined by [ADR-0000](0000-adr-process.md): context,
+decision, consequences, alternatives, enforcement, and related specs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ This document describes the internal architecture of tokmd for contributors and 
 
 ## Crate Hierarchy
 
-tokmd follows a tiered microcrate architecture with strict dependency rules.
+tokmd follows a tiered crate-and-module architecture with strict dependency rules.
 
 ```
 Tier 0 (Contracts)     tokmd-types, tokmd-analysis-types, tokmd-settings,
@@ -85,7 +85,7 @@ CLI/config/progress/tool-schema/explain wiring in `tokmd`.
 
 | Crate | Purpose |
 |-------|---------|
-| `tokmd-core` | Library facade with FFI layer; exposes analysis formatting via `analysis_facade` module (see ADR-001) |
+| `tokmd-core` | Library facade with FFI layer; exposes analysis formatting via `analysis_facade` module |
 
 ### Tier 5: Products
 
@@ -100,7 +100,7 @@ CLI/config/progress/tool-schema/explain wiring in `tokmd`.
 
 1. **Contracts MUST NOT depend on clap** — Keep `tokmd-types` and `tokmd-analysis-types` pure
 2. **Lower tiers MUST NOT depend on higher tiers** — No upward dependencies
-3. **Tier boundary compliance via facade** — Tier 5 products access Tier 3 orchestration only through Tier 4 facades (e.g., `tokmd-core::analysis_facade`). See ADR-001.
+3. **Tier boundary compliance via facade** — Tier 5 products access Tier 3 orchestration only through Tier 4 facades (e.g., `tokmd-core::analysis_facade`). See ADR-0002 for the crate/module boundary policy.
 4. **Feature flags control optional adapters** — `git`, `walk`, `content` features
 5. **IO adapters depend on domain/contracts, never reverse**
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,137 @@
+# tokmd Specification
+
+This document records tokmd's current product contracts across CLI, library,
+binding, and receipt surfaces. Normative keywords `MUST`, `SHOULD`, and `MAY`
+use RFC 2119 meaning.
+
+## Scope
+
+tokmd is a deterministic repository inventory and analysis system. It produces
+machine-readable receipts and human-readable summaries from the same scan,
+model, analysis, and formatting surfaces.
+
+tokmd is not a linter, build system, developer scoring tool, vulnerability
+database, or SAST replacement. It reports repository facts, diff-aware evidence,
+and degraded capability states so downstream humans or directors can decide what
+to do.
+
+## Architecture Contracts
+
+- Public crates represent stable contracts, facades, adapters, or products.
+- Implementation details SHOULD live as single-responsibility owner modules
+  inside the owning crate unless a public crate boundary is justified by
+  ADR-0002.
+- Lower tiers MUST NOT depend on higher tiers.
+- Contract/type crates MUST remain free of `clap` and product-specific CLI UX.
+- `tokmd-core` is the clap-free workflow facade for embedding and FFI.
+
+## CLI Contracts
+
+- `tokmd` and `tokmd lang` produce language summaries.
+- `tokmd module`, `export`, `run`, `analyze`, `badge`, `diff`, `cockpit`,
+  `gate`, `tools`, `context`, `init`, `check-ignore`, and `completions` are
+  product CLI surfaces.
+- `tokmd <existing-path>` MUST preserve zero-config language-summary behavior.
+- Unknown bare subcommands MUST fail as unrecognized commands instead of being
+  silently treated as missing paths.
+- CLI paths and diagnostics SHOULD be normalized before user-facing output.
+- Optional color or terminal styling MUST respect no-color policy before it is
+  enabled by default.
+
+## Receipt Determinism
+
+Receipt and stable renderer outputs are deterministic by contract.
+
+- Emitted keyed data MUST use stable ordering.
+- Ranked rows SHOULD sort by descending code lines, then stable name/key
+  tie-break unless the surface documents a different order.
+- Paths emitted in receipts MUST use forward slashes on all platforms.
+- Locale-sensitive ordering MUST NOT be used for generated deterministic
+  browser, HTML, or JavaScript artifacts.
+- Same input corpus, options, capability set, and tokmd version SHOULD produce
+  byte-stable outputs except for explicitly timestamped metadata.
+
+## Children And Embedded Languages
+
+Children-mode behavior is part of the receipt contract.
+
+- `collapse` merges embedded-language children into parent totals.
+- `separate` emits embedded-language rows distinctly.
+- Language, module, export, run, and analysis workflows SHOULD describe or
+  preserve the selected children mode consistently.
+
+## Schema Versioning
+
+Schema families version independently.
+
+| Receipt family | Version identifier |
+|----------------|--------------------|
+| Core receipts | `SCHEMA_VERSION` |
+| Analysis receipts | `ANALYSIS_SCHEMA_VERSION` |
+| Cockpit receipts | `COCKPIT_SCHEMA_VERSION` |
+| Handoff manifests | `HANDOFF_SCHEMA_VERSION` |
+| Context receipts | `CONTEXT_SCHEMA_VERSION` |
+| Context bundles | `CONTEXT_BUNDLE_SCHEMA_VERSION` |
+| Sensor reports | `SENSOR_REPORT_SCHEMA` |
+| Baselines | `BASELINE_VERSION` |
+
+Breaking structure or semantic changes MUST bump the affected family version and
+update the matching docs/schema references. Additive optional fields MAY remain
+within the current family version when old consumers can ignore them safely.
+
+## Git Range Semantics
+
+- `A..B` means commits reachable from `B` but not `A`.
+- `A...B` means symmetric difference from the merge base.
+- Release/tag comparisons and `tokmd cockpit` / `tokmd diff` release-style
+  flows SHOULD use two-dot ranges.
+- CI branch-divergence workflows MAY use three-dot ranges when comparing a PR to
+  its merge base.
+
+## Binding And Runtime Contracts
+
+- FFI JSON entrypoints return envelopes with `ok`, `data`, and `error` rather
+  than panicking across the boundary.
+- Python bindings return native Python dictionaries and should release the GIL
+  during long scans.
+- Node bindings return Promises and should move blocking work off the event
+  loop.
+- WASM/browser surfaces MUST report unsupported capabilities honestly instead
+  of implying unavailable checks passed.
+- Browser GitHub ingest caches MUST partition authenticated data without storing
+  raw tokens.
+
+## Cockpit And Review Evidence
+
+`tokmd cockpit` is the current PR-review evidence surface.
+
+- Cockpit receipts and comment output MUST distinguish passed evidence from
+  missing, skipped, or degraded evidence.
+- Mutation/cache evidence MUST be invalidated by commit/scope mismatches rather
+  than reused silently.
+- A separate `tokmd review` command should not duplicate cockpit semantics unless
+  it has a distinct orchestrator contract.
+
+## Validation Expectations
+
+Changes SHOULD run the smallest relevant gate first, then broader gates when the
+blast radius warrants it.
+
+Common gates include:
+
+- `cargo fmt-check`
+- `cargo clippy -- -D warnings`
+- crate-specific `cargo test -p <crate>`
+- `cargo xtask docs --check`
+- `cargo xtask version-consistency`
+- schema/publish-surface checks for public contract changes
+- web runner tests for browser/worker behavior
+
+## Related Documents
+
+- `docs/architecture.md`
+- `docs/design.md`
+- `docs/requirements.md`
+- `docs/SCHEMA.md`
+- `docs/schema.json`
+- `docs/testing.md`


### PR DESCRIPTION
## Summary
- add a canonical ADR index for the existing docs/adr layout
- add accepted ADRs for deterministic receipts/renderers and independent schema-family versioning
- add a current product specification aligned with tokmd-config retirement, crate/module consolidation, cockpit as the current review surface, and capability honesty
- fix stale architecture references that pointed at the wrong ADR number

## Validation
- cargo xtask docs --check
- typos README.md docs/architecture.md docs/specification.md docs/adr
- git diff --check