### PR TITLE
feat(web): read wasm capability payload in runner

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -69,6 +69,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The browser runner UI now displays worker-run progress in a dedicated run-progress panel, while preserving the latest successful result during later repo-load or worker-run progress updates.
 - Browser runner GitHub token UX now uses session-only storage, shows anonymous/authenticated state without exposing the raw token, and provides an explicit clear-token action.
 - Browser GitHub ingest now surfaces numeric or HTTP-date `Retry-After` guidance in the UI and enables a manual retry action only for retryable GitHub rate-limit failures.
+- Browser worker mode and preset reporting now reads the `tokmd-wasm` capability payload when present and intersects it with actual exported entrypoints, so the UI and runtime validation do not promise modes the loaded bundle cannot execute.
 - `cargo xtask proof-execution-artifacts-check` now verifies that executed entries with declared artifact paths point at existing, non-empty files, so a passing executor command cannot claim missing LCOV evidence.
 - Executed coverage artifacts now must be LCOV-shaped text with `SF:` and `end_of_record` records before `proof-execution-artifacts-check` accepts them.
 - `cargo xtask proof-execution-observation` now turns verified executed summary/manifest pairs into `proof-executor-observation.json`, a compact cross-PR observation artifact for collecting non-required executor runs without promoting them to required gates or default Codecov uploads.

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -15,6 +15,8 @@ Use this project when you want `tokmd` inside a browser worker, backed by
 - runtime validation and protocol handling in `runtime.js`
 - public GitHub repo ingestion through browser-safe tree + contents APIs
 - `lang`, `module`, `export`, and `analyze` with `receipt` or `estimate`
+- worker mode/preset reporting from the `tokmd-wasm` capability payload, guarded
+  by actual exported entrypoints
 - worker run progress events for `start`, `scan` or `analyze`, `done`, and `error`
 - visible run-progress and repo-load-progress panels in the browser shell
 - session-only GitHub token UX with explicit clear behavior

--- a/web/runner/index.html
+++ b/web/runner/index.html
@@ -9,14 +9,15 @@
   <body>
     <main>
       <section class="hero">
-        <p class="eyebrow">tokmd 1.9.0 browser runner</p>
+        <p class="eyebrow">tokmd browser runner</p>
         <h1>Worker-first browser runner</h1>
         <p>
           This page boots <code>tokmd-wasm</code> inside a dedicated Worker and
           exercises the current browser-safe in-memory modes. Public GitHub repo
-          fetch now uses browser-safe tree and contents APIs. Repo-load progress
-          and cancel are wired in the main thread, worker runs emit progress,
-          and worker run-cancel stays explicitly unavailable.
+          fetch now uses browser-safe tree and contents APIs. The worker reports
+          the loaded wasm bundle's capability surface, repo-load progress and
+          cancel are wired in the main thread, worker runs emit progress, and
+          worker run-cancel stays explicitly unavailable.
         </p>
       </section>
 

--- a/web/runner/worker.js
+++ b/web/runner/worker.js
@@ -13,6 +13,12 @@ let nodeWorkerData = null;
 let isNodeWorker = false;
 const DEFAULT_WASM_MODULE_URL = new URL("./vendor/tokmd-wasm/tokmd_wasm.js", import.meta.url);
 const DEFAULT_WASM_BINARY_URL = new URL("./vendor/tokmd-wasm/tokmd_wasm_bg.wasm", import.meta.url);
+const MODE_EXPORTS = Object.freeze({
+    lang: "runLang",
+    module: "runModule",
+    export: "runExport",
+    analyze: "runAnalyze",
+});
 
 if (
     typeof globalThis.postMessage === "function" &&
@@ -110,27 +116,77 @@ function describeMissingExports(wasmModule) {
     return missing;
 }
 
-function buildModeCapabilities(wasmModule) {
-    const modes = [];
-    if (typeof wasmModule.runLang === "function") {
-        modes.push("lang");
+function uniqueSupportedStrings(values, allowedValues) {
+    const allowed = new Set(allowedValues);
+    const seen = new Set();
+    const result = [];
+
+    for (const value of Array.isArray(values) ? values : []) {
+        if (typeof value !== "string" || !allowed.has(value) || seen.has(value)) {
+            continue;
+        }
+
+        seen.add(value);
+        result.push(value);
     }
 
-    if (typeof wasmModule.runModule === "function") {
-        modes.push("module");
-    }
+    return result;
+}
 
-    if (typeof wasmModule.runExport === "function") {
-        modes.push("export");
-    }
-
-    if (typeof wasmModule.runAnalyze === "function") {
-        modes.push("analyze");
-    }
+function buildExportCapabilities(wasmModule) {
+    const modes = Object.entries(MODE_EXPORTS)
+        .filter(([, exportName]) => typeof wasmModule[exportName] === "function")
+        .map(([mode]) => mode);
 
     return {
         modes,
         analyzePresets: typeof wasmModule.runAnalyze === "function" ? [...SUPPORTED_ANALYZE_PRESETS] : [],
+    };
+}
+
+function readWasmCapabilityPayload(wasmModule) {
+    if (typeof wasmModule.capabilities !== "function") {
+        return null;
+    }
+
+    let capabilities;
+    try {
+        capabilities = wasmModule.capabilities();
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`tokmd-wasm capabilities export failed: ${message}`);
+    }
+
+    if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) {
+        throw new Error("tokmd-wasm capabilities export returned an invalid payload");
+    }
+
+    return capabilities;
+}
+
+function buildModeCapabilities(wasmModule) {
+    const exportCapabilities = buildExportCapabilities(wasmModule);
+    const wasmCapabilities = readWasmCapabilityPayload(wasmModule);
+
+    if (!wasmCapabilities) {
+        return exportCapabilities;
+    }
+
+    const exportedModes = new Set(exportCapabilities.modes);
+    const modes = uniqueSupportedStrings(
+        wasmCapabilities.modes,
+        Object.keys(MODE_EXPORTS)
+    ).filter((mode) => exportedModes.has(mode));
+    const analyzePresets = modes.includes("analyze")
+        ? uniqueSupportedStrings(
+              wasmCapabilities.analyze?.rootlessPresets,
+              SUPPORTED_ANALYZE_PRESETS
+          )
+        : [];
+
+    return {
+        modes,
+        analyzePresets,
     };
 }
 
@@ -206,7 +262,7 @@ async function loadTokmdRunner() {
         throw createMissingExportsError(missingExports);
     }
 
-    const modeCapabilities = buildModeCapabilities(wasmModule);
+    const modeCapabilities = buildExportCapabilities(wasmModule);
     const hasAnyModes = modeCapabilities.modes.length > 0;
 
     if (!hasAnyModes) {

--- a/web/runner/worker.test.mjs
+++ b/web/runner/worker.test.mjs
@@ -58,14 +58,24 @@ function createMockWasmBundle(options = {}) {
         includeRunModule = false,
         includeRunExport = false,
         includeRunAnalyze = false,
+        capabilities = null,
+        capabilitiesRequiresInit = false,
         version = "1.9.0",
         schemaVersion = 2,
         analysisSchemaVersion = 9,
     } = options;
 
     const moduleSourceLines = [];
+    if (capabilitiesRequiresInit) {
+        moduleSourceLines.push("let initialized = false;");
+    }
+
     if (includeDefault) {
-        moduleSourceLines.push("export default async function init() {}");
+        moduleSourceLines.push(
+            capabilitiesRequiresInit
+                ? "export default async function init() { initialized = true; }"
+                : "export default async function init() {}"
+        );
     }
 
     if (includeVersion) {
@@ -98,6 +108,14 @@ function createMockWasmBundle(options = {}) {
         moduleSourceLines.push(
             `export function analysisSchemaVersion() { return ${analysisSchemaVersion}; }`,
             "export function runAnalyze(args) { return { mode: 'analysis', preset: args.preset ?? 'receipt', source: { inputs: args.inputs.map((input) => input.path) } }; }"
+        );
+    }
+
+    if (capabilities !== null) {
+        moduleSourceLines.push(
+            capabilitiesRequiresInit
+                ? `export function capabilities() { if (!initialized) { throw new Error("capabilities before init"); } return ${JSON.stringify(capabilities)}; }`
+                : `export function capabilities() { return ${JSON.stringify(capabilities)}; }`
         );
     }
 
@@ -306,6 +324,122 @@ test("worker advertises analyze support when runAnalyze exists", async () => {
         assert.equal(message.type, MESSAGE_TYPES.READY);
         assert.deepEqual(message.capabilities.modes, ["lang", "analyze"]);
         assert.deepEqual(message.capabilities.analyzePresets, ["receipt", "estimate"]);
+    } finally {
+        await worker.terminate();
+        cleanup();
+    }
+});
+
+test("worker uses wasm capabilities payload for advertised modes and presets", async () => {
+    const { worker, cleanup } = createWorkerForMockWasm({
+        includeRunLang: true,
+        includeRunModule: true,
+        includeRunAnalyze: true,
+        capabilities: {
+            modes: ["lang", "analyze"],
+            analyze: {
+                rootlessPresets: ["estimate"],
+            },
+        },
+    });
+
+    try {
+        const message = await onceMessage(worker);
+
+        assert.equal(message.type, MESSAGE_TYPES.READY);
+        assert.deepEqual(message.capabilities.modes, ["lang", "analyze"]);
+        assert.deepEqual(message.capabilities.analyzePresets, ["estimate"]);
+
+        worker.postMessage({
+            type: "run",
+            requestId: "mock-hidden-module",
+            mode: "module",
+            args: {
+                inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}" }],
+            },
+        });
+
+        const hiddenMode = await onceMessage(worker);
+        assert.equal(hiddenMode.type, MESSAGE_TYPES.ERROR);
+        assert.equal(hiddenMode.error.code, "unsupported_mode");
+
+        worker.postMessage({
+            type: "run",
+            requestId: "mock-hidden-preset",
+            mode: "analyze",
+            args: {
+                inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}" }],
+                preset: "receipt",
+            },
+        });
+
+        const hiddenPreset = await onceMessage(worker);
+        assert.equal(hiddenPreset.type, MESSAGE_TYPES.ERROR);
+        assert.equal(hiddenPreset.error.code, "unsupported_preset");
+
+        worker.postMessage({
+            type: "run",
+            requestId: "mock-cap-estimate",
+            mode: "analyze",
+            args: {
+                inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}" }],
+                preset: "estimate",
+            },
+        });
+
+        const { message: result } = await nextMessageOfType(worker, MESSAGE_TYPES.RESULT);
+        assert.equal(result.type, MESSAGE_TYPES.RESULT);
+        assert.equal(result.requestId, "mock-cap-estimate");
+        assert.equal(result.data.mode, "analysis");
+        assert.equal(result.data.preset, "estimate");
+    } finally {
+        await worker.terminate();
+        cleanup();
+    }
+});
+
+test("worker reads wasm capabilities payload only after initialization", async () => {
+    const { worker, cleanup } = createWorkerForMockWasm({
+        includeRunLang: true,
+        capabilitiesRequiresInit: true,
+        capabilities: {
+            modes: ["lang"],
+            analyze: {
+                rootlessPresets: [],
+            },
+        },
+    });
+
+    try {
+        const message = await onceMessage(worker);
+
+        assert.equal(message.type, MESSAGE_TYPES.READY);
+        assert.deepEqual(message.capabilities.modes, ["lang"]);
+        assert.deepEqual(message.capabilities.analyzePresets, []);
+    } finally {
+        await worker.terminate();
+        cleanup();
+    }
+});
+
+test("worker does not advertise wasm-declared modes without matching exports", async () => {
+    const { worker, cleanup } = createWorkerForMockWasm({
+        includeRunLang: true,
+        includeRunAnalyze: false,
+        capabilities: {
+            modes: ["lang", "analyze"],
+            analyze: {
+                rootlessPresets: ["receipt", "estimate"],
+            },
+        },
+    });
+
+    try {
+        const message = await onceMessage(worker);
+
+        assert.equal(message.type, MESSAGE_TYPES.READY);
+        assert.deepEqual(message.capabilities.modes, ["lang"]);
+        assert.deepEqual(message.capabilities.analyzePresets, []);
     } finally {
         await worker.terminate();
         cleanup();


### PR DESCRIPTION
## Summary
- Have the browser worker read the loaded `tokmd-wasm` `capabilities()` payload when present.
- Intersect advertised modes/presets with actual exported entrypoints so the UI/runtime never promises a mode the loaded bundle cannot execute.
- Add worker tests for capability-declared hidden modes, narrowed analyze presets, and export/capability mismatches; remove the stale hard-coded `1.9.0` browser-runner label.

## Validation
- `npm --prefix web/runner test`
- `npm --prefix web/runner run check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `git diff --check origin/main...HEAD`