### PR TITLE
Add lint policy governance scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ default-members = [
 [workspace.package]
 version = "1.10.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/EffortlessMetrics/tokmd"
 repository = "https://github.com/EffortlessMetrics/tokmd"
@@ -53,6 +53,13 @@ authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 
 [workspace.metadata.crane]
 name = "tokmd-workspace"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_mutation = "deny"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# Repo-local Clippy configuration.
+#
+# Do not add test carveouts here. The workspace policy is panic-free across
+# production and tests; temporary exceptions belong in policy/clippy-debt.toml
+# or as narrow #[expect(..., reason = "...")] attributes.

--- a/crates/tokmd-analysis-types/Cargo.toml
+++ b/crates/tokmd-analysis-types/Cargo.toml
@@ -24,3 +24,6 @@ js-sys = "0.3.91"
 chrono = "0.4.44"
 proptest.workspace = true
 tokmd-scan = { path = "../tokmd-scan", version = ">=1.9, <2" }
+
+[lints]
+workspace = true

--- a/crates/tokmd-analysis/Cargo.toml
+++ b/crates/tokmd-analysis/Cargo.toml
@@ -54,3 +54,6 @@ tempfile.workspace = true
 proptest.workspace = true
 serde.workspace = true
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tokmd-cockpit/Cargo.toml
+++ b/crates/tokmd-cockpit/Cargo.toml
@@ -34,3 +34,6 @@ insta = { workspace = true }
 proptest.workspace = true
 tempfile.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/tokmd-core/Cargo.toml
+++ b/crates/tokmd-core/Cargo.toml
@@ -56,3 +56,6 @@ js-sys = "0.3.91"
 [dev-dependencies]
 proptest.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tokmd-envelope/Cargo.toml
+++ b/crates/tokmd-envelope/Cargo.toml
@@ -19,3 +19,6 @@ serde_json.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 tokmd-core = { path = "../tokmd-core", version = ">=1.9, <2" }
+
+[lints]
+workspace = true

--- a/crates/tokmd-format/Cargo.toml
+++ b/crates/tokmd-format/Cargo.toml
@@ -35,3 +35,6 @@ uuid = { version = "1.23", features = ["v4", "js"] }
 proptest.workspace = true
 insta = { workspace = true }
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tokmd-gate/Cargo.toml
+++ b/crates/tokmd-gate/Cargo.toml
@@ -21,3 +21,6 @@ proptest.workspace = true
 tempfile.workspace = true
 
 
+
+[lints]
+workspace = true

--- a/crates/tokmd-git/Cargo.toml
+++ b/crates/tokmd-git/Cargo.toml
@@ -20,3 +20,6 @@ proptest.workspace = true
 tempfile.workspace = true
 
 
+
+[lints]
+workspace = true

--- a/crates/tokmd-io-port/Cargo.toml
+++ b/crates/tokmd-io-port/Cargo.toml
@@ -16,3 +16,6 @@ documentation = "https://docs.rs/tokmd-io-port"
 [dev-dependencies]
 proptest.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -22,3 +22,6 @@ proptest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/tokmd-node/Cargo.toml
+++ b/crates/tokmd-node/Cargo.toml
@@ -29,3 +29,6 @@ napi-build = "2"
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tokmd-python/Cargo.toml
+++ b/crates/tokmd-python/Cargo.toml
@@ -31,3 +31,6 @@ extension-module = ["pyo3/extension-module"]
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tokmd-scan/Cargo.toml
+++ b/crates/tokmd-scan/Cargo.toml
@@ -23,3 +23,6 @@ tokmd-types.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 tokmd-model = { path = "../tokmd-model", version = ">=1.9, <2" }
+
+[lints]
+workspace = true

--- a/crates/tokmd-sensor/Cargo.toml
+++ b/crates/tokmd-sensor/Cargo.toml
@@ -28,3 +28,6 @@ proptest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/tokmd-settings/Cargo.toml
+++ b/crates/tokmd-settings/Cargo.toml
@@ -20,3 +20,6 @@ tokmd-types.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tokmd-types/Cargo.toml
+++ b/crates/tokmd-types/Cargo.toml
@@ -25,3 +25,6 @@ insta = { workspace = true }
 tokmd-scan = { path = "../tokmd-scan", version = ">=1.9, <2" }
 tokmd-format = { path = "../tokmd-format", version = ">=1.9, <2" }
 tokmd-model = { path = "../tokmd-model", version = ">=1.9, <2" }
+
+[lints]
+workspace = true

--- a/crates/tokmd-wasm/Cargo.toml
+++ b/crates/tokmd-wasm/Cargo.toml
@@ -31,3 +31,6 @@ wasm-bindgen-test = "0.3.70"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
+
+[lints]
+workspace = true

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -89,3 +89,6 @@ regex = "1.12.3"
 proptest.workspace = true
 jsonschema = { version = "0.46.4", default-features = false, features = ["resolve-file"] }
 toml = "1.1.2"
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,84 @@
+# Clippy policy
+
+`tokmd` uses the Effortless Metrics Rust lint policy as a governed engineering
+surface, not as an informal collection of local preferences. The policy is
+intended to make the workspace panic-free, suppression-governed, and safe around
+text, paths, file handles, async work, and numeric edge cases.
+
+## Source of truth
+
+The root `Cargo.toml` contains the active Rust workspace lint block under
+`[workspace.lints.rust]`. The strict Clippy profile is tracked as staged policy
+debt in `policy/clippy-lints.toml` so follow-up PRs can promote it without
+surprise breakage. Every workspace package
+must inherit that block with:
+
+```toml
+[lints]
+workspace = true
+```
+
+`policy/clippy-lints.toml` is the machine-readable ledger that mirrors the
+active block, records the staged strict Clippy profile, and tracks planned
+Rust/Clippy flips before the MSRV bump. The
+ledger records each lint's level, status, class, and reason so policy changes can
+be reviewed as explicit governance changes.
+
+## Panic-free workspace posture
+
+The policy bans panic-family and unchecked-collapse shapes in production and
+tests:
+
+- `panic!`, `todo!`, `unimplemented!`, `unreachable!`, and `dbg!`
+- unchecked `unwrap`/`expect` result or option collapse
+- unchecked indexing and string slicing
+- panic-prone time subtraction
+
+There are no test carveouts. Tests should return `Result` and use fallible setup
+or assertion helpers rather than panic-driven fixture setup.
+
+```rust
+#[test]
+fn parses_fixture() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = std::fs::read_to_string("tests/fixtures/input.rs")?;
+    let parsed = parse(&fixture)?;
+
+    ensure_eq(parsed.items.len(), 3, "fixture should expose three items")?;
+
+    Ok(())
+}
+```
+
+## Suppression style
+
+Do not use broad or silent `#[allow(...)]` suppressions for policy lints. If a
+local exception is unavoidable, use a narrow `#[expect(..., reason = "...")]`
+attribute and explain why the exception is safe and temporary. Longer-lived or
+repo-wide exceptions belong in `policy/clippy-debt.toml` with an owner, path,
+lint, reason, and expiry.
+
+## Policy files
+
+- `policy/clippy-lints.toml` — active lint ledger plus planned Rust 1.94 and
+  Rust 1.95 flips.
+- `policy/clippy-debt.toml` — temporary lint-policy exceptions. Expired debt
+  fails the policy check.
+- `policy/no-panic-allowlist.toml` — semantic panic-family exception schema for
+  identity by path, family, and selector. `last_seen` locations are advisory.
+- `policy/non-rust-allowlist.toml` — structured file-policy exceptions for
+  non-Rust implementation, fixture, config, schema, and asset surfaces.
+- `clippy.toml` — repo-local Clippy configuration only. It must not contain test
+  carveouts such as `allow-unwrap-in-tests = true`.
+
+## Check command
+
+Run the policy check with:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The check verifies that the workspace MSRV matches the policy ledger, every
+workspace package inherits workspace lints, active lints match `Cargo.toml`,
+planned Rust 1.94/1.95 lints are not accidentally activated early, test carveouts
+are absent from `clippy.toml`, and debt entries are complete and unexpired.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -342,3 +342,6 @@ path = "fuzz_targets/fuzz_badge_svg.rs"
 test = false
 doc = false
 required-features = ["badge"]
+
+[lints]
+workspace = true

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,11 @@
+schema = 1
+
+# Temporary repo-specific exceptions to the shared lint policy live here.
+# Each entry must include lint, path, owner, reason, and expires.
+#
+# [[debt]]
+# lint = "clippy::indexing_slicing"
+# path = "crates/example/src/parser/table.rs"
+# owner = "parser"
+# reason = "Generated table access; replace with checked table abstraction."
+# expires = "2026-07-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,794 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+# Active lint ledger: this mirrors the root workspace lint block.
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "forbid"
+status = "active"
+class = "unsafe"
+reason = "Part of the shared Effortless Metrics Rust lint baseline."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe"
+reason = "Part of the shared Effortless Metrics Rust lint baseline."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics Rust lint baseline."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "cfg"
+reason = "Part of the shared Effortless Metrics Rust lint baseline."
+
+[[lint]]
+name = "rust::const_item_mutation"
+level = "deny"
+status = "active"
+class = "correctness"
+reason = "Part of the shared Effortless Metrics Rust lint baseline."
+
+# Staged strict Clippy profile. These entries become active as debt is paid down.
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "staged"
+class = "strict-clippy"
+reason = "Part of the standard panic-free, suppression-governed Clippy baseline; staged until current debt is resolved."
+
+# Planned Rust/Clippy flips tracked before the MSRV bump.
+
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "numeric"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "ownership"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "collections"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "time"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,22 @@
+schema_version = "0.3"
+
+# Semantic no-panic exceptions use identity = path + family + selector.
+# last_seen is advisory only and should be refreshed when locations drift.
+#
+# [[allow]]
+# path = "crates/example/src/parser.rs"
+# family = "unwrap"
+# classification = "test_only"
+# owner = "parser"
+# explanation = "Fixture setup path; covered by follow-up panic-free test helper migration."
+# expires = "2026-07-01"
+#
+# [allow.selector]
+# kind = "method_call"
+# container = "parses_fixture_with_boundary_case"
+# callee = "unwrap"
+# receiver_fingerprint = "std::fs::read_to_string(path)"
+#
+# [allow.last_seen]
+# line = 42
+# column = 17

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,55 @@
+schema_version = "1.0"
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+surface = "ci"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "docs/**/*.json"
+kind = "schema_or_capability_doc"
+owner = "docs/schema"
+reason = "Checked-in JSON schemas and capability examples are product documentation surfaces."
+surface = "docs"
+classification = "config"
+covered_by = ["cargo xtask docs --check"]
+
+[[allow]]
+glob = "docs/assets/*.svg"
+kind = "documentation_asset"
+owner = "docs/assets"
+reason = "Documentation badges and images are rendered assets, not implementation code."
+surface = "docs"
+classification = "asset"
+covered_by = ["cargo xtask docs --check"]
+
+[[allow]]
+glob = "crates/tokmd/tests/data/**"
+kind = "fixture_input"
+owner = "cli-tests"
+reason = "Integration fixture workspaces intentionally contain analyzed source files."
+surface = "fixtures"
+classification = "test"
+covered_by = ["cargo test -p tokmd"]
+
+[[allow]]
+glob = "fuzz/corpus/**"
+kind = "fixture_input"
+owner = "fuzzing"
+reason = "Seed corpus files are fuzzing inputs rather than implementation surfaces."
+surface = "fixtures"
+classification = "test"
+covered_by = ["cargo +nightly fuzz list"]
+
+[[allow]]
+glob = "vendor/home-0.5.12/**"
+kind = "vendored_dependency"
+owner = "build-platform"
+reason = "Temporary vendored patch for the upstream home crate fallback behavior."
+surface = "vendor"
+classification = "third_party"
+covered_by = ["cargo check"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1"
 serde_json = "1"
 tempfile.workspace = true
 toml = "1.1.2"
+
+[lints]
+workspace = true

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -36,11 +36,16 @@ pub enum Commands {
     Gate(GateArgs),
     /// Auto-fix lint issues (fmt + clippy --fix) then verify
     LintFix(LintFixArgs),
+    /// Verify workspace lint policy ledgers and inheritance
+    CheckLintPolicy(CheckLintPolicyArgs),
     /// Run Cargo through an opt-in local sccache wrapper
     Sccache(SccacheArgs),
     /// Reclaim target/debug space by trimming Windows PDBs and incremental state
     TrimTarget(TrimTargetArgs),
 }
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct CheckLintPolicyArgs {}
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct DocsArgs {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),
         Some(cli::Commands::Gate(args)) => tasks::gate::run(args),
         Some(cli::Commands::LintFix(args)) => tasks::lint_fix::run(args),
+        Some(cli::Commands::CheckLintPolicy(args)) => tasks::lint_policy::run(args),
         Some(cli::Commands::Sccache(args)) => tasks::sccache::run(args),
         Some(cli::Commands::TrimTarget(args)) => tasks::trim_target::run(args),
         None => tasks::publish::run(PublishArgs::default()),

--- a/xtask/src/tasks/lint_policy.rs
+++ b/xtask/src/tasks/lint_policy.rs
@@ -1,0 +1,372 @@
+use anyhow::{Context, Result, bail};
+use chrono::{NaiveDate, Utc};
+use semver::Version;
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::cli::CheckLintPolicyArgs;
+
+const ROOT_MANIFEST: &str = "Cargo.toml";
+const LINT_LEDGER: &str = "policy/clippy-lints.toml";
+const LINT_DEBT: &str = "policy/clippy-debt.toml";
+const CLIPPY_CONFIG: &str = "clippy.toml";
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+#[derive(Debug, Deserialize)]
+struct LintLedger {
+    schema: u64,
+    msrv: String,
+    policy: LintPolicy,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintPolicy {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    #[serde(default)]
+    activate_when_msrv: Option<String>,
+    #[serde(rename = "class")]
+    class_name: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+pub fn run(_args: CheckLintPolicyArgs) -> Result<()> {
+    let repo_root = std::env::current_dir().context("failed to determine repository root")?;
+    let root_manifest = load_toml_value(&repo_root.join(ROOT_MANIFEST))?;
+    let ledger: LintLedger = load_toml(&repo_root.join(LINT_LEDGER))?;
+    let debt: DebtLedger = load_toml(&repo_root.join(LINT_DEBT))?;
+
+    let mut violations = Vec::new();
+
+    validate_ledger_shape(&ledger, &mut violations);
+    validate_msrv(&root_manifest, &ledger, &mut violations);
+    validate_workspace_lints(&root_manifest, &ledger, &mut violations);
+    validate_lint_inheritance(&repo_root, &root_manifest, &mut violations)?;
+    validate_clippy_config(&repo_root.join(CLIPPY_CONFIG), &mut violations)?;
+    validate_debt(&debt, &mut violations);
+
+    if !violations.is_empty() {
+        for violation in &violations {
+            eprintln!("::error::{}", violation);
+        }
+        bail!(
+            "lint policy check failed with {} violation(s)",
+            violations.len()
+        );
+    }
+
+    println!(
+        "Lint policy OK: {} active lint(s), {} staged lint(s), {} planned lint(s), {} debt entry/entries",
+        ledger
+            .lint
+            .iter()
+            .filter(|entry| entry.status == "active")
+            .count(),
+        ledger
+            .lint
+            .iter()
+            .filter(|entry| entry.status == "staged")
+            .count(),
+        ledger
+            .lint
+            .iter()
+            .filter(|entry| entry.status == "planned")
+            .count(),
+        debt.debt.len()
+    );
+    Ok(())
+}
+
+fn load_toml<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn load_toml_value(path: &Path) -> Result<toml::Value> {
+    load_toml(path)
+}
+
+fn validate_ledger_shape(ledger: &LintLedger, violations: &mut Vec<String>) {
+    if ledger.schema != 1 {
+        violations.push(format!("{LINT_LEDGER}: schema must be 1"));
+    }
+    if !ledger.policy.panic_free_tests {
+        violations.push(format!(
+            "{LINT_LEDGER}: policy.panic_free_tests must be true"
+        ));
+    }
+    if ledger.policy.allow_test_carveouts {
+        violations.push(format!(
+            "{LINT_LEDGER}: policy.allow_test_carveouts must be false"
+        ));
+    }
+    if ledger.policy.suppression_style != "expect-with-reason" {
+        violations.push(format!(
+            "{LINT_LEDGER}: policy.suppression_style must be expect-with-reason"
+        ));
+    }
+    if ledger.policy.blanket_categories {
+        violations.push(format!(
+            "{LINT_LEDGER}: policy.blanket_categories must be false"
+        ));
+    }
+
+    let mut seen = BTreeSet::new();
+    for entry in &ledger.lint {
+        if !seen.insert(entry.name.clone()) {
+            violations.push(format!(
+                "{LINT_LEDGER}: duplicate lint entry {}",
+                entry.name
+            ));
+        }
+        if entry.name.trim().is_empty()
+            || entry.level.trim().is_empty()
+            || entry.status.trim().is_empty()
+            || entry.class_name.trim().is_empty()
+            || entry.reason.trim().is_empty()
+        {
+            violations.push(format!(
+                "{LINT_LEDGER}: lint {} must include name, level, status, class, and reason",
+                entry.name
+            ));
+        }
+        if entry.status == "planned" && entry.activate_when_msrv.is_none() {
+            violations.push(format!(
+                "{LINT_LEDGER}: planned lint {} must include activate_when_msrv",
+                entry.name
+            ));
+        }
+        if entry.status != "active" && entry.status != "staged" && entry.status != "planned" {
+            violations.push(format!(
+                "{LINT_LEDGER}: lint {} has unsupported status {}",
+                entry.name, entry.status
+            ));
+        }
+    }
+}
+
+fn validate_msrv(root_manifest: &toml::Value, ledger: &LintLedger, violations: &mut Vec<String>) {
+    let workspace_msrv = root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("rust-version"))
+        .and_then(toml::Value::as_str);
+
+    if workspace_msrv != Some(ledger.msrv.as_str()) {
+        violations.push(format!(
+            "workspace.package.rust-version ({:?}) must match {LINT_LEDGER} msrv ({})",
+            workspace_msrv, ledger.msrv
+        ));
+    }
+}
+
+fn validate_workspace_lints(
+    root_manifest: &toml::Value,
+    ledger: &LintLedger,
+    violations: &mut Vec<String>,
+) {
+    let active_from_manifest = active_lints_from_manifest(root_manifest);
+    let active_from_ledger: BTreeMap<_, _> = ledger
+        .lint
+        .iter()
+        .filter(|entry| entry.status == "active")
+        .map(|entry| (entry.name.clone(), entry.level.clone()))
+        .collect();
+
+    for (name, level) in &active_from_ledger {
+        match active_from_manifest.get(name) {
+            Some(manifest_level) if manifest_level == level => {}
+            Some(manifest_level) => violations.push(format!(
+                "{name} level mismatch: Cargo.toml has {manifest_level}, {LINT_LEDGER} has {level}"
+            )),
+            None => violations.push(format!(
+                "{name} is active in {LINT_LEDGER} but missing from root Cargo.toml"
+            )),
+        }
+    }
+
+    for (name, level) in &active_from_manifest {
+        if !active_from_ledger.contains_key(name) {
+            violations.push(format!(
+                "{name} = {level} is active in root Cargo.toml but missing from {LINT_LEDGER}"
+            ));
+        }
+    }
+
+    let current_msrv = parse_version(&ledger.msrv);
+    for entry in ledger.lint.iter().filter(|entry| entry.status == "planned") {
+        if active_from_manifest.contains_key(&entry.name) {
+            violations.push(format!(
+                "planned lint {} is already active before its planned MSRV {:?}",
+                entry.name, entry.activate_when_msrv
+            ));
+        }
+        if let (Some(current), Some(activate)) = (
+            current_msrv.as_ref(),
+            entry.activate_when_msrv.as_deref().and_then(parse_version),
+        ) && &activate <= current
+        {
+            violations.push(format!(
+                "planned lint {} activates at {}, which is not after current MSRV {}",
+                entry.name, activate, current
+            ));
+        }
+    }
+}
+
+fn active_lints_from_manifest(root_manifest: &toml::Value) -> BTreeMap<String, String> {
+    let mut lints = BTreeMap::new();
+    let Some(workspace_lints) = root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("lints"))
+        .and_then(toml::Value::as_table)
+    else {
+        return lints;
+    };
+
+    for group in ["rust", "clippy"] {
+        if let Some(table) = workspace_lints.get(group).and_then(toml::Value::as_table) {
+            for (name, level) in table {
+                if let Some(level) = level.as_str() {
+                    lints.insert(format!("{group}::{name}"), level.to_string());
+                }
+            }
+        }
+    }
+
+    lints
+}
+
+fn validate_lint_inheritance(
+    repo_root: &Path,
+    root_manifest: &toml::Value,
+    violations: &mut Vec<String>,
+) -> Result<()> {
+    for member in workspace_members(root_manifest) {
+        let manifest_path = repo_root.join(member).join("Cargo.toml");
+        let manifest = load_toml_value(&manifest_path)?;
+        let inherits = manifest
+            .get("lints")
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(toml::Value::as_bool)
+            == Some(true);
+        if !inherits {
+            violations.push(format!(
+                "{} must include [lints] workspace = true",
+                manifest_path
+                    .strip_prefix(repo_root)
+                    .unwrap_or(&manifest_path)
+                    .display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn workspace_members(root_manifest: &toml::Value) -> Vec<PathBuf> {
+    root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(toml::Value::as_array)
+        .map(|members| {
+            members
+                .iter()
+                .filter_map(toml::Value::as_str)
+                .map(PathBuf::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn validate_clippy_config(path: &Path, violations: &mut Vec<String>) -> Result<()> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    for carveout in TEST_CARVEOUTS {
+        if content.contains(carveout) {
+            violations.push(format!(
+                "{} must not contain test carveout `{}`",
+                path.display(),
+                carveout
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_debt(debt: &DebtLedger, violations: &mut Vec<String>) {
+    if debt.schema != 1 {
+        violations.push(format!("{LINT_DEBT}: schema must be 1"));
+    }
+
+    let today = Utc::now().date_naive();
+    for (index, entry) in debt.debt.iter().enumerate() {
+        let label = format!("{LINT_DEBT}: debt entry {}", index + 1);
+        if entry.lint.trim().is_empty()
+            || entry.path.trim().is_empty()
+            || entry.owner.trim().is_empty()
+            || entry.reason.trim().is_empty()
+            || entry.expires.trim().is_empty()
+        {
+            violations.push(format!(
+                "{label} must include lint, path, owner, reason, and expires"
+            ));
+            continue;
+        }
+
+        match NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d") {
+            Ok(expires) if expires < today => {
+                violations.push(format!("{label} for {} expired on {expires}", entry.lint));
+            }
+            Ok(_) => {}
+            Err(_) => violations.push(format!(
+                "{label} expires value `{}` must use YYYY-MM-DD",
+                entry.expires
+            )),
+        }
+    }
+}
+
+fn parse_version(version: &str) -> Option<Version> {
+    let mut parts = version.split('.');
+    let major = parts.next()?;
+    let minor = parts.next().unwrap_or("0");
+    let patch = parts.next().unwrap_or("0");
+    Version::parse(&format!("{major}.{minor}.{patch}")).ok()
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -7,6 +7,7 @@ pub mod docs;
 pub mod fixture_blobs_check;
 pub mod gate;
 pub mod lint_fix;
+pub mod lint_policy;
 pub mod proof_plan;
 pub mod proof_policy;
 pub mod publish;


### PR DESCRIPTION
### Motivation

- Establish a governed, workspace-level Rust lint baseline (panic-free, no silent suppression) and a machine-readable policy model to avoid ad-hoc per-crate clippy drift. 
- Ratchet the repo to the intended MSRV and provide a repeatable rollout model (staged strict Clippy + planned Rust 1.94/1.95 flips) rather than copying a strict block ad-hoc. 
- Surface and track temporary exceptions as explicit, expiring debt and structured allowlists so CI and reviewers can treat lint rules as infrastructure instead of local preference. 

### Description

- Bump workspace MSRV to `1.93` and add an active Rust lint baseline under `[workspace.lints.rust]` in `Cargo.toml`. 
- Add a machine-readable policy ledger at `policy/clippy-lints.toml` that records active, staged and planned lints, and add `policy/clippy-debt.toml`, `policy/no-panic-allowlist.toml`, and `policy/non-rust-allowlist.toml` for tracked exceptions. 
- Add documentation `docs/CLIPPY_POLICY.md` and a repo-local `clippy.toml` (explicitly forbidding test-carveouts), and add `[lints] workspace = true` inheritance to workspace member manifests. 
- Implement `cargo xtask check-lint-policy` by adding `xtask/src/tasks/lint_policy.rs`, wire the CLI command, and make the check validate MSRV parity, lint ledger shape/parity, workspace inheritance, planned flips staging, absence of clippy test carveouts, and debt completeness/expiry. 

### Testing

- Ran `cargo fmt --all --check` which completed successfully. 
- Ran `cargo xtask check-lint-policy` which reported the lint ledger and staged/planned counts and returned OK. 
- Built and verified `xtask` with `cargo check -p xtask` and ran `cargo clippy` with `-D warnings` against the workspace, both of which completed successfully. 
- Ran `cargo test -p xtask` (unit and integration xtask tests) and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb084ff1788333a4ce8a93966e8fec)