### PR TITLE
ci(ripr): require acknowledgement for high-confidence new oracle gaps

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -94,6 +94,47 @@ jobs:
             cat target/ripr/ripr.md >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Evaluate ripr soft-gate
+        if: github.event_name == 'pull_request'
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          set -euo pipefail
+          # The soft-gate is opt-in via [soft_gate].enabled in ripr.toml.
+          # Until that flag is true, this step only logs the planned
+          # decision so reviewers can see what would have been gated.
+          enabled=$(grep -E '^enabled\s*=\s*true' ripr.toml | head -1 || true)
+          if [ -z "$enabled" ]; then
+            echo "::notice::ripr soft-gate is disabled in ripr.toml. Findings remain advisory."
+            exit 0
+          fi
+          # Override label check.
+          for lbl in "ripr-waive" "full-ci" "ci-budget-ack"; do
+            if echo "$LABELS_JSON" | grep -q "\"name\":\"$lbl\""; then
+              echo "::warning::ripr soft-gate satisfied by override label '$lbl'."
+              exit 0
+            fi
+          done
+          # If a real ripr report exists, look for high-confidence
+          # reachable_unrevealed / weakly_exposed entries that are not
+          # suppressed. The placeholder run produces no JSON, so this
+          # remains a no-op until ripr is wired up.
+          if [ ! -s target/ripr/ripr.json ]; then
+            echo "::notice::ripr soft-gate enabled but no JSON report; nothing to gate."
+            exit 0
+          fi
+          high=$(jq '[.findings[]?
+            | select(.kind == "reachable_unrevealed" or .kind == "weakly_exposed")
+            | select(.confidence == "high")
+            | select(.suppressed != true)
+            | select(.test_changed_nearby != true)] | length' \
+            target/ripr/ripr.json)
+          if [ "${high:-0}" -gt 0 ]; then
+            echo "::error::ripr soft-gate: ${high} high-confidence finding(s); apply 'ripr-waive' to acknowledge."
+            exit 1
+          fi
+          echo "ripr soft-gate clean."
+
       - name: Upload ripr report
         if: always()
         uses: actions/upload-artifact@v7

--- a/ripr.toml
+++ b/ripr.toml
@@ -23,3 +23,26 @@ static_unknown = "notice"
 
 [suppressions]
 path = "policy/ripr-suppressions.toml"
+
+# Soft-gate phase (PR 16). Off by default until the calibration window
+# has produced enough advisory data; toggle `enabled = true` to opt in
+# once findings are stable. The narrow rule below soft-gates ONLY:
+#   * new reachable_unrevealed or weakly_exposed findings
+#   * touching production Rust (no tests / fuzz)
+#   * with no test changed nearby
+#   * not suppressed in policy/ripr-suppressions.toml
+#   * marked high-confidence by ripr
+#
+# Override labels: ripr-waive (acknowledge a specific finding),
+# full-ci (deep mutation lane will run anyway), ci-budget-ack (PR is
+# otherwise within scope). Baseline findings and static_unknown are
+# never gated.
+
+[soft_gate]
+enabled = false
+require_high_confidence = true
+require_production_rust = true
+require_no_nearby_test_change = true
+gated_kinds = ["reachable_unrevealed", "weakly_exposed"]
+exempt_kinds = ["static_unknown", "no_static_path"]
+override_labels = ["ripr-waive", "full-ci", "ci-budget-ack"]


### PR DESCRIPTION
## Summary

PR 16 of 16 — the final step of the rollout. Adds the ripr soft-gate phase on top of PR 11's advisory baseline.

`ripr.toml` gains a `[soft_gate]` section:

```toml
[soft_gate]
enabled = false                            # opt-in; flip to true after calibration
require_high_confidence = true
require_production_rust = true
require_no_nearby_test_change = true
gated_kinds = ["reachable_unrevealed", "weakly_exposed"]
exempt_kinds = ["static_unknown", "no_static_path"]
override_labels = ["ripr-waive", "full-ci", "ci-budget-ack"]
```

`.github/workflows/ripr.yml` gains an "Evaluate ripr soft-gate" step that:

- Skips when `soft_gate.enabled` is false (rollout default).
- Acknowledges a PR carrying any override label.
- When a real `ripr.json` exists, blocks on high-confidence `reachable_unrevealed` / `weakly_exposed` findings with no nearby test change that are not suppressed.
- Never gates `static_unknown`, `no_static_path`, or baseline findings.

Stacks on PR 11 (#1705).

## CI economics

- **Default PR LEM impact:** none until `soft_gate.enabled = true`.
- **Workflows touched:** `.github/workflows/ripr.yml` (extends ripr only).
- **Branch protection impact:** ripr can fail once flipped; override labels documented.
- **Failure mode caught:** changes that introduce new oracle gaps slipping through silently.
- **Cheaper signal considered:** keep ripr advisory forever. Rejected — without a soft-gate, real findings get the same severity as `static_unknown` baselines and reviewers tune them out.
- **Rollback path:** set `soft_gate.enabled = false` (default).
- **Commands run:** YAML clean; `cargo xtask proof-policy --check` OK; `cargo xtask affected` zero unknown files.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ripr.yml'))"` clean.
- [x] `cargo xtask proof-policy --check` OK.
- [x] `cargo xtask affected --base origin/main --head HEAD --json` zero unknown files.
- [ ] Reviewers calibrate against real ripr findings before flipping `enabled = true`.

---

This is PR 16 of 16. The full rollout: #1687, #1688, #1690, #1691, #1692, #1693, #1694, #1695, #1696, #1702, #1705, #1706, #1708, #1709, #1710, #1711.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfhWd4fwwsvK84CChQgPVy)_