### PR TITLE
Use proof policy for fixture blob checks

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -49,3 +49,34 @@ name = "retired_tokmd_config_must_not_return"
 packages = ["*"]
 forbid = ["tokmd-config"]
 reason = "tokmd-config is retired; ownership lives in tokmd-settings, tokmd-core, and tokmd."
+
+[[forbid.fixture_blob]]
+name = "committed_crypto_fixture_blobs"
+extensions = [
+  "cer",
+  "crt",
+  "der",
+  "jwk",
+  "jwks",
+  "key",
+  "p12",
+  "p8",
+  "pem",
+  "pfx",
+  "pk8",
+]
+markers = [
+  "BEGIN CERTIFICATE",
+  "BEGIN EC PRIVATE KEY",
+  "BEGIN OPENSSH PRIVATE KEY",
+  "BEGIN PRIVATE KEY",
+  "BEGIN RSA PRIVATE KEY",
+]
+allow = [
+  ".claude/**",
+  ".jules/**",
+  "ci/proof.toml",
+  "vendor/**",
+  "xtask/src/tasks/fixture_blobs_check.rs",
+]
+reason = "Crypto material should be generated at runtime or explicitly documented in an allowlisted workspace area."

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -26,7 +26,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 ## Checkpoints
 
 - Dependency-boundary checks now read `ci/proof.toml` while preserving the existing sorted `tokmd-analysis*` manifest scan and `dependencies` / `dev-dependencies` / `build-dependencies` coverage.
-- Next proof-policy operational slice: move `fixture-blobs-check` extensions, markers, and allowlists into `ci/proof.toml`.
+- Fixture-blob checks now read `ci/proof.toml` while preserving the existing crypto extension and marker detection plus the `.claude`, `.jules`, `vendor`, proof-policy source, and checker-source allowlist behavior.
+- Next proof-policy operational slice: add `cargo xtask affected --base origin/main --head HEAD --json` for changed-file to proof-scope discovery.
 
 ## References
 

--- a/xtask/src/proof/policy_ast.rs
+++ b/xtask/src/proof/policy_ast.rs
@@ -21,6 +21,9 @@ pub struct ProofPolicy {
     pub allow: Allow,
 
     #[serde(default)]
+    pub forbid: Forbid,
+
+    #[serde(default)]
     pub dependency_boundary: Vec<DependencyBoundary>,
 }
 
@@ -91,6 +94,30 @@ pub struct WorkspaceAreaAllow {
 
     #[serde(default)]
     pub discourage: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Forbid {
+    #[serde(default)]
+    pub fixture_blob: Vec<FixtureBlobRule>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureBlobRule {
+    pub name: String,
+
+    #[serde(default)]
+    pub extensions: Vec<String>,
+
+    #[serde(default)]
+    pub markers: Vec<String>,
+
+    #[serde(default)]
+    pub allow: Vec<String>,
+
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/xtask/src/proof/validate.rs
+++ b/xtask/src/proof/validate.rs
@@ -1,5 +1,6 @@
 use super::policy_ast::{
-    EXPECTED_SCHEMA, ProofPolicy, RETIRED_TOKMD_CONFIG, ScopeKind, WorkspaceAreaAllow,
+    EXPECTED_SCHEMA, FixtureBlobRule, ProofPolicy, RETIRED_TOKMD_CONFIG, ScopeKind,
+    WorkspaceAreaAllow,
 };
 use globset::Glob;
 use serde::Serialize;
@@ -32,6 +33,7 @@ pub fn validate_policy(policy: &ProofPolicy) -> Vec<PolicyViolation> {
 
     validate_scopes(policy, &mut violations);
     validate_workspace_allowlists(&policy.allow.workspace_area, &mut violations);
+    validate_fixture_blob_rules(&policy.forbid.fixture_blob, &mut violations);
     validate_dependency_boundaries(policy, &mut violations);
 
     violations
@@ -151,6 +153,66 @@ fn validate_workspace_allowlists(
                 ));
             }
         }
+    }
+}
+
+fn validate_fixture_blob_rules(rules: &[FixtureBlobRule], violations: &mut Vec<PolicyViolation>) {
+    let mut names = BTreeSet::new();
+
+    for (index, rule) in rules.iter().enumerate() {
+        let base = format!("forbid.fixture_blob[{index}]");
+
+        if rule.name.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                "fixture blob rule name must not be empty",
+            ));
+        } else if !names.insert(rule.name.as_str()) {
+            violations.push(PolicyViolation::new(
+                format!("{base}.name"),
+                format!("duplicate fixture blob rule name `{}`", rule.name),
+            ));
+        }
+
+        if rule.reason.trim().is_empty() {
+            violations.push(PolicyViolation::new(
+                format!("{base}.reason"),
+                "fixture blob rules must include a reason",
+            ));
+        }
+
+        if rule.extensions.is_empty() && rule.markers.is_empty() {
+            violations.push(PolicyViolation::new(
+                base.clone(),
+                "fixture blob rules must forbid at least one extension or marker",
+            ));
+        }
+
+        for (extension_index, extension) in rule.extensions.iter().enumerate() {
+            let trimmed = extension.trim();
+            if trimmed.is_empty() {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.extensions[{extension_index}]"),
+                    "forbidden fixture blob extensions must not be empty",
+                ));
+            } else if trimmed.starts_with('.') {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.extensions[{extension_index}]"),
+                    "forbidden fixture blob extensions should omit the leading dot",
+                ));
+            }
+        }
+
+        for (marker_index, marker) in rule.markers.iter().enumerate() {
+            if marker.trim().is_empty() {
+                violations.push(PolicyViolation::new(
+                    format!("{base}.markers[{marker_index}]"),
+                    "forbidden fixture blob markers must not be empty",
+                ));
+            }
+        }
+
+        validate_glob_list(&format!("{base}.allow"), &rule.allow, false, violations);
     }
 }
 
@@ -381,6 +443,58 @@ reason = " "
                     .message
                     .contains("allowlist entries must include a reason")
         }));
+    }
+
+    #[test]
+    fn rejects_fixture_blob_rule_without_reason() {
+        let policy = parse_policy_str(&policy_with(
+            r#"
+[[forbid.fixture_blob]]
+name = "crypto"
+extensions = ["pem"]
+reason = " "
+"#,
+        ))
+        .expect("policy should parse");
+
+        let violations = validate_policy(&policy);
+
+        assert!(violations.iter().any(|violation| {
+            violation.path == "forbid.fixture_blob[0].reason"
+                && violation
+                    .message
+                    .contains("fixture blob rules must include a reason")
+        }));
+    }
+
+    #[test]
+    fn rejects_fixture_blob_rule_without_forbidden_patterns() {
+        let messages = messages_for(&policy_with(
+            r#"
+[[forbid.fixture_blob]]
+name = "crypto"
+reason = "Crypto material is forbidden."
+"#,
+        ));
+
+        assert!(messages.iter().any(|msg| {
+            msg.contains("fixture blob rules must forbid at least one extension or marker")
+        }));
+    }
+
+    #[test]
+    fn rejects_fixture_blob_allow_invalid_globs() {
+        let messages = messages_for(&policy_with(
+            r#"
+[[forbid.fixture_blob]]
+name = "crypto"
+extensions = ["pem"]
+allow = ["["]
+reason = "Crypto material is forbidden."
+"#,
+        ));
+
+        assert!(messages.iter().any(|msg| msg.contains("invalid glob")));
     }
 
     #[test]

--- a/xtask/src/tasks/fixture_blobs_check.rs
+++ b/xtask/src/tasks/fixture_blobs_check.rs
@@ -1,21 +1,16 @@
 use crate::cli::FixtureBlobsCheckArgs;
+use crate::proof::policy::load_policy;
+use crate::proof::policy_ast::{FixtureBlobRule, ProofPolicy};
+use crate::proof::validate::validate_policy;
 use anyhow::{Context, Result, bail};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-const ALLOWLIST_PREFIXES: &[&str] = &[".claude/", ".jules/", "vendor/"];
-const ALLOWLIST_PATHS: &[&str] = &["xtask/src/tasks/fixture_blobs_check.rs"];
-const FORBIDDEN_EXTENSIONS: &[&str] = &[
-    "cer", "crt", "der", "jwk", "jwks", "key", "p12", "p8", "pem", "pfx", "pk8",
-];
-const FORBIDDEN_MARKERS: &[&str] = &[
-    "BEGIN CERTIFICATE",
-    "BEGIN EC PRIVATE KEY",
-    "BEGIN OPENSSH PRIVATE KEY",
-    "BEGIN PRIVATE KEY",
-    "BEGIN RSA PRIVATE KEY",
-];
+/// Repo-owned proof policy path. Fixture blob rules live here so the crypto
+/// guardrail stays aligned with the broader proof control plane.
+const PROOF_POLICY_PATH: &str = "ci/proof.toml";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Violation {
@@ -23,35 +18,87 @@ struct Violation {
     reason: String,
 }
 
-fn is_allowlisted(path: &str) -> bool {
-    if ALLOWLIST_PATHS.contains(&path) {
-        return true;
+#[derive(Debug)]
+struct FixtureBlobPolicy {
+    rules: Vec<FixtureBlobRule>,
+    allow: GlobSet,
+}
+
+fn load_checked_policy(path: &Path) -> Result<ProofPolicy> {
+    let policy = load_policy(path)?;
+    let violations = validate_policy(&policy);
+    if !violations.is_empty() {
+        for violation in &violations {
+            eprintln!("::error file={}::{}", path.display(), violation.message);
+        }
+        bail!(
+            "proof policy is invalid; run `cargo xtask proof-policy --check` before fixture-blobs-check"
+        );
+    }
+    Ok(policy)
+}
+
+fn fixture_blob_policy(policy: &ProofPolicy) -> Result<FixtureBlobPolicy> {
+    if policy.forbid.fixture_blob.is_empty() {
+        bail!("proof policy must include at least one forbid.fixture_blob rule");
     }
 
-    ALLOWLIST_PREFIXES
-        .iter()
-        .any(|prefix| path.starts_with(prefix))
+    let mut allow_builder = GlobSetBuilder::new();
+    for rule in &policy.forbid.fixture_blob {
+        for pattern in &rule.allow {
+            allow_builder.add(
+                Glob::new(pattern)
+                    .with_context(|| format!("invalid fixture blob allow glob `{pattern}`"))?,
+            );
+        }
+    }
+
+    Ok(FixtureBlobPolicy {
+        rules: policy.forbid.fixture_blob.clone(),
+        allow: allow_builder
+            .build()
+            .context("failed to build fixture blob allowlist")?,
+    })
 }
 
-fn forbidden_extension(path: &str) -> Option<String> {
-    Path::new(path)
+fn is_allowlisted(policy: &FixtureBlobPolicy, path: &str) -> bool {
+    policy.allow.is_match(path)
+}
+
+fn forbidden_extension(policy: &FixtureBlobPolicy, path: &str) -> Option<String> {
+    let extension = Path::new(path)
         .extension()
         .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
-        .filter(|ext| FORBIDDEN_EXTENSIONS.contains(&ext.as_str()))
+        .map(|ext| ext.to_ascii_lowercase())?;
+
+    policy
+        .rules
+        .iter()
+        .any(|rule| {
+            rule.extensions
+                .iter()
+                .any(|forbidden| forbidden.eq_ignore_ascii_case(&extension))
+        })
+        .then_some(extension)
 }
 
-fn contains_forbidden_marker(path: &Path) -> Result<Option<&'static str>> {
+fn contains_forbidden_marker(policy: &FixtureBlobPolicy, path: &Path) -> Result<Option<String>> {
     let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
     let text = String::from_utf8_lossy(&bytes);
-    Ok(FORBIDDEN_MARKERS
+    Ok(policy
+        .rules
         .iter()
-        .copied()
-        .find(|marker| text.contains(marker)))
+        .flat_map(|rule| &rule.markers)
+        .find(|marker| text.contains(marker.as_str()))
+        .cloned())
 }
 
-fn evaluate_candidate(repo_root: &Path, rel_path: &str) -> Result<Option<Violation>> {
-    if is_allowlisted(rel_path) {
+fn evaluate_candidate(
+    policy: &FixtureBlobPolicy,
+    repo_root: &Path,
+    rel_path: &str,
+) -> Result<Option<Violation>> {
+    if is_allowlisted(policy, rel_path) {
         return Ok(None);
     }
 
@@ -60,7 +107,7 @@ fn evaluate_candidate(repo_root: &Path, rel_path: &str) -> Result<Option<Violati
         return Ok(None);
     }
 
-    if let Some(ext) = forbidden_extension(rel_path) {
+    if let Some(ext) = forbidden_extension(policy, rel_path) {
         return Ok(Some(Violation {
             path: rel_path.to_string(),
             reason: format!(
@@ -69,7 +116,7 @@ fn evaluate_candidate(repo_root: &Path, rel_path: &str) -> Result<Option<Violati
         }));
     }
 
-    if let Some(marker) = contains_forbidden_marker(&abs_path)? {
+    if let Some(marker) = contains_forbidden_marker(policy, &abs_path)? {
         return Ok(Some(Violation {
             path: rel_path.to_string(),
             reason: format!(
@@ -99,11 +146,15 @@ fn tracked_files() -> Result<Vec<String>> {
         .collect())
 }
 
-fn collect_violations(repo_root: &Path, tracked: &[String]) -> Result<Vec<Violation>> {
+fn collect_violations(
+    policy: &FixtureBlobPolicy,
+    repo_root: &Path,
+    tracked: &[String],
+) -> Result<Vec<Violation>> {
     let mut violations = Vec::new();
 
     for rel_path in tracked {
-        if let Some(violation) = evaluate_candidate(repo_root, rel_path)? {
+        if let Some(violation) = evaluate_candidate(policy, repo_root, rel_path)? {
             violations.push(violation);
         }
     }
@@ -113,11 +164,16 @@ fn collect_violations(repo_root: &Path, tracked: &[String]) -> Result<Vec<Violat
 
 pub fn run(_args: FixtureBlobsCheckArgs) -> Result<()> {
     let repo_root = std::env::current_dir()?;
+    let policy = load_checked_policy(&repo_root.join(PROOF_POLICY_PATH))?;
+    let fixture_policy = fixture_blob_policy(&policy)?;
     let tracked = tracked_files()?;
-    let violations = collect_violations(&repo_root, &tracked)?;
+    let violations = collect_violations(&fixture_policy, &repo_root, &tracked)?;
 
     if violations.is_empty() {
-        println!("No committed crypto fixture blobs found");
+        println!(
+            "No committed crypto fixture blobs found ({} policy rule(s))",
+            fixture_policy.rules.len()
+        );
         return Ok(());
     }
 
@@ -135,36 +191,92 @@ pub fn run(_args: FixtureBlobsCheckArgs) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_violations, evaluate_candidate, forbidden_extension};
+    use super::{
+        collect_violations, evaluate_candidate, fixture_blob_policy, forbidden_extension,
+        load_checked_policy,
+    };
+    use crate::proof::policy::parse_policy_str;
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::tempdir;
+
+    fn workspace_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root")
+            .to_path_buf()
+    }
+
+    fn test_policy() -> super::FixtureBlobPolicy {
+        let policy = parse_policy_str(
+            r#"
+schema = "tokmd.proof_policy.v1"
+
+[[forbid.fixture_blob]]
+name = "committed_crypto_fixture_blobs"
+extensions = ["pem", "pk8"]
+markers = ["BEGIN PRIVATE KEY"]
+allow = [".claude/**", ".jules/**", "vendor/**", "xtask/src/tasks/fixture_blobs_check.rs"]
+reason = "Crypto material should be generated at runtime or explicitly documented."
+"#,
+        )
+        .expect("policy should parse");
+
+        fixture_blob_policy(&policy).expect("fixture policy should build")
+    }
 
     #[test]
     fn detects_forbidden_extension() {
-        assert_eq!(forbidden_extension("fixtures/key.pem"), Some("pem".into()));
-        assert_eq!(forbidden_extension("fixtures/key.PK8"), Some("pk8".into()));
-        assert_eq!(forbidden_extension("src/lib.rs"), None);
+        let policy = test_policy();
+
+        assert_eq!(
+            forbidden_extension(&policy, "fixtures/key.pem"),
+            Some("pem".into())
+        );
+        assert_eq!(
+            forbidden_extension(&policy, "fixtures/key.PK8"),
+            Some("pk8".into())
+        );
+        assert_eq!(forbidden_extension(&policy, "src/lib.rs"), None);
     }
 
     #[test]
     fn skips_allowlisted_vendor_paths() {
+        let policy = test_policy();
         let dir = tempdir().expect("tempdir");
         let vendor_file = dir.path().join("vendor").join("fixture.pem");
         fs::create_dir_all(vendor_file.parent().unwrap()).expect("vendor dir");
         fs::write(&vendor_file, "BEGIN PRIVATE KEY").expect("write");
 
-        let violation = evaluate_candidate(dir.path(), "vendor/fixture.pem").expect("check");
+        let violation =
+            evaluate_candidate(&policy, dir.path(), "vendor/fixture.pem").expect("check");
         assert!(violation.is_none());
     }
 
     #[test]
+    fn skips_allowlisted_jules_and_claude_paths() {
+        let policy = test_policy();
+        let dir = tempdir().expect("tempdir");
+
+        for rel_path in [".jules/run/fixture.pem", ".claude/context/fixture.pem"] {
+            let abs_path = dir.path().join(rel_path);
+            fs::create_dir_all(abs_path.parent().unwrap()).expect("allowlist dir");
+            fs::write(&abs_path, "BEGIN PRIVATE KEY").expect("write");
+
+            let violation = evaluate_candidate(&policy, dir.path(), rel_path).expect("check");
+            assert!(violation.is_none(), "{rel_path} should be allowlisted");
+        }
+    }
+
+    #[test]
     fn detects_forbidden_marker_in_text_file() {
+        let policy = test_policy();
         let dir = tempdir().expect("tempdir");
         let manifest = dir.path().join("docs").join("example.md");
         fs::create_dir_all(manifest.parent().unwrap()).expect("docs dir");
         fs::write(&manifest, "-----BEGIN PRIVATE KEY-----").expect("write");
 
-        let violation = evaluate_candidate(dir.path(), "docs/example.md")
+        let violation = evaluate_candidate(&policy, dir.path(), "docs/example.md")
             .expect("check")
             .expect("violation");
 
@@ -174,16 +286,22 @@ mod tests {
 
     #[test]
     fn allows_checker_source_file() {
+        let policy = test_policy();
         let dir = tempdir().expect("tempdir");
 
-        let violation = evaluate_candidate(dir.path(), "xtask/src/tasks/fixture_blobs_check.rs")
-            .expect("check");
+        let violation = evaluate_candidate(
+            &policy,
+            dir.path(),
+            "xtask/src/tasks/fixture_blobs_check.rs",
+        )
+        .expect("check");
 
         assert!(violation.is_none());
     }
 
     #[test]
     fn collects_violations_across_multiple_paths() {
+        let policy = test_policy();
         let dir = tempdir().expect("tempdir");
         let pem = dir.path().join("fixtures").join("bad.pem");
         let readme = dir.path().join("README.md");
@@ -192,9 +310,46 @@ mod tests {
         fs::write(&readme, "no secrets here").expect("write readme");
 
         let tracked = vec!["fixtures/bad.pem".to_string(), "README.md".to_string()];
-        let violations = collect_violations(dir.path(), &tracked).expect("collect");
+        let violations = collect_violations(&policy, dir.path(), &tracked).expect("collect");
 
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].path, "fixtures/bad.pem");
+    }
+
+    #[test]
+    fn repo_policy_loads_fixture_blob_rule() {
+        let policy = load_checked_policy(&workspace_root().join("ci/proof.toml"))
+            .expect("repo proof policy should load");
+        let fixture_policy =
+            fixture_blob_policy(&policy).expect("repo fixture policy should build");
+
+        assert!(fixture_policy.rules.iter().any(|rule| {
+            rule.name == "committed_crypto_fixture_blobs"
+                && rule.extensions.iter().any(|extension| extension == "pem")
+                && rule
+                    .markers
+                    .iter()
+                    .any(|marker| marker == "BEGIN PRIVATE KEY")
+        }));
+    }
+
+    #[test]
+    fn missing_policy_is_reported() {
+        let dir = tempdir().expect("tempdir");
+        let err = load_checked_policy(&dir.path().join("missing.toml"))
+            .expect_err("missing policy should fail");
+
+        assert!(err.to_string().contains("failed to read"));
+    }
+
+    #[test]
+    fn malformed_policy_is_reported() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("proof.toml");
+        fs::write(&path, "schema = [").expect("write malformed policy");
+
+        let err = load_checked_policy(&path).expect_err("malformed policy should fail");
+
+        assert!(err.to_string().contains("failed to parse"));
     }
 }

--- a/xtask/src/tasks/proof_policy.rs
+++ b/xtask/src/tasks/proof_policy.rs
@@ -12,6 +12,7 @@ struct ProofPolicyReport {
     schema: String,
     scope_count: usize,
     allowlist_count: usize,
+    fixture_blob_rule_count: usize,
     dependency_boundary_count: usize,
     violations: Vec<PolicyViolation>,
 }
@@ -27,6 +28,7 @@ pub fn run(args: ProofPolicyArgs) -> Result<()> {
         schema: policy.schema.clone(),
         scope_count: policy.scope.len(),
         allowlist_count: policy.allow.workspace_area.len(),
+        fixture_blob_rule_count: policy.forbid.fixture_blob.len(),
         dependency_boundary_count: policy.dependency_boundary.len(),
         violations,
     };
@@ -50,11 +52,12 @@ pub fn run(args: ProofPolicyArgs) -> Result<()> {
 fn print_human_report(report: &ProofPolicyReport) {
     if report.ok {
         println!(
-            "Proof policy OK: {} (schema {}, {} scope(s), {} allowlist(s), {} dependency boundary rule(s))",
+            "Proof policy OK: {} (schema {}, {} scope(s), {} allowlist(s), {} fixture blob rule(s), {} dependency boundary rule(s))",
             report.policy,
             report.schema,
             report.scope_count,
             report.allowlist_count,
+            report.fixture_blob_rule_count,
             report.dependency_boundary_count
         );
         return;

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -44,6 +44,7 @@ fn proof_policy_json_reports_current_schema() {
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
     assert_eq!(value["scope_count"], 2);
     assert_eq!(value["allowlist_count"], 1);
+    assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);
 }
 


### PR DESCRIPTION
## Summary
- move fixture blob extensions, markers, and allow globs into `ci/proof.toml`
- make `fixture-blobs-check` load and validate the proof policy before scanning tracked files
- add fixture policy validation/tests and expose fixture rule count in `proof-policy --json`
- update `docs/NEXT.md` to mark the fixture-blob policy slice complete

## Validation
- `cargo xtask proof-policy --check`
- `cargo xtask fixture-blobs-check`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `git diff --check`