### PR TITLE
policy(ci): add CI lane whitelist

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -634,6 +634,20 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "ci_economics_policy"
+kind = "non_rust"
+paths = [
+  "policy/ci-lane-whitelist.toml",
+  "policy/ci-whitelist-exceptions.toml",
+]
+proof = [
+  "cargo xtask proof-policy --check",
+]
+reason = "CI lane whitelist and its docs govern verification economics receipts; checked via proof-policy and the lane whitelist linter (PR 03 onward)."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "schema_contracts"
 kind = "rust"
 paths = [

--- a/docs/ci/ci-lane-whitelist.md
+++ b/docs/ci/ci-lane-whitelist.md
@@ -1,0 +1,59 @@
+# CI lane whitelist
+
+The lane whitelist is the single map from CI item → purpose, cost,
+trigger, owner, and evidence. The TOML lives at
+`policy/ci-lane-whitelist.toml`. This doc is the human-facing pointer.
+
+## Schema
+
+Each `[[lane]]` entry records:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `id` | yes | Stable identifier; referenced by PR Plan, exceptions, and the linter. |
+| `workflow` | yes | The `.github/workflows/*.yml` file the lane lives in. |
+| `job` | yes | The job's `name:` in the workflow. |
+| `kind` | yes | `rust` / `policy` / `mutation` / `wasm` / `packaging` / `release` / `lint` / `summary` / etc. |
+| `tier` | yes | `frontdoor` (cheap default) / `risk-gated` (default with risk pack) / `deep` (label/main/nightly) / `summary`. |
+| `default_pr` | yes | Whether this lane runs on ordinary PRs today. |
+| `blocking` | yes | Whether failure currently blocks merge. |
+| `runner` | yes | Runner label for LEM multiplier; `mixed` for matrix jobs. |
+| `base_lem` | yes | Static LEM floor used until actuals exist. |
+| `owner` | yes | Team/role that owns the lane. |
+| `intent` | yes | What the lane is *for*. |
+| `failure_mode` | yes | What slips through if the lane is removed. |
+| `proof_obligation` | yes | The literal commands or evidence the lane must produce. |
+| `evidence` | for blocking | Concrete artifact / log entries that demonstrate the obligation was met. |
+| `allowed_triggers` | yes | `pull_request` / `push` / `schedule` / `workflow_dispatch`. |
+| `expensive` | optional | `true` if the lane needs a default-PR exception. |
+| `default_pr_exception` | optional | ID in `policy/ci-whitelist-exceptions.toml` that allows the expensive default. |
+| `duplicate_of` | optional | List of lane IDs that already cover this surface. `future:*` references are permitted to forward-declare. |
+| `review_after` / `expires` | yes | Calendar dates — when to re-review and when the entry must be re-justified. |
+
+## Exceptions
+
+`policy/ci-whitelist-exceptions.toml` holds the carve-outs needed during
+the rollout. Each exception names the lane it covers, why it is allowed,
+and when it must be reviewed and retired.
+
+## Lifecycle
+
+1. New lane added → entry in `ci-lane-whitelist.toml` + (if expensive
+   default) entry in `ci-whitelist-exceptions.toml`.
+2. Linter (PR 03) verifies workflows match the whitelist and exceptions
+   are valid.
+3. As risk-pack routing lands (PR 12), expensive default lanes get demoted
+   and their exceptions retire.
+4. Exceptions never extend silently — `expires` is enforced.
+
+## Budget
+
+```toml
+[budget]
+preferred_default_lem = 25
+default_limit_lem     = 35
+elevated_limit_lem    = 75
+hard_limit_lem        = 125
+```
+
+These are the bands the PR Plan job (PR 08) and budget guard (PR 14) read.

--- a/docs/ci/inventory.md
+++ b/docs/ci/inventory.md
@@ -1,0 +1,62 @@
+# tokmd CI inventory snapshot
+
+Snapshot of CI lanes as of 2026-05-07. Generated as the human-readable
+companion to `policy/ci-lane-whitelist.toml`. Update on rollout PRs.
+
+## Frontdoor (cheap default)
+
+| Lane ID | Job | Runner | Base LEM | Notes |
+|---------|-----|--------|----------|-------|
+| `msrv_check` | MSRV Check | ubuntu | 5 | MSRV cargo check. PR 04 moves to 1.93. |
+| `quality_gate` | Quality Gate | ubuntu | 8 | `cargo xtask gate --check`. |
+| `proof_policy` | Proof Policy | ubuntu | 3 | `cargo xtask proof-policy --check`. |
+| `affected_proof_plan` | Affected Proof Plan | ubuntu | 4 | Wrapped by PR 08 PR Plan. |
+| `feature_boundaries` | Feature Boundaries | ubuntu | 10 | Analysis microcrate boundaries. |
+| `typos` | Typos | ubuntu | 1 | crate-ci/typos. |
+| `cargo_deny` | Cargo Deny | ubuntu | 4 | Advisories + licenses. |
+| `version_consistency` | Version consistency | ubuntu | 2 | Release metadata alignment. |
+| `docs_check` | Docs Check | ubuntu | 4 | `cargo xtask docs --check`. |
+| `ci_required` | CI (Required) | ubuntu | 1 | Aggregator. |
+
+## Expensive default — needs exception during rollout
+
+| Lane ID | Job | Runner | Base LEM | Exception |
+|---------|-----|--------|----------|-----------|
+| `build_test_linux_windows` | Build & Test | mixed | 40 | `ci_exception_windows_full_test_default` |
+| `wasm_compile_test` | Wasm Compile & Test | ubuntu | 25 | `ci_exception_wasm_default` |
+| `nix_pr_package_gate` | Nix PR Package Gate | ubuntu | 35 | `ci_exception_nix_default` |
+| `mutation_required` | Mutation Testing (Required) | ubuntu | 45 | `ci_exception_mutation_default` |
+| `proptest_smoke` | Proptest Smoke | ubuntu | 8 | (no exception; fits frontdoor band) |
+| `publish_surface` | Publish Surface | ubuntu | 8 | (no exception; cheap dry-run) |
+
+## Push / main-only
+
+| Lane ID | Job | Runner | Base LEM | Notes |
+|---------|-----|--------|----------|-------|
+| `build_macos_push` | Build & Test (macOS) | macOS | 60 | `if: github.event_name == 'push'`. |
+
+## Estimated default-PR LEM today
+
+```text
+msrv_check                  5
+quality_gate                8
+proof_policy                3
+affected_proof_plan         4
+feature_boundaries         10
+typos                       1
+cargo_deny                  4
+version_consistency         2
+docs_check                  4
+build_test_linux_windows   40
+wasm_compile_test          25
+nix_pr_package_gate        35
+mutation_required          45
+proptest_smoke              8
+publish_surface             8
+ci_required                 1
+                          ----
+                           203  (high-cost / override band)
+```
+
+PR 10–12 demote the bottom block to risk-pack routing. The target frontdoor
+band drops to roughly 30–40 LEM for an ordinary Rust-only PR.

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -1,0 +1,398 @@
+schema_version = "1.0"
+policy = "ci-lane-whitelist"
+owner = "release/ci"
+status = "advisory"
+updated = "2026-05-07"
+
+# CI lane whitelist: every CI item maps to purpose, cost, trigger, owner,
+# and evidence. Reviewers and the future xtask check (PR 03) read from this
+# file. Exceptions for default-PR expensive lanes live in
+# `policy/ci-whitelist-exceptions.toml`.
+
+[budget]
+preferred_default_lem = 25
+default_limit_lem     = 35
+elevated_limit_lem    = 75
+hard_limit_lem        = 125
+
+[runner_multipliers]
+ubuntu_latest      = 1.0
+windows_latest     = 2.0
+macos_latest       = 10.0
+nix_build          = 4.0
+external_ai_review = 4.0
+
+# -----------------------------------------------------------------------
+# Frontdoor / cheap default-PR lanes
+# -----------------------------------------------------------------------
+
+[[lane]]
+id               = "msrv_check"
+workflow         = ".github/workflows/ci.yml"
+job              = "MSRV Check"
+kind             = "compatibility"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 5
+owner            = "release/compat"
+intent           = "Validate declared MSRV compatibility."
+failure_mode     = "Repo claims MSRV support but fails to compile on that toolchain."
+proof_obligation = "Run cargo check on the MSRV toolchain."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "quality_gate"
+workflow         = ".github/workflows/ci.yml"
+job              = "Quality Gate"
+kind             = "policy"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 8
+owner            = "core/policy"
+intent           = "Run repo quality gate through xtask."
+failure_mode     = "Formatting, lint, policy, or product gate drift reaches main."
+proof_obligation = "Run cargo xtask gate --check."
+evidence         = ["job logs", "future policy reports"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "proof_policy"
+workflow         = ".github/workflows/ci.yml"
+job              = "Proof Policy"
+kind             = "policy"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 3
+owner            = "proof"
+intent           = "Validate proof policy configuration."
+failure_mode     = "Proof policy config drifts or becomes internally inconsistent."
+proof_obligation = "Run cargo xtask proof-policy --check."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "affected_proof_plan"
+workflow         = ".github/workflows/ci.yml"
+job              = "Affected Proof Plan"
+kind             = "planner"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 4
+owner            = "proof"
+intent           = "Generate affected proof artifacts for changed files."
+failure_mode     = "Reviewers cannot see the proof plan for a PR's changed surface."
+proof_obligation = "Run cargo xtask affected and proof --profile affected."
+evidence = [
+  "target/proof/affected.json",
+  "target/proof/proof-plan.md",
+  "target/proof/proof-evidence.json",
+  "target/proof/executor-summary.json",
+  "target/proof/executor-manifest.json",
+]
+allowed_triggers = ["pull_request"]
+duplicate_of     = ["future:pr_plan"]
+review_after     = "2026-06-07"
+expires          = "2026-08-07"
+
+[[lane]]
+id               = "feature_boundaries"
+workflow         = ".github/workflows/ci.yml"
+job              = "Feature Boundaries"
+kind             = "rust"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 10
+owner            = "core/build"
+intent           = "Validate analysis microcrate boundaries and feature combinations."
+failure_mode     = "Feature default-on/default-off drift breaks the analysis surface."
+proof_obligation = "Run cargo test -p tokmd-analysis with --all-features and --no-default-features, then cargo xtask boundaries-check."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "typos"
+workflow         = ".github/workflows/ci.yml"
+job              = "Typos"
+kind             = "lint"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 1
+owner            = "docs"
+intent           = "Catch typos in source, docs, and config."
+failure_mode     = "Typos in user-facing docs or schemas reach main."
+proof_obligation = "Run crate-ci/typos."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "cargo_deny"
+workflow         = ".github/workflows/ci.yml"
+job              = "Cargo Deny"
+kind             = "supply_chain"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 4
+owner            = "release/dependencies"
+intent           = "Enforce advisory and license policy on the dependency graph."
+failure_mode     = "Disallowed license or known-vulnerable advisory reaches main."
+proof_obligation = "Run cargo deny --all-features check."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "version_consistency"
+workflow         = ".github/workflows/ci.yml"
+job              = "Version consistency"
+kind             = "release"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 2
+owner            = "release/metadata"
+intent           = "Check release metadata alignment across crates and packaging."
+failure_mode     = "Crate, packaging, and changelog versions drift apart."
+proof_obligation = "Run cargo xtask version-consistency."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "docs_check"
+workflow         = ".github/workflows/ci.yml"
+job              = "Docs Check"
+kind             = "docs"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 4
+owner            = "docs"
+intent           = "Detect documentation drift relative to schemas and CLI."
+failure_mode     = "Reference docs go out of sync with shipped behavior."
+proof_obligation = "Run cargo xtask docs --check."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+# -----------------------------------------------------------------------
+# Expensive default-PR lanes (transition exceptions in
+# policy/ci-whitelist-exceptions.toml)
+# -----------------------------------------------------------------------
+
+[[lane]]
+id                     = "build_test_linux_windows"
+workflow               = ".github/workflows/ci.yml"
+job                    = "Build & Test"
+kind                   = "rust"
+tier                   = "frontdoor"
+default_pr             = true
+blocking               = true
+runner                 = "mixed"
+runners_used           = ["ubuntu_latest", "windows_latest"]
+base_lem               = 40
+owner                  = "core/build"
+intent                 = "Run full all-features tests on Ubuntu and Windows."
+failure_mode           = "All-features test failure or Windows-specific failure reaches main."
+proof_obligation       = "Run cargo test --all-features on Linux and Windows."
+evidence               = ["job logs"]
+allowed_triggers       = ["pull_request", "push"]
+expensive              = true
+expensive_reason       = "Windows doubles Linux-equivalent cost and all-features is broad."
+default_pr_exception   = "ci_exception_windows_full_test_default"
+duplicate_of           = ["quality_gate"]
+review_after           = "2026-06-07"
+expires                = "2026-08-07"
+
+[[lane]]
+id                     = "wasm_compile_test"
+workflow               = ".github/workflows/ci.yml"
+job                    = "Wasm Compile & Test"
+kind                   = "wasm"
+tier                   = "risk-gated"
+default_pr             = true
+blocking               = true
+runner                 = "ubuntu_latest"
+base_lem               = 25
+owner                  = "wasm"
+intent                 = "Validate tokmd WASM packages, Node tests, and browser runner."
+failure_mode           = "WASM/browser-facing product surface breaks."
+proof_obligation       = "Check tokmd-scan/core/wasm for wasm32, run wasm-pack tests, build/test web runner."
+evidence               = ["job logs"]
+allowed_triggers       = ["pull_request", "push"]
+expensive              = true
+default_pr_exception   = "ci_exception_wasm_default"
+duplicate_of           = []
+review_after           = "2026-06-07"
+expires                = "2026-08-07"
+
+[[lane]]
+id                     = "nix_pr_package_gate"
+workflow               = ".github/workflows/ci.yml"
+job                    = "Nix PR Package Gate"
+kind                   = "packaging"
+tier                   = "deep"
+default_pr             = true
+blocking               = true
+runner                 = "ubuntu_latest"
+base_lem               = 35
+owner                  = "release/nix"
+intent                 = "Validate Nix flake and package build."
+failure_mode           = "Nix package or flake breaks despite Rust build passing."
+proof_obligation       = "Run nix flake check --no-build and nix build .#tokmd."
+evidence               = ["job logs"]
+allowed_triggers       = ["pull_request", "push"]
+expensive              = true
+default_pr_exception   = "ci_exception_nix_default"
+duplicate_of           = ["publish_surface"]
+review_after           = "2026-06-07"
+expires                = "2026-08-07"
+
+[[lane]]
+id                     = "mutation_required"
+workflow               = ".github/workflows/ci.yml"
+job                    = "Mutation Testing (Required)"
+kind                   = "mutation"
+tier                   = "deep"
+default_pr             = true
+blocking               = true
+runner                 = "ubuntu_latest"
+base_lem               = 45
+owner                  = "testing/oracle"
+intent                 = "Run runtime mutation testing on changed production Rust files."
+failure_mode           = "Changed code is covered but tests do not kill concrete mutants."
+proof_obligation       = "Run cargo-mutants on changed production Rust files."
+evidence               = ["mutants.out artifacts"]
+allowed_triggers       = ["pull_request"]
+expensive              = true
+default_pr_exception   = "ci_exception_mutation_default"
+duplicate_of           = ["future:ripr_advisory"]
+review_after           = "2026-06-07"
+expires                = "2026-08-07"
+
+[[lane]]
+id                     = "proptest_smoke"
+workflow               = ".github/workflows/ci.yml"
+job                    = "Proptest Smoke"
+kind                   = "property"
+tier                   = "risk-gated"
+default_pr             = true
+blocking               = true
+runner                 = "ubuntu_latest"
+base_lem               = 8
+owner                  = "testing/oracle"
+intent                 = "Reduced-iteration property test smoke for tokmd-model/types/tokmd."
+failure_mode           = "Property regression slips by because expanded proptest runs only on main."
+proof_obligation       = "Run PROPTEST_CASES=50 cargo test --test properties on selected crates."
+evidence               = ["job logs"]
+allowed_triggers       = ["pull_request", "push"]
+duplicate_of           = []
+review_after           = "2026-06-07"
+expires                = "2026-08-07"
+
+[[lane]]
+id                     = "publish_surface"
+workflow               = ".github/workflows/ci.yml"
+job                    = "Publish Surface"
+kind                   = "release"
+tier                   = "risk-gated"
+default_pr             = true
+blocking               = true
+runner                 = "ubuntu_latest"
+base_lem               = 8
+owner                  = "release/publish"
+intent                 = "Verify publish surface and dry-run publish checks."
+failure_mode           = "Crate publish breaks despite local builds passing."
+proof_obligation       = "Run cargo xtask publish-surface --json --verify-publish."
+evidence               = ["job logs"]
+allowed_triggers       = ["pull_request", "push"]
+duplicate_of           = ["nix_pr_package_gate"]
+review_after           = "2026-06-07"
+expires                = "2026-08-07"
+
+# -----------------------------------------------------------------------
+# Push / main-only lanes
+# -----------------------------------------------------------------------
+
+[[lane]]
+id               = "build_macos_push"
+workflow         = ".github/workflows/ci.yml"
+job              = "Build & Test (macOS)"
+kind             = "rust"
+tier             = "deep"
+default_pr       = false
+blocking         = false
+runner           = "macos_latest"
+base_lem         = 60
+owner            = "platform/macos"
+intent           = "Run all-features tests on macOS for main pushes only."
+failure_mode     = "macOS-specific regression reaches a release without being caught."
+proof_obligation = "Run cargo test --all-features on macOS."
+evidence         = ["job logs"]
+allowed_triggers = ["push"]
+expensive        = true
+expensive_reason = "macOS-hosted runner minutes are billed at 10× Linux."
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+# -----------------------------------------------------------------------
+# Required summary
+# -----------------------------------------------------------------------
+
+[[lane]]
+id               = "ci_required"
+workflow         = ".github/workflows/ci.yml"
+job              = "CI (Required)"
+kind             = "summary"
+tier             = "summary"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 1
+owner            = "release/ci"
+intent           = "Aggregate required CI jobs into a single branch-protection target."
+failure_mode     = "Branch protection fragments across many required jobs and drifts."
+proof_obligation = "Read needs context and fail if any required job failed or was cancelled."
+evidence         = ["GITHUB_STEP_SUMMARY"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = []
+review_after     = "2026-06-07"
+expires          = "2026-11-07"

--- a/policy/ci-whitelist-exceptions.toml
+++ b/policy/ci-whitelist-exceptions.toml
@@ -1,0 +1,58 @@
+schema_version = "1.0"
+policy = "ci-whitelist-exceptions"
+owner = "release/ci"
+status = "active"
+
+# Carve-outs that allow current CI to pass the lane whitelist check while
+# the rollout (PRs 10–12) demotes expensive default-PR lanes to risk-pack
+# routing. Each exception MUST have an owner, a reason, a creation date,
+# and an expiry. Expired exceptions are surfaced by the lane whitelist
+# linter (PR 03).
+
+[[exception]]
+id           = "ci_exception_mutation_default"
+kind         = "expensive_default_pr_lane"
+lane         = "mutation_required"
+allowed      = true
+owner        = "testing/oracle"
+issue        = "TODO"
+reason       = "Runtime mutation is currently required on PRs. Replace ordinary PR default with ripr advisory plus label/main/nightly mutation after baseline review."
+created      = "2026-05-07"
+review_after = "2026-06-07"
+expires      = "2026-08-07"
+
+[[exception]]
+id           = "ci_exception_wasm_default"
+kind         = "expensive_default_pr_lane"
+lane         = "wasm_compile_test"
+allowed      = true
+owner        = "wasm"
+issue        = "TODO"
+reason       = "WASM/browser runner is important but should route only on WASM/web/capability changes after PR Plan lands."
+created      = "2026-05-07"
+review_after = "2026-06-07"
+expires      = "2026-08-07"
+
+[[exception]]
+id           = "ci_exception_nix_default"
+kind         = "expensive_default_pr_lane"
+lane         = "nix_pr_package_gate"
+allowed      = true
+owner        = "release/nix"
+issue        = "TODO"
+reason       = "Nix package proof is currently required; move to release/main/label once publish-surface and package risk packs are wired."
+created      = "2026-05-07"
+review_after = "2026-06-07"
+expires      = "2026-08-07"
+
+[[exception]]
+id           = "ci_exception_windows_full_test_default"
+kind         = "expensive_default_pr_lane"
+lane         = "build_test_linux_windows"
+allowed      = true
+owner        = "platform/windows"
+issue        = "TODO"
+reason       = "Windows currently runs full all-features test matrix. Retain temporarily until Windows risk pack separates path/platform checks from every Rust PR."
+created      = "2026-05-07"
+review_after = "2026-06-07"
+expires      = "2026-08-07"


### PR DESCRIPTION
## Summary

PR 02 of 16 in the tokmd CI economics rollout. Maps every CI item to
purpose, cost, trigger, owner, and evidence. Exceptions during the
rollout get explicit dated entries with owners and expiry so future
automation (PR 03) can retire them.

Adds:
- `policy/ci-lane-whitelist.toml` — lanes + budget + runner multipliers.
- `policy/ci-whitelist-exceptions.toml` — dated carve-outs for default-PR expensive lanes.
- `docs/ci/ci-lane-whitelist.md` — schema + lifecycle.
- `docs/ci/inventory.md` — snapshot of current LEM cost (~203 LEM today).

Updates:
- `ci/proof.toml` — adds `ci_economics_policy` non-Rust scope so the new files don't trip the proof scope discovery.

## CI economics

- **Default PR LEM impact:** none (policy data + docs only).
- **Workflows touched:** none.
- **Branch protection impact:** none.
- **Failure mode caught:** lane drift — sets the source of truth that PR 03's linter consumes.
- **Cheaper signal considered:** scattering ownership inline across workflows. Rejected — single TOML lets PR Plan, exceptions, and budget guard read one shape.
- **Rollback path:** `git revert`. No workflow consumes these files yet.
- **Commands run:** `python3 tomllib` parses both TOML files; `cargo xtask proof-policy --check` clean; `cargo xtask affected` reports zero unknown files.

## Test plan

- [x] `cargo xtask proof-policy --check`
- [x] `cargo xtask affected --base origin/main --head HEAD --json` — zero unknowns.
- [x] TOML files parse with `tomllib`.
- [ ] Reviewers confirm lane intent / failure modes are accurate.

Depends on: PR #1687 for the verification economics framing (no file overlap).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_