### PR TITLE
feat(cockpit): link packet artifacts in comment

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -578,6 +578,18 @@ pub fn render_comment_md(receipt: &CockpitReceipt) -> String {
     s
 }
 
+fn render_review_packet_comment_md(receipt: &CockpitReceipt) -> String {
+    use std::fmt::Write;
+
+    let mut s = render_comment_md(receipt);
+    let _ = writeln!(s, "**Review packet artifacts**:");
+    let _ = writeln!(s, "- [Evidence gates](evidence.json)");
+    let _ = writeln!(s, "- [Review map](review-map.md)");
+    let _ = writeln!(s, "- [Full cockpit receipt](cockpit.json)");
+    let _ = writeln!(s);
+    s
+}
+
 /// Write artifacts to directory.
 pub fn write_artifacts(dir: &Path, receipt: &CockpitReceipt) -> Result<()> {
     std::fs::create_dir_all(dir)?;
@@ -634,7 +646,7 @@ pub fn write_review_packet(dir: &Path, receipt: &CockpitReceipt) -> Result<()> {
     let evidence_json = serde_json::to_string_pretty(&review_packet_evidence(receipt))?;
     let review_map_json = serde_json::to_string_pretty(&review_packet_review_map(receipt))?;
     let review_map_md = render_review_map_md(receipt);
-    let comment_md = render_comment_md(receipt);
+    let comment_md = render_review_packet_comment_md(receipt);
 
     std::fs::write(dir.join("cockpit.json"), &cockpit_json)?;
     std::fs::write(dir.join("evidence.json"), &evidence_json)?;

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -849,6 +849,10 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert!(comment_md.contains("Evidence availability"));
     assert!(comment_md.contains("1 available"));
     assert!(comment_md.contains("5 unavailable"));
+    assert!(comment_md.contains("Review packet artifacts"));
+    assert!(comment_md.contains("[Evidence gates](evidence.json)"));
+    assert!(comment_md.contains("[Review map](review-map.md)"));
+    assert!(comment_md.contains("[Full cockpit receipt](cockpit.json)"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -651,6 +651,10 @@ fn test_cockpit_review_packet_dir() {
         comment_md.contains("unavailable"),
         "comment.md should expose unavailable evidence, not just evidence.json"
     );
+    assert!(comment_md.contains("Review packet artifacts"));
+    assert!(comment_md.contains("[Evidence gates](evidence.json)"));
+    assert!(comment_md.contains("[Review map](review-map.md)"));
+    assert!(comment_md.contains("[Full cockpit receipt](cockpit.json)"));
 }
 
 #[test]

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -55,7 +55,7 @@ The review packet directory is:
 | `manifest.json` | Packet index with schema name, generated-by metadata, base/head refs, artifact paths, hashes, and verdict metadata. |
 | `cockpit.json` | Full `CockpitReceipt` JSON. This is the same receipt produced by `tokmd cockpit --format json`. |
 | `evidence.json` | Evidence availability and gate status. It distinguishes passed evidence from missing, skipped, stale, degraded, or unavailable evidence. |
-| `comment.md` | PR-comment-ready summary. It stays concise and links readers to packet artifacts when hosted by CI. |
+| `comment.md` | PR-comment-ready summary. It stays concise and points readers to packet artifacts when hosted by CI. |
 | `review-map.json` | Machine-readable prioritized review plan with files, reasons, evidence references, and reproduction commands derived from `cockpit.json#/review_plan`. |
 | `review-map.md` | Human-readable review plan for artifact browsing and local review. |
 


### PR DESCRIPTION
## Summary
- make review-packet `comment.md` point to `evidence.json`, `review-map.md`, and `cockpit.json`
- keep generic `--format comment` / `--artifacts-dir` comment output unchanged
- add packet and CLI integration assertions; align review-packet docs wording

## Validation
- `cargo test -p tokmd-cockpit scenario_write_review_packet_creates_contract_files --verbose`
- `cargo test -p tokmd --test cockpit_integration test_cockpit_review_packet_dir --features git --verbose`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo clippy -p tokmd --test cockpit_integration --features git -- -D warnings`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

Advisory coverage and mutation commands were generated by the affected proof plan, but were not promoted or run.