### PR TITLE
Prototype coverage executor summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json > target/proof/affected.json
           affected_status=$?
 
-          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json > target/proof/proof-plan.json
+          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json > target/proof/proof-plan.json
           proof_plan_status=$?
 
           {

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -36,7 +36,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Affected proof plans now include advisory scoped coverage and mutation commands derived from matched scope metadata while leaving existing proof commands required and CI behavior unchanged.
 - `cargo xtask proof --plan --summary-md <path>` now writes a Markdown proof-plan artifact, and the informational PR affected-plan job appends that Rust-generated summary while keeping existing CI jobs authoritative.
 - `cargo xtask proof --plan --evidence-json <path>` now writes a machine-readable planned-evidence artifact for scoped coverage and mutation commands. The artifact records `planned` / `not_executed` status and zero executed counts so consumers do not confuse planned advisory evidence with passing evidence.
-- Next proof-policy operational slice: prototype a non-required executor summary for one scoped evidence family without replacing existing GitHub YAML logic.
+- `cargo xtask proof --plan --executor-summary <path>` now writes an informational coverage-only executor summary prototype. It selects non-required coverage commands, records them as skipped with `tool_execution_not_enabled`, and does not invoke `cargo llvm-cov`.
+- Next proof-policy operational slice: add a dry-runnable executor mode boundary for one scoped coverage command before allowing any CI job to execute planner-selected evidence.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -121,6 +121,10 @@ pub struct ProofArgs {
     #[arg(long, value_name = "PATH")]
     pub evidence_json: Option<std::path::PathBuf>,
 
+    /// Write a prototype executor summary for selected non-required evidence commands
+    #[arg(long, value_name = "PATH")]
+    pub executor_summary: Option<std::path::PathBuf>,
+
     /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -70,6 +70,45 @@ struct ProofEvidenceEntry {
     artifact_path: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct ProofExecutorSummary {
+    schema: String,
+    status: String,
+    execution_status: String,
+    family: String,
+    required: bool,
+    profile: String,
+    base: String,
+    head: String,
+    ok: bool,
+    changed_files: Vec<String>,
+    counts: ProofExecutorCounts,
+    entries: Vec<ProofExecutorEntry>,
+    unknown_files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProofExecutorCounts {
+    commands_total: usize,
+    family_planned: usize,
+    selected: usize,
+    skipped: usize,
+    executed: usize,
+    required_excluded: usize,
+    non_family_excluded: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ProofExecutorEntry {
+    scope: String,
+    kind: String,
+    required: bool,
+    command: String,
+    artifact_path: Option<String>,
+    status: String,
+    skip_reason: String,
+}
+
 pub fn run(args: ProofArgs) -> Result<()> {
     if !args.plan {
         bail!("proof execution is not implemented yet; pass --plan to print the proof plan");
@@ -82,6 +121,9 @@ pub fn run(args: ProofArgs) -> Result<()> {
     }
     if let Some(path) = &args.evidence_json {
         write_evidence_json(path, &report)?;
+    }
+    if let Some(path) = &args.executor_summary {
+        write_executor_summary(path, &report)?;
     }
     println!("{}", serde_json::to_string_pretty(&report)?);
 
@@ -288,6 +330,15 @@ fn write_evidence_json(path: &Path, report: &ProofPlanReport) -> Result<()> {
     Ok(())
 }
 
+fn write_executor_summary(path: &Path, report: &ProofPlanReport) -> Result<()> {
+    ensure_parent_dir(path)?;
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&proof_executor_summary(report))?,
+    )?;
+    Ok(())
+}
+
 fn ensure_parent_dir(path: &Path) -> Result<()> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -372,6 +423,61 @@ fn evidence_artifact_path(command: &ProofPlanCommand) -> Option<String> {
 
 fn is_evidence_kind(kind: &str) -> bool {
     matches!(kind, "coverage" | "mutation")
+}
+
+fn proof_executor_summary(report: &ProofPlanReport) -> ProofExecutorSummary {
+    let family = "coverage";
+    let family_commands = report
+        .commands
+        .iter()
+        .filter(|command| command.kind == family)
+        .collect::<Vec<_>>();
+    let entries = family_commands
+        .iter()
+        .filter(|command| !command.required)
+        .map(|command| executor_entry(command))
+        .collect::<Vec<_>>();
+    let required_excluded = family_commands
+        .iter()
+        .filter(|command| command.required)
+        .count();
+    let selected = entries.len();
+
+    ProofExecutorSummary {
+        schema: "tokmd.proof_executor_summary.v1".to_string(),
+        status: "prototype".to_string(),
+        execution_status: "not_executed".to_string(),
+        family: family.to_string(),
+        required: false,
+        profile: report.profile.clone(),
+        base: report.base.clone(),
+        head: report.head.clone(),
+        ok: report.ok,
+        changed_files: report.changed_files.clone(),
+        counts: ProofExecutorCounts {
+            commands_total: report.commands.len(),
+            family_planned: family_commands.len(),
+            selected,
+            skipped: selected,
+            executed: 0,
+            required_excluded,
+            non_family_excluded: report.commands.len() - family_commands.len(),
+        },
+        entries,
+        unknown_files: report.unknown_files.clone(),
+    }
+}
+
+fn executor_entry(command: &ProofPlanCommand) -> ProofExecutorEntry {
+    ProofExecutorEntry {
+        scope: command.scope.clone(),
+        kind: command.kind.clone(),
+        required: command.required,
+        command: command.command.clone(),
+        artifact_path: evidence_artifact_path(command),
+        status: "skipped".to_string(),
+        skip_reason: "tool_execution_not_enabled".to_string(),
+    }
 }
 
 fn render_markdown_summary(report: &ProofPlanReport) -> String {
@@ -533,8 +639,8 @@ fn profile_name(profile: ProofProfile) -> &'static str {
 mod tests {
     use super::{
         ProofPlanCommand, ProofPlanReport, affected_commands, dedupe_commands,
-        is_mutation_candidate, proof_evidence_plan, render_markdown_summary,
-        static_profile_commands,
+        is_mutation_candidate, proof_evidence_plan, proof_executor_summary,
+        render_markdown_summary, static_profile_commands,
     };
     use crate::cli::ProofProfile;
     use crate::proof::policy::parse_policy_str;
@@ -740,6 +846,70 @@ coverage = "cargo-llvm-cov"
         );
         assert_eq!(evidence.entries[1].kind, "mutation");
         assert_eq!(evidence.entries[1].artifact_path, None);
+    }
+
+    #[test]
+    fn executor_summary_selects_only_advisory_coverage_without_execution() {
+        let report = ProofPlanReport {
+            schema: "tokmd.proof_plan.v1".to_string(),
+            ok: true,
+            profile: "affected".to_string(),
+            base: "origin/main".to_string(),
+            head: "HEAD".to_string(),
+            changed_files: vec!["crates/tokmd-core/src/ffi.rs".to_string()],
+            commands: vec![
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "proof".to_string(),
+                    required: true,
+                    command: "cargo test -p tokmd-core ffi".to_string(),
+                },
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "coverage".to_string(),
+                    required: false,
+                    command: "cargo llvm-cov -p tokmd-core --all-features --lcov --output-path target/proof/coverage/tokmd_core_ffi.lcov".to_string(),
+                },
+                ProofPlanCommand {
+                    scope: "coverage".to_string(),
+                    kind: "coverage".to_string(),
+                    required: true,
+                    command: "cargo llvm-cov --workspace --lcov".to_string(),
+                },
+                ProofPlanCommand {
+                    scope: "tokmd_core_ffi".to_string(),
+                    kind: "mutation".to_string(),
+                    required: false,
+                    command: "cargo mutants --file crates/tokmd-core/src/ffi.rs --timeout 300"
+                        .to_string(),
+                },
+            ],
+            unknown_files: Vec::new(),
+        };
+
+        let summary = proof_executor_summary(&report);
+
+        assert_eq!(summary.schema, "tokmd.proof_executor_summary.v1");
+        assert_eq!(summary.status, "prototype");
+        assert_eq!(summary.execution_status, "not_executed");
+        assert_eq!(summary.family, "coverage");
+        assert!(!summary.required);
+        assert_eq!(summary.counts.commands_total, 4);
+        assert_eq!(summary.counts.family_planned, 2);
+        assert_eq!(summary.counts.selected, 1);
+        assert_eq!(summary.counts.skipped, 1);
+        assert_eq!(summary.counts.executed, 0);
+        assert_eq!(summary.counts.required_excluded, 1);
+        assert_eq!(summary.counts.non_family_excluded, 2);
+        assert_eq!(summary.entries.len(), 1);
+        assert_eq!(summary.entries[0].kind, "coverage");
+        assert!(!summary.entries[0].required);
+        assert_eq!(summary.entries[0].status, "skipped");
+        assert_eq!(summary.entries[0].skip_reason, "tool_execution_not_enabled");
+        assert_eq!(
+            summary.entries[0].artifact_path.as_deref(),
+            Some("target/proof/coverage/tokmd_core_ffi.lcov")
+        );
     }
 
     #[test]

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -33,6 +33,7 @@ fn proof_help_mentions_profile_and_plan() {
     assert!(stdout.contains("--plan"), "stdout: {stdout}");
     assert!(stdout.contains("--summary-md"), "stdout: {stdout}");
     assert!(stdout.contains("--evidence-json"), "stdout: {stdout}");
+    assert!(stdout.contains("--executor-summary"), "stdout: {stdout}");
 }
 
 #[test]
@@ -161,4 +162,40 @@ fn proof_plan_writes_evidence_json_artifact() {
     assert_eq!(evidence["counts"]["coverage"]["executed"], 0);
     assert_eq!(evidence["counts"]["mutation"]["executed"], 0);
     assert!(evidence["entries"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn proof_plan_writes_executor_summary_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let executor_path = temp.path().join("executor-summary.json");
+    let executor_arg = executor_path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof",
+        "--profile",
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--plan",
+        "--executor-summary",
+        &executor_arg,
+    ]);
+
+    assert!(success, "proof --executor-summary failed. stderr: {stderr}");
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("proof --plan should still emit JSON");
+    assert_eq!(value["schema"], "tokmd.proof_plan.v1");
+
+    let summary = fs::read_to_string(executor_path).expect("executor summary should be written");
+    let summary: serde_json::Value =
+        serde_json::from_str(&summary).expect("executor summary should be valid JSON");
+    assert_eq!(summary["schema"], "tokmd.proof_executor_summary.v1");
+    assert_eq!(summary["status"], "prototype");
+    assert_eq!(summary["execution_status"], "not_executed");
+    assert_eq!(summary["family"], "coverage");
+    assert_eq!(summary["required"], false);
+    assert_eq!(summary["counts"]["selected"], 0);
+    assert_eq!(summary["counts"]["executed"], 0);
+    assert!(summary["entries"].as_array().unwrap().is_empty());
 }


### PR DESCRIPTION
## Summary
- add cargo xtask proof --plan --executor-summary <path> as a coverage-only executor-summary prototype
- select only non-required coverage commands and mark them skipped with 	ool_execution_not_enabled
- upload the prototype summary from the informational affected-plan CI artifact bundle without changing required coverage or mutation workflows

## Validation
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask affected --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_policy --verbose
- cargo test -p xtask lint_policy --verbose
- cargo xtask proof-policy --check
- cargo xtask check-lint-policy
- cargo xtask proof --profile affected --base HEAD --head HEAD --plan --executor-summary target/proof/executor-summary.json
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/branch-proof-summary.md --evidence-json target/proof/branch-proof-evidence.json --executor-summary target/proof/branch-executor-summary.json
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- python yaml safe_load for .github/workflows/ci.yml
- git diff --check