### PR TITLE
docs: align analysis ownership guidance

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -617,6 +617,18 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "crate_guidance_docs"
+kind = "non_rust"
+paths = [
+  "crates/*/CLAUDE.md",
+  "crates/*/README.md",
+]
+proof = ["cargo xtask docs --check"]
+reason = "Crate-local README and agent guidance files are contributor-facing architecture surfaces; edits should route to documentation checks instead of appearing as unknown files."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "project_truth_docs"
 kind = "non_rust"
 paths = [

--- a/crates/tokmd-analysis/README.md
+++ b/crates/tokmd-analysis/README.md
@@ -14,7 +14,9 @@ You need one analysis entrypoint that can assemble receipt enrichments without w
 ## Integration notes
 - Default features: `fun`, `topics`, `archetype`, `effort`.
 - Optional features: `git`, `walk`, `content`, `halstead`, `effort`, `fun`, `topics`, `archetype`.
-- Use this crate when you want preset-driven orchestration; use the leaf crates directly when you only need one report.
+- Use this crate when you want preset-driven orchestration or a focused analysis report.
+- Analysis leaf implementations are owner modules inside this crate, not separate public crates to depend on or restore.
+- Rendering analysis receipts belongs in `tokmd-format::analysis`.
 
 ## Go deeper
 - Tutorial: [Tutorial](../../docs/tutorial.md)

--- a/crates/tokmd-format/CLAUDE.md
+++ b/crates/tokmd-format/CLAUDE.md
@@ -93,6 +93,7 @@ When `--meta` is enabled:
 
 - `serde_json`, `csv`, `uuid`, `time`
 - `tokmd-types`
+- `tokmd-analysis-types` for analysis receipt rendering
 
 ## Testing
 
@@ -108,6 +109,6 @@ Tests cover:
 
 ## Do NOT
 
-- Add analysis-specific formatting under `src/analysis/`
+- Add analysis computation or enrichment logic (use `tokmd-analysis`)
 - Add scanning logic
 - Modify JSON schema without updating version


### PR DESCRIPTION
## Summary

- Align `tokmd-analysis` crate README with the current owner-module architecture instead of pointing readers at retired analysis leaf crates.
- Fix `tokmd-format` crate guidance so `src/analysis/` is the analysis rendering home while computation remains in `tokmd-analysis`.
- Add a `crate_guidance_docs` proof-policy scope so crate-local `README.md` and `CLAUDE.md` edits route to docs checks instead of becoming unknown files.

Closes #1298.
Closes #1299.

## Validation

- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`