### PR TITLE
Guard proof executor CI opt-in

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -38,7 +38,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof --plan --evidence-json <path>` now writes a machine-readable planned-evidence artifact for scoped coverage and mutation commands. The artifact records `planned` / `not_executed` status and zero executed counts so consumers do not confuse planned advisory evidence with passing evidence.
 - `cargo xtask proof --plan --executor-summary <path>` now writes an informational coverage-only executor summary prototype. It selects non-required coverage commands, records them as skipped with `tool_execution_not_enabled`, and does not invoke `cargo llvm-cov`.
 - `cargo xtask proof --plan --executor-summary <path> --executor-mode dry-run` now exercises the executor selection boundary for at most one non-required coverage command without invoking `cargo llvm-cov`.
-- Next proof-policy operational slice: add an explicit opt-in guard before any CI job is allowed to execute planner-selected evidence commands.
+- Executor summaries now include an `execution_guard` block. CI evidence execution remains disabled unless a future workflow explicitly passes `--allow-ci-evidence-execution`, and current executor modes still report zero executed commands.
+- Next proof-policy operational slice: surface executor guard status in the affected-plan summary before any CI job starts executing planner-selected evidence commands.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -129,6 +129,10 @@ pub struct ProofArgs {
     #[arg(long, value_enum, default_value_t = ProofExecutorMode::Prototype)]
     pub executor_mode: ProofExecutorMode,
 
+    /// Explicitly opt a CI invocation into future planner-selected evidence execution
+    #[arg(long)]
+    pub allow_ci_evidence_execution: bool,
+
     /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -10,6 +10,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
+const CI_ENV_VAR: &str = "CI";
+
 #[derive(Debug, Serialize)]
 struct ProofPlanReport {
     schema: String,
@@ -76,6 +78,7 @@ struct ProofExecutorSummary {
     mode: String,
     status: String,
     execution_status: String,
+    execution_guard: ProofExecutorExecutionGuard,
     family: String,
     required: bool,
     profile: String,
@@ -112,6 +115,15 @@ struct ProofExecutorEntry {
     skip_reason: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct ProofExecutorExecutionGuard {
+    required: bool,
+    enabled: bool,
+    ci: bool,
+    allow_ci_evidence_execution: bool,
+    reason: String,
+}
+
 pub fn run(args: ProofArgs) -> Result<()> {
     if !args.plan {
         bail!("proof execution is not implemented yet; pass --plan to print the proof plan");
@@ -126,7 +138,12 @@ pub fn run(args: ProofArgs) -> Result<()> {
         write_evidence_json(path, &report)?;
     }
     if let Some(path) = &args.executor_summary {
-        write_executor_summary(path, &report, args.executor_mode)?;
+        write_executor_summary(
+            path,
+            &report,
+            args.executor_mode,
+            proof_executor_execution_guard(args.allow_ci_evidence_execution),
+        )?;
     }
     println!("{}", serde_json::to_string_pretty(&report)?);
 
@@ -337,11 +354,12 @@ fn write_executor_summary(
     path: &Path,
     report: &ProofPlanReport,
     mode: ProofExecutorMode,
+    execution_guard: ProofExecutorExecutionGuard,
 ) -> Result<()> {
     ensure_parent_dir(path)?;
     fs::write(
         path,
-        serde_json::to_string_pretty(&proof_executor_summary(report, mode))?,
+        serde_json::to_string_pretty(&proof_executor_summary(report, mode, execution_guard))?,
     )?;
     Ok(())
 }
@@ -435,6 +453,7 @@ fn is_evidence_kind(kind: &str) -> bool {
 fn proof_executor_summary(
     report: &ProofPlanReport,
     mode: ProofExecutorMode,
+    execution_guard: ProofExecutorExecutionGuard,
 ) -> ProofExecutorSummary {
     let family = "coverage";
     let family_commands = report
@@ -471,6 +490,7 @@ fn proof_executor_summary(
         mode: executor_mode_name(mode).to_string(),
         status: executor_status(mode).to_string(),
         execution_status: executor_execution_status(mode).to_string(),
+        execution_guard,
         family: family.to_string(),
         required: false,
         profile: report.profile.clone(),
@@ -491,6 +511,39 @@ fn proof_executor_summary(
         },
         entries,
         unknown_files: report.unknown_files.clone(),
+    }
+}
+
+fn proof_executor_execution_guard(
+    allow_ci_evidence_execution: bool,
+) -> ProofExecutorExecutionGuard {
+    proof_executor_execution_guard_for(ci_env_enabled(), allow_ci_evidence_execution)
+}
+
+fn ci_env_enabled() -> bool {
+    std::env::var(CI_ENV_VAR)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn proof_executor_execution_guard_for(
+    ci: bool,
+    allow_ci_evidence_execution: bool,
+) -> ProofExecutorExecutionGuard {
+    let enabled = ci && allow_ci_evidence_execution;
+    let reason = match (ci, allow_ci_evidence_execution) {
+        (true, true) => "ci_explicit_opt_in_enabled",
+        (true, false) => "ci_requires_--allow-ci-evidence-execution",
+        (false, true) => "not_ci_execution_context",
+        (false, false) => "not_ci_and_no_--allow-ci-evidence-execution",
+    };
+
+    ProofExecutorExecutionGuard {
+        required: true,
+        enabled,
+        ci,
+        allow_ci_evidence_execution,
+        reason: reason.to_string(),
     }
 }
 
@@ -710,8 +763,8 @@ fn profile_name(profile: ProofProfile) -> &'static str {
 mod tests {
     use super::{
         ProofPlanCommand, ProofPlanReport, affected_commands, dedupe_commands,
-        is_mutation_candidate, proof_evidence_plan, proof_executor_summary,
-        render_markdown_summary, static_profile_commands,
+        is_mutation_candidate, proof_evidence_plan, proof_executor_execution_guard_for,
+        proof_executor_summary, render_markdown_summary, static_profile_commands,
     };
     use crate::cli::{ProofExecutorMode, ProofProfile};
     use crate::proof::policy::parse_policy_str;
@@ -958,12 +1011,24 @@ coverage = "cargo-llvm-cov"
             unknown_files: Vec::new(),
         };
 
-        let summary = proof_executor_summary(&report, ProofExecutorMode::Prototype);
+        let summary = proof_executor_summary(
+            &report,
+            ProofExecutorMode::Prototype,
+            proof_executor_execution_guard_for(false, false),
+        );
 
         assert_eq!(summary.schema, "tokmd.proof_executor_summary.v1");
         assert_eq!(summary.mode, "prototype");
         assert_eq!(summary.status, "prototype");
         assert_eq!(summary.execution_status, "not_executed");
+        assert!(summary.execution_guard.required);
+        assert!(!summary.execution_guard.enabled);
+        assert!(!summary.execution_guard.ci);
+        assert!(!summary.execution_guard.allow_ci_evidence_execution);
+        assert_eq!(
+            summary.execution_guard.reason,
+            "not_ci_and_no_--allow-ci-evidence-execution"
+        );
         assert_eq!(summary.family, "coverage");
         assert!(!summary.required);
         assert_eq!(summary.counts.commands_total, 4);
@@ -1022,11 +1087,23 @@ coverage = "cargo-llvm-cov"
             unknown_files: Vec::new(),
         };
 
-        let summary = proof_executor_summary(&report, ProofExecutorMode::DryRun);
+        let summary = proof_executor_summary(
+            &report,
+            ProofExecutorMode::DryRun,
+            proof_executor_execution_guard_for(true, false),
+        );
 
         assert_eq!(summary.mode, "dry_run");
         assert_eq!(summary.status, "dry_run");
         assert_eq!(summary.execution_status, "dry_run");
+        assert!(summary.execution_guard.required);
+        assert!(!summary.execution_guard.enabled);
+        assert!(summary.execution_guard.ci);
+        assert!(!summary.execution_guard.allow_ci_evidence_execution);
+        assert_eq!(
+            summary.execution_guard.reason,
+            "ci_requires_--allow-ci-evidence-execution"
+        );
         assert_eq!(summary.counts.family_planned, 2);
         assert_eq!(summary.counts.selected, 1);
         assert_eq!(summary.counts.skipped, 0);
@@ -1037,6 +1114,32 @@ coverage = "cargo-llvm-cov"
         assert_eq!(summary.entries[0].status, "dry_run");
         assert_eq!(summary.entries[0].skip_reason, "dry_run_only");
         assert_eq!(summary.entries[0].scope, "tokmd_core_ffi");
+    }
+
+    #[test]
+    fn executor_execution_guard_requires_ci_and_explicit_flag() {
+        let local_default = proof_executor_execution_guard_for(false, false);
+        assert!(local_default.required);
+        assert!(!local_default.enabled);
+        assert_eq!(
+            local_default.reason,
+            "not_ci_and_no_--allow-ci-evidence-execution"
+        );
+
+        let ci_without_flag = proof_executor_execution_guard_for(true, false);
+        assert!(!ci_without_flag.enabled);
+        assert_eq!(
+            ci_without_flag.reason,
+            "ci_requires_--allow-ci-evidence-execution"
+        );
+
+        let local_with_flag = proof_executor_execution_guard_for(false, true);
+        assert!(!local_with_flag.enabled);
+        assert_eq!(local_with_flag.reason, "not_ci_execution_context");
+
+        let ci_with_flag = proof_executor_execution_guard_for(true, true);
+        assert!(ci_with_flag.enabled);
+        assert_eq!(ci_with_flag.reason, "ci_explicit_opt_in_enabled");
     }
 
     #[test]

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -8,8 +8,13 @@ fn workspace_root() -> PathBuf {
 }
 
 fn run_xtask(args: &[&str]) -> (String, String, bool) {
+    run_xtask_with_env(args, &[])
+}
+
+fn run_xtask_with_env(args: &[&str], envs: &[(&str, &str)]) -> (String, String, bool) {
     let root = workspace_root();
-    let output = Command::new("cargo")
+    let mut command = Command::new("cargo");
+    command
         .arg("run")
         .arg("-q")
         .arg("-p")
@@ -17,8 +22,12 @@ fn run_xtask(args: &[&str]) -> (String, String, bool) {
         .arg("--")
         .args(args)
         .current_dir(&root)
-        .output()
-        .expect("failed to run cargo xtask");
+        .env_remove("CI");
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+
+    let output = command.output().expect("failed to run cargo xtask");
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     (stdout, stderr, output.status.success())
@@ -35,6 +44,10 @@ fn proof_help_mentions_profile_and_plan() {
     assert!(stdout.contains("--evidence-json"), "stdout: {stdout}");
     assert!(stdout.contains("--executor-summary"), "stdout: {stdout}");
     assert!(stdout.contains("--executor-mode"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("--allow-ci-evidence-execution"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]
@@ -195,6 +208,17 @@ fn proof_plan_writes_executor_summary_artifact() {
     assert_eq!(summary["mode"], "prototype");
     assert_eq!(summary["status"], "prototype");
     assert_eq!(summary["execution_status"], "not_executed");
+    assert_eq!(summary["execution_guard"]["required"], true);
+    assert_eq!(summary["execution_guard"]["enabled"], false);
+    assert_eq!(summary["execution_guard"]["ci"], false);
+    assert_eq!(
+        summary["execution_guard"]["allow_ci_evidence_execution"],
+        false
+    );
+    assert_eq!(
+        summary["execution_guard"]["reason"],
+        "not_ci_and_no_--allow-ci-evidence-execution"
+    );
     assert_eq!(summary["family"], "coverage");
     assert_eq!(summary["required"], false);
     assert_eq!(summary["counts"]["selected"], 0);
@@ -235,10 +259,90 @@ fn proof_plan_writes_dry_run_executor_summary_artifact() {
     assert_eq!(summary["mode"], "dry_run");
     assert_eq!(summary["status"], "dry_run");
     assert_eq!(summary["execution_status"], "dry_run");
+    assert_eq!(summary["execution_guard"]["enabled"], false);
+    assert_eq!(
+        summary["execution_guard"]["allow_ci_evidence_execution"],
+        false
+    );
     assert_eq!(summary["family"], "coverage");
     assert_eq!(summary["counts"]["family_planned"], 1);
     assert_eq!(summary["counts"]["selected"], 0);
     assert_eq!(summary["counts"]["required_excluded"], 1);
     assert_eq!(summary["counts"]["executed"], 0);
     assert!(summary["entries"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn ci_executor_summary_requires_explicit_evidence_execution_opt_in() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let blocked_path = temp.path().join("blocked-executor-summary.json");
+    let blocked_arg = blocked_path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask_with_env(
+        &[
+            "proof",
+            "--profile",
+            "affected",
+            "--base",
+            "HEAD",
+            "--head",
+            "HEAD",
+            "--plan",
+            "--executor-summary",
+            &blocked_arg,
+        ],
+        &[("CI", "true")],
+    );
+
+    assert!(
+        success,
+        "CI proof executor summary failed. stderr: {stderr}"
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("proof --plan should still emit JSON");
+    assert_eq!(value["schema"], "tokmd.proof_plan.v1");
+
+    let blocked = fs::read_to_string(blocked_path).expect("executor summary should be written");
+    let blocked: serde_json::Value =
+        serde_json::from_str(&blocked).expect("executor summary should be valid JSON");
+    assert_eq!(blocked["execution_guard"]["ci"], true);
+    assert_eq!(blocked["execution_guard"]["enabled"], false);
+    assert_eq!(
+        blocked["execution_guard"]["reason"],
+        "ci_requires_--allow-ci-evidence-execution"
+    );
+    assert_eq!(blocked["counts"]["executed"], 0);
+
+    let enabled_path = temp.path().join("enabled-executor-summary.json");
+    let enabled_arg = enabled_path.to_string_lossy().to_string();
+    let (_stdout, stderr, success) = run_xtask_with_env(
+        &[
+            "proof",
+            "--profile",
+            "affected",
+            "--base",
+            "HEAD",
+            "--head",
+            "HEAD",
+            "--plan",
+            "--executor-summary",
+            &enabled_arg,
+            "--allow-ci-evidence-execution",
+        ],
+        &[("CI", "true")],
+    );
+
+    assert!(
+        success,
+        "CI proof executor summary with opt-in failed. stderr: {stderr}"
+    );
+    let enabled = fs::read_to_string(enabled_path).expect("executor summary should be written");
+    let enabled: serde_json::Value =
+        serde_json::from_str(&enabled).expect("executor summary should be valid JSON");
+    assert_eq!(enabled["execution_guard"]["ci"], true);
+    assert_eq!(enabled["execution_guard"]["enabled"], true);
+    assert_eq!(
+        enabled["execution_guard"]["reason"],
+        "ci_explicit_opt_in_enabled"
+    );
+    assert_eq!(enabled["counts"]["executed"], 0);
 }


### PR DESCRIPTION
## Summary
- add an explicit CI opt-in flag for future planner-selected evidence execution
- include execution_guard metadata in proof executor summaries
- document the guard checkpoint in docs/NEXT.md

## Validation
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask --test proof_plan_w92 --verbose
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check HEAD
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/guard-summary.md --evidence-json target/proof/guard-evidence.json --executor-summary target/proof/guard-executor-summary.json
- cargo test -p xtask affected --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_policy --verbose
- cargo test -p xtask lint_policy --verbose
- cargo xtask check-lint-policy