### PR TITLE
chore: discover proof executor observations by directory

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -67,7 +67,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof-execution-artifacts-check` now verifies that executed entries with declared artifact paths point at existing, non-empty files, so a passing executor command cannot claim missing LCOV evidence.
 - Executed coverage artifacts now must be LCOV-shaped text with `SF:` and `end_of_record` records before `proof-execution-artifacts-check` accepts them.
 - `cargo xtask proof-execution-observation` now turns verified executed summary/manifest pairs into `proof-executor-observation.json`, a compact cross-PR observation artifact for collecting non-required executor runs without promoting them to required gates or default Codecov uploads.
-- `cargo xtask proof-execution-observations-summary --observation <path>...` now summarizes downloaded executor observation artifacts by family, scope, and source run, giving maintainers a Rust-owned collection view before any required-gate or default Codecov-upload promotion.
+- `cargo xtask proof-execution-observations-summary --observation <path>...` now summarizes downloaded executor observation artifacts by family, scope, and source run, giving maintainers a Rust-owned collection view before any required-gate or default Codecov-upload promotion. It also accepts `--observations-dir <dir>` to recursively collect `proof-executor-observation.json` artifacts from downloaded GitHub run directories.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -238,12 +238,12 @@ pub struct ProofExecutionObservationArgs {
 #[derive(Args, Debug, Clone)]
 pub struct ProofExecutionObservationsSummaryArgs {
     /// Proof executor observation artifact to include. Repeat for multiple runs.
-    #[arg(
-        long = "observation",
-        value_name = "PATH",
-        default_value = "target/proof/proof-executor-observation.json"
-    )]
+    #[arg(long = "observation", value_name = "PATH")]
     pub observations: Vec<std::path::PathBuf>,
+
+    /// Directory tree to scan for proof-executor-observation.json artifacts.
+    #[arg(long = "observations-dir", value_name = "DIR")]
+    pub observation_dirs: Vec<std::path::PathBuf>,
 
     /// Output path for the collection summary. Prints JSON to stdout when omitted.
     #[arg(long, value_name = "PATH")]

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -4,9 +4,10 @@ use crate::cli::{
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
 
 const SUMMARY_SCHEMA: &str = "tokmd.proof_executor_summary.v1";
 const MANIFEST_SCHEMA: &str = "tokmd.proof_executor_manifest.v1";
@@ -78,7 +79,8 @@ pub fn run_observation(args: ProofExecutionObservationArgs) -> Result<()> {
 }
 
 pub fn run_observations_summary(args: ProofExecutionObservationsSummaryArgs) -> Result<()> {
-    let collection = proof_execution_observation_collection(&args.observations)?;
+    let observations = collect_observation_paths(&args)?;
+    let collection = proof_execution_observation_collection(&observations)?;
     let json = serde_json::to_string_pretty(&collection)?;
 
     if let Some(output) = &args.output {
@@ -367,6 +369,48 @@ fn proof_execution_observation_collection(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(summarize_observations(&observations))
+}
+
+fn collect_observation_paths(args: &ProofExecutionObservationsSummaryArgs) -> Result<Vec<PathBuf>> {
+    let mut paths = BTreeSet::new();
+
+    if args.observations.is_empty() && args.observation_dirs.is_empty() {
+        paths.insert(PathBuf::from(
+            "target/proof/proof-executor-observation.json",
+        ));
+    }
+
+    paths.extend(args.observations.iter().cloned());
+    for dir in &args.observation_dirs {
+        collect_observation_paths_from_dir(dir, &mut paths)?;
+    }
+
+    if paths.is_empty() {
+        bail!("no proof executor observation artifacts found");
+    }
+
+    Ok(paths.into_iter().collect())
+}
+
+fn collect_observation_paths_from_dir(dir: &Path, paths: &mut BTreeSet<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        bail!(
+            "observation directory `{}` is not a directory",
+            dir.display()
+        );
+    }
+
+    for entry in WalkDir::new(dir) {
+        let entry = entry
+            .with_context(|| format!("failed to scan observation directory `{}`", dir.display()))?;
+        if entry.file_type().is_file()
+            && entry.file_name().to_string_lossy() == "proof-executor-observation.json"
+        {
+            paths.insert(entry.path().to_path_buf());
+        }
+    }
+
+    Ok(())
 }
 
 fn read_sourced_observation(path: &Path) -> Result<SourcedProofExecutionObservation> {

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -101,6 +101,7 @@ fn proof_execution_observations_summary_help_mentions_observation_paths() {
         "proof-execution-observations-summary --help failed. stderr: {stderr}"
     );
     assert!(stdout.contains("--observation"), "stdout: {stdout}");
+    assert!(stdout.contains("--observations-dir"), "stdout: {stdout}");
     assert!(stdout.contains("--output"), "stdout: {stdout}");
 }
 
@@ -410,6 +411,24 @@ fn local_execute_can_write_zero_command_executor_artifacts() {
     assert_eq!(collection["counts"]["executed"], 0);
     assert!(collection["scopes"].as_array().unwrap().is_empty());
     assert_eq!(collection["sources"].as_array().unwrap().len(), 1);
+
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-execution-observations-summary",
+        "--observations-dir",
+        &temp.path().to_string_lossy(),
+    ]);
+    assert!(
+        success,
+        "proof-execution-observations-summary --observations-dir failed. stderr: {stderr}"
+    );
+    let collection: serde_json::Value =
+        serde_json::from_str(&stdout).expect("directory collection should be valid JSON");
+    assert_eq!(
+        collection["schema"],
+        "tokmd.proof_executor_observation_collection.v1"
+    );
+    assert_eq!(collection["counts"]["observations"], 1);
+    assert_eq!(collection["counts"]["executed"], 0);
 
     let (_stdout, stderr, success) = run_xtask(&[
         "proof-artifacts-check",


### PR DESCRIPTION
## Summary
- let `cargo xtask proof-execution-observations-summary` recursively discover `proof-executor-observation.json` files under `--observations-dir`
- keep explicit `--observation` paths supported and retain the default single-run artifact when no inputs are supplied
- cover directory discovery in the existing proof executor observation integration path

## Validation
- cargo test -p xtask proof_execution_observations_summary --verbose
- cargo test -p xtask local_execute_can_write_zero_command_executor_artifacts --verbose
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo test -p xtask --verbose
- cargo xtask proof-execution-observations-summary --observations-dir target/proof-observations
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo xtask check-lint-policy
- cargo xtask check-no-panic-family