### PR TITLE
feat: emit browser worker progress events

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -61,6 +61,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `tokmd cockpit --review-packet-dir <dir>` now emits the cockpit review packet while leaving default stdout and the existing `--artifacts-dir` director contract unchanged.
 - The cockpit review packet now includes `review-map.json` / `review-map.md` generated from the existing cockpit `review_plan`, giving packet consumers a stable prioritized review map without introducing a separate `tokmd review` command.
 - The composite GitHub Action now exposes an opt-in cockpit `review-packet` input. In `mode: cockpit`, `review-packet: true` writes `.tokmd/review`, exposes it as the `review-packet` output, and uses `.tokmd/review/comment.md` as the optional pull request comment body.
+- Browser worker protocol v2 now emits run progress messages for in-memory worker execution. Worker runs produce `start`, `scan` or `analyze`, `done`, and `error` progress phases while keeping cancellation explicitly unavailable.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -15,6 +15,7 @@ Use this project when you want `tokmd` inside a browser worker, backed by
 - runtime validation and protocol handling in `runtime.js`
 - public GitHub repo ingestion through browser-safe tree + contents APIs
 - `lang`, `module`, `export`, and `analyze` with `receipt` or `estimate`
+- worker run progress events for `start`, `scan` or `analyze`, `done`, and `error`
 - `cancel` reserved in the protocol but not wired yet
 - live result panes with downloadable JSON artifacts
 

--- a/web/runner/index.html
+++ b/web/runner/index.html
@@ -15,8 +15,8 @@
           This page boots <code>tokmd-wasm</code> inside a dedicated Worker and
           exercises the current browser-safe in-memory modes. Public GitHub repo
           fetch now uses browser-safe tree and contents APIs. Repo-load progress
-          and cancel are wired in the main thread, while worker run-cancel stays
-          explicitly unavailable.
+          and cancel are wired in the main thread, worker runs emit progress,
+          and worker run-cancel stays explicitly unavailable.
         </p>
       </section>
 

--- a/web/runner/main.js
+++ b/web/runner/main.js
@@ -284,6 +284,26 @@ function describeLoadError(error) {
         : error.message;
 }
 
+function describeWorkerProgress(message) {
+    if (typeof message.message === "string" && message.message.trim()) {
+        return message.message;
+    }
+
+    return message.phase ? `worker ${message.phase}` : "worker progress";
+}
+
+function workerProgressTone(phase) {
+    if (phase === "done") {
+        return "success";
+    }
+
+    if (phase === "error") {
+        return "error";
+    }
+
+    return "working";
+}
+
 function renderLoadProgress(update = null) {
     if (!update) {
         loadProgressPanel.hidden = true;
@@ -413,6 +433,15 @@ worker.addEventListener("message", (event) => {
                     : "worker ready",
                 "success"
             );
+            break;
+        case MESSAGE_TYPES.PROGRESS:
+            if (!message.requestId || state.activeRequestId === message.requestId) {
+                setStatus(
+                    runStatusOutput,
+                    describeWorkerProgress(message),
+                    workerProgressTone(message.phase)
+                );
+            }
             break;
         case MESSAGE_TYPES.RESULT:
             if (state.activeRequestId === message.requestId) {

--- a/web/runner/messages.js
+++ b/web/runner/messages.js
@@ -1,8 +1,9 @@
-export const RUNNER_PROTOCOL_VERSION = 1;
+export const RUNNER_PROTOCOL_VERSION = 2;
 
 export const MESSAGE_TYPES = Object.freeze({
     READY: "ready",
     RUN: "run",
+    PROGRESS: "progress",
     RESULT: "result",
     ERROR: "error",
     CANCEL: "cancel",
@@ -62,6 +63,33 @@ export function createCancelMessage(requestId) {
         type: MESSAGE_TYPES.CANCEL,
         requestId,
     };
+}
+
+export function createProgressMessage(requestId, phase, options = {}) {
+    const { mode = null, message = null, current = null, total = null } = options;
+    const progress = {
+        type: MESSAGE_TYPES.PROGRESS,
+        requestId,
+        phase,
+    };
+
+    if (mode) {
+        progress.mode = mode;
+    }
+
+    if (message) {
+        progress.message = message;
+    }
+
+    if (Number.isFinite(current)) {
+        progress.current = current;
+    }
+
+    if (Number.isFinite(total)) {
+        progress.total = total;
+    }
+
+    return progress;
 }
 
 export function createResultMessage(requestId, data) {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -8,6 +8,7 @@ import {
     SUPPORTED_ANALYZE_PRESETS,
     SUPPORTED_MODES,
     createCancelMessage,
+    createProgressMessage,
     createReadyMessage,
     createRunMessage,
     isCancelMessage,
@@ -45,6 +46,7 @@ test("ready message exposes protocol version and capabilities", () => {
     );
     assert.equal(message.capabilities.wasm, false);
     assert.equal(message.capabilities.zipball, false);
+    assert.equal(message.capabilities.progress, false);
 });
 
 test("supported modes stay aligned with the WASM capability matrix", () => {
@@ -111,6 +113,25 @@ test("run and cancel helpers produce valid protocol messages", () => {
     assert.equal(isRunMessage(run), true);
     assert.equal(isCancelMessage(cancel), true);
     assert.equal(isRunMessage(cancel), false);
+});
+
+test("progress helper produces protocol messages with stable fields", () => {
+    const message = createProgressMessage("run-1", "scan", {
+        mode: "lang",
+        message: "Scanning inputs",
+        current: 1,
+        total: 3,
+    });
+
+    assert.deepEqual(message, {
+        type: MESSAGE_TYPES.PROGRESS,
+        requestId: "run-1",
+        phase: "scan",
+        mode: "lang",
+        message: "Scanning inputs",
+        current: 1,
+        total: 3,
+    });
 });
 
 test("run messages require explicit in-memory inputs", () => {

--- a/web/runner/runtime.js
+++ b/web/runner/runtime.js
@@ -3,6 +3,7 @@ import {
     SUPPORTED_ANALYZE_PRESETS,
     SUPPORTED_MODES,
     createErrorMessage,
+    createProgressMessage,
     createResultMessage,
     normalizeAnalyzePreset,
     isCancelMessage,
@@ -68,11 +69,22 @@ async function invokeRunner(runner, mode, args) {
     }
 }
 
+function progressPhaseForMode(mode) {
+    return mode === "analyze" ? "analyze" : "scan";
+}
+
+function emitProgress(onProgress, message) {
+    if (typeof onProgress === "function") {
+        onProgress(message);
+    }
+}
+
 export async function handleRunnerMessage(message, options = {}) {
     const {
         runner = null,
         bootError = null,
         runnerCapabilities = null,
+        onProgress = null,
     } = options;
 
     if (isCancelMessage(message)) {
@@ -138,10 +150,38 @@ export async function handleRunnerMessage(message, options = {}) {
     }
 
     try {
+        emitProgress(
+            onProgress,
+            createProgressMessage(message.requestId, "start", {
+                mode: message.mode,
+                message: `Starting ${message.mode} run`,
+            })
+        );
+        emitProgress(
+            onProgress,
+            createProgressMessage(message.requestId, progressPhaseForMode(message.mode), {
+                mode: message.mode,
+                message: `Running ${message.mode}`,
+            })
+        );
         const data = await invokeRunner(runner, message.mode, message.args);
+        emitProgress(
+            onProgress,
+            createProgressMessage(message.requestId, "done", {
+                mode: message.mode,
+                message: `Completed ${message.mode} run`,
+            })
+        );
         return createResultMessage(message.requestId, data);
     } catch (error) {
         const extracted = extractRunnerError(error);
+        emitProgress(
+            onProgress,
+            createProgressMessage(message.requestId, "error", {
+                mode: message.mode,
+                message: extracted.message,
+            })
+        );
         return createErrorMessage(
             message.requestId,
             extracted.code,

--- a/web/runner/runtime.test.mjs
+++ b/web/runner/runtime.test.mjs
@@ -376,6 +376,7 @@ test("runtime applies bracket format codes over duck-typed codes", async () => {
 });
 
 test("runtime returns results once a runner is available", async () => {
+    const progress = [];
     const message = await handleRunnerMessage(
         createRunMessage({
             requestId: "run-8",
@@ -384,16 +385,28 @@ test("runtime returns results once a runner is available", async () => {
                 inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
             },
         }),
-        { runner: createStubRunner() }
+        {
+            runner: createStubRunner(),
+            onProgress: (update) => progress.push(update),
+        }
     );
 
     assert.equal(message.type, MESSAGE_TYPES.RESULT);
     assert.equal(message.requestId, "run-8");
     assert.equal(message.data.mode, "lang");
     assert.equal(message.data.total.files, 1);
+    assert.deepEqual(
+        progress.map((update) => update.phase),
+        ["start", "scan", "done"]
+    );
+    assert.deepEqual(
+        progress.map((update) => update.type),
+        [MESSAGE_TYPES.PROGRESS, MESSAGE_TYPES.PROGRESS, MESSAGE_TYPES.PROGRESS]
+    );
 });
 
 test("analyze without preset defaults to receipt and returns a result", async () => {
+    const progress = [];
     const message = await handleRunnerMessage(
         createRunMessage({
             requestId: "run-9",
@@ -402,13 +415,20 @@ test("analyze without preset defaults to receipt and returns a result", async ()
                 inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
             },
         }),
-        { runner: createStubRunner() }
+        {
+            runner: createStubRunner(),
+            onProgress: (update) => progress.push(update),
+        }
     );
 
     assert.equal(message.type, MESSAGE_TYPES.RESULT);
     assert.equal(message.requestId, "run-9");
     assert.equal(message.data.mode, "analysis");
     assert.equal(message.data.preset, "receipt");
+    assert.deepEqual(
+        progress.map((update) => update.phase),
+        ["start", "analyze", "done"]
+    );
 });
 
 test("analyze rejects unsupported presets before runner execution", async () => {
@@ -443,4 +463,35 @@ test("runtime reports boot failures against run requests", async () => {
     assert.equal(message.type, MESSAGE_TYPES.ERROR);
     assert.equal(message.error.code, "wasm_boot_failed");
     assert.match(message.error.message, /missing tokmd_wasm\.js/);
+});
+
+test("runtime emits error progress when runner execution fails", async () => {
+    const progress = [];
+    const runner = {
+        runExport() {
+            throw new Error("[invalid_settings] Cannot use both paths and inputs");
+        },
+    };
+
+    const message = await handleRunnerMessage(
+        createRunMessage({
+            requestId: "run-progress-error",
+            mode: "export",
+            args: {
+                inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+            },
+        }),
+        {
+            runner,
+            onProgress: (update) => progress.push(update),
+        }
+    );
+
+    assert.equal(message.type, MESSAGE_TYPES.ERROR);
+    assert.equal(message.error.code, "invalid_settings");
+    assert.deepEqual(
+        progress.map((update) => update.phase),
+        ["start", "scan", "error"]
+    );
+    assert.match(progress.at(-1).message, /Cannot use both paths and inputs/);
 });

--- a/web/runner/worker.js
+++ b/web/runner/worker.js
@@ -235,6 +235,7 @@ const runnerReady = loadTokmdRunner()
                 capabilities: {
                     wasm: true,
                     downloads: true,
+                    progress: true,
                     modes: loadedRunner.capabilities.modes,
                     analyzePresets: loadedRunner.capabilities.analyzePresets,
                 },
@@ -261,6 +262,7 @@ subscribe((message) => {
             runner,
             runnerCapabilities: runner?.capabilities ?? {},
             bootError,
+            onProgress: emitMessage,
         }));
     });
 });

--- a/web/runner/worker.test.mjs
+++ b/web/runner/worker.test.mjs
@@ -32,6 +32,19 @@ function onceMessage(worker) {
     });
 }
 
+async function nextMessageOfType(worker, type) {
+    const messages = [];
+
+    while (true) {
+        const message = await onceMessage(worker);
+        messages.push(message);
+
+        if (message.type === type) {
+            return { message, messages };
+        }
+    }
+}
+
 function createMockWasmBundle(options = {}) {
     const tempDir = mkdtempSync(join(tmpdir(), "tokmd-mock-wasm-"));
     const wasmModulePath = join(tempDir, "tokmd_wasm.js");
@@ -131,6 +144,7 @@ test("worker publishes ready on boot", async () => {
         assert.equal(message.type, MESSAGE_TYPES.READY);
         assert.equal(message.capabilities.cancel, false);
         assert.equal(message.capabilities.downloads, true);
+        assert.equal(message.capabilities.progress, true);
         assert.equal(message.capabilities.wasm, true);
         assert.equal(message.engine.version, "stub");
         assert.deepEqual(message.capabilities.modes, ["lang", "module", "export", "analyze"]);
@@ -163,11 +177,29 @@ test("worker forwards nested scan inputs through the stub runner", async () => {
             },
         });
 
-        const result = await onceMessage(worker);
+        const { message: result, messages } = await nextMessageOfType(
+            worker,
+            MESSAGE_TYPES.RESULT
+        );
         assert.equal(result.type, MESSAGE_TYPES.RESULT);
         assert.equal(result.requestId, "stub-scan-inputs");
         assert.equal(result.data.mode, "analysis");
         assert.deepEqual(result.data.source.inputs, ["src/lib.rs"]);
+        assert.deepEqual(
+            messages.map((message) => message.type),
+            [
+                MESSAGE_TYPES.PROGRESS,
+                MESSAGE_TYPES.PROGRESS,
+                MESSAGE_TYPES.PROGRESS,
+                MESSAGE_TYPES.RESULT,
+            ]
+        );
+        assert.deepEqual(
+            messages
+                .filter((message) => message.type === MESSAGE_TYPES.PROGRESS)
+                .map((message) => message.phase),
+            ["start", "analyze", "done"]
+        );
     } finally {
         await worker.terminate();
     }
@@ -195,7 +227,7 @@ test("worker advertises only supported modes from a minimal wasm module", async 
             },
         });
 
-        const result = await onceMessage(worker);
+        const { message: result } = await nextMessageOfType(worker, MESSAGE_TYPES.RESULT);
         assert.equal(result.type, MESSAGE_TYPES.RESULT);
         assert.equal(result.requestId, "mock-minimal");
         assert.equal(result.data.mode, "lang");
@@ -329,7 +361,7 @@ test("worker forwards run messages through the runtime", async () => {
             },
         });
 
-        const message = await onceMessage(worker);
+        const { message } = await nextMessageOfType(worker, MESSAGE_TYPES.RESULT);
 
         assert.equal(message.type, MESSAGE_TYPES.RESULT);
         assert.equal(message.requestId, "run-3");
@@ -345,6 +377,7 @@ test(
     async (t) => {
         if (!HAS_REAL_WASM_BUNDLE) {
             t.skip("built tokmd-wasm bundle not present");
+            return;
         }
 
         const worker = new Worker(new URL("./worker.js", import.meta.url), {
@@ -369,7 +402,10 @@ test(
                 },
             });
 
-            const result = await onceMessage(worker);
+            const { message: result } = await nextMessageOfType(
+                worker,
+                MESSAGE_TYPES.RESULT
+            );
 
             assert.equal(result.type, MESSAGE_TYPES.RESULT);
             assert.equal(result.requestId, "run-real-lang");
@@ -387,7 +423,10 @@ test(
                 },
             });
 
-            const analyze = await onceMessage(worker);
+            const { message: analyze } = await nextMessageOfType(
+                worker,
+                MESSAGE_TYPES.RESULT
+            );
 
             assert.equal(analyze.type, MESSAGE_TYPES.RESULT);
             assert.equal(analyze.requestId, "run-real-estimate");


### PR DESCRIPTION
## Summary

- bump the browser runner protocol to v2 with explicit `progress` messages
- emit worker run progress for `start`, `scan`/`analyze`, `done`, and `error` phases before final result/error messages
- surface worker progress in the browser runner UI and document the runner capability

## Validation

- `npm --prefix web/runner test`
- `npm --prefix web/runner run check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask proof-policy --check`
- `git diff --check origin/main..HEAD`