### PR TITLE
Add affected proof plan output

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -24,9 +24,11 @@ paths = [
   "xtask/src/tasks/boundaries_check.rs",
   "xtask/src/tasks/fixture_blobs_check.rs",
   "xtask/src/tasks/proof_policy.rs",
+  "xtask/src/tasks/proof_plan.rs",
   "xtask/tests/affected_w91.rs",
   "xtask/tests/fixture_blobs_w83.rs",
   "xtask/tests/proof_policy_w90.rs",
+  "xtask/tests/proof_plan_w92.rs",
 ]
 packages = ["xtask"]
 proof = [
@@ -34,6 +36,7 @@ proof = [
   "cargo test -p xtask proof_policy --verbose",
   "cargo test -p xtask affected --verbose",
   "cargo test -p xtask fixture_blob --verbose",
+  "cargo test -p xtask proof_plan --verbose",
 ]
 mutation = false
 coverage = false

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -28,7 +28,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Dependency-boundary checks now read `ci/proof.toml` while preserving the existing sorted `tokmd-analysis*` manifest scan and `dependencies` / `dev-dependencies` / `build-dependencies` coverage.
 - Fixture-blob checks now read `ci/proof.toml` while preserving the existing crypto extension and marker detection plus the `.claude`, `.jules`, `vendor`, proof-policy source, and checker-source allowlist behavior.
 - `cargo xtask affected --base origin/main --head HEAD --json` now maps changed files to proof scopes from `ci/proof.toml`, reports unknown files, and keeps non-Rust unknown handling policy-driven.
-- Next proof-policy operational slice: add `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` to print a stable proof plan without running it.
+- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` now prints a stable proof plan without running commands; `fast`, `release`, and `deep` profiles are plan-only placeholders for the next CI integration slices.
+- Next proof-policy operational slice: wire policy validation and affected-plan artifacts into CI while keeping existing jobs authoritative.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(name = "xtask")]
@@ -24,6 +24,8 @@ pub enum Commands {
     ProofPolicy(ProofPolicyArgs),
     /// Discover proof scopes affected by a git diff
     Affected(AffectedArgs),
+    /// Print proof command plans without executing them
+    Proof(ProofArgs),
     /// Verify all release-facing version surfaces are in sync
     VersionConsistency(VersionConsistencyArgs),
     /// Verify dependency boundaries for analysis microcrates
@@ -86,6 +88,37 @@ pub struct AffectedArgs {
     /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ProofArgs {
+    /// Proof profile to plan
+    #[arg(long, value_enum, default_value_t = ProofProfile::Affected)]
+    pub profile: ProofProfile,
+
+    /// Base git revision for affected profile discovery
+    #[arg(long, default_value = "origin/main")]
+    pub base: String,
+
+    /// Head git revision for affected profile discovery
+    #[arg(long, default_value = "HEAD")]
+    pub head: String,
+
+    /// Print the proof plan without executing commands
+    #[arg(long)]
+    pub plan: bool,
+
+    /// Policy file to use for scope matching
+    #[arg(long, default_value = "ci/proof.toml")]
+    pub policy: std::path::PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProofProfile {
+    Fast,
+    Affected,
+    Release,
+    Deep,
 }
 
 #[derive(Args, Debug, Clone, Default)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::Docs(args)) => tasks::docs::run(args),
         Some(cli::Commands::ProofPolicy(args)) => tasks::proof_policy::run(args),
         Some(cli::Commands::Affected(args)) => tasks::affected::run(args),
+        Some(cli::Commands::Proof(args)) => tasks::proof_plan::run(args),
         Some(cli::Commands::VersionConsistency(args)) => tasks::version_consistency::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),

--- a/xtask/src/tasks/affected.rs
+++ b/xtask/src/tasks/affected.rs
@@ -10,25 +10,25 @@ use std::path::Path;
 use std::process::Command;
 
 #[derive(Debug, Serialize)]
-struct AffectedReport {
-    schema: String,
-    ok: bool,
-    base: String,
-    head: String,
-    changed_files: Vec<String>,
-    scopes: Vec<AffectedScope>,
-    unknown_files: Vec<String>,
+pub(crate) struct AffectedReport {
+    pub(crate) schema: String,
+    pub(crate) ok: bool,
+    pub(crate) base: String,
+    pub(crate) head: String,
+    pub(crate) changed_files: Vec<String>,
+    pub(crate) scopes: Vec<AffectedScope>,
+    pub(crate) unknown_files: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct AffectedScope {
-    name: String,
-    kind: ScopeKind,
-    reason: String,
-    packages: Vec<String>,
-    proof: Vec<String>,
-    mutation: bool,
-    coverage: bool,
+pub(crate) struct AffectedScope {
+    pub(crate) name: String,
+    pub(crate) kind: ScopeKind,
+    pub(crate) reason: String,
+    pub(crate) packages: Vec<String>,
+    pub(crate) proof: Vec<String>,
+    pub(crate) mutation: bool,
+    pub(crate) coverage: bool,
 }
 
 #[derive(Debug)]
@@ -58,19 +58,21 @@ pub fn run(args: AffectedArgs) -> Result<()> {
     }
 }
 
-fn load_checked_policy(path: &Path) -> Result<ProofPolicy> {
+pub(crate) fn load_checked_policy(path: &Path) -> Result<ProofPolicy> {
     let policy = load_policy(path)?;
     let violations = validate_policy(&policy);
     if !violations.is_empty() {
         for violation in &violations {
             eprintln!("::error file={}::{}", path.display(), violation.message);
         }
-        bail!("proof policy is invalid; run `cargo xtask proof-policy --check` before affected");
+        bail!(
+            "proof policy is invalid; run `cargo xtask proof-policy --check` before affected/proof planning"
+        );
     }
     Ok(policy)
 }
 
-fn changed_files(base: &str, head: &str) -> Result<Vec<String>> {
+pub(crate) fn changed_files(base: &str, head: &str) -> Result<Vec<String>> {
     let output = Command::new("git")
         .args(["diff", "--name-only", base, head, "--"])
         .output()
@@ -96,7 +98,7 @@ fn changed_files(base: &str, head: &str) -> Result<Vec<String>> {
     Ok(files)
 }
 
-fn affected_report(
+pub(crate) fn affected_report(
     policy: &ProofPolicy,
     base: &str,
     head: &str,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -7,6 +7,7 @@ pub mod docs;
 pub mod fixture_blobs_check;
 pub mod gate;
 pub mod lint_fix;
+pub mod proof_plan;
 pub mod proof_policy;
 pub mod publish;
 pub mod publish_surface;

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -1,0 +1,199 @@
+use crate::cli::{ProofArgs, ProofProfile};
+use crate::proof::policy_ast::ProofPolicy;
+use crate::tasks::affected::{affected_report, changed_files, load_checked_policy};
+use anyhow::{Result, bail};
+use serde::Serialize;
+use std::collections::BTreeSet;
+
+#[derive(Debug, Serialize)]
+struct ProofPlanReport {
+    schema: String,
+    ok: bool,
+    profile: String,
+    base: String,
+    head: String,
+    changed_files: Vec<String>,
+    commands: Vec<ProofPlanCommand>,
+    unknown_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+struct ProofPlanCommand {
+    scope: String,
+    kind: String,
+    command: String,
+}
+
+pub fn run(args: ProofArgs) -> Result<()> {
+    if !args.plan {
+        bail!("proof execution is not implemented yet; pass --plan to print the proof plan");
+    }
+
+    let policy = load_checked_policy(&args.policy)?;
+    let report = proof_plan_report(&policy, &args)?;
+    println!("{}", serde_json::to_string_pretty(&report)?);
+
+    if report.ok {
+        Ok(())
+    } else {
+        bail!(
+            "proof plan has {} unknown file(s) that need scope policy",
+            report.unknown_files.len()
+        )
+    }
+}
+
+fn proof_plan_report(policy: &ProofPolicy, args: &ProofArgs) -> Result<ProofPlanReport> {
+    match args.profile {
+        ProofProfile::Affected => affected_plan_report(policy, args),
+        profile => Ok(static_plan_report(profile, &args.base, &args.head)),
+    }
+}
+
+fn affected_plan_report(policy: &ProofPolicy, args: &ProofArgs) -> Result<ProofPlanReport> {
+    let changed_files = changed_files(&args.base, &args.head)?;
+    let affected = affected_report(policy, &args.base, &args.head, changed_files)?;
+    let mut commands = Vec::new();
+
+    for scope in &affected.scopes {
+        for command in &scope.proof {
+            commands.push(ProofPlanCommand {
+                scope: scope.name.clone(),
+                kind: "proof".to_string(),
+                command: command.clone(),
+            });
+        }
+    }
+
+    Ok(ProofPlanReport {
+        schema: "tokmd.proof_plan.v1".to_string(),
+        ok: affected.ok,
+        profile: profile_name(args.profile).to_string(),
+        base: affected.base,
+        head: affected.head,
+        changed_files: affected.changed_files,
+        commands: dedupe_commands(commands),
+        unknown_files: affected.unknown_files,
+    })
+}
+
+fn static_plan_report(profile: ProofProfile, base: &str, head: &str) -> ProofPlanReport {
+    ProofPlanReport {
+        schema: "tokmd.proof_plan.v1".to_string(),
+        ok: true,
+        profile: profile_name(profile).to_string(),
+        base: base.to_string(),
+        head: head.to_string(),
+        changed_files: Vec::new(),
+        commands: static_profile_commands(profile),
+        unknown_files: Vec::new(),
+    }
+}
+
+fn static_profile_commands(profile: ProofProfile) -> Vec<ProofPlanCommand> {
+    let commands = match profile {
+        ProofProfile::Fast => vec![
+            command("workspace", "format", "cargo fmt-check"),
+            command("proof_policy", "policy", "cargo xtask proof-policy --check"),
+            command(
+                "fixture_blobs",
+                "guardrail",
+                "cargo xtask fixture-blobs-check",
+            ),
+            command("boundaries", "guardrail", "cargo xtask boundaries-check"),
+        ],
+        ProofProfile::Release => vec![
+            command("docs", "docs", "cargo xtask docs --check"),
+            command("version", "release", "cargo xtask version-consistency"),
+            command(
+                "publish_surface",
+                "release",
+                "cargo xtask publish-surface --json --verify-publish",
+            ),
+            command(
+                "dependencies",
+                "security",
+                "cargo deny --all-features check",
+            ),
+        ],
+        ProofProfile::Deep => vec![
+            command("workspace", "test", "cargo test --workspace"),
+            command("coverage", "coverage", "cargo llvm-cov --workspace --lcov"),
+            command("mutation", "mutation", "cargo mutants --timeout 300"),
+            command("fuzz", "fuzz", "cargo +nightly fuzz list"),
+        ],
+        ProofProfile::Affected => Vec::new(),
+    };
+
+    dedupe_commands(commands)
+}
+
+fn command(scope: &str, kind: &str, command: &str) -> ProofPlanCommand {
+    ProofPlanCommand {
+        scope: scope.to_string(),
+        kind: kind.to_string(),
+        command: command.to_string(),
+    }
+}
+
+fn dedupe_commands(commands: Vec<ProofPlanCommand>) -> Vec<ProofPlanCommand> {
+    commands
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn profile_name(profile: ProofProfile) -> &'static str {
+    match profile {
+        ProofProfile::Fast => "fast",
+        ProofProfile::Affected => "affected",
+        ProofProfile::Release => "release",
+        ProofProfile::Deep => "deep",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dedupe_commands, static_profile_commands};
+    use crate::cli::ProofProfile;
+
+    #[test]
+    fn static_profiles_have_deterministic_commands() {
+        let fast = static_profile_commands(ProofProfile::Fast);
+
+        assert!(!fast.is_empty());
+        assert_eq!(fast, dedupe_commands(fast.clone()));
+        assert!(fast.iter().any(|cmd| cmd.command == "cargo fmt-check"));
+    }
+
+    #[test]
+    fn release_profile_includes_release_facing_checks() {
+        let release = static_profile_commands(ProofProfile::Release);
+
+        assert!(
+            release
+                .iter()
+                .any(|cmd| cmd.command.contains("docs --check"))
+        );
+        assert!(
+            release
+                .iter()
+                .any(|cmd| cmd.command.contains("version-consistency"))
+        );
+        assert!(
+            release
+                .iter()
+                .any(|cmd| cmd.command.contains("publish-surface"))
+        );
+    }
+
+    #[test]
+    fn deep_profile_includes_heavy_evidence_commands() {
+        let deep = static_profile_commands(ProofProfile::Deep);
+
+        assert!(deep.iter().any(|cmd| cmd.kind == "coverage"));
+        assert!(deep.iter().any(|cmd| cmd.kind == "mutation"));
+        assert!(deep.iter().any(|cmd| cmd.kind == "fuzz"));
+    }
+}

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -1,0 +1,99 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.parent().unwrap().to_path_buf()
+}
+
+fn run_xtask(args: &[&str]) -> (String, String, bool) {
+    let root = workspace_root();
+    let output = Command::new("cargo")
+        .arg("run")
+        .arg("-q")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .args(args)
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cargo xtask");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (stdout, stderr, output.status.success())
+}
+
+#[test]
+fn proof_help_mentions_profile_and_plan() {
+    let (stdout, stderr, success) = run_xtask(&["proof", "--help"]);
+
+    assert!(success, "proof --help failed. stderr: {stderr}");
+    assert!(stdout.contains("--profile"), "stdout: {stdout}");
+    assert!(stdout.contains("--plan"), "stdout: {stdout}");
+}
+
+#[test]
+fn affected_proof_plan_reports_no_changes_for_same_ref() {
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof",
+        "--profile",
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--plan",
+    ]);
+
+    assert!(success, "proof --plan failed. stderr: {stderr}");
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("proof --plan should emit JSON");
+
+    assert_eq!(value["schema"], "tokmd.proof_plan.v1");
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["profile"], "affected");
+    assert_eq!(value["base"], "HEAD");
+    assert_eq!(value["head"], "HEAD");
+    assert!(value["commands"].as_array().unwrap().is_empty());
+    assert!(value["unknown_files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn proof_without_plan_refuses_to_execute() {
+    let (_stdout, stderr, success) = run_xtask(&["proof", "--profile", "affected"]);
+
+    assert!(!success, "proof without --plan should fail for now");
+    assert!(
+        stderr.contains("--plan") || stderr.contains("not implemented"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn fast_proof_plan_includes_policy_and_guardrails() {
+    let (stdout, stderr, success) = run_xtask(&["proof", "--profile", "fast", "--plan"]);
+
+    assert!(success, "proof fast --plan failed. stderr: {stderr}");
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("proof fast --plan should emit JSON");
+    let commands = value["commands"]
+        .as_array()
+        .expect("commands should be array");
+
+    assert_eq!(value["profile"], "fast");
+    assert!(
+        commands
+            .iter()
+            .any(|cmd| cmd["command"] == "cargo xtask proof-policy --check")
+    );
+    assert!(
+        commands
+            .iter()
+            .any(|cmd| cmd["command"] == "cargo xtask fixture-blobs-check")
+    );
+    assert!(
+        commands
+            .iter()
+            .any(|cmd| cmd["command"] == "cargo xtask boundaries-check")
+    );
+}


### PR DESCRIPTION
## Summary
- add plan-only `cargo xtask proof --profile ... --plan` output with `fast`, `affected`, `release`, and `deep` profiles
- reuse affected proof-scope discovery so `--profile affected` emits deterministic proof commands from `ci/proof.toml`
- refuse proof execution without `--plan` until execution semantics are intentionally implemented
- update `docs/NEXT.md` and proof-control-plane scope entries for the next CI artifact slice

## Validation
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-policy --check`
- `cargo test -p xtask proof --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `git diff origin/main..HEAD --check`