### PR TITLE
Expand proof policy product scopes

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -55,6 +55,77 @@ mutation = true
 coverage = true
 
 [[scope]]
+name = "tokmd_cli"
+kind = "rust"
+paths = [
+  "crates/tokmd/src/bin/**",
+  "crates/tokmd/src/cli/**",
+  "crates/tokmd/src/commands/**",
+  "crates/tokmd/src/config.rs",
+  "crates/tokmd/src/error_hints.rs",
+  "crates/tokmd/tests/cli_*.rs",
+  "crates/tokmd/tests/config_resolution.rs",
+  "docs/reference-cli.md",
+]
+packages = ["tokmd"]
+proof = [
+  "cargo test -p tokmd --test cli_snapshot_golden --verbose",
+  "cargo test -p tokmd --test cli_e2e --verbose",
+  "cargo test -p tokmd --test config_resolution --verbose",
+]
+mutation = true
+coverage = true
+
+[[scope]]
+name = "tokmd_gate"
+kind = "rust"
+paths = [
+  "crates/tokmd-gate/**",
+  "crates/tokmd/src/commands/gate.rs",
+  "crates/tokmd/tests/gate_integration.rs",
+]
+packages = ["tokmd-gate", "tokmd"]
+proof = [
+  "cargo test -p tokmd-gate --verbose",
+  "cargo test -p tokmd --test gate_integration --verbose",
+]
+mutation = true
+coverage = true
+
+[[scope]]
+name = "tokmd_cockpit"
+kind = "rust"
+paths = [
+  ".github/workflows/cockpit.yml",
+  "crates/tokmd-cockpit/**",
+  "crates/tokmd-types/src/cockpit.rs",
+  "crates/tokmd-types/tests/cockpit_tests.rs",
+  "crates/tokmd/src/commands/cockpit.rs",
+  "crates/tokmd/tests/cockpit_*.rs",
+  "docs/tokmd-in-cockpit.md",
+]
+packages = ["tokmd-cockpit", "tokmd-types", "tokmd"]
+proof = [
+  "cargo test -p tokmd-cockpit --verbose",
+  "cargo test -p tokmd-types cockpit --verbose",
+  "cargo test -p tokmd --test cockpit_integration --verbose",
+]
+mutation = true
+coverage = true
+
+[[scope]]
+name = "tokmd_wasm"
+kind = "rust"
+paths = [
+  "crates/tokmd-wasm/**",
+  "docs/capabilities/wasm.json",
+]
+packages = ["tokmd-wasm"]
+proof = ["cargo test -p tokmd-wasm --verbose"]
+mutation = true
+coverage = true
+
+[[scope]]
 name = "browser_runner"
 kind = "non_rust"
 paths = ["web/runner/**", "docs/capabilities/wasm.json"]
@@ -65,6 +136,47 @@ proof = [
 reason = "Browser worker and GitHub ingest logic are JavaScript/WASM-facing surfaces."
 mutation = false
 coverage = false
+
+[[scope]]
+name = "github_action"
+kind = "non_rust"
+paths = [
+  ".github/workflows/test-action.yml",
+  "action.yml",
+  "docs/github-action.md",
+]
+proof = [
+  "cargo xtask docs --check",
+  "cargo test -p tokmd --test docs --verbose",
+]
+reason = "The composite GitHub Action is a YAML and documentation contract for repository consumers."
+mutation = false
+coverage = false
+
+[[scope]]
+name = "schema_contracts"
+kind = "rust"
+paths = [
+  "crates/tokmd/schemas/**",
+  "crates/tokmd/tests/schema*.rs",
+  "crates/tokmd-types/src/lib.rs",
+  "crates/tokmd-types/tests/schema*.rs",
+  "docs/SCHEMA.md",
+  "docs/adr/0007-schema-family-versioning.md",
+  "docs/baseline.schema.json",
+  "docs/handoff.schema.json",
+  "docs/handoff-schema.md",
+  "docs/schema.json",
+]
+packages = ["tokmd-types", "tokmd"]
+proof = [
+  "cargo test -p tokmd-types schema --verbose",
+  "cargo test -p tokmd --test schema_sync --verbose",
+  "cargo test -p tokmd --test schema_doc_sync --verbose",
+  "cargo xtask docs --check",
+]
+mutation = false
+coverage = true
 
 [[allow.workspace_area]]
 name = "jules_knowledge_workspace"

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -30,7 +30,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask affected --base origin/main --head HEAD --json` now maps changed files to proof scopes from `ci/proof.toml`, reports unknown files, and keeps non-Rust unknown handling policy-driven.
 - `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` now prints a stable proof plan without running commands; `fast`, `release`, and `deep` profiles are plan-only placeholders for the next CI integration slices.
 - CI now validates `cargo xtask proof-policy --check` as part of the required aggregate and uploads PR-only affected proof artifacts while keeping existing jobs authoritative.
-- Next proof-policy operational slice: expand the proof scope registry for the main product surfaces before using affected plans to drive required checks.
+- The proof scope registry now covers first-class product/control-plane surfaces for CLI, gate, cockpit, WASM, browser runner, the composite GitHub Action, schema contracts, and the proof control plane.
+- Next proof-policy operational slice: expand analysis and formatting module scopes before using affected plans to drive required checks.
 
 ## References
 

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -42,7 +42,7 @@ fn proof_policy_json_reports_current_schema() {
 
     assert_eq!(value["ok"], true);
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
-    assert_eq!(value["scope_count"], 3);
+    assert_eq!(value["scope_count"], 9);
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);


### PR DESCRIPTION
## Summary
- add first-class proof policy scopes for CLI, gate, cockpit, WASM, GitHub Action, and schema contracts
- update the proof-policy JSON count test for the expanded registry
- record the post-drain checkpoint in docs/NEXT.md

## Validation
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask proof_policy --verbose
- cargo test -p xtask affected --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_plan --verbose
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo test -p tokmd-wasm --verbose
- cargo test -p tokmd --test docs --verbose
- cargo xtask docs --check
- cargo fmt-check
- git diff origin/main..HEAD --check