### PR TITLE
feat(analysis): add AST shadow scaffold

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -248,6 +248,19 @@ mutation = true
 coverage = true
 
 [[scope]]
+name = "analysis_ast_shadow"
+kind = "rust"
+paths = [
+  "crates/tokmd-analysis/Cargo.toml",
+  "crates/tokmd-analysis/src/ast/**",
+  "docs/adr/0008-ast-foundation.md",
+]
+packages = ["tokmd-analysis"]
+proof = ["cargo test -p tokmd-analysis --features ast ast --verbose"]
+mutation = false
+coverage = false
+
+[[scope]]
 name = "analysis_complexity"
 kind = "rust"
 paths = [

--- a/crates/tokmd-analysis/Cargo.toml
+++ b/crates/tokmd-analysis/Cargo.toml
@@ -31,6 +31,7 @@ effort = []
 fun = []
 topics = []
 archetype = []
+ast = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/tokmd-analysis/src/ast/capability.rs
+++ b/crates/tokmd-analysis/src/ast/capability.rs
@@ -1,0 +1,63 @@
+use super::rust;
+
+pub const AST_SHADOW_SCHEMA_VERSION: &str = "tokmd.ast_shadow.v1";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AstLanguage {
+    Rust,
+}
+
+impl AstLanguage {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AstParserStatus {
+    PlannedShadow,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AstCapability {
+    pub language: AstLanguage,
+    pub parser_crate: &'static str,
+    pub parser_status: AstParserStatus,
+    pub shadow_only: bool,
+    pub changes_default_receipts: bool,
+}
+
+impl AstCapability {
+    pub const fn planned_shadow(language: AstLanguage, parser_crate: &'static str) -> Self {
+        Self {
+            language,
+            parser_crate,
+            parser_status: AstParserStatus::PlannedShadow,
+            shadow_only: true,
+            changes_default_receipts: false,
+        }
+    }
+}
+
+#[must_use]
+pub fn capabilities() -> &'static [AstCapability] {
+    rust::CAPABILITIES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AstCapability, AstLanguage, AstParserStatus};
+
+    #[test]
+    fn planned_shadow_constructor_never_changes_default_receipts() {
+        let capability = AstCapability::planned_shadow(AstLanguage::Rust, "tree-sitter-rust");
+
+        assert_eq!(capability.language.as_str(), "rust");
+        assert_eq!(capability.parser_status, AstParserStatus::PlannedShadow);
+        assert!(capability.shadow_only);
+        assert!(!capability.changes_default_receipts);
+    }
+}

--- a/crates/tokmd-analysis/src/ast/mod.rs
+++ b/crates/tokmd-analysis/src/ast/mod.rs
@@ -1,0 +1,51 @@
+//! Feature-gated AST foundation.
+//!
+//! This module is intentionally shadow-only. It records the initial capability
+//! and artifact contract from ADR-0008 without changing default receipt
+//! semantics or adding parser dependencies.
+
+mod capability;
+mod rust;
+mod shadow;
+
+pub use capability::{
+    AST_SHADOW_SCHEMA_VERSION, AstCapability, AstLanguage, AstParserStatus, capabilities,
+};
+pub use shadow::{DEFAULT_SHADOW_OUTPUT_DIR, ShadowArtifactSet, default_shadow_artifacts};
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AST_SHADOW_SCHEMA_VERSION, AstLanguage, AstParserStatus, capabilities,
+        default_shadow_artifacts,
+    };
+
+    #[test]
+    fn rust_capability_is_shadow_only_and_not_default_receipts() {
+        let capabilities = capabilities();
+
+        assert_eq!(capabilities.len(), 1);
+        assert_eq!(capabilities[0].language, AstLanguage::Rust);
+        assert_eq!(
+            capabilities[0].parser_status,
+            AstParserStatus::PlannedShadow
+        );
+        assert!(capabilities[0].shadow_only);
+        assert!(!capabilities[0].changes_default_receipts);
+    }
+
+    #[test]
+    fn shadow_artifact_contract_is_stable() {
+        let artifacts = default_shadow_artifacts();
+
+        assert_eq!(artifacts.output_dir, "target/tokmd-ast-shadow");
+        assert_eq!(artifacts.heuristic, "heuristic.json");
+        assert_eq!(artifacts.ast, "ast.json");
+        assert_eq!(artifacts.diff, "diff.json");
+    }
+
+    #[test]
+    fn shadow_schema_name_is_ast_scoped() {
+        assert_eq!(AST_SHADOW_SCHEMA_VERSION, "tokmd.ast_shadow.v1");
+    }
+}

--- a/crates/tokmd-analysis/src/ast/rust.rs
+++ b/crates/tokmd-analysis/src/ast/rust.rs
@@ -1,0 +1,6 @@
+use super::capability::{AstCapability, AstLanguage};
+
+pub const TREE_SITTER_RUST_CRATE: &str = "tree-sitter-rust";
+pub const RUST_CAPABILITY: AstCapability =
+    AstCapability::planned_shadow(AstLanguage::Rust, TREE_SITTER_RUST_CRATE);
+pub static CAPABILITIES: &[AstCapability] = &[RUST_CAPABILITY];

--- a/crates/tokmd-analysis/src/ast/shadow.rs
+++ b/crates/tokmd-analysis/src/ast/shadow.rs
@@ -1,0 +1,36 @@
+pub const DEFAULT_SHADOW_OUTPUT_DIR: &str = "target/tokmd-ast-shadow";
+pub const HEURISTIC_ARTIFACT: &str = "heuristic.json";
+pub const AST_ARTIFACT: &str = "ast.json";
+pub const DIFF_ARTIFACT: &str = "diff.json";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ShadowArtifactSet {
+    pub output_dir: &'static str,
+    pub heuristic: &'static str,
+    pub ast: &'static str,
+    pub diff: &'static str,
+}
+
+pub const DEFAULT_SHADOW_ARTIFACTS: ShadowArtifactSet = ShadowArtifactSet {
+    output_dir: DEFAULT_SHADOW_OUTPUT_DIR,
+    heuristic: HEURISTIC_ARTIFACT,
+    ast: AST_ARTIFACT,
+    diff: DIFF_ARTIFACT,
+};
+
+#[must_use]
+pub const fn default_shadow_artifacts() -> &'static ShadowArtifactSet {
+    &DEFAULT_SHADOW_ARTIFACTS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AST_ARTIFACT, DEFAULT_SHADOW_ARTIFACTS, DIFF_ARTIFACT, HEURISTIC_ARTIFACT};
+
+    #[test]
+    fn artifact_names_match_adr_contract() {
+        assert_eq!(DEFAULT_SHADOW_ARTIFACTS.heuristic, HEURISTIC_ARTIFACT);
+        assert_eq!(DEFAULT_SHADOW_ARTIFACTS.ast, AST_ARTIFACT);
+        assert_eq!(DEFAULT_SHADOW_ARTIFACTS.diff, DIFF_ARTIFACT);
+    }
+}

--- a/crates/tokmd-analysis/src/lib.rs
+++ b/crates/tokmd-analysis/src/lib.rs
@@ -23,6 +23,8 @@ mod api_surface;
 mod archetype;
 #[cfg(feature = "walk")]
 mod assets;
+#[cfg(feature = "ast")]
+pub mod ast;
 mod cocomo81_core;
 #[cfg(all(feature = "content", feature = "walk"))]
 mod complexity;

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -164,6 +164,10 @@ architecture-consolidation program.
 - ADR-0008 now defines the AST foundation as feature-gated, Rust-first, and
   shadow-mode-only until real comparison evidence justifies schema or default
   metric changes.
+- The first `tokmd-analysis` AST scaffold now exists behind the `ast` feature
+  with shadow-only capability metadata, stable shadow artifact names, and a
+  dedicated proof-policy scope. It adds no parser dependency and changes no
+  default receipts.
 
 ## References
 


### PR DESCRIPTION
## Summary
- add a feature-gated `tokmd-analysis::ast` scaffold for ADR-0008
- record Rust AST as planned shadow-only capability metadata with stable shadow artifact names
- add an `analysis_ast_shadow` proof-policy scope and NEXT checkpoint without adding parser dependencies or changing default receipts

## Validation
- `cargo test -p tokmd-analysis --features ast ast --verbose`
- `cargo clippy -p tokmd-analysis --features ast --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd-analysis --all-features feature --verbose`
- `cargo test -p tokmd-analysis --all-features orchestration --verbose`
- `cargo test -p tokmd --test analyze_integration --verbose`
- `cargo xtask boundaries-check`
- `cargo xtask publish-surface --json`
- `cargo deny --all-features check`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_policy --verbose`