### PR TITLE
feat: add action review packet option

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -338,6 +338,15 @@ jobs:
         shell: bash
         run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
 
+      - name: Set up Rust for local review packet binary
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install local tokmd for review packet mode
+        shell: bash
+        run: |
+          cargo install --path crates/tokmd --features git --locked --force --root "$HOME/.local"
+          "$HOME/.local/bin/tokmd" cockpit --help | grep -q -- '--review-packet-dir'
+
       - name: Run cockpit mode with review packet
         id: cockpit_packet
         uses: ./

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -328,11 +328,64 @@ jobs:
             echo "::error::baseline-report output should be empty in cockpit mode"
             exit 1
           fi
+          if [ -n "${{ steps.cockpit.outputs['review-packet'] }}" ]; then
+            echo "::error::review-packet output should be empty in cockpit mode without review-packet=true"
+            exit 1
+          fi
           grep -q '"mode": "cockpit"' tokmd-cockpit-report.json
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
+
+      - name: Run cockpit mode with review packet
+        id: cockpit_packet
+        uses: ./
+        with:
+          mode: cockpit
+          base: HEAD
+          head: HEAD
+          review-packet: 'true'
+          comment: 'false'
+          artifact: 'false'
+
+      - name: Verify cockpit review packet mode
+        shell: bash
+        run: |
+          if [ ! -f tokmd-cockpit-report.json ]; then
+            echo "::error::tokmd-cockpit-report.json not generated with cockpit review packet"
+            exit 1
+          fi
+          if [ "${{ steps.cockpit_packet.outputs['cockpit-report'] }}" != "tokmd-cockpit-report.json" ]; then
+            echo "::error::cockpit-report output did not point to tokmd-cockpit-report.json with review packet"
+            exit 1
+          fi
+          if [ "${{ steps.cockpit_packet.outputs['review-packet'] }}" != ".tokmd/review" ]; then
+            echo "::error::review-packet output did not point to .tokmd/review"
+            exit 1
+          fi
+          if [ "${{ steps.cockpit_packet.outputs.summary }}" != ".tokmd/review/comment.md" ]; then
+            echo "::error::summary output did not point to review packet comment.md"
+            exit 1
+          fi
+          for path in \
+            .tokmd/review/manifest.json \
+            .tokmd/review/cockpit.json \
+            .tokmd/review/evidence.json \
+            .tokmd/review/review-map.json \
+            .tokmd/review/review-map.md \
+            .tokmd/review/comment.md; do
+            if [ ! -f "$path" ]; then
+              echo "::error::$path not generated in cockpit review packet mode"
+              exit 1
+            fi
+          done
+          grep -q '"schema": "tokmd.review_packet_manifest.v1"' .tokmd/review/manifest.json
+          grep -q '"schema": "tokmd.review_map.v1"' .tokmd/review/review-map.json
+
+      - name: Clean generated files
+        shell: bash
+        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
 
       - name: Run cockpit mode with inferred pull request base
         id: cockpit_inferred_base

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   comment:
     description: 'Whether to post the generated Markdown summary as a pull request comment'
     default: 'true'
+  review-packet:
+    description: 'Whether mode: cockpit should emit a review packet directory and use its comment.md as the PR comment body'
+    default: 'false'
 
 outputs:
   receipt:
@@ -50,6 +53,9 @@ outputs:
   cockpit-report:
     description: 'Path to the generated cockpit report JSON file'
     value: ${{ steps.generate.outputs['cockpit-report'] }}
+  review-packet:
+    description: 'Path to the generated cockpit review packet directory when mode: cockpit and review-packet: true are used'
+    value: ${{ steps.generate.outputs['review-packet'] }}
   sensor-report:
     description: 'Path to the generated sensor report JSON file'
     value: ${{ steps.generate.outputs['sensor-report'] }}
@@ -166,6 +172,7 @@ runs:
         TOKMD_ACTION_MODE: ${{ inputs.mode }}
         TOKMD_ACTION_MODULE_ROOTS: ${{ inputs.module-roots }}
         TOKMD_ACTION_PATHS: ${{ inputs.paths }}
+        TOKMD_ACTION_REVIEW_PACKET: ${{ inputs.review-packet }}
         TOKMD_ACTION_TOP: ${{ inputs.top }}
       run: |
         set -euo pipefail
@@ -199,9 +206,24 @@ runs:
         receipt_file=""
         gate_verdict_file=""
         cockpit_report_file=""
+        review_packet_dir=""
         sensor_report_file=""
         baseline_report_file=""
         command_status=0
+        review_packet="${TOKMD_ACTION_REVIEW_PACKET}"
+
+        case "$review_packet" in
+          true|false) ;;
+          *)
+            echo "::error::review-packet must be 'true' or 'false'"
+            exit 1
+            ;;
+        esac
+
+        if [ "$review_packet" = "true" ] && [ "$mode" != "cockpit" ]; then
+          echo "::error::review-packet is only supported with mode=cockpit"
+          exit 1
+        fi
 
         ensure_git_ref() {
           local ref="$1"
@@ -294,10 +316,19 @@ runs:
           cockpit)
             cockpit_report_file="tokmd-cockpit-report.json"
             compare_base="$(resolve_base_ref cockpit)"
+            cockpit_args=(
+              --base "$compare_base"
+              --head "$TOKMD_ACTION_HEAD"
+            )
+
+            if [ "$review_packet" = "true" ]; then
+              review_packet_dir=".tokmd/review"
+              summary_file="$review_packet_dir/comment.md"
+              cockpit_args+=(--review-packet-dir "$review_packet_dir")
+            fi
 
             tokmd cockpit \
-              --base "$compare_base" \
-              --head "$TOKMD_ACTION_HEAD" \
+              "${cockpit_args[@]}" \
               --format json > "$cockpit_report_file"
             ;;
           sensor)
@@ -335,6 +366,7 @@ runs:
           echo "summary=$summary_file"
           echo "gate-verdict=$gate_verdict_file"
           echo "cockpit-report=$cockpit_report_file"
+          echo "review-packet=$review_packet_dir"
           echo "sensor-report=$sensor_report_file"
           echo "baseline-report=$baseline_report_file"
           echo "command-status=$command_status"
@@ -350,6 +382,7 @@ runs:
           ${{ steps.generate.outputs.receipt }}
           ${{ steps.generate.outputs['gate-verdict'] }}
           ${{ steps.generate.outputs['cockpit-report'] }}
+          ${{ steps.generate.outputs['review-packet'] }}
           ${{ steps.generate.outputs['sensor-report'] }}
           ${{ steps.generate.outputs['baseline-report'] }}
           extras/
@@ -369,6 +402,7 @@ runs:
         RECEIPT_FILE: ${{ steps.generate.outputs.receipt }}
         GATE_VERDICT_FILE: ${{ steps.generate.outputs['gate-verdict'] }}
         COCKPIT_REPORT_FILE: ${{ steps.generate.outputs['cockpit-report'] }}
+        REVIEW_PACKET_DIR: ${{ steps.generate.outputs['review-packet'] }}
         SENSOR_REPORT_FILE: ${{ steps.generate.outputs['sensor-report'] }}
         BASELINE_REPORT_FILE: ${{ steps.generate.outputs['baseline-report'] }}
         COMMAND_STATUS: ${{ steps.generate.outputs['command-status'] }}
@@ -396,6 +430,7 @@ runs:
           echo "| Receipt | \`$(value_or_missing "$RECEIPT_FILE")\` |"
           echo "| Gate verdict | \`$(value_or_missing "$GATE_VERDICT_FILE")\` |"
           echo "| Cockpit report | \`$(value_or_missing "$COCKPIT_REPORT_FILE")\` |"
+          echo "| Review packet | \`$(value_or_missing "$REVIEW_PACKET_DIR")\` |"
           echo "| Sensor report | \`$(value_or_missing "$SENSOR_REPORT_FILE")\` |"
           echo "| Baseline report | \`$(value_or_missing "$BASELINE_REPORT_FILE")\` |"
           echo

--- a/action.yml
+++ b/action.yml
@@ -322,6 +322,10 @@ runs:
             )
 
             if [ "$review_packet" = "true" ]; then
+              if ! tokmd cockpit --help | grep -q -- '--review-packet-dir'; then
+                echo "::error::review-packet=true requires a tokmd binary that supports cockpit --review-packet-dir. Set version to a compatible release or install a matching tokmd before running the Action."
+                exit 1
+              fi
               review_packet_dir=".tokmd/review"
               summary_file="$review_packet_dir/comment.md"
               cockpit_args+=(--review-packet-dir "$review_packet_dir")

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -60,6 +60,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The proof executor workflow now runs on pull requests as `Scoped Coverage Executor (Non-Required)`. It remains outside the required CI aggregate, executes only planner-selected non-required coverage commands, keeps Codecov upload manual-only, and leaves existing proof jobs authoritative.
 - `tokmd cockpit --review-packet-dir <dir>` now emits the cockpit review packet while leaving default stdout and the existing `--artifacts-dir` director contract unchanged.
 - The cockpit review packet now includes `review-map.json` / `review-map.md` generated from the existing cockpit `review_plan`, giving packet consumers a stable prioritized review map without introducing a separate `tokmd review` command.
+- The composite GitHub Action now exposes an opt-in cockpit `review-packet` input. In `mode: cockpit`, `review-packet: true` writes `.tokmd/review`, exposes it as the `review-packet` output, and uses `.tokmd/review/comment.md` as the optional pull request comment body.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -77,6 +77,7 @@ If `version` does not start with `v`, the Action prepends it before downloading 
 | `head` | no | `HEAD` | Head git ref for `cockpit` and `sensor`. |
 | `artifact` | no | `true` | Upload generated tokmd files as workflow artifacts. |
 | `comment` | no | `true` | Post the generated Markdown summary as a pull request comment when running on `pull_request` events. |
+| `review-packet` | no | `false` | For `mode: cockpit`, also emit the cockpit review packet directory and use its `comment.md` as the Markdown summary/comment body. |
 
 ## Outputs
 
@@ -86,6 +87,7 @@ If `version` does not start with `v`, the Action prepends it before downloading 
 | `summary` | Path to `tokmd-summary.md`, `comment.md`, or another mode-specific Markdown summary when one is produced. |
 | `gate-verdict` | Path to `tokmd-gate-verdict.json` when `mode: gate` is used. |
 | `cockpit-report` | Path to `tokmd-cockpit-report.json` when `mode: cockpit` is used. |
+| `review-packet` | Path to `.tokmd/review` when `mode: cockpit` and `review-packet: 'true'` are used. |
 | `sensor-report` | Path to `tokmd-sensor-report.json` when `mode: sensor` is used. |
 | `baseline-report` | Path to `tokmd-baseline.json` when `mode: baseline` is used. |
 
@@ -122,6 +124,11 @@ Runs `tokmd cockpit --format json` and writes `tokmd-cockpit-report.json`.
 
 If `base` is omitted, the Action infers a repository-aware base ref. Set `base` only when you want to override that inference.
 
+When `review-packet: 'true'`, cockpit mode also runs with
+`--review-packet-dir .tokmd/review`. The `review-packet` output points to that
+directory, and the `summary` output points to `.tokmd/review/comment.md` so the
+existing `comment` input can post the packet summary on pull requests.
+
 ### `sensor`
 
 Runs `tokmd sensor --format json` and writes:
@@ -148,6 +155,7 @@ Artifact candidates include:
 - `tokmd-receipt.*`
 - `tokmd-gate-verdict.json`
 - `tokmd-cockpit-report.json`
+- `.tokmd/review`
 - `tokmd-sensor-report.json`
 - `tokmd-baseline.json`
 - `comment.md`
@@ -165,7 +173,7 @@ permissions:
 
 Commenting only runs on `pull_request` events. Set `comment: 'false'` for scheduled jobs, push jobs, private smoke tests, or workflows where comments are not desired.
 
-The default flow comments with `tokmd-summary.md`. `sensor` comments with `comment.md`. JSON-only modes such as `gate`, `cockpit`, and `baseline` normally leave the `summary` output empty.
+The default flow comments with `tokmd-summary.md`. `sensor` comments with `comment.md`. JSON-only modes such as `gate`, `cockpit`, and `baseline` normally leave the `summary` output empty. `cockpit` with `review-packet: 'true'` comments with `.tokmd/review/comment.md`.
 
 ## Checkout Guidance
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -126,17 +126,17 @@ behavior.
 
 ## GitHub Action Behavior
 
-The Action should upload the packet as an artifact before any optional comment
-step. Comment posting must remain fork-safe and must not be required for packet
-generation.
+The Action uploads the packet as an artifact when `artifact: 'true'` and
+`review-packet: 'true'` are both set. Comment posting remains fork-safe and is
+not required for packet generation.
 
-Future Action inputs should build on the cockpit surface first:
+Action inputs build on the cockpit surface first:
 
 ```yaml
 mode: cockpit
 review-packet: true
-post-comment: true
-upload-artifacts: true
+comment: true
+artifact: true
 ```
 
 Do not add `mode: review` until there is a distinct review orchestrator contract


### PR DESCRIPTION
## Summary
- add an opt-in `review-packet` input/output to the composite action for `mode: cockpit`
- generate `.tokmd/review` via `tokmd cockpit --review-packet-dir` while preserving `tokmd-cockpit-report.json`
- make the packet `comment.md` feed the existing `summary`/comment path when enabled, and cover it in the action self-test workflow

## Validation
- python YAML safe_load for `action.yml`, `.github/workflows/test-action.yml`, `.github/workflows/cockpit.yml`
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo xtask docs --check
- cargo test -p tokmd --test docs --verbose
- cargo test -p xtask affected --verbose
- cargo test -p xtask fixture_blob --verbose
- cargo test -p xtask proof_artifacts --verbose
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask proof_policy --verbose
- cargo xtask proof-policy --check
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo fmt-check
- git diff --check