### PR TITLE
Add proof policy validation foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
+ "globset",
  "petgraph",
  "semver",
  "serde",

--- a/PR_DRAIN.md
+++ b/PR_DRAIN.md
@@ -1,7 +1,7 @@
 ## 2026-05-05 PR drain
 
 - Merged #1548: dependabot rust minor/patch dependency bump for `jsonschema`, `napi`, `napi-derive`, `tokio`, and `wasm-bindgen-test`. Gates: `cargo check --workspace`; `cargo test --workspace`; `cargo deny --all-features check`; `npm --prefix web/runner test`.
-- Held #1541: external Factory Droid review workflow requires maintainer approval and secret/API-key policy.
+- Closed #1541: declined for now. External Factory Droid review workflows require an approved service, API-key, secret-rotation, fork-PR, and failure-behavior policy before introduction.
 - Merged #1549: synthesized keeper for stale `deny.toml` advisory cleanup. Removed only the obsolete `RUSTSEC-2023-0071` ignore. Gates: `cargo deny --all-features check`; `git diff --check`; GitHub CI.
 - Closed #1546/#1540/#1523 as superseded by #1549.
 - Merged #1551: synthesized keeper for JS deterministic sorting. Replaced `localeCompare` with explicit Unicode code point comparison and added a browser-runner regression test. Gates: `npm --prefix web/runner run check`; `npm --prefix web/runner test`; `git diff --check`; GitHub CI.
@@ -103,7 +103,8 @@
 - Closed #1370/#1371/#1372/#1373/#1374/#1375/#1376/#1377/#1378/#1380/#1381/#1382/#1383/#1384/#1385/#1386 as superseded by #1613. The generated variants competed on ADR/spec directory layout, numbering, and stale microcrate framing; #1613 kept the useful deterministic/schema/spec content in the current canonical layout.
 - Closed #1484/#1485/#1486/#1487 as stale generated GitHub Action PR-mode branches. Current main treats cockpit as the PR-review evidence surface after #1598/#1613; any future Action PR/review mode should start fresh from a stabilized review-packet contract.
 - Closed #1488/#1489/#1490/#1491 as stale competing `tokmd review` implementations. #1598 merged explicit cockpit comment output and #1613 records cockpit as the current review evidence surface; a separate command should start fresh only if it has a distinct orchestrator contract.
-- Remaining open PR after this drain: #1541, held for explicit maintainer approval of the external Factory Droid service and API-key/secret policy.
+- Closed #1541 as declined for now. External Factory Droid workflows require an approved external-service, API-key/secret, rotation, fork-PR, and failure-behavior policy before introduction.
+- PR drain is complete. This ledger is historical; active post-drain planning moved to `docs/NEXT.md`.
 
 ## Operating decisions
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1,0 +1,51 @@
+schema = "tokmd.proof_policy.v1"
+
+[defaults]
+mutation_timeout_seconds = 300
+coverage = "scoped"
+fail_on_unknown_non_rust = true
+
+[tools]
+rust = "stable"
+coverage = "cargo-llvm-cov"
+javascript = "npm"
+
+[[scope]]
+name = "tokmd_core_ffi"
+kind = "rust"
+paths = ["crates/tokmd-core/src/ffi.rs", "crates/tokmd-core/tests/**"]
+packages = ["tokmd-core"]
+proof = [
+  "cargo test -p tokmd-core ffi",
+  "cargo test -p tokmd-core --test ffi_parity_w53",
+]
+mutation = true
+coverage = true
+
+[[scope]]
+name = "browser_runner"
+kind = "non_rust"
+paths = ["web/runner/**", "docs/capabilities/wasm.json"]
+proof = [
+  "npm --prefix web/runner test",
+  "npm --prefix web/runner run check",
+]
+reason = "Browser worker and GitHub ingest logic are JavaScript/WASM-facing surfaces."
+mutation = false
+coverage = false
+
+[[allow.workspace_area]]
+name = "jules_knowledge_workspace"
+paths = [".jules/**"]
+reason = "Durable specs, investigations, friction notes, persona learnings, and generated indexes are allowed here."
+discourage = [
+  "raw terminal logs",
+  "duplicated run transcripts",
+  "large binary artifacts",
+]
+
+[[dependency_boundary]]
+name = "retired_tokmd_config_must_not_return"
+packages = ["*"]
+forbid = ["tokmd-config"]
+reason = "tokmd-config is retired; ownership lives in tokmd-settings, tokmd-core, and tokmd."

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -1,0 +1,29 @@
+# Next Program
+
+The generated PR drain is complete. `PR_DRAIN.md` is now a historical ledger for the duplicate/stale queue and should only change for PR-drain-specific corrections. Active product and control-plane work moves here.
+
+Factory Droid PR #1541 was declined for now. External review services require an approved service, API-key, secret-rotation, fork-PR, and failure-behavior policy before workflow introduction.
+
+## Active Program: Rust-Native Proof Control Plane
+
+Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-owned `xtask` policy and planning logic. GitHub Actions should eventually install tools, restore cache, run `cargo xtask proof ...`, upload artifacts, and show summaries while Rust owns scope mapping, allowlists, dependency boundaries, fixture policy, mutation targeting, coverage targeting, and proof reports.
+
+## Initial Work Packets
+
+1. Add `ci/proof.toml` and `cargo xtask proof-policy --check`.
+2. Move fixture/blob and dependency-boundary allowlists into the proof policy while keeping current behavior as fallback.
+3. Add `cargo xtask affected --base origin/main --head HEAD --json` for changed-file to proof-scope discovery.
+4. Add `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` to print a stable proof plan without running it.
+5. Wire policy validation into CI as a small standalone job before replacing larger workflow logic.
+
+## Directional Rules
+
+- `tokmd-config` is retired. It must remain forbidden by policy, with ownership in `tokmd-settings`, `tokmd-core`, and `tokmd`.
+- `.jules` is an allowed knowledge workspace for durable specs, investigations, friction notes, persona learnings, runbooks, ledgers, envelopes, and generated indexes.
+- Coverage remains advisory telemetry until maintainers intentionally promote it to a gate.
+- Cockpit remains the current PR-review evidence surface until a separate review command has a distinct artifact contract.
+
+## References
+
+- Historical drain ledger: [PR_DRAIN.md](../PR_DRAIN.md)
+- Current testing strategy: [testing.md](testing.md)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,7 @@ toml = "1.1.2"
 cargo_metadata = "0.23.1"
 petgraph = "0.8.3"
 chrono = "0.4"
+globset = "0.4.18"
 semver = "1"
 serde_json = "1"
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -20,6 +20,8 @@ pub enum Commands {
     Cockpit(CockpitArgs),
     /// Manage documentation and verify examples
     Docs(DocsArgs),
+    /// Validate the Rust-native proof policy
+    ProofPolicy(ProofPolicyArgs),
     /// Verify all release-facing version surfaces are in sync
     VersionConsistency(VersionConsistencyArgs),
     /// Verify dependency boundaries for analysis microcrates
@@ -49,6 +51,21 @@ pub struct DocsArgs {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct VersionConsistencyArgs {}
+
+#[derive(Args, Debug, Clone)]
+pub struct ProofPolicyArgs {
+    /// Validate the proof policy and print a human-readable summary
+    #[arg(long)]
+    pub check: bool,
+
+    /// Emit a machine-readable validation report
+    #[arg(long)]
+    pub json: bool,
+
+    /// Policy file to validate
+    #[arg(long, default_value = "ci/proof.toml")]
+    pub policy: std::path::PathBuf,
+}
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct PublishArgs {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 
 mod cli;
+mod proof;
 mod tasks;
 
 use cli::{PublishArgs, XtaskCli};
@@ -15,6 +16,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::PublishSurface(args)) => tasks::publish_surface::run(args),
         Some(cli::Commands::Cockpit(args)) => tasks::cockpit::run(args),
         Some(cli::Commands::Docs(args)) => tasks::docs::run(args),
+        Some(cli::Commands::ProofPolicy(args)) => tasks::proof_policy::run(args),
         Some(cli::Commands::VersionConsistency(args)) => tasks::version_consistency::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),

--- a/xtask/src/proof/mod.rs
+++ b/xtask/src/proof/mod.rs
@@ -1,0 +1,3 @@
+pub mod policy;
+pub mod policy_ast;
+pub mod validate;

--- a/xtask/src/proof/policy.rs
+++ b/xtask/src/proof/policy.rs
@@ -1,0 +1,50 @@
+use super::policy_ast::ProofPolicy;
+use anyhow::{Context, Result};
+use std::path::Path;
+
+pub fn load_policy(path: &Path) -> Result<ProofPolicy> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    parse_policy_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+pub fn parse_policy_str(content: &str) -> Result<ProofPolicy> {
+    toml::from_str(content).context("proof policy TOML is invalid")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_policy_str;
+
+    #[test]
+    fn rejects_unknown_top_level_keys() {
+        let err = parse_policy_str(
+            r#"
+schema = "tokmd.proof_policy.v1"
+surprise = true
+"#,
+        )
+        .expect_err("unknown top-level keys should fail");
+
+        assert!(err.to_string().contains("proof policy TOML is invalid"));
+    }
+
+    #[test]
+    fn rejects_unknown_nested_keys() {
+        let err = parse_policy_str(
+            r#"
+schema = "tokmd.proof_policy.v1"
+
+[[scope]]
+name = "core"
+kind = "rust"
+paths = ["crates/tokmd-core/**"]
+proof = ["cargo test -p tokmd-core"]
+unexpected = "nope"
+"#,
+        )
+        .expect_err("unknown scope keys should fail");
+
+        assert!(err.to_string().contains("proof policy TOML is invalid"));
+    }
+}

--- a/xtask/src/proof/policy_ast.rs
+++ b/xtask/src/proof/policy_ast.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+
+pub const EXPECTED_SCHEMA: &str = "tokmd.proof_policy.v1";
+pub const RETIRED_TOKMD_CONFIG: &str = "tokmd-config";
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProofPolicy {
+    pub schema: String,
+
+    #[serde(default)]
+    pub defaults: Defaults,
+
+    #[serde(default)]
+    pub tools: Tools,
+
+    #[serde(default)]
+    pub scope: Vec<Scope>,
+
+    #[serde(default)]
+    pub allow: Allow,
+
+    #[serde(default)]
+    pub dependency_boundary: Vec<DependencyBoundary>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Defaults {
+    pub mutation_timeout_seconds: Option<u64>,
+    pub coverage: Option<String>,
+    pub fail_on_unknown_non_rust: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Tools {
+    pub rust: Option<String>,
+    pub coverage: Option<String>,
+    pub javascript: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeKind {
+    Rust,
+    NonRust,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Scope {
+    pub name: String,
+    pub kind: ScopeKind,
+
+    #[serde(default)]
+    pub paths: Vec<String>,
+
+    #[serde(default)]
+    pub packages: Vec<String>,
+
+    #[serde(default)]
+    pub proof: Vec<String>,
+
+    #[serde(default)]
+    pub mutation: bool,
+
+    #[serde(default)]
+    pub coverage: bool,
+
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Allow {
+    #[serde(default)]
+    pub workspace_area: Vec<WorkspaceAreaAllow>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceAreaAllow {
+    pub name: String,
+
+    #[serde(default)]
+    pub paths: Vec<String>,
+
+    pub reason: String,
+
+    #[serde(default)]
+    pub discourage: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DependencyBoundary {
+    pub name: String,
+
+    #[serde(default)]
+    pub packages: Vec<String>,
+
+    #[serde(default)]
+    pub forbid: Vec<String>,
+
+    pub reason: String,
+}

--- a/xtask/src/proof/validate.rs
+++ b/xtask/src/proof/validate.rs
@@ -1,0 +1,437 @@
+use super::policy_ast::{
+    EXPECTED_SCHEMA, ProofPolicy, RETIRED_TOKMD_CONFIG, ScopeKind, WorkspaceAreaAllow,
+};
+use globset::Glob;
+use serde::Serialize;
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PolicyViolation {
+    pub path: String,
+    pub message: String,
+}
+
+impl PolicyViolation {
+    fn new(path: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+}
+
+pub fn validate_policy(policy: &ProofPolicy) -> Vec<PolicyViolation> {
+    let mut violations = Vec::new();
+
+    if policy.schema != EXPECTED_SCHEMA {
+        violations.push(PolicyViolation::new(
+            "schema",
+            format!("expected schema {EXPECTED_SCHEMA}, found {}", policy.schema),
+        ));
+    }
+
+    validate_scopes(policy, &mut violations);
+    validate_workspace_allowlists(&policy.allow.workspace_area, &mut violations);
+    validate_dependency_boundaries(policy, &mut violations);
+
+    violations
+}
+
+fn validate_scopes(policy: &ProofPolicy, violations: &mut Vec<PolicyViolation>) {
+    let mut names = BTreeSet::new();
+
+    for (index, scope) in policy.scope.iter().enumerate() {
+        let base = format!("scope[{index}]");
+
+        if scope.name.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                "scope name must not be empty",
+            ));
+        } else if !names.insert(scope.name.as_str()) {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                format!("duplicate scope name `{}`", scope.name),
+            ));
+        }
+
+        validate_glob_list(&format!("{base}.paths"), &scope.paths, true, violations);
+        for (path_index, pattern) in scope.paths.iter().enumerate() {
+            if pattern.contains(RETIRED_TOKMD_CONFIG) {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.paths[{path_index}]"),
+                    format!(
+                        "retired `{RETIRED_TOKMD_CONFIG}` paths must not return as proof scopes"
+                    ),
+                ));
+            }
+        }
+
+        if scope.proof.is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.proof"),
+                "proof command list must not be empty",
+            ));
+        }
+
+        for (proof_index, proof) in scope.proof.iter().enumerate() {
+            if proof.trim().is_empty() {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.proof[{proof_index}]"),
+                    "proof command must not be empty",
+                ));
+            }
+            if proof.contains(RETIRED_TOKMD_CONFIG) {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.proof[{proof_index}]"),
+                    format!("retired `{RETIRED_TOKMD_CONFIG}` proof commands must not return"),
+                ));
+            }
+        }
+
+        for (package_index, package) in scope.packages.iter().enumerate() {
+            if package.trim().is_empty() {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.packages[{package_index}]"),
+                    "package name must not be empty",
+                ));
+            }
+            if package == RETIRED_TOKMD_CONFIG {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.packages[{package_index}]"),
+                    format!("retired package `{RETIRED_TOKMD_CONFIG}` must not return as a proof scope package"),
+                ));
+            }
+        }
+
+        if scope.kind == ScopeKind::NonRust && is_blank(scope.reason.as_deref()) {
+            violations.push(PolicyViolation::new(
+                format!("{base}.reason"),
+                "non-Rust scopes must explain why they are part of the proof policy",
+            ));
+        }
+    }
+}
+
+fn validate_workspace_allowlists(
+    allowlists: &[WorkspaceAreaAllow],
+    violations: &mut Vec<PolicyViolation>,
+) {
+    let mut names = BTreeSet::new();
+
+    for (index, allow) in allowlists.iter().enumerate() {
+        let base = format!("allow.workspace_area[{index}]");
+
+        if allow.name.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                "allowlist name must not be empty",
+            ));
+        } else if !names.insert(allow.name.as_str()) {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                format!("duplicate allowlist name `{}`", allow.name),
+            ));
+        }
+
+        if allow.reason.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.reason"),
+                "allowlist entries must include a reason",
+            ));
+        }
+
+        validate_glob_list(&format!("{base}.paths"), &allow.paths, true, violations);
+
+        for (discourage_index, discourage) in allow.discourage.iter().enumerate() {
+            if discourage.trim().is_empty() {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.discourage[{discourage_index}]"),
+                    "discouraged content notes must not be empty",
+                ));
+            }
+        }
+    }
+}
+
+fn validate_dependency_boundaries(policy: &ProofPolicy, violations: &mut Vec<PolicyViolation>) {
+    let mut names = BTreeSet::new();
+    let mut forbids_retired_config = false;
+
+    for (index, boundary) in policy.dependency_boundary.iter().enumerate() {
+        let base = format!("dependency_boundary[{index}]");
+
+        if boundary.name.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                "dependency boundary name must not be empty",
+            ));
+        } else if !names.insert(boundary.name.as_str()) {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                format!("duplicate dependency boundary name `{}`", boundary.name),
+            ));
+        }
+
+        if boundary.reason.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.reason"),
+                "dependency boundaries must include a reason",
+            ));
+        }
+
+        for (package_index, package) in boundary.packages.iter().enumerate() {
+            if package.trim().is_empty() {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.packages[{package_index}]"),
+                    "dependency boundary package selectors must not be empty",
+                ));
+            }
+        }
+
+        if boundary.forbid.is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.forbid"),
+                "dependency boundaries must forbid at least one package",
+            ));
+        }
+
+        for (forbid_index, forbidden) in boundary.forbid.iter().enumerate() {
+            if forbidden.trim().is_empty() {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.forbid[{forbid_index}]"),
+                    "forbidden package names must not be empty",
+                ));
+            }
+            if forbidden == RETIRED_TOKMD_CONFIG {
+                forbids_retired_config = true;
+            }
+        }
+    }
+
+    if !forbids_retired_config {
+        violations.push(PolicyViolation::new(
+            "dependency_boundary",
+            format!("policy must keep retired `{RETIRED_TOKMD_CONFIG}` dependency forbidden"),
+        ));
+    }
+}
+
+fn validate_glob_list(
+    path: &str,
+    globs: &[String],
+    require_nonempty: bool,
+    violations: &mut Vec<PolicyViolation>,
+) {
+    if require_nonempty && globs.is_empty() {
+        violations.push(PolicyViolation::new(path, "glob list must not be empty"));
+    }
+
+    for (index, pattern) in globs.iter().enumerate() {
+        if pattern.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{path}[{index}]"),
+                "glob must not be empty",
+            ));
+            continue;
+        }
+
+        if let Err(err) = Glob::new(pattern) {
+            violations.push(PolicyViolation::new(
+                format!("{path}[{index}]"),
+                format!("invalid glob `{pattern}`: {err}"),
+            ));
+        }
+    }
+}
+
+fn is_blank(value: Option<&str>) -> bool {
+    value.map(str::trim).unwrap_or("").is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_policy;
+    use crate::proof::policy::parse_policy_str;
+
+    fn policy_with(extra: &str) -> String {
+        format!(
+            r#"
+schema = "tokmd.proof_policy.v1"
+
+{extra}
+
+[[dependency_boundary]]
+name = "retired_tokmd_config_must_not_return"
+packages = ["*"]
+forbid = ["tokmd-config"]
+reason = "tokmd-config is retired."
+"#
+        )
+    }
+
+    fn messages_for(content: &str) -> Vec<String> {
+        let policy = parse_policy_str(content).expect("policy should parse");
+        validate_policy(&policy)
+            .into_iter()
+            .map(|violation| violation.message)
+            .collect()
+    }
+
+    #[test]
+    fn valid_policy_has_no_violations() {
+        let policy = parse_policy_str(include_str!("../../../ci/proof.toml")).expect("parse");
+        assert_eq!(validate_policy(&policy), Vec::new());
+    }
+
+    #[test]
+    fn rejects_duplicate_scope_names() {
+        let messages = messages_for(&policy_with(
+            r#"
+[[scope]]
+name = "core"
+kind = "rust"
+paths = ["crates/tokmd-core/**"]
+proof = ["cargo test -p tokmd-core"]
+
+[[scope]]
+name = "core"
+kind = "rust"
+paths = ["crates/tokmd/**"]
+proof = ["cargo test -p tokmd"]
+"#,
+        ));
+
+        assert!(
+            messages
+                .iter()
+                .any(|msg| msg.contains("duplicate scope name"))
+        );
+    }
+
+    #[test]
+    fn rejects_empty_proof_commands() {
+        let messages = messages_for(&policy_with(
+            r#"
+[[scope]]
+name = "core"
+kind = "rust"
+paths = ["crates/tokmd-core/**"]
+proof = [" "]
+"#,
+        ));
+
+        assert!(
+            messages
+                .iter()
+                .any(|msg| msg.contains("proof command must not be empty"))
+        );
+    }
+
+    #[test]
+    fn rejects_scopes_without_proof_commands() {
+        let messages = messages_for(&policy_with(
+            r#"
+[[scope]]
+name = "core"
+kind = "rust"
+paths = ["crates/tokmd-core/**"]
+"#,
+        ));
+
+        assert!(
+            messages
+                .iter()
+                .any(|msg| msg.contains("proof command list must not be empty"))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_globs() {
+        let messages = messages_for(&policy_with(
+            r#"
+[[scope]]
+name = "core"
+kind = "rust"
+paths = ["["]
+proof = ["cargo test -p tokmd-core"]
+"#,
+        ));
+
+        assert!(messages.iter().any(|msg| msg.contains("invalid glob")));
+    }
+
+    #[test]
+    fn rejects_allowlist_without_reason() {
+        let policy = parse_policy_str(&policy_with(
+            r#"
+[[allow.workspace_area]]
+name = "scratch"
+paths = ["scratch/**"]
+reason = " "
+"#,
+        ))
+        .expect("policy should parse");
+
+        let violations = validate_policy(&policy);
+
+        assert!(violations.iter().any(|violation| {
+            violation.path == "allow.workspace_area[0].reason"
+                && violation
+                    .message
+                    .contains("allowlist entries must include a reason")
+        }));
+    }
+
+    #[test]
+    fn rejects_tokmd_config_scope_packages() {
+        let messages = messages_for(&policy_with(
+            r#"
+[[scope]]
+name = "bad_config"
+kind = "rust"
+paths = ["crates/tokmd-config/**"]
+packages = ["tokmd-config"]
+proof = ["cargo test -p tokmd-config"]
+"#,
+        ));
+
+        assert!(
+            messages
+                .iter()
+                .any(|msg| msg.contains("retired package `tokmd-config`"))
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|msg| msg.contains("retired `tokmd-config` paths"))
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|msg| msg.contains("retired `tokmd-config` proof commands"))
+        );
+    }
+
+    #[test]
+    fn requires_retired_config_boundary() {
+        let policy = parse_policy_str(
+            r#"
+schema = "tokmd.proof_policy.v1"
+
+[[dependency_boundary]]
+name = "other"
+packages = ["*"]
+forbid = ["some-old-crate"]
+reason = "Old crate."
+"#,
+        )
+        .expect("policy should parse");
+
+        let violations = validate_policy(&policy);
+
+        assert!(violations.iter().any(|violation| {
+            violation.path == "dependency_boundary" && violation.message.contains("tokmd-config")
+        }));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -6,6 +6,7 @@ pub mod docs;
 pub mod fixture_blobs_check;
 pub mod gate;
 pub mod lint_fix;
+pub mod proof_policy;
 pub mod publish;
 pub mod publish_surface;
 pub mod sccache;

--- a/xtask/src/tasks/proof_policy.rs
+++ b/xtask/src/tasks/proof_policy.rs
@@ -1,0 +1,71 @@
+use crate::cli::ProofPolicyArgs;
+use crate::proof::policy::load_policy;
+use crate::proof::validate::{PolicyViolation, validate_policy};
+use anyhow::{Result, bail};
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+struct ProofPolicyReport {
+    ok: bool,
+    policy: String,
+    schema: String,
+    scope_count: usize,
+    allowlist_count: usize,
+    dependency_boundary_count: usize,
+    violations: Vec<PolicyViolation>,
+}
+
+pub fn run(args: ProofPolicyArgs) -> Result<()> {
+    let _check_requested = args.check || !args.json;
+    let path = args.policy;
+    let policy = load_policy(&path)?;
+    let violations = validate_policy(&policy);
+    let report = ProofPolicyReport {
+        ok: violations.is_empty(),
+        policy: display_path(&path),
+        schema: policy.schema.clone(),
+        scope_count: policy.scope.len(),
+        allowlist_count: policy.allow.workspace_area.len(),
+        dependency_boundary_count: policy.dependency_boundary.len(),
+        violations,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human_report(&report);
+    }
+
+    if report.ok {
+        Ok(())
+    } else {
+        bail!(
+            "proof policy validation failed with {} violation(s)",
+            report.violations.len()
+        )
+    }
+}
+
+fn print_human_report(report: &ProofPolicyReport) {
+    if report.ok {
+        println!(
+            "Proof policy OK: {} (schema {}, {} scope(s), {} allowlist(s), {} dependency boundary rule(s))",
+            report.policy,
+            report.schema,
+            report.scope_count,
+            report.allowlist_count,
+            report.dependency_boundary_count
+        );
+        return;
+    }
+
+    eprintln!("Proof policy violations in {}:", report.policy);
+    for violation in &report.violations {
+        eprintln!("  - {}: {}", violation.path, violation.message);
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.parent().unwrap().to_path_buf()
+}
+
+fn run_xtask(args: &[&str]) -> (String, String, bool) {
+    let root = workspace_root();
+    let output = Command::new("cargo")
+        .arg("run")
+        .arg("-q")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .args(args)
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cargo xtask");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (stdout, stderr, output.status.success())
+}
+
+#[test]
+fn proof_policy_check_accepts_repo_policy() {
+    let (stdout, stderr, success) = run_xtask(&["proof-policy", "--check"]);
+
+    assert!(success, "proof-policy --check failed. stderr: {stderr}");
+    assert!(stdout.contains("Proof policy OK"), "stdout: {stdout}");
+    assert!(stdout.contains("ci/proof.toml"), "stdout: {stdout}");
+}
+
+#[test]
+fn proof_policy_json_reports_current_schema() {
+    let (stdout, stderr, success) = run_xtask(&["proof-policy", "--json"]);
+
+    assert!(success, "proof-policy --json failed. stderr: {stderr}");
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("proof-policy --json should emit JSON");
+
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["schema"], "tokmd.proof_policy.v1");
+    assert_eq!(value["scope_count"], 2);
+    assert_eq!(value["allowlist_count"], 1);
+    assert_eq!(value["dependency_boundary_count"], 1);
+}
+
+#[test]
+fn xtask_help_mentions_proof_policy() {
+    let (stdout, stderr, success) = run_xtask(&["--help"]);
+
+    assert!(success, "xtask --help failed. stderr: {stderr}");
+    assert!(stdout.contains("proof-policy"), "stdout: {stdout}");
+}


### PR DESCRIPTION
## Summary
- close the PR-drain ledger by recording #1541 as declined pending an external-service/secret policy
- add `docs/NEXT.md` as the post-drain planning surface
- add `ci/proof.toml` plus `cargo xtask proof-policy --check/--json` with typed TOML parsing and validation for schema, unknown keys, duplicate scopes, invalid/empty globs, proof commands, allowlist reasons, and retired `tokmd-config` references

## Validation
- `cargo xtask proof-policy --check`
- `cargo xtask proof-policy --json`
- `cargo test -p xtask --test proof_policy_w90 --verbose`
- `cargo test -p xtask rejects_ --verbose`
- `cargo test -p xtask valid_policy_has_no_violations --verbose`
- `cargo test -p xtask --test xtask_contract_w65 publish_plan_succeeds -- --nocapture`
- `cargo test -p xtask --test xtask_contract_w65 docs_check_succeeds_or_reports_drift -- --nocapture`
- `cargo test -p xtask --test xtask_contract_w65 docs_without_flags_reports_status -- --nocapture`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `git diff --check`

Note: full `cargo test -p xtask` on this Windows worktree still hits the existing recursive `cargo run -p xtask` integration-test/file-lock/abort hazard when many xtask contract tests run together. The directly affected and previously reported failing tests pass when run individually.