### PR TITLE
feat(browser): stabilize worker progress phases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ This document outlines the evolution of `tokmd` and the path forward.
 | **v1.9.0** | ✅ Complete | Browser/WASM productization: parity-covered wasm entrypoints, browser runner MVP, and public repo ingestion via tree+contents |
 | **v1.10.0-rc.1** | ✅ Complete | Release-candidate proof for CI control plane, bounded trust hardening, WASM truth, and proof stability. |
 | **v1.10.0** | ✅ Complete | Stable CI control plane, trust hardening, WASM truth, Action release, and proof stability. |
-| **v1.11.0** | 🔭 Planned | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
+| **v1.11.0** | ✅ Complete | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
 | **v3.0.0** | 🔭 Long-term | Tree-sitter AST integration (requires significant R&D).      |
 | **v4.0.0** | 🔭 Long-term | Adze AST integration.      |
@@ -551,12 +551,12 @@ UX work is explicitly **incremental and non-breaking**:
 
 **Goal:** Deliver the browser runtime polish deferred from the v1.10 release fence: explicit cache semantics, visible progress, resilient fetch UX, and safe authenticated-fetch boundaries.
 
-### What is planned for v1.11.0
+### What shipped for v1.11.0
 
-- Browser cache key/invalidation semantics.
-- Browser progress events.
-- Retry and rate-limit UX.
-- Auth-safe fetch/cache boundaries.
+- [x] Browser cache key/invalidation semantics.
+- [x] Browser worker and repo-load progress visibility.
+- [x] Retry and rate-limit UX with retry-after guidance.
+- [x] Auth-safe fetch/cache boundaries with session-only token state.
 
 ## Future Horizons
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -608,9 +608,11 @@ name = "project_truth_docs"
 kind = "non_rust"
 paths = [
   "ROADMAP.md",
+  "docs/NOW.md",
   "docs/architecture.md",
   "docs/design.md",
   "docs/implementation-plan.md",
+  "docs/progress-events.md",
   "docs/requirements.md",
   "docs/specification.md",
 ]

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -68,7 +68,7 @@ Goal: move proof orchestration out of ad hoc GitHub YAML and into checked Rust-o
 - The composite Action self-test now exercises `mode: cockpit`, `review-packet: true`, `artifact: true`, and `comment: false` together, proving packet artifact upload stays independent from pull request commenting.
 - `tokmd_core::cockpit_workflow` now has a feature-gated contract test against a real temporary git repo, and the cockpit proof scope routes that facade test through the affected proof plan.
 - Cockpit `comment.md` now includes compact evidence availability counts so missing, degraded, stale, skipped, or unavailable evidence is visible in the PR-comment-ready artifact, not only in packet JSON.
-- Browser worker protocol v2 now emits run progress messages for in-memory worker execution. Worker runs produce `start`, `scan` or `analyze`, `done`, and `error` progress phases while keeping cancellation explicitly unavailable.
+- Browser worker protocol v2 now emits run progress messages for in-memory worker execution. Worker runs produce `start`, `fetch`, optional `analyze`, `done`, and `error` progress phases while keeping cancellation explicitly unavailable.
 - The browser runner UI now displays worker-run progress in a dedicated run-progress panel, while preserving the latest successful result during later repo-load or worker-run progress updates.
 - Browser runner terminal worker messages now follow the same active-request guard as progress messages, so stale `result` or `error` events from an older run cannot overwrite a newer run's UI state.
 - Browser runner GitHub token UX now uses session-only storage, shows anonymous/authenticated state without exposing the raw token, and provides an explicit clear-token action.

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,17 +1,17 @@
 # NOW / NEXT / LATER
 
-> One-screen operational truth. Updated after the `1.10.0` release.
+> One-screen operational truth. Updated after the v1.11 browser runtime polish implementation.
 
 ## NOW (active)
 
-- **Release aftermath is closed**: `1.10.0` is out, the release pipeline proved green end-to-end with the CI control plane, trust hardening, WASM truth, and proof stability work complete. `main` is back to the normal development lane.
+- **Browser runtime polish is closed on main**: cache semantics, worker/repo-load progress, retry/rate-limit guidance, and session-only authenticated fetch UX are implemented.
 - **Main must stay boring**: keep CI green, keep `--no-default-features` builds honest, and avoid reintroducing release-only branch noise or operator caveats.
-- **Docs and operator surfaces should match reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what actually shipped in `1.10.0`.
+- **Docs and operator surfaces should match reality**: keep roadmap, release instructions, architecture docs, and repo-native commands aligned with what is actually implemented.
 
 ## NEXT (short horizon)
 
-- **Browser runtime polish (v1.11.0)**: define cache key and invalidation semantics, emit progress events, improve retry and rate-limit UX, and partition authenticated fetch/cache behavior safely.
-- **Low-blast-radius follow-ons**: prefer narrow docs, compat, and workflow fixes that preserve the newly boring release path and the new effort-estimation surfaces.
+- **Cockpit/review evidence hardening**: keep improving cockpit as the PR-review evidence surface before adding any separate `review` command.
+- **Architecture consolidation prep**: prefer proof-scoped SRP module consolidation over new implementation microcrates.
 
 ## LATER (roadmap)
 

--- a/docs/progress-events.md
+++ b/docs/progress-events.md
@@ -25,6 +25,30 @@ Fields:
 Events are informational. They do not change command stdout, receipt schemas, or
 exit-code policy.
 
+## Browser Worker Progress
+
+The browser runner uses worker protocol v2 progress messages while keeping final
+`result` and `error` messages as the receipt-carrying contract. A progress
+message has this shape:
+
+```json
+{"type":"progress","requestId":"run-1","phase":"fetch","mode":"lang","message":"Fetching in-memory inputs"}
+```
+
+Fields:
+
+- `type`: always `progress`.
+- `requestId`: the active worker run id.
+- `phase`: one of `start`, `fetch`, `analyze`, `done`, or `error`.
+- `mode`: the active browser-safe run mode when available.
+- `message`: human-readable progress text.
+- `current` and `total`: optional numeric counters.
+
+Worker runs emit `start`, then `fetch`, then `done` for `lang`, `module`, and
+`export`. Analyze runs emit `start`, `fetch`, `analyze`, then `done`. Failed
+runs emit `error` after the last phase reached. These events are informational
+and do not change the final result payload or native receipt schemas.
+
 ## Example
 
 ```console

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -21,7 +21,8 @@ Use this project when you want `tokmd` inside a browser worker, backed by
   default analyze preset from the loaded bundle
 - local file or directory selection that fills the existing ordered in-memory
   `inputs` payload without requiring GitHub or network access
-- worker run progress events for `start`, `scan` or `analyze`, `done`, and `error`
+- worker run progress events for `start`, `fetch`, optional `analyze`, `done`,
+  and `error`
 - visible run-progress and repo-load-progress panels in the browser shell
 - session-only GitHub token UX with explicit clear behavior and rejected-token
   state

--- a/web/runner/main.test.mjs
+++ b/web/runner/main.test.mjs
@@ -338,6 +338,14 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     });
     assert.match(runProgressText.textContent, /Starting lang run/);
     worker.emit({
+        type: "progress",
+        requestId: runMessage.requestId,
+        phase: "fetch",
+        mode: "lang",
+        message: "Fetching in-memory inputs",
+    });
+    assert.match(runProgressText.textContent, /Fetching in-memory inputs/);
+    worker.emit({
         type: "result",
         requestId: runMessage.requestId,
         data: {

--- a/web/runner/messages.test.mjs
+++ b/web/runner/messages.test.mjs
@@ -116,9 +116,9 @@ test("run and cancel helpers produce valid protocol messages", () => {
 });
 
 test("progress helper produces protocol messages with stable fields", () => {
-    const message = createProgressMessage("run-1", "scan", {
+    const message = createProgressMessage("run-1", "fetch", {
         mode: "lang",
-        message: "Scanning inputs",
+        message: "Fetching in-memory inputs",
         current: 1,
         total: 3,
     });
@@ -126,9 +126,9 @@ test("progress helper produces protocol messages with stable fields", () => {
     assert.deepEqual(message, {
         type: MESSAGE_TYPES.PROGRESS,
         requestId: "run-1",
-        phase: "scan",
+        phase: "fetch",
         mode: "lang",
-        message: "Scanning inputs",
+        message: "Fetching in-memory inputs",
         current: 1,
         total: 3,
     });

--- a/web/runner/runtime.js
+++ b/web/runner/runtime.js
@@ -69,8 +69,8 @@ async function invokeRunner(runner, mode, args) {
     }
 }
 
-function progressPhaseForMode(mode) {
-    return mode === "analyze" ? "analyze" : "scan";
+function progressPhasesForMode(mode) {
+    return mode === "analyze" ? ["fetch", "analyze"] : ["fetch"];
 }
 
 function emitProgress(onProgress, message) {
@@ -157,13 +157,18 @@ export async function handleRunnerMessage(message, options = {}) {
                 message: `Starting ${message.mode} run`,
             })
         );
-        emitProgress(
-            onProgress,
-            createProgressMessage(message.requestId, progressPhaseForMode(message.mode), {
-                mode: message.mode,
-                message: `Running ${message.mode}`,
-            })
-        );
+        for (const phase of progressPhasesForMode(message.mode)) {
+            emitProgress(
+                onProgress,
+                createProgressMessage(message.requestId, phase, {
+                    mode: message.mode,
+                    message:
+                        phase === "fetch"
+                            ? "Fetching in-memory inputs"
+                            : `Running ${message.mode}`,
+                })
+            );
+        }
         const data = await invokeRunner(runner, message.mode, message.args);
         emitProgress(
             onProgress,

--- a/web/runner/runtime.test.mjs
+++ b/web/runner/runtime.test.mjs
@@ -397,7 +397,7 @@ test("runtime returns results once a runner is available", async () => {
     assert.equal(message.data.total.files, 1);
     assert.deepEqual(
         progress.map((update) => update.phase),
-        ["start", "scan", "done"]
+        ["start", "fetch", "done"]
     );
     assert.deepEqual(
         progress.map((update) => update.type),
@@ -427,7 +427,7 @@ test("analyze without preset defaults to receipt and returns a result", async ()
     assert.equal(message.data.preset, "receipt");
     assert.deepEqual(
         progress.map((update) => update.phase),
-        ["start", "analyze", "done"]
+        ["start", "fetch", "analyze", "done"]
     );
 });
 
@@ -491,7 +491,38 @@ test("runtime emits error progress when runner execution fails", async () => {
     assert.equal(message.error.code, "invalid_settings");
     assert.deepEqual(
         progress.map((update) => update.phase),
-        ["start", "scan", "error"]
+        ["start", "fetch", "error"]
     );
     assert.match(progress.at(-1).message, /Cannot use both paths and inputs/);
+});
+
+test("runtime emits analyze progress before analyze runner failures", async () => {
+    const progress = [];
+    const runner = {
+        runAnalyze() {
+            throw new Error("[analysis_failed] analysis exploded");
+        },
+    };
+
+    const message = await handleRunnerMessage(
+        createRunMessage({
+            requestId: "run-analyze-progress-error",
+            mode: "analyze",
+            args: {
+                inputs: [{ path: "src/lib.rs", text: "pub fn alpha() {}\n" }],
+            },
+        }),
+        {
+            runner,
+            onProgress: (update) => progress.push(update),
+        }
+    );
+
+    assert.equal(message.type, MESSAGE_TYPES.ERROR);
+    assert.equal(message.error.code, "analysis_failed");
+    assert.deepEqual(
+        progress.map((update) => update.phase),
+        ["start", "fetch", "analyze", "error"]
+    );
+    assert.match(progress.at(-1).message, /analysis exploded/);
 });

--- a/web/runner/worker.test.mjs
+++ b/web/runner/worker.test.mjs
@@ -209,6 +209,7 @@ test("worker forwards nested scan inputs through the stub runner", async () => {
                 MESSAGE_TYPES.PROGRESS,
                 MESSAGE_TYPES.PROGRESS,
                 MESSAGE_TYPES.PROGRESS,
+                MESSAGE_TYPES.PROGRESS,
                 MESSAGE_TYPES.RESULT,
             ]
         );
@@ -216,7 +217,7 @@ test("worker forwards nested scan inputs through the stub runner", async () => {
             messages
                 .filter((message) => message.type === MESSAGE_TYPES.PROGRESS)
                 .map((message) => message.phase),
-            ["start", "analyze", "done"]
+            ["start", "fetch", "analyze", "done"]
         );
     } finally {
         await worker.terminate();


### PR DESCRIPTION
## Summary
- stabilize browser worker progress phases around `start -> fetch -> done` and `start -> fetch -> analyze -> done` while preserving final `result` / `error` payload semantics
- document the browser worker progress contract and update browser runner README/NEXT/NOW/ROADMAP truth surfaces for v1.11 browser runtime polish
- add `docs/NOW.md` and `docs/progress-events.md` to the project truth docs proof scope so affected planning no longer reports them as unknown files

## Validation
- `npm --prefix web/runner test`
- `npm --prefix web/runner run check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`