### PR TITLE
chore: add proof observation collection markdown summary

### DIFF
--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -82,7 +82,7 @@ jobs:
               cargo xtask proof-execution-observation --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --output target/proof/proof-executor-observation.json > target/proof/proof-execution-observation.txt 2>&1
               observation_status=$?
               if [ "${observation_status}" -eq 0 ]; then
-                cargo xtask proof-execution-observations-summary --observations-dir target/proof --output target/proof/proof-executor-observation-collection.json > target/proof/proof-execution-observations-summary.txt 2>&1
+                cargo xtask proof-execution-observations-summary --observations-dir target/proof --output target/proof/proof-executor-observation-collection.json --summary-md target/proof/proof-executor-observation-collection.md > target/proof/proof-execution-observations-summary.txt 2>&1
                 collection_status=$?
               else
                 collection_status=1
@@ -129,6 +129,10 @@ jobs:
             cat target/proof/proof-execution-observation.txt
             echo ""
             cat target/proof/proof-execution-observations-summary.txt
+            if [ -f target/proof/proof-executor-observation-collection.md ]; then
+              echo ""
+              cat target/proof/proof-executor-observation-collection.md
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${affected_status}" -ne 0 ]; then

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -70,6 +70,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask proof-execution-observations-summary --observation <path>...` now summarizes downloaded executor observation artifacts by family, scope, and source run, giving maintainers a Rust-owned collection view before any required-gate or default Codecov-upload promotion. It also accepts `--observations-dir <dir>` to recursively collect `proof-executor-observation.json` artifacts from downloaded GitHub run directories.
 - The proof executor workflow now uploads `proof-executor-observation-collection.json` alongside the per-run observation by running the Rust-owned observation summary command over `target/proof`.
 - Observation collection can now enforce readiness thresholds with `--min-observations`, `--min-executed`, `--min-scopes`, and `--min-artifacts`, so downloaded non-required executor runs can prove a multi-run/multi-scope evidence floor before any promotion decision.
+- Observation collection can now also write `--summary-md`, and the proof executor workflow appends that Rust-generated Markdown collection report to the GitHub job summary while still uploading the JSON artifact.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -264,6 +264,10 @@ pub struct ProofExecutionObservationsSummaryArgs {
     /// Output path for the collection summary. Prints JSON to stdout when omitted.
     #[arg(long, value_name = "PATH")]
     pub output: Option<std::path::PathBuf>,
+
+    /// Output path for a human-readable Markdown collection summary.
+    #[arg(long, value_name = "PATH")]
+    pub summary_md: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/xtask/src/tasks/proof_artifacts_check.rs
+++ b/xtask/src/tasks/proof_artifacts_check.rs
@@ -82,16 +82,32 @@ pub fn run_observations_summary(args: ProofExecutionObservationsSummaryArgs) -> 
     let observations = collect_observation_paths(&args)?;
     let collection = proof_execution_observation_collection(&observations)?;
     validate_observation_collection_thresholds(&collection, &args)?;
+    if let Some(summary_md) = &args.summary_md {
+        write_text(
+            summary_md,
+            &render_observation_collection_markdown(&collection, &args),
+        )?;
+    }
     let json = serde_json::to_string_pretty(&collection)?;
 
     if let Some(output) = &args.output {
         write_text(output, &json)?;
-        println!(
-            "Proof execution observation collection OK: {} observation(s), {} scope(s), wrote `{}`",
-            collection.counts.observations,
-            collection.scopes.len(),
-            output.display()
-        );
+        if let Some(summary_md) = &args.summary_md {
+            println!(
+                "Proof execution observation collection OK: {} observation(s), {} scope(s), wrote `{}` and `{}`",
+                collection.counts.observations,
+                collection.scopes.len(),
+                output.display(),
+                summary_md.display()
+            );
+        } else {
+            println!(
+                "Proof execution observation collection OK: {} observation(s), {} scope(s), wrote `{}`",
+                collection.counts.observations,
+                collection.scopes.len(),
+                output.display()
+            );
+        }
     } else {
         println!("{json}");
     }
@@ -411,6 +427,114 @@ fn validate_minimum(flag: &str, display_label: &str, actual: usize, required: us
     }
 
     Ok(())
+}
+
+fn render_observation_collection_markdown(
+    collection: &ProofExecutionObservationCollection,
+    args: &ProofExecutionObservationsSummaryArgs,
+) -> String {
+    let mut out = String::new();
+    out.push_str("# Proof Executor Observation Collection\n\n");
+    out.push_str("| Metric | Count |\n");
+    out.push_str("| --- | ---: |\n");
+    push_count_row(&mut out, "Observations", collection.counts.observations);
+    push_count_row(&mut out, "Selected commands", collection.counts.selected);
+    push_count_row(&mut out, "Executed commands", collection.counts.executed);
+    push_count_row(&mut out, "Passed commands", collection.counts.passed);
+    push_count_row(&mut out, "Failed commands", collection.counts.failed);
+    push_count_row(&mut out, "Artifacts", collection.counts.artifacts);
+    push_count_row(&mut out, "Distinct scopes", collection.scopes.len());
+
+    out.push_str("\n## Thresholds\n\n");
+    out.push_str("| Threshold | Required | Actual | Status |\n");
+    out.push_str("| --- | ---: | ---: | --- |\n");
+    push_threshold_row(
+        &mut out,
+        "Observations",
+        args.min_observations,
+        collection.counts.observations,
+    );
+    push_threshold_row(
+        &mut out,
+        "Executed commands",
+        args.min_executed,
+        collection.counts.executed,
+    );
+    push_threshold_row(
+        &mut out,
+        "Distinct scopes",
+        args.min_scopes,
+        collection.scopes.len(),
+    );
+    push_threshold_row(
+        &mut out,
+        "Artifacts",
+        args.min_artifacts,
+        collection.counts.artifacts,
+    );
+
+    if !collection.families.is_empty() {
+        out.push_str("\n## Families\n\n");
+        out.push_str("| Family | Observations | Executed | Artifacts |\n");
+        out.push_str("| --- | ---: | ---: | ---: |\n");
+        for family in &collection.families {
+            out.push_str(&format!(
+                "| `{}` | {} | {} | {} |\n",
+                md_cell(&family.family),
+                family.observations,
+                family.executed,
+                family.artifacts
+            ));
+        }
+    }
+
+    if !collection.scopes.is_empty() {
+        out.push_str("\n## Scopes\n\n");
+        out.push_str("| Scope | Kind | Family | Observations | Executed | Artifacts |\n");
+        out.push_str("| --- | --- | --- | ---: | ---: | ---: |\n");
+        for scope in &collection.scopes {
+            out.push_str(&format!(
+                "| `{}` | `{}` | `{}` | {} | {} | {} |\n",
+                md_cell(&scope.name),
+                md_cell(&scope.kind),
+                md_cell(&scope.family),
+                scope.observations,
+                scope.executed,
+                scope.artifacts
+            ));
+        }
+    }
+
+    if !collection.sources.is_empty() {
+        out.push_str("\n## Sources\n\n");
+        out.push_str("| Source | Family | Executed | Artifacts | Guard |\n");
+        out.push_str("| --- | --- | ---: | ---: | --- |\n");
+        for source in &collection.sources {
+            out.push_str(&format!(
+                "| `{}` | `{}` | {} | {} | `{}` |\n",
+                md_cell(&source.path),
+                md_cell(&source.family),
+                source.executed,
+                source.artifacts,
+                md_cell(&source.guard_reason)
+            ));
+        }
+    }
+
+    out
+}
+
+fn push_count_row(out: &mut String, label: &str, count: usize) {
+    out.push_str(&format!("| {label} | {count} |\n"));
+}
+
+fn push_threshold_row(out: &mut String, label: &str, required: usize, actual: usize) {
+    let status = if actual >= required { "ok" } else { "below" };
+    out.push_str(&format!("| {label} | {required} | {actual} | {status} |\n"));
+}
+
+fn md_cell(value: &str) -> String {
+    value.replace('|', "\\|")
 }
 
 fn collect_observation_paths(args: &ProofExecutionObservationsSummaryArgs) -> Result<Vec<PathBuf>> {
@@ -1349,6 +1473,26 @@ mod tests {
     }
 
     #[test]
+    fn renders_observation_collection_markdown_summary() {
+        let (summary, manifest) = executed_artifacts();
+        let observation = proof_execution_observation(&summary, &manifest).unwrap();
+        let collection = summarize_observations(&[sourced(
+            "target/proof/run-a/proof-executor-observation.json",
+            observation,
+        )]);
+        let args = summary_args_with_thresholds(1, 1, 1, 1);
+
+        let markdown = render_observation_collection_markdown(&collection, &args);
+
+        assert!(markdown.contains("# Proof Executor Observation Collection"));
+        assert!(markdown.contains("| Observations | 1 |"));
+        assert!(markdown.contains("| Executed commands | 1 |"));
+        assert!(markdown.contains("| Distinct scopes | 1 |"));
+        assert!(markdown.contains("| `tokmd_core_ffi` | `coverage` | `coverage` | 1 | 1 | 1 |"));
+        assert!(markdown.contains("| Observations | 1 | 1 | ok |"));
+    }
+
+    #[test]
     fn rejects_observation_collection_below_thresholds() {
         let (summary, manifest) = executed_artifacts();
         let observation = proof_execution_observation(&summary, &manifest).unwrap();
@@ -1552,6 +1696,7 @@ mod tests {
             min_scopes,
             min_artifacts,
             output: None,
+            summary_md: None,
         }
     }
 

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -107,6 +107,7 @@ fn proof_execution_observations_summary_help_mentions_observation_paths() {
     assert!(stdout.contains("--min-scopes"), "stdout: {stdout}");
     assert!(stdout.contains("--min-artifacts"), "stdout: {stdout}");
     assert!(stdout.contains("--output"), "stdout: {stdout}");
+    assert!(stdout.contains("--summary-md"), "stdout: {stdout}");
 }
 
 #[test]
@@ -175,6 +176,10 @@ fn scoped_coverage_executor_is_pr_visible_but_not_required() {
     assert!(
         executor.contains("proof-executor-observation-collection.json"),
         "executor collection summary artifact should have a stable name"
+    );
+    assert!(
+        executor.contains("--summary-md target/proof/proof-executor-observation-collection.md"),
+        "executor should append a Rust-generated Markdown collection summary"
     );
     assert!(
         !ci.contains("scoped-coverage-executor"),
@@ -441,6 +446,36 @@ fn local_execute_can_write_zero_command_executor_artifacts() {
     );
     assert_eq!(collection["counts"]["observations"], 1);
     assert_eq!(collection["counts"]["executed"], 0);
+
+    let collection_path = temp
+        .path()
+        .join("proof-executor-observation-collection.json");
+    let collection_arg = collection_path.to_string_lossy().to_string();
+    let summary_path = temp.path().join("proof-executor-observation-collection.md");
+    let summary_md_arg = summary_path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-execution-observations-summary",
+        "--observation",
+        &observation_arg,
+        "--output",
+        &collection_arg,
+        "--summary-md",
+        &summary_md_arg,
+    ]);
+    assert!(
+        success,
+        "proof-execution-observations-summary --summary-md failed. stderr: {stderr}"
+    );
+    assert!(stdout.contains("wrote"), "stdout: {stdout}");
+    let summary_md = fs::read_to_string(summary_path).expect("summary markdown should be written");
+    assert!(
+        summary_md.contains("# Proof Executor Observation Collection"),
+        "{summary_md}"
+    );
+    assert!(
+        summary_md.contains("| Executed commands | 0 |"),
+        "{summary_md}"
+    );
 
     let (_stdout, stderr, success) = run_xtask(&[
         "proof-execution-observations-summary",


### PR DESCRIPTION
## Summary
- add `--summary-md` to `proof-execution-observations-summary`
- render observation collection counts, thresholds, families, scopes, and sources as Markdown
- append the Rust-generated collection report to the non-required proof executor workflow summary

## Validation
- cargo fmt-fix
- python YAML parse for `.github/workflows/proof-executor.yml`
- cargo test -p xtask proof_artifacts --verbose
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask proof_execution_observations_summary --verbose
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask --verbose
- cargo xtask check-lint-policy
- cargo xtask check-no-panic-family