### PR TITLE
chore: classify fuzz harness changes in proof policy

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -34,6 +34,23 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "fuzz_harnesses"
+kind = "rust"
+paths = [
+  "fuzz/Cargo.toml",
+  "fuzz/README.md",
+  "fuzz/corpus/**",
+  "fuzz/dict/**",
+  "fuzz/fuzz_targets/**",
+]
+packages = ["tokmd-fuzz"]
+proof = [
+  "cargo +nightly fuzz list",
+]
+mutation = false
+coverage = false
+
+[[scope]]
 name = "proof_control_plane"
 kind = "rust"
 paths = [

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -50,6 +50,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The proof scope registry now classifies model/scan path-normalization changes and `.jules` provenance updates so generated knowledge artifacts and core path hot-path work do not appear as unknown files in affected plans.
 - No-panic policy now has a governed allowlist (`policy/no-panic-allowlist.toml`, schema 0.3) and a semantic checker (`cargo xtask check-no-panic-family`). Identity is `path + family + selector` so reformatting source files does not invalidate receipts. Default mode is advisory: schema/shape, expired entries, and stale entries block; unallowlisted findings are reported only. `cargo xtask no-panic-propose` writes proposed allowlist entries to `target/no-panic-proposed-allowlist.toml`. The strict (blocking) flip is staged behind member-crate `[lints] workspace = true` adoption and a panic-family debt burn-down.
 - Workspace dependency graph changes now have an explicit proof scope for root/workspace manifests and `Cargo.lock`, routing affected plans to deny, dependency-boundary, and publish-surface checks instead of leaving lockfile-only changes unknown.
+- Fuzz harness changes now have an explicit proof scope for `fuzz/Cargo.toml`, targets, dictionaries, corpora, and harness docs, routing affected plans to the fuzz harness inventory check before deeper fuzz execution is promoted.
 - Next proof-policy operational slice: decide whether affected/proof-plan generation failures should stay reported-only or become blocking after more soak time.
 
 ## References

--- a/xtask/src/tasks/affected.rs
+++ b/xtask/src/tasks/affected.rs
@@ -280,6 +280,15 @@ proof = ["cargo deny --all-features check"]
 mutation = false
 coverage = false
 
+[[scope]]
+name = "fuzz_harnesses"
+kind = "rust"
+paths = ["fuzz/Cargo.toml", "fuzz/corpus/**", "fuzz/dict/**", "fuzz/fuzz_targets/**"]
+packages = ["tokmd-fuzz"]
+proof = ["cargo +nightly fuzz list"]
+mutation = false
+coverage = false
+
 [[dependency_boundary]]
 name = "retired_tokmd_config_must_not_return"
 packages = ["*"]
@@ -375,6 +384,29 @@ reason = "tokmd-config is retired."
             report.scopes[0].proof,
             vec!["cargo deny --all-features check"]
         );
+    }
+
+    #[test]
+    fn fuzz_corpus_maps_to_fuzz_harness_scope() {
+        let policy = policy_with_defaults(true);
+        let report = affected_report(
+            &policy,
+            "base",
+            "head",
+            vec!["fuzz/corpus/fuzz_run_json/seed_version.txt".to_string()],
+        )
+        .expect("report");
+
+        assert!(report.ok);
+        assert!(report.unknown_files.is_empty());
+        assert_eq!(report.scopes.len(), 1);
+        assert_eq!(report.scopes[0].name, "fuzz_harnesses");
+        assert_eq!(
+            report.scopes[0].matched_files,
+            vec!["fuzz/corpus/fuzz_run_json/seed_version.txt"]
+        );
+        assert_eq!(report.scopes[0].packages, vec!["tokmd-fuzz"]);
+        assert_eq!(report.scopes[0].proof, vec!["cargo +nightly fuzz list"]);
     }
 
     #[test]

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -63,6 +63,7 @@ fn proof_policy_includes_current_product_scopes() {
         "format_analysis_rendering",
         "format_core_outputs",
         "format_redaction_scan_args",
+        "fuzz_harnesses",
         "jules_workspace",
         "model_scan_path_normalization",
         "no_panic_policy",
@@ -124,6 +125,29 @@ fn proof_policy_includes_current_product_scopes() {
     assert!(dependency_proof.contains("cargo deny --all-features check"));
     assert!(dependency_proof.contains("cargo xtask boundaries-check"));
     assert!(dependency_proof.contains("cargo xtask publish-surface --json"));
+
+    let fuzz_harnesses = scopes
+        .iter()
+        .find(|scope| scope["name"].as_str() == Some("fuzz_harnesses"))
+        .expect("fuzz_harnesses scope should exist");
+    let fuzz_paths = fuzz_harnesses["paths"]
+        .as_array()
+        .expect("fuzz_harnesses should expose path globs")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+    let fuzz_proof = fuzz_harnesses["proof"]
+        .as_array()
+        .expect("fuzz_harnesses should expose proof commands")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+
+    assert!(fuzz_paths.contains("fuzz/Cargo.toml"));
+    assert!(fuzz_paths.contains("fuzz/corpus/**"));
+    assert!(fuzz_paths.contains("fuzz/dict/**"));
+    assert!(fuzz_paths.contains("fuzz/fuzz_targets/**"));
+    assert!(fuzz_proof.contains("cargo +nightly fuzz list"));
 }
 
 #[test]
@@ -148,7 +172,7 @@ fn proof_policy_json_reports_current_schema() {
 
     assert_eq!(value["ok"], true);
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
-    assert_eq!(value["scope_count"], 33);
+    assert_eq!(value["scope_count"], 34);
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);


### PR DESCRIPTION
## Summary
- add a first-class `fuzz_harnesses` proof scope for fuzz manifests, harness targets, dictionaries, corpora, and harness docs
- route fuzz harness changes to `cargo +nightly fuzz list` as the inventory proof before deeper fuzz execution is promoted
- add affected-scope and proof-policy tests so fuzz corpus changes are classified deterministically

## Validation
- `cargo fmt-check`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask proof-policy --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo +nightly fuzz list`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`