### PR TITLE
fix: allow enabled guards in no-execution artifact checks

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -52,6 +52,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Workspace dependency graph changes now have an explicit proof scope for root/workspace manifests and `Cargo.lock`, routing affected plans to deny, dependency-boundary, and publish-surface checks instead of leaving lockfile-only changes unknown.
 - Fuzz harness changes now have an explicit proof scope for `fuzz/Cargo.toml`, targets, dictionaries, corpora, and harness docs, routing affected plans to the fuzz harness inventory check before deeper fuzz execution is promoted.
 - The proof executor now has a deliberately opt-in local coverage execution experiment. `--executor-mode execute` cannot be combined with `--plan`, requires explicit local or CI opt-in, runs only planner-selected non-required coverage commands, and writes executor summary/manifest artifacts while required proof jobs remain authoritative.
+- `cargo xtask proof-artifacts-check` now allows enabled execution guards for non-executed artifacts; this verifier still rejects executed artifacts by `execution_status` and executed counts until an execution verifier lands.
 - Next proof-policy operational slice: add a workflow-dispatch-only coverage executor experiment, or add an execution verifier for opted-in executor artifacts, before any required PR job can run planner-selected evidence commands.
 
 ## References

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -78,17 +78,6 @@ fn validate_executor_artifacts(summary: &Value, manifest: &Value) -> Result<Proo
         );
     }
 
-    let guard_enabled = expect_bool(
-        field(summary, "execution_guard.enabled", "executor summary")?,
-        "execution_guard.enabled",
-        "executor summary",
-    )?;
-    if guard_enabled {
-        bail!(
-            "executor artifacts have execution_guard.enabled=true; no-execution verifier requires a blocked guard"
-        );
-    }
-
     let summary_selected = expect_usize(
         field(summary, "counts.selected", "executor summary")?,
         "counts.selected",
@@ -335,16 +324,44 @@ mod tests {
     }
 
     #[test]
-    fn rejects_enabled_execution_guard() {
+    fn accepts_enabled_execution_guard_when_no_commands_executed() {
         let (mut summary, mut manifest) = matching_artifacts();
         summary["execution_guard"]["enabled"] = json!(true);
         manifest["execution_guard"]["enabled"] = json!(true);
+        summary["execution_guard"]["ci"] = json!(true);
+        manifest["execution_guard"]["ci"] = json!(true);
+        summary["execution_guard"]["allow_ci_evidence_execution"] = json!(true);
+        manifest["execution_guard"]["allow_ci_evidence_execution"] = json!(true);
+        summary["execution_guard"]["reason"] = json!("ci_explicit_opt_in_enabled");
+        manifest["execution_guard"]["reason"] = json!("ci_explicit_opt_in_enabled");
+
+        let report = validate_executor_artifacts(&summary, &manifest).unwrap();
+
+        assert_eq!(
+            report,
+            ProofArtifactsReport {
+                selected: 1,
+                execution_status: "dry_run".to_string(),
+                guard_reason: "ci_explicit_opt_in_enabled".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_executed_artifacts_even_when_guard_enabled() {
+        let (mut summary, mut manifest) = matching_artifacts();
+        summary["execution_status"] = json!("executed");
+        manifest["execution_status"] = json!("executed");
+        summary["execution_guard"]["enabled"] = json!(true);
+        manifest["execution_guard"]["enabled"] = json!(true);
+        summary["counts"]["executed"] = json!(1);
+        manifest["selection"]["executed"] = json!(1);
 
         let error = validate_executor_artifacts(&summary, &manifest)
             .unwrap_err()
             .to_string();
 
-        assert!(error.contains("execution_guard.enabled=true"));
+        assert!(error.contains("executed commands"));
     }
 
     fn matching_artifacts() -> (Value, Value) {


### PR DESCRIPTION
## Summary

- allow `proof-artifacts-check` to accept enabled executor guards when artifacts still report no executed commands
- keep executed artifacts rejected by `execution_status` and executed-count checks until an execution verifier exists
- update `docs/NEXT.md` with the current proof-artifact verifier checkpoint

Synthesized from the signal in draft #1656 without carrying over stale `.jules` run receipts.

## Validation

- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask --test proof_plan_w92 --verbose`
- `cargo xtask proof --profile affected --base HEAD --head HEAD --plan --executor-summary target/proof/enabled-guard-summary.json --executor-manifest target/proof/enabled-guard-manifest.json --executor-mode dry-run --allow-ci-evidence-execution` with `CI=true`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/enabled-guard-summary.json --executor-manifest target/proof/enabled-guard-manifest.json`
- `cargo fmt-check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `git diff --check`