### PR TITLE
policy(files): add non-Rust file allowlist

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -73,6 +73,7 @@ paths = [
   "xtask/src/tasks/boundaries_check.rs",
   "xtask/src/tasks/ci_actuals.rs",
   "xtask/src/tasks/coverage_receipt.rs",
+  "xtask/src/tasks/file_policy.rs",
   "xtask/src/tasks/fixture_blobs_check.rs",
   "xtask/src/tasks/proof_artifacts_check.rs",
   "xtask/src/tasks/proof_policy.rs",
@@ -615,6 +616,20 @@ proof = [
   "cargo xtask proof-policy --check",
 ]
 reason = "ripr static-mutation analyzer config + suppressions ledger; advisory until PR 16 soft-gate."
+mutation = false
+coverage = false
+
+[[scope]]
+name = "file_policy"
+kind = "non_rust"
+paths = [
+  "docs/FILE_POLICY.md",
+  "policy/non-rust-allowlist.toml",
+]
+proof = [
+  "cargo xtask check-file-policy",
+]
+reason = "Non-Rust file allowlist governance: every non-Rust file in the repo must match an explicit allow entry."
 mutation = false
 coverage = false
 

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -1,0 +1,55 @@
+# tokmd file policy
+
+tokmd is Rust-first but legitimately contains non-Rust surfaces:
+
+- GitHub Actions YAML
+- Nix flake / lock
+- Documentation
+- JSON schemas
+- Test fixtures
+- Browser runner assets and Node package files
+- Release packaging (Homebrew, AUR, Scoop, winget, Docker)
+- Vendored / patched dependencies
+
+These should be **explicit, owned, and covered** rather than tolerated by silence.
+
+## Allowlist shape
+
+`policy/non-rust-allowlist.toml` lists `[[allow]]` entries:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `glob` | yes | What the entry covers (e.g. `.github/workflows/*.yml`). |
+| `kind` | yes | Structural category (e.g. `ci_declarative`, `documentation`, `test_fixture`). |
+| `owner` | yes | Team/role responsible. "tokmd" is not an owner. |
+| `surface` | yes | Where the file shows up — `build`, `release`, `ci`, `docs`, `agents`, etc. |
+| `classification` | yes | `production` / `config` / `documentation` / `vendor` / `test_fixture`. |
+| `reason` | yes | Why a non-Rust file lives in a Rust-first repo. |
+| `covered_by` | optional | The proof obligation that exercises it. |
+
+## Checker
+
+```bash
+cargo xtask check-file-policy
+```
+
+The checker walks the repo (excluding `.git/` and `target/`), normalises
+file paths, and reports any non-Rust file that does not match an
+`[[allow]]` glob. Rust source files (`*.rs`) are not the subject of this
+policy and are skipped.
+
+The advisory phase reports drift; `--strict` turns drift into a non-zero
+exit.
+
+## Adding a new non-Rust file
+
+1. Add a `[[allow]]` entry with the right `kind`, `owner`,
+   `classification`, and `reason`.
+2. Re-run `cargo xtask check-file-policy` and confirm the file matches.
+3. Commit the policy edit alongside the file change.
+
+## Rust files
+
+Rust files are governed by the workspace lints, the proof policy
+(`ci/proof.toml`), and the lint/no-panic ledgers. They are deliberately
+out of scope here.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,800 @@
+schema_version = "1.0"
+policy = "non-rust-allowlist"
+owner = "release/files"
+status = "advisory"
+updated = "2026-05-07"
+
+# Non-Rust file surfaces. Each [[allow]] entry pins:
+#   glob   - what the entry covers
+#   kind   - structural category for the report
+#   owner  - team/role responsible
+#   surface - where this file shows up to consumers
+#   classification - production / config / documentation / vendor / test_fixture
+#   reason - why a non-Rust file lives in a Rust-first repo
+#   covered_by - the proof obligation that exercises it
+#
+# Files that match nothing are reported by `cargo xtask check-file-policy`.
+# The advisory phase reports drift; --strict turns drift into an error.
+
+# -----------------------------------------------------------------------
+# Top-level repo metadata
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = "Cargo.toml"
+kind = "rust_workspace_root"
+owner = "release/build"
+surface = "build"
+classification = "config"
+reason = "Workspace manifest is the entry point for cargo workflows."
+covered_by = ["cargo check --workspace --locked"]
+
+[[allow]]
+glob = "Cargo.lock"
+kind = "rust_workspace_lockfile"
+owner = "release/dependencies"
+surface = "build"
+classification = "config"
+reason = "Lockfile pin is required for reproducible builds and cargo deny."
+covered_by = ["cargo deny --all-features check"]
+
+[[allow]]
+glob = "*.md"
+kind = "documentation"
+owner = "docs"
+surface = "docs"
+classification = "documentation"
+reason = "Top-level project docs (README, CONTRIBUTING, CHANGELOG, etc.)."
+covered_by = ["cargo xtask docs --check"]
+
+[[allow]]
+glob = "LICENSE-*"
+kind = "license"
+owner = "release/legal"
+surface = "release"
+classification = "documentation"
+reason = "Required license texts for dual-licensed Apache-2.0 / MIT distribution."
+covered_by = ["cargo deny --all-features check"]
+
+[[allow]]
+glob = "CITATION.cff"
+kind = "metadata"
+owner = "release/metadata"
+surface = "release"
+classification = "documentation"
+reason = "Citation metadata for academic/release tooling."
+covered_by = ["cargo xtask version-consistency"]
+
+[[allow]]
+glob = "deny.toml"
+kind = "policy"
+owner = "release/dependencies"
+surface = "build"
+classification = "config"
+reason = "cargo-deny advisory and license policy."
+covered_by = ["cargo deny --all-features check"]
+
+[[allow]]
+glob = "clippy.toml"
+kind = "policy"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Clippy disallowed-* policy; must not weaken workspace baseline."
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "_typos.toml"
+kind = "policy"
+owner = "docs"
+surface = "build"
+classification = "config"
+reason = "crate-ci/typos configuration."
+covered_by = ["typos workflow"]
+
+[[allow]]
+glob = "proptest.toml"
+kind = "policy"
+owner = "testing/oracle"
+surface = "build"
+classification = "config"
+reason = "proptest runtime configuration for property tests."
+covered_by = ["proptest smoke job"]
+
+[[allow]]
+glob = "codecov.yml"
+kind = "policy"
+owner = "testing/oracle"
+surface = "build"
+classification = "config"
+reason = "Codecov upload configuration."
+covered_by = ["coverage workflow"]
+
+[[allow]]
+glob = "rustfmt.toml"
+kind = "policy"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Workspace rustfmt configuration if present."
+covered_by = ["cargo xtask gate --check"]
+
+[[allow]]
+glob = ".editorconfig"
+kind = "editor"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Cross-editor whitespace policy."
+covered_by = []
+
+[[allow]]
+glob = ".gitattributes"
+kind = "git"
+owner = "release/build"
+surface = "build"
+classification = "config"
+reason = "Git attribute policy for line endings, generated, etc."
+covered_by = []
+
+[[allow]]
+glob = ".gitignore"
+kind = "git"
+owner = "release/build"
+surface = "build"
+classification = "config"
+reason = "Repo-wide ignore patterns."
+covered_by = []
+
+[[allow]]
+glob = ".dockerignore"
+kind = "release"
+owner = "release/publish"
+surface = "release"
+classification = "config"
+reason = "Docker build context exclusions."
+covered_by = ["release docker job"]
+
+[[allow]]
+glob = "Dockerfile"
+kind = "release"
+owner = "release/publish"
+surface = "release"
+classification = "production"
+reason = "Container build for releases."
+covered_by = ["release docker job"]
+
+[[allow]]
+glob = "Justfile"
+kind = "tooling"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Local task runner shortcuts."
+covered_by = []
+
+[[allow]]
+glob = "action.yml"
+kind = "github_action"
+owner = "release/action"
+surface = "downstream"
+classification = "production"
+reason = "Composite GitHub Action contract for downstream consumers."
+covered_by = [".github/workflows/test-action.yml", "cargo xtask docs --check"]
+
+[[allow]]
+glob = "flake.nix"
+kind = "packaging_nix"
+owner = "release/nix"
+surface = "release"
+classification = "production"
+reason = "Nix flake for packaging and reproducible builds."
+covered_by = ["nix flake check --no-build", "nix build .#tokmd"]
+
+[[allow]]
+glob = "flake.lock"
+kind = "packaging_nix"
+owner = "release/nix"
+surface = "release"
+classification = "config"
+reason = "Pinned Nix flake inputs."
+covered_by = ["nix flake check --no-build"]
+
+# -----------------------------------------------------------------------
+# .github/ tree
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+covered_by = ["cargo xtask ci-lane-whitelist"]
+
+[[allow]]
+glob = ".github/CODEOWNERS"
+kind = "github"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "Code ownership policy."
+covered_by = []
+
+[[allow]]
+glob = ".github/dependabot.yml"
+kind = "github"
+owner = "release/dependencies"
+surface = "ci"
+classification = "config"
+reason = "Dependabot configuration."
+covered_by = []
+
+[[allow]]
+glob = ".github/labels.yml"
+kind = "github"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "Repository label declarations."
+covered_by = [".github/workflows/sync-labels.yml"]
+
+[[allow]]
+glob = ".github/settings.yml"
+kind = "github"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "Repo settings declared as policy-as-code."
+covered_by = []
+
+[[allow]]
+glob = ".github/FUNDING.yml"
+kind = "github"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "GitHub funding metadata."
+covered_by = []
+
+[[allow]]
+glob = ".github/ISSUE_TEMPLATE/**"
+kind = "github"
+owner = "core/policy"
+surface = "ci"
+classification = "documentation"
+reason = "Issue triage templates."
+covered_by = []
+
+[[allow]]
+glob = ".github/pull_request_template.md"
+kind = "github"
+owner = "core/policy"
+surface = "ci"
+classification = "documentation"
+reason = "PR template; co-evolves with cockpit metrics."
+covered_by = ["PR Cockpit job"]
+
+[[allow]]
+glob = ".github/agents/**"
+kind = "agents"
+owner = "core/policy"
+surface = "ci"
+classification = "documentation"
+reason = "Agent runbook docs for CI assistants."
+covered_by = []
+
+# -----------------------------------------------------------------------
+# Documentation surfaces
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = "docs/**"
+kind = "documentation"
+owner = "docs"
+surface = "docs"
+classification = "documentation"
+reason = "Documentation is a first-class tokmd product surface."
+covered_by = ["cargo xtask docs --check"]
+
+[[allow]]
+glob = "docs/capabilities/*.json"
+kind = "capability_contract"
+owner = "product/contracts"
+surface = "contract"
+classification = "production"
+reason = "Machine-readable capability contracts are product artifacts."
+covered_by = ["cargo xtask docs --check"]
+
+[[allow]]
+glob = "docs/baseline.schema.json"
+kind = "schema"
+owner = "product/contracts"
+surface = "contract"
+classification = "production"
+reason = "Baseline JSON schema contract."
+covered_by = ["cargo test -p tokmd-types schema"]
+
+[[allow]]
+glob = "docs/handoff.schema.json"
+kind = "schema"
+owner = "product/contracts"
+surface = "contract"
+classification = "production"
+reason = "Handoff JSON schema contract."
+covered_by = ["cargo test -p tokmd-types schema"]
+
+[[allow]]
+glob = "docs/schema.json"
+kind = "schema"
+owner = "product/contracts"
+surface = "contract"
+classification = "production"
+reason = "Top-level tokmd JSON schema."
+covered_by = ["cargo test -p tokmd-types schema"]
+
+# -----------------------------------------------------------------------
+# Browser runner / web surfaces
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = "web/runner/**"
+kind = "browser_runner"
+owner = "wasm"
+surface = "wasm-browser"
+classification = "production"
+reason = "Browser runner validates tokmd-wasm capability contract."
+covered_by = ["npm --prefix web/runner test", "npm --prefix web/runner run check"]
+
+# -----------------------------------------------------------------------
+# Packaging surfaces
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = "Formula/**"
+kind = "packaging_homebrew"
+owner = "release/publish"
+surface = "release"
+classification = "production"
+reason = "Homebrew formula for downstream installs."
+covered_by = ["release publish job"]
+
+[[allow]]
+glob = "aur/**"
+kind = "packaging_aur"
+owner = "release/publish"
+surface = "release"
+classification = "production"
+reason = "Arch User Repository PKGBUILD."
+covered_by = ["release publish job"]
+
+[[allow]]
+glob = "bucket/**"
+kind = "packaging_scoop"
+owner = "release/publish"
+surface = "release"
+classification = "production"
+reason = "Scoop bucket manifest for Windows installs."
+covered_by = ["release publish job"]
+
+[[allow]]
+glob = "winget/**"
+kind = "packaging_winget"
+owner = "release/publish"
+surface = "release"
+classification = "production"
+reason = "winget manifest for Windows installs."
+covered_by = ["release publish job"]
+
+# -----------------------------------------------------------------------
+# Policy + ci/ + agents/ + contracts/
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = "policy/*.toml"
+kind = "policy"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Policy ledgers for Clippy, no-panic, lane whitelist, etc."
+covered_by = [
+  "cargo xtask check-lint-policy",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask ci-lane-whitelist",
+]
+
+[[allow]]
+glob = "ci/proof.toml"
+kind = "policy"
+owner = "proof"
+surface = "build"
+classification = "config"
+reason = "Proof policy authoring and scope coverage."
+covered_by = ["cargo xtask proof-policy --check"]
+
+[[allow]]
+glob = "agents/**"
+kind = "agents"
+owner = "core/policy"
+surface = "agents"
+classification = "documentation"
+reason = "Agent runbook and persona shared docs."
+covered_by = []
+
+[[allow]]
+glob = ".jules/**"
+kind = "agents"
+owner = "core/policy"
+surface = "agents"
+classification = "documentation"
+reason = "Jules workspace artifacts and indexes."
+covered_by = ["cargo xtask proof-policy --check"]
+
+[[allow]]
+glob = ".claude/**"
+kind = "agents"
+owner = "core/policy"
+surface = "agents"
+classification = "config"
+reason = "Claude harness settings and hooks."
+covered_by = []
+
+[[allow]]
+glob = ".vscode/**"
+kind = "editor"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Repo-wide VSCode workspace settings."
+covered_by = []
+
+[[allow]]
+glob = ".cargo/**"
+kind = "build"
+owner = "release/build"
+surface = "build"
+classification = "config"
+reason = "Cargo configuration overrides."
+covered_by = []
+
+[[allow]]
+glob = ".githooks/**"
+kind = "git"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Optional git hooks (pre-commit / pre-push)."
+covered_by = []
+
+[[allow]]
+glob = "contracts/**"
+kind = "contract"
+owner = "product/contracts"
+surface = "contract"
+classification = "production"
+reason = "Machine-readable contracts for downstream consumers."
+covered_by = ["cargo xtask docs --check"]
+
+# -----------------------------------------------------------------------
+# Fixtures and snapshots
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = "crates/**/tests/**/*.snap"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "insta snapshot fixtures."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/tests/**/*.json"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "JSON fixtures used by integration tests."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/tests/**/*.md"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "Markdown fixtures used by integration tests."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/tests/**/*.toml"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "TOML fixtures used by integration tests."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/tests/**/*.txt"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "Plain-text fixtures used by integration tests."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/tests/**/*.svg"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "SVG output fixtures (badges, exports)."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/tests/**/*.html"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "HTML output fixtures."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/tokmd/schemas/**"
+kind = "schema"
+owner = "product/contracts"
+surface = "contract"
+classification = "production"
+reason = "JSON schemas embedded into the tokmd crate."
+covered_by = ["cargo test -p tokmd schema"]
+
+[[allow]]
+glob = "fuzz/corpus/**"
+kind = "test_fixture"
+owner = "testing/fuzz"
+surface = "test"
+classification = "test_fixture"
+reason = "cargo-fuzz seed corpora."
+covered_by = ["nightly fuzz job"]
+
+[[allow]]
+glob = "fuzz/dict/**"
+kind = "test_fixture"
+owner = "testing/fuzz"
+surface = "test"
+classification = "test_fixture"
+reason = "cargo-fuzz dictionaries."
+covered_by = ["nightly fuzz job"]
+
+# -----------------------------------------------------------------------
+# Vendored / patched
+# -----------------------------------------------------------------------
+
+[[allow]]
+glob = "crates/**/Cargo.toml"
+kind = "rust_workspace_member"
+owner = "release/build"
+surface = "build"
+classification = "config"
+reason = "Per-crate cargo manifests for workspace members."
+covered_by = ["cargo check --workspace --locked"]
+
+[[allow]]
+glob = "xtask/Cargo.toml"
+kind = "rust_workspace_member"
+owner = "release/build"
+surface = "build"
+classification = "config"
+reason = "Cargo manifest for the xtask helper crate."
+covered_by = ["cargo check -p xtask --locked"]
+
+[[allow]]
+glob = "fuzz/Cargo.toml"
+kind = "rust_workspace_member"
+owner = "testing/fuzz"
+surface = "build"
+classification = "config"
+reason = "Cargo manifest for the fuzz harness package."
+covered_by = ["cargo +nightly fuzz list"]
+
+[[allow]]
+glob = "**/.gitignore"
+kind = "git"
+owner = "release/build"
+surface = "build"
+classification = "config"
+reason = "Per-directory git ignore patterns."
+covered_by = []
+
+[[allow]]
+glob = "**/proptest-regressions/**"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "proptest seed file for failing-case regression coverage."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "**/*.proptest-regressions"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "proptest seed file for failing-case regression coverage."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/snapshots/**"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "insta in-source snapshot directories."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/**/*.snap"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "insta snapshot files (in-tree)."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "crates/tokmd-format/src/analysis/templates/**"
+kind = "asset"
+owner = "core/format"
+surface = "build"
+classification = "production"
+reason = "Embedded report templates for the analysis HTML output."
+covered_by = ["cargo test -p tokmd-format --test analysis_html"]
+
+[[allow]]
+glob = "crates/tokmd-format/proptest-regressions/**"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "proptest regressions colocated with the format crate."
+covered_by = ["cargo test -p tokmd-format"]
+
+[[allow]]
+glob = "crates/tokmd-node/**"
+kind = "node_package"
+owner = "release/publish"
+surface = "downstream"
+classification = "production"
+reason = "Node.js binding package: package.json, TypeScript declarations, JS shim, and tests."
+covered_by = ["release publish job"]
+
+[[allow]]
+glob = "crates/tokmd-python/**"
+kind = "python_package"
+owner = "release/publish"
+surface = "downstream"
+classification = "production"
+reason = "Python binding package: pyproject, source, type marker, integration tests."
+covered_by = ["release publish job"]
+
+[[allow]]
+glob = "crates/tokmd-wasm/LICENSE-*"
+kind = "license"
+owner = "release/legal"
+surface = "release"
+classification = "documentation"
+reason = "Required license texts for the published WASM crate."
+covered_by = ["cargo deny --all-features check"]
+
+[[allow]]
+glob = "crates/tokmd-core/test_doctest.patch"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "Patch fixture used by tokmd-core tests."
+covered_by = ["cargo test -p tokmd-core"]
+
+[[allow]]
+glob = "crates/tokmd/tests/data/**"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "Integration test data fixtures (JS, JSON, etc.)."
+covered_by = ["cargo test -p tokmd"]
+
+[[allow]]
+glob = "*.patch"
+kind = "tooling"
+owner = "release/dependencies"
+surface = "build"
+classification = "config"
+reason = "Top-level patches kept for manual recovery and reproducibility."
+covered_by = []
+
+[[allow]]
+glob = "*.ps1"
+kind = "tooling"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Local convenience PowerShell scripts."
+covered_by = []
+
+[[allow]]
+glob = "*.bat"
+kind = "tooling"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Local convenience batch scripts."
+covered_by = []
+
+[[allow]]
+glob = "*.txt"
+kind = "tooling"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Top-level text files (PR bodies, transient notes)."
+covered_by = []
+
+[[allow]]
+glob = "*.log"
+kind = "tooling"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Top-level log fixtures (gate.log, etc.)."
+covered_by = []
+
+[[allow]]
+glob = "tokmd-role.md"
+kind = "documentation"
+owner = "docs"
+surface = "docs"
+classification = "documentation"
+reason = "Top-level role doc."
+covered_by = []
+
+[[allow]]
+glob = "AGENTS.md"
+kind = "documentation"
+owner = "docs"
+surface = "agents"
+classification = "documentation"
+reason = "Top-level agent guidance."
+covered_by = []
+
+[[allow]]
+glob = "CLAUDE.md"
+kind = "documentation"
+owner = "docs"
+surface = "agents"
+classification = "documentation"
+reason = "Top-level Claude adapter doc."
+covered_by = []
+
+[[allow]]
+glob = "GEMINI.md"
+kind = "documentation"
+owner = "docs"
+surface = "agents"
+classification = "documentation"
+reason = "Top-level Gemini adapter doc."
+covered_by = []
+
+[[allow]]
+glob = "vendor/**"
+kind = "vendored_patch"
+owner = "release/dependencies"
+surface = "vendor"
+classification = "production"
+reason = "Pinned patched dependency required until upstream fallback exists."
+covered_by = ["cargo check --workspace --locked"]

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -48,6 +48,8 @@ pub enum Commands {
     CoverageReceipt(CoverageReceiptArgs),
     /// Emit a durable receipt for CI job actuals
     CiActuals(CiActualsArgs),
+    /// Verify the non-Rust file allowlist (file policy checker)
+    CheckFilePolicy(FilePolicyArgs),
     /// Verify the workspace panic-family allowlist (semantic no-panic checker)
     CheckNoPanicFamily(NoPanicArgs),
     /// Propose new no-panic allowlist entries from current findings
@@ -168,6 +170,31 @@ impl Default for CiActualsArgs {
             repo: "tokmd".to_string(),
             workflow: "CI".to_string(),
             sha: None,
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FilePolicyArgs {
+    /// Path to the non-Rust allowlist TOML
+    #[arg(long, default_value = "policy/non-rust-allowlist.toml")]
+    pub allowlist: std::path::PathBuf,
+
+    /// Optional report output directory
+    #[arg(long, value_name = "DIR")]
+    pub report_dir: Option<std::path::PathBuf>,
+
+    /// Treat findings as errors (default is advisory)
+    #[arg(long)]
+    pub strict: bool,
+}
+
+impl Default for FilePolicyArgs {
+    fn default() -> Self {
+        Self {
+            allowlist: std::path::PathBuf::from("policy/non-rust-allowlist.toml"),
+            report_dir: None,
+            strict: false,
         }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,6 +36,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::CheckLintPolicy(args)) => tasks::lint_policy::run(args),
         Some(cli::Commands::CoverageReceipt(args)) => tasks::coverage_receipt::run(args),
         Some(cli::Commands::CiActuals(args)) => tasks::ci_actuals::run(args),
+        Some(cli::Commands::CheckFilePolicy(args)) => tasks::file_policy::run(args),
         Some(cli::Commands::CheckNoPanicFamily(args)) => tasks::no_panic::run_check(args),
         Some(cli::Commands::NoPanicPropose(args)) => tasks::no_panic::run_propose(args),
         Some(cli::Commands::LintFix(args)) => tasks::lint_fix::run(args),

--- a/xtask/src/tasks/file_policy.rs
+++ b/xtask/src/tasks/file_policy.rs
@@ -1,0 +1,314 @@
+//! Non-Rust file policy checker.
+//!
+//! Walks the repo and reports any non-Rust file that does not match a
+//! `[[allow]]` glob in `policy/non-rust-allowlist.toml`. Rust files are
+//! governed by the workspace lints + proof policy and are skipped here.
+//!
+//! Advisory by default: returns non-zero only with `--strict` or on a
+//! hard parse / schema error.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde::Deserialize;
+use walkdir::WalkDir;
+
+use crate::cli::FilePolicyArgs;
+
+const SKIP_DIRS: &[&str] = &[".git", "target", "node_modules", "run-artifacts", "plans"];
+
+#[derive(Debug, Deserialize)]
+struct AllowlistFile {
+    schema_version: String,
+    #[serde(default)]
+    policy: Option<String>,
+    #[serde(default)]
+    owner: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    updated: Option<String>,
+    #[serde(default)]
+    allow: Vec<Entry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Entry {
+    glob: String,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    owner: String,
+    #[serde(default)]
+    surface: String,
+    #[serde(default)]
+    classification: String,
+    #[serde(default)]
+    reason: String,
+    #[serde(default)]
+    covered_by: Vec<String>,
+}
+
+pub fn run(args: FilePolicyArgs) -> Result<()> {
+    let root = workspace_root()?;
+    let allowlist_path = root.join(&args.allowlist);
+    let allowlist = parse(&allowlist_path)?;
+
+    let mut hard_errors = Vec::new();
+    if allowlist.schema_version != "1.0" {
+        hard_errors.push(format!(
+            "{}: unsupported schema_version {:?}",
+            allowlist_path.display(),
+            allowlist.schema_version
+        ));
+    }
+
+    let mut findings: Vec<String> = Vec::new();
+    validate_entries(&allowlist.allow, &mut findings);
+
+    let mut builder = GlobSetBuilder::new();
+    for entry in &allowlist.allow {
+        builder
+            .add(Glob::new(&entry.glob).with_context(|| format!("compile glob {:?}", entry.glob))?);
+    }
+    let set: GlobSet = builder.build()?;
+
+    let mut unmatched = Vec::new();
+    let mut covered = 0usize;
+    let mut rust_skipped = 0usize;
+
+    for entry in WalkDir::new(&root)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|e| !is_skipped(e.path(), &root))
+    {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                hard_errors.push(format!("walk: {err}"));
+                continue;
+            }
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let rel = match entry.path().strip_prefix(&root) {
+            Ok(p) => p.to_path_buf(),
+            Err(_) => continue,
+        };
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        if rel_str.ends_with(".rs") {
+            rust_skipped += 1;
+            continue;
+        }
+        if set.is_match(&rel_str) {
+            covered += 1;
+        } else {
+            unmatched.push(rel_str);
+        }
+    }
+
+    unmatched.sort();
+    for path in &unmatched {
+        findings.push(format!(
+            "file {path} does not match any non-Rust allowlist glob"
+        ));
+    }
+
+    if let Some(report_dir) = &args.report_dir {
+        let dir = root.join(report_dir);
+        fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+        let out = dir.join("file-policy-report.txt");
+        let body = render_report(&allowlist, covered, rust_skipped, &unmatched, &findings);
+        fs::write(&out, &body).with_context(|| format!("write {}", out.display()))?;
+        println!("file-policy report written to {}", out.display());
+    }
+
+    if !hard_errors.is_empty() {
+        for err in &hard_errors {
+            eprintln!("error: {err}");
+        }
+        bail!("file-policy: {} hard error(s)", hard_errors.len());
+    }
+
+    if findings.is_empty() {
+        println!(
+            "file-policy OK: {} entries, {} non-Rust files covered, {} Rust files skipped",
+            allowlist.allow.len(),
+            covered,
+            rust_skipped
+        );
+        return Ok(());
+    }
+
+    println!("file-policy findings ({}):", findings.len());
+    for finding in findings.iter().take(50) {
+        println!("  - {finding}");
+    }
+    if findings.len() > 50 {
+        println!("  ... ({} more, see report)", findings.len() - 50);
+    }
+
+    if args.strict {
+        bail!("file-policy: {} finding(s) (strict)", findings.len());
+    }
+    println!("(advisory mode; rerun with --strict to fail on findings)");
+    Ok(())
+}
+
+fn validate_entries(entries: &[Entry], findings: &mut Vec<String>) {
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for entry in entries {
+        if !seen.insert(entry.glob.as_str()) {
+            findings.push(format!("duplicate glob {:?}", entry.glob));
+        }
+        if entry.owner.is_empty() {
+            findings.push(format!("entry {:?}: missing owner", entry.glob));
+        }
+        if entry.kind.is_empty() {
+            findings.push(format!("entry {:?}: missing kind", entry.glob));
+        }
+        if entry.classification.is_empty() {
+            findings.push(format!("entry {:?}: missing classification", entry.glob));
+        }
+        if entry.reason.is_empty() {
+            findings.push(format!("entry {:?}: missing reason", entry.glob));
+        }
+        if entry.surface.is_empty() {
+            findings.push(format!("entry {:?}: missing surface", entry.glob));
+        }
+        if entry.classification == "production" && entry.covered_by.is_empty() {
+            findings.push(format!(
+                "entry {:?}: production classification needs at least one covered_by",
+                entry.glob
+            ));
+        }
+    }
+}
+
+fn is_skipped(path: &Path, root: &Path) -> bool {
+    let Ok(rel) = path.strip_prefix(root) else {
+        return false;
+    };
+    let Some(first) = rel.iter().next().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    SKIP_DIRS.contains(&first)
+}
+
+fn parse(path: &Path) -> Result<AllowlistFile> {
+    let body = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&body).with_context(|| format!("parse {}", path.display()))
+}
+
+fn render_report(
+    allowlist: &AllowlistFile,
+    covered: usize,
+    rust_skipped: usize,
+    unmatched: &[String],
+    findings: &[String],
+) -> String {
+    let mut out = String::new();
+    out.push_str("# Non-Rust file policy report\n\n");
+    if let Some(name) = &allowlist.policy {
+        out.push_str(&format!("- policy: {name}\n"));
+    }
+    if let Some(owner) = &allowlist.owner {
+        out.push_str(&format!("- owner: {owner}\n"));
+    }
+    if let Some(status) = &allowlist.status {
+        out.push_str(&format!("- status: {status}\n"));
+    }
+    if let Some(updated) = &allowlist.updated {
+        out.push_str(&format!("- updated: {updated}\n"));
+    }
+    out.push_str(&format!("- allow entries: {}\n", allowlist.allow.len()));
+    out.push_str(&format!("- non-Rust files covered: {covered}\n"));
+    out.push_str(&format!("- Rust files skipped: {rust_skipped}\n"));
+    out.push_str(&format!("- unmatched: {}\n", unmatched.len()));
+    out.push_str(&format!("- findings: {}\n\n", findings.len()));
+
+    if !unmatched.is_empty() {
+        out.push_str("## Unmatched files\n\n");
+        for path in unmatched {
+            out.push_str(&format!("- {path}\n"));
+        }
+        out.push('\n');
+    }
+
+    if !findings.is_empty() {
+        out.push_str("## Findings\n\n");
+        for finding in findings {
+            out.push_str(&format!("- {finding}\n"));
+        }
+    }
+
+    out
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("locate workspace root")?;
+    Ok(metadata.workspace_root.into_std_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(glob: &str) -> Entry {
+        Entry {
+            glob: glob.into(),
+            kind: "documentation".into(),
+            owner: "docs".into(),
+            surface: "docs".into(),
+            classification: "documentation".into(),
+            reason: "test".into(),
+            covered_by: vec![],
+        }
+    }
+
+    #[test]
+    fn duplicate_glob_is_finding() {
+        let entries = vec![entry("docs/**"), entry("docs/**")];
+        let mut findings = Vec::new();
+        validate_entries(&entries, &mut findings);
+        assert!(
+            findings.iter().any(|f| f.contains("duplicate glob")),
+            "{findings:?}"
+        );
+    }
+
+    #[test]
+    fn missing_owner_is_finding() {
+        let mut e = entry("docs/**");
+        e.owner.clear();
+        let entries = vec![e];
+        let mut findings = Vec::new();
+        validate_entries(&entries, &mut findings);
+        assert!(
+            findings.iter().any(|f| f.contains("missing owner")),
+            "{findings:?}"
+        );
+    }
+
+    #[test]
+    fn production_without_covered_by_is_finding() {
+        let mut e = entry("Formula/**");
+        e.classification = "production".into();
+        let entries = vec![e];
+        let mut findings = Vec::new();
+        validate_entries(&entries, &mut findings);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.contains("needs at least one covered_by")),
+            "{findings:?}"
+        );
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -6,6 +6,7 @@ pub mod ci_actuals;
 pub mod cockpit;
 pub mod coverage_receipt;
 pub mod docs;
+pub mod file_policy;
 pub mod fixture_blobs_check;
 pub mod gate;
 pub mod lint_fix;


### PR DESCRIPTION
## Summary

PR 05 of 16. Adds an explicit allowlist for every non-Rust file in the repo (policy ledgers, workflows, docs, schemas, packaging manifests, fixtures, vendored deps, etc.) plus a `cargo xtask check-file-policy` walker that reports any non-Rust file that does not match an `[[allow]]` glob.

- `policy/non-rust-allowlist.toml` — 83 entries with `glob`, `kind`, `owner`, `surface`, `classification`, `reason`, `covered_by`.
- `xtask/src/tasks/file_policy.rs` — walker + glob matcher + per-entry validator. 3 unit tests.
- `xtask/src/cli.rs` / `main.rs` / `tasks/mod.rs` — wire `check-file-policy`.
- `docs/FILE_POLICY.md` — schema + lifecycle docs.
- `ci/proof.toml` — `file_policy` scope.

The checker is **advisory** by default. `--strict` turns drift into a non-zero exit.

## CI economics

- **Default PR LEM impact:** none (no workflow added; checker is xtask-local until a later PR wires it into CI).
- **Workflows touched:** none.
- **Branch protection impact:** none.
- **Failure mode caught:** silent non-Rust drift — a new YAML/JSON/TOML/snapshot landing without owner or covering proof.
- **Cheaper signal considered:** rely on grep + reviewer attention. Rejected — this is exactly the kind of drift that escapes review attention as the repo grows.
- **Rollback path:** `git revert`. Nothing else depends on the file or command yet.
- **Commands run:** `cargo xtask check-file-policy` reports 906 covered, 936 Rust skipped, 0 unmatched; `cargo clippy -p xtask --all-targets -- -D warnings` clean; `cargo test -p xtask file_policy` 3 passed.

## Test plan

- [x] `cargo xtask check-file-policy` advisory-clean.
- [x] `cargo xtask proof-policy --check` OK.
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` clean.
- [x] `cargo test -p xtask file_policy` — 3 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_