### PR TITLE
docs(jules): refresh generated run index

### DIFF
--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -13,12 +13,14 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `auditor_bindings_manifests` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `bolt-run-001` | Bolt | Refactorer | core-pipeline | in-progress | 0 | live |
 | `bolt_analysis_stack_builder` | Unknown | Unknown | Unknown | in-progress | 0 | live |
-| `cartographer_roadmap_design` | Unknown | Unknown | Unknown | in-progress | 0 | live |
+| `cartographer_roadmap_design` | Cartographer | Builder | tooling-governance | in-progress | 3 | live |
+| `cartographer_roadmap_design_1` | cartographer | builder | tooling-governance | success | 0 | live |
 | `compat_interfaces_matrix_01` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `d657338a-caa9-4ccf-93a1-4733ada7154c` | Gatekeeper | Unknown | quality | completed | 0 | live |
 | `gatekeeper_contracts` | Gatekeeper | Builder | tooling-governance | in-progress | 6 | live |
 | `librarian_api_doctests` | Librarian | Prover | interfaces | in-progress | 0 | live |
-| `librarian_docs_examples` | Unknown | Unknown | Unknown | in-progress | 0 | live |
+| `librarian_docs_examples` | librarian | Builder | tooling-governance | in-progress | 1 | live |
+| `palette_runtime_dx_interfaces` | Palette 🎨 | Builder | interfaces | in-progress | 0 | live |
 | `run-specsmith-1` | Specsmith | Builder | analysis-stack | in-progress | 3 | live |
 | `run_perf_cockpit_entry` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `run_sentinel_redaction_1` | Sentinel | Stabilizer | core-pipeline | success | 3 | live |


### PR DESCRIPTION
## Summary
- regenerate `.jules/index/generated/RUNS_ROLLUP.md` from current `main`
- preserve existing live run rows that draft #1745 would have dropped from a stale branch
- add the currently discoverable `cartographer_roadmap_design_1` and `palette_runtime_dx_interfaces` generated index rows

## Supersedes
- Supersedes #1745, which was generated from stale `.jules` state and rewrote the `archivist_jules` run packet while omitting live run directories that exist on current `main`.

## Verification
- `python .jules/bin/build_index.py`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff origin/main --check`