### PR TITLE
ci: fail affected plan on proof artifact drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json
           proof_plan_status=$?
 
-          cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-artifacts-check.txt
+          cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-artifacts-check.txt 2>&1
           proof_artifacts_status=$?
 
           {
@@ -168,6 +168,10 @@ jobs:
               cat target/proof/proof-plan.md
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${proof_artifacts_status}" -ne 0 ]; then
+            exit "${proof_artifacts_status}"
+          fi
 
           exit 0
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -46,7 +46,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The PR-only affected-plan CI artifact job now writes and uploads `executor-manifest.json` alongside `affected.json`, `proof-plan.json`, `proof-evidence.json`, `executor-summary.json`, and `proof-plan.md`, without opting into executor command execution.
 - `cargo xtask proof-artifacts-check` now verifies executor summary/manifest consistency without executing planned commands, including schema, guard, count, and command-entry drift checks.
 - The PR-only affected-plan CI artifact job now runs `cargo xtask proof-artifacts-check` after artifact generation, records its status, and uploads the verifier output while remaining informational.
-- Next proof-policy operational slice: decide whether artifact-verifier failures should fail the affected-plan job or remain reported-only until executor promotion.
+- The affected-plan CI job now fails on proof artifact verifier failure, while executor command execution remains disabled and existing proof commands remain separately authoritative.
+- Next proof-policy operational slice: decide whether affected/proof-plan generation failures should stay reported-only or become blocking after more soak time.
 
 ## References
 


### PR DESCRIPTION
## Summary
- make affected-plan fail when `proof-artifacts-check` detects summary/manifest drift
- capture verifier stderr in `proof-artifacts-check.txt` so failures are visible in uploaded artifacts and the step summary
- keep executor command execution disabled and leave affected/proof-plan generation statuses reported separately

## Validation
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text(encoding='utf-8'))"`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/ci-fail-artifact-drift-plan.md --evidence-json target/proof/ci-fail-artifact-drift-evidence.json --executor-summary target/proof/ci-fail-artifact-drift-summary.json --executor-manifest target/proof/ci-fail-artifact-drift-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/ci-fail-artifact-drift-summary.json --executor-manifest target/proof/ci-fail-artifact-drift-manifest.json`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `git diff --check`