### PR TITLE
Add affected proof scope discovery

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -11,6 +11,34 @@ coverage = "cargo-llvm-cov"
 javascript = "npm"
 
 [[scope]]
+name = "proof_control_plane"
+kind = "rust"
+paths = [
+  "ci/proof.toml",
+  "docs/NEXT.md",
+  "xtask/src/cli.rs",
+  "xtask/src/main.rs",
+  "xtask/src/proof/**",
+  "xtask/src/tasks/mod.rs",
+  "xtask/src/tasks/affected.rs",
+  "xtask/src/tasks/boundaries_check.rs",
+  "xtask/src/tasks/fixture_blobs_check.rs",
+  "xtask/src/tasks/proof_policy.rs",
+  "xtask/tests/affected_w91.rs",
+  "xtask/tests/fixture_blobs_w83.rs",
+  "xtask/tests/proof_policy_w90.rs",
+]
+packages = ["xtask"]
+proof = [
+  "cargo xtask proof-policy --check",
+  "cargo test -p xtask proof_policy --verbose",
+  "cargo test -p xtask affected --verbose",
+  "cargo test -p xtask fixture_blob --verbose",
+]
+mutation = false
+coverage = false
+
+[[scope]]
 name = "tokmd_core_ffi"
 kind = "rust"
 paths = ["crates/tokmd-core/src/ffi.rs", "crates/tokmd-core/tests/**"]

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -27,7 +27,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 
 - Dependency-boundary checks now read `ci/proof.toml` while preserving the existing sorted `tokmd-analysis*` manifest scan and `dependencies` / `dev-dependencies` / `build-dependencies` coverage.
 - Fixture-blob checks now read `ci/proof.toml` while preserving the existing crypto extension and marker detection plus the `.claude`, `.jules`, `vendor`, proof-policy source, and checker-source allowlist behavior.
-- Next proof-policy operational slice: add `cargo xtask affected --base origin/main --head HEAD --json` for changed-file to proof-scope discovery.
+- `cargo xtask affected --base origin/main --head HEAD --json` now maps changed files to proof scopes from `ci/proof.toml`, reports unknown files, and keeps non-Rust unknown handling policy-driven.
+- Next proof-policy operational slice: add `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` to print a stable proof plan without running it.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -22,6 +22,8 @@ pub enum Commands {
     Docs(DocsArgs),
     /// Validate the Rust-native proof policy
     ProofPolicy(ProofPolicyArgs),
+    /// Discover proof scopes affected by a git diff
+    Affected(AffectedArgs),
     /// Verify all release-facing version surfaces are in sync
     VersionConsistency(VersionConsistencyArgs),
     /// Verify dependency boundaries for analysis microcrates
@@ -63,6 +65,25 @@ pub struct ProofPolicyArgs {
     pub json: bool,
 
     /// Policy file to validate
+    #[arg(long, default_value = "ci/proof.toml")]
+    pub policy: std::path::PathBuf,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct AffectedArgs {
+    /// Base git revision for changed-file discovery
+    #[arg(long, default_value = "origin/main")]
+    pub base: String,
+
+    /// Head git revision for changed-file discovery
+    #[arg(long, default_value = "HEAD")]
+    pub head: String,
+
+    /// Emit a machine-readable affected-scope report
+    #[arg(long)]
+    pub json: bool,
+
+    /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::Cockpit(args)) => tasks::cockpit::run(args),
         Some(cli::Commands::Docs(args)) => tasks::docs::run(args),
         Some(cli::Commands::ProofPolicy(args)) => tasks::proof_policy::run(args),
+        Some(cli::Commands::Affected(args)) => tasks::affected::run(args),
         Some(cli::Commands::VersionConsistency(args)) => tasks::version_consistency::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),

--- a/xtask/src/tasks/affected.rs
+++ b/xtask/src/tasks/affected.rs
@@ -1,0 +1,350 @@
+use crate::cli::AffectedArgs;
+use crate::proof::policy::load_policy;
+use crate::proof::policy_ast::{ProofPolicy, Scope, ScopeKind};
+use crate::proof::validate::validate_policy;
+use anyhow::{Context, Result, bail};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Serialize)]
+struct AffectedReport {
+    schema: String,
+    ok: bool,
+    base: String,
+    head: String,
+    changed_files: Vec<String>,
+    scopes: Vec<AffectedScope>,
+    unknown_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct AffectedScope {
+    name: String,
+    kind: ScopeKind,
+    reason: String,
+    packages: Vec<String>,
+    proof: Vec<String>,
+    mutation: bool,
+    coverage: bool,
+}
+
+#[derive(Debug)]
+struct CompiledScope<'a> {
+    scope: &'a Scope,
+    paths: GlobSet,
+}
+
+pub fn run(args: AffectedArgs) -> Result<()> {
+    let policy = load_checked_policy(&args.policy)?;
+    let changed_files = changed_files(&args.base, &args.head)?;
+    let report = affected_report(&policy, &args.base, &args.head, changed_files)?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human_report(&report);
+    }
+
+    if report.ok {
+        Ok(())
+    } else {
+        bail!(
+            "affected proof scope discovery found {} unknown file(s)",
+            report.unknown_files.len()
+        )
+    }
+}
+
+fn load_checked_policy(path: &Path) -> Result<ProofPolicy> {
+    let policy = load_policy(path)?;
+    let violations = validate_policy(&policy);
+    if !violations.is_empty() {
+        for violation in &violations {
+            eprintln!("::error file={}::{}", path.display(), violation.message);
+        }
+        bail!("proof policy is invalid; run `cargo xtask proof-policy --check` before affected");
+    }
+    Ok(policy)
+}
+
+fn changed_files(base: &str, head: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["diff", "--name-only", base, head, "--"])
+        .output()
+        .with_context(|| format!("failed to run `git diff --name-only {base} {head} --`"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`git diff --name-only {base} {head} --` failed: {}",
+            stderr.trim()
+        );
+    }
+
+    let mut files = String::from_utf8(output.stdout)
+        .context("`git diff --name-only` produced non-UTF-8 output")?
+        .lines()
+        .map(normalize_path)
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>();
+
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn affected_report(
+    policy: &ProofPolicy,
+    base: &str,
+    head: &str,
+    mut changed_files: Vec<String>,
+) -> Result<AffectedReport> {
+    changed_files.sort();
+    changed_files.dedup();
+
+    let compiled_scopes = compile_scopes(&policy.scope)?;
+    let mut matched_by_scope = BTreeMap::<String, (&Scope, BTreeSet<String>)>::new();
+    let mut unknown_files = Vec::new();
+
+    for file in &changed_files {
+        let mut matched = false;
+
+        for compiled in &compiled_scopes {
+            if compiled.paths.is_match(file) {
+                matched = true;
+                matched_by_scope
+                    .entry(compiled.scope.name.clone())
+                    .or_insert_with(|| (compiled.scope, BTreeSet::new()))
+                    .1
+                    .insert(file.clone());
+            }
+        }
+
+        if !matched {
+            unknown_files.push(file.clone());
+        }
+    }
+
+    unknown_files.sort();
+
+    let scopes = matched_by_scope
+        .into_iter()
+        .map(|(_name, (scope, matches))| affected_scope(scope, matches))
+        .collect();
+
+    let fail_on_unknown_non_rust = policy.defaults.fail_on_unknown_non_rust.unwrap_or(false);
+    let unknown_non_rust_count = unknown_files
+        .iter()
+        .filter(|file| !is_rust_source_or_manifest(file))
+        .count();
+    let ok = !(fail_on_unknown_non_rust && unknown_non_rust_count > 0);
+
+    Ok(AffectedReport {
+        schema: "tokmd.affected.v1".to_string(),
+        ok,
+        base: base.to_string(),
+        head: head.to_string(),
+        changed_files,
+        scopes,
+        unknown_files,
+    })
+}
+
+fn compile_scopes(scopes: &[Scope]) -> Result<Vec<CompiledScope<'_>>> {
+    scopes
+        .iter()
+        .map(|scope| {
+            let mut builder = GlobSetBuilder::new();
+            for pattern in &scope.paths {
+                builder.add(
+                    Glob::new(pattern)
+                        .with_context(|| format!("invalid scope glob `{pattern}`"))?,
+                );
+            }
+
+            Ok(CompiledScope {
+                scope,
+                paths: builder
+                    .build()
+                    .with_context(|| format!("failed to compile scope `{}` globs", scope.name))?,
+            })
+        })
+        .collect()
+}
+
+fn affected_scope(scope: &Scope, matches: BTreeSet<String>) -> AffectedScope {
+    AffectedScope {
+        name: scope.name.clone(),
+        kind: scope.kind.clone(),
+        reason: match_reason(&matches),
+        packages: sorted(scope.packages.clone()),
+        proof: sorted(scope.proof.clone()),
+        mutation: scope.mutation,
+        coverage: scope.coverage,
+    }
+}
+
+fn match_reason(matches: &BTreeSet<String>) -> String {
+    let mut files = matches.iter();
+    let first = files.next().cloned().unwrap_or_default();
+    if matches.len() == 1 {
+        format!("matched {first}")
+    } else {
+        let preview = matches
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("matched {} file(s): {preview}", matches.len())
+    }
+}
+
+fn sorted(mut values: Vec<String>) -> Vec<String> {
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn normalize_path(path: impl AsRef<str>) -> String {
+    path.as_ref().replace('\\', "/")
+}
+
+fn is_rust_source_or_manifest(path: &str) -> bool {
+    path.ends_with(".rs")
+        || matches!(path, "Cargo.toml" | "Cargo.lock")
+        || path.ends_with("/Cargo.toml")
+}
+
+fn print_human_report(report: &AffectedReport) {
+    println!(
+        "Affected proof scopes: {} changed file(s), {} scope(s), {} unknown file(s)",
+        report.changed_files.len(),
+        report.scopes.len(),
+        report.unknown_files.len()
+    );
+    println!("Range: {} -> {}", report.base, report.head);
+
+    for scope in &report.scopes {
+        println!("  - {} ({:?}): {}", scope.name, scope.kind, scope.reason);
+    }
+
+    for file in &report.unknown_files {
+        println!("  - unknown: {file}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{affected_report, normalize_path};
+    use crate::proof::policy::parse_policy_str;
+
+    fn policy_with_defaults(
+        fail_on_unknown_non_rust: bool,
+    ) -> crate::proof::policy_ast::ProofPolicy {
+        parse_policy_str(&format!(
+            r#"
+schema = "tokmd.proof_policy.v1"
+
+[defaults]
+fail_on_unknown_non_rust = {fail_on_unknown_non_rust}
+
+[[scope]]
+name = "core"
+kind = "rust"
+paths = ["crates/tokmd-core/src/ffi.rs", "crates/tokmd-core/tests/**"]
+packages = ["tokmd-core"]
+proof = ["cargo test -p tokmd-core ffi"]
+mutation = true
+coverage = true
+
+[[scope]]
+name = "browser"
+kind = "non_rust"
+paths = ["web/runner/**"]
+proof = ["npm --prefix web/runner test"]
+reason = "Browser runner tests."
+
+[[dependency_boundary]]
+name = "retired_tokmd_config_must_not_return"
+packages = ["*"]
+forbid = ["tokmd-config"]
+reason = "tokmd-config is retired."
+"#,
+        ))
+        .expect("policy should parse")
+    }
+
+    #[test]
+    fn maps_changed_files_to_sorted_scopes() {
+        let policy = policy_with_defaults(true);
+        let report = affected_report(
+            &policy,
+            "base",
+            "head",
+            vec![
+                "web/runner/ingest.test.mjs".to_string(),
+                "crates/tokmd-core/src/ffi.rs".to_string(),
+            ],
+        )
+        .expect("affected report");
+
+        assert!(report.ok);
+        assert_eq!(report.changed_files.len(), 2);
+        assert_eq!(report.scopes[0].name, "browser");
+        assert_eq!(report.scopes[1].name, "core");
+        assert!(report.unknown_files.is_empty());
+    }
+
+    #[test]
+    fn no_changes_produces_empty_success_report() {
+        let policy = policy_with_defaults(true);
+        let report = affected_report(&policy, "HEAD", "HEAD", Vec::new()).expect("report");
+
+        assert!(report.ok);
+        assert!(report.changed_files.is_empty());
+        assert!(report.scopes.is_empty());
+        assert!(report.unknown_files.is_empty());
+    }
+
+    #[test]
+    fn unknown_non_rust_files_make_report_not_ok_when_policy_requires_it() {
+        let policy = policy_with_defaults(true);
+        let report = affected_report(
+            &policy,
+            "base",
+            "head",
+            vec!["docs/unscoped.md".to_string()],
+        )
+        .expect("report");
+
+        assert!(!report.ok);
+        assert_eq!(report.unknown_files, vec!["docs/unscoped.md"]);
+    }
+
+    #[test]
+    fn unknown_rust_files_are_reported_without_failing_non_rust_policy() {
+        let policy = policy_with_defaults(true);
+        let report = affected_report(
+            &policy,
+            "base",
+            "head",
+            vec!["crates/new/src/lib.rs".to_string()],
+        )
+        .expect("report");
+
+        assert!(report.ok);
+        assert_eq!(report.unknown_files, vec!["crates/new/src/lib.rs"]);
+    }
+
+    #[test]
+    fn path_normalization_uses_forward_slashes() {
+        assert_eq!(
+            normalize_path("crates\\tokmd\\src\\main.rs"),
+            "crates/tokmd/src/main.rs"
+        );
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,3 +1,4 @@
+pub mod affected;
 pub mod boundaries_check;
 pub mod build_guard;
 pub mod bump;

--- a/xtask/tests/affected_w91.rs
+++ b/xtask/tests/affected_w91.rs
@@ -1,0 +1,70 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.parent().unwrap().to_path_buf()
+}
+
+fn run_xtask(args: &[&str]) -> (String, String, bool) {
+    let root = workspace_root();
+    let output = Command::new("cargo")
+        .arg("run")
+        .arg("-q")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .args(args)
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cargo xtask");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (stdout, stderr, output.status.success())
+}
+
+#[test]
+fn affected_help_mentions_base_head_and_json() {
+    let (stdout, stderr, success) = run_xtask(&["affected", "--help"]);
+
+    assert!(success, "affected --help failed. stderr: {stderr}");
+    assert!(stdout.contains("--base"), "stdout: {stdout}");
+    assert!(stdout.contains("--head"), "stdout: {stdout}");
+    assert!(stdout.contains("--json"), "stdout: {stdout}");
+}
+
+#[test]
+fn affected_json_reports_no_changes_for_same_ref() {
+    let (stdout, stderr, success) =
+        run_xtask(&["affected", "--base", "HEAD", "--head", "HEAD", "--json"]);
+
+    assert!(success, "affected --json failed. stderr: {stderr}");
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("affected --json should emit JSON");
+
+    assert_eq!(value["schema"], "tokmd.affected.v1");
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["base"], "HEAD");
+    assert_eq!(value["head"], "HEAD");
+    assert!(value["changed_files"].as_array().unwrap().is_empty());
+    assert!(value["scopes"].as_array().unwrap().is_empty());
+    assert!(value["unknown_files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn affected_bad_base_reports_git_error() {
+    let (_stdout, stderr, success) = run_xtask(&[
+        "affected",
+        "--base",
+        "definitely-not-a-real-ref",
+        "--head",
+        "HEAD",
+        "--json",
+    ]);
+
+    assert!(!success, "affected should fail for an invalid base ref");
+    assert!(
+        stderr.contains("git diff") || stderr.contains("bad revision"),
+        "stderr: {stderr}"
+    );
+}

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -42,7 +42,7 @@ fn proof_policy_json_reports_current_schema() {
 
     assert_eq!(value["ok"], true);
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
-    assert_eq!(value["scope_count"], 2);
+    assert_eq!(value["scope_count"], 3);
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);


### PR DESCRIPTION
## Summary
- add `cargo xtask affected --base ... --head ... --json` to map git-diff changed files to proof-policy scopes
- add a first `proof_control_plane` scope so proof-policy/xtask changes classify to targeted checks
- report deterministic changed files, matched scopes, proof commands, and unknown files with policy-driven non-Rust unknown handling
- update `docs/NEXT.md` to move the next control-plane slice to proof plan output

## Validation
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof-policy --check`
- `cargo xtask fixture-blobs-check`
- `cargo xtask boundaries-check`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `git diff origin/main..HEAD --check`