### PR TITLE
chore(xtask): report proof executor policy

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -41,7 +41,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Executor summaries now include an `execution_guard` block. CI evidence execution remains disabled unless a future workflow explicitly passes `--allow-ci-evidence-execution`, and current executor modes still report zero executed commands.
 - Rust-generated proof-plan Markdown now surfaces executor guard status whenever an executor summary is requested, so the affected-plan CI summary shows whether planner-selected evidence execution is blocked or explicitly opted in.
 - `ci/proof.toml` now declares the first executor promotion rule: coverage is the only supported executor family, CI execution requires explicit opt-in, and dry-run selection is policy-limited before any CI job can execute planner-selected evidence commands.
-- Next proof-policy operational slice: expose executor policy details in `cargo xtask proof-policy --json` and the human policy report before promoting any executor family from dry-run to real command execution.
+- `cargo xtask proof-policy --check` and `--json` now report the active executor policy rule alongside scope, allowlist, fixture blob, and dependency-boundary counts.
+- Next proof-policy operational slice: add a planner-selected executor command manifest artifact before promoting any executor family from dry-run to real command execution.
 
 ## References
 

--- a/xtask/src/tasks/proof_policy.rs
+++ b/xtask/src/tasks/proof_policy.rs
@@ -1,5 +1,6 @@
 use crate::cli::ProofPolicyArgs;
 use crate::proof::policy::load_policy;
+use crate::proof::policy_ast::{CiExecution, ProofPolicy};
 use crate::proof::validate::{PolicyViolation, validate_policy};
 use anyhow::{Result, bail};
 use serde::Serialize;
@@ -14,7 +15,15 @@ struct ProofPolicyReport {
     allowlist_count: usize,
     fixture_blob_rule_count: usize,
     dependency_boundary_count: usize,
+    executor: ExecutorPolicyReport,
     violations: Vec<PolicyViolation>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecutorPolicyReport {
+    family: Option<String>,
+    ci_execution: Option<String>,
+    max_dry_run_commands: Option<usize>,
 }
 
 pub fn run(args: ProofPolicyArgs) -> Result<()> {
@@ -22,6 +31,7 @@ pub fn run(args: ProofPolicyArgs) -> Result<()> {
     let path = args.policy;
     let policy = load_policy(&path)?;
     let violations = validate_policy(&policy);
+    let executor = ExecutorPolicyReport::from_policy(&policy);
     let report = ProofPolicyReport {
         ok: violations.is_empty(),
         policy: display_path(&path),
@@ -30,6 +40,7 @@ pub fn run(args: ProofPolicyArgs) -> Result<()> {
         allowlist_count: policy.allow.workspace_area.len(),
         fixture_blob_rule_count: policy.forbid.fixture_blob.len(),
         dependency_boundary_count: policy.dependency_boundary.len(),
+        executor,
         violations,
     };
 
@@ -49,16 +60,32 @@ pub fn run(args: ProofPolicyArgs) -> Result<()> {
     }
 }
 
+impl ExecutorPolicyReport {
+    fn from_policy(policy: &ProofPolicy) -> Self {
+        Self {
+            family: policy.executor.family.clone(),
+            ci_execution: policy
+                .executor
+                .ci_execution
+                .as_ref()
+                .map(ci_execution_name)
+                .map(str::to_string),
+            max_dry_run_commands: policy.executor.max_dry_run_commands,
+        }
+    }
+}
+
 fn print_human_report(report: &ProofPolicyReport) {
     if report.ok {
         println!(
-            "Proof policy OK: {} (schema {}, {} scope(s), {} allowlist(s), {} fixture blob rule(s), {} dependency boundary rule(s))",
+            "Proof policy OK: {} (schema {}, {} scope(s), {} allowlist(s), {} fixture blob rule(s), {} dependency boundary rule(s), executor {})",
             report.policy,
             report.schema,
             report.scope_count,
             report.allowlist_count,
             report.fixture_blob_rule_count,
-            report.dependency_boundary_count
+            report.dependency_boundary_count,
+            executor_summary(&report.executor)
         );
         return;
     }
@@ -71,4 +98,23 @@ fn print_human_report(report: &ProofPolicyReport) {
 
 fn display_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
+}
+
+fn executor_summary(executor: &ExecutorPolicyReport) -> String {
+    match (
+        executor.family.as_deref(),
+        executor.ci_execution.as_deref(),
+        executor.max_dry_run_commands,
+    ) {
+        (Some(family), Some(ci_execution), Some(max_dry_run_commands)) => {
+            format!("{family}/{ci_execution}/max-dry-run-{max_dry_run_commands}")
+        }
+        _ => "not-configured".to_string(),
+    }
+}
+
+fn ci_execution_name(ci_execution: &CiExecution) -> &'static str {
+    match ci_execution {
+        CiExecution::ExplicitOptIn => "explicit_opt_in",
+    }
 }

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -38,6 +38,10 @@ fn proof_policy_check_accepts_repo_policy() {
     assert!(success, "proof-policy --check failed. stderr: {stderr}");
     assert!(stdout.contains("Proof policy OK"), "stdout: {stdout}");
     assert!(stdout.contains("ci/proof.toml"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("executor coverage/explicit_opt_in/max-dry-run-1"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]
@@ -107,6 +111,9 @@ fn proof_policy_json_reports_current_schema() {
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);
+    assert_eq!(value["executor"]["family"], "coverage");
+    assert_eq!(value["executor"]["ci_execution"], "explicit_opt_in");
+    assert_eq!(value["executor"]["max_dry_run_commands"], 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- include the active executor policy in `cargo xtask proof-policy --check` output
- add an `executor` object to `cargo xtask proof-policy --json`
- update `docs/NEXT.md` to mark the reporting slice complete and name the next manifest-artifact slice

## Validation
- cargo fmt-fix
- cargo test -p xtask proof_policy --verbose
- cargo xtask proof-policy --check
- cargo xtask proof-policy --json
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/policy-report-plan.md --evidence-json target/proof/policy-report-evidence.json --executor-summary target/proof/policy-report-executor.json --executor-mode dry-run