### PR TITLE
policy(panic): add advisory no-panic CI job and family docs

### DIFF
--- a/.github/workflows/no-panic-policy.yml
+++ b/.github/workflows/no-panic-policy.yml
@@ -1,0 +1,67 @@
+name: No-panic Policy
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: no-panic-policy-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -C debuginfo=0
+
+jobs:
+  check-no-panic-family:
+    name: No-panic Family
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run no-panic family checker (advisory)
+        run: |
+          set +e
+          mkdir -p target/tokmd/reports
+          cargo xtask check-no-panic-family --json \
+            > target/tokmd/reports/no-panic-report.json 2> target/tokmd/reports/no-panic-stderr.txt
+          status=$?
+
+          {
+            echo "## No-panic policy"
+            echo ""
+            if [ "$status" -eq 0 ]; then
+              echo "Advisory check completed."
+            else
+              echo "Advisory check exited with status $status."
+            fi
+            echo ""
+            echo '```'
+            cat target/tokmd/reports/no-panic-stderr.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Schema/shape errors, expired entries, and stale entries are still
+          # blocking even in advisory mode.
+          exit "$status"
+
+      - name: Upload no-panic policy report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: no-panic-policy-report
+          path: target/tokmd/reports/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -55,6 +55,7 @@ name = "proof_control_plane"
 kind = "rust"
 paths = [
   ".github/workflows/ci.yml",
+  ".github/workflows/no-panic-policy.yml",
   ".github/workflows/proof-observation-collection.yml",
   ".github/workflows/proof-executor.yml",
   ".github/workflows/coverage.yml",

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -155,4 +155,39 @@ The flip from advisory to strict is gated on three things, in this order:
    matches the receipt ledger exactly.
 
 The checker is wired into the `no_panic_policy` proof scope in
-`ci/proof.toml`.
+`ci/proof.toml` and runs as an advisory job in
+`.github/workflows/no-panic-policy.yml` on every PR.
+
+## Family taxonomy
+
+The current detector recognises the following families
+(see `xtask/src/tasks/no_panic.rs :: Family`):
+
+| Family | Surface |
+|--------|---------|
+| `unwrap` | `.unwrap()` method calls. |
+| `expect` | `.expect("…")` method calls. |
+| `get_unwrap` | `.get(idx).unwrap()` chains. |
+| `panic_macro` | `panic!(…)`. |
+| `todo` | `todo!()`. |
+| `unimplemented` | `unimplemented!()`. |
+| `unreachable` | `unreachable!()`. |
+| `element_indexing` | `slice[idx]` element indexing. |
+| `range_indexing` | `slice[a..b]` range indexing. |
+
+Future families considered in the rollout plan but not yet implemented:
+`string_slice`, `unchecked_time_subtraction`. These can be added by
+extending `Family` and the AST visitor in `xtask/src/tasks/no_panic.rs`.
+
+## Adding entries
+
+```bash
+cargo xtask no-panic-propose
+```
+
+Writes proposed allowlist entries to
+`target/no-panic-proposed-allowlist.toml`. Edit each proposed entry to
+fill in `owner`, `classification`, `explanation`, and `expires`, then
+move the entry into `policy/no-panic-allowlist.toml`. Re-run
+`cargo xtask check-no-panic-family` to confirm the receipt covers the
+finding.


### PR DESCRIPTION
## Summary

PR 06 of 16. The semantic no-panic checker, allowlist TOML, and propose command already exist in tokmd. This PR closes the rollout's remaining gap by:

- Adding `.github/workflows/no-panic-policy.yml` — advisory PR job that runs `cargo xtask check-no-panic-family --json`, attaches the JSON report and stderr summary to the step summary, and uploads them as an artifact. Schema/shape errors, expired entries, and stale entries remain blocking; unallowlisted findings are advisory until the rollout flips to `--strict`.
- Documenting the current family taxonomy in `docs/NO_PANIC_POLICY.md` and pointing at `xtask/src/tasks/no_panic.rs :: Family` for future additions (`string_slice`, `unchecked_time_subtraction`).
- Scoping the new workflow under `proof_control_plane` in `ci/proof.toml`.

## CI economics

- **Default PR LEM impact:** `+5` (one new advisory ubuntu lane that compiles xtask once).
- **Workflows touched:** `+.github/workflows/no-panic-policy.yml`.
- **Branch protection impact:** none — new lane is non-blocking on findings (still blocks on expired/stale receipts, which is desired).
- **Failure mode caught:** silent panic-family debt accumulation; expired allowlist entries stay forever.
- **Cheaper signal considered:** rely on the proof scope's affected runner. Rejected — that only triggers when no-panic policy files change, not on PRs that *introduce* new panic-family code.
- **Rollback path:** `git revert`. The workflow is independent.
- **Commands run:** `cargo xtask check-no-panic-family` advisory; `cargo xtask proof-policy --check` OK; `cargo xtask affected` zero unknown files.

## Test plan

- [x] `cargo xtask check-no-panic-family` runs.
- [x] `cargo xtask proof-policy --check` OK.
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_