### PR TITLE
test(analysis): bound derived ratio properties

### DIFF
--- a/.jules/runs/invariant_model_analysis/decision.md
+++ b/.jules/runs/invariant_model_analysis/decision.md
@@ -1,0 +1,17 @@
+## Target Selection
+Target: `tokmd-analysis` derived property testing.
+Invariant: The `test_density` and `boilerplate` ratio metrics must always be bounded mathematically to the unit range `[0.0, 1.0]`.
+
+### Option A (recommended)
+Add property tests asserting the unit-range boundary invariants of `test_density` and `boilerplate` against the arbitrary `FileRow` generation corpus.
+- Fits this repo and shard as it strictly reinforces model guarantees.
+- Structure: high, guarantees expected output schema constraints.
+- Velocity: medium, low runtime impact, high stability.
+- Governance: matches the 'property' gate expectations for invariant testing.
+
+### Option B
+Manually exhaust all possible `lines`, `code`, `infra` and `test` combinations with targeted edge case unit tests.
+- High manual toil, does not fully lock the invariant against combinations proptest might surface later.
+
+## Decision
+Chosen Option A. Generating arbitrary file rows and evaluating `derive_report` is the highest-signal proof that the derived model does not break fundamental unit range mathematical constraints.

--- a/.jules/runs/invariant_model_analysis/envelope.json
+++ b/.jules/runs/invariant_model_analysis/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "invariant_model_analysis",
+  "persona": "invariant",
+  "style": "prover",
+  "primary_shard": "analysis-stack",
+  "allowed_paths": [
+    "crates/tokmd-analysis*/**",
+    "crates/tokmd-fun/**",
+    "crates/tokmd-gate/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/tests/**",
+    "docs/**"
+  ],
+  "gate_profile": "property",
+  "allowed_outcomes": [
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/invariant_model_analysis/pr_body.md
+++ b/.jules/runs/invariant_model_analysis/pr_body.md
@@ -1,0 +1,52 @@
+## 💡 Summary
+Added two new property-based tests in `tokmd-analysis` to explicitly lock in the unit range invariant `[0.0, 1.0]` for `test_density.ratio` and `boilerplate.ratio`.
+
+## 🎯 Why
+The codebase has `TestDensityReport` and `BoilerplateReport` outputs within the `AnalysisReceipt`. These reports calculate ratios based on code logic and infrastructure lines. By mathematically defining boundaries around these metric values, we strengthen the reliability of our reports across any potential combination of inputs. Missing property tests for these left edge behavior unverified against extreme values surfaced by proptest.
+
+## 🔎 Evidence
+- File path: `crates/tokmd-analysis/src/derived/tests/properties.rs`
+- Finding: `test_density` and `boilerplate` metrics lacked property-based test invariants verifying that the final generated output `.ratio` fields are securely bounded between `0.0` and `1.0`.
+
+## 🧭 Options considered
+### Option A (recommended)
+Add property tests asserting the unit-range boundary invariants of `test_density` and `boilerplate` against the arbitrary `FileRow` generation corpus.
+- Fits this repo and shard as it strictly reinforces model guarantees.
+- Structure: high, guarantees expected output schema constraints.
+- Velocity: medium, low runtime impact, high stability.
+- Governance: matches the 'property' gate expectations for invariant testing.
+
+### Option B
+Manually exhaust all possible `lines`, `code`, `infra` and `test` combinations with targeted edge case unit tests.
+- High manual toil, does not fully lock the invariant against combinations proptest might surface later.
+
+## ✅ Decision
+Chosen Option A. Generating arbitrary file rows and evaluating `derive_report` is the highest-signal proof that the derived model does not break fundamental unit range mathematical constraints.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-analysis/src/derived/tests/properties.rs`
+  - Added `test_density_ratio_in_unit_range`
+  - Added `boilerplate_ratio_in_unit_range`
+
+## 🧪 Verification receipts
+```text
+cargo test -p tokmd-analysis test_density_ratio_in_unit_range
+cargo test -p tokmd-analysis boilerplate_ratio_in_unit_range
+```
+
+## 🧭 Telemetry
+- Change shape: Internal tests only
+- Blast radius: `tokmd-analysis` tests
+- Risk class: Low
+- Rollback: Revert the PR
+- Gates run: `cargo test -p tokmd-analysis`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/invariant_model_analysis/envelope.json`
+- `.jules/runs/invariant_model_analysis/decision.md`
+- `.jules/runs/invariant_model_analysis/receipts.jsonl`
+- `.jules/runs/invariant_model_analysis/result.json`
+- `.jules/runs/invariant_model_analysis/pr_body.md`
+
+## 🔜 Follow-ups
+None

--- a/.jules/runs/invariant_model_analysis/receipts.jsonl
+++ b/.jules/runs/invariant_model_analysis/receipts.jsonl
@@ -1,0 +1,4 @@
+{"timestamp": "2026-05-07T19:25:20Z", "command": "wrote envelope.json"}
+{"timestamp": "2026-05-07T20:24:59Z", "command": "wrote decision.md"}
+{"timestamp": "2026-05-07T20:30:39Z", "command": "cargo test -p tokmd-analysis test_density_ratio_in_unit_range"}
+{"timestamp": "2026-05-07T20:30:39Z", "command": "cargo test -p tokmd-analysis boilerplate_ratio_in_unit_range"}

--- a/.jules/runs/invariant_model_analysis/result.json
+++ b/.jules/runs/invariant_model_analysis/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "patch_type": "proof-improvement",
+  "message": "Added property tests asserting unit-range bounds for test_density and boilerplate metrics."
+}

--- a/crates/tokmd-analysis/src/derived/tests/properties.rs
+++ b/crates/tokmd-analysis/src/derived/tests/properties.rs
@@ -257,4 +257,24 @@ proptest! {
             report.nesting.max, report.nesting.avg
         );
     }
+
+    #[test]
+    fn test_density_ratio_in_unit_range(rows in arb_file_rows()) {
+        let report = derive_report(&export(rows), None);
+        prop_assert!(
+            report.test_density.ratio >= 0.0 && report.test_density.ratio <= 1.0,
+            "test_density ratio must be in [0, 1], got {}",
+            report.test_density.ratio
+        );
+    }
+
+    #[test]
+    fn boilerplate_ratio_in_unit_range(rows in arb_file_rows()) {
+        let report = derive_report(&export(rows), None);
+        prop_assert!(
+            report.boilerplate.ratio >= 0.0 && report.boilerplate.ratio <= 1.0,
+            "boilerplate ratio must be in [0, 1], got {}",
+            report.boilerplate.ratio
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Synthesized keeper for #1757 on current main.
- Adds property tests that bound `test_density.ratio` and `boilerplate.ratio` to `[0.0, 1.0]` across arbitrary derived export rows.
- Keeps the scoped `.jules` invariant-analysis provenance while dropping stale duplicate branch churn from the generated draft.

Supersedes #1757 after this lands.

## Validation
- `cargo test -p tokmd-analysis ratio_in_unit_range --verbose`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd-analysis --all-features derived --verbose`
- `cargo test -p tokmd-analysis --all-features mutant --verbose`