### PR TITLE
proof: observe PR executor on coverage scope

### DIFF
--- a/crates/tokmd-core/tests/ffi_parity_w53.rs
+++ b/crates/tokmd-core/tests/ffi_parity_w53.rs
@@ -2,6 +2,7 @@
 //!
 //! Verifies that every documented mode returns the correct envelope shape,
 //! required fields are present, and error handling is robust.
+//! Proof-executor coverage-scope sentinel: behavior-neutral PR-only change.
 
 use serde_json::Value;
 use std::fs;


### PR DESCRIPTION
Disposable proof-only PR. Do not merge.

Purpose: collect a policy-backed pull_request proof-executor run on one coverage-enabled scope after #1734/#1735.

Expected evidence:
- `affected.json` maps `crates/tokmd-core/tests/ffi_parity_w53.rs` to `tokmd_core_ffi`.
- `proof-policy.json` reports `[executor.pr] default_enabled=true, required=false, max_commands=1, codecov_upload=false`.
- `executor-summary.json` selects and executes one non-required coverage command.
- `coverage/tokmd_core_ffi.lcov` is uploaded in `proof-executor-artifacts`.
- Codecov upload remains skipped on pull_request.

Local validation:
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --executor-mode dry-run --executor-summary target/proof-local/executor-summary.json --executor-manifest target/proof-local/executor-manifest.json`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`