### PR TITLE
ci: add proof executor observation collector

### DIFF
--- a/.github/workflows/proof-observation-collection.yml
+++ b/.github/workflows/proof-observation-collection.yml
@@ -1,0 +1,131 @@
+name: Proof Executor Observation Collection
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_limit:
+        description: Number of successful proof executor runs to inspect
+        required: false
+        default: "25"
+      min_observations:
+        description: Minimum observation artifacts required
+        required: false
+        default: "1"
+      min_executed:
+        description: Minimum executed advisory commands required
+        required: false
+        default: "1"
+      min_scopes:
+        description: Minimum distinct scopes required
+        required: false
+        default: "1"
+      min_artifacts:
+        description: Minimum produced evidence artifacts required
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: proof-observation-collection-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  GH_TOKEN: ${{ github.token }}
+  RUN_LIMIT: ${{ github.event.inputs.run_limit || '25' }}
+  MIN_OBSERVATIONS: ${{ github.event.inputs.min_observations || '1' }}
+  MIN_EXECUTED: ${{ github.event.inputs.min_executed || '1' }}
+  MIN_SCOPES: ${{ github.event.inputs.min_scopes || '1' }}
+  MIN_ARTIFACTS: ${{ github.event.inputs.min_artifacts || '1' }}
+
+jobs:
+  collect-observations:
+    name: Collect Proof Executor Observations
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Download successful proof executor artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p target/proof-observations/runs
+
+          gh run list --workflow proof-executor.yml --status success --limit "${RUN_LIMIT}" --json databaseId,event,headBranch,headSha,createdAt,url > target/proof-observations/runs.json
+          python - <<'PY' > target/proof-observations/run-ids.txt
+          import json
+
+          with open("target/proof-observations/runs.json", encoding="utf-8") as handle:
+              for run in json.load(handle):
+                  print(run["databaseId"])
+          PY
+
+          if [ ! -s target/proof-observations/run-ids.txt ]; then
+            echo "No successful proof executor runs found." > target/proof-observations/download.log
+            exit 1
+          fi
+
+          : > target/proof-observations/download.log
+          while IFS= read -r run_id; do
+            run_dir="target/proof-observations/runs/${run_id}"
+            mkdir -p "${run_dir}"
+            if gh run download "${run_id}" --name proof-executor-artifacts --dir "${run_dir}" >> target/proof-observations/download.log 2>&1; then
+              echo "downloaded ${run_id}" >> target/proof-observations/download.log
+            else
+              echo "missing proof-executor-artifacts for ${run_id}" >> target/proof-observations/download.log
+            fi
+          done < target/proof-observations/run-ids.txt
+
+      - name: Summarize downloaded observations
+        run: |
+          set -euo pipefail
+          cargo xtask proof-execution-observations-summary \
+            --observations-dir target/proof-observations/runs \
+            --output target/proof-observations/proof-executor-observation-collection.json \
+            --summary-md target/proof-observations/proof-executor-observation-collection.md \
+            --min-observations "${MIN_OBSERVATIONS}" \
+            --min-executed "${MIN_EXECUTED}" \
+            --min-scopes "${MIN_SCOPES}" \
+            --min-artifacts "${MIN_ARTIFACTS}" \
+            > target/proof-observations/proof-execution-observations-summary.txt
+
+      - name: Write collection summary
+        if: always()
+        run: |
+          {
+            echo "## Proof Executor Observation Collection"
+            echo ""
+            echo "| Input | Value |"
+            echo "| --- | ---: |"
+            echo "| Run limit | ${RUN_LIMIT} |"
+            echo "| Minimum observations | ${MIN_OBSERVATIONS} |"
+            echo "| Minimum executed commands | ${MIN_EXECUTED} |"
+            echo "| Minimum scopes | ${MIN_SCOPES} |"
+            echo "| Minimum artifacts | ${MIN_ARTIFACTS} |"
+            echo ""
+            if [ -f target/proof-observations/proof-executor-observation-collection.md ]; then
+              cat target/proof-observations/proof-executor-observation-collection.md
+            elif [ -f target/proof-observations/proof-execution-observations-summary.txt ]; then
+              cat target/proof-observations/proof-execution-observations-summary.txt
+            elif [ -f target/proof-observations/download.log ]; then
+              cat target/proof-observations/download.log
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload observation collection
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: proof-executor-observation-collection
+          path: target/proof-observations/
+          if-no-files-found: error
+          retention-days: 30

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -55,6 +55,7 @@ name = "proof_control_plane"
 kind = "rust"
 paths = [
   ".github/workflows/ci.yml",
+  ".github/workflows/proof-observation-collection.yml",
   ".github/workflows/proof-executor.yml",
   "ci/proof.toml",
   "docs/external-services.md",

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -72,6 +72,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - Observation collection can now enforce readiness thresholds with `--min-observations`, `--min-executed`, `--min-scopes`, and `--min-artifacts`, so downloaded non-required executor runs can prove a multi-run/multi-scope evidence floor before any promotion decision.
 - Observation collection can now also write `--summary-md`, and the proof executor workflow appends that Rust-generated Markdown collection report to the GitHub job summary while still uploading the JSON artifact.
 - `cargo xtask proof` now accepts `--executor-max-commands <n>` as a positive override for the policy-selected advisory executor command limit. The proof executor workflow keeps PR runs at one command by default, while manual dispatches can raise `max_evidence_commands` to collect multi-scope evidence without changing required gates.
+- `.github/workflows/proof-observation-collection.yml` now provides a manual collector for successful `proof-executor.yml` runs. It downloads prior `proof-executor-artifacts`, runs the Rust-owned observation collection thresholds over the downloaded artifacts, uploads the collection, and appends the Markdown collection summary without executing new evidence commands.
 - Next proof-policy operational slice: collect successful non-required PR executor runs across multiple affected scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -196,6 +196,53 @@ fn scoped_coverage_executor_is_pr_visible_but_not_required() {
 }
 
 #[test]
+fn proof_observation_collection_workflow_summarizes_downloaded_executor_runs() {
+    let root = workspace_root();
+    let collector =
+        fs::read_to_string(root.join(".github/workflows/proof-observation-collection.yml"))
+            .expect("proof observation collection workflow should be readable");
+    let ci =
+        fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("ci workflow readable");
+
+    assert!(
+        collector.contains("workflow_dispatch:"),
+        "collector should be manually dispatched"
+    );
+    assert!(
+        collector.contains("actions: read"),
+        "collector needs read-only workflow artifact access"
+    );
+    assert!(
+        collector.contains("gh run list --workflow proof-executor.yml --status success"),
+        "collector should enumerate successful proof executor runs"
+    );
+    assert!(
+        collector.contains("gh run download \"${run_id}\" --name proof-executor-artifacts"),
+        "collector should download the stable proof executor artifact"
+    );
+    assert!(
+        collector.contains("cargo xtask proof-execution-observations-summary"),
+        "collector should keep observation summarization Rust-owned"
+    );
+    assert!(
+        collector.contains("--min-observations \"${MIN_OBSERVATIONS}\""),
+        "collector should expose observation readiness thresholds"
+    );
+    assert!(
+        collector.contains("proof-executor-observation-collection.md"),
+        "collector should append the Rust-generated Markdown summary"
+    );
+    assert!(
+        !collector.contains("proof --profile affected"),
+        "collector must not execute new planner-selected evidence commands"
+    );
+    assert!(
+        !ci.contains("proof-observation-collection"),
+        "required CI aggregate must not depend on the manual collector"
+    );
+}
+
+#[test]
 fn affected_proof_plan_reports_no_changes_for_same_ref() {
     let (stdout, stderr, success) = run_xtask(&[
         "proof",


### PR DESCRIPTION
## Summary
- add a manual proof executor observation collection workflow
- download successful proof-executor artifacts and summarize them with the Rust-owned observation threshold command
- classify the collector under the proof control-plane scope and record the checkpoint in docs/NEXT.md

## Validation
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/proof-observation-collection.yml').read_text(encoding='utf-8'))"
- cargo xtask proof-policy --check
- cargo test -p xtask proof_observation_collection_workflow_summarizes_downloaded_executor_runs --verbose
- cargo test -p xtask proof_plan --verbose
- cargo xtask docs --check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- cargo xtask check-lint-policy
- cargo xtask check-no-panic-family
- cargo test -p xtask --verbose
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan