### PR TITLE
chore: classify dependency graph changes in proof policy

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -16,6 +16,24 @@ ci_execution = "explicit_opt_in"
 max_dry_run_commands = 1
 
 [[scope]]
+name = "workspace_dependency_graph"
+kind = "rust"
+paths = [
+  "Cargo.lock",
+  "Cargo.toml",
+  "crates/**/Cargo.toml",
+  "xtask/Cargo.toml",
+]
+packages = ["xtask"]
+proof = [
+  "cargo deny --all-features check",
+  "cargo xtask boundaries-check",
+  "cargo xtask publish-surface --json",
+]
+mutation = false
+coverage = false
+
+[[scope]]
 name = "proof_control_plane"
 kind = "rust"
 paths = [

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -49,6 +49,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The affected-plan CI job now fails on proof artifact verifier failure, while executor command execution remains disabled and existing proof commands remain separately authoritative.
 - The proof scope registry now classifies model/scan path-normalization changes and `.jules` provenance updates so generated knowledge artifacts and core path hot-path work do not appear as unknown files in affected plans.
 - No-panic policy now has a governed allowlist (`policy/no-panic-allowlist.toml`, schema 0.3) and a semantic checker (`cargo xtask check-no-panic-family`). Identity is `path + family + selector` so reformatting source files does not invalidate receipts. Default mode is advisory: schema/shape, expired entries, and stale entries block; unallowlisted findings are reported only. `cargo xtask no-panic-propose` writes proposed allowlist entries to `target/no-panic-proposed-allowlist.toml`. The strict (blocking) flip is staged behind member-crate `[lints] workspace = true` adoption and a panic-family debt burn-down.
+- Workspace dependency graph changes now have an explicit proof scope for root/workspace manifests and `Cargo.lock`, routing affected plans to deny, dependency-boundary, and publish-surface checks instead of leaving lockfile-only changes unknown.
 - Next proof-policy operational slice: decide whether affected/proof-plan generation failures should stay reported-only or become blocking after more soak time.
 
 ## References

--- a/xtask/src/tasks/affected.rs
+++ b/xtask/src/tasks/affected.rs
@@ -272,6 +272,14 @@ paths = ["web/runner/**"]
 proof = ["npm --prefix web/runner test"]
 reason = "Browser runner tests."
 
+[[scope]]
+name = "dependency_graph"
+kind = "rust"
+paths = ["Cargo.lock", "Cargo.toml", "crates/**/Cargo.toml"]
+proof = ["cargo deny --all-features check"]
+mutation = false
+coverage = false
+
 [[dependency_boundary]]
 name = "retired_tokmd_config_must_not_return"
 packages = ["*"]
@@ -350,6 +358,23 @@ reason = "tokmd-config is retired."
 
         assert!(report.ok);
         assert_eq!(report.unknown_files, vec!["crates/new/src/lib.rs"]);
+    }
+
+    #[test]
+    fn workspace_lockfile_maps_to_dependency_graph_scope() {
+        let policy = policy_with_defaults(true);
+        let report = affected_report(&policy, "base", "head", vec!["Cargo.lock".to_string()])
+            .expect("report");
+
+        assert!(report.ok);
+        assert!(report.unknown_files.is_empty());
+        assert_eq!(report.scopes.len(), 1);
+        assert_eq!(report.scopes[0].name, "dependency_graph");
+        assert_eq!(report.scopes[0].matched_files, vec!["Cargo.lock"]);
+        assert_eq!(
+            report.scopes[0].proof,
+            vec!["cargo deny --all-features check"]
+        );
     }
 
     #[test]

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -66,6 +66,7 @@ fn proof_policy_includes_current_product_scopes() {
         "jules_workspace",
         "model_scan_path_normalization",
         "no_panic_policy",
+        "workspace_dependency_graph",
     ] {
         assert!(
             names.contains(expected),
@@ -100,6 +101,29 @@ fn proof_policy_includes_current_product_scopes() {
 
     assert!(no_panic_proof.contains("cargo xtask check-no-panic-family"));
     assert!(no_panic_proof.contains("cargo test -p xtask no_panic --verbose"));
+
+    let dependency_graph = scopes
+        .iter()
+        .find(|scope| scope["name"].as_str() == Some("workspace_dependency_graph"))
+        .expect("workspace_dependency_graph scope should exist");
+    let dependency_paths = dependency_graph["paths"]
+        .as_array()
+        .expect("workspace_dependency_graph should expose path globs")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+    let dependency_proof = dependency_graph["proof"]
+        .as_array()
+        .expect("workspace_dependency_graph should expose proof commands")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+
+    assert!(dependency_paths.contains("Cargo.lock"));
+    assert!(dependency_paths.contains("Cargo.toml"));
+    assert!(dependency_proof.contains("cargo deny --all-features check"));
+    assert!(dependency_proof.contains("cargo xtask boundaries-check"));
+    assert!(dependency_proof.contains("cargo xtask publish-surface --json"));
 }
 
 #[test]
@@ -124,7 +148,7 @@ fn proof_policy_json_reports_current_schema() {
 
     assert_eq!(value["ok"], true);
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
-    assert_eq!(value["scope_count"], 32);
+    assert_eq!(value["scope_count"], 33);
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);


### PR DESCRIPTION
## Summary
- add a workspace_dependency_graph proof scope for Cargo.lock and workspace/package manifests
- route dependency graph changes to deny, boundary, and publish-surface checks in affected proof plans
- add focused affected/proof-policy tests for lockfile scope classification
- record the checkpoint in docs/NEXT.md

## Validation
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask affected --verbose
- cargo test -p xtask proof_policy --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_artifacts --verbose
- cargo test -p xtask proof_plan --verbose
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- cargo xtask docs --check
- cargo xtask boundaries-check
- cargo xtask publish-surface --json
- cargo deny --all-features check
- git diff --check