### PR TITLE
proof: observe two-scope PR executor default

### DIFF
--- a/crates/tokmd-core/tests/ffi_parity_w53.rs
+++ b/crates/tokmd-core/tests/ffi_parity_w53.rs
@@ -2,6 +2,7 @@
 //!
 //! Verifies that every documented mode returns the correct envelope shape,
 //! required fields are present, and error handling is robust.
+//! This file is also a useful scoped-coverage probe for FFI contract changes.
 
 use serde_json::Value;
 use std::fs;

--- a/crates/tokmd-format/src/redact/mod.rs
+++ b/crates/tokmd-format/src/redact/mod.rs
@@ -5,6 +5,7 @@
 //! This module provides redaction utilities for `tokmd` receipts.
 //! It's the canonical source for hashing functions used to redact sensitive
 //! information (paths, patterns) in output while preserving useful structure.
+//! This module is a focused scoped-coverage probe for redaction boundaries.
 //!
 //! ## What belongs here
 //! * Path redaction (hash while preserving extension)


### PR DESCRIPTION
## Purpose
Disposable proof-control-plane observation PR. This intentionally touches two coverage-enabled scopes with comment-only edits so the non-required proof executor can prove the `[executor.pr].max_commands = 2` default on a real pull_request run.

## Expected executor evidence
- affected scopes: `format_redaction_scan_args`, `tokmd_core_ffi`
- expected selected coverage commands: 2
- expected Codecov upload: skipped for pull_request

## Local validation
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --executor-mode dry-run --executor-max-commands 2 --executor-summary target\\proof-local\\executor-summary-pr-default.json --executor-manifest target\\proof-local\\executor-manifest-pr-default.json
- cargo fmt-check
- git diff --check
- cargo test -p tokmd-core --test ffi_parity_w53 --verbose
- cargo test -p tokmd-format redact --verbose

This PR should be closed unmerged after the proof-executor artifacts are captured.