### PR TITLE
ci: move expensive validation out of ordinary PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo check --workspace --all-features
 
   build:
-    name: Build & Test
+    name: Build & Test (Linux)
     runs-on: ubuntu-latest
 
     steps:
@@ -392,12 +392,14 @@ jobs:
         run: nix build -L .#tokmd
 
   mutation:
-    name: Mutation Testing (Required)
+    name: Mutation Testing
     runs-on: ubuntu-latest
-    # Runtime mutation testing moves to label/main/nightly so ordinary
+    # Runtime mutation testing moves to label/push-to-main so ordinary
     # PRs don't pay 45 LEM by default. PR 11 adds an advisory `ripr`
     # job that gives mutation-testing-lite signal at static-analysis
-    # prices for the default PR.
+    # prices for the default PR. The "(Required)" suffix is dropped to
+    # avoid implying this lane is a mandatory PR check; required-status
+    # guarantees live on the `CI (Required)` aggregator job.
     if: >-
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'mutation') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6
@@ -50,18 +47,38 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Use larger writable target dir on Linux
-      if: runner.os == 'Linux'
+    - name: Use larger writable target dir
       run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
 
     - uses: Swatinem/rust-cache@v2
-      if: runner.os == 'Linux'
       with:
-        save-if: ${{ github.ref == 'refs/heads/main' }}
         cache-directories: ${{ runner.temp }}/target
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+
+    - name: Run tests
+      run: cargo test --all-features --verbose
+      env:
+        CI: true
+
+  # Windows full-test moves off the default PR gate. It runs on push to
+  # main and on PRs explicitly labelled `windows` or `full-ci`. Rust path
+  # changes that are likely to behave differently on Windows go through
+  # the `git_io` risk pack (PR 12).
+  build-windows:
+    name: Build & Test (Windows)
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'windows') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
 
     - uses: Swatinem/rust-cache@v2
-      if: runner.os != 'Linux'
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -208,6 +225,10 @@ jobs:
 
   wasm-compile:
     name: Wasm Compile & Test
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'wasm') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -282,6 +303,10 @@ jobs:
 
   proptest-smoke:
     name: Proptest Smoke
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'property-tests') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -336,6 +361,11 @@ jobs:
 
   nix-pr:
     name: Nix PR Package Gate
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'nix') ||
+      contains(github.event.pull_request.labels.*.name, 'release-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -364,7 +394,14 @@ jobs:
   mutation:
     name: Mutation Testing (Required)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Runtime mutation testing moves to label/main/nightly so ordinary
+    # PRs don't pay 45 LEM by default. PR 11 adds an advisory `ripr`
+    # job that gives mutation-testing-lite signal at static-analysis
+    # prices for the default PR.
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'mutation') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
         with:
@@ -447,6 +484,7 @@ jobs:
     needs:
       - msrv
       - build
+      - build-windows
       - build-macos
       - gate
       - deny

--- a/docs/ci/default-pr-gate.md
+++ b/docs/ci/default-pr-gate.md
@@ -6,19 +6,19 @@ Expensive lanes are gated on labels and on push-to-main:
 
 | Job | Now triggers on PR when... |
 |-----|----------------------------|
-| `Build & Test` (Linux) | always |
+| `Build & Test (Linux)` | always |
 | `Build & Test (Windows)` | label `windows` / `full-ci` (still on every push) |
-| `Build & Test (macOS)` | push-only (was already) |
+| `Build & Test (macOS)` | push-only (unchanged) |
 | `Wasm Compile & Test` | label `wasm` / `full-ci` |
 | `Nix PR Package Gate` | label `nix` / `release-check` / `full-ci` |
-| `Mutation Testing (Required)` | label `mutation` / `full-ci` (replaced by ripr advisory in PR 11) |
+| `Mutation Testing` | label `mutation` / `full-ci` (replaced by ripr advisory in PR 11) |
 | `Proptest Smoke` | label `property-tests` / `full-ci` |
 | `MSRV Check` | always |
 | `Quality Gate` | always |
 | `Cargo Deny` | always |
 | `Typos` | always |
 | `Proof Policy` | always |
-| `Affected Proof Plan` | always |
+| `Affected Proof Plan` | pull_request only |
 | `Feature Boundaries` | always |
 | `Publish Surface` | always (small dry-run) |
 | `Version consistency` | always |

--- a/docs/ci/default-pr-gate.md
+++ b/docs/ci/default-pr-gate.md
@@ -1,0 +1,67 @@
+# Default PR gate
+
+After PR 10, the ordinary `pull_request` gate runs only the cheap
+"frontdoor" lanes plus the existing proof / cockpit / typos jobs.
+Expensive lanes are gated on labels and on push-to-main:
+
+| Job | Now triggers on PR when... |
+|-----|----------------------------|
+| `Build & Test` (Linux) | always |
+| `Build & Test (Windows)` | label `windows` / `full-ci` (still on every push) |
+| `Build & Test (macOS)` | push-only (was already) |
+| `Wasm Compile & Test` | label `wasm` / `full-ci` |
+| `Nix PR Package Gate` | label `nix` / `release-check` / `full-ci` |
+| `Mutation Testing (Required)` | label `mutation` / `full-ci` (replaced by ripr advisory in PR 11) |
+| `Proptest Smoke` | label `property-tests` / `full-ci` |
+| `MSRV Check` | always |
+| `Quality Gate` | always |
+| `Cargo Deny` | always |
+| `Typos` | always |
+| `Proof Policy` | always |
+| `Affected Proof Plan` | always |
+| `Feature Boundaries` | always |
+| `Publish Surface` | always (small dry-run) |
+| `Version consistency` | always |
+| `Docs Check` | always |
+
+## CI (Required) summary
+
+The aggregator's `if: always()` posture means **skipped jobs do not fail**
+the summary — only `failure` and `cancelled` results do. So a default PR
+that skips Windows, WASM, Nix, mutation, and proptest will still see a
+green `CI (Required)` row provided the lanes that *did* run all passed.
+
+## Default-PR LEM after the slimming
+
+Roughly (per PR 02's `inventory.md`, with cache normalised in PR 09):
+
+```text
+msrv_check                   5
+quality_gate                 8
+proof_policy                 3
+affected_proof_plan          4
+feature_boundaries          10
+typos                        1
+cargo_deny                   4
+version_consistency          2
+docs_check                   4
+build (Linux only)          12   (matrix Linux entry)
+publish_surface              8
+ci_required                  1
+                          ----
+                            62   default PR (was ~203)
+```
+
+PR 11 will add a `ripr` advisory at ~2 LEM in place of the demoted
+mutation lane, leaving the default ordinary PR around 64 LEM — within
+the `elevated` band on first roll-out, with PR 12's risk-pack routing
+designed to bring this further down for narrow PRs.
+
+## Anti-patterns
+
+- Don't use `full-ci` to dodge a real failure; the deep lanes catch
+  things the default lane is *intentionally* skipping.
+- Don't apply per-pack labels to silence routing — fix the change.
+- Don't depend on the matrix entry name "windows" appearing under
+  `build` — the matrix split is intentional so `if:` can gate Windows
+  independently.


### PR DESCRIPTION
## Summary

PR 10 of 16. Slims the default ordinary PR gate. Windows, WASM, Nix, runtime mutation, and proptest now run only when:

- the PR has the matching label (`windows`, `wasm`, `nix` / `release-check`, `mutation`, `property-tests`), or
- the PR has `full-ci`, or
- the event is a push to `main`.

The matrix in `Build & Test` is split into a Linux entry (always) and a separate `Build & Test (Windows)` job that gates on label/push. `ci-required` keeps `if: always()`, so a default PR that skips the gated jobs still gets a green required summary.

Adds `docs/ci/default-pr-gate.md` and a `ci_default_pr_gate` proof scope.

## Default-PR LEM after slimming

```text
msrv_check                   5
quality_gate                 8
proof_policy                 3
affected_proof_plan          4
feature_boundaries          10
typos                        1
cargo_deny                   4
version_consistency          2
docs_check                   4
build (Linux only)          12
publish_surface              8
ci_required                  1
                          ----
                            62   default PR (was ~203)
```

PR 11 will layer in the ripr advisory (~2 LEM) in place of the demoted runtime mutation. PR 12 will wire risk-pack routing for narrower opt-ins.

## CI economics

- **Default PR LEM impact:** ~`-141` (203 → 62 for ordinary Rust-only PR).
- **Workflows touched:** `.github/workflows/ci.yml`.
- **Branch protection impact:** none — `ci-required` aggregator stays the merge gate; skipped jobs do not fail.
- **Failure mode caught:** none lost — Windows / WASM / Nix / mutation / proptest still run on push and are reachable via labels for any PR that wants them.
- **Cheaper signal considered:** path-filter `paths:` triggers. Rejected — risk-pack routing (PR 12) makes path-driven inclusion explicit and reviewable; PR 10 is the conservative label-gated step.
- **Rollback path:** revert the `if:` conditions on the affected jobs.
- **Commands run:** `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` clean; `cargo xtask proof-policy --check` OK; `cargo xtask affected` zero unknown files.

## Test plan

- [x] YAML syntax-valid.
- [x] `cargo xtask proof-policy --check` OK.
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.
- [ ] Reviewers confirm gating set is appropriate; consider a real PR with the `wasm` label to verify the gate works.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_