### PR TITLE
Surface proof executor guard in summaries

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -39,7 +39,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof --plan --executor-summary <path>` now writes an informational coverage-only executor summary prototype. It selects non-required coverage commands, records them as skipped with `tool_execution_not_enabled`, and does not invoke `cargo llvm-cov`.
 - `cargo xtask proof --plan --executor-summary <path> --executor-mode dry-run` now exercises the executor selection boundary for at most one non-required coverage command without invoking `cargo llvm-cov`.
 - Executor summaries now include an `execution_guard` block. CI evidence execution remains disabled unless a future workflow explicitly passes `--allow-ci-evidence-execution`, and current executor modes still report zero executed commands.
-- Next proof-policy operational slice: surface executor guard status in the affected-plan summary before any CI job starts executing planner-selected evidence commands.
+- Rust-generated proof-plan Markdown now surfaces executor guard status whenever an executor summary is requested, so the affected-plan CI summary shows whether planner-selected evidence execution is blocked or explicitly opted in.
+- Next proof-policy operational slice: decide the first executor family promotion rule before any CI job starts executing planner-selected evidence commands.
 
 ## References
 

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -131,19 +131,21 @@ pub fn run(args: ProofArgs) -> Result<()> {
 
     let policy = load_checked_policy(&args.policy)?;
     let report = proof_plan_report(&policy, &args)?;
+    let executor_summary = args.executor_summary.as_ref().map(|_| {
+        proof_executor_summary(
+            &report,
+            args.executor_mode,
+            proof_executor_execution_guard(args.allow_ci_evidence_execution),
+        )
+    });
     if let Some(path) = &args.summary_md {
-        write_markdown_summary(path, &report)?;
+        write_markdown_summary(path, &report, executor_summary.as_ref())?;
     }
     if let Some(path) = &args.evidence_json {
         write_evidence_json(path, &report)?;
     }
-    if let Some(path) = &args.executor_summary {
-        write_executor_summary(
-            path,
-            &report,
-            args.executor_mode,
-            proof_executor_execution_guard(args.allow_ci_evidence_execution),
-        )?;
+    if let (Some(path), Some(summary)) = (&args.executor_summary, executor_summary.as_ref()) {
+        write_executor_summary(path, summary)?;
     }
     println!("{}", serde_json::to_string_pretty(&report)?);
 
@@ -335,9 +337,13 @@ fn dedupe_commands(commands: Vec<ProofPlanCommand>) -> Vec<ProofPlanCommand> {
     commands
 }
 
-fn write_markdown_summary(path: &Path, report: &ProofPlanReport) -> Result<()> {
+fn write_markdown_summary(
+    path: &Path,
+    report: &ProofPlanReport,
+    executor_summary: Option<&ProofExecutorSummary>,
+) -> Result<()> {
     ensure_parent_dir(path)?;
-    fs::write(path, render_markdown_summary(report))?;
+    fs::write(path, render_markdown_summary(report, executor_summary))?;
     Ok(())
 }
 
@@ -350,17 +356,9 @@ fn write_evidence_json(path: &Path, report: &ProofPlanReport) -> Result<()> {
     Ok(())
 }
 
-fn write_executor_summary(
-    path: &Path,
-    report: &ProofPlanReport,
-    mode: ProofExecutorMode,
-    execution_guard: ProofExecutorExecutionGuard,
-) -> Result<()> {
+fn write_executor_summary(path: &Path, summary: &ProofExecutorSummary) -> Result<()> {
     ensure_parent_dir(path)?;
-    fs::write(
-        path,
-        serde_json::to_string_pretty(&proof_executor_summary(report, mode, execution_guard))?,
-    )?;
+    fs::write(path, serde_json::to_string_pretty(summary)?)?;
     Ok(())
 }
 
@@ -604,7 +602,10 @@ fn executor_skip_reason(mode: ProofExecutorMode) -> &'static str {
     }
 }
 
-fn render_markdown_summary(report: &ProofPlanReport) -> String {
+fn render_markdown_summary(
+    report: &ProofPlanReport,
+    executor_summary: Option<&ProofExecutorSummary>,
+) -> String {
     let mut out = String::new();
 
     out.push_str("## Proof Plan Summary\n\n");
@@ -662,6 +663,45 @@ fn render_markdown_summary(report: &ProofPlanReport) -> String {
         for file in &report.unknown_files {
             out.push_str(&format!("- `{}`\n", escape_md(file)));
         }
+    }
+
+    if let Some(summary) = executor_summary {
+        out.push_str("\n### Executor Guard\n\n");
+        out.push_str("| Field | Value |\n");
+        out.push_str("| --- | --- |\n");
+        out.push_str(&format!("| Mode | `{}` |\n", escape_md(&summary.mode)));
+        out.push_str(&format!(
+            "| Execution status | `{}` |\n",
+            escape_md(&summary.execution_status)
+        ));
+        out.push_str(&format!(
+            "| Guard required | `{}` |\n",
+            summary.execution_guard.required
+        ));
+        out.push_str(&format!(
+            "| Guard enabled | `{}` |\n",
+            summary.execution_guard.enabled
+        ));
+        out.push_str(&format!("| CI | `{}` |\n", summary.execution_guard.ci));
+        out.push_str(&format!(
+            "| CI opt-in flag | `{}` |\n",
+            summary.execution_guard.allow_ci_evidence_execution
+        ));
+        out.push_str(&format!(
+            "| Reason | `{}` |\n",
+            escape_md(&summary.execution_guard.reason)
+        ));
+        out.push_str(&format!(
+            "| Selected commands | {} |\n",
+            summary.counts.selected
+        ));
+        out.push_str(&format!(
+            "| Executed commands | {} |\n",
+            summary.counts.executed
+        ));
+        out.push_str(
+            "\nPlanner-selected evidence commands remain informational until executor execution is implemented and intentionally enabled.\n",
+        );
     }
 
     out
@@ -907,13 +947,47 @@ coverage = "cargo-llvm-cov"
             unknown_files: Vec::new(),
         };
 
-        let summary = render_markdown_summary(&report);
+        let summary = render_markdown_summary(&report, None);
 
         assert!(summary.contains("Required commands are the current proof selection"));
         assert!(summary.contains("| `proof` | `true` | 1 |"));
         assert!(summary.contains("| `coverage` | `false` | 1 |"));
         assert!(summary.contains("| `mutation` | `false` | 1 |"));
         assert!(summary.contains("cargo mutants --file crates/tokmd-core/src/ffi.rs"));
+    }
+
+    #[test]
+    fn markdown_summary_surfaces_executor_guard_when_available() {
+        let report = ProofPlanReport {
+            schema: "tokmd.proof_plan.v1".to_string(),
+            ok: true,
+            profile: "affected".to_string(),
+            base: "origin/main".to_string(),
+            head: "HEAD".to_string(),
+            changed_files: vec!["crates/tokmd-core/src/ffi.rs".to_string()],
+            commands: vec![ProofPlanCommand {
+                scope: "tokmd_core_ffi".to_string(),
+                kind: "coverage".to_string(),
+                required: false,
+                command: "cargo llvm-cov -p tokmd-core --all-features --lcov --output-path target/proof/coverage/tokmd_core_ffi.lcov".to_string(),
+            }],
+            unknown_files: Vec::new(),
+        };
+        let executor_summary = proof_executor_summary(
+            &report,
+            ProofExecutorMode::DryRun,
+            proof_executor_execution_guard_for(true, false),
+        );
+
+        let summary = render_markdown_summary(&report, Some(&executor_summary));
+
+        assert!(summary.contains("### Executor Guard"));
+        assert!(summary.contains("| Mode | `dry_run` |"));
+        assert!(summary.contains("| Guard enabled | `false` |"));
+        assert!(summary.contains("| CI | `true` |"));
+        assert!(summary.contains("ci_requires_--allow-ci-evidence-execution"));
+        assert!(summary.contains("| Selected commands | 1 |"));
+        assert!(summary.contains("| Executed commands | 0 |"));
     }
 
     #[test]

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -142,6 +142,53 @@ fn proof_plan_writes_markdown_summary_artifact() {
     let summary = fs::read_to_string(summary_path).expect("summary should be written");
     assert!(summary.contains("## Proof Plan Summary"));
     assert!(summary.contains("No proof commands planned."));
+    assert!(!summary.contains("### Executor Guard"));
+}
+
+#[test]
+fn proof_plan_markdown_summary_includes_executor_guard_when_requested() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let summary_path = temp.path().join("proof-plan.md");
+    let summary_arg = summary_path.to_string_lossy().to_string();
+    let executor_path = temp.path().join("executor-summary.json");
+    let executor_arg = executor_path.to_string_lossy().to_string();
+    let (_stdout, stderr, success) = run_xtask_with_env(
+        &[
+            "proof",
+            "--profile",
+            "affected",
+            "--base",
+            "HEAD",
+            "--head",
+            "HEAD",
+            "--plan",
+            "--summary-md",
+            &summary_arg,
+            "--executor-summary",
+            &executor_arg,
+            "--executor-mode",
+            "dry-run",
+        ],
+        &[("CI", "true")],
+    );
+
+    assert!(
+        success,
+        "proof --summary-md with executor summary failed. stderr: {stderr}"
+    );
+    let summary = fs::read_to_string(summary_path).expect("summary should be written");
+    assert!(summary.contains("### Executor Guard"));
+    assert!(summary.contains("| Mode | `dry_run` |"));
+    assert!(summary.contains("| Guard enabled | `false` |"));
+    assert!(summary.contains("| CI | `true` |"));
+    assert!(summary.contains("ci_requires_--allow-ci-evidence-execution"));
+    assert!(summary.contains("| Executed commands | 0 |"));
+
+    let executor = fs::read_to_string(executor_path).expect("executor summary should be written");
+    let executor: serde_json::Value =
+        serde_json::from_str(&executor).expect("executor summary should be valid JSON");
+    assert_eq!(executor["execution_guard"]["enabled"], false);
+    assert_eq!(executor["counts"]["executed"], 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- include executor guard details in Rust-generated proof-plan Markdown when executor summaries are requested
- keep executor JSON and Markdown generated from the same summary model
- update docs/NEXT.md with the guard-summary checkpoint

## Validation
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask --test proof_plan_w92 --verbose
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/guard-summary-plan.md --evidence-json target/proof/guard-summary-evidence.json --executor-summary target/proof/guard-summary-executor.json --executor-mode dry-run
- cargo test -p xtask affected --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_policy --verbose