### PR TITLE
fix(browser): surface rejected token state

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -70,6 +70,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The browser runner UI now displays worker-run progress in a dedicated run-progress panel, while preserving the latest successful result during later repo-load or worker-run progress updates.
 - Browser runner terminal worker messages now follow the same active-request guard as progress messages, so stale `result` or `error` events from an older run cannot overwrite a newer run's UI state.
 - Browser runner GitHub token UX now uses session-only storage, shows anonymous/authenticated state without exposing the raw token, and provides an explicit clear-token action.
+- Browser runner GitHub token UX now marks rejected tokens after GitHub auth/access failures, surfaces update-or-clear guidance, and keeps raw token text out of logs and status output.
 - Browser GitHub ingest now surfaces numeric or HTTP-date `Retry-After` guidance in the UI and enables a manual retry action only for retryable GitHub rate-limit failures.
 - Browser worker mode and preset reporting now reads the `tokmd-wasm` capability payload when present and intersects it with actual exported entrypoints, so the UI and runtime validation do not promise modes the loaded bundle cannot execute.
 - Browser runner mode controls now consume that loaded worker capability surface: unavailable modes are disabled, unsupported current selections are switched to the first supported mode, and analyze sample args choose a preset advertised by the loaded bundle.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -374,11 +374,11 @@ authenticated fetch.
 
 ### Work Items
 
-- [ ] Define cache key and invalidation semantics
-- [ ] Emit explicit progress events (CLI grammar documented in
-      `docs/progress-events.md`; browser worker progress remains in scope)
-- [ ] Improve retry and rate-limit UX
-- [ ] Partition authenticated fetch/cache behavior safely
+- [x] Define cache key and invalidation semantics
+- [x] Emit explicit progress events (CLI grammar documented in
+      `docs/progress-events.md`; browser worker progress is shipped)
+- [x] Improve retry and rate-limit UX
+- [x] Partition authenticated fetch/cache behavior safely
 
 ### Tests
 

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -23,7 +23,8 @@ Use this project when you want `tokmd` inside a browser worker, backed by
   `inputs` payload without requiring GitHub or network access
 - worker run progress events for `start`, `scan` or `analyze`, `done`, and `error`
 - visible run-progress and repo-load-progress panels in the browser shell
-- session-only GitHub token UX with explicit clear behavior
+- session-only GitHub token UX with explicit clear behavior and rejected-token
+  state
 - explicit GitHub rate-limit retry guidance and a manual repo-load retry action
 - `cancel` reserved in the protocol but not wired yet
 - live result panes with downloadable JSON artifacts

--- a/web/runner/main.js
+++ b/web/runner/main.js
@@ -55,6 +55,7 @@ const state = {
     latestSource: null,
     latestIngest: null,
     latestLoadError: null,
+    latestAuthIssue: null,
     capabilities: {
         cancel: false,
         downloads: false,
@@ -319,6 +320,34 @@ function updateRepoLoadControls() {
     clearTokenButton.disabled = loading || authModeForToken(tokenInput.value) === "anonymous";
 }
 
+function isAuthRepairLoadError(error) {
+    return (
+        error instanceof Error &&
+        (error.code === "github_auth_required" || error.code === "github_repo_unavailable")
+    );
+}
+
+function renderAuthState() {
+    const authMode = authModeForToken(tokenInput.value);
+    if (authMode === "anonymous") {
+        authStateOutput.textContent = "anonymous";
+        authStateOutput.dataset.tone = "neutral";
+        return;
+    }
+
+    if (state.latestAuthIssue) {
+        authStateOutput.textContent =
+            state.latestAuthIssue.code === "github_repo_unavailable"
+                ? "check token/repo"
+                : "token rejected";
+        authStateOutput.dataset.tone = "error";
+        return;
+    }
+
+    authStateOutput.textContent = "authenticated";
+    authStateOutput.dataset.tone = "success";
+}
+
 function syncTokenState({ persist = true } = {}) {
     const storage = resolveSessionStorage();
     const token = persist
@@ -329,7 +358,7 @@ function syncTokenState({ persist = true } = {}) {
         tokenInput.value = token;
     }
 
-    authStateOutput.textContent = authModeForToken(token);
+    renderAuthState();
     updateRepoLoadControls();
 }
 
@@ -495,6 +524,9 @@ function loadErrorNoticeLines(error) {
     const lines = [describeLoadError(error)];
     if (isRetryableLoadError(error)) {
         lines.push(describeRetryWindow(error));
+    }
+    if (isAuthRepairLoadError(error)) {
+        lines.push("Update or clear the GitHub token, then verify the repository and ref.");
     }
 
     return lines;
@@ -750,7 +782,9 @@ loadRepoButton.addEventListener("click", async () => {
 
     state.repoLoadAbortController = controller;
     state.latestLoadError = null;
+    state.latestAuthIssue = null;
     updateRepoLoadControls();
+    renderAuthState();
     renderLoadProgress({
         phase: "start",
         current: 0,
@@ -779,7 +813,9 @@ loadRepoButton.addEventListener("click", async () => {
         state.latestSource = result.source;
         state.latestIngest = result.ingest;
         state.latestLoadError = null;
+        state.latestAuthIssue = null;
         renderRepoCapabilities();
+        renderAuthState();
         renderIngestSummary();
         argsInput.value = JSON.stringify(nextArgs, null, 2);
         appendLog("github -> main", {
@@ -805,7 +841,15 @@ loadRepoButton.addEventListener("click", async () => {
             state.latestIngest = repoError.ingest;
         }
         state.latestLoadError = repoError;
+        state.latestAuthIssue =
+            authModeForToken(tokenInput.value) === "authenticated" &&
+            isAuthRepairLoadError(repoError)
+                ? {
+                      code: repoError.code,
+                  }
+                : null;
         renderRepoCapabilities();
+        renderAuthState();
         renderIngestSummary();
         appendLog("github error -> main", sanitizeErrorForLog(repoError));
         renderLoadProgress({
@@ -937,11 +981,13 @@ retryLoadButton.addEventListener("click", () => {
 });
 
 tokenInput.addEventListener("input", () => {
+    state.latestAuthIssue = null;
     syncTokenState();
 });
 
 clearTokenButton.addEventListener("click", () => {
     tokenInput.value = "";
+    state.latestAuthIssue = null;
     clearSessionToken(resolveSessionStorage());
     syncTokenState({ persist: false });
     setStatus(loadStatusOutput, "GitHub token cleared", "neutral");

--- a/web/runner/main.test.mjs
+++ b/web/runner/main.test.mjs
@@ -427,6 +427,80 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     assert.equal(clearTokenButton.disabled, true);
 });
 
+test("main page marks rejected GitHub tokens without exposing token text", async (t) => {
+    const fetchCalls = [];
+    let responseStatus = 401;
+    let responseMessage = "Bad credentials";
+    const storage = createMemoryStorage({
+        "tokmd.githubToken": "  ghp_rejected  ",
+    });
+    const harness = installBrowserHarness(t, {
+        storage,
+        fetchImpl: async (url, options = {}) => {
+            fetchCalls.push({
+                url,
+                authorization: options.headers?.Authorization ?? null,
+            });
+
+            if (url.includes("/git/trees/")) {
+                return jsonResponse(
+                    { message: responseMessage },
+                    {
+                        status: responseStatus,
+                    }
+                );
+            }
+
+            throw new Error(`unexpected fetch url: ${url}`);
+        },
+    });
+
+    await import(`./main.js?authRejected=${Date.now()}`);
+
+    const tokenInput = harness.element("[data-token]");
+    const authState = harness.element("[data-auth-state]");
+    const clearTokenButton = harness.element("[data-clear-token]");
+    const loadRepoButton = harness.element("[data-load-repo]");
+    const retryLoadButton = harness.element("[data-retry-load]");
+    const loadStatusOutput = harness.element("[data-load-status]");
+    const ingestSummaryOutput = harness.element("[data-ingest-summary]");
+    const logOutput = harness.element("[data-log]");
+
+    assert.equal(tokenInput.value, "ghp_rejected");
+    assert.equal(authState.textContent, "authenticated");
+    assert.equal(authState.dataset.tone, "success");
+
+    await loadRepoButton.click();
+
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(fetchCalls[0].authorization, "token ghp_rejected");
+    assert.equal(authState.textContent, "token rejected");
+    assert.equal(authState.dataset.tone, "error");
+    assert.equal(clearTokenButton.disabled, false);
+    assert.equal(retryLoadButton.disabled, true);
+    assert.match(loadStatusOutput.textContent, /GitHub rejected the supplied token/);
+    assert.match(collectText(ingestSummaryOutput), /Update or clear the GitHub token/);
+    assert.doesNotMatch(collectText(logOutput), /ghp_rejected/);
+
+    responseStatus = 404;
+    responseMessage = "Not Found";
+    await loadRepoButton.click();
+
+    assert.equal(fetchCalls.length, 2);
+    assert.equal(fetchCalls[1].authorization, "token ghp_rejected");
+    assert.equal(authState.textContent, "check token/repo");
+    assert.equal(authState.dataset.tone, "error");
+    assert.match(loadStatusOutput.textContent, /not found for the supplied token/);
+    assert.doesNotMatch(collectText(logOutput), /ghp_rejected/);
+
+    await clearTokenButton.click();
+
+    assert.equal(tokenInput.value, "");
+    assert.equal(storage.getItem("tokmd.githubToken"), null);
+    assert.equal(authState.textContent, "anonymous");
+    assert.equal(authState.dataset.tone, "neutral");
+});
+
 test("main page loads local files into worker args without GitHub fetch", async (t) => {
     const harness = installBrowserHarness(t, {
         storage: createMemoryStorage(),

--- a/web/runner/styles.css
+++ b/web/runner/styles.css
@@ -142,6 +142,10 @@ h1 {
     letter-spacing: 0;
 }
 
+.auth-state[data-tone="error"] {
+    color: var(--accent);
+}
+
 select,
 input,
 textarea,


### PR DESCRIPTION
## Summary
- show a rejected-token state after GitHub auth/access failures in the browser runner
- add update-or-clear guidance for auth repair while keeping token text out of logs/status output
- update browser runtime docs and mark the shipped v1.11 browser polish items in the implementation plan

## Validation
- `npm --prefix web/runner test`
- `npm --prefix web/runner run check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `git diff --check origin/main..HEAD`

Security surface: GitHub token UI state only. The negative test covers 401 and token-scoped 404 responses and asserts the raw token is not rendered into the browser log.