### PR TITLE
test: tighten CLI error stderr assertions

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -449,6 +449,7 @@ paths = [
   "crates/tokmd/src/error_hints.rs",
   "crates/tokmd/tests/cli_*.rs",
   "crates/tokmd/tests/config_resolution.rs",
+  "crates/tokmd/tests/error_handling_w70.rs",
   "docs/reference-cli.md",
 ]
 packages = ["tokmd"]

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -45,7 +45,7 @@ fn negative_top_value_fails() {
         .args(["--top", "-1"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn module_negative_depth_fails() {
         .args(["module", "--module-depth", "-1"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -72,7 +72,9 @@ fn diff_no_arguments_fails() {
         .arg("diff")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "Provide either two positional refs",
+        ));
 }
 
 #[test]
@@ -81,7 +83,7 @@ fn gate_no_arguments_fails() {
         .arg("gate")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("No policy or ratchet rules"));
 }
 
 #[test]
@@ -113,7 +115,7 @@ fn lang_nonexistent_path_fails() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -124,7 +126,7 @@ fn module_nonexistent_path_fails() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -135,7 +137,7 @@ fn export_nonexistent_path_fails() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -146,7 +148,7 @@ fn analyze_nonexistent_path_fails() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -162,7 +164,7 @@ fn diff_nonexistent_before_after_fails() {
         .arg(b.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid reference"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cli_errors_w66.rs
+++ b/crates/tokmd/tests/cli_errors_w66.rs
@@ -71,7 +71,7 @@ fn non_numeric_top_flag_fails() {
         .args(["lang", "--top", "abc"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid value"));
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn negative_top_flag_fails() {
         .args(["lang", "--top", "-5"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn module_non_numeric_depth_fails() {
         .args(["module", "--module-depth", "xyz"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid value"));
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn completions_invalid_shell_fails() {
         .args(["completions", "invalid_shell"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid value"));
 }
 
 // ===========================================================================
@@ -121,7 +121,7 @@ fn lang_with_nonexistent_path_produces_error() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn module_with_nonexistent_path_produces_error() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn export_with_nonexistent_path_produces_error() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn analyze_with_nonexistent_path_produces_error() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -165,7 +165,7 @@ fn run_with_nonexistent_path_produces_error() {
         .arg(p.as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn diff_with_nonexistent_files_produces_error() {
         .arg(p.join("b.json").as_os_str())
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid reference"));
 }
 
 // ===========================================================================
@@ -259,7 +259,7 @@ fn unknown_subcommand_produces_helpful_error() {
         .arg("not-a-real-command")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Unrecognized subcommand"));
 }
 
 #[test]
@@ -268,7 +268,7 @@ fn empty_string_subcommand_fails_or_defaults() {
         .arg("")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("a value is required"));
 }
 
 // ===========================================================================
@@ -281,7 +281,9 @@ fn diff_without_required_args_fails() {
         .arg("diff")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "Provide either two positional refs",
+        ));
 }
 
 #[test]
@@ -290,7 +292,7 @@ fn gate_without_required_args_fails() {
         .arg("gate")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("No policy or ratchet rules"));
 }
 
 #[test]
@@ -299,7 +301,7 @@ fn cockpit_with_nonexistent_base_ref_fails() {
         .args(["cockpit", "--base", "nonexistent_ref_w66_abc"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("not inside a git repository"));
 }
 
 #[test]
@@ -308,5 +310,5 @@ fn unknown_global_flag_fails() {
         .arg("--does-not-exist")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("unexpected argument"));
 }

--- a/crates/tokmd/tests/error_handling_w70.rs
+++ b/crates/tokmd/tests/error_handling_w70.rs
@@ -127,7 +127,7 @@ fn lang_top_flag_with_non_numeric_value_fails() {
         .args(["lang", "--top", "not_a_number"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid value"));
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn module_depth_flag_with_non_numeric_value_fails() {
         .args(["module", "--depth", "abc"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn lang_top_flag_with_negative_value_fails() {
         .args(["lang", "--top", "-3"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 // ===========================================================================
@@ -158,7 +158,7 @@ fn unknown_subcommand_fails_with_stderr() {
         .arg("nonexistent_subcommand_w70")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("Unrecognized subcommand"));
 }
 
 // ===========================================================================
@@ -248,7 +248,9 @@ fn diff_missing_required_args_fails() {
         .arg("diff")
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains(
+            "Provide either two positional refs",
+        ));
 }
 
 // ===========================================================================
@@ -274,7 +276,7 @@ fn badge_with_invalid_metric_fails() {
         .args(["badge", "--metric", "nonexistent_metric_w70"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid value"));
 }
 
 // ===========================================================================
@@ -300,7 +302,7 @@ fn multiple_invalid_flags_still_produces_error() {
         .args(["lang", "--format", "yaml", "--top", "abc"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid value"));
 }
 
 #[test]
@@ -309,7 +311,7 @@ fn export_with_conflicting_invalid_format_fails() {
         .args(["export", "--format", "binary"])
         .assert()
         .failure()
-        .stderr(predicate::str::is_empty().not());
+        .stderr(predicate::str::contains("invalid value"));
 }
 
 // ===========================================================================

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -67,6 +67,7 @@ fn proof_policy_includes_current_product_scopes() {
         "jules_workspace",
         "model_scan_path_normalization",
         "no_panic_policy",
+        "tokmd_cli",
         "workspace_dependency_graph",
     ] {
         assert!(
@@ -148,6 +149,20 @@ fn proof_policy_includes_current_product_scopes() {
     assert!(fuzz_paths.contains("fuzz/dict/**"));
     assert!(fuzz_paths.contains("fuzz/fuzz_targets/**"));
     assert!(fuzz_proof.contains("cargo +nightly fuzz list"));
+
+    let tokmd_cli = scopes
+        .iter()
+        .find(|scope| scope["name"].as_str() == Some("tokmd_cli"))
+        .expect("tokmd_cli scope should exist");
+    let tokmd_cli_paths = tokmd_cli["paths"]
+        .as_array()
+        .expect("tokmd_cli should expose path globs")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+
+    assert!(tokmd_cli_paths.contains("crates/tokmd/tests/cli_*.rs"));
+    assert!(tokmd_cli_paths.contains("crates/tokmd/tests/error_handling_w70.rs"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- tighten CLI error-path tests to assert specific stderr fragments instead of only non-empty stderr
- add `error_handling_w70.rs` to the `tokmd_cli` proof scope so affected-plan classification stays complete
- synthesize the useful test changes from draft #1653 without deleting `plan.md` or rewriting existing `.jules` run provenance

## Validation
- `cargo test -p tokmd --test cli_error_paths_w51 --verbose`
- `cargo test -p tokmd --test cli_errors_w66 --verbose`
- `cargo test -p tokmd --test error_handling_w70 --verbose`
- `cargo fmt-check`
- `rg "is_empty\(\)\.not\(\)" crates\\tokmd\\tests\\cli_error_paths_w51.rs crates\\tokmd\\tests\\cli_errors_w66.rs crates\\tokmd\\tests\\error_handling_w70.rs` (no matches)
- `cargo xtask proof-policy --check`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask docs --check`
- `git diff --check`