### PR TITLE
ci: verify proof artifacts in affected plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,13 @@ jobs:
           cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json
           proof_plan_status=$?
 
+          cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-artifacts-check.txt
+          proof_artifacts_status=$?
+
           {
             echo "affected_status=${affected_status}"
             echo "proof_plan_status=${proof_plan_status}"
+            echo "proof_artifacts_status=${proof_artifacts_status}"
           } > target/proof/status.env
 
           {
@@ -152,8 +156,13 @@ jobs:
             echo "| --- | ---: |"
             echo "| affected | ${affected_status} |"
             echo "| proof plan | ${proof_plan_status} |"
+            echo "| proof artifacts | ${proof_artifacts_status} |"
             echo ""
             echo "This job is informational while proof planning is being adopted; existing CI jobs remain authoritative."
+            if [ -f target/proof/proof-artifacts-check.txt ]; then
+              echo ""
+              cat target/proof/proof-artifacts-check.txt
+            fi
             if [ -f target/proof/proof-plan.md ]; then
               echo ""
               cat target/proof/proof-plan.md

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -45,7 +45,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof --plan --executor-manifest <path>` now writes a planner-selected executor command manifest with the executor policy, guard status, selection rule, stable command ids, and zero executed counts.
 - The PR-only affected-plan CI artifact job now writes and uploads `executor-manifest.json` alongside `affected.json`, `proof-plan.json`, `proof-evidence.json`, `executor-summary.json`, and `proof-plan.md`, without opting into executor command execution.
 - `cargo xtask proof-artifacts-check` now verifies executor summary/manifest consistency without executing planned commands, including schema, guard, count, and command-entry drift checks.
-- Next proof-policy operational slice: wire `proof-artifacts-check` into the affected-plan CI job after artifact generation, still without promoting any executor family to execution.
+- The PR-only affected-plan CI artifact job now runs `cargo xtask proof-artifacts-check` after artifact generation, records its status, and uploads the verifier output while remaining informational.
+- Next proof-policy operational slice: decide whether artifact-verifier failures should fail the affected-plan job or remain reported-only until executor promotion.
 
 ## References
 


### PR DESCRIPTION
## Summary
- run `cargo xtask proof-artifacts-check` in the PR-only affected-plan job after generating executor summary and manifest artifacts
- record the verifier exit status and upload `proof-artifacts-check.txt` with the rest of `target/proof/`
- keep the job informational; existing CI jobs remain authoritative and no executor command execution is enabled

## Validation
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text(encoding='utf-8'))"`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/ci-proof-artifacts-plan.md --evidence-json target/proof/ci-proof-artifacts-evidence.json --executor-summary target/proof/ci-proof-artifacts-summary.json --executor-manifest target/proof/ci-proof-artifacts-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/ci-proof-artifacts-summary.json --executor-manifest target/proof/ci-proof-artifacts-manifest.json`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo xtask proof-policy --check`
- `git diff --check`