### PR TITLE
ci(telemetry): add JUnit, timing, and ci-actuals

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,26 @@
+# nextest configuration for tokmd.
+#
+# Currently the repo runs `cargo test --all-features --verbose`. This
+# config exists so any future migration to `cargo nextest` keeps the
+# emitted JUnit XML and timing posture consistent with the ci-actuals
+# pipeline (PR 13) and learned estimates (PR 15).
+
+[profile.default]
+# Match cargo test's default behaviour as closely as possible.
+slow-timeout = { period = "60s", terminate-after = 2 }
+status-level = "fail"
+
+[profile.ci]
+# Surface slow tests so they're visible to ci-actuals.
+slow-timeout = { period = "60s", terminate-after = 2 }
+fail-fast = false
+final-status-level = "slow"
+status-level = "skip"
+junit = { path = "target/nextest/junit.xml" }
+
+[profile.ci.junit]
+# Make per-test classnames emit cargo target + crate so reports group
+# usefully when the actuals pipeline ingests them.
+report-name = "tokmd"
+store-success-output = false
+store-failure-output = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,6 +436,40 @@ jobs:
       - feature-boundaries
       - proof-policy
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Persist needs context for ci-actuals
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          mkdir -p target/ci
+          printf '%s' "$NEEDS_JSON" > target/ci/needs.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Emit ci-actuals.json (advisory)
+        continue-on-error: true
+        run: |
+          cargo xtask ci-actuals \
+            --needs target/ci/needs.json \
+            --json-out target/ci/ci-actuals.json || true
+
+      - name: Upload ci-actuals
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-actuals
+          path: target/ci/ci-actuals.json
+          if-no-files-found: ignore
+          retention-days: 30
+
       - name: Check overall status
         env:
           NEEDS_JSON: ${{ toJson(needs) }}

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -66,6 +66,7 @@ paths = [
   "xtask/src/tasks/mod.rs",
   "xtask/src/tasks/affected.rs",
   "xtask/src/tasks/boundaries_check.rs",
+  "xtask/src/tasks/ci_actuals.rs",
   "xtask/src/tasks/fixture_blobs_check.rs",
   "xtask/src/tasks/proof_artifacts_check.rs",
   "xtask/src/tasks/proof_policy.rs",
@@ -565,6 +566,20 @@ proof = [
   "cargo test -p tokmd --test docs --verbose",
 ]
 reason = "The composite GitHub Action is a YAML and documentation contract for repository consumers."
+mutation = false
+coverage = false
+
+[[scope]]
+name = "ci_actuals"
+kind = "non_rust"
+paths = [
+  ".config/nextest.toml",
+  "docs/ci/ci-actuals.md",
+]
+proof = [
+  "cargo xtask docs --check",
+]
+reason = "ci-actuals telemetry config + docs; PR 14/15 read the artifact."
 mutation = false
 coverage = false
 

--- a/docs/ci/ci-actuals.md
+++ b/docs/ci/ci-actuals.md
@@ -1,0 +1,67 @@
+# ci-actuals.json
+
+`cargo xtask ci-actuals` emits the rolling per-job timing artifact that
+PR 14's budget guard and PR 15's learned estimates feed off.
+
+## When it runs
+
+The aggregator job in `.github/workflows/ci.yml` writes the literal
+`${{ toJson(needs) }}` payload to `target/ci/needs.json`, optionally
+appends per-job durations from a sidecar JSON (`target/ci/timings.json`),
+and then runs:
+
+```bash
+cargo xtask ci-actuals \
+  --needs target/ci/needs.json \
+  --timings target/ci/timings.json \
+  --json-out target/ci/ci-actuals.json
+```
+
+## Output schema
+
+```json
+{
+  "schema_version": 1,
+  "repo": "tokmd",
+  "sha": "<HEAD>",
+  "workflow": "CI",
+  "jobs": [
+    {
+      "name": "quality_gate",
+      "runner": "ubuntu_latest",
+      "estimated_lem": 8,
+      "actual_seconds": 320.0,
+      "actual_lem": 5.33,
+      "conclusion": "success",
+      "cache_hit": null,
+      "risk_packs": []
+    }
+  ]
+}
+```
+
+`actual_lem = (actual_seconds / 60) × runner_multiplier`.
+
+## Inputs
+
+- `--needs <PATH>` — JSON file containing the workflow's `needs`
+  context. The aggregator step writes this directly via
+  `echo "$NEEDS_JSON" > target/ci/needs.json`.
+- `--timings <PATH>` (optional) — `{ "<job-id>": <seconds> }`.
+- `--lanes <PATH>` (optional, defaults to
+  `policy/ci-lane-whitelist.toml`) — used to look up per-job static
+  `estimated_lem` and the runner multiplier.
+
+## Status
+
+- **PR 13** (this PR) — adds the command and the artifact, plus
+  `.config/nextest.toml` so a future migration to nextest fits the
+  same pipeline. The artifact is **purely advisory**: nothing reads
+  it yet.
+- **PR 14** — the soft budget guard reads `estimated_lem` and warns
+  when totals exceed the elevated band; uses actuals when present.
+- **PR 15** — replaces static `base_lem` with learned p50/p90/p95.
+
+The artifact starts empty (no actuals collected yet). It exists as a
+schema-stable receipt so the pipeline can land before the first
+calibration window.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -48,6 +48,8 @@ pub enum Commands {
     CheckNoPanicFamily(NoPanicArgs),
     /// Propose new no-panic allowlist entries from current findings
     NoPanicPropose(NoPanicProposeArgs),
+    /// Emit ci-actuals.json from the workflow `needs` context
+    CiActuals(CiActualsArgs),
     /// Auto-fix lint issues (fmt + clippy --fix) then verify
     LintFix(LintFixArgs),
     /// Run Cargo through an opt-in local sccache wrapper
@@ -72,6 +74,51 @@ pub struct VersionConsistencyArgs {}
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct LintPolicyArgs {}
+
+#[derive(Args, Debug, Clone)]
+pub struct CiActualsArgs {
+    /// Path to a JSON file containing the workflow's needs context
+    #[arg(long, default_value = "target/ci/needs.json")]
+    pub needs: std::path::PathBuf,
+
+    /// Optional path to a JSON file with per-job duration_seconds
+    #[arg(long, value_name = "PATH")]
+    pub timings: Option<std::path::PathBuf>,
+
+    /// Lane whitelist TOML (for static estimates)
+    #[arg(long, value_name = "PATH")]
+    pub lanes: Option<std::path::PathBuf>,
+
+    /// Output path for ci-actuals.json
+    #[arg(long, default_value = "target/ci/ci-actuals.json")]
+    pub json_out: std::path::PathBuf,
+
+    /// Repo identifier
+    #[arg(long, default_value = "tokmd")]
+    pub repo: String,
+
+    /// Commit SHA
+    #[arg(long, default_value = "HEAD")]
+    pub sha: String,
+
+    /// Workflow name
+    #[arg(long, default_value = "CI")]
+    pub workflow: String,
+}
+
+impl Default for CiActualsArgs {
+    fn default() -> Self {
+        Self {
+            needs: std::path::PathBuf::from("target/ci/needs.json"),
+            timings: None,
+            lanes: None,
+            json_out: std::path::PathBuf::from("target/ci/ci-actuals.json"),
+            repo: "tokmd".into(),
+            sha: "HEAD".into(),
+            workflow: "CI".into(),
+        }
+    }
+}
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct NoPanicArgs {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
         Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),
         Some(cli::Commands::Gate(args)) => tasks::gate::run(args),
+        Some(cli::Commands::CiActuals(args)) => tasks::ci_actuals::run(args),
         Some(cli::Commands::CheckLintPolicy(args)) => tasks::lint_policy::run(args),
         Some(cli::Commands::CheckNoPanicFamily(args)) => tasks::no_panic::run_check(args),
         Some(cli::Commands::NoPanicPropose(args)) => tasks::no_panic::run_propose(args),

--- a/xtask/src/tasks/ci_actuals.rs
+++ b/xtask/src/tasks/ci_actuals.rs
@@ -1,0 +1,219 @@
+//! Emit `ci-actuals.json` from the workflow's `needs` context.
+//!
+//! Inputs: a JSON file whose top-level shape is
+//!   {
+//!     "<job-id>": {
+//!       "result": "success" | "failure" | "skipped" | "cancelled",
+//!       "outputs": { ... }
+//!     }
+//!   }
+//! (the literal `${{ toJson(needs) }}` payload from a GitHub Actions
+//! aggregator step), plus optional per-job duration_seconds via a
+//! sidecar `--timings <PATH>` JSON of `{ "<job-id>": <seconds> }`.
+//!
+//! Output: `ci-actuals.json` whose schema is:
+//!   {
+//!     "schema_version": 1,
+//!     "repo": "tokmd",
+//!     "sha": "<HEAD>",
+//!     "workflow": "CI",
+//!     "jobs": [
+//!       {
+//!         "name": "<job-id>",
+//!         "runner": "<runner>",
+//!         "estimated_lem": <u64>,
+//!         "actual_seconds": <f64>,
+//!         "actual_lem": <f64>,
+//!         "conclusion": "success" | ...,
+//!         "cache_hit": <bool|null>,
+//!         "risk_packs": []
+//!       }
+//!     ]
+//!   }
+//!
+//! Static `estimated_lem` is sourced from `policy/ci-lane-whitelist.toml`
+//! when available, mapping `<job-id>` to a lane via the `id` field.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::cli::CiActualsArgs;
+
+#[derive(Debug, Deserialize)]
+struct WhitelistFile {
+    #[serde(default)]
+    runner_multipliers: BTreeMap<String, f64>,
+    #[serde(default)]
+    lane: Vec<Lane>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Lane {
+    id: String,
+    #[serde(default)]
+    runner: String,
+    #[serde(default)]
+    base_lem: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct Output {
+    schema_version: u32,
+    repo: String,
+    sha: String,
+    workflow: String,
+    jobs: Vec<JobActual>,
+}
+
+#[derive(Debug, Serialize)]
+struct JobActual {
+    name: String,
+    runner: String,
+    estimated_lem: u64,
+    actual_seconds: f64,
+    actual_lem: f64,
+    conclusion: String,
+    cache_hit: Option<bool>,
+    risk_packs: Vec<String>,
+}
+
+pub fn run(args: CiActualsArgs) -> Result<()> {
+    let root = workspace_root()?;
+    let needs_path = root.join(&args.needs);
+    let needs: BTreeMap<String, Value> = parse_json(&needs_path)?;
+
+    let timings: BTreeMap<String, f64> = match &args.timings {
+        Some(p) => parse_json(&root.join(p))?,
+        None => BTreeMap::new(),
+    };
+
+    let whitelist: Option<WhitelistFile> = match &args.lanes {
+        Some(p) => {
+            let lp = root.join(p);
+            if lp.is_file() {
+                Some(parse_toml(&lp)?)
+            } else {
+                None
+            }
+        }
+        None => {
+            let default = root.join("policy/ci-lane-whitelist.toml");
+            if default.is_file() {
+                Some(parse_toml(&default)?)
+            } else {
+                None
+            }
+        }
+    };
+
+    let lane_index: BTreeMap<&str, &Lane> = whitelist
+        .as_ref()
+        .map(|w| w.lane.iter().map(|l| (l.id.as_str(), l)).collect())
+        .unwrap_or_default();
+    let multipliers: BTreeMap<&str, f64> = whitelist
+        .as_ref()
+        .map(|w| {
+            w.runner_multipliers
+                .iter()
+                .map(|(k, v)| (k.as_str(), *v))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut jobs: Vec<JobActual> = Vec::new();
+    for (name, payload) in &needs {
+        let conclusion = payload
+            .get("result")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let lane = lane_index.get(name.as_str()).copied();
+        let runner = lane.map(|l| l.runner.clone()).unwrap_or_default();
+        let estimated_lem = lane.map(|l| l.base_lem).unwrap_or(0);
+        let actual_seconds = timings.get(name).copied().unwrap_or(0.0);
+        let multiplier = multipliers.get(runner.as_str()).copied().unwrap_or(1.0);
+        let actual_lem = (actual_seconds / 60.0) * multiplier;
+        jobs.push(JobActual {
+            name: name.clone(),
+            runner,
+            estimated_lem,
+            actual_seconds,
+            actual_lem,
+            conclusion,
+            cache_hit: None,
+            risk_packs: Vec::new(),
+        });
+    }
+
+    jobs.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let out = Output {
+        schema_version: 1,
+        repo: args.repo.clone(),
+        sha: args.sha.clone(),
+        workflow: args.workflow.clone(),
+        jobs,
+    };
+
+    let json = serde_json::to_string_pretty(&out).context("serialize ci-actuals")?;
+    let out_path = root.join(&args.json_out);
+    if let Some(parent) = out_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    fs::write(&out_path, &json).with_context(|| format!("write {}", out_path.display()))?;
+    println!(
+        "ci-actuals written to {} ({} job(s))",
+        out_path.display(),
+        out.jobs.len()
+    );
+    Ok(())
+}
+
+fn parse_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let body = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_str(&body).with_context(|| format!("parse json {}", path.display()))
+}
+
+fn parse_toml<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let body = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&body).with_context(|| format!("parse toml {}", path.display()))
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("locate workspace root")?;
+    Ok(metadata.workspace_root.into_std_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_needs_produces_empty_actuals() {
+        let needs: BTreeMap<String, Value> = BTreeMap::new();
+        // Don't actually run the full task here; just exercise that the
+        // BTreeMap iteration and JobActual construction is sound.
+        let jobs: Vec<JobActual> = needs
+            .keys()
+            .map(|name| JobActual {
+                name: name.clone(),
+                runner: String::new(),
+                estimated_lem: 0,
+                actual_seconds: 0.0,
+                actual_lem: 0.0,
+                conclusion: "unknown".into(),
+                cache_hit: None,
+                risk_packs: Vec::new(),
+            })
+            .collect();
+        assert!(jobs.is_empty());
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -2,6 +2,7 @@ pub mod affected;
 pub mod boundaries_check;
 pub mod build_guard;
 pub mod bump;
+pub mod ci_actuals;
 pub mod cockpit;
 pub mod docs;
 pub mod fixture_blobs_check;


### PR DESCRIPTION
## Summary

PR 13 of 16. Adds the `ci-actuals` telemetry pipeline so PR 14 (budget guard) and PR 15 (learned estimates) can read measurements rather than only static floors.

- `xtask/src/tasks/ci_actuals.rs` — `cargo xtask ci-actuals` reads the workflow's `needs` context, joins per-job durations with static lane estimates from `policy/ci-lane-whitelist.toml`, and writes `ci-actuals.json` (schema_version=1).
- `.config/nextest.toml` — future-proof JUnit + slow-test posture for any later migration to nextest.
- `docs/ci/ci-actuals.md` — schema + status.
- `.github/workflows/ci.yml` — `ci-required` now writes `target/ci/needs.json`, runs `cargo xtask ci-actuals` advisory, and uploads the artifact.
- `ci/proof.toml` — `ci_actuals` scope + `xtask/src/tasks/ci_actuals.rs` in `proof_control_plane`.

The artifact is purely advisory in this PR. PR 14 layers in budget warnings; PR 15 replaces static `base_lem` with learned p50/p90/p95.

## CI economics

- **Default PR LEM impact:** `+1` on the aggregator (xtask compile + ci-actuals).
- **Workflows touched:** `.github/workflows/ci.yml` (extends ci-required only).
- **Branch protection impact:** none — telemetry runs `continue-on-error: true`.
- **Failure mode caught:** invisible CI cost — without actuals there's no way to know whether estimates are meaningful.
- **Cheaper signal considered:** post-hoc inspection of run logs. Rejected — that's manual and doesn't scale to per-PR judgment.
- **Rollback path:** revert; nothing reads the artifact yet.
- **Commands run:** YAML clean; `cargo clippy -p xtask --all-targets -- -D warnings` clean; `cargo test -p xtask ci_actuals` 1 passed; `cargo xtask proof-policy --check` OK.

## Test plan

- [x] `cargo check -p xtask --locked`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo test -p xtask ci_actuals` — 1 passed.
- [x] `cargo xtask proof-policy --check` OK.
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_