### PR TITLE
feat: add browser token session UX

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -62,6 +62,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The cockpit review packet now includes `review-map.json` / `review-map.md` generated from the existing cockpit `review_plan`, giving packet consumers a stable prioritized review map without introducing a separate `tokmd review` command.
 - The composite GitHub Action now exposes an opt-in cockpit `review-packet` input. In `mode: cockpit`, `review-packet: true` writes `.tokmd/review`, exposes it as the `review-packet` output, and uses `.tokmd/review/comment.md` as the optional pull request comment body.
 - Browser worker protocol v2 now emits run progress messages for in-memory worker execution. Worker runs produce `start`, `scan` or `analyze`, `done`, and `error` progress phases while keeping cancellation explicitly unavailable.
+- Browser runner GitHub token UX now uses session-only storage, shows anonymous/authenticated state without exposing the raw token, and provides an explicit clear-token action.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -16,6 +16,7 @@ Use this project when you want `tokmd` inside a browser worker, backed by
 - public GitHub repo ingestion through browser-safe tree + contents APIs
 - `lang`, `module`, `export`, and `analyze` with `receipt` or `estimate`
 - worker run progress events for `start`, `scan` or `analyze`, `done`, and `error`
+- session-only GitHub token UX with explicit clear behavior
 - `cancel` reserved in the protocol but not wired yet
 - live result panes with downloadable JSON artifacts
 

--- a/web/runner/auth.js
+++ b/web/runner/auth.js
@@ -1,0 +1,61 @@
+export const GITHUB_TOKEN_STORAGE_KEY = "tokmd.githubToken";
+
+function normalizeToken(value) {
+    return typeof value === "string" ? value.trim() : "";
+}
+
+export function resolveSessionStorage(source = globalThis) {
+    try {
+        return source?.sessionStorage ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export function readSessionToken(storage) {
+    if (!storage || typeof storage.getItem !== "function") {
+        return "";
+    }
+
+    try {
+        return normalizeToken(storage.getItem(GITHUB_TOKEN_STORAGE_KEY));
+    } catch {
+        return "";
+    }
+}
+
+export function writeSessionToken(storage, value) {
+    const token = normalizeToken(value);
+
+    if (!storage) {
+        return token;
+    }
+
+    try {
+        if (token && typeof storage.setItem === "function") {
+            storage.setItem(GITHUB_TOKEN_STORAGE_KEY, token);
+        } else if (typeof storage.removeItem === "function") {
+            storage.removeItem(GITHUB_TOKEN_STORAGE_KEY);
+        }
+    } catch {
+        // Browsers can block sessionStorage; keep the in-memory field usable.
+    }
+
+    return token;
+}
+
+export function clearSessionToken(storage) {
+    if (!storage || typeof storage.removeItem !== "function") {
+        return;
+    }
+
+    try {
+        storage.removeItem(GITHUB_TOKEN_STORAGE_KEY);
+    } catch {
+        // Browser storage failures should not block clearing the visible field.
+    }
+}
+
+export function authModeForToken(value) {
+    return normalizeToken(value) ? "authenticated" : "anonymous";
+}

--- a/web/runner/auth.test.mjs
+++ b/web/runner/auth.test.mjs
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    GITHUB_TOKEN_STORAGE_KEY,
+    authModeForToken,
+    clearSessionToken,
+    readSessionToken,
+    resolveSessionStorage,
+    writeSessionToken,
+} from "./auth.js";
+
+function createMemoryStorage() {
+    const values = new Map();
+
+    return {
+        getItem(key) {
+            return values.has(key) ? values.get(key) : null;
+        },
+        removeItem(key) {
+            values.delete(key);
+        },
+        setItem(key, value) {
+            values.set(key, String(value));
+        },
+    };
+}
+
+test("session token helpers read, trim, write, and clear token values", () => {
+    const storage = createMemoryStorage();
+
+    assert.equal(readSessionToken(storage), "");
+    assert.equal(writeSessionToken(storage, "  ghp_example  "), "ghp_example");
+    assert.equal(storage.getItem(GITHUB_TOKEN_STORAGE_KEY), "ghp_example");
+    assert.equal(readSessionToken(storage), "ghp_example");
+
+    assert.equal(writeSessionToken(storage, "   "), "");
+    assert.equal(storage.getItem(GITHUB_TOKEN_STORAGE_KEY), null);
+
+    writeSessionToken(storage, "second");
+    clearSessionToken(storage);
+    assert.equal(readSessionToken(storage), "");
+});
+
+test("session token helpers tolerate unavailable storage", () => {
+    const throwingStorage = {
+        getItem() {
+            throw new Error("blocked");
+        },
+        removeItem() {
+            throw new Error("blocked");
+        },
+        setItem() {
+            throw new Error("blocked");
+        },
+    };
+
+    assert.equal(readSessionToken(throwingStorage), "");
+    assert.equal(writeSessionToken(throwingStorage, " token "), "token");
+    assert.doesNotThrow(() => clearSessionToken(throwingStorage));
+
+    assert.equal(resolveSessionStorage({}), null);
+    assert.equal(
+        resolveSessionStorage({
+            get sessionStorage() {
+                throw new Error("blocked");
+            },
+        }),
+        null,
+    );
+});
+
+test("auth mode never exposes token text", () => {
+    assert.equal(authModeForToken(""), "anonymous");
+    assert.equal(authModeForToken("   "), "anonymous");
+    assert.equal(authModeForToken("ghp_secret_value"), "authenticated");
+});

--- a/web/runner/index.html
+++ b/web/runner/index.html
@@ -38,6 +38,10 @@
               <div class="field">
                 <label for="token">GitHub Token</label>
                 <input id="token" data-token type="password" value="" placeholder="Optional PAT for higher limits" autocomplete="off" spellcheck="false">
+                <div class="token-controls">
+                  <span class="auth-state" data-auth-state>anonymous</span>
+                  <button class="secondary ghost" type="button" data-clear-token disabled>Clear Token</button>
+                </div>
               </div>
             </div>
 

--- a/web/runner/main.js
+++ b/web/runner/main.js
@@ -3,12 +3,21 @@ import {
     createRunMessage,
     MESSAGE_TYPES,
 } from "./messages.js";
+import {
+    authModeForToken,
+    clearSessionToken,
+    readSessionToken,
+    resolveSessionStorage,
+    writeSessionToken,
+} from "./auth.js";
 import { fetchGitHubRepoInputs } from "./ingest.js";
 import { isProtocolMessage } from "./runtime.js";
 
 const repoInput = document.querySelector("[data-repo]");
 const refInput = document.querySelector("[data-ref]");
 const tokenInput = document.querySelector("[data-token]");
+const clearTokenButton = document.querySelector("[data-clear-token]");
+const authStateOutput = document.querySelector("[data-auth-state]");
 const modeInput = document.querySelector("[data-mode]");
 const argsInput = document.querySelector("[data-args]");
 const loadRepoButton = document.querySelector("[data-load-repo]");
@@ -157,6 +166,21 @@ function updateRepoLoadControls() {
     repoInput.disabled = loading;
     refInput.disabled = loading;
     tokenInput.disabled = loading;
+    clearTokenButton.disabled = loading || authModeForToken(tokenInput.value) === "anonymous";
+}
+
+function syncTokenState({ persist = true } = {}) {
+    const storage = resolveSessionStorage();
+    const token = persist
+        ? writeSessionToken(storage, tokenInput.value)
+        : readSessionToken(storage);
+
+    if (!persist) {
+        tokenInput.value = token;
+    }
+
+    authStateOutput.textContent = authModeForToken(token);
+    updateRepoLoadControls();
 }
 
 function artifactFileName(data) {
@@ -579,6 +603,17 @@ cancelLoadButton.addEventListener("click", () => {
     setStatus(loadStatusOutput, "canceling repo load...", "warning");
 });
 
+tokenInput.addEventListener("input", () => {
+    syncTokenState();
+});
+
+clearTokenButton.addEventListener("click", () => {
+    tokenInput.value = "";
+    clearSessionToken(resolveSessionStorage());
+    syncTokenState({ persist: false });
+    setStatus(loadStatusOutput, "GitHub token cleared", "neutral");
+});
+
 window.addEventListener("beforeunload", () => {
     clearDownloadUrl();
 });
@@ -638,6 +673,7 @@ downloadButton.addEventListener("click", () => {
 
 setStatus(loadStatusOutput, "repo load idle", "neutral");
 setStatus(runStatusOutput, "starting worker...", "neutral");
+syncTokenState({ persist: false });
 renderRepoCapabilities();
 renderIngestSummary();
 updateRepoLoadControls();

--- a/web/runner/styles.css
+++ b/web/runner/styles.css
@@ -128,6 +128,20 @@ h1 {
     color: var(--muted);
 }
 
+.token-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.auth-state {
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0;
+}
+
 select,
 input,
 textarea,


### PR DESCRIPTION
## Summary
- add session-only GitHub token persistence helpers for the browser runner
- show anonymous/authenticated token state without exposing the raw token
- add an explicit clear-token action and focused helper tests

## Validation
- npm --prefix web/runner test
- npm --prefix web/runner run check
- cargo xtask docs --check
- cargo fmt-check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask --verbose
- cargo xtask proof-policy --check
- git diff --check origin/main..HEAD