### PR TITLE
fix(browser): ignore stale worker terminal messages

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -67,6 +67,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The composite GitHub Action now exposes an opt-in cockpit `review-packet` input. In `mode: cockpit`, `review-packet: true` writes `.tokmd/review`, exposes it as the `review-packet` output, and uses `.tokmd/review/comment.md` as the optional pull request comment body.
 - Browser worker protocol v2 now emits run progress messages for in-memory worker execution. Worker runs produce `start`, `scan` or `analyze`, `done`, and `error` progress phases while keeping cancellation explicitly unavailable.
 - The browser runner UI now displays worker-run progress in a dedicated run-progress panel, while preserving the latest successful result during later repo-load or worker-run progress updates.
+- Browser runner terminal worker messages now follow the same active-request guard as progress messages, so stale `result` or `error` events from an older run cannot overwrite a newer run's UI state.
 - Browser runner GitHub token UX now uses session-only storage, shows anonymous/authenticated state without exposing the raw token, and provides an explicit clear-token action.
 - Browser GitHub ingest now surfaces numeric or HTTP-date `Retry-After` guidance in the UI and enables a manual retry action only for retryable GitHub rate-limit failures.
 - Browser worker mode and preset reporting now reads the `tokmd-wasm` capability payload when present and intersects it with actual exported entrypoints, so the UI and runtime validation do not promise modes the loaded bundle cannot execute.

--- a/web/runner/main.js
+++ b/web/runner/main.js
@@ -413,6 +413,13 @@ function workerProgressTone(phase) {
     return "working";
 }
 
+function isStaleRunScopedWorkerMessage(message) {
+    return (
+        typeof message.requestId === "string" &&
+        state.activeRequestId !== message.requestId
+    );
+}
+
 function renderProgress(target, update = null) {
     const { panel, element, text } = target;
 
@@ -583,6 +590,9 @@ worker.addEventListener("message", (event) => {
             }
             break;
         case MESSAGE_TYPES.RESULT:
+            if (isStaleRunScopedWorkerMessage(message)) {
+                break;
+            }
             if (state.activeRequestId === message.requestId) {
                 state.activeRequestId = null;
             }
@@ -597,6 +607,9 @@ worker.addEventListener("message", (event) => {
             setStatus(runStatusOutput, `completed ${message.requestId}`, "success");
             break;
         case MESSAGE_TYPES.ERROR:
+            if (isStaleRunScopedWorkerMessage(message)) {
+                break;
+            }
             if (state.activeRequestId === message.requestId) {
                 state.activeRequestId = null;
             }

--- a/web/runner/main.test.mjs
+++ b/web/runner/main.test.mjs
@@ -301,6 +301,7 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     const resultOutput = harness.element("[data-result]");
     const repoCapabilitiesOutput = harness.element("[data-repo-capabilities]");
     const loadStatusOutput = harness.element("[data-load-status]");
+    const runStatusOutput = harness.element("[data-run-status]");
     const loadProgressPanel = harness.element("[data-load-progress-panel]");
     const loadProgressText = harness.element("[data-load-progress-text]");
     const runProgressPanel = harness.element("[data-run-progress-panel]");
@@ -344,6 +345,48 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     assert.match(resultBeforeRepoError, /"mode": "lang"/);
     assert.match(runProgressText.textContent, /completed run-1/);
 
+    await runButton.click();
+    const secondRunMessage = worker.messages.at(-1);
+    assert.equal(secondRunMessage.type, "run");
+    assert.equal(secondRunMessage.requestId, "run-2");
+    assert.match(runProgressText.textContent, /sent run-2/);
+
+    worker.emit({
+        type: "result",
+        requestId: runMessage.requestId,
+        data: {
+            mode: "export",
+            stale: true,
+        },
+    });
+    assert.equal(resultOutput.textContent, resultBeforeRepoError);
+    assert.match(runProgressText.textContent, /sent run-2/);
+    assert.match(runStatusOutput.textContent, /sent run-2/);
+
+    worker.emit({
+        type: "error",
+        requestId: runMessage.requestId,
+        error: {
+            code: "stale_worker_error",
+            message: "stale worker terminal error",
+        },
+    });
+    assert.equal(resultOutput.textContent, resultBeforeRepoError);
+    assert.match(runProgressText.textContent, /sent run-2/);
+    assert.doesNotMatch(runStatusOutput.textContent, /stale worker terminal error/);
+
+    worker.emit({
+        type: "result",
+        requestId: secondRunMessage.requestId,
+        data: {
+            mode: "lang",
+            total: { files: 2 },
+        },
+    });
+    const secondResultBeforeRepoError = resultOutput.textContent;
+    assert.match(secondResultBeforeRepoError, /"files": 2/);
+    assert.match(runProgressText.textContent, /completed run-2/);
+
     await loadRepoButton.click();
 
     assert.equal(fetchCalls.length, 1);
@@ -352,7 +395,7 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     assert.equal(loadProgressPanel.hidden, false);
     assert.match(loadProgressText.textContent, /Retry after 12s/);
     assert.match(loadStatusOutput.textContent, /repo load failed:/);
-    assert.equal(resultOutput.textContent, resultBeforeRepoError);
+    assert.equal(resultOutput.textContent, secondResultBeforeRepoError);
     assert.doesNotMatch(collectText(logOutput), /ghp_saved/);
 
     await retryLoadButton.click();
@@ -364,13 +407,13 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     assert.match(repoCapabilitiesOutput.textContent, /lastAuthMode: token/);
     assert.match(repoCapabilitiesOutput.textContent, /lastCache: memory miss/);
     assert.match(harness.element("[data-args]").value, /README\.md/);
-    assert.equal(resultOutput.textContent, resultBeforeRepoError);
+    assert.equal(resultOutput.textContent, secondResultBeforeRepoError);
 
     await loadRepoButton.click();
 
     assert.equal(fetchCalls.length, 3);
     assert.match(repoCapabilitiesOutput.textContent, /lastCache: memory hit/);
-    assert.equal(resultOutput.textContent, resultBeforeRepoError);
+    assert.equal(resultOutput.textContent, secondResultBeforeRepoError);
 
     await clearTokenButton.click();
 


### PR DESCRIPTION
## Summary
- Ignore stale run-scoped worker `result` and `error` messages when they do not match the active browser-runner request.
- Extend the main-page browser-runner test to prove stale terminal messages cannot overwrite a newer run's UI state or preserved result.
- Record the v1.11 browser runtime checkpoint in `docs/NEXT.md`.

## Validation
- `node --test web/runner/main.test.mjs`
- `npm --prefix web/runner test`
- `npm --prefix web/runner run check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask --verbose`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`