### PR TITLE
chore: add proof observation collection thresholds

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -69,6 +69,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof-execution-observation` now turns verified executed summary/manifest pairs into `proof-executor-observation.json`, a compact cross-PR observation artifact for collecting non-required executor runs without promoting them to required gates or default Codecov uploads.
 - `cargo xtask proof-execution-observations-summary --observation <path>...` now summarizes downloaded executor observation artifacts by family, scope, and source run, giving maintainers a Rust-owned collection view before any required-gate or default Codecov-upload promotion. It also accepts `--observations-dir <dir>` to recursively collect `proof-executor-observation.json` artifacts from downloaded GitHub run directories.
 - The proof executor workflow now uploads `proof-executor-observation-collection.json` alongside the per-run observation by running the Rust-owned observation summary command over `target/proof`.
+- Observation collection can now enforce readiness thresholds with `--min-observations`, `--min-executed`, `--min-scopes`, and `--min-artifacts`, so downloaded non-required executor runs can prove a multi-run/multi-scope evidence floor before any promotion decision.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -245,6 +245,22 @@ pub struct ProofExecutionObservationsSummaryArgs {
     #[arg(long = "observations-dir", value_name = "DIR")]
     pub observation_dirs: Vec<std::path::PathBuf>,
 
+    /// Minimum number of observation artifacts required in the collection.
+    #[arg(long, default_value_t = 0)]
+    pub min_observations: usize,
+
+    /// Minimum number of executed commands required in the collection.
+    #[arg(long, default_value_t = 0)]
+    pub min_executed: usize,
+
+    /// Minimum number of distinct scope rows required in the collection.
+    #[arg(long, default_value_t = 0)]
+    pub min_scopes: usize,
+
+    /// Minimum number of produced artifact paths required in the collection.
+    #[arg(long, default_value_t = 0)]
+    pub min_artifacts: usize,
+
     /// Output path for the collection summary. Prints JSON to stdout when omitted.
     #[arg(long, value_name = "PATH")]
     pub output: Option<std::path::PathBuf>,

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -81,13 +81,15 @@ pub fn run_observation(args: ProofExecutionObservationArgs) -> Result<()> {
 pub fn run_observations_summary(args: ProofExecutionObservationsSummaryArgs) -> Result<()> {
     let observations = collect_observation_paths(&args)?;
     let collection = proof_execution_observation_collection(&observations)?;
+    validate_observation_collection_thresholds(&collection, &args)?;
     let json = serde_json::to_string_pretty(&collection)?;
 
     if let Some(output) = &args.output {
         write_text(output, &json)?;
         println!(
-            "Proof execution observation collection OK: {} observation(s), wrote `{}`",
+            "Proof execution observation collection OK: {} observation(s), {} scope(s), wrote `{}`",
             collection.counts.observations,
+            collection.scopes.len(),
             output.display()
         );
     } else {
@@ -369,6 +371,46 @@ fn proof_execution_observation_collection(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(summarize_observations(&observations))
+}
+
+fn validate_observation_collection_thresholds(
+    collection: &ProofExecutionObservationCollection,
+    args: &ProofExecutionObservationsSummaryArgs,
+) -> Result<()> {
+    validate_minimum(
+        "--min-observations",
+        "observation(s)",
+        collection.counts.observations,
+        args.min_observations,
+    )?;
+    validate_minimum(
+        "--min-executed",
+        "executed command(s)",
+        collection.counts.executed,
+        args.min_executed,
+    )?;
+    validate_minimum(
+        "--min-scopes",
+        "scope(s)",
+        collection.scopes.len(),
+        args.min_scopes,
+    )?;
+    validate_minimum(
+        "--min-artifacts",
+        "artifact(s)",
+        collection.counts.artifacts,
+        args.min_artifacts,
+    )
+}
+
+fn validate_minimum(flag: &str, display_label: &str, actual: usize, required: usize) -> Result<()> {
+    if actual < required {
+        bail!(
+            "proof executor observation collection has {actual} {display_label}, below {flag} {required}"
+        );
+    }
+
+    Ok(())
 }
 
 fn collect_observation_paths(args: &ProofExecutionObservationsSummaryArgs) -> Result<Vec<PathBuf>> {
@@ -1291,6 +1333,39 @@ mod tests {
     }
 
     #[test]
+    fn validates_observation_collection_thresholds() {
+        let (summary, manifest) = executed_artifacts();
+        let first = proof_execution_observation(&summary, &manifest).unwrap();
+        let mut second = first.clone();
+        second.scopes[0].name = "analysis_derived".to_string();
+
+        let collection = summarize_observations(&[
+            sourced("target/proof/run-a/proof-executor-observation.json", first),
+            sourced("target/proof/run-b/proof-executor-observation.json", second),
+        ]);
+        let args = summary_args_with_thresholds(2, 2, 2, 2);
+
+        validate_observation_collection_thresholds(&collection, &args).unwrap();
+    }
+
+    #[test]
+    fn rejects_observation_collection_below_thresholds() {
+        let (summary, manifest) = executed_artifacts();
+        let observation = proof_execution_observation(&summary, &manifest).unwrap();
+        let collection = summarize_observations(&[sourced(
+            "target/proof/run-a/proof-executor-observation.json",
+            observation,
+        )]);
+        let args = summary_args_with_thresholds(2, 1, 1, 1);
+
+        let error = validate_observation_collection_thresholds(&collection, &args)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("--min-observations 2"));
+    }
+
+    #[test]
     fn rejects_failed_observation_for_collection() {
         let (summary, manifest) = executed_artifacts();
         let mut observation = proof_execution_observation(&summary, &manifest).unwrap();
@@ -1460,6 +1535,23 @@ mod tests {
         SourcedProofExecutionObservation {
             path: PathBuf::from(path),
             observation,
+        }
+    }
+
+    fn summary_args_with_thresholds(
+        min_observations: usize,
+        min_executed: usize,
+        min_scopes: usize,
+        min_artifacts: usize,
+    ) -> ProofExecutionObservationsSummaryArgs {
+        ProofExecutionObservationsSummaryArgs {
+            observations: Vec::new(),
+            observation_dirs: Vec::new(),
+            min_observations,
+            min_executed,
+            min_scopes,
+            min_artifacts,
+            output: None,
         }
     }
 

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -102,6 +102,10 @@ fn proof_execution_observations_summary_help_mentions_observation_paths() {
     );
     assert!(stdout.contains("--observation"), "stdout: {stdout}");
     assert!(stdout.contains("--observations-dir"), "stdout: {stdout}");
+    assert!(stdout.contains("--min-observations"), "stdout: {stdout}");
+    assert!(stdout.contains("--min-executed"), "stdout: {stdout}");
+    assert!(stdout.contains("--min-scopes"), "stdout: {stdout}");
+    assert!(stdout.contains("--min-artifacts"), "stdout: {stdout}");
     assert!(stdout.contains("--output"), "stdout: {stdout}");
 }
 
@@ -437,6 +441,19 @@ fn local_execute_can_write_zero_command_executor_artifacts() {
     );
     assert_eq!(collection["counts"]["observations"], 1);
     assert_eq!(collection["counts"]["executed"], 0);
+
+    let (_stdout, stderr, success) = run_xtask(&[
+        "proof-execution-observations-summary",
+        "--observation",
+        &observation_arg,
+        "--min-executed",
+        "1",
+    ]);
+    assert!(
+        !success,
+        "collection threshold should reject zero executed observations"
+    );
+    assert!(stderr.contains("--min-executed 1"), "stderr: {stderr}");
 
     let (_stdout, stderr, success) = run_xtask(&[
         "proof-artifacts-check",


### PR DESCRIPTION
## Summary
- add optional readiness thresholds to `proof-execution-observations-summary`
- let downloaded non-required executor observations require minimum observations, executed commands, distinct scopes, and artifact paths
- record the new threshold mechanism in `docs/NEXT.md`

## Validation
- cargo fmt-fix
- cargo test -p xtask proof_artifacts --verbose
- cargo test -p xtask proof_execution_observations_summary --verbose
- cargo test -p xtask proof_plan --verbose
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask --verbose
- cargo xtask check-lint-policy
- cargo xtask check-no-panic-family