### PR TITLE
docs: define AST shadow rollout

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -657,11 +657,11 @@ _Goal: Accurate parsing for precise metrics. This is a significant undertaking r
 
 #### J. Tree-sitter AST Parsing
 
-- `tokmd-treesitter` crate with multi-language AST parsing
-- Language-specific complexity rules (Rust, TypeScript, Python, Go, etc.)
-- Accurate function boundary detection
-- Nested scope analysis for cognitive complexity
-- Call graph extraction for coupling analysis
+- Feature-gated AST foundation defined by ADR-0008
+- Rust-first owner module under `tokmd-analysis` before any public parser crate
+- Shadow comparison artifacts for heuristic-vs-AST function, import, and control-flow evidence
+- Later language-specific complexity rules only after deterministic shadow evidence
+- Public receipt/schema changes only after schema review and migration policy
 
 ---
 
@@ -673,7 +673,7 @@ These are explicitly out of scope for tokmd:
 - **Dependency vulnerability scanning** — tokmd delegates to external tools (cargo-audit, npm audit) when available; it does not maintain its own advisory database
 - **Test execution** — Use cargo test, pytest, jest
 - **Build orchestration** — Use cargo, make, just
-- **Full AST analysis** — tokmd uses heuristics, not parsers (tree-sitter is a long-term v3.0 aspiration)
+- **Default full AST analysis** — tokmd remains heuristic-first until feature-gated AST shadow evidence justifies public receipt/schema changes
 
 ---
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -612,12 +612,13 @@ paths = [
   "docs/architecture.md",
   "docs/design.md",
   "docs/implementation-plan.md",
+  "docs/adr/**",
   "docs/progress-events.md",
   "docs/requirements.md",
   "docs/specification.md",
 ]
 proof = ["cargo xtask docs --check"]
-reason = "Top-level architecture, design, roadmap, and requirements docs are project truth surfaces; edits should route to documentation checks instead of appearing as unknown files."
+reason = "Top-level architecture, ADR, design, roadmap, and requirements docs are project truth surfaces; edits should route to documentation checks instead of appearing as unknown files."
 mutation = false
 coverage = false
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -123,7 +123,7 @@ architecture-consolidation program.
 - `cargo xtask coverage-receipt` now emits `tokmd.coverage_receipt.v1` for `coverage.json`, `coverage.txt`, and `lcov.info`, and the coverage workflow uploads `target/coverage/coverage-receipt.json` with the coverage artifacts. The receipt records coverage artifact presence and byte counts without making coverage a required gate.
 - Codecov project and patch statuses remain informational during the baseline phase, and coverage receipt generation is owned by `cargo xtask coverage-receipt` rather than a duplicate workflow heredoc.
 - `cargo xtask ci-actuals` now emits `tokmd.ci_actuals.v1` from a GitHub Actions `needs` payload plus optional timing sidecar data. Missing timing is recorded as missing rather than zero so later budget and learned-estimate work can consume the receipt without inventing measurements.
-- Top-level project truth docs (`ROADMAP.md`, architecture, design, implementation plan, requirements, and specification) now have a proof-policy scope that routes changes to `cargo xtask docs --check` instead of leaving architecture-doc-only fixes as unknown files.
+- Top-level project truth docs (`ROADMAP.md`, ADRs, architecture, design, implementation plan, requirements, and specification) now have a proof-policy scope that routes changes to `cargo xtask docs --check` instead of leaving architecture-doc-only fixes as unknown files.
 - The external-service policy now reflects the active safe Droid integration:
   Factory Droid is approved only through the pinned safe action wrapper,
   requires `FACTORY_API_KEY` and `MINIMAX_API_KEY`, skips fork PR auto-review,
@@ -161,6 +161,9 @@ architecture-consolidation program.
   extraction from the current owner-module consolidation shape, so future
   architecture work starts from the actual crate graph instead of retired
   package names.
+- ADR-0008 now defines the AST foundation as feature-gated, Rust-first, and
+  shadow-mode-only until real comparison evidence justifies schema or default
+  metric changes.
 
 ## References
 

--- a/docs/adr/0008-ast-foundation.md
+++ b/docs/adr/0008-ast-foundation.md
@@ -1,0 +1,126 @@
+# ADR-0008: AST foundation and shadow rollout
+
+- Status: proposed
+- Date: 2026-05-08
+
+## Context
+
+tokmd currently produces receipt-grade repository facts with deterministic
+heuristics. That is intentional: the tool is useful without owning a full parser
+stack, and current receipts are stable across native, binding, browser, and CI
+surfaces.
+
+The long-term roadmap calls for Tree-sitter AST integration because several
+surfaces are inherently approximate without syntax trees:
+
+- function boundary detection
+- function-level complexity
+- cognitive complexity
+- import and API-surface extraction
+- language-specific maintainability signals
+- later review evidence that needs source-structure precision
+
+AST support touches schema meaning, output stability, dependency footprint,
+WASM bundle size, performance, feature flags, and fallback behavior. It should
+therefore start as infrastructure and comparison evidence, not as a default
+metric rewrite.
+
+## Decision
+
+AST work must roll out in shadow mode before it changes public receipt
+semantics.
+
+The first implementation should:
+
+- live inside the owning analysis surface unless an independent public crate is
+  justified by ADR-0002;
+- start with Rust as the first language;
+- use Tree-sitter behind an explicit feature flag;
+- parse only a small source-structure surface at first: functions, imports, and
+  simple control-flow landmarks;
+- emit developer-only comparison artifacts rather than changing default
+  analysis receipts;
+- preserve heuristic fallback for every language and runtime that lacks AST
+  support;
+- keep browser/WASM support opt-in until bundle-size and initialization costs
+  are measured;
+- keep deterministic ordering and stable path normalization at the AST boundary.
+
+The recommended first module shape is:
+
+```text
+crates/tokmd-analysis/src/ast/
+  mod.rs
+  capability.rs
+  rust.rs
+  shadow.rs
+```
+
+The feature flag should describe the capability rather than a historical crate
+split:
+
+```toml
+[features]
+ast = []
+```
+
+If Tree-sitter dependencies need isolation after measurement, a crate boundary
+can be reconsidered as a capability/dependency-isolation boundary under
+ADR-0002. The default starting point remains an owner module.
+
+Shadow artifacts should be developer-facing and excluded from public receipt
+contracts:
+
+```text
+target/tokmd-ast-shadow/
+  heuristic.json
+  ast.json
+  diff.json
+```
+
+## Consequences
+
+- Existing receipt schemas and default outputs remain stable during the AST
+  foundation phase.
+- AST evidence can be evaluated across real repositories before downstream
+  consumers see semantic changes.
+- Browser/WASM capability honesty is preserved because AST support is not
+  promised until the loaded bundle actually exposes it.
+- Proof scopes can target AST parsing and shadow comparison without turning AST
+  precision into a global release blocker.
+- A future schema bump is required if any public field changes meaning because
+  AST replaces a heuristic.
+
+## Alternatives
+
+- Add Tree-sitter as a default analysis dependency and immediately replace
+  heuristic complexity/import metrics.
+- Create a new public `tokmd-ast` crate before there is external consumption or
+  a proven dependency-isolation need.
+- Keep AST work out of tree until a full v3 design is ready.
+
+These alternatives were rejected for the first slice because they either risk
+receipt churn, expand the public surface too early, or delay useful comparison
+evidence.
+
+## Enforcement
+
+- AST code must remain feature-gated until the maintainers accept a production
+  rollout.
+- Default CLI, library, FFI, Node, Python, and WASM outputs must not change in
+  the shadow phase.
+- AST-derived receipt fields require schema-version review under ADR-0007.
+- Any new AST dependency must be covered by proof policy scopes and publish
+  surface review.
+- WASM/browser AST exposure requires capability-matrix updates and bundle-size
+  evidence.
+- Shadow comparison output must be deterministic: sorted paths, normalized path
+  separators, stable node identifiers, and no timestamps in comparison payloads.
+
+## Related specs
+
+- `docs/architecture.md`
+- `docs/publish-surface.md`
+- `docs/adr/0002-crate-vs-module-boundaries.md`
+- `docs/adr/0006-deterministic-receipts.md`
+- `docs/adr/0007-schema-family-versioning.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,7 @@ surface-specific schema documents.
 | [0005](0005-release-train-and-rc-semantics.md) | accepted | Release train and RC semantics |
 | [0006](0006-deterministic-receipts.md) | accepted | Deterministic receipts and renderers |
 | [0007](0007-schema-family-versioning.md) | accepted | Independent schema-family versioning |
+| [0008](0008-ast-foundation.md) | proposed | AST foundation and shadow rollout |
 
 ## House Style
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -436,39 +436,50 @@ authenticated fetch.
 
 **Goal**: Accurate parsing for precise metrics. This is a significant R&D effort requiring multi-language grammar integration, cross-platform build toolchains, and extensive correctness validation. Intentionally deferred well beyond v2.x.
 
+ADR-0008 defines the rollout boundary: AST work starts as a feature-gated,
+Rust-first owner module with deterministic shadow comparison artifacts. It must
+not change default receipt semantics until maintainers accept the evidence,
+schema impact, and runtime capability story.
+
 ### Language Support
 
-1. **Parser crate**: `tokmd-treesitter` (new)
-2. **Languages**: Rust, TypeScript, Python, Go, Java
-3. **Feature-gated**: Optional dependency
+1. **First module**: `crates/tokmd-analysis/src/ast/`
+2. **First language**: Rust
+3. **Feature-gated**: explicit `ast` capability
+4. **Later languages**: TypeScript, Python, Go, and Java only after Rust shadow evidence
+5. **Optional crate boundary**: only if ADR-0002 justifies dependency isolation or a public contract
 
 ### Capabilities
 
 - Accurate function boundary detection
 - Nested scope analysis for cognitive complexity
 - Call graph extraction for coupling analysis
+- Deterministic heuristic-vs-AST shadow comparisons
 
 ### Prerequisites
 
 - Stable tokmd-core API (Phase 3)
 - Halstead and function-level metrics (Phase 4) as integration surface
 - MCP server mode (Phase 6) to validate use cases that require AST precision
+- Proof-policy scopes and publish-surface review for any new parser dependency
 
 ### Work Items
 
-- [ ] Evaluate tree-sitter grammar availability and build complexity per language
-- [ ] Create tokmd-treesitter crate with feature-gated dependency
-- [ ] Implement language-specific parsers
-- [ ] Integrate with tokmd-analysis content helpers for precise boundary detection
-- [ ] Update complexity calculation to use AST when available
-- [ ] Performance benchmarks (must not regress heuristic-based path)
+- [ ] Evaluate Tree-sitter Rust grammar availability, build complexity, and dependency footprint
+- [ ] Add feature-gated `tokmd-analysis::ast` owner module
+- [ ] Parse Rust functions, imports, and simple control-flow landmarks
+- [ ] Emit deterministic shadow artifacts under `target/tokmd-ast-shadow/`
+- [ ] Compare heuristic and AST evidence without changing default receipts
+- [ ] Add proof scope coverage and performance benchmarks
+- [ ] Decide later whether AST-derived public fields need schema changes
 
 ### Tests
 
-- Unit tests: Parser correctness per language
-- Golden tests: Parse tree snapshots
+- Unit tests: Rust parser fixture correctness
+- Golden tests: Deterministic shadow comparison artifacts
 - Fuzz tests: Parser robustness
 - Benchmarks: Performance regression detection
+- WASM/browser tests only before exposing AST capabilities in browser bundles
 
 ---
 


### PR DESCRIPTION
## Summary
- add ADR-0008 for a feature-gated, Rust-first AST shadow rollout
- align the roadmap and implementation plan away from a premature public `tokmd-treesitter` crate/default AST rewrite
- route `docs/adr/**` through the project-truth docs proof scope so ADR-only changes are not unknown files

## Validation
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`