### PR TITLE
ci: upload proof executor manifest artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json > target/proof/affected.json
           affected_status=$?
 
-          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json > target/proof/proof-plan.json
+          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json
           proof_plan_status=$?
 
           {

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -43,7 +43,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `ci/proof.toml` now declares the first executor promotion rule: coverage is the only supported executor family, CI execution requires explicit opt-in, and dry-run selection is policy-limited before any CI job can execute planner-selected evidence commands.
 - `cargo xtask proof-policy --check` and `--json` now report the active executor policy rule alongside scope, allowlist, fixture blob, and dependency-boundary counts.
 - `cargo xtask proof --plan --executor-manifest <path>` now writes a planner-selected executor command manifest with the executor policy, guard status, selection rule, stable command ids, and zero executed counts.
-- Next proof-policy operational slice: teach the affected-plan CI artifact job to upload the executor command manifest while keeping all executor commands non-executing.
+- The PR-only affected-plan CI artifact job now writes and uploads `executor-manifest.json` alongside `affected.json`, `proof-plan.json`, `proof-evidence.json`, `executor-summary.json`, and `proof-plan.md`, without opting into executor command execution.
+- Next proof-policy operational slice: add manifest/summary consistency checks or begin a no-execution executor artifact verifier before promoting any executor family.
 
 ## References
 


### PR DESCRIPTION
## Summary
- write `target/proof/executor-manifest.json` from the PR-only affected-plan job
- keep executor command execution disabled; this only adds another uploaded planning artifact
- update `docs/NEXT.md` with the completed checkpoint and next no-execution verifier direction

## Validation
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text(encoding='utf-8'))"`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/ci-executor-manifest-plan.md --evidence-json target/proof/ci-executor-manifest-evidence.json --executor-summary target/proof/ci-executor-manifest-summary.json --executor-manifest target/proof/ci-executor-manifest.json`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`