### PR TITLE
fix(analysis): avoid TODO tags inside identifiers

### DIFF
--- a/crates/tokmd-analysis/src/content/io.rs
+++ b/crates/tokmd-analysis/src/content/io.rs
@@ -122,6 +122,51 @@ pub fn count_tags(text: &str, tags: &[&str]) -> Vec<(String, usize)> {
         .collect()
 }
 
+pub(crate) fn count_delimited_tags(text: &str, tags: &[&str]) -> Vec<(String, usize)> {
+    let upper = text.to_uppercase();
+    tags.iter()
+        .map(|tag| {
+            let needle = tag.to_uppercase();
+            let count = count_delimited_matches(&upper, &needle);
+            (tag.to_string(), count)
+        })
+        .collect()
+}
+
+fn count_delimited_matches(haystack: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+
+    let mut count = 0;
+    let mut start = 0;
+    while let Some(offset) = haystack[start..].find(needle) {
+        let idx = start + offset;
+        let next = idx + needle.len();
+        if is_delimited_match(haystack, idx, next) {
+            count += 1;
+        }
+        start = next;
+    }
+    count
+}
+
+fn is_delimited_match(text: &str, start: usize, end: usize) -> bool {
+    let prev_delimited = text[..start]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !is_tag_continuation(ch));
+    let next_delimited = text[end..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !is_tag_continuation(ch));
+    prev_delimited && next_delimited
+}
+
+fn is_tag_continuation(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
 pub fn entropy_bits_per_byte(bytes: &[u8]) -> f32 {
     if bytes.is_empty() {
         return 0.0;
@@ -214,6 +259,26 @@ mod tests {
         // max_bytes = 5. half=2. head=2 ("01"), tail=3 ("789").
         let bytes = read_head_tail(&path, 5).unwrap();
         assert_eq!(bytes, b"01789");
+    }
+
+    #[test]
+    fn count_delimited_tags_counts_standalone_tags() {
+        let result = count_delimited_tags(
+            "// TODO: one\n// todo(two)\n// TODO-list\n// FIXME/XXX\n",
+            &["TODO", "FIXME", "XXX"],
+        );
+
+        assert_eq!(result[0], ("TODO".to_string(), 3));
+        assert_eq!(result[1], ("FIXME".to_string(), 1));
+        assert_eq!(result[2], ("XXX".to_string(), 1));
+    }
+
+    #[test]
+    fn count_delimited_tags_ignores_identifier_like_substrings() {
+        let result =
+            count_delimited_tags("todo_app TODO1 methodTODO TODOS // TODO: real", &["TODO"]);
+
+        assert_eq!(result[0], ("TODO".to_string(), 1));
     }
 
     // ========================

--- a/crates/tokmd-analysis/src/content/mod.rs
+++ b/crates/tokmd-analysis/src/content/mod.rs
@@ -52,7 +52,7 @@ pub(crate) fn build_todo_report(
             continue;
         }
         let text = String::from_utf8_lossy(&bytes);
-        for (tag, count) in crate::content::io::count_tags(&text, &tags) {
+        for (tag, count) in crate::content::io::count_delimited_tags(&text, &tags) {
             *counts.entry(tag).or_insert(0) += count;
         }
     }

--- a/crates/tokmd-analysis/src/content/tests/deep_w66.rs
+++ b/crates/tokmd-analysis/src/content/tests/deep_w66.rs
@@ -137,6 +137,29 @@ mod todo_density_w66 {
         let r = build_todo_report(tmp.path(), &[f], &default_limits(), 100).unwrap();
         assert_eq!(r.total, 1);
     }
+
+    #[test]
+    fn todo_report_ignores_identifier_like_tag_substrings() {
+        let tmp = TempDir::new().unwrap();
+        let content = "\
+let todo_app = 1;
+let TODO1 = 2;
+let methodTODO = 3;
+let todos = [];
+// TODO: real work
+// FIXME(real issue)
+";
+        let f = write_file(tmp.path(), "a.rs", content.as_bytes());
+        let r = build_todo_report(tmp.path(), &[f], &default_limits(), 1000).unwrap();
+
+        assert_eq!(r.total, 2);
+        assert!(r.tags.iter().any(|tag| tag.tag == "TODO" && tag.count == 1));
+        assert!(
+            r.tags
+                .iter()
+                .any(|tag| tag.tag == "FIXME" && tag.count == 1)
+        );
+    }
 }
 
 // ── Content limits ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- adds delimited TODO-tag counting for the production TODO report
- keeps generic `count_tags` substring behavior intact for existing content/import heuristics
- adds focused regressions for identifier-like false positives such as `todo_app`, `TODO1`, `methodTODO`, and `todos`

Supersedes draft #1738 with a narrower keeper that avoids changing `count_tags` globally.

## Validation
- `cargo test -p tokmd-analysis --features content --lib count_delimited_tags --verbose`
- `cargo test -p tokmd-analysis --features content --lib todo_report_ignores_identifier_like_tag_substrings --verbose`
- `cargo test -p tokmd-analysis --features content todo --verbose`
- `cargo clippy -p tokmd-analysis --all-features --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd-analysis --all-features content --verbose`
- `cargo test -p tokmd-analysis --all-features assets --verbose`