### PR TITLE
feat: add cockpit review map artifacts

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -9,8 +9,8 @@ use serde_json::{Value, json};
 use tokmd_envelope::{SensorReport, ToolMeta, Verdict};
 
 use crate::{
-    CockpitReceipt, CommitMatch, GateMeta, GateStatus, RiskLevel, format_signed_f64, now_iso8601,
-    sparkline, trend_direction_label,
+    CockpitReceipt, CommitMatch, GateMeta, GateStatus, ReviewItem, RiskLevel, format_signed_f64,
+    now_iso8601, sparkline, trend_direction_label,
 };
 
 /// Render receipt as JSON.
@@ -621,13 +621,24 @@ pub fn write_review_packet(dir: &Path, receipt: &CockpitReceipt) -> Result<()> {
 
     let cockpit_json = render_json(receipt)?;
     let evidence_json = serde_json::to_string_pretty(&review_packet_evidence(receipt))?;
+    let review_map_json = serde_json::to_string_pretty(&review_packet_review_map(receipt))?;
+    let review_map_md = render_review_map_md(receipt);
     let comment_md = render_comment_md(receipt);
 
     std::fs::write(dir.join("cockpit.json"), &cockpit_json)?;
     std::fs::write(dir.join("evidence.json"), &evidence_json)?;
+    std::fs::write(dir.join("review-map.json"), &review_map_json)?;
+    std::fs::write(dir.join("review-map.md"), &review_map_md)?;
     std::fs::write(dir.join("comment.md"), &comment_md)?;
 
-    let manifest = review_packet_manifest(receipt, &cockpit_json, &evidence_json, &comment_md);
+    let manifest = review_packet_manifest(
+        receipt,
+        &cockpit_json,
+        &evidence_json,
+        &review_map_json,
+        &review_map_md,
+        &comment_md,
+    );
     std::fs::write(
         dir.join("manifest.json"),
         serde_json::to_string_pretty(&manifest)?,
@@ -640,6 +651,8 @@ fn review_packet_manifest(
     receipt: &CockpitReceipt,
     cockpit_json: &str,
     evidence_json: &str,
+    review_map_json: &str,
+    review_map_md: &str,
     comment_md: &str,
 ) -> Value {
     json!({
@@ -672,6 +685,20 @@ fn review_packet_manifest(
                 "tokmd.review_packet_evidence.v1",
                 "application/json",
                 evidence_json,
+            ),
+            review_packet_artifact(
+                "review-map",
+                "review-map.json",
+                "tokmd.review_map.v1",
+                "application/json",
+                review_map_json,
+            ),
+            review_packet_artifact(
+                "review-map-md",
+                "review-map.md",
+                "markdown",
+                "text/markdown",
+                review_map_md,
             ),
             review_packet_artifact(
                 "comment",
@@ -733,6 +760,98 @@ fn review_packet_evidence(receipt: &CockpitReceipt) -> Value {
             ),
         ],
     })
+}
+
+fn review_packet_review_map(receipt: &CockpitReceipt) -> Value {
+    let items: Vec<_> = receipt
+        .review_plan
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| review_map_item(idx, item, receipt))
+        .collect();
+
+    json!({
+        "schema": "tokmd.review_map.v1",
+        "base_ref": receipt.base_ref,
+        "head_ref": receipt.head_ref,
+        "source": "cockpit.review_plan",
+        "item_count": items.len(),
+        "items": items,
+    })
+}
+
+fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> Value {
+    json!({
+        "rank": idx + 1,
+        "path": &item.path,
+        "priority": item.priority,
+        "priority_label": review_priority_label(item.priority),
+        "reason": &item.reason,
+        "complexity": item.complexity,
+        "lines_changed": item.lines_changed,
+        "evidence_refs": [
+            format!("cockpit.json#/review_plan/{idx}"),
+            "evidence.json#/gates",
+        ],
+        "reproduce": [
+            format!(
+                "tokmd cockpit --base {} --head {} --format json",
+                receipt.base_ref, receipt.head_ref
+            ),
+            format!(
+                "tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review",
+                receipt.base_ref, receipt.head_ref
+            ),
+        ],
+    })
+}
+
+fn review_priority_label(priority: u32) -> &'static str {
+    match priority {
+        1 => "highest",
+        2 => "medium",
+        _ => "low",
+    }
+}
+
+fn render_review_map_md(receipt: &CockpitReceipt) -> String {
+    use std::fmt::Write;
+
+    let mut s = String::new();
+    let _ = writeln!(s, "# Review Map");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "Base: `{}`", receipt.base_ref);
+    let _ = writeln!(s, "Head: `{}`", receipt.head_ref);
+    let _ = writeln!(s);
+
+    if receipt.review_plan.is_empty() {
+        let _ = writeln!(s, "No prioritized files were identified.");
+        return s;
+    }
+
+    for (idx, item) in receipt.review_plan.iter().enumerate() {
+        let _ = writeln!(
+            s,
+            "{}. `{}`
+   Priority: {} ({})
+   Reason: {}",
+            idx + 1,
+            item.path,
+            item.priority,
+            review_priority_label(item.priority),
+            item.reason
+        );
+
+        if let Some(lines_changed) = item.lines_changed {
+            let _ = writeln!(s, "   Lines changed: {lines_changed}");
+        }
+        if let Some(complexity) = item.complexity {
+            let _ = writeln!(s, "   Review complexity: {complexity}/5");
+        }
+        let _ = writeln!(s);
+    }
+
+    s
 }
 
 fn evidence_gate(id: &str, meta: Option<&GateMeta>) -> Value {

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -758,6 +758,13 @@ fn scenario_write_review_packet_creates_contract_files() {
     let mut receipt = minimal_receipt();
     receipt.evidence.mutation.meta.status = GateStatus::Pass;
     receipt.evidence.mutation.meta.commit_match = CommitMatch::Exact;
+    receipt.review_plan = vec![ReviewItem {
+        path: "src/lib.rs".to_string(),
+        reason: "Large changed file".to_string(),
+        priority: 1,
+        complexity: Some(4),
+        lines_changed: Some(240),
+    }];
     let out = dir.path().join("review");
 
     tokmd_cockpit::render::write_review_packet(&out, &receipt).unwrap();
@@ -765,6 +772,8 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert!(out.join("manifest.json").exists());
     assert!(out.join("cockpit.json").exists());
     assert!(out.join("evidence.json").exists());
+    assert!(out.join("review-map.json").exists());
+    assert!(out.join("review-map.md").exists());
     assert!(out.join("comment.md").exists());
 
     let manifest: serde_json::Value =
@@ -772,7 +781,7 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert_eq!(manifest["schema"], "tokmd.review_packet_manifest.v1");
     assert_eq!(manifest["generated_by"]["mode"], "cockpit");
     assert_eq!(manifest["verdict"]["blocking"].as_bool(), Some(false));
-    assert_eq!(manifest["artifacts"].as_array().unwrap().len(), 3);
+    assert_eq!(manifest["artifacts"].as_array().unwrap().len(), 5);
     assert_eq!(manifest["artifacts"][0]["path"], "cockpit.json");
     assert_eq!(manifest["artifacts"][0]["hash"]["algo"], "blake3");
     assert_eq!(
@@ -790,6 +799,21 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert_eq!(evidence["gates"][0]["availability"], "available");
     assert_eq!(evidence["gates"][1]["id"], "diff_coverage");
     assert_eq!(evidence["gates"][1]["availability"], "unavailable");
+
+    let review_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
+            .unwrap();
+    assert_eq!(review_map["schema"], "tokmd.review_map.v1");
+    assert_eq!(review_map["item_count"], 1);
+    assert_eq!(review_map["items"][0]["path"], "src/lib.rs");
+    assert_eq!(
+        review_map["items"][0]["evidence_refs"][0],
+        "cockpit.json#/review_plan/0"
+    );
+
+    let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    assert!(review_map_md.contains("# Review Map"));
+    assert!(review_map_md.contains("`src/lib.rs`"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -521,6 +521,8 @@ fn test_cockpit_review_packet_dir() {
         "manifest.json",
         "cockpit.json",
         "evidence.json",
+        "review-map.json",
+        "review-map.md",
         "comment.md",
     ] {
         assert!(
@@ -533,13 +535,22 @@ fn test_cockpit_review_packet_dir() {
         serde_json::from_str(&std::fs::read_to_string(packet_dir.join("manifest.json")).unwrap())
             .expect("valid manifest JSON");
     assert_eq!(manifest["schema"], "tokmd.review_packet_manifest.v1");
-    assert_eq!(manifest["artifacts"].as_array().unwrap().len(), 3);
+    assert_eq!(manifest["artifacts"].as_array().unwrap().len(), 5);
 
     let evidence: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(packet_dir.join("evidence.json")).unwrap())
             .expect("valid evidence JSON");
     assert_eq!(evidence["schema"], "tokmd.review_packet_evidence.v1");
     assert!(evidence["gates"].is_array());
+
+    let review_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packet_dir.join("review-map.json")).unwrap())
+            .expect("valid review map JSON");
+    assert_eq!(review_map["schema"], "tokmd.review_map.v1");
+    assert!(review_map["items"].is_array());
+
+    let review_map_md = std::fs::read_to_string(packet_dir.join("review-map.md")).unwrap();
+    assert!(review_map_md.contains("# Review Map"));
 }
 
 #[test]

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -58,7 +58,8 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Manual proof-executor run `25464543145` on `main` passed on 2026-05-06. It verified the workflow-dispatch no-diff path: `affected_status=0`, `executor_status=0`, `verifier_status=0`, `execution_guard.reason=ci_explicit_opt_in_enabled`, and zero selected/executed commands.
 - Manual proof-executor run `25465495509` on a disposable branch passed on 2026-05-06. It matched `crates/tokmd-core/tests/ffi_parity_w53.rs` to `tokmd_core_ffi`, selected one advisory coverage command, executed it with `exit_code=0`, produced `target/proof/coverage/tokmd_core_ffi.lcov`, and passed `cargo xtask proof-execution-artifacts-check`.
 - The proof executor workflow now runs on pull requests as `Scoped Coverage Executor (Non-Required)`. It remains outside the required CI aggregate, executes only planner-selected non-required coverage commands, keeps Codecov upload manual-only, and leaves existing proof jobs authoritative.
-- `tokmd cockpit --review-packet-dir <dir>` now emits the initial cockpit review packet (`manifest.json`, `cockpit.json`, `evidence.json`, `comment.md`) while leaving default stdout and the existing `--artifacts-dir` director contract unchanged. `review-map.json` / `review-map.md` remain future packet slices.
+- `tokmd cockpit --review-packet-dir <dir>` now emits the cockpit review packet while leaving default stdout and the existing `--artifacts-dir` director contract unchanged.
+- The cockpit review packet now includes `review-map.json` / `review-map.md` generated from the existing cockpit `review_plan`, giving packet consumers a stable prioritized review map without introducing a separate `tokmd review` command.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -1,8 +1,8 @@
 # Review Packet Contract
 
-Status: initial implementation. `tokmd cockpit --review-packet-dir <dir>`
-emits the first packet slice without changing the existing default
-`tokmd cockpit` stdout behavior or the shipped `--artifacts-dir` contract.
+Status: implemented. `tokmd cockpit --review-packet-dir <dir>` emits packet
+artifacts without changing the existing default `tokmd cockpit` stdout behavior
+or the shipped `--artifacts-dir` contract.
 
 ## Purpose
 
@@ -41,13 +41,12 @@ The review packet directory is:
   cockpit.json
   evidence.json
   comment.md
-  review-map.json   # future
-  review-map.md     # future
+  review-map.json
+  review-map.md
 ```
 
-The initial implementation emits `manifest.json`, `cockpit.json`,
-`evidence.json`, and `comment.md`. `review-map.json` and `review-map.md` should
-land once the priority model is stable enough to treat as a contract.
+`review-map.json` and `review-map.md` are derived from the existing cockpit
+`review_plan`. They do not add a new scoring model.
 
 ## Artifacts
 
@@ -57,7 +56,7 @@ land once the priority model is stable enough to treat as a contract.
 | `cockpit.json` | Full `CockpitReceipt` JSON. This is the same receipt produced by `tokmd cockpit --format json`. |
 | `evidence.json` | Evidence availability and gate status. It distinguishes passed evidence from missing, skipped, stale, degraded, or unavailable evidence. |
 | `comment.md` | PR-comment-ready summary. It stays concise and links readers to packet artifacts when hosted by CI. |
-| `review-map.json` | Machine-readable prioritized review plan with files, reasons, evidence references, and reproduction commands. |
+| `review-map.json` | Machine-readable prioritized review plan with files, reasons, evidence references, and reproduction commands derived from `cockpit.json#/review_plan`. |
 | `review-map.md` | Human-readable review plan for artifact browsing and local review. |
 
 ## Evidence Semantics
@@ -94,6 +93,20 @@ Missing, stale, degraded, and unavailable evidence should be visible in
 Artifact paths in the manifest are relative to the packet directory. Hashes use
 the repo-standard BLAKE3 digest and are computed from the final bytes written
 to disk.
+
+## Review Map Requirements
+
+`review-map.json` should use schema `tokmd.review_map.v1` and include:
+
+- `schema`
+- `base_ref` and `head_ref`
+- `source` identifying `cockpit.review_plan`
+- `item_count`
+- `items` sorted in cockpit review-plan order
+
+Each item includes rank, path, priority, priority label, reason, optional
+complexity, optional lines changed, evidence references, and reproduction
+commands. `review-map.md` is a Markdown rendering of the same ordered items.
 
 ## Exit Codes
 

--- a/docs/tokmd-in-cockpit.md
+++ b/docs/tokmd-in-cockpit.md
@@ -19,7 +19,8 @@ For packet-shaped PR-review artifacts, use
 `tokmd cockpit --review-packet-dir .tokmd/review`. The review-packet contract is
 documented separately in [`review-packet.md`](review-packet.md). It is an
 additive PR review artifact shape, not a replacement for the shipped
-`--artifacts-dir` contract.
+`--artifacts-dir` contract. The packet includes `review-map.json` and
+`review-map.md` derived from the cockpit review plan.
 
 ## Default Policy
 


### PR DESCRIPTION
## Summary
- add `review-map.json` and `review-map.md` to cockpit review packets
- derive the review map from the existing deterministic cockpit `review_plan`
- update packet docs and cockpit docs to mark the review-map artifacts as implemented

## Validation
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask affected --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_artifacts --verbose
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask proof_policy --verbose
- cargo test -p tokmd-cockpit scenario_write_review_packet_creates_contract_files --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration test_cockpit_review_packet_dir --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo clippy -p tokmd --all-targets -- -D warnings
- cargo fmt-check
- git diff --check