### PR TITLE
chore: upload proof executor observation collections

### DIFF
--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -81,15 +81,26 @@ jobs:
             if [ "${verifier_status}" -eq 0 ]; then
               cargo xtask proof-execution-observation --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --output target/proof/proof-executor-observation.json > target/proof/proof-execution-observation.txt 2>&1
               observation_status=$?
+              if [ "${observation_status}" -eq 0 ]; then
+                cargo xtask proof-execution-observations-summary --observations-dir target/proof --output target/proof/proof-executor-observation-collection.json > target/proof/proof-execution-observations-summary.txt 2>&1
+                collection_status=$?
+              else
+                collection_status=1
+                echo "executor observation did not pass generation" > target/proof/proof-execution-observations-summary.txt
+              fi
             else
               observation_status=1
+              collection_status=1
               echo "executor artifacts did not pass verification" > target/proof/proof-execution-observation.txt
+              echo "executor artifacts did not pass verification" > target/proof/proof-execution-observations-summary.txt
             fi
           else
             verifier_status=1
             observation_status=1
+            collection_status=1
             echo "executor artifacts were not generated" > target/proof/proof-execution-artifacts-check.txt
             echo "executor artifacts were not generated" > target/proof/proof-execution-observation.txt
+            echo "executor artifacts were not generated" > target/proof/proof-execution-observations-summary.txt
           fi
 
           {
@@ -97,6 +108,7 @@ jobs:
             echo "executor_status=${executor_status}"
             echo "verifier_status=${verifier_status}"
             echo "observation_status=${observation_status}"
+            echo "collection_status=${collection_status}"
           } > target/proof/status.env
 
           {
@@ -108,12 +120,15 @@ jobs:
             echo "| proof executor | ${executor_status} |"
             echo "| execution artifact verifier | ${verifier_status} |"
             echo "| execution observation | ${observation_status} |"
+            echo "| observation collection | ${collection_status} |"
             echo ""
             echo "This is an explicitly non-required PR/manual experiment. It runs only planner-selected non-required coverage commands and does not replace required PR proof jobs."
             echo ""
             cat target/proof/proof-execution-artifacts-check.txt
             echo ""
             cat target/proof/proof-execution-observation.txt
+            echo ""
+            cat target/proof/proof-execution-observations-summary.txt
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${affected_status}" -ne 0 ]; then
@@ -127,6 +142,9 @@ jobs:
           fi
           if [ "${observation_status}" -ne 0 ]; then
             exit "${observation_status}"
+          fi
+          if [ "${collection_status}" -ne 0 ]; then
+            exit "${collection_status}"
           fi
 
           exit 0

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -68,6 +68,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Executed coverage artifacts now must be LCOV-shaped text with `SF:` and `end_of_record` records before `proof-execution-artifacts-check` accepts them.
 - `cargo xtask proof-execution-observation` now turns verified executed summary/manifest pairs into `proof-executor-observation.json`, a compact cross-PR observation artifact for collecting non-required executor runs without promoting them to required gates or default Codecov uploads.
 - `cargo xtask proof-execution-observations-summary --observation <path>...` now summarizes downloaded executor observation artifacts by family, scope, and source run, giving maintainers a Rust-owned collection view before any required-gate or default Codecov-upload promotion. It also accepts `--observations-dir <dir>` to recursively collect `proof-executor-observation.json` artifacts from downloaded GitHub run directories.
+- The proof executor workflow now uploads `proof-executor-observation-collection.json` alongside the per-run observation by running the Rust-owned observation summary command over `target/proof`.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -165,6 +165,14 @@ fn scoped_coverage_executor_is_pr_visible_but_not_required() {
         "Codecov upload should remain manual-only"
     );
     assert!(
+        executor.contains("proof-execution-observations-summary --observations-dir target/proof"),
+        "executor should upload a Rust-generated observation collection summary"
+    );
+    assert!(
+        executor.contains("proof-executor-observation-collection.json"),
+        "executor collection summary artifact should have a stable name"
+    );
+    assert!(
         !ci.contains("scoped-coverage-executor"),
         "required CI aggregate must not depend on the executor experiment"
     );


### PR DESCRIPTION
## Summary
- run the Rust-owned proof executor observation summary inside the non-required executor workflow
- upload `proof-executor-observation-collection.json` with the existing proof executor artifacts
- keep the workflow explicitly advisory and add an xtask workflow assertion for the stable artifact name

## Validation
- cargo fmt-fix
- python YAML parse for `.github/workflows/proof-executor.yml`
- cargo test -p xtask scoped_coverage_executor_is_pr_visible_but_not_required --verbose
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo test -p xtask --verbose
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan