### PR TITLE
Add governed Clippy policy baseline (MSRV 1.93) and xtask lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Rust (MSRV)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92
+          toolchain: 1.93
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV compatibility
         run: cargo check --workspace --all-features
@@ -149,6 +149,9 @@ jobs:
         run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: Run lint policy gate
+        run: cargo xtask check-lint-policy
 
       - name: Run quality gate
         run: cargo xtask gate --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,135 @@ default-members = [
 [workspace.package]
 version = "1.10.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/EffortlessMetrics/tokmd"
 repository = "https://github.com/EffortlessMetrics/tokmd"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 [workspace.metadata.crane]
 name = "tokmd-workspace"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# tokmd keeps Clippy behavior in Cargo.toml and policy/clippy-lints.toml.
+# This file is reserved for repo-specific disallowed methods, types, macros, or
+# paths. Do not add test carveouts such as allow-unwrap-in-tests here; tokmd's
+# policy is workspace panic-free across production code and tests.

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,74 @@
+# Clippy policy
+
+Tokmd treats Clippy as a governed engineering surface rather than a local taste
+file. The root manifest declares one Effortless Metrics lint baseline, the same lints
+are tracked in `policy/clippy-lints.toml`, and repo-local exceptions live in
+explicit policy ledgers. Member inheritance is staged behind this policy gate so
+that a follow-up cleanup PR can make the stricter block blocking without
+silently weakening it.
+
+## Baseline
+
+The target baseline is intentionally workspace-wide:
+
+- panic-free production and test code (`unwrap`, `expect`, `panic!`, `todo!`,
+  `unimplemented!`, `unreachable!`, and related result-collapse shapes are
+  denied);
+- silent-failure prevention for discarded futures, locks, must-use values,
+  ignored errors, and lossy line iteration;
+- AST, UTF-8, string slicing, and indexing safety for parser/reporting code;
+- async, concurrency, unsafe/memory, numeric correctness, filesystem/process,
+  API-correctness, and reviewability lints;
+- suppression governance: blanket `#[allow]` usage is not the normal escape
+  hatch.
+
+Tests are not a carveout. Prefer tests that return `Result<(), Box<dyn
+std::error::Error>>`, propagate setup failures with `?`, and use assertion
+helpers that return structured errors when panic-free fixtures are needed.
+
+## Suppression style
+
+New suppressions must be narrow and reviewed:
+
+```rust
+#[expect(
+    clippy::indexing_slicing,
+    reason = "generated parser table access is tracked in policy/clippy-debt.toml"
+)]
+fn lookup_generated_table(...) { ... }
+```
+
+Do not add broad Clippy carveouts to `clippy.toml`, and do not enable test
+carveouts such as `allow-unwrap-in-tests`, `allow-expect-in-tests`,
+`allow-panic-in-tests`, `allow-indexing-slicing-in-tests`, or
+`allow-dbg-in-tests`.
+
+## Policy files
+
+- `policy/clippy-lints.toml` is the machine-readable source of truth for active
+  lints, MSRV, posture flags, and planned Rust 1.94/1.95 flips.
+- `policy/clippy-debt.toml` is for temporary repo-specific debt. Each debt entry
+  must include `lint`, `path`, `owner`, `reason`, and `expires`.
+- `clippy.toml` is reserved for repo-specific `disallowed-*` policy. It must not
+  weaken the workspace baseline.
+
+## Upgrade ledger
+
+The workspace currently targets Rust 1.93. Planned Clippy flips for Rust 1.94
+and 1.95 are recorded before the MSRV bump so that upgrades are reviewable,
+searchable, and gated by policy.
+
+## Gate
+
+Run the policy gate with:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The gate verifies that MSRV agrees with the policy ledger, active lint levels
+match the root manifest, planned lint flips are not activated too early,
+workspace members do not define repo-local lint overrides, `clippy.toml` does
+not contain test carveouts, and debt entries are complete and unexpired. A
+follow-up cleanup PR can then switch members to `[lints] workspace = true` once
+the inherited lint debt is reduced enough for CI.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,4 @@
+schema = 1
+
+# Temporary lint exceptions belong here, not in clippy.toml carveouts.
+# Each future debt entry must include lint, path, owner, reason, and expires.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,775 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "forbid"
+status = "active"
+class = "rust-safety"
+reason = "Workspace Rust lint `unsafe_code` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "rust-safety"
+reason = "Workspace Rust lint `unsafe_op_in_unsafe_fn` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "rust-safety"
+reason = "Workspace Rust lint `unused_must_use` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "rust-safety"
+reason = "Workspace Rust lint `unexpected_cfgs` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "rust-safety"
+reason = "Workspace Rust lint `const_item_interior_mutations` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "rust-safety"
+reason = "Workspace Rust lint `function_casts_as_integer` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `dbg_macro` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `todo` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `unimplemented` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `panic` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `unreachable` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `unwrap_used` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `expect_used` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `get_unwrap` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `unwrap_in_result` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Clippy lint `panic_in_result_fn` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "slice-safety"
+reason = "Clippy lint `string_slice` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "slice-safety"
+reason = "Clippy lint `indexing_slicing` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "slice-safety"
+reason = "Clippy lint `out_of_bounds_indexing` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "time"
+reason = "Clippy lint `unchecked_time_subtraction` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "utf8"
+reason = "Clippy lint `char_indices_as_byte_indices` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "utf8"
+reason = "Clippy lint `sliced_string_as_bytes` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "slice-safety"
+reason = "Clippy lint `index_refutable_slice` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Clippy lint `let_underscore_future` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Clippy lint `let_underscore_must_use` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Clippy lint `let_underscore_lock` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Clippy lint `unused_result_ok` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Clippy lint `map_err_ignore` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Clippy lint `assertions_on_result_states` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Clippy lint `lines_filter_map_ok` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `await_holding_lock` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `await_holding_refcell_ref` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `await_holding_invalid_type` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `future_not_send` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `large_futures` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `arc_with_non_send_sync` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `rc_mutex` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `mut_mutex_lock` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Clippy lint `readonly_write_lock` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Clippy lint `mem_forget` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Clippy lint `forget_non_drop` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Clippy lint `drop_non_drop` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Clippy lint `undocumented_unsafe_blocks` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Clippy lint `multiple_unsafe_ops_per_block` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Clippy lint `repr_packed_without_abi` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `float_cmp` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `float_cmp_const` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `float_equality_without_abs` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `lossy_float_literal` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `cast_sign_loss` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `cast_possible_wrap` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `cast_possible_truncation` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `cast_precision_loss` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `invalid_upcast_comparisons` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `cast_abs_to_unsigned` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `cast_enum_truncation` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `cast_nan_to_int` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `manual_midpoint` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `manual_is_multiple_of` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `manual_div_ceil` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Clippy lint `arithmetic_side_effects` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "fs-process"
+reason = "Clippy lint `suspicious_open_options` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "fs-process"
+reason = "Clippy lint `nonsensical_open_options` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "fs-process"
+reason = "Clippy lint `ineffective_open_options` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "fs-process"
+reason = "Clippy lint `path_buf_push_overwrite` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "fs-process"
+reason = "Clippy lint `join_absolute_paths` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "fs-process"
+reason = "Clippy lint `read_line_without_trim` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "fs-process"
+reason = "Clippy lint `exit` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Clippy lint `iter_not_returning_iterator` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Clippy lint `expl_impl_clone_on_copy` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Clippy lint `infallible_try_from` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Clippy lint `fallible_impl_from` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Clippy lint `error_impl_error` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api"
+reason = "Clippy lint `result_unit_err` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api"
+reason = "Clippy lint `result_large_err` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Clippy lint `format_in_format_args` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Clippy lint `to_string_in_format_args` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Clippy lint `unused_format_specs` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `unnecessary_debug_formatting` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `uninlined_format_args` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `manual_let_else` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `manual_ok_or` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `manual_strip` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `manual_split_once` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `manual_is_variant_and` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `filter_map_next` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `flat_map_option` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Clippy lint `match_result_ok` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `cloned_instead_of_copied` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `iter_cloned_collect` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `iter_overeager_cloned` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `needless_collect` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `redundant_closure` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Clippy lint `redundant_closure_for_method_calls` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "docs"
+reason = "Clippy lint `missing_panics_doc` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "docs"
+reason = "Clippy lint `missing_errors_doc` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Clippy lint `allow_attributes` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Clippy lint `allow_attributes_without_reason` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Clippy lint `blanket_clippy_restriction_lints` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Clippy lint `ignore_without_reason` is part of the shared Effortless Metrics baseline."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Clippy lint `should_panic_without_expect` is part of the shared Effortless Metrics baseline."
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -34,6 +34,8 @@ pub enum Commands {
     FixtureBlobsCheck(FixtureBlobsCheckArgs),
     /// Run pre-merge quality gate (fmt, check, clippy, test-compile)
     Gate(GateArgs),
+    /// Verify workspace Clippy lint policy and debt ledgers
+    CheckLintPolicy(LintPolicyArgs),
     /// Auto-fix lint issues (fmt + clippy --fix) then verify
     LintFix(LintFixArgs),
     /// Run Cargo through an opt-in local sccache wrapper
@@ -55,6 +57,9 @@ pub struct DocsArgs {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct VersionConsistencyArgs {}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct LintPolicyArgs {}
 
 #[derive(Args, Debug, Clone)]
 pub struct ProofPolicyArgs {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),
         Some(cli::Commands::Gate(args)) => tasks::gate::run(args),
+        Some(cli::Commands::CheckLintPolicy(args)) => tasks::lint_policy::run(args),
         Some(cli::Commands::LintFix(args)) => tasks::lint_fix::run(args),
         Some(cli::Commands::Sccache(args)) => tasks::sccache::run(args),
         Some(cli::Commands::TrimTarget(args)) => tasks::trim_target::run(args),

--- a/xtask/src/tasks/lint_policy.rs
+++ b/xtask/src/tasks/lint_policy.rs
@@ -1,0 +1,360 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use cargo_metadata::MetadataCommand;
+use chrono::{NaiveDate, Utc};
+use serde::Deserialize;
+use toml::Value;
+
+use crate::cli::LintPolicyArgs;
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+#[derive(Debug, Deserialize)]
+struct LintPolicyFile {
+    schema: u32,
+    msrv: String,
+    policy: PolicyPosture,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+    #[serde(default)]
+    planned: Vec<PlannedLint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyPosture {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlannedLint {
+    name: String,
+    level: String,
+    activate_when_msrv: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtFile {
+    schema: u32,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+pub fn run(_args: LintPolicyArgs) -> Result<()> {
+    let root = workspace_root()?;
+    let mut errors = Vec::new();
+
+    let cargo_toml = read_toml(&root.join("Cargo.toml"), &mut errors)?;
+    let policy = read_policy(&root.join("policy/clippy-lints.toml"), &mut errors)?;
+
+    validate_policy_shape(&policy, &mut errors);
+    validate_msrv(&cargo_toml, &policy, &mut errors);
+    validate_workspace_lints(&cargo_toml, &policy, &mut errors);
+    validate_workspace_members_do_not_override_lints(&root, &mut errors);
+    validate_clippy_toml(&root.join("clippy.toml"), &mut errors);
+    validate_planned_lints(&cargo_toml, &policy, &mut errors);
+    validate_debt(&root.join("policy/clippy-debt.toml"), &mut errors);
+
+    if !errors.is_empty() {
+        for error in &errors {
+            eprintln!("lint policy error: {error}");
+        }
+        bail!("lint policy check failed with {} error(s)", errors.len());
+    }
+
+    println!(
+        "lint policy ok: {} active lints, {} planned lints, MSRV {}",
+        policy.lint.len(),
+        policy.planned.len(),
+        policy.msrv
+    );
+    Ok(())
+}
+
+fn metadata_command() -> MetadataCommand {
+    let mut command = MetadataCommand::new();
+    command.no_deps();
+    command
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let metadata = metadata_command().exec().context("load cargo metadata")?;
+    Ok(metadata.workspace_root.into_std_path_buf())
+}
+
+fn read_toml(path: &Path, errors: &mut Vec<String>) -> Result<Value> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) => {
+            errors.push(format!("{} is unreadable: {err}", path.display()));
+            String::new()
+        }
+    };
+    if content.is_empty() {
+        return Ok(Value::Table(Default::default()));
+    }
+    match toml::from_str::<Value>(&content) {
+        Ok(value) => Ok(value),
+        Err(err) => {
+            errors.push(format!("{} is invalid TOML: {err}", path.display()));
+            Ok(Value::Table(Default::default()))
+        }
+    }
+}
+
+fn read_policy(path: &Path, errors: &mut Vec<String>) -> Result<LintPolicyFile> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&content).map_err(|err| {
+        errors.push(format!("{} is invalid policy TOML: {err}", path.display()));
+        anyhow!("invalid lint policy")
+    })
+}
+
+fn validate_policy_shape(policy: &LintPolicyFile, errors: &mut Vec<String>) {
+    if policy.schema != 1 {
+        errors.push(format!("policy schema must be 1, got {}", policy.schema));
+    }
+    if !policy.policy.panic_free_tests {
+        errors.push("policy.panic_free_tests must be true".to_string());
+    }
+    if policy.policy.allow_test_carveouts {
+        errors.push("policy.allow_test_carveouts must be false".to_string());
+    }
+    if policy.policy.suppression_style != "expect-with-reason" {
+        errors.push("policy.suppression_style must be expect-with-reason".to_string());
+    }
+    if policy.policy.blanket_categories {
+        errors.push("policy.blanket_categories must be false".to_string());
+    }
+
+    let mut seen = BTreeSet::new();
+    for lint in &policy.lint {
+        if !seen.insert(&lint.name) {
+            errors.push(format!("duplicate active lint {}", lint.name));
+        }
+        require_non_empty(&lint.name, "lint.name", errors);
+        require_non_empty(&lint.level, "lint.level", errors);
+        require_non_empty(&lint.status, "lint.status", errors);
+        require_non_empty(&lint.class, "lint.class", errors);
+        require_non_empty(&lint.reason, "lint.reason", errors);
+        if lint.status != "active" {
+            errors.push(format!("lint {} must have status = active", lint.name));
+        }
+    }
+
+    let mut planned_seen = BTreeSet::new();
+    for planned in &policy.planned {
+        if !planned_seen.insert(&planned.name) {
+            errors.push(format!("duplicate planned lint {}", planned.name));
+        }
+        require_non_empty(&planned.name, "planned.name", errors);
+        require_non_empty(&planned.level, "planned.level", errors);
+        require_non_empty(
+            &planned.activate_when_msrv,
+            "planned.activate_when_msrv",
+            errors,
+        );
+        require_non_empty(&planned.reason, "planned.reason", errors);
+    }
+}
+
+fn validate_msrv(cargo_toml: &Value, policy: &LintPolicyFile, errors: &mut Vec<String>) {
+    let rust_version = cargo_toml
+        .get("workspace")
+        .and_then(|v| v.get("package"))
+        .and_then(|v| v.get("rust-version"))
+        .and_then(Value::as_str);
+    if rust_version != Some(policy.msrv.as_str()) {
+        errors.push(format!(
+            "workspace.package.rust-version ({rust_version:?}) must equal policy msrv ({})",
+            policy.msrv
+        ));
+    }
+}
+
+fn validate_workspace_lints(cargo_toml: &Value, policy: &LintPolicyFile, errors: &mut Vec<String>) {
+    let rust_lints = cargo_toml
+        .get("workspace")
+        .and_then(|v| v.get("lints"))
+        .and_then(|v| v.get("rust"));
+    let clippy_lints = cargo_toml
+        .get("workspace")
+        .and_then(|v| v.get("lints"))
+        .and_then(|v| v.get("clippy"));
+
+    let active: BTreeMap<&str, &str> = policy
+        .lint
+        .iter()
+        .map(|lint| (lint.name.as_str(), lint.level.as_str()))
+        .collect();
+
+    for (name, level) in active {
+        let (table, key) = if let Some(key) = name.strip_prefix("rust::") {
+            (rust_lints, key)
+        } else if let Some(key) = name.strip_prefix("clippy::") {
+            (clippy_lints, key)
+        } else {
+            errors.push(format!("lint {name} must start with rust:: or clippy::"));
+            continue;
+        };
+        let actual = table.and_then(|v| v.get(key)).and_then(Value::as_str);
+        if actual != Some(level) {
+            errors.push(format!(
+                "workspace lint {name} must be {level:?}, got {actual:?}"
+            ));
+        }
+    }
+}
+
+fn validate_workspace_members_do_not_override_lints(root: &Path, errors: &mut Vec<String>) {
+    let metadata = match metadata_command().current_dir(root).exec() {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            errors.push(format!("could not load cargo metadata: {err}"));
+            return;
+        }
+    };
+    let root_manifest = root.join("Cargo.toml");
+    for package in metadata.packages {
+        let manifest = package.manifest_path.into_std_path_buf();
+        if manifest == root_manifest {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&manifest) else {
+            errors.push(format!("{} is unreadable", manifest.display()));
+            continue;
+        };
+        let Ok(value) = toml::from_str::<Value>(&content) else {
+            errors.push(format!("{} is invalid TOML", manifest.display()));
+            continue;
+        };
+
+        if let Some(lints) = value.get("lints") {
+            let inherits = lints.get("workspace").and_then(Value::as_bool) == Some(true);
+            if !inherits {
+                errors.push(format!(
+                    "{} must not define repo-local lint overrides; use [lints] workspace = true when enabling inheritance",
+                    manifest.display()
+                ));
+            }
+        }
+    }
+}
+
+fn validate_clippy_toml(path: &Path, errors: &mut Vec<String>) {
+    if !path.exists() {
+        errors.push(format!("{} must exist", path.display()));
+        return;
+    }
+    let value = match read_toml(path, errors) {
+        Ok(value) => value,
+        Err(err) => {
+            errors.push(format!("{} could not be read: {err}", path.display()));
+            return;
+        }
+    };
+    for key in TEST_CARVEOUTS {
+        if value.get(*key).and_then(Value::as_bool) == Some(true) {
+            errors.push(format!("clippy.toml must not enable {key}"));
+        }
+    }
+}
+
+fn validate_planned_lints(cargo_toml: &Value, policy: &LintPolicyFile, errors: &mut Vec<String>) {
+    let rust_version = cargo_toml
+        .get("workspace")
+        .and_then(|v| v.get("package"))
+        .and_then(|v| v.get("rust-version"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let active = cargo_toml
+        .get("workspace")
+        .and_then(|v| v.get("lints"))
+        .and_then(|v| v.get("clippy"));
+    for planned in &policy.planned {
+        if planned.activate_when_msrv.as_str() > rust_version {
+            let key = planned.name.trim_start_matches("clippy::");
+            if active.and_then(|v| v.get(key)).is_some() {
+                errors.push(format!(
+                    "planned lint {} is active before MSRV {}",
+                    planned.name, planned.activate_when_msrv
+                ));
+            }
+        }
+    }
+}
+
+fn validate_debt(path: &Path, errors: &mut Vec<String>) {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) => {
+            errors.push(format!("{} is unreadable: {err}", path.display()));
+            return;
+        }
+    };
+    let debt_file = match toml::from_str::<DebtFile>(&content) {
+        Ok(debt_file) => debt_file,
+        Err(err) => {
+            errors.push(format!("{} is invalid TOML: {err}", path.display()));
+            return;
+        }
+    };
+    if debt_file.schema != 1 {
+        errors.push(format!("debt schema must be 1, got {}", debt_file.schema));
+    }
+    let today = Utc::now().date_naive();
+    for debt in debt_file.debt {
+        require_non_empty(&debt.lint, "debt.lint", errors);
+        require_non_empty(&debt.path, "debt.path", errors);
+        require_non_empty(&debt.owner, "debt.owner", errors);
+        require_non_empty(&debt.reason, "debt.reason", errors);
+        require_non_empty(&debt.expires, "debt.expires", errors);
+        match NaiveDate::parse_from_str(&debt.expires, "%Y-%m-%d") {
+            Ok(expires) if expires < today => errors.push(format!(
+                "debt {} at {} expired on {}",
+                debt.lint, debt.path, debt.expires
+            )),
+            Ok(_) => {}
+            Err(err) => errors.push(format!(
+                "debt {} at {} has invalid expires date {}: {err}",
+                debt.lint, debt.path, debt.expires
+            )),
+        }
+    }
+}
+
+fn require_non_empty(value: &str, field: &str, errors: &mut Vec<String>) {
+    if value.trim().is_empty() {
+        errors.push(format!("{field} must not be empty"));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -7,6 +7,7 @@ pub mod docs;
 pub mod fixture_blobs_check;
 pub mod gate;
 pub mod lint_fix;
+pub mod lint_policy;
 pub mod proof_plan;
 pub mod proof_policy;
 pub mod publish;


### PR DESCRIPTION
### Motivation
- Establish a single, workspace-wide Effortless Metrics Rust/Clippy baseline (MSRV `1.93`) so linting is an infrastructure gate rather than repo-local taste. 
- Record active and planned lint posture in a machine-readable ledger and track temporary exceptions as explicit debt to avoid silent policy drift. 
- Provide an executable CI gate that verifies MSRV, lint inheritance, planned flips, no test carveouts, and debt expiry before the quality gate runs. 

### Description
- Bumped workspace `rust-version` to `1.93` and added `workspace.lints.rust` and `workspace.lints.clippy` blocks to `Cargo.toml` implementing the shared deny/warn baseline. 
- Added `policy/clippy-lints.toml` (machine-readable active + planned lint ledger), `policy/clippy-debt.toml` (debt ledger), `clippy.toml` (reserved for disallowed policy), and `docs/CLIPPY_POLICY.md` (policy and suppression style). 
- Implemented `xtask` lint policy checker as `xtask/src/tasks/lint_policy.rs` and wired a new `CheckLintPolicy` command into `xtask` (CLI, main, and tasks module). 
- Updated CI (`.github/workflows/ci.yml`) to target Rust `1.93` for MSRV checks and to run `cargo xtask check-lint-policy` before the existing quality gate. 

### Testing
- Ran `cargo fmt-check` and `cargo fmt-fix` (format verification/auto-fix) and they completed successfully. 
- Ran `cargo xtask check-lint-policy` which validated policy shape, MSRV agreement, active lint levels, absence of test-carveouts in `clippy.toml`, planned flips, and debt entries; the check reported OK. 
- Built and validated `xtask` with `cargo check -p xtask` and exercised linting with `cargo clippy -p xtask -- -D warnings` and `cargo clippy -- -D warnings`; these tasks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb084ff1788333a4ce8a93966e8fec)