### PR TITLE
chore: allow manual proof executor command limit override

### DIFF
--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: boolean
         default: false
+      max_evidence_commands:
+        description: Maximum advisory evidence commands to execute
+        required: false
+        default: "1"
 
 permissions:
   contents: read
@@ -35,6 +39,7 @@ jobs:
       contents: read
     env:
       PROOF_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.inputs.base_ref || 'main' }}
+      PROOF_EXECUTOR_MAX_COMMANDS: ${{ github.event.inputs.max_evidence_commands || '1' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -72,7 +77,7 @@ jobs:
           cargo xtask affected --base "origin/${PROOF_BASE_REF}" --head HEAD --json > target/proof/affected.json
           affected_status=$?
 
-          cargo xtask proof --profile affected --base "origin/${PROOF_BASE_REF}" --head HEAD --executor-mode execute --allow-ci-evidence-execution --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json
+          cargo xtask proof --profile affected --base "origin/${PROOF_BASE_REF}" --head HEAD --executor-mode execute --executor-max-commands "${PROOF_EXECUTOR_MAX_COMMANDS}" --allow-ci-evidence-execution --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json
           executor_status=$?
 
           if [ -f target/proof/executor-summary.json ] && [ -f target/proof/executor-manifest.json ]; then

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -71,6 +71,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The proof executor workflow now uploads `proof-executor-observation-collection.json` alongside the per-run observation by running the Rust-owned observation summary command over `target/proof`.
 - Observation collection can now enforce readiness thresholds with `--min-observations`, `--min-executed`, `--min-scopes`, and `--min-artifacts`, so downloaded non-required executor runs can prove a multi-run/multi-scope evidence floor before any promotion decision.
 - Observation collection can now also write `--summary-md`, and the proof executor workflow appends that Rust-generated Markdown collection report to the GitHub job summary while still uploading the JSON artifact.
+- `cargo xtask proof` now accepts `--executor-max-commands <n>` as a positive override for the policy-selected advisory executor command limit. The proof executor workflow keeps PR runs at one command by default, while manual dispatches can raise `max_evidence_commands` to collect multi-scope evidence without changing required gates.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -176,6 +176,10 @@ pub struct ProofArgs {
     #[arg(long, value_enum, default_value_t = ProofExecutorMode::Prototype)]
     pub executor_mode: ProofExecutorMode,
 
+    /// Override the policy-selected maximum number of advisory executor commands.
+    #[arg(long)]
+    pub executor_max_commands: Option<usize>,
+
     /// Explicitly opt a CI invocation into future planner-selected evidence execution
     #[arg(long)]
     pub allow_ci_evidence_execution: bool,

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -192,7 +192,7 @@ pub fn run(args: ProofArgs) -> Result<()> {
 
     let policy = load_checked_policy(&args.policy)?;
     let report = proof_plan_report(&policy, &args)?;
-    let executor_config = proof_executor_config(&policy);
+    let executor_config = proof_executor_config(&policy, args.executor_max_commands)?;
 
     if args.executor_mode == ProofExecutorMode::Execute {
         run_executor_mode(&args, &report, &executor_config)?;
@@ -772,8 +772,17 @@ fn proof_executor_manifest_from_summary(
     }
 }
 
-fn proof_executor_config(policy: &ProofPolicy) -> ProofExecutorConfig {
-    ProofExecutorConfig {
+fn proof_executor_config(
+    policy: &ProofPolicy,
+    max_commands_override: Option<usize>,
+) -> Result<ProofExecutorConfig> {
+    let max_dry_run_commands = match max_commands_override {
+        Some(0) => bail!("--executor-max-commands must be greater than zero"),
+        Some(max) => max,
+        None => policy.executor.max_dry_run_commands.unwrap_or(1),
+    };
+
+    Ok(ProofExecutorConfig {
         family: policy
             .executor
             .family
@@ -784,8 +793,8 @@ fn proof_executor_config(policy: &ProofPolicy) -> ProofExecutorConfig {
             .ci_execution
             .clone()
             .unwrap_or(CiExecution::ExplicitOptIn),
-        max_dry_run_commands: policy.executor.max_dry_run_commands.unwrap_or(1),
-    }
+        max_dry_run_commands,
+    })
 }
 
 fn proof_executor_execution_guard(
@@ -1210,9 +1219,10 @@ fn profile_name(profile: ProofProfile) -> &'static str {
 mod tests {
     use super::{
         ProofExecutorConfig, ProofPlanCommand, ProofPlanReport, affected_commands, dedupe_commands,
-        is_mutation_candidate, proof_evidence_plan, proof_executor_execute_summary,
-        proof_executor_execution_guard_for, proof_executor_manifest, proof_executor_summary,
-        render_markdown_summary, split_command, static_profile_commands,
+        is_mutation_candidate, proof_evidence_plan, proof_executor_config,
+        proof_executor_execute_summary, proof_executor_execution_guard_for,
+        proof_executor_manifest, proof_executor_summary, render_markdown_summary, split_command,
+        static_profile_commands,
     };
     use crate::cli::{ProofExecutorMode, ProofProfile};
     use crate::proof::policy::parse_policy_str;
@@ -1284,6 +1294,58 @@ mod tests {
         assert!(deep.iter().any(|cmd| cmd.kind == "coverage"));
         assert!(deep.iter().any(|cmd| cmd.kind == "mutation"));
         assert!(deep.iter().any(|cmd| cmd.kind == "fuzz"));
+    }
+
+    #[test]
+    fn executor_config_uses_policy_limit_by_default() {
+        let policy = parse_policy_str(
+            r#"
+schema = "tokmd.proof_policy.v1"
+
+[executor]
+family = "coverage"
+max_dry_run_commands = 2
+"#,
+        )
+        .expect("policy should parse");
+
+        let config = proof_executor_config(&policy, None).expect("config should load");
+
+        assert_eq!(config.max_dry_run_commands, 2);
+    }
+
+    #[test]
+    fn executor_config_allows_positive_selection_override() {
+        let policy = parse_policy_str(
+            r#"
+schema = "tokmd.proof_policy.v1"
+
+[executor]
+family = "coverage"
+max_dry_run_commands = 1
+"#,
+        )
+        .expect("policy should parse");
+
+        let config = proof_executor_config(&policy, Some(3)).expect("config should load");
+
+        assert_eq!(config.max_dry_run_commands, 3);
+    }
+
+    #[test]
+    fn executor_config_rejects_zero_selection_override() {
+        let policy = parse_policy_str(
+            r#"
+schema = "tokmd.proof_policy.v1"
+"#,
+        )
+        .expect("policy should parse");
+
+        let error = proof_executor_config(&policy, Some(0))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("--executor-max-commands"));
     }
 
     #[test]

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -46,6 +46,10 @@ fn proof_help_mentions_profile_and_plan() {
     assert!(stdout.contains("--executor-manifest"), "stdout: {stdout}");
     assert!(stdout.contains("--executor-mode"), "stdout: {stdout}");
     assert!(
+        stdout.contains("--executor-max-commands"),
+        "stdout: {stdout}"
+    );
+    assert!(
         stdout.contains("--allow-ci-evidence-execution"),
         "stdout: {stdout}"
     );
@@ -182,6 +186,10 @@ fn scoped_coverage_executor_is_pr_visible_but_not_required() {
         "executor should append a Rust-generated Markdown collection summary"
     );
     assert!(
+        executor.contains("--executor-max-commands \"${PROOF_EXECUTOR_MAX_COMMANDS}\""),
+        "executor workflow should keep the command selection limit Rust-owned and manually tunable"
+    );
+    assert!(
         !ci.contains("scoped-coverage-executor"),
         "required CI aggregate must not depend on the executor experiment"
     );
@@ -282,6 +290,31 @@ fn proof_plan_refuses_execute_executor_mode() {
     assert!(!success, "proof --plan --executor-mode execute should fail");
     assert!(stderr.contains("--plan"), "stderr: {stderr}");
     assert!(stderr.contains("execute"), "stderr: {stderr}");
+}
+
+#[test]
+fn proof_plan_rejects_zero_executor_max_commands() {
+    let (_stdout, stderr, success) = run_xtask(&[
+        "proof",
+        "--profile",
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--plan",
+        "--executor-max-commands",
+        "0",
+    ]);
+
+    assert!(
+        !success,
+        "proof --plan should reject zero executor command limit"
+    );
+    assert!(
+        stderr.contains("--executor-max-commands"),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `--executor-max-commands` to override the policy-selected advisory executor command limit
- keep PR proof-executor runs at the current one-command default
- add a manual `max_evidence_commands` workflow_dispatch input for multi-scope executor evidence collection experiments

## Validation
- cargo fmt-fix
- python YAML parse for `.github/workflows/proof-executor.yml`
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask proof_help_mentions_profile_and_plan --verbose
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask --verbose
- cargo xtask check-lint-policy
- cargo xtask check-no-panic-family