### PR TITLE
feat(cockpit): enrich review map markdown

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -963,6 +963,20 @@ fn render_review_map_md(receipt: &CockpitReceipt) -> String {
         if let Some(complexity) = item.complexity {
             let _ = writeln!(s, "   Review complexity: {complexity}/5");
         }
+        let _ = writeln!(s, "   Evidence references:");
+        let _ = writeln!(s, "   - cockpit.json#/review_plan/{idx}");
+        let _ = writeln!(s, "   - evidence.json#/gates");
+        let _ = writeln!(s, "   Reproduce:");
+        let _ = writeln!(
+            s,
+            "   - `tokmd cockpit --base {} --head {} --format json`",
+            receipt.base_ref, receipt.head_ref
+        );
+        let _ = writeln!(
+            s,
+            "   - `tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review`",
+            receipt.base_ref, receipt.head_ref
+        );
         let _ = writeln!(s);
     }
 

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -835,6 +835,15 @@ fn scenario_write_review_packet_creates_contract_files() {
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("# Review Map"));
     assert!(review_map_md.contains("`src/lib.rs`"));
+    assert!(review_map_md.contains("Evidence references:"));
+    assert!(review_map_md.contains("cockpit.json#/review_plan/0"));
+    assert!(review_map_md.contains("evidence.json#/gates"));
+    assert!(review_map_md.contains("Reproduce:"));
+    assert!(review_map_md.contains("tokmd cockpit --base main --head feature --format json"));
+    assert!(
+        review_map_md
+            .contains("tokmd cockpit --base main --head feature --review-packet-dir .tokmd/review")
+    );
 
     let comment_md = std::fs::read_to_string(out.join("comment.md")).unwrap();
     assert!(comment_md.contains("Evidence availability"));

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -635,6 +635,15 @@ fn test_cockpit_review_packet_dir() {
 
     let review_map_md = std::fs::read_to_string(packet_dir.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("# Review Map"));
+    assert!(review_map_md.contains("Evidence references:"));
+    assert!(review_map_md.contains("cockpit.json#/review_plan/0"));
+    assert!(review_map_md.contains("evidence.json#/gates"));
+    assert!(review_map_md.contains("Reproduce:"));
+    assert!(review_map_md.contains("tokmd cockpit --base main --head HEAD --format json"));
+    assert!(
+        review_map_md
+            .contains("tokmd cockpit --base main --head HEAD --review-packet-dir .tokmd/review")
+    );
 
     let comment_md = std::fs::read_to_string(packet_dir.join("comment.md")).unwrap();
     assert!(comment_md.contains("Evidence availability"));

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -114,7 +114,9 @@ to disk.
 
 Each item includes rank, path, priority, priority label, reason, optional
 complexity, optional lines changed, evidence references, and reproduction
-commands. `review-map.md` is a Markdown rendering of the same ordered items.
+commands. `review-map.md` is a Markdown rendering of the same ordered items,
+including the evidence references and reproduction commands for artifact
+browsing and local review.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary
- include evidence references and reproduction commands in review-map.md
- document review-map.md as the human rendering of the same evidence/replay handles carried by review-map.json
- add cockpit packet and CLI integration assertions for the Markdown artifact

## Validation
- cargo test -p tokmd-cockpit scenario_write_review_packet_creates_contract_files --verbose
- cargo test -p tokmd --test cockpit_integration test_cockpit_review_packet_dir --features git --verbose
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo clippy -p tokmd --test cockpit_integration --features git -- -D warnings
- cargo fmt-check
- git diff --check origin/main..HEAD

Advisory coverage and mutation commands were generated by the affected proof plan but not promoted or run for this narrow artifact rendering change.