### PR TITLE
docs: define cockpit review packet contract

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -506,6 +506,7 @@ paths = [
   "crates/tokmd-types/tests/cockpit_tests.rs",
   "crates/tokmd/src/commands/cockpit.rs",
   "crates/tokmd/tests/cockpit_*.rs",
+  "docs/review-packet.md",
   "docs/tokmd-in-cockpit.md",
 ]
 packages = ["tokmd-cockpit", "tokmd-types", "tokmd"]

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -58,10 +58,12 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Manual proof-executor run `25464543145` on `main` passed on 2026-05-06. It verified the workflow-dispatch no-diff path: `affected_status=0`, `executor_status=0`, `verifier_status=0`, `execution_guard.reason=ci_explicit_opt_in_enabled`, and zero selected/executed commands.
 - Manual proof-executor run `25465495509` on a disposable branch passed on 2026-05-06. It matched `crates/tokmd-core/tests/ffi_parity_w53.rs` to `tokmd_core_ffi`, selected one advisory coverage command, executed it with `exit_code=0`, produced `target/proof/coverage/tokmd_core_ffi.lcov`, and passed `cargo xtask proof-execution-artifacts-check`.
 - The proof executor workflow now runs on pull requests as `Scoped Coverage Executor (Non-Required)`. It remains outside the required CI aggregate, executes only planner-selected non-required coverage commands, keeps Codecov upload manual-only, and leaves existing proof jobs authoritative.
+- The cockpit review-packet contract now has a doc-first draft in `docs/review-packet.md`. It keeps cockpit as the current PR-review evidence surface, records the target packet artifacts, and blocks a separate `tokmd review` command until there is a distinct orchestrator contract.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References
 
 - Historical drain ledger: [PR_DRAIN.md](../PR_DRAIN.md)
 - External service policy: [external-services.md](external-services.md)
+- Review packet contract: [review-packet.md](review-packet.md)
 - Current testing strategy: [testing.md](testing.md)

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -1,0 +1,144 @@
+# Review Packet Contract
+
+Status: draft contract. This document defines the intended cockpit review-packet
+artifact shape before adding a new command or changing the existing default
+`tokmd cockpit` behavior.
+
+## Purpose
+
+The review packet is a stable artifact directory for PR review evidence. It
+lets a maintainer inspect what changed, what evidence is available, what is
+missing or degraded, and which files deserve attention first.
+
+`tokmd cockpit` remains the current PR-review evidence surface. A future
+`tokmd review` command should not be introduced unless it becomes a distinct
+orchestrator over this packet instead of duplicating cockpit computation.
+
+## Existing Cockpit Artifacts
+
+Today, `tokmd cockpit --artifacts-dir <dir>` writes:
+
+```text
+<dir>/
+  cockpit.json
+  report.json
+  comment.md
+```
+
+Those artifacts remain the shipped contract until packet emission is
+implemented. Sensor mode continues to use the `sensor.report.v1` envelope and
+its documented sidecars.
+
+## Target Layout
+
+The target review packet directory is:
+
+```text
+.tokmd/review/
+  manifest.json
+  cockpit.json
+  evidence.json
+  comment.md
+  review-map.json
+  review-map.md
+```
+
+The first implementation may emit only `manifest.json`, `cockpit.json`,
+`evidence.json`, and `comment.md`. `review-map.json` and `review-map.md` should
+land once the priority model is stable enough to treat as a contract.
+
+## Artifacts
+
+| Artifact | Contract |
+| --- | --- |
+| `manifest.json` | Packet index with schema name, generated-by metadata, base/head refs, artifact paths, hashes, and verdict metadata. |
+| `cockpit.json` | Full `CockpitReceipt` JSON. This is the same receipt produced by `tokmd cockpit --format json`. |
+| `evidence.json` | Evidence availability and gate status. It distinguishes passed evidence from missing, skipped, stale, degraded, or unavailable evidence. |
+| `comment.md` | PR-comment-ready summary. It stays concise and links readers to packet artifacts when hosted by CI. |
+| `review-map.json` | Machine-readable prioritized review plan with files, reasons, evidence references, and reproduction commands. |
+| `review-map.md` | Human-readable review plan for artifact browsing and local review. |
+
+## Evidence Semantics
+
+Packet consumers must not treat unavailable evidence as passing evidence.
+
+Recommended evidence status values:
+
+| Status | Meaning |
+| --- | --- |
+| `passed` | Evidence ran for the requested commit/scope and met the configured policy. |
+| `failed` | Evidence ran and violated the configured policy. |
+| `missing` | Evidence was expected but no usable result was found. |
+| `skipped` | Evidence was intentionally not requested for this run. |
+| `stale` | Evidence exists but does not match the requested commit or scope. |
+| `degraded` | Evidence exists but is partial, incomplete, or lower confidence than the normal policy requires. |
+| `unavailable` | The runtime or checkout cannot support the evidence source. |
+
+Missing, stale, degraded, and unavailable evidence should be visible in
+`comment.md`, `evidence.json`, and `manifest.json` verdict metadata.
+
+## Manifest Requirements
+
+`manifest.json` should use schema `tokmd.review_packet_manifest.v1` and include:
+
+- `schema`
+- `generated_by` with `name`, `version`, and command arguments
+- `generated_at_ms`
+- `base_ref` and `head_ref`
+- `artifacts` with `id`, `path`, `schema`, `sha256`, and `media_type`
+- `verdict` with `status`, `blocking`, and `reason`
+- `capabilities` or links to capability details when checks are unavailable
+
+Artifact paths in the manifest are relative to the packet directory. Hashes are
+computed from the final bytes written to disk.
+
+## Exit Codes
+
+Packet emission success means the requested artifacts were written and are
+internally consistent. Evidence verdicts are data inside the packet.
+
+Future gate modes may map evidence verdicts to exit codes:
+
+| Mode | Behavior |
+| --- | --- |
+| `off` | Never fail because of evidence verdicts. |
+| `advisory` | Write failing or missing evidence into the packet but exit successfully when artifacts are valid. |
+| `blocking` | Exit non-zero when configured blocking evidence fails or is missing. |
+
+The default should remain advisory unless a repo explicitly chooses blocking
+behavior.
+
+## GitHub Action Behavior
+
+The Action should upload the packet as an artifact before any optional comment
+step. Comment posting must remain fork-safe and must not be required for packet
+generation.
+
+Future Action inputs should build on the cockpit surface first:
+
+```yaml
+mode: cockpit
+review-packet: true
+post-comment: true
+upload-artifacts: true
+```
+
+Do not add `mode: review` until there is a distinct review orchestrator contract
+that uses this packet.
+
+## Non-Goals
+
+- Replacing tests, coverage, mutation testing, SAST, or human review.
+- Treating missing evidence as a successful check.
+- Introducing an external review service or secret requirement.
+- Adding AI-written recommendations without deterministic evidence references.
+
+## Implementation Checklist
+
+- `tokmd cockpit` can emit packet artifacts without changing default stdout.
+- `manifest.json` hashes every artifact it lists.
+- `cockpit.json` remains a valid cockpit receipt with the current cockpit schema.
+- `evidence.json` records unavailable and degraded evidence explicitly.
+- `comment.md` remains concise enough for PR comments.
+- Existing `--format comment` and `--artifacts-dir` behavior remains compatible.
+- Action artifact upload works even when comments are disabled or unavailable.

--- a/docs/tokmd-in-cockpit.md
+++ b/docs/tokmd-in-cockpit.md
@@ -14,6 +14,11 @@ artifacts/tokmd/
 
 These paths are the stable integration contract for cockpit directors.
 
+The planned review-packet contract is documented separately in
+[`review-packet.md`](review-packet.md). It is a future packet shape for PR
+review artifacts, not a replacement for the shipped `--artifacts-dir` contract
+until packet emission is implemented.
+
 ## Default Policy
 
 tokmd is **informational by default**. A repo may choose to gate on tokmd output,


### PR DESCRIPTION
## Summary

- add `docs/review-packet.md` as the doc-first contract for future cockpit review-packet artifacts
- link the contract from cockpit docs and `docs/NEXT.md`
- classify the new review-packet doc under the `tokmd_cockpit` proof scope

## Validation

- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`