### PR TITLE
chore: tighten no-panic policy staging checks

### DIFF
--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -14,8 +14,9 @@ in production or tests*. The policy is enforced by two complementary rails:
 2. **The semantic checker** (rail B), `cargo xtask check-no-panic-family`, is
    the authoritative exception mechanism. It parses every workspace `.rs` file
    with `syn`, finds panic-family expressions, and matches each finding against
-   `policy/no-panic-allowlist.toml`. Findings without an allowlist entry, stale
-   entries, and expired entries all fail the gate.
+   `policy/no-panic-allowlist.toml`. Stale and expired entries fail the gate in
+   both modes; findings without an allowlist entry become blocking when the
+   checker is run with `--strict`.
 
 ## Families
 

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -15,6 +15,6 @@ schema_version = "0.3"
 # proposed entries from `target/no-panic-proposed-allowlist.toml` after filling
 # in `owner`, `classification`, `explanation`, and `expires`.
 
-# The tokmd workspace is panic-free across production and tests; this ledger is
-# intentionally empty. Removing this comment when the first allowlist entry
-# lands is fine.
+# The ledger starts empty while `cargo xtask check-no-panic-family` runs in
+# advisory mode. Current unallowlisted findings are reported by the checker but
+# do not block until the strict rollout has a receipted baseline.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -69,7 +69,7 @@ pub struct LintPolicyArgs {}
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct NoPanicArgs {
-    /// Emit a machine-readable JSON report alongside human output
+    /// Emit a machine-readable JSON report instead of human output
     #[arg(long)]
     pub json: bool,
 

--- a/xtask/src/tasks/no_panic.rs
+++ b/xtask/src/tasks/no_panic.rs
@@ -184,6 +184,7 @@ pub fn run_propose(args: NoPanicProposeArgs) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AllowlistFile {
     schema_version: String,
     #[serde(default)]
@@ -191,6 +192,7 @@ struct AllowlistFile {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AllowEntry {
     id: String,
     path: String,
@@ -206,6 +208,7 @@ struct AllowEntry {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SelectorTable {
     kind: String,
     container: String,
@@ -214,6 +217,7 @@ struct SelectorTable {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct LastSeenTable {
     #[allow(dead_code)]
     line: usize,
@@ -1235,6 +1239,19 @@ receiver_fingerprint = "x"
                 .iter()
                 .any(|s| s.contains("classification must be one of")),
             "{report:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_allowlist_fields() {
+        let allowlist_toml = r#"
+schema_version = "0.3"
+unknown = "ignored would hide typos"
+"#;
+        let err = toml::from_str::<AllowlistFile>(allowlist_toml).expect_err("unknown key");
+        assert!(
+            err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
         );
     }
 

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -65,6 +65,7 @@ fn proof_policy_includes_current_product_scopes() {
         "format_redaction_scan_args",
         "jules_workspace",
         "model_scan_path_normalization",
+        "no_panic_policy",
     ] {
         assert!(
             names.contains(expected),
@@ -85,6 +86,20 @@ fn proof_policy_includes_current_product_scopes() {
 
     assert!(proof.contains("cargo test -p tokmd-format --test analysis_format --verbose"));
     assert!(proof.contains("cargo test -p tokmd-format --test analysis_html --verbose"));
+
+    let no_panic = scopes
+        .iter()
+        .find(|scope| scope["name"].as_str() == Some("no_panic_policy"))
+        .expect("no_panic_policy scope should exist");
+    let no_panic_proof = no_panic["proof"]
+        .as_array()
+        .expect("no_panic_policy should expose proof commands")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+
+    assert!(no_panic_proof.contains("cargo xtask check-no-panic-family"));
+    assert!(no_panic_proof.contains("cargo test -p xtask no_panic --verbose"));
 }
 
 #[test]
@@ -109,7 +124,7 @@ fn proof_policy_json_reports_current_schema() {
 
     assert_eq!(value["ok"], true);
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
-    assert_eq!(value["scope_count"], 31);
+    assert_eq!(value["scope_count"], 32);
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);


### PR DESCRIPTION
## Summary
- clarify that the empty no-panic ledger is an advisory rollout baseline, not proof that the workspace is panic-free
- make the no-panic TOML parser reject unknown fields so policy typos do not disappear silently
- update proof-policy coverage for the new no_panic_policy scope and scope count

## Validation
- cargo test -p xtask no_panic --verbose
- cargo test -p xtask proof_policy --verbose
- cargo xtask check-no-panic-family
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- cargo xtask docs --check
- git diff --check