### PR TITLE
feat(xtask): verify proof executor artifacts

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -29,6 +29,7 @@ paths = [
   "xtask/src/tasks/affected.rs",
   "xtask/src/tasks/boundaries_check.rs",
   "xtask/src/tasks/fixture_blobs_check.rs",
+  "xtask/src/tasks/proof_artifacts_check.rs",
   "xtask/src/tasks/proof_policy.rs",
   "xtask/src/tasks/proof_plan.rs",
   "xtask/tests/affected_w91.rs",
@@ -42,6 +43,7 @@ proof = [
   "cargo test -p xtask proof_policy --verbose",
   "cargo test -p xtask affected --verbose",
   "cargo test -p xtask fixture_blob --verbose",
+  "cargo test -p xtask proof_artifacts --verbose",
   "cargo test -p xtask proof_plan --verbose",
 ]
 mutation = false

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -44,7 +44,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof-policy --check` and `--json` now report the active executor policy rule alongside scope, allowlist, fixture blob, and dependency-boundary counts.
 - `cargo xtask proof --plan --executor-manifest <path>` now writes a planner-selected executor command manifest with the executor policy, guard status, selection rule, stable command ids, and zero executed counts.
 - The PR-only affected-plan CI artifact job now writes and uploads `executor-manifest.json` alongside `affected.json`, `proof-plan.json`, `proof-evidence.json`, `executor-summary.json`, and `proof-plan.md`, without opting into executor command execution.
-- Next proof-policy operational slice: add manifest/summary consistency checks or begin a no-execution executor artifact verifier before promoting any executor family.
+- `cargo xtask proof-artifacts-check` now verifies executor summary/manifest consistency without executing planned commands, including schema, guard, count, and command-entry drift checks.
+- Next proof-policy operational slice: wire `proof-artifacts-check` into the affected-plan CI job after artifact generation, still without promoting any executor family to execution.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -26,6 +26,8 @@ pub enum Commands {
     Affected(AffectedArgs),
     /// Print proof command plans without executing them
     Proof(ProofArgs),
+    /// Verify generated proof artifacts agree without executing planned commands
+    ProofArtifactsCheck(ProofArtifactsCheckArgs),
     /// Verify all release-facing version surfaces are in sync
     VersionConsistency(VersionConsistencyArgs),
     /// Verify dependency boundaries for analysis microcrates
@@ -140,6 +142,25 @@ pub struct ProofArgs {
     /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ProofArtifactsCheckArgs {
+    /// Executor summary artifact to verify
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/executor-summary.json"
+    )]
+    pub executor_summary: std::path::PathBuf,
+
+    /// Executor command manifest artifact to verify
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/executor-manifest.json"
+    )]
+    pub executor_manifest: std::path::PathBuf,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::ProofPolicy(args)) => tasks::proof_policy::run(args),
         Some(cli::Commands::Affected(args)) => tasks::affected::run(args),
         Some(cli::Commands::Proof(args)) => tasks::proof_plan::run(args),
+        Some(cli::Commands::ProofArtifactsCheck(args)) => tasks::proof_artifacts_check::run(args),
         Some(cli::Commands::VersionConsistency(args)) => tasks::version_consistency::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -8,6 +8,7 @@ pub mod fixture_blobs_check;
 pub mod gate;
 pub mod lint_fix;
 pub mod lint_policy;
+pub mod proof_artifacts_check;
 pub mod proof_plan;
 pub mod proof_policy;
 pub mod publish;

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -1,0 +1,429 @@
+use crate::cli::ProofArtifactsCheckArgs;
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+const SUMMARY_SCHEMA: &str = "tokmd.proof_executor_summary.v1";
+const MANIFEST_SCHEMA: &str = "tokmd.proof_executor_manifest.v1";
+
+const SHARED_FIELDS: &[&str] = &[
+    "mode",
+    "status",
+    "execution_status",
+    "execution_guard",
+    "family",
+    "required",
+    "profile",
+    "base",
+    "head",
+    "ok",
+    "changed_files",
+    "unknown_files",
+];
+
+const ENTRY_FIELDS: &[&str] = &[
+    "scope",
+    "kind",
+    "required",
+    "command",
+    "artifact_path",
+    "status",
+    "skip_reason",
+];
+
+pub fn run(args: ProofArtifactsCheckArgs) -> Result<()> {
+    let summary = read_json(&args.executor_summary, "executor summary")?;
+    let manifest = read_json(&args.executor_manifest, "executor manifest")?;
+
+    let report = validate_executor_artifacts(&summary, &manifest)?;
+    println!(
+        "Proof artifacts OK: {} command(s), execution_status {}, guard {}",
+        report.selected, report.execution_status, report.guard_reason
+    );
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ProofArtifactsReport {
+    selected: usize,
+    execution_status: String,
+    guard_reason: String,
+}
+
+fn read_json(path: &Path, label: &str) -> Result<Value> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read {label} artifact `{}`", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse {label} artifact `{}`", path.display()))
+}
+
+fn validate_executor_artifacts(summary: &Value, manifest: &Value) -> Result<ProofArtifactsReport> {
+    expect_schema(summary, SUMMARY_SCHEMA, "executor summary")?;
+    expect_schema(manifest, MANIFEST_SCHEMA, "executor manifest")?;
+
+    for field in SHARED_FIELDS {
+        expect_equal(summary, manifest, field)?;
+    }
+
+    let execution_status = expect_string(
+        field(summary, "execution_status", "executor summary")?,
+        "execution_status",
+        "executor summary",
+    )?;
+    if execution_status == "executed" {
+        bail!(
+            "executor artifacts report executed commands; use a future execution verifier instead"
+        );
+    }
+
+    let guard_enabled = expect_bool(
+        field(summary, "execution_guard.enabled", "executor summary")?,
+        "execution_guard.enabled",
+        "executor summary",
+    )?;
+    if guard_enabled {
+        bail!(
+            "executor artifacts have execution_guard.enabled=true; no-execution verifier requires a blocked guard"
+        );
+    }
+
+    let summary_selected = expect_usize(
+        field(summary, "counts.selected", "executor summary")?,
+        "counts.selected",
+        "executor summary",
+    )?;
+    let summary_executed = expect_usize(
+        field(summary, "counts.executed", "executor summary")?,
+        "counts.executed",
+        "executor summary",
+    )?;
+    let manifest_selected = expect_usize(
+        field(manifest, "selection.selected", "executor manifest")?,
+        "selection.selected",
+        "executor manifest",
+    )?;
+    let manifest_executed = expect_usize(
+        field(manifest, "selection.executed", "executor manifest")?,
+        "selection.executed",
+        "executor manifest",
+    )?;
+
+    if summary_selected != manifest_selected {
+        bail!(
+            "executor artifact mismatch at selected count: summary {summary_selected} != manifest {manifest_selected}"
+        );
+    }
+    if summary_executed != manifest_executed {
+        bail!(
+            "executor artifact mismatch at executed count: summary {summary_executed} != manifest {manifest_executed}"
+        );
+    }
+    if summary_executed != 0 {
+        bail!(
+            "executor artifacts report {summary_executed} executed command(s); no-execution verifier requires zero"
+        );
+    }
+
+    expect_string_value(
+        field(manifest, "selection.source", "executor manifest")?,
+        "proof_plan",
+        "selection.source",
+        "executor manifest",
+    )?;
+    expect_bool_value(
+        field(manifest, "selection.required_included", "executor manifest")?,
+        false,
+        "selection.required_included",
+        "executor manifest",
+    )?;
+
+    let entries = expect_array(
+        field(summary, "entries", "executor summary")?,
+        "entries",
+        "executor summary",
+    )?;
+    let commands = expect_array(
+        field(manifest, "commands", "executor manifest")?,
+        "commands",
+        "executor manifest",
+    )?;
+    if entries.len() != summary_selected {
+        bail!(
+            "executor summary entries length {} does not match selected count {summary_selected}",
+            entries.len()
+        );
+    }
+    if commands.len() != manifest_selected {
+        bail!(
+            "executor manifest commands length {} does not match selected count {manifest_selected}",
+            commands.len()
+        );
+    }
+
+    for (index, (entry, command)) in entries.iter().zip(commands.iter()).enumerate() {
+        validate_command_entry(index, entry, command)?;
+    }
+
+    let guard_reason = expect_string(
+        field(summary, "execution_guard.reason", "executor summary")?,
+        "execution_guard.reason",
+        "executor summary",
+    )?;
+
+    Ok(ProofArtifactsReport {
+        selected: summary_selected,
+        execution_status,
+        guard_reason,
+    })
+}
+
+fn validate_command_entry(index: usize, entry: &Value, command: &Value) -> Result<()> {
+    let expected_index = index + 1;
+    let manifest_index = expect_usize(
+        field(command, "index", "executor manifest command")?,
+        "index",
+        "executor manifest command",
+    )?;
+    if manifest_index != expected_index {
+        bail!(
+            "executor manifest command index mismatch at position {expected_index}: got {manifest_index}"
+        );
+    }
+
+    let id = expect_string(
+        field(command, "id", "executor manifest command")?,
+        "id",
+        "executor manifest command",
+    )?;
+    let expected_prefix = format!("{expected_index:04}-");
+    if !id.starts_with(&expected_prefix) {
+        bail!("executor manifest command id `{id}` does not start with `{expected_prefix}`");
+    }
+
+    for field_name in ENTRY_FIELDS {
+        let entry_value = field(entry, field_name, "executor summary entry")?;
+        let command_value = field(command, field_name, "executor manifest command")?;
+        if entry_value != command_value {
+            bail!(
+                "executor command mismatch at `{field_name}` for command {expected_index}: summary {} != manifest {}",
+                render_json(entry_value),
+                render_json(command_value)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn expect_schema(value: &Value, expected: &str, label: &str) -> Result<()> {
+    expect_string_value(field(value, "schema", label)?, expected, "schema", label)
+}
+
+fn expect_equal(summary: &Value, manifest: &Value, path: &str) -> Result<()> {
+    let summary_value = field(summary, path, "executor summary")?;
+    let manifest_value = field(manifest, path, "executor manifest")?;
+    if summary_value != manifest_value {
+        bail!(
+            "executor artifact mismatch at `{path}`: summary {} != manifest {}",
+            render_json(summary_value),
+            render_json(manifest_value)
+        );
+    }
+    Ok(())
+}
+
+fn field<'a>(value: &'a Value, path: &str, label: &str) -> Result<&'a Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current
+            .get(segment)
+            .with_context(|| format!("{label} artifact is missing `{path}`"))?;
+    }
+    Ok(current)
+}
+
+fn expect_array<'a>(value: &'a Value, path: &str, label: &str) -> Result<&'a Vec<Value>> {
+    value
+        .as_array()
+        .with_context(|| format!("{label} `{path}` must be an array"))
+}
+
+fn expect_bool(value: &Value, path: &str, label: &str) -> Result<bool> {
+    value
+        .as_bool()
+        .with_context(|| format!("{label} `{path}` must be a boolean"))
+}
+
+fn expect_bool_value(value: &Value, expected: bool, path: &str, label: &str) -> Result<()> {
+    let actual = expect_bool(value, path, label)?;
+    if actual != expected {
+        bail!("{label} `{path}` must be {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+fn expect_string(value: &Value, path: &str, label: &str) -> Result<String> {
+    value
+        .as_str()
+        .map(ToOwned::to_owned)
+        .with_context(|| format!("{label} `{path}` must be a string"))
+}
+
+fn expect_string_value(value: &Value, expected: &str, path: &str, label: &str) -> Result<()> {
+    let actual = expect_string(value, path, label)?;
+    if actual != expected {
+        bail!("{label} `{path}` must be `{expected}`, got `{actual}`");
+    }
+    Ok(())
+}
+
+fn expect_usize(value: &Value, path: &str, label: &str) -> Result<usize> {
+    let number = value
+        .as_u64()
+        .with_context(|| format!("{label} `{path}` must be a non-negative integer"))?;
+    usize::try_from(number).with_context(|| format!("{label} `{path}` is too large"))
+}
+
+fn render_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "<unrenderable>".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_matching_no_execution_artifacts() {
+        let (summary, manifest) = matching_artifacts();
+
+        let report = validate_executor_artifacts(&summary, &manifest).unwrap();
+
+        assert_eq!(
+            report,
+            ProofArtifactsReport {
+                selected: 1,
+                execution_status: "dry_run".to_string(),
+                guard_reason: "not_ci_and_no_--allow-ci-evidence-execution".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_selected_count_drift() {
+        let (summary, mut manifest) = matching_artifacts();
+        manifest["selection"]["selected"] = json!(2);
+
+        let error = validate_executor_artifacts(&summary, &manifest)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("selected count"));
+    }
+
+    #[test]
+    fn rejects_command_payload_drift() {
+        let (summary, mut manifest) = matching_artifacts();
+        manifest["commands"][0]["command"] = json!("cargo llvm-cov -p tokmd-gate");
+
+        let error = validate_executor_artifacts(&summary, &manifest)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("executor command mismatch"));
+    }
+
+    #[test]
+    fn rejects_enabled_execution_guard() {
+        let (mut summary, mut manifest) = matching_artifacts();
+        summary["execution_guard"]["enabled"] = json!(true);
+        manifest["execution_guard"]["enabled"] = json!(true);
+
+        let error = validate_executor_artifacts(&summary, &manifest)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("execution_guard.enabled=true"));
+    }
+
+    fn matching_artifacts() -> (Value, Value) {
+        let guard = json!({
+            "required": true,
+            "enabled": false,
+            "ci": false,
+            "ci_execution": "explicit_opt_in",
+            "allow_ci_evidence_execution": false,
+            "reason": "not_ci_and_no_--allow-ci-evidence-execution"
+        });
+        let entry = json!({
+            "scope": "tokmd_core_ffi",
+            "kind": "coverage",
+            "required": false,
+            "command": "cargo llvm-cov -p tokmd-core --lcov --output-path target/proof/coverage/tokmd_core_ffi.lcov",
+            "artifact_path": "target/proof/coverage/tokmd_core_ffi.lcov",
+            "status": "dry_run",
+            "skip_reason": "dry_run_only"
+        });
+        let summary = json!({
+            "schema": SUMMARY_SCHEMA,
+            "mode": "dry_run",
+            "status": "dry_run",
+            "execution_status": "dry_run",
+            "execution_guard": guard.clone(),
+            "family": "coverage",
+            "required": false,
+            "profile": "affected",
+            "base": "origin/main",
+            "head": "HEAD",
+            "ok": true,
+            "changed_files": ["crates/tokmd-core/src/ffi.rs"],
+            "counts": {
+                "commands_total": 2,
+                "family_planned": 1,
+                "selected": 1,
+                "skipped": 0,
+                "dry_run": 1,
+                "executed": 0,
+                "required_excluded": 0,
+                "selection_excluded": 0,
+                "non_family_excluded": 1
+            },
+            "entries": [entry.clone()],
+            "unknown_files": []
+        });
+        let manifest = json!({
+            "schema": MANIFEST_SCHEMA,
+            "mode": "dry_run",
+            "status": "dry_run",
+            "execution_status": "dry_run",
+            "execution_guard": guard,
+            "family": "coverage",
+            "required": false,
+            "profile": "affected",
+            "base": "origin/main",
+            "head": "HEAD",
+            "ok": true,
+            "changed_files": ["crates/tokmd-core/src/ffi.rs"],
+            "selection": {
+                "source": "proof_plan",
+                "max_dry_run_commands": 1,
+                "required_included": false,
+                "selected": 1,
+                "executed": 0
+            },
+            "commands": [{
+                "id": "0001-tokmd_core_ffi-coverage",
+                "index": 1,
+                "scope": "tokmd_core_ffi",
+                "kind": "coverage",
+                "required": false,
+                "command": "cargo llvm-cov -p tokmd-core --lcov --output-path target/proof/coverage/tokmd_core_ffi.lcov",
+                "artifact_path": "target/proof/coverage/tokmd_core_ffi.lcov",
+                "status": "dry_run",
+                "skip_reason": "dry_run_only"
+            }],
+            "unknown_files": []
+        });
+        (summary, manifest)
+    }
+}

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -52,6 +52,18 @@ fn proof_help_mentions_profile_and_plan() {
 }
 
 #[test]
+fn proof_artifacts_check_help_mentions_executor_paths() {
+    let (stdout, stderr, success) = run_xtask(&["proof-artifacts-check", "--help"]);
+
+    assert!(
+        success,
+        "proof-artifacts-check --help failed. stderr: {stderr}"
+    );
+    assert!(stdout.contains("--executor-summary"), "stdout: {stdout}");
+    assert!(stdout.contains("--executor-manifest"), "stdout: {stdout}");
+}
+
+#[test]
 fn affected_proof_plan_reports_no_changes_for_same_ref() {
     let (stdout, stderr, success) = run_xtask(&[
         "proof",
@@ -75,6 +87,46 @@ fn affected_proof_plan_reports_no_changes_for_same_ref() {
     assert_eq!(value["head"], "HEAD");
     assert!(value["commands"].as_array().unwrap().is_empty());
     assert!(value["unknown_files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn proof_artifacts_check_accepts_generated_executor_artifacts() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let summary_path = temp.path().join("executor-summary.json");
+    let manifest_path = temp.path().join("executor-manifest.json");
+    let summary_arg = summary_path.to_string_lossy().to_string();
+    let manifest_arg = manifest_path.to_string_lossy().to_string();
+
+    let (_stdout, stderr, success) = run_xtask(&[
+        "proof",
+        "--profile",
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--plan",
+        "--executor-summary",
+        &summary_arg,
+        "--executor-manifest",
+        &manifest_arg,
+    ]);
+    assert!(
+        success,
+        "proof artifact generation failed. stderr: {stderr}"
+    );
+
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-artifacts-check",
+        "--executor-summary",
+        &summary_arg,
+        "--executor-manifest",
+        &manifest_arg,
+    ]);
+
+    assert!(success, "proof-artifacts-check failed. stderr: {stderr}");
+    assert!(stdout.contains("Proof artifacts OK"), "stdout: {stdout}");
+    assert!(stdout.contains("0 command(s)"), "stdout: {stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `cargo xtask proof-artifacts-check` to verify executor summary and manifest artifacts agree without running planned commands
- validate schemas, shared fields, blocked execution guard, zero executed counts, selection counts, and manifest command payload drift
- add verifier coverage to the proof-control-plane scope and update `docs/NEXT.md` with the next CI wiring step

## Validation
- `cargo fmt-fix`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --executor-summary target/proof/proof-artifacts-check-summary.json --executor-manifest target/proof/proof-artifacts-check-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/proof-artifacts-check-summary.json --executor-manifest target/proof/proof-artifacts-check-manifest.json`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo test -p xtask lint_policy --verbose`
- `cargo xtask check-lint-policy`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `git diff --check origin/main...HEAD`