### PR TITLE
feat(analysis): parse Rust AST shadow landmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2275,6 +2276,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -2547,6 +2554,8 @@ dependencies = [
  "tokmd-git",
  "tokmd-scan",
  "tokmd-types",
+ "tree-sitter",
+ "tree-sitter-rust",
 ]
 
 [[package]]
@@ -2873,6 +2882,36 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "typenum"

--- a/crates/tokmd-analysis/Cargo.toml
+++ b/crates/tokmd-analysis/Cargo.toml
@@ -31,7 +31,10 @@ effort = []
 fun = []
 topics = []
 archetype = []
-ast = []
+ast = [
+    "dep:tree-sitter",
+    "dep:tree-sitter-rust",
+]
 
 [dependencies]
 anyhow.workspace = true
@@ -40,6 +43,8 @@ serde_json.workspace = true
 globset = { version = "0.4.18", optional = true }
 regex = { version = "1.12.3", optional = true }
 rustc-hash = { version = "2", optional = true }
+tree-sitter = { version = "0.26.8", optional = true }
+tree-sitter-rust = { version = "0.24.2", optional = true }
 
 # Core contracts
 tokmd-analysis-types.workspace = true

--- a/crates/tokmd-analysis/src/ast/capability.rs
+++ b/crates/tokmd-analysis/src/ast/capability.rs
@@ -18,7 +18,7 @@ impl AstLanguage {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AstParserStatus {
-    PlannedShadow,
+    ParserBackedShadow,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -31,11 +31,11 @@ pub struct AstCapability {
 }
 
 impl AstCapability {
-    pub const fn planned_shadow(language: AstLanguage, parser_crate: &'static str) -> Self {
+    pub const fn parser_backed_shadow(language: AstLanguage, parser_crate: &'static str) -> Self {
         Self {
             language,
             parser_crate,
-            parser_status: AstParserStatus::PlannedShadow,
+            parser_status: AstParserStatus::ParserBackedShadow,
             shadow_only: true,
             changes_default_receipts: false,
         }
@@ -52,11 +52,14 @@ mod tests {
     use super::{AstCapability, AstLanguage, AstParserStatus};
 
     #[test]
-    fn planned_shadow_constructor_never_changes_default_receipts() {
-        let capability = AstCapability::planned_shadow(AstLanguage::Rust, "tree-sitter-rust");
+    fn parser_backed_shadow_constructor_never_changes_default_receipts() {
+        let capability = AstCapability::parser_backed_shadow(AstLanguage::Rust, "tree-sitter-rust");
 
         assert_eq!(capability.language.as_str(), "rust");
-        assert_eq!(capability.parser_status, AstParserStatus::PlannedShadow);
+        assert_eq!(
+            capability.parser_status,
+            AstParserStatus::ParserBackedShadow
+        );
         assert!(capability.shadow_only);
         assert!(!capability.changes_default_receipts);
     }

--- a/crates/tokmd-analysis/src/ast/mod.rs
+++ b/crates/tokmd-analysis/src/ast/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is intentionally shadow-only. It records the initial capability
 //! and artifact contract from ADR-0008 without changing default receipt
-//! semantics or adding parser dependencies.
+//! semantics.
 
 mod capability;
 mod rust;
@@ -11,6 +11,7 @@ mod shadow;
 pub use capability::{
     AST_SHADOW_SCHEMA_VERSION, AstCapability, AstLanguage, AstParserStatus, capabilities,
 };
+pub use rust::{RustAstError, RustAstShadow, RustLandmark, RustLandmarkKind, parse_rust_landmarks};
 pub use shadow::{DEFAULT_SHADOW_OUTPUT_DIR, ShadowArtifactSet, default_shadow_artifacts};
 
 #[cfg(test)]
@@ -28,7 +29,7 @@ mod tests {
         assert_eq!(capabilities[0].language, AstLanguage::Rust);
         assert_eq!(
             capabilities[0].parser_status,
-            AstParserStatus::PlannedShadow
+            AstParserStatus::ParserBackedShadow
         );
         assert!(capabilities[0].shadow_only);
         assert!(!capabilities[0].changes_default_receipts);

--- a/crates/tokmd-analysis/src/ast/rust.rs
+++ b/crates/tokmd-analysis/src/ast/rust.rs
@@ -1,6 +1,169 @@
 use super::capability::{AstCapability, AstLanguage};
+use std::error::Error;
+use std::fmt;
+use tree_sitter::{Node, Parser};
 
 pub const TREE_SITTER_RUST_CRATE: &str = "tree-sitter-rust";
 pub const RUST_CAPABILITY: AstCapability =
-    AstCapability::planned_shadow(AstLanguage::Rust, TREE_SITTER_RUST_CRATE);
+    AstCapability::parser_backed_shadow(AstLanguage::Rust, TREE_SITTER_RUST_CRATE);
 pub static CAPABILITIES: &[AstCapability] = &[RUST_CAPABILITY];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RustAstShadow {
+    pub has_error: bool,
+    pub landmarks: Vec<RustLandmark>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RustLandmark {
+    pub kind: RustLandmarkKind,
+    pub name: String,
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum RustLandmarkKind {
+    Function,
+}
+
+#[derive(Debug)]
+pub enum RustAstError {
+    Language(tree_sitter::LanguageError),
+    ParseFailed,
+}
+
+impl fmt::Display for RustAstError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Language(error) => write!(f, "failed to load Rust Tree-sitter language: {error}"),
+            Self::ParseFailed => f.write_str("failed to parse Rust source"),
+        }
+    }
+}
+
+impl Error for RustAstError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Language(error) => Some(error),
+            Self::ParseFailed => None,
+        }
+    }
+}
+
+pub fn parse_rust_landmarks(source: &str) -> Result<RustAstShadow, RustAstError> {
+    let mut parser = Parser::new();
+    let language = tree_sitter_rust::LANGUAGE;
+    parser
+        .set_language(&language.into())
+        .map_err(RustAstError::Language)?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or(RustAstError::ParseFailed)?;
+
+    let mut landmarks = Vec::new();
+    collect_landmarks(tree.root_node(), source.as_bytes(), &mut landmarks);
+    landmarks.sort_by(|left, right| {
+        left.start_byte
+            .cmp(&right.start_byte)
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    Ok(RustAstShadow {
+        has_error: tree.root_node().has_error(),
+        landmarks,
+    })
+}
+
+fn collect_landmarks(node: Node<'_>, source: &[u8], landmarks: &mut Vec<RustLandmark>) {
+    if node.kind() == "function_item"
+        && let Some(name) = function_name(node, source)
+    {
+        let start = node.start_position();
+        let end = node.end_position();
+        landmarks.push(RustLandmark {
+            kind: RustLandmarkKind::Function,
+            name,
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
+            start_line: start.row + 1,
+            end_line: end.row + 1,
+        });
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_landmarks(child, source, landmarks);
+    }
+}
+
+fn function_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    node.child_by_field_name("name")
+        .and_then(|name| name.utf8_text(source).ok())
+        .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RustLandmarkKind, parse_rust_landmarks};
+
+    #[test]
+    fn parses_top_level_and_impl_function_landmarks() {
+        let source = r#"
+fn top_level() {}
+
+impl Widget {
+    pub fn method(&self) {}
+}
+
+async fn compute() {}
+"#;
+
+        let shadow = parse_rust_landmarks(source).expect("Rust source should parse");
+
+        assert!(!shadow.has_error);
+        assert_eq!(
+            shadow
+                .landmarks
+                .iter()
+                .map(|landmark| (landmark.kind, landmark.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (RustLandmarkKind::Function, "top_level"),
+                (RustLandmarkKind::Function, "method"),
+                (RustLandmarkKind::Function, "compute"),
+            ]
+        );
+        assert!(
+            shadow
+                .landmarks
+                .windows(2)
+                .all(|pair| pair[0].start_byte < pair[1].start_byte)
+        );
+    }
+
+    #[test]
+    fn reports_parse_errors_without_dropping_valid_landmarks() {
+        let source = "fn ok() {}\nfn broken(";
+
+        let shadow = parse_rust_landmarks(source).expect("Tree-sitter recovers from syntax errors");
+
+        assert!(shadow.has_error);
+        assert_eq!(shadow.landmarks.len(), 1);
+        assert_eq!(shadow.landmarks[0].name, "ok");
+    }
+
+    #[test]
+    fn records_one_based_line_numbers() {
+        let source = "\n\nfn third_line() {\n}\n";
+
+        let shadow = parse_rust_landmarks(source).expect("Rust source should parse");
+
+        assert_eq!(shadow.landmarks.len(), 1);
+        assert_eq!(shadow.landmarks[0].start_line, 3);
+        assert_eq!(shadow.landmarks[0].end_line, 4);
+    }
+}

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -168,6 +168,10 @@ architecture-consolidation program.
   with shadow-only capability metadata, stable shadow artifact names, and a
   dedicated proof-policy scope. It adds no parser dependency and changes no
   default receipts.
+- The Rust AST shadow scaffold now uses optional `tree-sitter` /
+  `tree-sitter-rust` dependencies behind the `ast` feature to parse
+  deterministic Rust function landmarks. It still emits no default receipt
+  changes and does not expose browser/WASM AST capability.
 
 ## References
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -465,12 +465,14 @@ schema impact, and runtime capability story.
 
 ### Work Items
 
-- [ ] Evaluate Tree-sitter Rust grammar availability, build complexity, and dependency footprint
-- [ ] Add feature-gated `tokmd-analysis::ast` owner module
-- [ ] Parse Rust functions, imports, and simple control-flow landmarks
+- [x] Evaluate Tree-sitter Rust grammar availability and dependency footprint for a first shadow slice
+- [x] Add feature-gated `tokmd-analysis::ast` owner module
+- [x] Parse initial Rust function landmarks
+- [ ] Add Rust import and simple control-flow landmarks
 - [ ] Emit deterministic shadow artifacts under `target/tokmd-ast-shadow/`
 - [ ] Compare heuristic and AST evidence without changing default receipts
-- [ ] Add proof scope coverage and performance benchmarks
+- [x] Add proof scope coverage for AST shadow parsing
+- [ ] Add performance benchmarks
 - [ ] Decide later whether AST-derived public fields need schema changes
 
 ### Tests


### PR DESCRIPTION
## Summary
- add optional `tree-sitter` and `tree-sitter-rust` dependencies behind the `tokmd-analysis` `ast` feature
- parse deterministic Rust function landmarks in the shadow-only AST module, including syntax-error recovery metadata and one-based line numbers
- update AST rollout docs to mark the first parser-backed landmark slice complete while preserving no-default-receipt and no browser/WASM AST capability semantics

## Validation
- `cargo test -p tokmd-analysis --features ast ast --verbose`
- `cargo clippy -p tokmd-analysis --features ast --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo test -p tokmd-analysis --all-features feature --verbose`
- `cargo test -p tokmd-analysis --all-features orchestration --verbose`
- `cargo test -p tokmd --test analyze_integration --verbose`
- `cargo xtask boundaries-check`
- `cargo xtask publish-surface --json`
- `cargo deny --all-features check` (passes with existing duplicate-crate warnings)
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`