### PR TITLE
perf(ci): normalize cache save policy and label-event cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only cancel on synchronize (new commits). Label add/remove must not
+  # cancel an in-flight run: it triggers a fresh run with the new label
+  # set without throwing away work.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -29,6 +32,8 @@ jobs:
         with:
           toolchain: 1.93
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check MSRV compatibility
         run: cargo check --workspace --all-features
 
@@ -52,10 +57,13 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       if: runner.os == 'Linux'
       with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
         cache-directories: ${{ runner.temp }}/target
 
     - uses: Swatinem/rust-cache@v2
       if: runner.os != 'Linux'
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Run tests
       run: cargo test --all-features --verbose
@@ -74,6 +82,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Run tests
       run: cargo test --all-features --verbose
@@ -88,6 +98,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-directories: ${{ runner.temp }}/target
 
       - name: tokmd-analysis with all features
@@ -110,6 +121,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Validate proof policy
         run: cargo xtask proof-policy --check
 
@@ -125,6 +138,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Fetch base ref
         run: git fetch origin "${{ github.base_ref }}":"refs/remotes/origin/${{ github.base_ref }}" || true
@@ -204,6 +219,8 @@ jobs:
         with:
           tool: wasm-pack
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check tokmd-scan for wasm32
         run: cargo check -p tokmd-scan --target wasm32-unknown-unknown
       - name: Check tokmd-core analysis for wasm32
@@ -237,6 +254,8 @@ jobs:
         run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run quality gate
         run: cargo xtask gate --check
@@ -268,6 +287,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run property tests (reduced iterations)
         run: |
           PROPTEST_CASES=50 cargo test -p tokmd-model --test properties --all-features --verbose
@@ -283,6 +304,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Verify publish surface and dry-run checks
         run: cargo xtask publish-surface --json --verify-publish
         env:
@@ -304,6 +327,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check documentation drift
         run: cargo xtask docs --check
         env:

--- a/.github/workflows/cockpit.yml
+++ b/.github/workflows/cockpit.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: cockpit-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -32,6 +36,7 @@ jobs:
         with:
           shared-key: cockpit
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and install tokmd
         run: cargo install --path crates/tokmd --features git --locked

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ permissions:
 
 concurrency:
   group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/nix-full.yml
+++ b/.github/workflows/nix-full.yml
@@ -16,7 +16,7 @@ concurrency:
   # Keep workflow_run validation and nightly schedule runs from canceling each
   # other when they target the same main-branch commit.
   group: nix-full-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   nix-full:

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: nix-macos-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   nix-macos:

--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -24,7 +24,7 @@ permissions:
 
 concurrency:
   group: proof-executor-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -56,6 +56,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-directories: ${{ runner.temp }}/target
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/proof-observation-collection.yml
+++ b/.github/workflows/proof-observation-collection.yml
@@ -30,7 +30,7 @@ permissions:
 
 concurrency:
   group: proof-observation-collection-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -54,6 +54,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Download successful proof executor artifacts
         run: |

--- a/docs/ci/cache-and-cancellation.md
+++ b/docs/ci/cache-and-cancellation.md
@@ -1,0 +1,53 @@
+# CI cache + cancellation policy
+
+## Cancellation
+
+Every workflow defines a `concurrency` group with the shape:
+
+```yaml
+concurrency:
+  group: <name>-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+```
+
+**Why the conditional?** With plain `cancel-in-progress: true`, label
+add/remove on a PR cancels in-flight runs. That throws away work and
+makes lane routing (PR 08, PR 12) painful — adding the `wasm` label on a
+PR with `Wasm Compile & Test` already running just kills the run instead
+of letting the new run start with the new label set.
+
+The conditional cancels only when GitHub fires `synchronize` (a new
+commit pushed). All other PR events — `labeled`, `unlabeled`, `opened`,
+`reopened` — leave existing runs alone, and their replacement runs start
+fresh with the new state.
+
+## Cache save policy
+
+Every `Swatinem/rust-cache@v2` use sets:
+
+```yaml
+- uses: Swatinem/rust-cache@v2
+  with:
+    save-if: ${{ github.ref == 'refs/heads/main' }}
+```
+
+PRs **restore** caches but never **save** them. `main` is the only ref
+that writes the canonical cache.
+
+This avoids per-PR cache churn: every fork/branch was previously
+producing its own cache entries that competed for the GitHub Actions
+cache budget (10GB per repo by default), evicting useful caches in
+seconds. Save-on-main means new PRs get a warm cache from main and
+return without writing.
+
+## Affected workflows
+
+| Workflow | Cancel | Cache save policy |
+|----------|--------|-------------------|
+| `ci.yml` | sync-only | `save-if: main` on every cache use |
+| `coverage.yml` | sync-only | `save-if: main` |
+| `cockpit.yml` | sync-only | `save-if: main` |
+| `proof-executor.yml` | sync-only | `save-if: main` |
+| `proof-observation-collection.yml` | sync-only | `save-if: main` |
+| `nix-full.yml` | sync-only | n/a |
+| `nix-macos.yml` | sync-only | n/a |


### PR DESCRIPTION
## Summary

PR 09 of 16. Two systematic changes across every workflow:

1. **`cancel-in-progress` is conditional on `synchronize`** — label add/remove no longer cancels in-flight runs. New commits still cancel stale runs.
2. **Cache save policy** — every `Swatinem/rust-cache@v2` step now sets `save-if: ${{ github.ref == 'refs/heads/main' }}`. PRs restore caches; only main writes them.

Workflows touched: `ci.yml`, `coverage.yml`, `cockpit.yml`, `proof-executor.yml`, `proof-observation-collection.yml`, `nix-full.yml`, `nix-macos.yml`.

Adds `docs/ci/cache-and-cancellation.md` documenting the policy.

## CI economics

- **Default PR LEM impact:** small *reduction* — cache restores stay warm because main is no longer evicted by per-PR writes.
- **Workflows touched:** all listed above; behavior changes are conservative (cancel less, write less).
- **Branch protection impact:** none.
- **Failure mode caught:** `LABEL_EVENT_CANCELS_PR_RUN` (label add/remove cancels in-flight runs); cache eviction by per-PR writes.
- **Cheaper signal considered:** rely on the cache to self-regulate. Rejected — without `save-if`, every fork/branch competes for the 10GB cache budget.
- **Rollback path:** `git revert`. Each workflow change is small and isolated.
- **Commands run:** `cargo xtask proof-policy --check` OK; `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.

## Test plan

- [x] `cargo xtask proof-policy --check` OK.
- [x] Workflows YAML-syntax-valid (no parser errors locally).
- [ ] Reviewers confirm the synchronize-only cancellation matches GitHub semantics.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_