### PR TITLE
fix: harden git subprocess environment boundary

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -351,6 +351,23 @@ mutation = true
 coverage = true
 
 [[scope]]
+name = "git_subprocess_boundary"
+kind = "rust"
+paths = [
+  "crates/tokmd-git/src/lib.rs",
+  "crates/tokmd-scan/src/walk/mod.rs",
+  "crates/tokmd/src/git_support.rs",
+]
+packages = ["tokmd-git", "tokmd-scan", "tokmd"]
+proof = [
+  "cargo test -p tokmd-git git_cmd_removes_repo_shaping_env_overrides --verbose",
+  "cargo test -p tokmd-scan git_cmd_removes_repo_shaping_env_overrides --verbose",
+  "cargo test -p tokmd git_cmd_removes_repo_shaping_env_overrides --verbose",
+]
+mutation = true
+coverage = true
+
+[[scope]]
 name = "format_analysis_rendering"
 kind = "rust"
 paths = [

--- a/crates/tokmd-git/src/lib.rs
+++ b/crates/tokmd-git/src/lib.rs
@@ -22,14 +22,26 @@ use std::process::{Command, Stdio};
 use anyhow::{Context, Result};
 pub use tokmd_types::CommitIntentKind;
 
+const GIT_REPO_SHAPING_ENV: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+];
+
 /// Create a `Command` for git with process-environment isolation.
 ///
-/// Strips `GIT_DIR` and `GIT_WORK_TREE` so that inherited environment
-/// variables cannot override the explicit `-C` path used by all
-/// functions in this crate.
+/// Strips repo, worktree, index, object-store, and discovery overrides so
+/// inherited environment variables cannot bypass the explicit `-C` path used
+/// by functions in this crate.
 pub fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
-    cmd.env_remove("GIT_DIR").env_remove("GIT_WORK_TREE");
+    for name in GIT_REPO_SHAPING_ENV {
+        cmd.env_remove(name);
+    }
     cmd
 }
 
@@ -435,11 +447,25 @@ fn contains_word(haystack: &str, word: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     fn test_git(dir: &Path) -> Command {
         let mut cmd = git_cmd();
         cmd.arg("-C").arg(dir);
         cmd
+    }
+
+    #[test]
+    fn git_cmd_removes_repo_shaping_env_overrides() {
+        let removed: BTreeSet<_> = git_cmd()
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect();
+
+        for name in GIT_REPO_SHAPING_ENV {
+            assert!(removed.contains(*name), "missing env_remove for {name}");
+        }
     }
 
     #[test]

--- a/crates/tokmd-scan/src/walk/mod.rs
+++ b/crates/tokmd-scan/src/walk/mod.rs
@@ -28,9 +28,21 @@ pub struct LicenseCandidates {
     pub metadata_files: Vec<PathBuf>,
 }
 
+const GIT_REPO_SHAPING_ENV: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+];
+
 fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
-    cmd.env_remove("GIT_DIR").env_remove("GIT_WORK_TREE");
+    for name in GIT_REPO_SHAPING_ENV {
+        cmd.env_remove(name);
+    }
     cmd
 }
 
@@ -244,9 +256,23 @@ fn memfs_relative_path(path: &Path, root: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use std::fs;
 
     // ---- license_candidates tests ----
+
+    #[test]
+    fn git_cmd_removes_repo_shaping_env_overrides() {
+        let removed: BTreeSet<_> = git_cmd()
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect();
+
+        for name in GIT_REPO_SHAPING_ENV {
+            assert!(removed.contains(*name), "missing env_remove for {name}");
+        }
+    }
 
     #[test]
     fn test_license_candidates_detects_license_files() {

--- a/crates/tokmd/src/git_support.rs
+++ b/crates/tokmd/src/git_support.rs
@@ -1,8 +1,39 @@
 use std::process::Command;
 
+const GIT_REPO_SHAPING_ENV: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+];
+
 /// Create a `git` command without inheriting repo-shaping overrides.
 pub(crate) fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
-    cmd.env_remove("GIT_DIR").env_remove("GIT_WORK_TREE");
+    for name in GIT_REPO_SHAPING_ENV {
+        cmd.env_remove(name);
+    }
     cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn git_cmd_removes_repo_shaping_env_overrides() {
+        let removed: BTreeSet<_> = git_cmd()
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect();
+
+        for name in GIT_REPO_SHAPING_ENV {
+            assert!(removed.contains(*name), "missing env_remove for {name}");
+        }
+    }
 }

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -187,7 +187,7 @@ fn proof_policy_json_reports_current_schema() {
 
     assert_eq!(value["ok"], true);
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
-    assert_eq!(value["scope_count"], 34);
+    assert_eq!(value["scope_count"], 35);
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);


### PR DESCRIPTION
## Summary
- extend git subprocess helpers to scrub repository-shaping environment overrides beyond `GIT_DIR` / `GIT_WORK_TREE`
- add targeted tests for the `tokmd-git`, `tokmd-scan`, and CLI git helper surfaces
- add a `git_subprocess_boundary` proof-policy scope so affected planning maps this surface explicitly

Supersedes draft #1661 with a narrow keeper that drops unrelated generated/run churn and stale file deletion.

## Validation
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd-git git_cmd_removes_repo_shaping_env_overrides --verbose`
- `cargo test -p tokmd-scan git_cmd_removes_repo_shaping_env_overrides --verbose`
- `cargo test -p tokmd git_cmd_removes_repo_shaping_env_overrides --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo fmt-check`
- `cargo clippy -p xtask -p tokmd-git -p tokmd-scan -p tokmd --all-targets -- -D warnings`
- `cargo xtask docs --check`
- `git diff --check`