### PR TITLE
chore: emit proof executor observations

### DIFF
--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -78,15 +78,25 @@ jobs:
           if [ -f target/proof/executor-summary.json ] && [ -f target/proof/executor-manifest.json ]; then
             cargo xtask proof-execution-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-execution-artifacts-check.txt 2>&1
             verifier_status=$?
+            if [ "${verifier_status}" -eq 0 ]; then
+              cargo xtask proof-execution-observation --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --output target/proof/proof-executor-observation.json > target/proof/proof-execution-observation.txt 2>&1
+              observation_status=$?
+            else
+              observation_status=1
+              echo "executor artifacts did not pass verification" > target/proof/proof-execution-observation.txt
+            fi
           else
             verifier_status=1
+            observation_status=1
             echo "executor artifacts were not generated" > target/proof/proof-execution-artifacts-check.txt
+            echo "executor artifacts were not generated" > target/proof/proof-execution-observation.txt
           fi
 
           {
             echo "affected_status=${affected_status}"
             echo "executor_status=${executor_status}"
             echo "verifier_status=${verifier_status}"
+            echo "observation_status=${observation_status}"
           } > target/proof/status.env
 
           {
@@ -97,10 +107,13 @@ jobs:
             echo "| affected | ${affected_status} |"
             echo "| proof executor | ${executor_status} |"
             echo "| execution artifact verifier | ${verifier_status} |"
+            echo "| execution observation | ${observation_status} |"
             echo ""
             echo "This is an explicitly non-required PR/manual experiment. It runs only planner-selected non-required coverage commands and does not replace required PR proof jobs."
             echo ""
             cat target/proof/proof-execution-artifacts-check.txt
+            echo ""
+            cat target/proof/proof-execution-observation.txt
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${affected_status}" -ne 0 ]; then
@@ -111,6 +124,9 @@ jobs:
           fi
           if [ "${verifier_status}" -ne 0 ]; then
             exit "${verifier_status}"
+          fi
+          if [ "${observation_status}" -ne 0 ]; then
+            exit "${observation_status}"
           fi
 
           exit 0

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -66,6 +66,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Browser GitHub ingest now surfaces numeric or HTTP-date `Retry-After` guidance in the UI and enables a manual retry action only for retryable GitHub rate-limit failures.
 - `cargo xtask proof-execution-artifacts-check` now verifies that executed entries with declared artifact paths point at existing, non-empty files, so a passing executor command cannot claim missing LCOV evidence.
 - Executed coverage artifacts now must be LCOV-shaped text with `SF:` and `end_of_record` records before `proof-execution-artifacts-check` accepts them.
+- `cargo xtask proof-execution-observation` now turns verified executed summary/manifest pairs into `proof-executor-observation.json`, a compact cross-PR observation artifact for collecting non-required executor runs without promoting them to required gates or default Codecov uploads.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -30,6 +30,8 @@ pub enum Commands {
     ProofArtifactsCheck(ProofArtifactsCheckArgs),
     /// Verify opted-in executed proof artifacts agree and passed
     ProofExecutionArtifactsCheck(ProofArtifactsCheckArgs),
+    /// Write a compact observation report for opted-in executed proof artifacts
+    ProofExecutionObservation(ProofExecutionObservationArgs),
     /// Verify all release-facing version surfaces are in sync
     VersionConsistency(VersionConsistencyArgs),
     /// Verify dependency boundaries for analysis microcrates
@@ -202,6 +204,33 @@ pub struct ProofArtifactsCheckArgs {
         default_value = "target/proof/executor-manifest.json"
     )]
     pub executor_manifest: std::path::PathBuf,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ProofExecutionObservationArgs {
+    /// Executor summary artifact to observe
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/executor-summary.json"
+    )]
+    pub executor_summary: std::path::PathBuf,
+
+    /// Executor command manifest artifact to observe
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/executor-manifest.json"
+    )]
+    pub executor_manifest: std::path::PathBuf,
+
+    /// Output path for the compact observation report
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/proof-executor-observation.json"
+    )]
+    pub output: std::path::PathBuf,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,9 @@ fn main() -> Result<()> {
         Some(cli::Commands::ProofExecutionArtifactsCheck(args)) => {
             tasks::proof_artifacts_check::run_execution(args)
         }
+        Some(cli::Commands::ProofExecutionObservation(args)) => {
+            tasks::proof_artifacts_check::run_observation(args)
+        }
         Some(cli::Commands::VersionConsistency(args)) => tasks::version_consistency::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -1,11 +1,13 @@
-use crate::cli::ProofArtifactsCheckArgs;
+use crate::cli::{ProofArtifactsCheckArgs, ProofExecutionObservationArgs};
 use anyhow::{Context, Result, bail};
+use serde::Serialize;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
 
 const SUMMARY_SCHEMA: &str = "tokmd.proof_executor_summary.v1";
 const MANIFEST_SCHEMA: &str = "tokmd.proof_executor_manifest.v1";
+const OBSERVATION_SCHEMA: &str = "tokmd.proof_executor_observation.v1";
 
 const SHARED_FIELDS: &[&str] = &[
     "mode",
@@ -57,6 +59,20 @@ pub fn run_execution(args: ProofArtifactsCheckArgs) -> Result<()> {
     Ok(())
 }
 
+pub fn run_observation(args: ProofExecutionObservationArgs) -> Result<()> {
+    let summary = read_json(&args.executor_summary, "executor summary")?;
+    let manifest = read_json(&args.executor_manifest, "executor manifest")?;
+
+    let observation = proof_execution_observation(&summary, &manifest)?;
+    write_observation(&args.output, &observation)?;
+    println!(
+        "Proof execution observation OK: {} executed command(s), wrote `{}`",
+        observation.counts.executed,
+        args.output.display()
+    );
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VerificationMode {
     NoExecution,
@@ -71,11 +87,203 @@ struct ProofArtifactsReport {
     guard_reason: String,
 }
 
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ProofExecutionObservation {
+    schema: String,
+    status: String,
+    execution_status: String,
+    profile: String,
+    base: String,
+    head: String,
+    family: String,
+    required: bool,
+    ok: bool,
+    execution_guard: ProofExecutionObservationGuard,
+    counts: ProofExecutionObservationCounts,
+    scopes: Vec<ProofExecutionObservationScope>,
+    changed_files: Vec<String>,
+    unknown_files: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ProofExecutionObservationGuard {
+    enabled: bool,
+    ci: bool,
+    reason: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ProofExecutionObservationCounts {
+    selected: usize,
+    executed: usize,
+    passed: usize,
+    failed: usize,
+    artifacts: usize,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ProofExecutionObservationScope {
+    name: String,
+    kind: String,
+    command: String,
+    artifact_path: Option<String>,
+    status: String,
+    exit_code: Option<i64>,
+}
+
 fn read_json(path: &Path, label: &str) -> Result<Value> {
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed to read {label} artifact `{}`", path.display()))?;
     serde_json::from_str(&raw)
         .with_context(|| format!("failed to parse {label} artifact `{}`", path.display()))
+}
+
+fn write_observation(path: &Path, observation: &ProofExecutionObservation) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create `{}`", parent.display()))?;
+    }
+    fs::write(path, serde_json::to_string_pretty(observation)?)
+        .with_context(|| format!("failed to write `{}`", path.display()))
+}
+
+fn proof_execution_observation(
+    summary: &Value,
+    manifest: &Value,
+) -> Result<ProofExecutionObservation> {
+    let report = validate_executor_artifacts(summary, manifest, VerificationMode::Execution)?;
+    let entries = expect_array(
+        field(summary, "entries", "executor summary")?,
+        "entries",
+        "executor summary",
+    )?;
+    let mut scopes = entries
+        .iter()
+        .map(observation_scope)
+        .collect::<Result<Vec<_>>>()?;
+    scopes.sort_by(|left, right| {
+        (&left.name, &left.kind, &left.command).cmp(&(&right.name, &right.kind, &right.command))
+    });
+    let artifacts = scopes
+        .iter()
+        .filter(|scope| scope.artifact_path.is_some())
+        .count();
+
+    Ok(ProofExecutionObservation {
+        schema: OBSERVATION_SCHEMA.to_string(),
+        status: expect_string(
+            field(summary, "status", "executor summary")?,
+            "status",
+            "executor summary",
+        )?,
+        execution_status: report.execution_status,
+        profile: expect_string(
+            field(summary, "profile", "executor summary")?,
+            "profile",
+            "executor summary",
+        )?,
+        base: expect_string(
+            field(summary, "base", "executor summary")?,
+            "base",
+            "executor summary",
+        )?,
+        head: expect_string(
+            field(summary, "head", "executor summary")?,
+            "head",
+            "executor summary",
+        )?,
+        family: expect_string(
+            field(summary, "family", "executor summary")?,
+            "family",
+            "executor summary",
+        )?,
+        required: expect_bool(
+            field(summary, "required", "executor summary")?,
+            "required",
+            "executor summary",
+        )?,
+        ok: expect_bool(
+            field(summary, "ok", "executor summary")?,
+            "ok",
+            "executor summary",
+        )?,
+        execution_guard: ProofExecutionObservationGuard {
+            enabled: expect_bool(
+                field(summary, "execution_guard.enabled", "executor summary")?,
+                "execution_guard.enabled",
+                "executor summary",
+            )?,
+            ci: expect_bool(
+                field(summary, "execution_guard.ci", "executor summary")?,
+                "execution_guard.ci",
+                "executor summary",
+            )?,
+            reason: report.guard_reason,
+        },
+        counts: ProofExecutionObservationCounts {
+            selected: report.selected,
+            executed: report.executed,
+            passed: expect_usize(
+                field(summary, "counts.passed", "executor summary")?,
+                "counts.passed",
+                "executor summary",
+            )?,
+            failed: expect_usize(
+                field(summary, "counts.failed", "executor summary")?,
+                "counts.failed",
+                "executor summary",
+            )?,
+            artifacts,
+        },
+        scopes,
+        changed_files: expect_string_array(
+            field(summary, "changed_files", "executor summary")?,
+            "changed_files",
+            "executor summary",
+        )?,
+        unknown_files: expect_string_array(
+            field(summary, "unknown_files", "executor summary")?,
+            "unknown_files",
+            "executor summary",
+        )?,
+    })
+}
+
+fn observation_scope(entry: &Value) -> Result<ProofExecutionObservationScope> {
+    Ok(ProofExecutionObservationScope {
+        name: expect_string(
+            field(entry, "scope", "executor summary entry")?,
+            "scope",
+            "executor summary entry",
+        )?,
+        kind: expect_string(
+            field(entry, "kind", "executor summary entry")?,
+            "kind",
+            "executor summary entry",
+        )?,
+        command: expect_string(
+            field(entry, "command", "executor summary entry")?,
+            "command",
+            "executor summary entry",
+        )?,
+        artifact_path: expect_optional_string(
+            field(entry, "artifact_path", "executor summary entry")?,
+            "artifact_path",
+            "executor summary entry",
+        )?,
+        status: expect_string(
+            field(entry, "status", "executor summary entry")?,
+            "status",
+            "executor summary entry",
+        )?,
+        exit_code: expect_optional_i64(
+            field(entry, "exit_code", "executor summary entry")?,
+            "exit_code",
+            "executor summary entry",
+        )?,
+    })
 }
 
 fn validate_executor_artifacts(
@@ -465,12 +673,42 @@ fn expect_string(value: &Value, path: &str, label: &str) -> Result<String> {
         .with_context(|| format!("{label} `{path}` must be a string"))
 }
 
+fn expect_optional_string(value: &Value, path: &str, label: &str) -> Result<Option<String>> {
+    if value.is_null() {
+        Ok(None)
+    } else {
+        expect_string(value, path, label).map(Some)
+    }
+}
+
 fn expect_string_value(value: &Value, expected: &str, path: &str, label: &str) -> Result<()> {
     let actual = expect_string(value, path, label)?;
     if actual != expected {
         bail!("{label} `{path}` must be `{expected}`, got `{actual}`");
     }
     Ok(())
+}
+
+fn expect_string_array(value: &Value, path: &str, label: &str) -> Result<Vec<String>> {
+    let values = expect_array(value, path, label)?;
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            expect_string(value, &format!("{path}[{index}]"), label)
+                .with_context(|| format!("{label} `{path}` entry {index} must be a string"))
+        })
+        .collect()
+}
+
+fn expect_optional_i64(value: &Value, path: &str, label: &str) -> Result<Option<i64>> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    value
+        .as_i64()
+        .map(Some)
+        .with_context(|| format!("{label} `{path}` must be an integer or null"))
 }
 
 fn expect_usize(value: &Value, path: &str, label: &str) -> Result<usize> {
@@ -595,6 +833,45 @@ mod tests {
     }
 
     #[test]
+    fn builds_compact_observation_for_executed_artifacts() {
+        let (summary, manifest) = executed_artifacts();
+
+        let observation = proof_execution_observation(&summary, &manifest).unwrap();
+
+        assert_eq!(observation.schema, OBSERVATION_SCHEMA);
+        assert_eq!(observation.status, "passed");
+        assert_eq!(observation.execution_status, "executed");
+        assert_eq!(observation.family, "coverage");
+        assert_eq!(
+            observation.execution_guard.reason,
+            "local_explicit_opt_in_enabled"
+        );
+        assert_eq!(
+            observation.counts,
+            ProofExecutionObservationCounts {
+                selected: 1,
+                executed: 1,
+                passed: 1,
+                failed: 0,
+                artifacts: 1,
+            }
+        );
+        assert_eq!(observation.changed_files, ["crates/tokmd-core/src/ffi.rs"]);
+        assert!(observation.unknown_files.is_empty());
+        assert_eq!(observation.scopes.len(), 1);
+        assert_eq!(observation.scopes[0].name, "tokmd_core_ffi");
+        assert_eq!(observation.scopes[0].kind, "coverage");
+        assert_eq!(observation.scopes[0].status, "passed");
+        assert_eq!(observation.scopes[0].exit_code, Some(0));
+        assert!(
+            observation.scopes[0]
+                .artifact_path
+                .as_ref()
+                .is_some_and(|path| path.contains("tokmd-proof-artifact"))
+        );
+    }
+
+    #[test]
     fn rejects_execution_artifacts_without_enabled_guard() {
         let (mut summary, mut manifest) = executed_artifacts();
         summary["execution_guard"]["enabled"] = json!(false);
@@ -671,6 +948,17 @@ mod tests {
         let (summary, manifest) = matching_artifacts();
 
         let error = validate_executor_artifacts(&summary, &manifest, VerificationMode::Execution)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("`mode` must be `execute`"));
+    }
+
+    #[test]
+    fn rejects_dry_run_artifacts_for_observation() {
+        let (summary, manifest) = matching_artifacts();
+
+        let error = proof_execution_observation(&summary, &manifest)
             .unwrap_err()
             .to_string();
 

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -80,6 +80,19 @@ fn proof_execution_artifacts_check_help_mentions_executor_paths() {
 }
 
 #[test]
+fn proof_execution_observation_help_mentions_executor_paths_and_output() {
+    let (stdout, stderr, success) = run_xtask(&["proof-execution-observation", "--help"]);
+
+    assert!(
+        success,
+        "proof-execution-observation --help failed. stderr: {stderr}"
+    );
+    assert!(stdout.contains("--executor-summary"), "stdout: {stdout}");
+    assert!(stdout.contains("--executor-manifest"), "stdout: {stdout}");
+    assert!(stdout.contains("--output"), "stdout: {stdout}");
+}
+
+#[test]
 fn affected_plan_ci_blocks_on_planner_generation_failures() {
     let ci = fs::read_to_string(workspace_root().join(".github/workflows/ci.yml"))
         .expect("ci workflow should be readable");
@@ -337,6 +350,34 @@ fn local_execute_can_write_zero_command_executor_artifacts() {
         stdout.contains("Proof execution artifacts OK"),
         "stdout: {stdout}"
     );
+
+    let observation_path = temp.path().join("proof-executor-observation.json");
+    let observation_arg = observation_path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-execution-observation",
+        "--executor-summary",
+        &summary_arg,
+        "--executor-manifest",
+        &manifest_arg,
+        "--output",
+        &observation_arg,
+    ]);
+    assert!(
+        success,
+        "proof-execution-observation failed. stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Proof execution observation OK"),
+        "stdout: {stdout}"
+    );
+    let observation = fs::read_to_string(observation_path).expect("observation should be written");
+    let observation: serde_json::Value =
+        serde_json::from_str(&observation).expect("observation should be valid JSON");
+    assert_eq!(observation["schema"], "tokmd.proof_executor_observation.v1");
+    assert_eq!(observation["execution_status"], "executed");
+    assert_eq!(observation["counts"]["selected"], 0);
+    assert_eq!(observation["counts"]["executed"], 0);
+    assert!(observation["scopes"].as_array().unwrap().is_empty());
 
     let (_stdout, stderr, success) = run_xtask(&[
         "proof-artifacts-check",


### PR DESCRIPTION
## Summary
- add `cargo xtask proof-execution-observation` for compact JSON observations from verified executed executor artifacts
- have the non-required proof executor workflow emit `proof-executor-observation.json` after execution artifact verification succeeds
- cover the new command with unit and integration tests, and record the checkpoint in `docs/NEXT.md`

## Validation
- cargo test -p xtask proof_artifacts --verbose
- cargo test -p xtask proof_execution_observation --verbose
- cargo test -p xtask local_execute_can_write_zero_command_executor_artifacts --verbose
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- python PyYAML parse of .github/workflows/proof-executor.yml
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo xtask docs --check
- cargo test -p xtask --verbose
- cargo xtask check-lint-policy
- cargo xtask check-no-panic-family