### PR TITLE
ci: make affected proof planning failures blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
             echo "| proof plan | ${proof_plan_status} |"
             echo "| proof artifacts | ${proof_artifacts_status} |"
             echo ""
-            echo "This job is informational while proof planning is being adopted; existing CI jobs remain authoritative."
+            echo "Affected/proof-plan artifact generation is blocking; executor command execution remains disabled, and existing CI jobs remain authoritative for executing required checks."
             if [ -f target/proof/proof-artifacts-check.txt ]; then
               echo ""
               cat target/proof/proof-artifacts-check.txt
@@ -168,6 +168,14 @@ jobs:
               cat target/proof/proof-plan.md
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${affected_status}" -ne 0 ]; then
+            exit "${affected_status}"
+          fi
+
+          if [ "${proof_plan_status}" -ne 0 ]; then
+            exit "${proof_plan_status}"
+          fi
 
           if [ "${proof_artifacts_status}" -ne 0 ]; then
             exit "${proof_artifacts_status}"

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -46,12 +46,12 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The PR-only affected-plan CI artifact job now writes and uploads `executor-manifest.json` alongside `affected.json`, `proof-plan.json`, `proof-evidence.json`, `executor-summary.json`, and `proof-plan.md`, without opting into executor command execution.
 - `cargo xtask proof-artifacts-check` now verifies executor summary/manifest consistency without executing planned commands, including schema, guard, count, and command-entry drift checks.
 - The PR-only affected-plan CI artifact job now runs `cargo xtask proof-artifacts-check` after artifact generation, records its status, and uploads the verifier output while remaining informational.
-- The affected-plan CI job now fails on proof artifact verifier failure, while executor command execution remains disabled and existing proof commands remain separately authoritative.
+- The affected-plan CI job now fails on affected-scope generation, proof-plan generation, or proof artifact verifier failure, while executor command execution remains disabled and existing proof commands remain separately authoritative.
 - The proof scope registry now classifies model/scan path-normalization changes and `.jules` provenance updates so generated knowledge artifacts and core path hot-path work do not appear as unknown files in affected plans.
 - No-panic policy now has a governed allowlist (`policy/no-panic-allowlist.toml`, schema 0.3) and a semantic checker (`cargo xtask check-no-panic-family`). Identity is `path + family + selector` so reformatting source files does not invalidate receipts. Default mode is advisory: schema/shape, expired entries, and stale entries block; unallowlisted findings are reported only. `cargo xtask no-panic-propose` writes proposed allowlist entries to `target/no-panic-proposed-allowlist.toml`. The strict (blocking) flip is staged behind member-crate `[lints] workspace = true` adoption and a panic-family debt burn-down.
 - Workspace dependency graph changes now have an explicit proof scope for root/workspace manifests and `Cargo.lock`, routing affected plans to deny, dependency-boundary, and publish-surface checks instead of leaving lockfile-only changes unknown.
 - Fuzz harness changes now have an explicit proof scope for `fuzz/Cargo.toml`, targets, dictionaries, corpora, and harness docs, routing affected plans to the fuzz harness inventory check before deeper fuzz execution is promoted.
-- Next proof-policy operational slice: decide whether affected/proof-plan generation failures should stay reported-only or become blocking after more soak time.
+- Next proof-policy operational slice: choose the first deliberately opt-in executor experiment, likely a local-only or workflow-dispatch coverage dry run that still records zero required-check authority until maintainers promote it.
 
 ## References
 

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -64,6 +64,39 @@ fn proof_artifacts_check_help_mentions_executor_paths() {
 }
 
 #[test]
+fn affected_plan_ci_blocks_on_planner_generation_failures() {
+    let ci = fs::read_to_string(workspace_root().join(".github/workflows/ci.yml"))
+        .expect("ci workflow should be readable");
+
+    assert!(
+        ci.contains("Affected/proof-plan artifact generation is blocking"),
+        "affected-plan summary should describe blocking planner artifacts"
+    );
+    assert!(
+        ci.contains("executor command execution remains disabled"),
+        "affected-plan summary should keep executor command execution disabled"
+    );
+    assert!(
+        ci.contains(
+            "if [ \"${affected_status}\" -ne 0 ]; then\n            exit \"${affected_status}\"\n          fi"
+        ),
+        "affected-plan job must fail when affected-scope generation fails"
+    );
+    assert!(
+        ci.contains(
+            "if [ \"${proof_plan_status}\" -ne 0 ]; then\n            exit \"${proof_plan_status}\"\n          fi"
+        ),
+        "affected-plan job must fail when proof-plan generation fails"
+    );
+    assert!(
+        ci.contains(
+            "if [ \"${proof_artifacts_status}\" -ne 0 ]; then\n            exit \"${proof_artifacts_status}\"\n          fi"
+        ),
+        "affected-plan job must still fail when proof artifact verification fails"
+    );
+}
+
+#[test]
 fn affected_proof_plan_reports_no_changes_for_same_ref() {
     let (stdout, stderr, success) = run_xtask(&[
         "proof",


### PR DESCRIPTION
## Summary
- make the PR-only affected-plan job fail when affected-scope generation or proof-plan generation fails
- keep executor command execution disabled and leave existing CI jobs authoritative for executing required checks
- add a workflow regression test so the blocking boundary does not silently drift back to reported-only

## Validation
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask --test proof_plan_w92 --verbose`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- Python/PyYAML parse of `.github/workflows/ci.yml`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/local-proof-plan.md --evidence-json target/proof/local-proof-evidence.json --executor-summary target/proof/local-executor-summary.json --executor-manifest target/proof/local-executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/local-executor-summary.json --executor-manifest target/proof/local-executor-manifest.json`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask docs --check`
- `git diff --check`

Note: Ruby is not installed in this Windows environment, so YAML sanity used Python/PyYAML instead.