### PR TITLE
docs: record proof executor affected checkpoint

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -56,7 +56,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof-execution-artifacts-check` now verifies opted-in executed executor artifacts separately from the no-execution verifier, requiring executed status, an enabled guard, zero failed commands, and matching summary/manifest command records.
 - `.github/workflows/proof-executor.yml` now provides a workflow-dispatch-only scoped coverage executor experiment. It runs planner-selected non-required coverage commands with explicit CI opt-in, verifies executed artifacts, uploads proof artifacts, and leaves required PR proof jobs unchanged.
 - Manual proof-executor run `25464543145` on `main` passed on 2026-05-06. It verified the workflow-dispatch no-diff path: `affected_status=0`, `executor_status=0`, `verifier_status=0`, `execution_guard.reason=ci_explicit_opt_in_enabled`, and zero selected/executed commands.
-- Next proof-policy operational slice: evaluate a workflow-dispatch run against a branch with an affected Rust coverage scope before promoting any planner-selected evidence execution into PR workflows.
+- Manual proof-executor run `25465495509` on a disposable branch passed on 2026-05-06. It matched `crates/tokmd-core/tests/ffi_parity_w53.rs` to `tokmd_core_ffi`, selected one advisory coverage command, executed it with `exit_code=0`, produced `target/proof/coverage/tokmd_core_ffi.lcov`, and passed `cargo xtask proof-execution-artifacts-check`.
+- Next proof-policy operational slice: promote the executor only to an explicitly non-required PR job, keep Codecov upload advisory, and keep required proof commands authoritative until executor evidence has multiple successful affected-scope runs.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Record the successful workflow-dispatch proof executor run against a disposable affected Rust scope branch.
- Capture that the executor selected and passed one advisory tokmd_core_ffi coverage command with CI opt-in.
- Set the next promotion step as non-required PR visibility, with Codecov advisory and required proof jobs still authoritative.

## Validation
- workflow_dispatch Proof Executor Experiment run 25465495509
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask affected --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_artifacts --verbose
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask proof_policy --verbose
- cargo fmt-check
- git diff --check