### PR TITLE
feat: add proof execution artifact verifier

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -53,7 +53,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Fuzz harness changes now have an explicit proof scope for `fuzz/Cargo.toml`, targets, dictionaries, corpora, and harness docs, routing affected plans to the fuzz harness inventory check before deeper fuzz execution is promoted.
 - The proof executor now has a deliberately opt-in local coverage execution experiment. `--executor-mode execute` cannot be combined with `--plan`, requires explicit local or CI opt-in, runs only planner-selected non-required coverage commands, and writes executor summary/manifest artifacts while required proof jobs remain authoritative.
 - `cargo xtask proof-artifacts-check` now allows enabled execution guards for non-executed artifacts; this verifier still rejects executed artifacts by `execution_status` and executed counts until an execution verifier lands.
-- Next proof-policy operational slice: add a workflow-dispatch-only coverage executor experiment, or add an execution verifier for opted-in executor artifacts, before any required PR job can run planner-selected evidence commands.
+- `cargo xtask proof-execution-artifacts-check` now verifies opted-in executed executor artifacts separately from the no-execution verifier, requiring executed status, an enabled guard, zero failed commands, and matching summary/manifest command records.
+- Next proof-policy operational slice: add a workflow-dispatch-only coverage executor experiment before any required PR job can run planner-selected evidence commands.
 
 ## References
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -28,6 +28,8 @@ pub enum Commands {
     Proof(ProofArgs),
     /// Verify generated proof artifacts agree without executing planned commands
     ProofArtifactsCheck(ProofArtifactsCheckArgs),
+    /// Verify opted-in executed proof artifacts agree and passed
+    ProofExecutionArtifactsCheck(ProofArtifactsCheckArgs),
     /// Verify all release-facing version surfaces are in sync
     VersionConsistency(VersionConsistencyArgs),
     /// Verify dependency boundaries for analysis microcrates

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,9 @@ fn main() -> Result<()> {
         Some(cli::Commands::Affected(args)) => tasks::affected::run(args),
         Some(cli::Commands::Proof(args)) => tasks::proof_plan::run(args),
         Some(cli::Commands::ProofArtifactsCheck(args)) => tasks::proof_artifacts_check::run(args),
+        Some(cli::Commands::ProofExecutionArtifactsCheck(args)) => {
+            tasks::proof_artifacts_check::run_execution(args)
+        }
         Some(cli::Commands::VersionConsistency(args)) => tasks::version_consistency::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -37,7 +37,7 @@ pub fn run(args: ProofArtifactsCheckArgs) -> Result<()> {
     let summary = read_json(&args.executor_summary, "executor summary")?;
     let manifest = read_json(&args.executor_manifest, "executor manifest")?;
 
-    let report = validate_executor_artifacts(&summary, &manifest)?;
+    let report = validate_executor_artifacts(&summary, &manifest, VerificationMode::NoExecution)?;
     println!(
         "Proof artifacts OK: {} command(s), execution_status {}, guard {}",
         report.selected, report.execution_status, report.guard_reason
@@ -45,9 +45,28 @@ pub fn run(args: ProofArtifactsCheckArgs) -> Result<()> {
     Ok(())
 }
 
+pub fn run_execution(args: ProofArtifactsCheckArgs) -> Result<()> {
+    let summary = read_json(&args.executor_summary, "executor summary")?;
+    let manifest = read_json(&args.executor_manifest, "executor manifest")?;
+
+    let report = validate_executor_artifacts(&summary, &manifest, VerificationMode::Execution)?;
+    println!(
+        "Proof execution artifacts OK: {} executed command(s), guard {}",
+        report.executed, report.guard_reason
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VerificationMode {
+    NoExecution,
+    Execution,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct ProofArtifactsReport {
     selected: usize,
+    executed: usize,
     execution_status: String,
     guard_reason: String,
 }
@@ -59,7 +78,11 @@ fn read_json(path: &Path, label: &str) -> Result<Value> {
         .with_context(|| format!("failed to parse {label} artifact `{}`", path.display()))
 }
 
-fn validate_executor_artifacts(summary: &Value, manifest: &Value) -> Result<ProofArtifactsReport> {
+fn validate_executor_artifacts(
+    summary: &Value,
+    manifest: &Value,
+    mode: VerificationMode,
+) -> Result<ProofArtifactsReport> {
     expect_schema(summary, SUMMARY_SCHEMA, "executor summary")?;
     expect_schema(manifest, MANIFEST_SCHEMA, "executor manifest")?;
 
@@ -72,11 +95,11 @@ fn validate_executor_artifacts(summary: &Value, manifest: &Value) -> Result<Proo
         "execution_status",
         "executor summary",
     )?;
-    if execution_status == "executed" {
-        bail!(
-            "executor artifacts report executed commands; use a future execution verifier instead"
-        );
-    }
+    let guard_enabled = expect_bool(
+        field(summary, "execution_guard.enabled", "executor summary")?,
+        "execution_guard.enabled",
+        "executor summary",
+    )?;
 
     let summary_selected = expect_usize(
         field(summary, "counts.selected", "executor summary")?,
@@ -107,11 +130,6 @@ fn validate_executor_artifacts(summary: &Value, manifest: &Value) -> Result<Proo
     if summary_executed != manifest_executed {
         bail!(
             "executor artifact mismatch at executed count: summary {summary_executed} != manifest {manifest_executed}"
-        );
-    }
-    if summary_executed != 0 {
-        bail!(
-            "executor artifacts report {summary_executed} executed command(s); no-execution verifier requires zero"
         );
     }
 
@@ -155,6 +173,16 @@ fn validate_executor_artifacts(summary: &Value, manifest: &Value) -> Result<Proo
         validate_command_entry(index, entry, command)?;
     }
 
+    validate_execution_state(
+        summary,
+        entries,
+        mode,
+        &execution_status,
+        guard_enabled,
+        summary_selected,
+        summary_executed,
+    )?;
+
     let guard_reason = expect_string(
         field(summary, "execution_guard.reason", "executor summary")?,
         "execution_guard.reason",
@@ -163,9 +191,133 @@ fn validate_executor_artifacts(summary: &Value, manifest: &Value) -> Result<Proo
 
     Ok(ProofArtifactsReport {
         selected: summary_selected,
+        executed: summary_executed,
         execution_status,
         guard_reason,
     })
+}
+
+fn validate_execution_state(
+    summary: &Value,
+    entries: &[Value],
+    mode: VerificationMode,
+    execution_status: &str,
+    guard_enabled: bool,
+    selected: usize,
+    executed: usize,
+) -> Result<()> {
+    match mode {
+        VerificationMode::NoExecution => {
+            if execution_status == "executed" {
+                bail!(
+                    "executor artifacts report executed commands; use proof-execution-artifacts-check for executed artifacts"
+                );
+            }
+            if executed != 0 {
+                bail!(
+                    "executor artifacts report {executed} executed command(s); no-execution verifier requires zero"
+                );
+            }
+        }
+        VerificationMode::Execution => {
+            expect_string_value(
+                field(summary, "mode", "executor summary")?,
+                "execute",
+                "mode",
+                "executor summary",
+            )?;
+            if execution_status != "executed" {
+                bail!(
+                    "executor artifacts have execution_status `{execution_status}`; execution verifier requires `executed`"
+                );
+            }
+            if !guard_enabled {
+                bail!(
+                    "executor artifacts have execution_guard.enabled=false; execution verifier requires explicit opt-in"
+                );
+            }
+
+            let failed = expect_usize(
+                field(summary, "counts.failed", "executor summary")?,
+                "counts.failed",
+                "executor summary",
+            )?;
+            if failed != 0 {
+                bail!(
+                    "executor artifacts report {failed} failed command(s); execution verifier requires zero"
+                );
+            }
+
+            let skipped = expect_usize(
+                field(summary, "counts.skipped", "executor summary")?,
+                "counts.skipped",
+                "executor summary",
+            )?;
+            let dry_run = expect_usize(
+                field(summary, "counts.dry_run", "executor summary")?,
+                "counts.dry_run",
+                "executor summary",
+            )?;
+            let passed = expect_usize(
+                field(summary, "counts.passed", "executor summary")?,
+                "counts.passed",
+                "executor summary",
+            )?;
+            if skipped != 0 || dry_run != 0 {
+                bail!(
+                    "executor artifacts report skipped={skipped} dry_run={dry_run}; execution verifier requires executed commands only"
+                );
+            }
+            if executed != selected {
+                bail!(
+                    "executor artifacts report {executed} executed command(s) for {selected} selected command(s)"
+                );
+            }
+            if passed != selected {
+                bail!(
+                    "executor artifacts report {passed} passed command(s) for {selected} selected command(s)"
+                );
+            }
+            expect_string_value(
+                field(summary, "status", "executor summary")?,
+                "passed",
+                "status",
+                "executor summary",
+            )?;
+
+            for (index, entry) in entries.iter().enumerate() {
+                validate_executed_entry(index, entry)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_executed_entry(index: usize, entry: &Value) -> Result<()> {
+    let expected_index = index + 1;
+    expect_string_value(
+        field(entry, "status", "executor summary entry")?,
+        "passed",
+        "status",
+        "executor summary entry",
+    )
+    .with_context(|| format!("executor summary entry {expected_index} failed status check"))?;
+    expect_string_value(
+        field(entry, "skip_reason", "executor summary entry")?,
+        "",
+        "skip_reason",
+        "executor summary entry",
+    )
+    .with_context(|| format!("executor summary entry {expected_index} failed skip check"))?;
+
+    let exit_code = field(entry, "exit_code", "executor summary entry")?;
+    if exit_code.as_i64() != Some(0) {
+        bail!(
+            "executor summary entry {expected_index} exit_code must be 0 for passed execution, got {}",
+            render_json(exit_code)
+        );
+    }
+    Ok(())
 }
 
 fn validate_command_entry(index: usize, entry: &Value, command: &Value) -> Result<()> {
@@ -287,12 +439,15 @@ mod tests {
     fn accepts_matching_no_execution_artifacts() {
         let (summary, manifest) = matching_artifacts();
 
-        let report = validate_executor_artifacts(&summary, &manifest).unwrap();
+        let report =
+            validate_executor_artifacts(&summary, &manifest, VerificationMode::NoExecution)
+                .unwrap();
 
         assert_eq!(
             report,
             ProofArtifactsReport {
                 selected: 1,
+                executed: 0,
                 execution_status: "dry_run".to_string(),
                 guard_reason: "local_requires_--allow-local-evidence-execution".to_string(),
             }
@@ -304,7 +459,7 @@ mod tests {
         let (summary, mut manifest) = matching_artifacts();
         manifest["selection"]["selected"] = json!(2);
 
-        let error = validate_executor_artifacts(&summary, &manifest)
+        let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::NoExecution)
             .unwrap_err()
             .to_string();
 
@@ -316,7 +471,7 @@ mod tests {
         let (summary, mut manifest) = matching_artifacts();
         manifest["commands"][0]["command"] = json!("cargo llvm-cov -p tokmd-gate");
 
-        let error = validate_executor_artifacts(&summary, &manifest)
+        let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::NoExecution)
             .unwrap_err()
             .to_string();
 
@@ -335,12 +490,15 @@ mod tests {
         summary["execution_guard"]["reason"] = json!("ci_explicit_opt_in_enabled");
         manifest["execution_guard"]["reason"] = json!("ci_explicit_opt_in_enabled");
 
-        let report = validate_executor_artifacts(&summary, &manifest).unwrap();
+        let report =
+            validate_executor_artifacts(&summary, &manifest, VerificationMode::NoExecution)
+                .unwrap();
 
         assert_eq!(
             report,
             ProofArtifactsReport {
                 selected: 1,
+                executed: 0,
                 execution_status: "dry_run".to_string(),
                 guard_reason: "ci_explicit_opt_in_enabled".to_string(),
             }
@@ -357,11 +515,102 @@ mod tests {
         summary["counts"]["executed"] = json!(1);
         manifest["selection"]["executed"] = json!(1);
 
-        let error = validate_executor_artifacts(&summary, &manifest)
+        let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::NoExecution)
             .unwrap_err()
             .to_string();
 
         assert!(error.contains("executed commands"));
+    }
+
+    #[test]
+    fn accepts_matching_executed_artifacts() {
+        let (summary, manifest) = executed_artifacts();
+
+        let report =
+            validate_executor_artifacts(&summary, &manifest, VerificationMode::Execution).unwrap();
+
+        assert_eq!(
+            report,
+            ProofArtifactsReport {
+                selected: 1,
+                executed: 1,
+                execution_status: "executed".to_string(),
+                guard_reason: "local_explicit_opt_in_enabled".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_execution_artifacts_without_enabled_guard() {
+        let (mut summary, mut manifest) = executed_artifacts();
+        summary["execution_guard"]["enabled"] = json!(false);
+        manifest["execution_guard"]["enabled"] = json!(false);
+
+        let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::Execution)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("execution_guard.enabled=false"));
+    }
+
+    #[test]
+    fn rejects_execution_artifacts_with_failed_commands() {
+        let (mut summary, mut manifest) = executed_artifacts();
+        summary["status"] = json!("failed");
+        manifest["status"] = json!("failed");
+        summary["counts"]["passed"] = json!(0);
+        summary["counts"]["failed"] = json!(1);
+        summary["entries"][0]["status"] = json!("failed");
+        manifest["commands"][0]["status"] = json!("failed");
+        summary["entries"][0]["skip_reason"] = json!("command_failed");
+        manifest["commands"][0]["skip_reason"] = json!("command_failed");
+        summary["entries"][0]["exit_code"] = json!(1);
+        manifest["commands"][0]["exit_code"] = json!(1);
+
+        let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::Execution)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("failed command"));
+    }
+
+    #[test]
+    fn rejects_dry_run_artifacts_with_execution_verifier() {
+        let (summary, manifest) = matching_artifacts();
+
+        let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::Execution)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("`mode` must be `execute`"));
+    }
+
+    fn executed_artifacts() -> (Value, Value) {
+        let (mut summary, mut manifest) = matching_artifacts();
+        summary["mode"] = json!("execute");
+        manifest["mode"] = json!("execute");
+        summary["status"] = json!("passed");
+        manifest["status"] = json!("passed");
+        summary["execution_status"] = json!("executed");
+        manifest["execution_status"] = json!("executed");
+        summary["execution_guard"]["enabled"] = json!(true);
+        manifest["execution_guard"]["enabled"] = json!(true);
+        summary["execution_guard"]["allow_local_evidence_execution"] = json!(true);
+        manifest["execution_guard"]["allow_local_evidence_execution"] = json!(true);
+        summary["execution_guard"]["reason"] = json!("local_explicit_opt_in_enabled");
+        manifest["execution_guard"]["reason"] = json!("local_explicit_opt_in_enabled");
+        summary["counts"]["dry_run"] = json!(0);
+        summary["counts"]["executed"] = json!(1);
+        summary["counts"]["passed"] = json!(1);
+        summary["counts"]["failed"] = json!(0);
+        manifest["selection"]["executed"] = json!(1);
+        summary["entries"][0]["status"] = json!("passed");
+        manifest["commands"][0]["status"] = json!("passed");
+        summary["entries"][0]["skip_reason"] = json!("");
+        manifest["commands"][0]["skip_reason"] = json!("");
+        summary["entries"][0]["exit_code"] = json!(0);
+        manifest["commands"][0]["exit_code"] = json!(0);
+        (summary, manifest)
     }
 
     fn matching_artifacts() -> (Value, Value) {

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -68,6 +68,18 @@ fn proof_artifacts_check_help_mentions_executor_paths() {
 }
 
 #[test]
+fn proof_execution_artifacts_check_help_mentions_executor_paths() {
+    let (stdout, stderr, success) = run_xtask(&["proof-execution-artifacts-check", "--help"]);
+
+    assert!(
+        success,
+        "proof-execution-artifacts-check --help failed. stderr: {stderr}"
+    );
+    assert!(stdout.contains("--executor-summary"), "stdout: {stdout}");
+    assert!(stdout.contains("--executor-manifest"), "stdout: {stdout}");
+}
+
+#[test]
 fn affected_plan_ci_blocks_on_planner_generation_failures() {
     let ci = fs::read_to_string(workspace_root().join(".github/workflows/ci.yml"))
         .expect("ci workflow should be readable");
@@ -277,6 +289,38 @@ fn local_execute_can_write_zero_command_executor_artifacts() {
     assert_eq!(manifest["mode"], "execute");
     assert_eq!(manifest["selection"]["selected"], 0);
     assert_eq!(manifest["selection"]["executed"], 0);
+
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-execution-artifacts-check",
+        "--executor-summary",
+        &summary_arg,
+        "--executor-manifest",
+        &manifest_arg,
+    ]);
+    assert!(
+        success,
+        "proof-execution-artifacts-check failed. stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Proof execution artifacts OK"),
+        "stdout: {stdout}"
+    );
+
+    let (_stdout, stderr, success) = run_xtask(&[
+        "proof-artifacts-check",
+        "--executor-summary",
+        &summary_arg,
+        "--executor-manifest",
+        &manifest_arg,
+    ]);
+    assert!(
+        !success,
+        "no-execution verifier should reject executed artifacts"
+    );
+    assert!(
+        stderr.contains("proof-execution-artifacts-check"),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `cargo xtask proof-execution-artifacts-check` as the verifier for opted-in executed executor artifacts
- keep `proof-artifacts-check` scoped to no-execution/prototype/dry-run artifacts
- require executed artifacts to have `mode=execute`, `execution_status=executed`, enabled guard, zero failures, matching summary/manifest records, and passed command entries
- update `docs/NEXT.md` so the next control-plane slice is the workflow-dispatch coverage executor experiment

## Validation

- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask --test proof_plan_w92 --verbose`
- `cargo fmt-check`
- `git diff --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask docs --check`
- `cargo xtask proof --profile affected --base HEAD --head HEAD --executor-mode execute --allow-local-evidence-execution --executor-summary target/proof/local-execution-summary.json --executor-manifest target/proof/local-execution-manifest.json`
- `cargo xtask proof-execution-artifacts-check --executor-summary target/proof/local-execution-summary.json --executor-manifest target/proof/local-execution-manifest.json`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask lint_policy --verbose`
- `cargo test -p xtask no_panic --verbose`
- `cargo xtask check-lint-policy`
- `cargo xtask check-no-panic-family`