### PR TITLE
ci(ripr): add advisory static exposure analyzer

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -1,0 +1,104 @@
+name: ripr (advisory)
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ripr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -C debuginfo=0
+
+jobs:
+  ripr:
+    name: ripr (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Fetch base ref
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}":"refs/remotes/origin/${{ github.base_ref }}" || true
+
+      - name: Identify changed Rust files (production only)
+        id: changed
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p target/ripr
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- '*.rs' \
+            | grep -v '/tests/' \
+            | grep -v '_test\.rs$' \
+            | grep -v '^fuzz/' \
+            | grep -v '/fuzz/' \
+            > target/ripr/changed.txt || true
+          COUNT="$(wc -l < target/ripr/changed.txt | tr -d ' ')"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Install ripr (best-effort)
+        id: install
+        run: |
+          set +e
+          if cargo install ripr --locked >/dev/null 2>&1; then
+            echo "installed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "installed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ripr not yet available on crates.io; running advisory placeholder."
+          fi
+
+      - name: Run ripr or placeholder
+        run: |
+          set -euo pipefail
+          mkdir -p target/ripr
+          if [ "${{ steps.install.outputs.installed }}" = "true" ]; then
+            ripr analyze \
+              --config ripr.toml \
+              --diff-only \
+              --json target/ripr/ripr.json \
+              --sarif target/ripr/ripr.sarif \
+              --markdown target/ripr/ripr.md \
+              || true
+            {
+              echo "## ripr (advisory)"
+              echo ""
+              if [ -f target/ripr/ripr.md ]; then
+                cat target/ripr/ripr.md
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat <<'EOF' > target/ripr/ripr.md
+          ## ripr (advisory)
+
+          ripr is not yet wired up in this repo. This advisory job is a
+          placeholder so the slot exists in the lane whitelist and the
+          rollout (PR 11) lands. When ripr ships, replace the install
+          step's fallback with the real binary and remove this notice.
+          EOF
+            cat target/ripr/ripr.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload ripr report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ripr-report
+          path: target/ripr/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -603,6 +603,21 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "ripr_policy"
+kind = "non_rust"
+paths = [
+  ".github/workflows/ripr.yml",
+  "policy/ripr-suppressions.toml",
+  "ripr.toml",
+]
+proof = [
+  "cargo xtask proof-policy --check",
+]
+reason = "ripr static-mutation analyzer config + suppressions ledger; advisory until PR 16 soft-gate."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "schema_contracts"
 kind = "rust"
 paths = [

--- a/policy/ripr-suppressions.toml
+++ b/policy/ripr-suppressions.toml
@@ -1,0 +1,26 @@
+schema_version = "1.0"
+policy = "ripr-suppressions"
+owner = "testing/oracle"
+status = "advisory"
+updated = "2026-05-07"
+
+# ripr suppressions ledger.
+#
+# Each [[suppression]] entry pins:
+#   id        - "ripr-NNNN" with zero-padded counter, unique.
+#   path      - file or glob the suppression covers.
+#   kind      - which finding class is suppressed
+#               (exposed | weakly_exposed | reachable_unrevealed |
+#                no_static_path | infection_unknown |
+#                propagation_unknown | static_unknown).
+#   selector  - semantic selector
+#               (function name / fingerprint).
+#   owner     - team/role.
+#   reason    - why the test gap is intentional and explained.
+#   expires   - ISO-8601 date; expired entries fail the gate.
+#
+# Don't suppress because a finding is annoying. Suppress because the
+# test gap is intentional and explained.
+
+# The ledger starts empty during the advisory phase. PR 16 adds the
+# soft-gate that uses these entries.

--- a/ripr.toml
+++ b/ripr.toml
@@ -1,0 +1,25 @@
+# ripr — static "mutation-testing-lite" configuration.
+#
+# ripr does not run mutants. It asks whether a changed behavior appears
+# exposed to a meaningful test discriminator. Severities map to advisory
+# notice / warning levels for the rollout phase; PR 16 may flip narrow
+# cases to soft-block.
+
+[analysis]
+mode = "diff"
+
+[report]
+max_related_tests = 8
+include_context = true
+
+[severity]
+exposed = "notice"
+weakly_exposed = "warning"
+reachable_unrevealed = "warning"
+no_static_path = "notice"
+infection_unknown = "notice"
+propagation_unknown = "notice"
+static_unknown = "notice"
+
+[suppressions]
+path = "policy/ripr-suppressions.toml"


### PR DESCRIPTION
## Summary

PR 11 of 16. Adds the ripr advisory lane — mutation-testing-lite at static-analysis prices — to fill the default-PR slot vacated by PR 10's runtime-mutation demotion.

- `ripr.toml` — severity map (exposed=notice, weakly_exposed=warning, reachable_unrevealed=warning, etc.), diff-mode, suppressions path.
- `policy/ripr-suppressions.toml` — empty ledger; PR 16 wires the soft-gate.
- `.github/workflows/ripr.yml` — PR + push job that runs ripr on changed production Rust files. Falls back to a placeholder advisory until ripr is published, so the rollout step lands now.
- `ci/proof.toml` — `ripr_policy` non-Rust scope.

The mutation demotion itself happened in PR 10 (`Mutation Testing (Required)` is now gated on `mutation` / `full-ci` labels and push-to-main).

## CI economics

- **Default PR LEM impact:** `+2` for the advisory lane; net `+2` after PR 10's demotions.
- **Workflows touched:** `+.github/workflows/ripr.yml`.
- **Branch protection impact:** none — non-blocking.
- **Failure mode caught:** mutation-shaped oracle gaps that runtime mutation used to catch, now visible at static-analysis cost.
- **Cheaper signal considered:** keep runtime mutation on default PR. Rejected — 45 LEM × every PR vs 2 LEM × every PR + cargo-mutants on label/main/nightly.
- **Rollback path:** revert this PR.
- **Commands run:** YAML clean; `cargo xtask proof-policy --check` OK; `cargo xtask affected` zero unknown files.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ripr.yml'))"` clean.
- [x] `cargo xtask proof-policy --check` OK.
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_