### PR TITLE
jules: record steward learning on release hygiene 🚢

### DIFF
--- a/.jules/friction/open/steward-release-clean-state.md
+++ b/.jules/friction/open/steward-release-clean-state.md
@@ -1,0 +1,12 @@
+# Friction Item: Clean State
+
+**Surface:** `tooling-governance` shard / release checks
+
+**Context:**
+A prompt (`steward_release`) requested finding release/governance improvements (e.g. publish-plan drift, changelog mismatch).
+
+**Friction:**
+All release and governance tests currently pass (`xtask version-consistency`, `xtask docs --check`, `xtask publish --plan`). Since no factual drift was present, forcing a fake patch would violate instructions.
+
+**Recommendation:**
+None. It's a positive signal that the system is currently in a good state for the `1.10.0` version line.

--- a/.jules/personas/steward/notes/release_hygiene.md
+++ b/.jules/personas/steward/notes/release_hygiene.md
@@ -1,0 +1,3 @@
+# Steward Learning
+
+The tokmd `1.10.0` release state is clean. Version consistency checks across Rust crates and JS manifests pass, the `xtask publish --plan` operates correctly on 16 packages while successfully excluding development packages like `tokmd-fuzz`, `tokmd-node`, and `xtask`, and documentation generation verifies cleanly.

--- a/.jules/runs/steward_1778084540/decision.md
+++ b/.jules/runs/steward_1778084540/decision.md
@@ -1,0 +1,15 @@
+## 🧭 Options considered
+
+### Option A (recommended)
+- Create a learning PR to document that the workspace is currently in an acceptable state for release governance.
+- All versions match, publish plan accurately lists exactly 16 packages with the proper exclusions (fuzz, node, python, xtask aren't in publish plan), and documents check succeeds.
+- Why it fits: The instruction tells me "If no honest code/docs/test patch is justified, finish with a learning PR instead of forcing a fake fix."
+- Trade-offs: Structure is minimal, no code changes. Velocity is fast since no code change is required. Governance is strong because no fake patches are introduced.
+
+### Option B
+- Modify a docs file to add a "clarification" to make a patch.
+- When to choose it instead: If a document clearly lacked a section, but here they seem robust and checked via xtask docs --check.
+- Trade-offs: Increases the risk of hallucinated work or breaking check gates for minimal value.
+
+## ✅ Decision
+Option A. The repository passes all `xtask` governance checks (`version-consistency`, `docs --check`, `publish --plan`). A fake patch would violate the directive "If no honest code/docs/test patch is justified, finish with a learning PR instead of forcing a fake fix."

--- a/.jules/runs/steward_1778084540/envelope.json
+++ b/.jules/runs/steward_1778084540/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "steward_release",
+  "persona": "Steward",
+  "style": "Stabilizer",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/**/Cargo.toml",
+    ".cargo/**"
+  ],
+  "gate_profile": "governance-release",
+  "allowed_outcomes": ["pr_ready_patch", "learning_pr"]
+}

--- a/.jules/runs/steward_1778084540/pr_body.md
+++ b/.jules/runs/steward_1778084540/pr_body.md
@@ -1,0 +1,78 @@
+## 💡 Summary
+This is a learning PR. I ran through the `governance-release` validation suite looking for publish-plan drift, version inconsistencies, or documentation mismatches. All checks passed cleanly.
+
+## 🎯 Why
+The `steward_release` prompt instructed me to focus on low-risk release/governance improvements and RC-hardening surfaces. Because the codebase currently passes all validation gates natively without error, introducing a hallucinated patch would violate the prompt constraint.
+
+## 🔎 Evidence
+- `cargo xtask version-consistency` ran cleanly against `1.10.0`.
+- `cargo xtask publish --plan --verbose` correctly ordered 16 crates and accurately excluded non-publishable dev packages.
+- `cargo xtask docs --check` confirmed that CLI documentation is not drifting from the executable interface.
+- `cargo deny --all-features check` found no problematic supply chain advisories.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Submit a learning PR containing the clean-state receipts and skip creating a fake code patch.
+- Fits the `tooling-governance` shard by correctly observing the state of the workflow/checks.
+- Structure / Velocity / Governance: Zero drift risk, correctly obeys "If no honest code/docs/test patch is justified, finish with a learning PR".
+
+### Option B
+- Modify a README or docs file trivially to pad out a patch.
+- Reduces velocity and introduces minor noise into history for a non-material change.
+- Trade-offs: Degrades trust by pretending to fix an issue that didn't exist.
+
+## ✅ Decision
+Option A. The repository passes all `xtask` governance checks (`version-consistency`, `docs --check`, `publish --plan`). A fake patch violates instructions.
+
+## 🧱 Changes made (SRP)
+- Recorded the clean state as a learning run packet.
+- No Rust/Markdown/JSON code changes were made to the primary application source.
+
+## 🧪 Verification receipts
+```text
+$ cargo xtask version-consistency
+Checking version consistency against workspace version 1.10.0
+  ✓ Cargo crate versions match 1.10.0.
+  ✓ Cargo workspace dependency versions match 1.10.0.
+  ✓ Node package manifest versions match 1.10.0.
+  ✓ No case-insensitive tracked-path collisions detected.
+Version consistency checks passed.
+
+$ cargo xtask publish --plan
+=== Publish Plan ===
+Workspace version: 1.10.0
+Publish order (16 crates):
+   1. tokmd-gate
+...
+  16. tokmd
+Excluded crates:
+  - tokmd-fuzz: NotPublishable
+  - tokmd-node: NotPublishable
+  - tokmd-python: NotPublishable
+  - xtask: NotPublishable
+
+$ cargo xtask docs --check
+Documentation is up to date.
+
+$ cargo deny --all-features check
+advisories ok, bans ok, licenses ok, sources ok
+```
+
+## 🧭 Telemetry
+- Change shape: Metadata/Learning
+- Blast radius: Zero (No product changes)
+- Risk class: None
+- Rollback: Revert PR
+- Gates run: `version-consistency`, `publish --plan`, `docs --check`, `deny`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/steward_<run-id>/envelope.json`
+- `.jules/runs/steward_<run-id>/decision.md`
+- `.jules/runs/steward_<run-id>/receipts.jsonl`
+- `.jules/runs/steward_<run-id>/result.json`
+- `.jules/runs/steward_<run-id>/pr_body.md`
+- `.jules/friction/open/steward-release-clean-state.md`
+- `.jules/personas/steward/notes/release_hygiene.md`
+
+## 🔜 Follow-ups
+- Friction item logged: `steward-release-clean-state.md` documenting the clean pass.

--- a/.jules/runs/steward_1778084540/receipts.jsonl
+++ b/.jules/runs/steward_1778084540/receipts.jsonl
@@ -1,0 +1,4 @@
+{"command": "cargo xtask version-consistency", "outcome": "Success. All cargo crate versions, workspace dependency versions, and Node package manifest versions match 1.10.0. No case-insensitive tracked-path collisions detected."}
+{"command": "cargo xtask publish --plan", "outcome": "Success. Listed 16 crates in correct order and excluded non-publishable ones."}
+{"command": "cargo xtask docs --check", "outcome": "Success. Documentation is up to date."}
+{"command": "cargo deny --all-features check", "outcome": "Success. Advisories ok, bans ok, licenses ok, sources ok."}

--- a/.jules/runs/steward_1778084540/result.json
+++ b/.jules/runs/steward_1778084540/result.json
@@ -1,0 +1,10 @@
+{
+  "status": "learning_pr",
+  "reason": "All governance and release hygiene checks pass natively. A fake fix would violate the prompt constraint.",
+  "gates_run": [
+    "cargo xtask version-consistency",
+    "cargo xtask publish --plan --verbose",
+    "cargo xtask docs --check",
+    "cargo deny --all-features check"
+  ]
+}


### PR DESCRIPTION
## 💡 Summary
This is a learning PR. I ran through the `governance-release` validation suite looking for publish-plan drift, version inconsistencies, or documentation mismatches. All checks passed cleanly.

## 🎯 Why
The `steward_release` prompt instructed me to focus on low-risk release/governance improvements and RC-hardening surfaces. Because the codebase currently passes all validation gates natively without error, introducing a hallucinated patch would violate the prompt constraint.

## 🔎 Evidence
- `cargo xtask version-consistency` ran cleanly against `1.10.0`.
- `cargo xtask publish --plan --verbose` correctly ordered 16 crates and accurately excluded non-publishable dev packages.
- `cargo xtask docs --check` confirmed that CLI documentation is not drifting from the executable interface.
- `cargo deny --all-features check` found no problematic supply chain advisories.

## 🧭 Options considered
### Option A (recommended)
- Submit a learning PR containing the clean-state receipts and skip creating a fake code patch.
- Fits the `tooling-governance` shard by correctly observing the state of the workflow/checks.
- Structure / Velocity / Governance: Zero drift risk, correctly obeys "If no honest code/docs/test patch is justified, finish with a learning PR".

### Option B
- Modify a README or docs file trivially to pad out a patch.
- Reduces velocity and introduces minor noise into history for a non-material change.
- Trade-offs: Degrades trust by pretending to fix an issue that didn't exist.

## ✅ Decision
Option A. The repository passes all `xtask` governance checks (`version-consistency`, `docs --check`, `publish --plan`). A fake patch violates instructions. 

## 🧱 Changes made (SRP)
- Recorded the clean state as a learning run packet.
- No Rust/Markdown/JSON code changes were made to the primary application source.

## 🧪 Verification receipts
```text
$ cargo xtask version-consistency
Checking version consistency against workspace version 1.10.0
  ✓ Cargo crate versions match 1.10.0.
  ✓ Cargo workspace dependency versions match 1.10.0.
  ✓ Node package manifest versions match 1.10.0.
  ✓ No case-insensitive tracked-path collisions detected.
Version consistency checks passed.

$ cargo xtask publish --plan
=== Publish Plan ===
Workspace version: 1.10.0
Publish order (16 crates):
   1. tokmd-gate
...
  16. tokmd
Excluded crates:
  - tokmd-fuzz: NotPublishable
  - tokmd-node: NotPublishable
  - tokmd-python: NotPublishable
  - xtask: NotPublishable

$ cargo xtask docs --check
Documentation is up to date.

$ cargo deny --all-features check
advisories ok, bans ok, licenses ok, sources ok
```

## 🧭 Telemetry
- Change shape: Metadata/Learning 
- Blast radius: Zero (No product changes)
- Risk class: None
- Rollback: Revert PR
- Gates run: `version-consistency`, `publish --plan`, `docs --check`, `deny`

## 🗂️ .jules artifacts
- `.jules/runs/steward_1778084540/envelope.json`
- `.jules/runs/steward_1778084540/decision.md`
- `.jules/runs/steward_1778084540/receipts.jsonl`
- `.jules/runs/steward_1778084540/result.json`
- `.jules/runs/steward_1778084540/pr_body.md`
- `.jules/friction/open/steward-release-clean-state.md`
- `.jules/personas/steward/notes/release_hygiene.md`

## 🔜 Follow-ups
- Friction item logged: `steward-release-clean-state.md` documenting the clean pass.

---
*PR created automatically by Jules for task [6411379736331214003](https://jules.google.com/task/6411379736331214003) started by @EffortlessSteven*