### PR TITLE
feat(action): annotate hosted review packets

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -391,6 +391,10 @@ jobs:
           done
           grep -q '"schema": "tokmd.review_packet_manifest.v1"' .tokmd/review/manifest.json
           grep -q '"schema": "tokmd.review_map.v1"' .tokmd/review/review-map.json
+          grep -q 'Hosted packet' .tokmd/review/comment.md
+          grep -q 'Workflow run:' .tokmd/review/comment.md
+          grep -q 'Artifact: `tokmd-receipts`' .tokmd/review/comment.md
+          grep -q 'Packet path: `.tokmd/review`' .tokmd/review/comment.md
 
       - name: Clean generated files
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -376,6 +376,34 @@ runs:
           echo "command-status=$command_status"
         } >> "$GITHUB_OUTPUT"
 
+    - name: Annotate Review Packet Comment
+      if: steps.generate.outputs['review-packet'] != '' && steps.generate.outputs.summary != ''
+      shell: bash
+      env:
+        SUMMARY_FILE: ${{ steps.generate.outputs.summary }}
+        REVIEW_PACKET_DIR: ${{ steps.generate.outputs['review-packet'] }}
+        ARTIFACT_ENABLED: ${{ inputs.artifact }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -f "$SUMMARY_FILE" ]; then
+          exit 0
+        fi
+
+        {
+          echo
+          echo "**Hosted packet**:"
+          if [ "$ARTIFACT_ENABLED" = "true" ]; then
+            echo "- Workflow run: [$RUN_ID]($RUN_URL)"
+            echo "- Artifact: \`tokmd-receipts\`"
+          else
+            echo "- Workflow artifact upload: disabled"
+          fi
+          echo "- Packet path: \`$REVIEW_PACKET_DIR\`"
+        } >> "$SUMMARY_FILE"
+
     - name: Upload Artifact
       if: inputs.artifact == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -152,6 +152,7 @@ architecture-consolidation program.
 - Proof-control-plane status: routine PR observations continue under the two-command default. There is no active promotion slice for a required gate, default Codecov upload, or larger command-limit default.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
+- The composite Action now appends hosted packet metadata to review-packet comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.
 
 ## References
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -129,6 +129,11 @@ When `review-packet: 'true'`, cockpit mode also runs with
 directory, and the `summary` output points to `.tokmd/review/comment.md` so the
 existing `comment` input can post the packet summary on pull requests.
 
+When artifact upload is enabled, the Action also appends hosted packet metadata
+to `.tokmd/review/comment.md`: the workflow run URL, the `tokmd-receipts`
+artifact name, and the packet path. This keeps pull request comments useful even
+though the packet's local file links are artifact-relative.
+
 ### `sensor`
 
 Runs `tokmd sensor --format json` and writes:
@@ -174,6 +179,13 @@ permissions:
 Commenting only runs on `pull_request` events. Set `comment: 'false'` for scheduled jobs, push jobs, private smoke tests, or workflows where comments are not desired.
 
 The default flow comments with `tokmd-summary.md`. `sensor` comments with `comment.md`. JSON-only modes such as `gate`, `cockpit`, and `baseline` normally leave the `summary` output empty. `cockpit` with `review-packet: 'true'` comments with `.tokmd/review/comment.md`.
+
+For cockpit review packets, the Action appends a short hosted-packet block to
+that comment before posting it. With `artifact: 'true'`, the block points
+reviewers to the workflow run and `tokmd-receipts` artifact that contains the
+full `.tokmd/review/` directory. With artifact upload disabled, the comment
+states that the packet was generated locally in the workflow workspace but not
+uploaded.
 
 ## Checkout Guidance
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -140,6 +140,12 @@ The Action uploads the packet as an artifact when `artifact: 'true'` and
 `review-packet: 'true'` are both set. Comment posting remains fork-safe and is
 not required for packet generation.
 
+When the composite Action generates a review packet, it appends a hosted-packet
+block to `.tokmd/review/comment.md` before artifact upload and PR commenting.
+With artifact upload enabled, that block points to the workflow run, the
+`tokmd-receipts` artifact, and the packet path. With artifact upload disabled,
+it states that the packet was not uploaded.
+
 Action inputs build on the cockpit surface first:
 
 ```yaml


### PR DESCRIPTION
## Summary
- append hosted workflow/artifact metadata to review-packet comments generated by the composite Action
- prove the Action self-test expects the hosted packet block in `.tokmd/review/comment.md`
- document the hosted packet comment behavior in Action/review-packet docs and NEXT

## Validation
- `python - <<'PY' ... yaml.safe_load(...)`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd --test docs --verbose`
- `cargo test -p xtask --verbose`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

Affected proof planning also reported advisory coverage/mutation commands for `tokmd_cockpit`; this PR does not promote advisory coverage, mutation, or fast proof gates.