### PR TITLE
docs(readme): add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/EffortlessMetrics/tokmd?display_name=tag)](https://github.com/EffortlessMetrics/tokmd/releases)
 [![Docs.rs](https://img.shields.io/docsrs/tokmd)](https://docs.rs/tokmd)
 [![CI](https://github.com/EffortlessMetrics/tokmd/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/tokmd/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/tokmd/graph/badge.svg?branch=main)](https://codecov.io/gh/EffortlessMetrics/tokmd)
 [![License](https://img.shields.io/crates/l/tokmd)](https://crates.io/crates/tokmd)
 [![Downloads](https://img.shields.io/crates/d/tokmd)](https://crates.io/crates/tokmd)
 


### PR DESCRIPTION
## Summary

Adds step 3 of the tokmd Codecov rollout: a Codecov badge in the README badge block, alongside the existing CI badge.

## CI economics

- Default PR LEM impact: None (documentation only)
- Workflow touched: None (README only)
- Branch protection impact: None
- Failure mode caught: Coverage status regressed without visibility
- Cheaper signal considered: Coverage is advisory until PR #1700 (baseline and ratchet)
- Rollback path: Remove badge line from README

## Claim boundary

Coverage is execution-surface evidence only. It does not prove mutation adequacy, proof-policy completeness, WASM behavior, release packaging, or security posture.

## Changes

- Add Codecov badge to README badge block
- Position: after CI badge, before License badge
- Link: points to Codecov repository dashboard
- Badge: displays main branch coverage status

## Validation

- [x] Badge positioned correctly in badge block
- [x] Badge link valid
- [ ] Codecov dashboard accessible after PR #1697 merges

---
_Generated by [Claude Code](https://claude.ai/code/session_01NH5QgZvQQR4kDEFGFHvAUP)_