### PR TITLE
feat(cockpit): classify missing packet evidence

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -830,6 +830,7 @@ fn review_packet_evidence_capabilities(receipt: &CockpitReceipt) -> Value {
     let mut stale = Vec::new();
     let mut skipped = Vec::new();
     let mut unavailable = Vec::new();
+    let mut missing = Vec::new();
 
     for (id, meta) in review_packet_evidence_gate_specs(receipt) {
         match evidence_availability_optional(meta) {
@@ -838,6 +839,7 @@ fn review_packet_evidence_capabilities(receipt: &CockpitReceipt) -> Value {
             "stale" => stale.push(id),
             "skipped" => skipped.push(id),
             "unavailable" => unavailable.push(id),
+            "missing" => missing.push(id),
             _ => {}
         }
     }
@@ -849,7 +851,7 @@ fn review_packet_evidence_capabilities(receipt: &CockpitReceipt) -> Value {
         "stale": stale,
         "skipped": skipped,
         "unavailable": unavailable,
-        "missing": Vec::<&str>::new(),
+        "missing": missing,
     })
 }
 
@@ -1035,6 +1037,13 @@ fn evidence_gate(id: &str, meta: Option<&GateMeta>) -> Value {
 fn evidence_availability(meta: &GateMeta) -> &'static str {
     if matches!(meta.status, GateStatus::Skipped) {
         return "skipped";
+    }
+
+    if matches!(meta.status, GateStatus::Pending)
+        && !meta.scope.relevant.is_empty()
+        && meta.scope.tested.is_empty()
+    {
+        return "missing";
     }
 
     match meta.commit_match {

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -761,6 +761,30 @@ fn scenario_write_review_packet_creates_contract_files() {
     let mut receipt = minimal_receipt();
     receipt.evidence.mutation.meta.status = GateStatus::Pass;
     receipt.evidence.mutation.meta.commit_match = CommitMatch::Exact;
+    receipt.evidence.diff_coverage = Some(DiffCoverageGate {
+        meta: GateMeta {
+            status: GateStatus::Pending,
+            source: EvidenceSource::CiArtifact,
+            commit_match: CommitMatch::Unknown,
+            scope: ScopeCoverage {
+                relevant: vec!["src/lib.rs".to_string()],
+                tested: Vec::new(),
+                ratio: 0.0,
+                lines_relevant: Some(42),
+                lines_tested: Some(0),
+            },
+            evidence_commit: None,
+            evidence_generated_at_ms: None,
+        },
+        lines_added: 42,
+        lines_covered: 0,
+        coverage_pct: 0.0,
+        uncovered_hunks: vec![UncoveredHunk {
+            file: "src/lib.rs".to_string(),
+            start_line: 1,
+            end_line: 42,
+        }],
+    });
     receipt.review_plan = vec![ReviewItem {
         path: "src/lib.rs".to_string(),
         reason: "Large changed file".to_string(),
@@ -790,17 +814,22 @@ fn scenario_write_review_packet_creates_contract_files() {
     );
     assert_eq!(manifest["verdict"]["evidence"]["total_gates"], 6);
     assert_eq!(manifest["verdict"]["evidence"]["available"], 1);
-    assert_eq!(manifest["verdict"]["evidence"]["unavailable"], 5);
+    assert_eq!(manifest["verdict"]["evidence"]["missing"], 1);
+    assert_eq!(manifest["verdict"]["evidence"]["unavailable"], 4);
     assert_eq!(
         manifest["capabilities"]["evidence"]["available"][0],
         "mutation"
+    );
+    assert_eq!(
+        manifest["capabilities"]["evidence"]["missing"][0],
+        "diff_coverage"
     );
     assert!(
         manifest["capabilities"]["evidence"]["unavailable"]
             .as_array()
             .unwrap()
             .iter()
-            .any(|gate| gate == "diff_coverage")
+            .any(|gate| gate == "contracts")
     );
     assert_eq!(manifest["artifacts"].as_array().unwrap().len(), 5);
     assert_eq!(manifest["artifacts"][0]["path"], "cockpit.json");
@@ -819,7 +848,15 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert_eq!(evidence["gates"][0]["id"], "mutation");
     assert_eq!(evidence["gates"][0]["availability"], "available");
     assert_eq!(evidence["gates"][1]["id"], "diff_coverage");
-    assert_eq!(evidence["gates"][1]["availability"], "unavailable");
+    assert_eq!(evidence["gates"][1]["availability"], "missing");
+    assert_eq!(evidence["gates"][1]["scope"]["relevant"][0], "src/lib.rs");
+    assert_eq!(
+        evidence["gates"][1]["scope"]["tested"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
 
     let review_map: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
@@ -848,7 +885,8 @@ fn scenario_write_review_packet_creates_contract_files() {
     let comment_md = std::fs::read_to_string(out.join("comment.md")).unwrap();
     assert!(comment_md.contains("Evidence availability"));
     assert!(comment_md.contains("1 available"));
-    assert!(comment_md.contains("5 unavailable"));
+    assert!(comment_md.contains("4 unavailable"));
+    assert!(comment_md.contains("1 missing"));
     assert!(comment_md.contains("Review packet artifacts"));
     assert!(comment_md.contains("[Evidence gates](evidence.json)"));
     assert!(comment_md.contains("[Review map](review-map.md)"));

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -151,6 +151,7 @@ architecture-consolidation program.
 - Manual proof-observation collector run `25516861742` on `main` passed on 2026-05-07 after #1750 merged. The collection recorded 82 observations, 16 selected/executed/passed coverage commands, 16 artifacts, and 7 distinct scopes: `analysis_complexity`, `analysis_content_assets`, `format_redaction_scan_args`, `tokmd_cli`, `tokmd_cockpit`, `tokmd_core_ffi`, and `tokmd_gate`. The new source-run window accounting reported `expected_runs = 99`, `observed_runs = 82`, `missing_runs = 17`, and `unmatched_observations = 0`, proving the collector can distinguish successful executor runs that lacked downloadable observation artifacts from observations outside the saved run window.
 - Proof-control-plane status: routine PR observations continue under the two-command default. There is no active promotion slice for a required gate, default Codecov upload, or larger command-limit default.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
+- Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
 
 ## References
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -74,7 +74,7 @@ Recommended evidence availability values:
 | Availability | Meaning |
 | --- | --- |
 | `available` | Evidence ran for the requested commit/scope and can be interpreted with the gate status. |
-| `missing` | Evidence was expected but no usable result was found. |
+| `missing` | Evidence was expected for a relevant scope, but no tested scope or usable result was found. |
 | `skipped` | Evidence was intentionally not requested for this run. |
 | `stale` | Evidence exists but does not match the requested commit or scope. |
 | `degraded` | Evidence exists but is partial, incomplete, or lower confidence than the normal policy requires. |


### PR DESCRIPTION
## Summary

- classify review-packet evidence gates with relevant-but-untested scope as `missing`
- keep absent optional gates classified as `unavailable`
- cover manifest/comment capability counts and update review-packet docs/NEXT checkpoint

## Validation

- `cargo test -p tokmd-cockpit scenario_write_review_packet_creates_contract_files --verbose`
- `cargo test -p tokmd --test cockpit_integration test_cockpit_review_packet_dir --features git --verbose`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask --verbose`
- `cargo xtask proof-policy --check`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo clippy -p tokmd --features git --test cockpit_integration -- -D warnings`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

Affected proof plan also listed advisory coverage/mutation commands; those were not run and were not promoted.