### PR TITLE
Add proof policy and affected plan CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,69 @@ jobs:
       - name: Guard analysis microcrate boundaries
         run: cargo xtask boundaries-check
 
+  proof-policy:
+    name: Proof Policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Validate proof policy
+        run: cargo xtask proof-policy --check
+
+  affected-plan:
+    name: Affected Proof Plan
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Fetch base ref
+        run: git fetch origin "${{ github.base_ref }}":"refs/remotes/origin/${{ github.base_ref }}" || true
+
+      - name: Generate affected proof artifacts
+        run: |
+          set +e
+          mkdir -p target/proof
+
+          cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json > target/proof/affected.json
+          affected_status=$?
+
+          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan > target/proof/proof-plan.json
+          proof_plan_status=$?
+
+          {
+            echo "affected_status=${affected_status}"
+            echo "proof_plan_status=${proof_plan_status}"
+          } > target/proof/status.env
+
+          {
+            echo "## Affected Proof Plan"
+            echo ""
+            echo "| Command | Exit |"
+            echo "| --- | ---: |"
+            echo "| affected | ${affected_status} |"
+            echo "| proof plan | ${proof_plan_status} |"
+            echo ""
+            echo "This job is informational while proof planning is being adopted; existing CI jobs remain authoritative."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit 0
+
+      - name: Upload affected proof artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: affected-proof-plan
+          path: target/proof/
+          if-no-files-found: error
+
   wasm-compile:
     name: Wasm Compile & Test
     runs-on: ubuntu-latest
@@ -346,6 +409,7 @@ jobs:
       - nix-pr
       - mutation
       - feature-boundaries
+      - proof-policy
     steps:
       - name: Check overall status
         env:

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -14,6 +14,7 @@ javascript = "npm"
 name = "proof_control_plane"
 kind = "rust"
 paths = [
+  ".github/workflows/ci.yml",
   "ci/proof.toml",
   "docs/NEXT.md",
   "xtask/src/cli.rs",

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -14,7 +14,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 2. Move dependency-boundary and fixture/blob allowlists into the proof policy while preserving current behavior.
 3. Add `cargo xtask affected --base origin/main --head HEAD --json` for changed-file to proof-scope discovery.
 4. Add `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` to print a stable proof plan without running it.
-5. Wire policy validation into CI as a small standalone job before replacing larger workflow logic.
+5. Wire policy validation and affected-plan artifacts into CI before replacing larger workflow logic.
 
 ## Directional Rules
 
@@ -29,7 +29,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Fixture-blob checks now read `ci/proof.toml` while preserving the existing crypto extension and marker detection plus the `.claude`, `.jules`, `vendor`, proof-policy source, and checker-source allowlist behavior.
 - `cargo xtask affected --base origin/main --head HEAD --json` now maps changed files to proof scopes from `ci/proof.toml`, reports unknown files, and keeps non-Rust unknown handling policy-driven.
 - `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` now prints a stable proof plan without running commands; `fast`, `release`, and `deep` profiles are plan-only placeholders for the next CI integration slices.
-- Next proof-policy operational slice: wire policy validation and affected-plan artifacts into CI while keeping existing jobs authoritative.
+- CI now validates `cargo xtask proof-policy --check` as part of the required aggregate and uploads PR-only affected proof artifacts while keeping existing jobs authoritative.
+- Next proof-policy operational slice: expand the proof scope registry for the main product surfaces before using affected plans to drive required checks.
 
 ## References
 


### PR DESCRIPTION
## Summary
- add a required `Proof Policy` CI job that runs `cargo xtask proof-policy --check`
- add an informational PR-only `Affected Proof Plan` job that uploads `affected.json`, `proof-plan.json`, and status metadata
- keep existing CI jobs authoritative while proof planning is adopted
- include `.github/workflows/ci.yml` in the proof-control-plane scope and update `docs/NEXT.md`

## Validation
- `python - <<'PY' ... yaml.safe_load(...) ... PY`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff origin/main..HEAD --check`