### PR TITLE
cartographer: sync fun feature flag in architecture docs to match cargo.toml 🗺️

### DIFF
--- a/.jules/runs/cartographer_roadmap_design/decision.md
+++ b/.jules/runs/cartographer_roadmap_design/decision.md
@@ -1,0 +1,28 @@
+# Decision
+
+## What was inspected
+
+I broadly explored the `tooling-governance` shard, specifically looking at `docs/architecture.md`, `ROADMAP.md`, `docs/implementation-plan.md`, `docs/design.md`, `docs/specification.md`, and compared them against `crates/tokmd/Cargo.toml` and other truth sources. The goal was to find factual drift between shipped reality and roadmap/design/requirements docs.
+
+During this investigation, I noticed a discrepancy in `docs/architecture.md` regarding the `fun` feature flag. The documentation listed `fun = ["tokmd-analysis/fun", "tokmd-format/fun"]`, but the actual `crates/tokmd/Cargo.toml` implements `fun = ["tokmd-analysis/fun", "tokmd-core/fun"]`.
+
+I also checked for larger discrepancies like `tokmd serve` vs `tokmd tools`, but the docs correctly labeled `serve` as a Phase 6 future goal, and `tools` as a shipped capability. Overall, the documentation is well-aligned with the v1.10.0 release.
+
+## Options considered
+
+### Option A (recommended)
+- **What it is:** Update `docs/architecture.md` to fix the factual drift in the `fun` feature flag.
+- **Why it fits this repo and this shard:** It resolves a small but real factual drift between the architecture documentation and the shipped workspace features.
+- **Trade-offs:**
+  - *Structure:* Corrects documentation to align with code.
+  - *Velocity:* Quick and low-risk change.
+  - *Governance:* Preserves the accuracy of the architecture doc.
+
+### Option B
+- **What it is:** Do not change the docs and only create a learning PR documenting that the current state of the design/roadmap docs is perfectly aligned with the codebase for the v1.10.0 release.
+- **When to choose it instead:** When absolutely no factual drift can be found, or when fixing the drift would violate the boundaries of the shard or the assignment.
+- **Trade-offs:** Misses the opportunity to fix a small real factual error.
+
+## Decision
+
+**Option A**, because there was a clear, small factual drift regarding the `fun` feature flag in `docs/architecture.md` versus `crates/tokmd/Cargo.toml`. Fixing it directly improves the quality of the architecture documentation.

--- a/.jules/runs/cartographer_roadmap_design/envelope.json
+++ b/.jules/runs/cartographer_roadmap_design/envelope.json
@@ -1,0 +1,32 @@
+{
+  "prompt_id": "cartographer_roadmap_design",
+  "persona": "Cartographer",
+  "style": "Builder",
+  "primary_shard": "tooling-governance",
+  "gate_profile": "governance-release",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/**/Cargo.toml",
+    ".cargo/**"
+  ],
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ],
+  "option_a": "Update `docs/architecture.md` to fix the stale `fun` feature flag mapping.",
+  "option_b": "Create a learning PR documenting that the current state of the design/roadmap docs is perfectly aligned with the codebase for the v1.10.0 release.",
+  "decision": "Option A, because there was a clear, small factual drift regarding the `fun` feature flag in `docs/architecture.md` versus `crates/tokmd/Cargo.toml`.",
+  "artifacts": [
+    ".jules/runs/cartographer_roadmap_design/envelope.json",
+    ".jules/runs/cartographer_roadmap_design/decision.md",
+    ".jules/runs/cartographer_roadmap_design/receipts.jsonl",
+    ".jules/runs/cartographer_roadmap_design/result.json",
+    ".jules/runs/cartographer_roadmap_design/pr_body.md"
+  ]
+}

--- a/.jules/runs/cartographer_roadmap_design/pr_body.md
+++ b/.jules/runs/cartographer_roadmap_design/pr_body.md
@@ -1,0 +1,52 @@
+## 💡 Summary
+Fixed a small factual drift in `docs/architecture.md` where the `fun` feature flag was incorrectly documented as mapping to `tokmd-format/fun`. It has been updated to correctly map to `tokmd-core/fun`, matching the shipped reality in `crates/tokmd/Cargo.toml`.
+
+## 🎯 Why
+The `docs/architecture.md` file serves as a reference for the workspace's feature flags. Stale or incorrect feature flag documentation can mislead contributors trying to understand the dependency boundaries.
+
+## 🔎 Evidence
+- `docs/architecture.md` (prior to fix)
+- `crates/tokmd/Cargo.toml`
+- Checked `crates/tokmd/Cargo.toml` and found: `fun = ["tokmd-analysis/fun", "tokmd-core/fun"]`
+- Checked `docs/architecture.md` and found the stale mapping: `fun = ["tokmd-analysis/fun", "tokmd-format/fun"]`
+
+## 🧭 Options considered
+### Option A (recommended)
+- Update `docs/architecture.md` to match the actual implementation in `crates/tokmd/Cargo.toml`.
+- Fits the `tooling-governance` shard by maintaining workspace documentation alignment.
+- Trade-offs: Structure is improved, Velocity impact is negligible, Governance is maintained.
+
+### Option B
+- Ignore the drift and create a learning PR documenting that the docs are otherwise well-aligned with the v1.10.0 release.
+- Choose this if no actionable drift could be found.
+- Trade-offs: Misses fixing a real, easily fixable factual error.
+
+## ✅ Decision
+Option A, because it directly resolves a small but real factual drift between the architecture documentation and the shipped workspace features.
+
+## 🧱 Changes made (SRP)
+- `docs/architecture.md`: Updated `fun` feature flag mapping from `tokmd-format/fun` to `tokmd-core/fun`.
+
+## 🧪 Verification receipts
+```text
+{"ts_utc": "2026-05-07T11:13:54Z", "phase": "investigation", "cwd": ".", "cmd": "cat crates/tokmd/Cargo.toml | grep -A 10 \"\\[features\\]\"", "status": "success", "summary": "Inspected Cargo.toml features", "artifacts": []}
+{"ts_utc": "2026-05-07T11:13:54Z", "phase": "investigation", "cwd": ".", "cmd": "cat docs/architecture.md | grep -A 10 \"\\[features\\]\"", "status": "success", "summary": "Inspected architecture.md features", "artifacts": []}
+{"ts_utc": "2026-05-07T11:13:54Z", "phase": "execution", "cwd": ".", "cmd": "git diff docs/architecture.md", "status": "success", "summary": "Verified drift fix", "artifacts": ["docs/architecture.md"]}
+```
+
+## 🧭 Telemetry
+- Change shape: Documentation patch
+- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): Docs only. No code or schema impact.
+- Risk class + why: Low. Just a documentation typo fix.
+- Rollback: `git checkout -- docs/architecture.md`
+- Gates run: `cargo xtask docs --check`, `cargo fmt -- --check`, `cargo test -p xtask`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/cartographer_roadmap_design/envelope.json`
+- `.jules/runs/cartographer_roadmap_design/decision.md`
+- `.jules/runs/cartographer_roadmap_design/receipts.jsonl`
+- `.jules/runs/cartographer_roadmap_design/result.json`
+- `.jules/runs/cartographer_roadmap_design/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/cartographer_roadmap_design/receipts.jsonl
+++ b/.jules/runs/cartographer_roadmap_design/receipts.jsonl
@@ -1,0 +1,3 @@
+{"ts_utc": "2026-05-07T11:13:54Z", "phase": "investigation", "cwd": ".", "cmd": "cat crates/tokmd/Cargo.toml | grep -A 10 \"\\[features\\]\"", "status": "success", "summary": "Inspected Cargo.toml features", "artifacts": []}
+{"ts_utc": "2026-05-07T11:13:54Z", "phase": "investigation", "cwd": ".", "cmd": "cat docs/architecture.md | grep -A 10 \"\\[features\\]\"", "status": "success", "summary": "Inspected architecture.md features", "artifacts": []}
+{"ts_utc": "2026-05-07T11:13:54Z", "phase": "execution", "cwd": ".", "cmd": "git diff docs/architecture.md", "status": "success", "summary": "Verified drift fix", "artifacts": ["docs/architecture.md"]}

--- a/.jules/runs/cartographer_roadmap_design/result.json
+++ b/.jules/runs/cartographer_roadmap_design/result.json
@@ -1,0 +1,18 @@
+{
+  "outcome": "patch",
+  "title": "cartographer: sync fun feature flag in architecture docs to match cargo.toml 🗺️",
+  "summary": "Fixed factual drift in `docs/architecture.md` where the `fun` feature flag mapping incorrectly listed `tokmd-format/fun` instead of `tokmd-core/fun`.",
+  "target_paths": [
+    "docs/architecture.md"
+  ],
+  "proof_summary": "Compared `crates/tokmd/Cargo.toml` with `docs/architecture.md` and corrected the mismatch.",
+  "gates_run": [
+    "cargo xtask docs --check",
+    "cargo fmt -- --check",
+    "cargo test -p xtask"
+  ],
+  "friction_items_created": [],
+  "persona_notes_created": [],
+  "rollback": "git checkout -- docs/architecture.md",
+  "follow_ups": []
+}

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -559,6 +559,22 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "project_truth_docs"
+kind = "non_rust"
+paths = [
+  "ROADMAP.md",
+  "docs/architecture.md",
+  "docs/design.md",
+  "docs/implementation-plan.md",
+  "docs/requirements.md",
+  "docs/specification.md",
+]
+proof = ["cargo xtask docs --check"]
+reason = "Top-level architecture, design, roadmap, and requirements docs are project truth surfaces; edits should route to documentation checks instead of appearing as unknown files."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "browser_runner"
 kind = "non_rust"
 paths = ["web/runner/**", "docs/capabilities/wasm.json"]

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -81,6 +81,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - `cargo xtask coverage-receipt` now emits `tokmd.coverage_receipt.v1` for `coverage.json`, `coverage.txt`, and `lcov.info`, and the coverage workflow uploads `target/coverage/coverage-receipt.json` with the coverage artifacts. The receipt records coverage artifact presence and byte counts without making coverage a required gate.
 - Codecov project and patch statuses remain informational during the baseline phase, and coverage receipt generation is owned by `cargo xtask coverage-receipt` rather than a duplicate workflow heredoc.
 - `cargo xtask ci-actuals` now emits `tokmd.ci_actuals.v1` from a GitHub Actions `needs` payload plus optional timing sidecar data. Missing timing is recorded as missing rather than zero so later budget and learned-estimate work can consume the receipt without inventing measurements.
+- Top-level project truth docs (`ROADMAP.md`, architecture, design, implementation plan, requirements, and specification) now have a proof-policy scope that routes changes to `cargo xtask docs --check` instead of leaving architecture-doc-only fixes as unknown files.
 - Next proof-policy operational slice: collect additional coverage-enabled executor observations across more product scopes before considering any required-gate or default Codecov-upload promotion.
 
 ## References

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,7 +185,7 @@ tokmd guarantees byte-stable output for identical inputs:
 git = ["tokmd-analysis/git", "dep:tokmd-git", "dep:tokmd-cockpit", "tokmd-cockpit/git", "tokmd-core/git"]
 walk = ["tokmd-analysis/walk"]
 content = ["tokmd-analysis/content"]
-fun = ["tokmd-analysis/fun", "tokmd-format/fun"]
+fun = ["tokmd-analysis/fun", "tokmd-core/fun"]
 topics = ["tokmd-analysis/topics"]
 archetype = ["tokmd-analysis/archetype"]
 ui = ["dep:dialoguer", "dep:console", "dep:toml", "dep:indicatif"]

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -188,7 +188,7 @@ fn proof_policy_json_reports_current_schema() {
 
     assert_eq!(value["ok"], true);
     assert_eq!(value["schema"], "tokmd.proof_policy.v1");
-    assert_eq!(value["scope_count"], 37);
+    assert_eq!(value["scope_count"], 38);
     assert_eq!(value["allowlist_count"], 1);
     assert_eq!(value["fixture_blob_rule_count"], 1);
     assert_eq!(value["dependency_boundary_count"], 1);


### PR DESCRIPTION
## Summary
- sync `docs/architecture.md` so the `fun` feature flag maps to `tokmd-core/fun`, matching `crates/tokmd/Cargo.toml`
- keep the Jules cartographer provenance for the docs-truth finding
- add a `project_truth_docs` proof-policy scope so architecture/design/roadmap truth-doc edits route to `cargo xtask docs --check` instead of appearing as unknown files

## Verification
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check origin/main...HEAD`