### PR TITLE
ci(plan): add advisory LEM-aware PR Plan

### DIFF
--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -1,0 +1,60 @@
+name: PR Plan
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-plan-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -C debuginfo=0
+
+jobs:
+  pr-plan:
+    name: PR Plan (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Fetch base ref
+        run: git fetch origin "${{ github.base_ref }}":"refs/remotes/origin/${{ github.base_ref }}" || true
+
+      - name: Generate PR plan
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          mkdir -p target/ci
+          cargo xtask ci-plan \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            --labels-json "$LABELS_JSON" \
+            --lanes policy/ci-lane-whitelist.toml \
+            --risk-packs policy/ci-risk-packs.toml \
+            --json-out target/ci/ci-plan.json \
+            --github-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload PR plan
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-plan
+          path: target/ci/ci-plan.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -56,6 +56,7 @@ kind = "rust"
 paths = [
   ".github/workflows/ci.yml",
   ".github/workflows/no-panic-policy.yml",
+  ".github/workflows/pr-plan.yml",
   ".github/workflows/proof-observation-collection.yml",
   ".github/workflows/proof-executor.yml",
   ".github/workflows/coverage.yml",
@@ -81,6 +82,7 @@ paths = [
   "xtask/src/tasks/affected.rs",
   "xtask/src/tasks/boundaries_check.rs",
   "xtask/src/tasks/ci_actuals.rs",
+  "xtask/src/tasks/ci_plan.rs",
   "xtask/src/tasks/coverage_receipt.rs",
   "xtask/src/tasks/file_policy.rs",
   "xtask/src/tasks/fixture_blobs_check.rs",
@@ -673,6 +675,19 @@ proof = [
   "cargo xtask proof-policy --check",
 ]
 reason = "CI lane whitelist and its docs govern verification economics receipts; checked via proof-policy and the lane whitelist linter (PR 03 onward)."
+mutation = false
+coverage = false
+
+[[scope]]
+name = "ci_pr_plan"
+kind = "non_rust"
+paths = [
+  "policy/ci-risk-packs.toml",
+]
+proof = [
+  "cargo xtask proof-policy --check",
+]
+reason = "PR Plan policy data: risk-pack routing and the LEM-aware advisory plan."
 mutation = false
 coverage = false
 

--- a/docs/ci/pr-plan.md
+++ b/docs/ci/pr-plan.md
@@ -1,0 +1,81 @@
+# PR Plan
+
+The PR Plan job (`.github/workflows/pr-plan.yml`) emits an advisory
+`ci-plan.json` for every PR. It is the source of truth for which risk
+packs the change touches, which lanes will run, and the estimated LEM
+band.
+
+## How it works
+
+1. Fetch the base ref and compute `git diff --name-only base...head`.
+2. Read `policy/ci-lane-whitelist.toml` for the lane catalogue + budget.
+3. Read `policy/ci-risk-packs.toml` for path → lane routing.
+4. For each non-expensive `default_pr` lane: include it always.
+5. For each risk pack whose paths match a changed file: include its
+   `lanes`, and (if a matching label or `full-ci` is set) its
+   `deep_lanes`.
+6. Compute the runner-multiplied LEM estimate per lane and the total.
+7. Classify the band:
+
+   | Band | LEM range |
+   |------|-----------|
+   | `normal` | ≤ default_limit_lem (35) |
+   | `elevated` | ≤ elevated_limit_lem (75) |
+   | `high-cost` | ≤ hard_limit_lem (125) |
+   | `override-required` | > hard_limit_lem |
+
+8. Write `target/ci/ci-plan.json` and append a Markdown summary to
+   `GITHUB_STEP_SUMMARY`.
+
+## Output
+
+```json
+{
+  "schema_version": 1,
+  "base": "origin/main",
+  "head": "HEAD",
+  "labels": ["wasm"],
+  "changed_files": [...],
+  "risk_packs_hit": [
+    { "name": "wasm", "description": "...", "matched_files": [...] }
+  ],
+  "lanes_selected": [
+    {
+      "id": "rust_fast_gate",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "Rust Fast Gate",
+      "kind": "rust",
+      "tier": "frontdoor",
+      "runner": "ubuntu_latest",
+      "blocking": true,
+      "estimated_lem": 12,
+      "reason": "default_pr"
+    }
+  ],
+  "estimated_lem": 32,
+  "band": "normal",
+  "budget": { ... }
+}
+```
+
+## Status
+
+- **PR 08 (this PR)** — adds the planner, the workflow, and the schema.
+  The plan is **advisory**: existing CI still routes via `affected proof
+  plan` and the static workflow.
+- **PR 12** — wires risk-pack routing into the existing workflows so
+  expensive lanes only run when the plan says so.
+- **PR 14** — adds the soft budget guard that warns above the elevated
+  limit and fails above the hard limit.
+- **PR 15** — replaces static `base_lem` with learned p50/p90/p95
+  estimates from `ci-actuals.json` (PR 13).
+
+## Local invocation
+
+```bash
+cargo xtask ci-plan \
+  --base "origin/main" \
+  --head HEAD \
+  --labels-json '[{"name":"full-ci"}]' \
+  --json-out target/ci/ci-plan.json
+```

--- a/policy/ci-risk-packs.toml
+++ b/policy/ci-risk-packs.toml
@@ -1,0 +1,103 @@
+schema_version = "1.0"
+policy = "ci-risk-packs"
+owner = "release/ci"
+status = "advisory"
+updated = "2026-05-07"
+
+# Risk packs map paths in a PR's diff to the lanes that should run for
+# that risk surface. The PR Plan job (cargo xtask ci plan) reads this
+# file along with policy/ci-lane-whitelist.toml and emits an advisory
+# ci-plan.json.
+#
+# Conventions:
+#   description     - one-line human summary of what the pack covers.
+#   paths           - globs (relative to repo root) that select changed
+#                     files into this pack.
+#   lanes           - lane IDs that should run on ordinary PRs hitting
+#                     this pack.
+#   deep_lanes      - lane IDs that should run when the pack is hit and
+#                     the PR has the matching label, or on main/nightly.
+
+[risk_pack.core_receipts]
+description = "Receipt generation, deterministic export, summaries, formats."
+paths = [
+  "crates/tokmd/**",
+  "crates/tokmd-core/**",
+  "crates/tokmd-envelope/**",
+  "crates/tokmd-format/**",
+]
+lanes = ["rust_fast_gate", "proof_policy", "ripr"]
+deep_lanes = ["build_test_linux_windows", "proptest_smoke"]
+
+[risk_pack.analysis]
+description = "Risk, effort, complexity, duplication, git, API-surface reports."
+paths = [
+  "crates/tokmd-analysis/**",
+  "crates/tokmd-analysis-types/**",
+  "crates/tokmd-model/**",
+]
+lanes = ["rust_fast_gate", "affected_proof_plan", "ripr"]
+deep_lanes = ["proptest_smoke"]
+
+[risk_pack.gate_sensor]
+description = "Gate verdicts, sensor envelopes, cockpit review artifacts."
+paths = [
+  "crates/tokmd-gate/**",
+  "crates/tokmd-sensor/**",
+  "crates/tokmd-cockpit/**",
+]
+lanes = ["rust_fast_gate", "proof_policy", "ripr"]
+deep_lanes = ["publish_surface"]
+
+[risk_pack.git_io]
+description = "Git, IO port, file scanning, path handling."
+paths = [
+  "crates/tokmd-git/**",
+  "crates/tokmd-io-port/**",
+  "crates/tokmd-scan/**",
+]
+lanes = ["rust_fast_gate", "ripr"]
+deep_lanes = ["build_test_linux_windows"]
+
+[risk_pack.wasm]
+description = "WASM/browser runner and web capability surface."
+paths = [
+  "crates/tokmd-wasm/**",
+  "web/runner/**",
+  "docs/capabilities/wasm.json",
+]
+lanes = ["wasm_compile_test"]
+deep_lanes = ["nix_pr_package_gate"]
+
+[risk_pack.release]
+description = "Release metadata, Nix, publish surface, version consistency."
+paths = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "flake.nix",
+  "flake.lock",
+  "deny.toml",
+  "docs/install.md",
+]
+lanes = ["msrv_check", "publish_surface", "version_consistency"]
+deep_lanes = ["nix_pr_package_gate", "cargo_deny"]
+
+[risk_pack.policy]
+description = "Policy ledgers, xtask proof/gate behavior, CI workflow shape."
+paths = [
+  "policy/**",
+  "xtask/**",
+  ".github/workflows/**",
+]
+lanes = ["proof_policy", "quality_gate", "ci_lane_whitelist"]
+deep_lanes = ["build_test_linux_windows"]
+
+[risk_pack.docs]
+description = "Documentation-only changes."
+paths = [
+  "docs/**",
+  "*.md",
+  ".github/pull_request_template.md",
+]
+lanes = ["docs_check", "typos"]
+deep_lanes = []

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -52,6 +52,8 @@ pub enum Commands {
     CheckFilePolicy(FilePolicyArgs),
     /// Verify the AST-backed Clippy exception ledger
     CheckClippyExceptions(ClippyExceptionsArgs),
+    /// Generate the LEM-aware advisory PR Plan
+    CiPlan(CiPlanArgs),
     /// Verify the workspace panic-family allowlist (semantic no-panic checker)
     CheckNoPanicFamily(NoPanicArgs),
     /// Propose new no-panic allowlist entries from current findings
@@ -222,6 +224,51 @@ impl Default for ClippyExceptionsArgs {
             policy: std::path::PathBuf::from("policy/clippy-exceptions.toml"),
             report_dir: None,
             strict: false,
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CiPlanArgs {
+    /// Base git revision
+    #[arg(long, default_value = "origin/main")]
+    pub base: String,
+
+    /// Head git revision
+    #[arg(long, default_value = "HEAD")]
+    pub head: String,
+
+    /// JSON labels payload (object form, bare-array form, or CSV)
+    #[arg(long, value_name = "JSON")]
+    pub labels_json: Option<String>,
+
+    /// Lane whitelist TOML
+    #[arg(long, default_value = "policy/ci-lane-whitelist.toml")]
+    pub lanes: std::path::PathBuf,
+
+    /// Risk-pack TOML
+    #[arg(long, default_value = "policy/ci-risk-packs.toml")]
+    pub risk_packs: std::path::PathBuf,
+
+    /// Output path for the JSON plan; if absent, prints to stdout
+    #[arg(long, value_name = "PATH")]
+    pub json_out: Option<std::path::PathBuf>,
+
+    /// Optional path to GITHUB_STEP_SUMMARY (the workflow appends to it)
+    #[arg(long, value_name = "PATH")]
+    pub github_summary: Option<std::path::PathBuf>,
+}
+
+impl Default for CiPlanArgs {
+    fn default() -> Self {
+        Self {
+            base: "origin/main".into(),
+            head: "HEAD".into(),
+            labels_json: None,
+            lanes: std::path::PathBuf::from("policy/ci-lane-whitelist.toml"),
+            risk_packs: std::path::PathBuf::from("policy/ci-risk-packs.toml"),
+            json_out: None,
+            github_summary: None,
         }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),
         Some(cli::Commands::Gate(args)) => tasks::gate::run(args),
+        Some(cli::Commands::CiPlan(args)) => tasks::ci_plan::run(args),
         Some(cli::Commands::CheckLintPolicy(args)) => tasks::lint_policy::run(args),
         Some(cli::Commands::CoverageReceipt(args)) => tasks::coverage_receipt::run(args),
         Some(cli::Commands::CiActuals(args)) => tasks::ci_actuals::run(args),

--- a/xtask/src/tasks/ci_plan.rs
+++ b/xtask/src/tasks/ci_plan.rs
@@ -1,0 +1,499 @@
+//! LEM-aware advisory PR Plan.
+//!
+//! Inputs:
+//! - `policy/ci-lane-whitelist.toml` — lane catalogue + LEM budget.
+//! - `policy/ci-risk-packs.toml` — path → lane routing.
+//! - the PR diff `base..head` — selects risk packs.
+//!
+//! Output: `ci-plan.json` describing which risk packs were hit, which
+//! lanes will run on this PR, the estimated LEM, and the LEM band.
+//!
+//! Advisory only — does not change which jobs actually run. PR 12 wires
+//! workflows to consume the plan; PR 14 layers in the budget warning.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::CiPlanArgs;
+
+#[derive(Debug, Deserialize)]
+struct WhitelistFile {
+    #[serde(default)]
+    budget: Option<Budget>,
+    #[serde(default)]
+    runner_multipliers: BTreeMap<String, f64>,
+    #[serde(default)]
+    lane: Vec<Lane>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+struct Budget {
+    preferred_default_lem: u64,
+    default_limit_lem: u64,
+    elevated_limit_lem: u64,
+    hard_limit_lem: u64,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct Lane {
+    id: String,
+    #[serde(default)]
+    workflow: String,
+    #[serde(default)]
+    job: String,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    tier: String,
+    #[serde(default)]
+    default_pr: bool,
+    #[serde(default)]
+    blocking: bool,
+    #[serde(default)]
+    runner: String,
+    #[serde(default)]
+    base_lem: u64,
+    #[serde(default)]
+    expensive: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RiskPacksFile {
+    #[serde(default)]
+    risk_pack: BTreeMap<String, RiskPack>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RiskPack {
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    paths: Vec<String>,
+    #[serde(default)]
+    lanes: Vec<String>,
+    #[serde(default)]
+    deep_lanes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PlanOutput {
+    schema_version: u32,
+    base: String,
+    head: String,
+    labels: Vec<String>,
+    changed_files: Vec<String>,
+    risk_packs_hit: Vec<RiskPackHit>,
+    lanes_selected: Vec<LaneSelection>,
+    estimated_lem: u64,
+    band: String,
+    budget: BudgetView,
+}
+
+#[derive(Debug, Serialize)]
+struct RiskPackHit {
+    name: String,
+    description: String,
+    matched_files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LaneSelection {
+    id: String,
+    workflow: String,
+    job: String,
+    kind: String,
+    tier: String,
+    runner: String,
+    blocking: bool,
+    estimated_lem: u64,
+    reason: String,
+}
+
+#[derive(Debug, Serialize, Clone, Copy)]
+struct BudgetView {
+    preferred_default_lem: u64,
+    default_limit_lem: u64,
+    elevated_limit_lem: u64,
+    hard_limit_lem: u64,
+}
+
+pub fn run(args: CiPlanArgs) -> Result<()> {
+    let root = workspace_root()?;
+    let whitelist: WhitelistFile = parse_toml(&root.join(&args.lanes), "ci-lane-whitelist")?;
+    let risk_packs: RiskPacksFile = parse_toml(&root.join(&args.risk_packs), "ci-risk-packs")?;
+
+    let budget = whitelist.budget.unwrap_or(Budget {
+        preferred_default_lem: 25,
+        default_limit_lem: 35,
+        elevated_limit_lem: 75,
+        hard_limit_lem: 125,
+    });
+
+    let labels = parse_labels(args.labels_json.as_deref());
+    let changed = git_diff_names(&root, &args.base, &args.head)?;
+
+    let lane_index: BTreeMap<&str, &Lane> =
+        whitelist.lane.iter().map(|l| (l.id.as_str(), l)).collect();
+
+    let mut hits: Vec<RiskPackHit> = Vec::new();
+    let mut selected: BTreeMap<String, LaneSelection> = BTreeMap::new();
+
+    let labels_set: BTreeSet<&str> = labels.iter().map(|s| s.as_str()).collect();
+    let want_full_ci = labels_set.contains("full-ci");
+
+    // Always-on default-PR lanes from the whitelist (frontdoor + cheap
+    // policy lanes). Risk packs add to this rather than replacing it.
+    for lane in whitelist
+        .lane
+        .iter()
+        .filter(|l| l.default_pr && !l.expensive)
+    {
+        selected.entry(lane.id.clone()).or_insert_with(|| {
+            lane_to_selection(lane, &whitelist.runner_multipliers, "default_pr")
+        });
+    }
+
+    for (name, pack) in &risk_packs.risk_pack {
+        let matched = match_paths(&pack.paths, &changed)?;
+        if matched.is_empty() {
+            continue;
+        }
+        hits.push(RiskPackHit {
+            name: name.clone(),
+            description: pack.description.clone(),
+            matched_files: matched.clone(),
+        });
+        for lane_id in &pack.lanes {
+            if let Some(lane) = lane_index.get(lane_id.as_str()) {
+                selected.entry(lane.id.clone()).or_insert_with(|| {
+                    lane_to_selection(
+                        lane,
+                        &whitelist.runner_multipliers,
+                        &format!("risk_pack:{name}"),
+                    )
+                });
+            }
+        }
+        if want_full_ci || labels_set.contains(name.as_str()) {
+            for lane_id in &pack.deep_lanes {
+                if let Some(lane) = lane_index.get(lane_id.as_str()) {
+                    selected.entry(lane.id.clone()).or_insert_with(|| {
+                        lane_to_selection(
+                            lane,
+                            &whitelist.runner_multipliers,
+                            &format!("risk_pack:{name}:deep"),
+                        )
+                    });
+                }
+            }
+        }
+    }
+
+    if want_full_ci {
+        for lane in &whitelist.lane {
+            selected.entry(lane.id.clone()).or_insert_with(|| {
+                lane_to_selection(lane, &whitelist.runner_multipliers, "label:full-ci")
+            });
+        }
+    }
+
+    let lanes_selected: Vec<LaneSelection> = selected.into_values().collect();
+    let estimated_lem: u64 = lanes_selected.iter().map(|l| l.estimated_lem).sum();
+    let band = classify_band(estimated_lem, budget);
+
+    let plan = PlanOutput {
+        schema_version: 1,
+        base: args.base.clone(),
+        head: args.head.clone(),
+        labels,
+        changed_files: changed,
+        risk_packs_hit: hits,
+        lanes_selected,
+        estimated_lem,
+        band: band.to_string(),
+        budget: BudgetView {
+            preferred_default_lem: budget.preferred_default_lem,
+            default_limit_lem: budget.default_limit_lem,
+            elevated_limit_lem: budget.elevated_limit_lem,
+            hard_limit_lem: budget.hard_limit_lem,
+        },
+    };
+
+    let json = serde_json::to_string_pretty(&plan).context("serialize ci-plan")?;
+    if let Some(out) = &args.json_out {
+        let path = root.join(out);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+        }
+        fs::write(&path, &json).with_context(|| format!("write {}", path.display()))?;
+        println!("ci-plan written to {}", path.display());
+    } else {
+        println!("{json}");
+    }
+
+    if let Some(summary_path) = &args.github_summary {
+        let body = render_step_summary(&plan);
+        let mut existing = fs::read_to_string(summary_path).unwrap_or_default();
+        existing.push_str(&body);
+        fs::write(summary_path, existing)
+            .with_context(|| format!("append {}", summary_path.display()))?;
+    }
+
+    println!(
+        "ci-plan: {} risk-packs hit, {} lane(s) selected, estimated {} LEM ({})",
+        plan.risk_packs_hit.len(),
+        plan.lanes_selected.len(),
+        plan.estimated_lem,
+        plan.band,
+    );
+
+    Ok(())
+}
+
+fn parse_toml<T: for<'de> Deserialize<'de>>(path: &Path, kind: &str) -> Result<T> {
+    let body =
+        fs::read_to_string(path).with_context(|| format!("read {} ({kind})", path.display()))?;
+    toml::from_str(&body).with_context(|| format!("parse {} ({kind})", path.display()))
+}
+
+fn parse_labels(raw: Option<&str>) -> Vec<String> {
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    // GITHUB_PR_LABELS_JSON shape is `[{"name":"X"},{"name":"Y"}]` or
+    // `["X","Y"]` depending on how it was extracted. Accept both.
+    if let Ok(values) = serde_json::from_str::<Vec<LabelEntry>>(trimmed) {
+        return values.into_iter().map(|v| v.into_name()).collect();
+    }
+    if let Ok(values) = serde_json::from_str::<Vec<String>>(trimmed) {
+        return values;
+    }
+    // Fall back to a comma-separated list.
+    trimmed
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum LabelEntry {
+    Object { name: String },
+    Bare(String),
+}
+
+impl LabelEntry {
+    fn into_name(self) -> String {
+        match self {
+            LabelEntry::Object { name } => name,
+            LabelEntry::Bare(s) => s,
+        }
+    }
+}
+
+fn git_diff_names(root: &Path, base: &str, head: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .arg("diff")
+        .arg("--name-only")
+        .arg(format!("{base}...{head}"))
+        .current_dir(root)
+        .output()
+        .context("git diff")?;
+    if !output.status.success() {
+        bail!(
+            "git diff exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect())
+}
+
+fn match_paths(globs: &[String], files: &[String]) -> Result<Vec<String>> {
+    let mut builder = GlobSetBuilder::new();
+    for g in globs {
+        builder.add(Glob::new(g).with_context(|| format!("compile glob {g:?}"))?);
+    }
+    let set: GlobSet = builder.build()?;
+    let mut matched: Vec<String> = files.iter().filter(|f| set.is_match(f)).cloned().collect();
+    matched.sort();
+    matched.dedup();
+    Ok(matched)
+}
+
+fn lane_to_selection(
+    lane: &Lane,
+    runner_multipliers: &BTreeMap<String, f64>,
+    reason: &str,
+) -> LaneSelection {
+    let multiplier = runner_multipliers
+        .get(lane.runner.as_str())
+        .copied()
+        .unwrap_or(1.0);
+    let estimated = ((lane.base_lem as f64) * multiplier).round() as u64;
+    LaneSelection {
+        id: lane.id.clone(),
+        workflow: lane.workflow.clone(),
+        job: lane.job.clone(),
+        kind: lane.kind.clone(),
+        tier: lane.tier.clone(),
+        runner: lane.runner.clone(),
+        blocking: lane.blocking,
+        estimated_lem: estimated,
+        reason: reason.to_string(),
+    }
+}
+
+fn classify_band(lem: u64, budget: Budget) -> &'static str {
+    if lem <= budget.default_limit_lem {
+        "normal"
+    } else if lem <= budget.elevated_limit_lem {
+        "elevated"
+    } else if lem <= budget.hard_limit_lem {
+        "high-cost"
+    } else {
+        "override-required"
+    }
+}
+
+fn render_step_summary(plan: &PlanOutput) -> String {
+    let mut out = String::new();
+    out.push_str("\n## PR Plan (advisory)\n\n");
+    out.push_str(&format!("- estimated LEM: **{}**\n", plan.estimated_lem));
+    out.push_str(&format!("- band: **{}**\n", plan.band));
+    out.push_str(&format!(
+        "- budget: preferred {}, default {}, elevated {}, hard {}\n",
+        plan.budget.preferred_default_lem,
+        plan.budget.default_limit_lem,
+        plan.budget.elevated_limit_lem,
+        plan.budget.hard_limit_lem,
+    ));
+    out.push_str(&format!("- changed files: {}\n", plan.changed_files.len()));
+    out.push_str(&format!("- labels: {}\n\n", plan.labels.join(", ")));
+
+    if plan.risk_packs_hit.is_empty() {
+        out.push_str("No risk packs hit.\n\n");
+    } else {
+        out.push_str("### Risk packs hit\n\n");
+        for hit in &plan.risk_packs_hit {
+            out.push_str(&format!("- **{}** — {}\n", hit.name, hit.description));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("### Lanes selected\n\n");
+    out.push_str("| Lane | Tier | Runner | LEM | Reason |\n");
+    out.push_str("|------|------|--------|----:|--------|\n");
+    for lane in &plan.lanes_selected {
+        out.push_str(&format!(
+            "| `{}` | `{}` | `{}` | {} | {} |\n",
+            lane.id, lane.tier, lane.runner, lane.estimated_lem, lane.reason
+        ));
+    }
+    out
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("locate workspace root")?;
+    Ok(metadata.workspace_root.into_std_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn budget() -> Budget {
+        Budget {
+            preferred_default_lem: 25,
+            default_limit_lem: 35,
+            elevated_limit_lem: 75,
+            hard_limit_lem: 125,
+        }
+    }
+
+    #[test]
+    fn band_classification() {
+        let b = budget();
+        assert_eq!(classify_band(0, b), "normal");
+        assert_eq!(classify_band(35, b), "normal");
+        assert_eq!(classify_band(36, b), "elevated");
+        assert_eq!(classify_band(75, b), "elevated");
+        assert_eq!(classify_band(76, b), "high-cost");
+        assert_eq!(classify_band(125, b), "high-cost");
+        assert_eq!(classify_band(126, b), "override-required");
+    }
+
+    #[test]
+    fn parse_labels_object_form() {
+        let labels = parse_labels(Some(r#"[{"name":"wasm"},{"name":"full-ci"}]"#));
+        assert_eq!(labels, vec!["wasm".to_string(), "full-ci".to_string()]);
+    }
+
+    #[test]
+    fn parse_labels_bare_array() {
+        let labels = parse_labels(Some(r#"["mutation","release-check"]"#));
+        assert_eq!(
+            labels,
+            vec!["mutation".to_string(), "release-check".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_labels_csv() {
+        let labels = parse_labels(Some("ripr-waive, full-ci"));
+        assert_eq!(
+            labels,
+            vec!["ripr-waive".to_string(), "full-ci".to_string()]
+        );
+    }
+
+    #[test]
+    fn match_paths_basic() {
+        let files = vec![
+            "crates/tokmd/src/main.rs".to_string(),
+            "docs/README.md".to_string(),
+        ];
+        let globs = vec!["crates/tokmd/**".to_string()];
+        let matched = match_paths(&globs, &files).expect("globs valid");
+        assert_eq!(matched, vec!["crates/tokmd/src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn lane_to_selection_uses_runner_multiplier() {
+        let lane = Lane {
+            id: "x".into(),
+            workflow: "w.yml".into(),
+            job: "X".into(),
+            kind: "rust".into(),
+            tier: "frontdoor".into(),
+            default_pr: true,
+            blocking: true,
+            runner: "windows_latest".into(),
+            base_lem: 10,
+            expensive: false,
+        };
+        let mut multipliers = BTreeMap::new();
+        multipliers.insert("windows_latest".into(), 2.0);
+        let sel = lane_to_selection(&lane, &multipliers, "test");
+        assert_eq!(sel.estimated_lem, 20);
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -3,6 +3,7 @@ pub mod boundaries_check;
 pub mod build_guard;
 pub mod bump;
 pub mod ci_actuals;
+pub mod ci_plan;
 pub mod clippy_exceptions;
 pub mod cockpit;
 pub mod coverage_receipt;


### PR DESCRIPTION
## Summary

PR 08 of 16. Adds `cargo xtask ci-plan` plus `.github/workflows/pr-plan.yml`, an advisory PR Plan that reads `policy/ci-lane-whitelist.toml` and `policy/ci-risk-packs.toml`, walks the PR diff `base..head`, and emits `ci-plan.json`:

- Which risk packs are hit (8 packs: `core_receipts`, `analysis`, `gate_sensor`, `git_io`, `wasm`, `release`, `policy`, `docs`).
- Which lanes will run, with runner-multiplied LEM estimates and reasons.
- Total estimated LEM and the band (`normal` / `elevated` / `high-cost` / `override-required`).
- Markdown summary appended to `GITHUB_STEP_SUMMARY`.

The plan is **advisory**. PR 12 will wire risk-pack routing into workflow execution; PR 14 will layer the budget warning; PR 15 will replace static `base_lem` with learned p50/p90/p95 from `ci-actuals.json` (PR 13).

Depends on `policy/ci-lane-whitelist.toml` from #1688 (PR 02).

## CI economics

- **Default PR LEM impact:** `+5` (one new advisory ubuntu lane that compiles xtask once and runs the planner).
- **Workflows touched:** `+.github/workflows/pr-plan.yml`.
- **Branch protection impact:** none — new lane is non-blocking.
- **Failure mode caught:** invisible CI cost — reviewers can now see what a PR will spend before merge.
- **Cheaper signal considered:** post-hoc cost reports. Rejected — pre-merge visibility is the lever for "split this PR" before CI fans out.
- **Rollback path:** `git revert`. Plan is self-contained.
- **Commands run:** `cargo clippy -p xtask --all-targets -- -D warnings` clean; `cargo test -p xtask ci_plan` 6 passed; `cargo xtask proof-policy --check` OK; `cargo xtask affected` zero unknown files.

## Test plan

- [x] `cargo check -p xtask --locked`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo test -p xtask ci_plan` — 6 passed (band classification, label parsing object/bare/CSV, glob matching, runner multiplier).
- [x] `cargo xtask proof-policy --check`
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_