### PR TITLE
ci(budget): warn on elevated LEM and guard hard ceiling

### DIFF
--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -48,7 +48,8 @@ jobs:
             --lanes policy/ci-lane-whitelist.toml \
             --risk-packs policy/ci-risk-packs.toml \
             --json-out target/ci/ci-plan.json \
-            --github-summary "$GITHUB_STEP_SUMMARY"
+            --github-summary "$GITHUB_STEP_SUMMARY" \
+            --enforce
 
       - name: Upload PR plan
         if: always()

--- a/docs/ci/budget-guard.md
+++ b/docs/ci/budget-guard.md
@@ -1,0 +1,37 @@
+# Soft budget guard
+
+PR 14 wires `cargo xtask ci-plan --enforce` into the PR Plan workflow.
+Estimated LEM bands map to advisory severity:
+
+| Estimated LEM | Behavior | Override |
+|---------------|----------|----------|
+| `0–35` (normal) | green | — |
+| `36–75` (elevated) | warning | `ci-budget-ack` suppresses |
+| `76–125` (high-cost) | strong warning | `ci-budget-override` or `full-ci` |
+| `>125` (override-required) | non-zero exit (when `--enforce`) | `ci-budget-override` or `full-ci` |
+
+The PR Plan workflow runs with `--enforce`. Without an override label, a
+plan that estimates over the hard ceiling fails the PR Plan job and
+shows a `::error::` annotation explaining what to do (apply the label,
+or split the PR).
+
+Bands ≤ hard ceiling never fail; they only emit `::warning::`
+annotations and a step-summary banner. This matches the rollout intent:
+
+- Don't fail normal 40 LEM PRs until learned actuals exist (PR 15).
+- Visibly nudge for elevated band so reviewers know the PR is broad.
+- Refuse the worst case (>125) without an explicit override.
+
+## Static estimates today; learned tomorrow
+
+`base_lem` in `policy/ci-lane-whitelist.toml` is the static floor used
+until PR 15 swaps in `p50 × 1.15` learned from `ci-actuals.json`. The
+guard logic is the same in both phases; only the input changes.
+
+## Suppressions
+
+- `ci-budget-ack` — apply when the PR is intentionally elevated and the
+  reviewer has confirmed the spend is worth it.
+- `ci-budget-override` — bypass the hard ceiling for one PR. Use
+  sparingly.
+- `full-ci` — also acts as override; the deep lanes will run anyway.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -259,6 +259,11 @@ pub struct CiPlanArgs {
     /// Optional path to GITHUB_STEP_SUMMARY (the workflow appends to it)
     #[arg(long, value_name = "PATH")]
     pub github_summary: Option<std::path::PathBuf>,
+
+    /// Fail with a non-zero exit when the estimated LEM exceeds the hard
+    /// ceiling and no override label is present
+    #[arg(long)]
+    pub enforce: bool,
 }
 
 impl Default for CiPlanArgs {
@@ -271,6 +276,7 @@ impl Default for CiPlanArgs {
             risk_packs: std::path::PathBuf::from("policy/ci-risk-packs.toml"),
             json_out: None,
             github_summary: None,
+            enforce: false,
         }
     }
 }

--- a/xtask/src/tasks/ci_plan.rs
+++ b/xtask/src/tasks/ci_plan.rs
@@ -253,6 +253,54 @@ pub fn run(args: CiPlanArgs) -> Result<()> {
         plan.band,
     );
 
+    // Soft budget guard. Always reports advisory diagnostics. Only fails
+    // when --enforce is set, and then only on the over-hard-limit case
+    // unless an override label is present.
+    let labels_set: BTreeSet<&str> = plan.labels.iter().map(|s| s.as_str()).collect();
+    let override_present =
+        labels_set.contains("full-ci") || labels_set.contains("ci-budget-override");
+    let ack_present = labels_set.contains("ci-budget-ack");
+
+    match plan.band.as_str() {
+        "elevated" if !ack_present => {
+            println!(
+                "::warning::PR plan estimated {} LEM (elevated band; expected ≤ {}). \
+                Apply `ci-budget-ack` to acknowledge.",
+                plan.estimated_lem, plan.budget.default_limit_lem
+            );
+        }
+        "high-cost" if !override_present => {
+            println!(
+                "::warning::PR plan estimated {} LEM (high-cost band; expected ≤ {}). \
+                Apply `ci-budget-override` or `full-ci` to bypass.",
+                plan.estimated_lem, plan.budget.elevated_limit_lem
+            );
+        }
+        "override-required" => {
+            if override_present {
+                println!(
+                    "::warning::PR plan estimated {} LEM (>{} hard ceiling) — \
+                    proceeding because override label is present.",
+                    plan.estimated_lem, plan.budget.hard_limit_lem
+                );
+            } else {
+                println!(
+                    "::error::PR plan estimated {} LEM (>{} hard ceiling) — \
+                    apply `ci-budget-override` or `full-ci` to bypass, or split the PR.",
+                    plan.estimated_lem, plan.budget.hard_limit_lem
+                );
+                if args.enforce {
+                    bail!(
+                        "ci-plan: estimated {} LEM exceeds hard ceiling {}",
+                        plan.estimated_lem,
+                        plan.budget.hard_limit_lem
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

PR 14 of 16. Layers a soft budget guard on top of PR 08's planner.

| Estimated LEM | Behavior | Override |
|---------------|----------|----------|
| 0–35 (normal) | green | — |
| 36–75 (elevated) | `::warning::` | `ci-budget-ack` |
| 76–125 (high-cost) | strong `::warning::` | `ci-budget-override` / `full-ci` |
| >125 (override-required) | `::error::`, non-zero exit when `--enforce` | `ci-budget-override` / `full-ci` |

The `pr-plan.yml` workflow now invokes `cargo xtask ci-plan --enforce`. Elevated and high-cost bands stay warning-only — the rollout intent is to nudge, not block normal-sized PRs. Only the >125 case fails the job, and only without an override label.

Stacks on PR 08 (#1695).

## CI economics

- **Default PR LEM impact:** none (PR Plan job already runs).
- **Workflows touched:** `.github/workflows/pr-plan.yml`.
- **Branch protection impact:** PR Plan can now fail if the diff produces a >125 LEM plan with no override. Deliberate.
- **Failure mode caught:** runaway PRs that route into Windows + WASM + Nix + mutation + proptest at once without a label or PR split.
- **Cheaper signal considered:** keep all bands warning-only forever. Rejected — the rollout intent is to refuse the worst case while leaving normal-sized broad PRs un-blocked.
- **Rollback path:** revert the `--enforce` flag in `pr-plan.yml`; the planner stays advisory.
- **Commands run:** `cargo clippy -p xtask --all-targets -- -D warnings` clean; `cargo test -p xtask ci_plan` 6 passed; `cargo xtask proof-policy --check` OK.

## Test plan

- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo test -p xtask ci_plan` — 6 passed.
- [x] `cargo xtask proof-policy --check` OK.
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_