### PR TITLE
chore: validate executed LCOV artifact shape

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -65,6 +65,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Browser runner GitHub token UX now uses session-only storage, shows anonymous/authenticated state without exposing the raw token, and provides an explicit clear-token action.
 - Browser GitHub ingest now surfaces numeric or HTTP-date `Retry-After` guidance in the UI and enables a manual retry action only for retryable GitHub rate-limit failures.
 - `cargo xtask proof-execution-artifacts-check` now verifies that executed entries with declared artifact paths point at existing, non-empty files, so a passing executor command cannot claim missing LCOV evidence.
+- Executed coverage artifacts now must be LCOV-shaped text with `SF:` and `end_of_record` records before `proof-execution-artifacts-check` accepts them.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -323,6 +323,11 @@ fn validate_executed_entry(index: usize, entry: &Value) -> Result<()> {
 
 fn validate_executed_artifact_path(index: usize, entry: &Value) -> Result<()> {
     let expected_index = index + 1;
+    let kind = expect_string(
+        field(entry, "kind", "executor summary entry")?,
+        "kind",
+        "executor summary entry",
+    )?;
     let artifact_path = field(entry, "artifact_path", "executor summary entry")?;
     if artifact_path.is_null() {
         return Ok(());
@@ -341,6 +346,29 @@ fn validate_executed_artifact_path(index: usize, entry: &Value) -> Result<()> {
     }
     if metadata.len() == 0 {
         bail!("executor summary entry {expected_index} artifact `{artifact_path}` is empty");
+    }
+
+    if kind == "coverage" {
+        validate_lcov_artifact(expected_index, &artifact_path)?;
+    }
+
+    Ok(())
+}
+
+fn validate_lcov_artifact(index: usize, artifact_path: &str) -> Result<()> {
+    let raw = fs::read_to_string(artifact_path).with_context(|| {
+        format!(
+            "executor summary entry {index} LCOV artifact `{artifact_path}` is not readable text"
+        )
+    })?;
+
+    if !raw.lines().any(|line| line.starts_with("SF:")) {
+        bail!("executor summary entry {index} LCOV artifact `{artifact_path}` has no `SF:` record");
+    }
+    if !raw.lines().any(|line| line == "end_of_record") {
+        bail!(
+            "executor summary entry {index} LCOV artifact `{artifact_path}` has no `end_of_record`"
+        );
     }
 
     Ok(())
@@ -622,6 +650,23 @@ mod tests {
     }
 
     #[test]
+    fn rejects_execution_artifacts_with_malformed_lcov_output() {
+        let (mut summary, mut manifest) = executed_artifacts();
+        let malformed = write_test_artifact(
+            "tokmd-malformed-proof-artifact",
+            "this is not an LCOV payload\n",
+        );
+        summary["entries"][0]["artifact_path"] = json!(malformed);
+        manifest["commands"][0]["artifact_path"] = json!(malformed);
+
+        let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::Execution)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("SF:"));
+    }
+
+    #[test]
     fn rejects_dry_run_artifacts_with_execution_verifier() {
         let (summary, manifest) = matching_artifacts();
 
@@ -664,13 +709,15 @@ mod tests {
     }
 
     fn write_test_lcov_artifact() -> String {
-        let path =
-            std::env::temp_dir().join(format!("tokmd-proof-artifact-{}.lcov", std::process::id()));
-        fs::write(
-            &path,
+        write_test_artifact(
+            "tokmd-proof-artifact",
             "TN:\nSF:crates/tokmd-core/src/ffi.rs\nend_of_record\n",
         )
-        .expect("test LCOV artifact should be writable");
+    }
+
+    fn write_test_artifact(name: &str, content: &str) -> String {
+        let path = std::env::temp_dir().join(format!("{name}-{}.lcov", std::process::id()));
+        fs::write(&path, content).expect("test artifact should be writable");
         path.to_string_lossy().to_string()
     }
 


### PR DESCRIPTION
## Summary
- require executed coverage artifacts to be LCOV-shaped text before accepting proof execution artifacts
- reject malformed LCOV payloads that lack `SF:` or `end_of_record` records
- record the proof-control-plane checkpoint in `docs/NEXT.md`

## Validation
- cargo test -p xtask proof_artifacts --verbose
- cargo fmt-check
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask --verbose
- cargo xtask proof-policy --check
- git diff --check origin/main..HEAD