### PR TITLE
Write proof plan summary artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json > target/proof/affected.json
           affected_status=$?
 
-          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan > target/proof/proof-plan.json
+          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md > target/proof/proof-plan.json
           proof_plan_status=$?
 
           {
@@ -154,6 +154,10 @@ jobs:
             echo "| proof plan | ${proof_plan_status} |"
             echo ""
             echo "This job is informational while proof planning is being adopted; existing CI jobs remain authoritative."
+            if [ -f target/proof/proof-plan.md ]; then
+              echo ""
+              cat target/proof/proof-plan.md
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           exit 0

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -34,7 +34,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Clippy policy now has a governed ledger and `cargo xtask check-lint-policy` check while keeping the repository MSRV at 1.92 and leaving crate-wide lint inheritance as a later cleanup stack.
 - Analysis and formatting module scopes now route `tokmd-analysis`, `tokmd-analysis-types`, and `tokmd-format` changes to targeted package, snapshot, renderer, and module proof commands.
 - Affected proof plans now include advisory scoped coverage and mutation commands derived from matched scope metadata while leaving existing proof commands required and CI behavior unchanged.
-- Next proof-policy operational slice: turn planned coverage and mutation evidence into generated CI artifacts and summaries before replacing existing GitHub YAML logic.
+- `cargo xtask proof --plan --summary-md <path>` now writes a Markdown proof-plan artifact, and the informational PR affected-plan job appends that Rust-generated summary while keeping existing CI jobs authoritative.
+- Next proof-policy operational slice: use the generated plan artifacts to prototype scoped coverage/mutation execution summaries without replacing existing GitHub YAML logic.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -113,6 +113,10 @@ pub struct ProofArgs {
     #[arg(long)]
     pub plan: bool,
 
+    /// Write a Markdown summary for the generated proof plan
+    #[arg(long, value_name = "PATH")]
+    pub summary_md: Option<std::path::PathBuf>,
+
     /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -6,7 +6,9 @@ use crate::tasks::affected::{
 use anyhow::{Result, bail};
 use serde::Serialize;
 use std::cmp::Ordering;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
 
 #[derive(Debug, Serialize)]
 struct ProofPlanReport {
@@ -35,6 +37,9 @@ pub fn run(args: ProofArgs) -> Result<()> {
 
     let policy = load_checked_policy(&args.policy)?;
     let report = proof_plan_report(&policy, &args)?;
+    if let Some(path) = &args.summary_md {
+        write_markdown_summary(path, &report)?;
+    }
     println!("{}", serde_json::to_string_pretty(&report)?);
 
     if report.ok {
@@ -225,6 +230,93 @@ fn dedupe_commands(commands: Vec<ProofPlanCommand>) -> Vec<ProofPlanCommand> {
     commands
 }
 
+fn write_markdown_summary(path: &Path, report: &ProofPlanReport) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, render_markdown_summary(report))?;
+    Ok(())
+}
+
+fn render_markdown_summary(report: &ProofPlanReport) -> String {
+    let mut out = String::new();
+
+    out.push_str("## Proof Plan Summary\n\n");
+    out.push_str("| Field | Value |\n");
+    out.push_str("| --- | --- |\n");
+    out.push_str(&format!("| Profile | `{}` |\n", escape_md(&report.profile)));
+    out.push_str(&format!("| Base | `{}` |\n", escape_md(&report.base)));
+    out.push_str(&format!("| Head | `{}` |\n", escape_md(&report.head)));
+    out.push_str(&format!("| OK | `{}` |\n", report.ok));
+    out.push_str(&format!(
+        "| Changed files | {} |\n",
+        report.changed_files.len()
+    ));
+    out.push_str(&format!(
+        "| Unknown files | {} |\n",
+        report.unknown_files.len()
+    ));
+    out.push_str(&format!("| Commands | {} |\n", report.commands.len()));
+    out.push('\n');
+    out.push_str(
+        "Required commands are the current proof selection. Advisory commands are planned evidence candidates and are not CI gates yet.\n\n",
+    );
+
+    if report.commands.is_empty() {
+        out.push_str("No proof commands planned.\n");
+    } else {
+        out.push_str("### Command Counts\n\n");
+        out.push_str("| Kind | Required | Count |\n");
+        out.push_str("| --- | --- | ---: |\n");
+        for ((kind, required), count) in command_counts(report) {
+            out.push_str(&format!(
+                "| `{}` | `{}` | {} |\n",
+                escape_md(&kind),
+                required,
+                count
+            ));
+        }
+
+        out.push_str("\n### Commands\n\n");
+        out.push_str("| Scope | Kind | Required | Command |\n");
+        out.push_str("| --- | --- | --- | --- |\n");
+        for command in &report.commands {
+            out.push_str(&format!(
+                "| `{}` | `{}` | `{}` | `{}` |\n",
+                escape_md(&command.scope),
+                escape_md(&command.kind),
+                command.required,
+                escape_md(&command.command)
+            ));
+        }
+    }
+
+    if !report.unknown_files.is_empty() {
+        out.push_str("\n### Unknown Files\n\n");
+        for file in &report.unknown_files {
+            out.push_str(&format!("- `{}`\n", escape_md(file)));
+        }
+    }
+
+    out
+}
+
+fn command_counts(report: &ProofPlanReport) -> BTreeMap<(String, bool), usize> {
+    let mut counts = BTreeMap::new();
+    for command in &report.commands {
+        *counts
+            .entry((command.kind.clone(), command.required))
+            .or_insert(0) += 1;
+    }
+    counts
+}
+
+fn escape_md(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', " ")
+}
+
 fn compare_commands(left: &ProofPlanCommand, right: &ProofPlanCommand) -> Ordering {
     left.scope
         .cmp(&right.scope)
@@ -306,7 +398,8 @@ fn profile_name(profile: ProofProfile) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        affected_commands, dedupe_commands, is_mutation_candidate, static_profile_commands,
+        ProofPlanCommand, ProofPlanReport, affected_commands, dedupe_commands,
+        is_mutation_candidate, render_markdown_summary, static_profile_commands,
     };
     use crate::cli::ProofProfile;
     use crate::proof::policy::parse_policy_str;
@@ -414,6 +507,48 @@ coverage = "cargo-llvm-cov"
                 .iter()
                 .any(|cmd| cmd.command.contains("crates/tokmd-core/tests/ffi.rs"))
         );
+    }
+
+    #[test]
+    fn markdown_summary_marks_advisory_evidence_commands() {
+        let report = ProofPlanReport {
+            schema: "tokmd.proof_plan.v1".to_string(),
+            ok: true,
+            profile: "affected".to_string(),
+            base: "origin/main".to_string(),
+            head: "HEAD".to_string(),
+            changed_files: vec!["crates/tokmd-core/src/ffi.rs".to_string()],
+            commands: vec![
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "proof".to_string(),
+                    required: true,
+                    command: "cargo test -p tokmd-core ffi".to_string(),
+                },
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "coverage".to_string(),
+                    required: false,
+                    command: "cargo llvm-cov -p tokmd-core --all-features --lcov".to_string(),
+                },
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "mutation".to_string(),
+                    required: false,
+                    command: "cargo mutants --file crates/tokmd-core/src/ffi.rs --timeout 300"
+                        .to_string(),
+                },
+            ],
+            unknown_files: Vec::new(),
+        };
+
+        let summary = render_markdown_summary(&report);
+
+        assert!(summary.contains("Required commands are the current proof selection"));
+        assert!(summary.contains("| `proof` | `true` | 1 |"));
+        assert!(summary.contains("| `coverage` | `false` | 1 |"));
+        assert!(summary.contains("| `mutation` | `false` | 1 |"));
+        assert!(summary.contains("cargo mutants --file crates/tokmd-core/src/ffi.rs"));
     }
 
     #[test]

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -30,6 +31,7 @@ fn proof_help_mentions_profile_and_plan() {
     assert!(success, "proof --help failed. stderr: {stderr}");
     assert!(stdout.contains("--profile"), "stdout: {stdout}");
     assert!(stdout.contains("--plan"), "stdout: {stdout}");
+    assert!(stdout.contains("--summary-md"), "stdout: {stdout}");
 }
 
 #[test]
@@ -96,4 +98,32 @@ fn fast_proof_plan_includes_policy_and_guardrails() {
             .iter()
             .any(|cmd| cmd["command"] == "cargo xtask boundaries-check")
     );
+}
+
+#[test]
+fn proof_plan_writes_markdown_summary_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let summary_path = temp.path().join("proof-plan.md");
+    let summary_arg = summary_path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof",
+        "--profile",
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--plan",
+        "--summary-md",
+        &summary_arg,
+    ]);
+
+    assert!(success, "proof --summary-md failed. stderr: {stderr}");
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("proof --plan should still emit JSON");
+    assert_eq!(value["schema"], "tokmd.proof_plan.v1");
+
+    let summary = fs::read_to_string(summary_path).expect("summary should be written");
+    assert!(summary.contains("## Proof Plan Summary"));
+    assert!(summary.contains("No proof commands planned."));
 }


### PR DESCRIPTION
## Summary
- add `cargo xtask proof --plan --summary-md <path>` for Rust-generated Markdown proof-plan summaries
- append the generated proof-plan summary in the informational PR affected-plan CI job and upload it with existing proof artifacts
- update NEXT and proof-plan tests for the new artifact path and advisory evidence summary language

## Validation
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask affected --verbose
- cargo test -p xtask proof_policy --verbose
- cargo test -p xtask lint_policy --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo xtask proof-policy --check
- cargo xtask check-lint-policy
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-summary.md
- cargo xtask proof --profile affected --base HEAD --head HEAD --plan --summary-md target/proof/proof-summary.md
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- python PyYAML safe_load of .github/workflows/ci.yml
- git diff --check