### PR TITLE
docs: align agent architecture guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,33 +39,40 @@ For cross-worktree cache reuse, use `cargo xtask sccache --basedir <PATH> -- <ca
 
 ## Architecture
 
-The codebase follows a tiered microcrate architecture: **types → scan → model → format → analysis → CLI**
+The codebase follows a tiered crate-and-module architecture:
+**types → scan/model → format/adapters → analysis/cockpit/gate → core → products**.
+Public crates represent durable contracts, facades, adapters, or products.
+Implementation details that do not need an independent package live as
+single-responsibility owner modules inside those crates.
 
 ### Crate Hierarchy
 
 | Tier | Crate | Purpose |
 |------|-------|---------|
-| 0 | `tokmd-types` | Core data structures, no dependencies |
+| 0 | `tokmd-types` | Core receipt data structures |
 | 0 | `tokmd-analysis-types` | Analysis receipt types |
+| 0 | `tokmd-settings` | Clap-free workflow settings |
+| 0 | `tokmd-envelope` | Shared sensor/FFI envelope contracts |
+| 0 | `tokmd-io-port` | Host-abstracted file access contracts |
 | 1 | `tokmd-scan` | tokei wrapper for code scanning |
 | 1 | `tokmd-model` | Aggregation logic (lang, module, file rows) |
-| 2 | `tokmd-format` | Output rendering (Markdown, TSV, JSON) |
-| 2 | `tokmd-walk` | File system traversal for assets |
-| 2 | `tokmd-content` | File content scanning (entropy, imports) |
+| 1 | `tokmd-sensor` | Sensor substrate and report builder |
+| 2 | `tokmd-format` | Output rendering, redaction, badges, export-tree, analysis rendering |
 | 2 | `tokmd-git` | Git history analysis |
 | 3 | `tokmd-analysis` | Analysis orchestration and enrichers |
-| 3 | `tokmd-analysis-format` | Analysis output rendering |
-| 3 | `tokmd-fun` | Novelty outputs (eco-label, etc.) |
+| 3 | `tokmd-cockpit` | PR cockpit metrics and review evidence |
 | 3 | `tokmd-gate` | Policy evaluation with JSON pointer rules |
 | 4 | `tokmd-core` | Library facade with FFI layer |
 | 5 | `tokmd` | CLI binary |
 | 5 | `tokmd-python` | PyO3 bindings for PyPI |
 | 5 | `tokmd-node` | napi-rs bindings for npm |
+| 5 | `tokmd-wasm` | wasm-bindgen bindings for browser/worker callers |
 
 Former helper microcrates such as redaction, scan-args, badge rendering,
-progress, module-key, path/exclude/math, tokeignore, context policy/git, and
-tool-schema now live as owner modules inside `tokmd-format`, `tokmd-scan`,
-`tokmd-model`, `tokmd-core`, or `tokmd`.
+analysis rendering, progress, module-key, path/exclude/math, tokeignore,
+context policy/git, fun renderers, content/import enrichers, and tool-schema now
+live as owner modules inside `tokmd-format`, `tokmd-scan`, `tokmd-model`,
+`tokmd-analysis`, `tokmd-core`, or `tokmd`.
 
 ### CLI Commands
 

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -32,9 +32,13 @@ git config core.hooksPath .githooks
 
 ## Architecture
 
-The codebase follows a tiered microcrate architecture:
+The codebase follows a tiered crate-and-module architecture:
 
-`types -> scan -> model -> format -> analysis -> CLI`
+`types -> scan/model -> format/adapters -> analysis/cockpit/gate -> core -> products`
+
+Public crates represent durable contracts, facades, adapters, or products.
+Implementation details that do not need an independent package live as
+single-responsibility owner modules inside those crates.
 
 Tier summary:
 
@@ -42,15 +46,16 @@ Tier summary:
 |------|---------|----------------|
 | 0 | Contracts and settings | `tokmd-types`, `tokmd-analysis-types`, `tokmd-settings`, `tokmd-envelope`, `tokmd-io-port` |
 | 1 | Core scan and aggregation | `tokmd-scan`, `tokmd-model`, `tokmd-sensor` |
-| 2 | Adapters and rendering | `tokmd-format`, `tokmd-walk`, `tokmd-content`, `tokmd-git` |
-| 3 | Analysis orchestration | `tokmd-analysis`, `tokmd-analysis-format`, `tokmd-analysis-*`, `tokmd-fun`, `tokmd-gate` |
+| 2 | Adapters and rendering | `tokmd-format`, `tokmd-git` |
+| 3 | Analysis and review orchestration | `tokmd-analysis`, `tokmd-cockpit`, `tokmd-gate` |
 | 4 | Library facade | `tokmd-core` |
 | 5 | End-user products | `tokmd`, `tokmd-python`, `tokmd-node`, `tokmd-wasm` |
 
 Former helper microcrates such as redaction, scan-args, badge rendering,
-progress, module-key, path/exclude/math, tokeignore, context policy/git, and
-tool-schema now live as owner modules inside `tokmd-format`, `tokmd-scan`,
-`tokmd-model`, `tokmd-core`, or `tokmd`.
+analysis rendering, progress, module-key, path/exclude/math, tokeignore,
+context policy/git, fun renderers, content/import enrichers, and tool-schema now
+live as owner modules inside `tokmd-format`, `tokmd-scan`, `tokmd-model`,
+`tokmd-analysis`, `tokmd-core`, or `tokmd`.
 
 Dependency rule:
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -153,6 +153,10 @@ architecture-consolidation program.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
 - The composite Action now appends hosted packet metadata to review-packet comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.
+- Agent-facing architecture docs now reflect the current crate-and-module
+  ownership model: analysis rendering lives in `tokmd-format`, review evidence
+  in `tokmd-cockpit`, and implementation details should stay as SRP owner
+  modules unless they are durable public surfaces.
 
 ## References
 

--- a/docs/agent-context/review-invariants.md
+++ b/docs/agent-context/review-invariants.md
@@ -61,10 +61,10 @@ Tier 1: Core scan and aggregation
   tokmd-scan, tokmd-model, tokmd-sensor
 
 Tier 2: Adapters and rendering
-  tokmd-format, tokmd-walk, tokmd-content, tokmd-git
+  tokmd-format, tokmd-git
 
-Tier 3: Analysis orchestration
-  tokmd-analysis, tokmd-analysis-format, tokmd-analysis-*, tokmd-fun, tokmd-gate
+Tier 3: Analysis and review orchestration
+  tokmd-analysis, tokmd-cockpit, tokmd-gate
 
 Tier 4: Library facade
   tokmd-core
@@ -90,9 +90,9 @@ Supported feature flags:
 | Flag | Purpose | Tier Gate |
 |------|---------|-----------|
 | `git` | Git history analysis | Gate at Tier 2+ (tokmd-git) |
-| `content` | File content scanning | Gate at Tier 2+ (tokmd-content) |
-| `walk` | Filesystem traversal | Gate at Tier 2+ (tokmd-walk) |
-| `halstead` | Halstead metrics (requires `content` + `walk`) | Gate at Tier 2+ |
+| `content` | File content scanning | Gate at Tier 3+ (`tokmd-analysis` content modules) |
+| `walk` | Filesystem traversal helpers | Gate at Tier 1+ (`tokmd-scan` owner modules) |
+| `halstead` | Halstead metrics (requires `content` + `walk`) | Gate at Tier 3+ (`tokmd-analysis`) |
 
 **Rules**:
 - Feature gate must be applied at the crate that introduces the feature

--- a/docs/ci/inventory.md
+++ b/docs/ci/inventory.md
@@ -11,7 +11,7 @@ companion to `policy/ci-lane-whitelist.toml`. Update on rollout PRs.
 | `quality_gate` | Quality Gate | ubuntu | 8 | `cargo xtask gate --check`. |
 | `proof_policy` | Proof Policy | ubuntu | 3 | `cargo xtask proof-policy --check`. |
 | `affected_proof_plan` | Affected Proof Plan | ubuntu | 4 | Wrapped by PR 08 PR Plan. |
-| `feature_boundaries` | Feature Boundaries | ubuntu | 10 | Analysis microcrate boundaries. |
+| `feature_boundaries` | Feature Boundaries | ubuntu | 10 | Analysis feature/module boundaries. |
 | `typos` | Typos | ubuntu | 1 | crate-ci/typos. |
 | `cargo_deny` | Cargo Deny | ubuntu | 4 | Advisories + licenses. |
 | `version_consistency` | Version consistency | ubuntu | 2 | Release metadata alignment. |


### PR DESCRIPTION
## Summary
- align agent-facing architecture guidance with the current crate-and-module ownership model
- remove current-surface references to retired `tokmd-analysis-format`, `tokmd-walk`, `tokmd-content`, and `tokmd-fun` crates
- update review invariants, CI inventory wording, and NEXT checkpoint for architecture-consolidation truth

## Validation
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask --verbose`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`