### PR TITLE
jules: regenerate generated indexes

### DIFF
--- a/.jules/index/generated/FRICTION_ROLLUP.md
+++ b/.jules/index/generated/FRICTION_ROLLUP.md
@@ -7,3 +7,4 @@ It rolls up active friction metadata from `.jules/friction/open/`.
 |---|---|---|---|---|---|
 | `fuzz_toolchain_blocker` | fuzzer | prover | interfaces | open | `cargo fuzz` is not a reliable local gate in the current agent environments. Repeated runs hit either missing nightly-toolchain support in sandboxed Linux environments or sanitizer/LLVM link failures on Windows/MSVC before the target starts. |
 | `librarian_doctest_git_dependency` | Unknown | Unknown | Doctests (`crates/tokmd-core/src/lib.rs`) | open | The `cockpit_workflow` public API doctest is marked as `no_run` and skipping validation because it implicitly requires an active Git repository to execute (it fails with `not inside a git repository` when executed normally). |
+| `steward-release-clean-state` | Unknown | Unknown | `tooling-governance` shard / release checks | open | A prompt (`steward_release`) requested finding release/governance improvements (e.g. publish-plan drift, changelog mismatch). |

--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -8,8 +8,10 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `09c9d819-02cd-4f63-b662-921c812f93dd` | Gatekeeper | Builder | quality | completed | 4 | live |
 | `20260428130048-fuzzer` | fuzzer | prover | interfaces | in-progress | 1 | live |
 | `36cec87d-2836-42ed-9ae1-33dbf2702319` | Librarian | Explorer | docs | completed | 3 | live |
+| `37581ca1` | Sentinel | Stabilizer | core-pipeline | in-progress | 0 | live |
 | `archivist_jules` | Archivist | Builder | workspace-wide | in-progress | 2 | live |
 | `auditor_bindings_manifests` | Unknown | Unknown | Unknown | in-progress | 0 | live |
+| `bolt-run-001` | Bolt | Refactorer | core-pipeline | in-progress | 0 | live |
 | `bolt_analysis_stack_builder` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `cartographer_roadmap_design` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `compat_interfaces_matrix_01` | Unknown | Unknown | Unknown | in-progress | 0 | live |
@@ -22,3 +24,4 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `run_sentinel_redaction_1` | Sentinel | Stabilizer | core-pipeline | success | 3 | live |
 | `sentinel_redaction` | Sentinel | Stabilizer | core-pipeline | success | 4 | live |
 | `steward_1` | Steward | Stabilizer | tooling-governance | success | 0 | live |
+| `steward_1778084540` | Steward | Stabilizer | tooling-governance | learning_pr | 4 | live |


### PR DESCRIPTION
## Summary
- regenerate the current Jules generated rollups from `origin/main`
- keep the useful index refresh signal from #1650 without rewriting the existing `archivist_jules` run packet
- update both run and friction rollups so generated indexes match the current `.jules` source packets

## Validation
- `python .jules/bin/build_index.py`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-policy --check`

Supersedes draft #1650 after merge.