### PR TITLE
policy(rust): move tokmd to MSRV 1.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Rust (MSRV)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92
+          toolchain: 1.93
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV compatibility
         run: cargo check --workspace --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ default-members = [
 [workspace.package]
 version = "1.10.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/EffortlessMetrics/tokmd"
 repository = "https://github.com/EffortlessMetrics/tokmd"

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -54,7 +54,7 @@ carveouts such as `allow-unwrap-in-tests`, `allow-expect-in-tests`,
 
 ## Upgrade ledger
 
-The workspace currently targets Rust 1.92. Planned Clippy flips for Rust 1.94
+The workspace currently targets Rust 1.93. Planned Clippy flips for Rust 1.94
 and 1.95 are recorded before the MSRV bump so that upgrades are reviewable,
 searchable, and gated by policy.
 

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,5 +1,5 @@
 schema = 1
-msrv = "1.92"
+msrv = "1.93"
 
 [policy]
 panic_free_tests = true

--- a/xtask/tests/lint_policy_w93.rs
+++ b/xtask/tests/lint_policy_w93.rs
@@ -29,7 +29,7 @@ fn lint_policy_accepts_repo_policy() {
 
     assert!(success, "check-lint-policy failed. stderr: {stderr}");
     assert!(stdout.contains("lint policy ok"), "stdout: {stdout}");
-    assert!(stdout.contains("MSRV 1.92"), "stdout: {stdout}");
+    assert!(stdout.contains("MSRV 1.93"), "stdout: {stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

PR 04 of 16. Bumps the workspace MSRV from 1.92 to 1.93 to align with the shared estate baseline. The existing planned-Clippy ledger entries for Rust 1.94/1.95 stay gated; bumping MSRV does not activate them.

## CI economics

- **Default PR LEM impact:** none (MSRV check still runs, on a different toolchain).
- **Workflows touched:** `.github/workflows/ci.yml` (MSRV toolchain pin only).
- **Branch protection impact:** none.
- **Failure mode caught:** silent compatibility drift between code shipped and the declared MSRV.
- **Cheaper signal considered:** waiting until a feature requires it. Rejected — we already have planned-lint entries pinned to 1.94/1.95, and the verification ladder benefits from being on the shared estate baseline.
- **Rollback path:** `git revert`. The bump is self-contained.
- **Commands run:** `cargo xtask check-lint-policy` reports MSRV 1.93; `cargo check --workspace --locked` clean; `cargo test -p xtask --test lint_policy_w93` 2 passed.

## Test plan

- [x] `cargo xtask check-lint-policy`
- [x] `cargo check --workspace --locked`
- [x] `cargo test -p xtask --test lint_policy_w93`
- [ ] CI passes MSRV check on 1.93.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_