### PR TITLE
Write planned proof evidence artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json > target/proof/affected.json
           affected_status=$?
 
-          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md > target/proof/proof-plan.json
+          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json > target/proof/proof-plan.json
           proof_plan_status=$?
 
           {

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -35,7 +35,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Analysis and formatting module scopes now route `tokmd-analysis`, `tokmd-analysis-types`, and `tokmd-format` changes to targeted package, snapshot, renderer, and module proof commands.
 - Affected proof plans now include advisory scoped coverage and mutation commands derived from matched scope metadata while leaving existing proof commands required and CI behavior unchanged.
 - `cargo xtask proof --plan --summary-md <path>` now writes a Markdown proof-plan artifact, and the informational PR affected-plan job appends that Rust-generated summary while keeping existing CI jobs authoritative.
-- Next proof-policy operational slice: use the generated plan artifacts to prototype scoped coverage/mutation execution summaries without replacing existing GitHub YAML logic.
+- `cargo xtask proof --plan --evidence-json <path>` now writes a machine-readable planned-evidence artifact for scoped coverage and mutation commands. The artifact records `planned` / `not_executed` status and zero executed counts so consumers do not confuse planned advisory evidence with passing evidence.
+- Next proof-policy operational slice: prototype a non-required executor summary for one scoped evidence family without replacing existing GitHub YAML logic.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -117,6 +117,10 @@ pub struct ProofArgs {
     #[arg(long, value_name = "PATH")]
     pub summary_md: Option<std::path::PathBuf>,
 
+    /// Write a machine-readable planned evidence summary for the generated proof plan
+    #[arg(long, value_name = "PATH")]
+    pub evidence_json: Option<std::path::PathBuf>,
+
     /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -30,6 +30,46 @@ struct ProofPlanCommand {
     command: String,
 }
 
+#[derive(Debug, Serialize)]
+struct ProofEvidencePlan {
+    schema: String,
+    status: String,
+    execution_status: String,
+    profile: String,
+    base: String,
+    head: String,
+    ok: bool,
+    changed_files: Vec<String>,
+    counts: ProofEvidenceCounts,
+    entries: Vec<ProofEvidenceEntry>,
+    unknown_files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProofEvidenceCounts {
+    commands_total: usize,
+    required_total: usize,
+    advisory_total: usize,
+    coverage: ProofEvidenceKindCounts,
+    mutation: ProofEvidenceKindCounts,
+}
+
+#[derive(Debug, Serialize)]
+struct ProofEvidenceKindCounts {
+    planned: usize,
+    executed: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ProofEvidenceEntry {
+    scope: String,
+    kind: String,
+    status: String,
+    required: bool,
+    command: String,
+    artifact_path: Option<String>,
+}
+
 pub fn run(args: ProofArgs) -> Result<()> {
     if !args.plan {
         bail!("proof execution is not implemented yet; pass --plan to print the proof plan");
@@ -39,6 +79,9 @@ pub fn run(args: ProofArgs) -> Result<()> {
     let report = proof_plan_report(&policy, &args)?;
     if let Some(path) = &args.summary_md {
         write_markdown_summary(path, &report)?;
+    }
+    if let Some(path) = &args.evidence_json {
+        write_evidence_json(path, &report)?;
     }
     println!("{}", serde_json::to_string_pretty(&report)?);
 
@@ -231,13 +274,104 @@ fn dedupe_commands(commands: Vec<ProofPlanCommand>) -> Vec<ProofPlanCommand> {
 }
 
 fn write_markdown_summary(path: &Path, report: &ProofPlanReport) -> Result<()> {
+    ensure_parent_dir(path)?;
+    fs::write(path, render_markdown_summary(report))?;
+    Ok(())
+}
+
+fn write_evidence_json(path: &Path, report: &ProofPlanReport) -> Result<()> {
+    ensure_parent_dir(path)?;
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&proof_evidence_plan(report))?,
+    )?;
+    Ok(())
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<()> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
         fs::create_dir_all(parent)?;
     }
-    fs::write(path, render_markdown_summary(report))?;
     Ok(())
+}
+
+fn proof_evidence_plan(report: &ProofPlanReport) -> ProofEvidencePlan {
+    let entries = report
+        .commands
+        .iter()
+        .filter(|command| is_evidence_kind(&command.kind))
+        .map(evidence_entry)
+        .collect::<Vec<_>>();
+    let coverage_planned = entries
+        .iter()
+        .filter(|entry| entry.kind == "coverage")
+        .count();
+    let mutation_planned = entries
+        .iter()
+        .filter(|entry| entry.kind == "mutation")
+        .count();
+
+    ProofEvidencePlan {
+        schema: "tokmd.proof_evidence_plan.v1".to_string(),
+        status: "planned".to_string(),
+        execution_status: "not_executed".to_string(),
+        profile: report.profile.clone(),
+        base: report.base.clone(),
+        head: report.head.clone(),
+        ok: report.ok,
+        changed_files: report.changed_files.clone(),
+        counts: ProofEvidenceCounts {
+            commands_total: report.commands.len(),
+            required_total: report
+                .commands
+                .iter()
+                .filter(|command| command.required)
+                .count(),
+            advisory_total: report
+                .commands
+                .iter()
+                .filter(|command| !command.required)
+                .count(),
+            coverage: ProofEvidenceKindCounts {
+                planned: coverage_planned,
+                executed: 0,
+            },
+            mutation: ProofEvidenceKindCounts {
+                planned: mutation_planned,
+                executed: 0,
+            },
+        },
+        entries,
+        unknown_files: report.unknown_files.clone(),
+    }
+}
+
+fn evidence_entry(command: &ProofPlanCommand) -> ProofEvidenceEntry {
+    ProofEvidenceEntry {
+        scope: command.scope.clone(),
+        kind: command.kind.clone(),
+        status: "planned".to_string(),
+        required: command.required,
+        command: command.command.clone(),
+        artifact_path: evidence_artifact_path(command),
+    }
+}
+
+fn evidence_artifact_path(command: &ProofPlanCommand) -> Option<String> {
+    if command.kind != "coverage" {
+        return None;
+    }
+
+    command
+        .command
+        .split_once("--output-path ")
+        .map(|(_, path)| path.split_whitespace().next().unwrap_or(path).to_string())
+}
+
+fn is_evidence_kind(kind: &str) -> bool {
+    matches!(kind, "coverage" | "mutation")
 }
 
 fn render_markdown_summary(report: &ProofPlanReport) -> String {
@@ -399,7 +533,8 @@ fn profile_name(profile: ProofProfile) -> &'static str {
 mod tests {
     use super::{
         ProofPlanCommand, ProofPlanReport, affected_commands, dedupe_commands,
-        is_mutation_candidate, render_markdown_summary, static_profile_commands,
+        is_mutation_candidate, proof_evidence_plan, render_markdown_summary,
+        static_profile_commands,
     };
     use crate::cli::ProofProfile;
     use crate::proof::policy::parse_policy_str;
@@ -549,6 +684,62 @@ coverage = "cargo-llvm-cov"
         assert!(summary.contains("| `coverage` | `false` | 1 |"));
         assert!(summary.contains("| `mutation` | `false` | 1 |"));
         assert!(summary.contains("cargo mutants --file crates/tokmd-core/src/ffi.rs"));
+    }
+
+    #[test]
+    fn evidence_plan_marks_scoped_evidence_as_planned_not_executed() {
+        let report = ProofPlanReport {
+            schema: "tokmd.proof_plan.v1".to_string(),
+            ok: true,
+            profile: "affected".to_string(),
+            base: "origin/main".to_string(),
+            head: "HEAD".to_string(),
+            changed_files: vec!["crates/tokmd-core/src/ffi.rs".to_string()],
+            commands: vec![
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "proof".to_string(),
+                    required: true,
+                    command: "cargo test -p tokmd-core ffi".to_string(),
+                },
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "coverage".to_string(),
+                    required: false,
+                    command: "cargo llvm-cov -p tokmd-core --all-features --lcov --output-path target/proof/coverage/tokmd_core_ffi.lcov".to_string(),
+                },
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "mutation".to_string(),
+                    required: false,
+                    command: "cargo mutants --file crates/tokmd-core/src/ffi.rs --timeout 300"
+                        .to_string(),
+                },
+            ],
+            unknown_files: Vec::new(),
+        };
+
+        let evidence = proof_evidence_plan(&report);
+
+        assert_eq!(evidence.schema, "tokmd.proof_evidence_plan.v1");
+        assert_eq!(evidence.status, "planned");
+        assert_eq!(evidence.execution_status, "not_executed");
+        assert_eq!(evidence.counts.commands_total, 3);
+        assert_eq!(evidence.counts.required_total, 1);
+        assert_eq!(evidence.counts.advisory_total, 2);
+        assert_eq!(evidence.counts.coverage.planned, 1);
+        assert_eq!(evidence.counts.coverage.executed, 0);
+        assert_eq!(evidence.counts.mutation.planned, 1);
+        assert_eq!(evidence.counts.mutation.executed, 0);
+        assert_eq!(evidence.entries.len(), 2);
+        assert_eq!(evidence.entries[0].kind, "coverage");
+        assert_eq!(evidence.entries[0].status, "planned");
+        assert_eq!(
+            evidence.entries[0].artifact_path.as_deref(),
+            Some("target/proof/coverage/tokmd_core_ffi.lcov")
+        );
+        assert_eq!(evidence.entries[1].kind, "mutation");
+        assert_eq!(evidence.entries[1].artifact_path, None);
     }
 
     #[test]

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -32,6 +32,7 @@ fn proof_help_mentions_profile_and_plan() {
     assert!(stdout.contains("--profile"), "stdout: {stdout}");
     assert!(stdout.contains("--plan"), "stdout: {stdout}");
     assert!(stdout.contains("--summary-md"), "stdout: {stdout}");
+    assert!(stdout.contains("--evidence-json"), "stdout: {stdout}");
 }
 
 #[test]
@@ -126,4 +127,38 @@ fn proof_plan_writes_markdown_summary_artifact() {
     let summary = fs::read_to_string(summary_path).expect("summary should be written");
     assert!(summary.contains("## Proof Plan Summary"));
     assert!(summary.contains("No proof commands planned."));
+}
+
+#[test]
+fn proof_plan_writes_evidence_json_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let evidence_path = temp.path().join("proof-evidence.json");
+    let evidence_arg = evidence_path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof",
+        "--profile",
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--plan",
+        "--evidence-json",
+        &evidence_arg,
+    ]);
+
+    assert!(success, "proof --evidence-json failed. stderr: {stderr}");
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("proof --plan should still emit JSON");
+    assert_eq!(value["schema"], "tokmd.proof_plan.v1");
+
+    let evidence = fs::read_to_string(evidence_path).expect("evidence should be written");
+    let evidence: serde_json::Value =
+        serde_json::from_str(&evidence).expect("evidence should be valid JSON");
+    assert_eq!(evidence["schema"], "tokmd.proof_evidence_plan.v1");
+    assert_eq!(evidence["status"], "planned");
+    assert_eq!(evidence["execution_status"], "not_executed");
+    assert_eq!(evidence["counts"]["coverage"]["executed"], 0);
+    assert_eq!(evidence["counts"]["mutation"]["executed"], 0);
+    assert!(evidence["entries"].as_array().unwrap().is_empty());
 }


### PR DESCRIPTION
## Summary
- add cargo xtask proof --plan --evidence-json <path> for machine-readable planned coverage/mutation evidence
- mark planned evidence as 
ot_executed with zero executed counts so consumers do not treat it as passing evidence
- upload the new JSON artifact from the informational affected-plan CI job

## Validation
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask affected --verbose
- cargo test -p xtask lint_policy --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_policy --verbose
- cargo xtask proof-policy --check
- cargo xtask check-lint-policy
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/branch-proof-summary.md --evidence-json target/proof/branch-proof-evidence.json
- cargo xtask proof --profile deep --plan --evidence-json target/proof/deep-proof-evidence.json
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- python yaml safe_load for .github/workflows/ci.yml
- git diff --check