### PR TITLE
feat: add browser rate-limit retry UX

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -63,6 +63,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The composite GitHub Action now exposes an opt-in cockpit `review-packet` input. In `mode: cockpit`, `review-packet: true` writes `.tokmd/review`, exposes it as the `review-packet` output, and uses `.tokmd/review/comment.md` as the optional pull request comment body.
 - Browser worker protocol v2 now emits run progress messages for in-memory worker execution. Worker runs produce `start`, `scan` or `analyze`, `done`, and `error` progress phases while keeping cancellation explicitly unavailable.
 - Browser runner GitHub token UX now uses session-only storage, shows anonymous/authenticated state without exposing the raw token, and provides an explicit clear-token action.
+- Browser GitHub ingest now surfaces numeric or HTTP-date `Retry-After` guidance in the UI and enables a manual retry action only for retryable GitHub rate-limit failures.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -17,6 +17,7 @@ Use this project when you want `tokmd` inside a browser worker, backed by
 - `lang`, `module`, `export`, and `analyze` with `receipt` or `estimate`
 - worker run progress events for `start`, `scan` or `analyze`, `done`, and `error`
 - session-only GitHub token UX with explicit clear behavior
+- explicit GitHub rate-limit retry guidance and a manual repo-load retry action
 - `cancel` reserved in the protocol but not wired yet
 - live result panes with downloadable JSON artifacts
 

--- a/web/runner/index.html
+++ b/web/runner/index.html
@@ -62,6 +62,7 @@
 
             <div class="actions">
               <button class="secondary" type="button" data-load-repo>Load GitHub Repo</button>
+              <button class="secondary" type="button" data-retry-load disabled>Retry Repo Load</button>
               <button class="secondary" type="button" data-cancel-load disabled>Cancel Repo Load</button>
               <button class="primary" type="button" data-run>Send Run</button>
               <button class="secondary" type="button" data-cancel disabled>Send Cancel</button>

--- a/web/runner/ingest.js
+++ b/web/runner/ingest.js
@@ -328,14 +328,38 @@ function withAbortSignal(promise, signal) {
     });
 }
 
-function parseRetryAfterSeconds(headers) {
+function parseRetryAfter(headers) {
     const raw = headers.get("retry-after");
     if (!raw) {
-        return null;
+        return {
+            retryAfterSeconds: null,
+            retryAt: null,
+        };
     }
 
-    const value = Number(raw);
-    return Number.isFinite(value) && value >= 0 ? value : null;
+    const seconds = Number(raw);
+    if (Number.isFinite(seconds)) {
+        return seconds >= 0
+            ? {
+                  retryAfterSeconds: Math.floor(seconds),
+                  retryAt: null,
+              }
+            : {
+                  retryAfterSeconds: null,
+                  retryAt: null,
+              };
+    }
+
+    const epochMs = Date.parse(raw);
+    return Number.isFinite(epochMs)
+        ? {
+              retryAfterSeconds: null,
+              retryAt: new Date(epochMs).toISOString(),
+          }
+        : {
+              retryAfterSeconds: null,
+              retryAt: null,
+          };
 }
 
 function parseRateLimitResetAt(headers) {
@@ -437,11 +461,12 @@ async function fetchWithRateLimitMessage(fetchImpl, url, options = {}) {
     const authMode = options.authMode ?? "anonymous";
     const message = await readResponseMessage(response);
     const remaining = response.headers.get("x-ratelimit-remaining");
-    const retryAfterSeconds = parseRetryAfterSeconds(response.headers);
+    const { retryAfterSeconds, retryAt } = parseRetryAfter(response.headers);
     const resetAt = parseRateLimitResetAt(response.headers);
     const secondaryLimited =
         response.status === 429 ||
         retryAfterSeconds !== null ||
+        retryAt !== null ||
         /secondary rate limit/i.test(message);
 
     if (response.status === 401) {
@@ -482,10 +507,13 @@ async function fetchWithRateLimitMessage(fetchImpl, url, options = {}) {
             "github_secondary_rate_limit",
             retryAfterSeconds !== null
                 ? `GitHub asked the browser runner to slow down. Retry after ${retryAfterSeconds}s.`
+                : retryAt !== null
+                  ? `GitHub asked the browser runner to slow down. Retry after ${retryAt}.`
                 : message || "GitHub temporarily rate-limited this browser repo load.",
             {
                 status: response.status,
                 retryAfterSeconds,
+                retryAt,
             }
         );
     }

--- a/web/runner/ingest.test.mjs
+++ b/web/runner/ingest.test.mjs
@@ -435,6 +435,25 @@ test("fetchGitHubRepoInputs surfaces primary and secondary rate limits", async (
             error?.code === "github_secondary_rate_limit" &&
             error?.retryAfterSeconds === 12
     );
+
+    await assert.rejects(
+        () =>
+            fetchGitHubRepoInputs({
+                repo: "EffortlessMetrics/tokmd",
+                ref: "main",
+                fetchImpl: async () =>
+                    new Response(JSON.stringify({ message: "Please retry later" }), {
+                        status: 429,
+                        headers: {
+                            "content-type": "application/json",
+                            "retry-after": "Wed, 18 May 2033 03:33:20 GMT",
+                        },
+                    }),
+            }),
+        (error) =>
+            error?.code === "github_secondary_rate_limit" &&
+            error?.retryAt === "2033-05-18T03:33:20.000Z"
+    );
 });
 
 test("fetchGitHubRepoInputs honors AbortSignal before starting network work", async () => {

--- a/web/runner/main.js
+++ b/web/runner/main.js
@@ -21,6 +21,7 @@ const authStateOutput = document.querySelector("[data-auth-state]");
 const modeInput = document.querySelector("[data-mode]");
 const argsInput = document.querySelector("[data-args]");
 const loadRepoButton = document.querySelector("[data-load-repo]");
+const retryLoadButton = document.querySelector("[data-retry-load]");
 const cancelLoadButton = document.querySelector("[data-cancel-load]");
 const runButton = document.querySelector("[data-run]");
 const cancelButton = document.querySelector("[data-cancel]");
@@ -162,6 +163,7 @@ function updateDownloadButtonState() {
 function updateRepoLoadControls() {
     const loading = Boolean(state.repoLoadAbortController);
     loadRepoButton.disabled = loading;
+    retryLoadButton.disabled = loading || !isRetryableLoadError(state.latestLoadError);
     cancelLoadButton.disabled = !loading;
     repoInput.disabled = loading;
     refInput.disabled = loading;
@@ -285,9 +287,38 @@ function sanitizeErrorForLog(error) {
         status: error.status ?? null,
         resetAt: error.resetAt ?? null,
         retryAfterSeconds: error.retryAfterSeconds ?? null,
+        retryAt: error.retryAt ?? null,
         responseMessage: error.responseMessage ?? null,
         ingest: error.ingest ?? null,
     };
+}
+
+function isRetryableLoadError(error) {
+    return (
+        error instanceof Error &&
+        (error.code === "github_primary_rate_limit" ||
+            error.code === "github_secondary_rate_limit")
+    );
+}
+
+function describeRetryWindow(error) {
+    if (!(error instanceof Error)) {
+        return "";
+    }
+
+    if (error.retryAfterSeconds !== undefined && error.retryAfterSeconds !== null) {
+        return `Retry after ${error.retryAfterSeconds}s.`;
+    }
+
+    if (error.retryAt) {
+        return `Retry after ${error.retryAt}.`;
+    }
+
+    if (error.resetAt) {
+        return `Retry after GitHub resets the quota at ${error.resetAt}.`;
+    }
+
+    return "Retry when GitHub accepts more browser repo requests.";
 }
 
 function describeLoadError(error) {
@@ -306,6 +337,15 @@ function describeLoadError(error) {
     return detail.length > 0
         ? `${error.message} (${detail.join(", ")})`
         : error.message;
+}
+
+function loadErrorNoticeLines(error) {
+    const lines = [describeLoadError(error)];
+    if (isRetryableLoadError(error)) {
+        lines.push(describeRetryWindow(error));
+    }
+
+    return lines;
 }
 
 function describeWorkerProgress(message) {
@@ -359,7 +399,11 @@ function renderIngestSummary() {
 
     if (state.latestLoadError) {
         ingestSummaryOutput.append(
-            createNotice("error", "Latest repo load error", [describeLoadError(state.latestLoadError)])
+            createNotice(
+                "error",
+                "Latest repo load error",
+                loadErrorNoticeLines(state.latestLoadError)
+            )
         );
     }
 
@@ -601,6 +645,15 @@ cancelLoadButton.addEventListener("click", () => {
 
     state.repoLoadAbortController.abort();
     setStatus(loadStatusOutput, "canceling repo load...", "warning");
+});
+
+retryLoadButton.addEventListener("click", () => {
+    if (!isRetryableLoadError(state.latestLoadError)) {
+        setStatus(loadStatusOutput, "no retryable repo load error", "warning");
+        return;
+    }
+
+    loadRepoButton.click();
 });
 
 tokenInput.addEventListener("input", () => {


### PR DESCRIPTION
## Summary
- parse numeric and HTTP-date `Retry-After` values for GitHub browser ingest
- surface retry timing in the latest repo-load error notice and sanitized log payload
- add a manual retry button that is enabled only for retryable GitHub rate-limit failures

## Validation
- npm --prefix web/runner test
- npm --prefix web/runner run check
- cargo xtask docs --check
- cargo fmt-check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask --verbose
- cargo xtask proof-policy --check
- git diff --check origin/main..HEAD