### PR TITLE
refactor(types): remove clap from contract crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,7 +2780,6 @@ dependencies = [
 name = "tokmd-types"
 version = "1.10.0"
 dependencies = [
- "clap",
  "insta",
  "proptest",
  "serde",

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -45,11 +45,13 @@ paths = [
   "Cargo.lock",
   "Cargo.toml",
   "crates/**/Cargo.toml",
+  "crates/tokmd-types/tests/manifest_contract.rs",
   "xtask/Cargo.toml",
 ]
 packages = ["xtask"]
 proof = [
   "cargo deny --all-features check",
+  "cargo test -p tokmd-types manifest_stays_clap_free --verbose",
   "cargo xtask boundaries-check",
   "cargo xtask publish-surface --json",
 ]

--- a/crates/tokmd-types/CLAUDE.md
+++ b/crates/tokmd-types/CLAUDE.md
@@ -58,7 +58,7 @@ This version applies to core receipts: `lang`, `module`, `export`, `diff`, `cont
 ## Dependencies
 
 - `serde` with derive feature (serialization)
-- Optional `clap` feature for shared CLI enum parsing
+- No CLI parser dependencies; `tokmd::cli` owns Clap-facing adapters for these contract types
 
 ## Testing
 

--- a/crates/tokmd-types/Cargo.toml
+++ b/crates/tokmd-types/Cargo.toml
@@ -11,12 +11,8 @@ keywords = ["code-analysis", "types", "receipts", "schema", "serde"]
 categories = ["development-tools", "data-structures"]
 documentation = "https://docs.rs/tokmd-types"
 
-[features]
-clap = ["dep:clap"]
-
 [dependencies]
 serde.workspace = true
-clap = { version = "4.6.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/tokmd-types/README.md
+++ b/crates/tokmd-types/README.md
@@ -13,7 +13,7 @@ Receipts, rows, and enums need one stable serde contract without pulling in CLI 
 
 ## API / usage notes
 - Use this crate for serde-compatible receipt payloads and report rows.
-- Enable the `clap` feature only if you need derive support for the exported enums.
+- CLI parsing lives in `tokmd::cli`; this contract crate intentionally stays `clap`-free.
 - `src/lib.rs` is the source of truth for field names, schema versions, and wrapper shapes.
 
 ## Go deeper

--- a/crates/tokmd-types/src/lib.rs
+++ b/crates/tokmd-types/src/lib.rs
@@ -587,7 +587,6 @@ pub struct DiffReceipt {
 // -----------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum TableFormat {
     /// Markdown table (great for pasting into ChatGPT).
@@ -599,7 +598,6 @@ pub enum TableFormat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum ExportFormat {
     /// CSV with a header row.
@@ -613,7 +611,6 @@ pub enum ExportFormat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum ConfigMode {
     /// Read scan config files (`tokei.toml` / `.tokeirc`) if present.
@@ -624,7 +621,6 @@ pub enum ConfigMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum ChildrenMode {
     /// Merge embedded content into the parent language totals.
@@ -634,7 +630,6 @@ pub enum ChildrenMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum ChildIncludeMode {
     /// Include embedded languages as separate contributions.
@@ -644,7 +639,6 @@ pub enum ChildIncludeMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum RedactMode {
     /// Do not redact.
@@ -656,7 +650,6 @@ pub enum RedactMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum AnalysisFormat {
     Md,

--- a/crates/tokmd-types/tests/manifest_contract.rs
+++ b/crates/tokmd-types/tests/manifest_contract.rs
@@ -1,0 +1,19 @@
+#[test]
+fn manifest_stays_clap_free() {
+    let manifest = include_str!("../Cargo.toml");
+
+    for line in manifest.lines().map(str::trim) {
+        assert_ne!(
+            line, r#"clap = ["dep:clap"]"#,
+            "tokmd-types must not expose a clap feature"
+        );
+        assert!(
+            !line.starts_with("clap ") && !line.starts_with("clap."),
+            "tokmd-types must not declare a clap dependency"
+        );
+        assert!(
+            !line.starts_with("clap="),
+            "tokmd-types must not declare a clap dependency"
+        );
+    }
+}

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -65,7 +65,7 @@ tokmd-settings.workspace = true
 
 tokmd-core.workspace = true
 tokmd-format.workspace = true
-tokmd-types = { workspace = true, features = ["clap"] }
+tokmd-types.workspace = true
 tokmd-cockpit = { workspace = true, optional = true }
 tokmd-git = { workspace = true, optional = true }
 clap_complete = "4.6.3"

--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -19,10 +19,234 @@ use std::path::PathBuf;
 pub use crate::tool_schema::ToolSchemaFormat;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
-pub use tokmd_types::{
-    AnalysisFormat, ChildIncludeMode, ChildrenMode, ConfigMode, ExportFormat, RedactMode,
-    TableFormat,
-};
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TableFormat {
+    /// Markdown table (great for pasting into ChatGPT).
+    Md,
+    /// Tab-separated values (good for piping to other tools).
+    Tsv,
+    /// JSON (compact).
+    Json,
+}
+
+impl From<TableFormat> for tokmd_types::TableFormat {
+    fn from(value: TableFormat) -> Self {
+        match value {
+            TableFormat::Md => Self::Md,
+            TableFormat::Tsv => Self::Tsv,
+            TableFormat::Json => Self::Json,
+        }
+    }
+}
+
+impl From<tokmd_types::TableFormat> for TableFormat {
+    fn from(value: tokmd_types::TableFormat) -> Self {
+        match value {
+            tokmd_types::TableFormat::Md => Self::Md,
+            tokmd_types::TableFormat::Tsv => Self::Tsv,
+            tokmd_types::TableFormat::Json => Self::Json,
+        }
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExportFormat {
+    /// CSV with a header row.
+    Csv,
+    /// One JSON object per line.
+    Jsonl,
+    /// A single JSON array.
+    Json,
+    /// CycloneDX 1.6 JSON SBOM format.
+    Cyclonedx,
+}
+
+impl From<ExportFormat> for tokmd_types::ExportFormat {
+    fn from(value: ExportFormat) -> Self {
+        match value {
+            ExportFormat::Csv => Self::Csv,
+            ExportFormat::Jsonl => Self::Jsonl,
+            ExportFormat::Json => Self::Json,
+            ExportFormat::Cyclonedx => Self::Cyclonedx,
+        }
+    }
+}
+
+impl From<tokmd_types::ExportFormat> for ExportFormat {
+    fn from(value: tokmd_types::ExportFormat) -> Self {
+        match value {
+            tokmd_types::ExportFormat::Csv => Self::Csv,
+            tokmd_types::ExportFormat::Jsonl => Self::Jsonl,
+            tokmd_types::ExportFormat::Json => Self::Json,
+            tokmd_types::ExportFormat::Cyclonedx => Self::Cyclonedx,
+        }
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConfigMode {
+    /// Read scan config files (`tokei.toml` / `.tokeirc`) if present.
+    #[default]
+    Auto,
+    /// Ignore config files.
+    None,
+}
+
+impl From<ConfigMode> for tokmd_types::ConfigMode {
+    fn from(value: ConfigMode) -> Self {
+        match value {
+            ConfigMode::Auto => Self::Auto,
+            ConfigMode::None => Self::None,
+        }
+    }
+}
+
+impl From<tokmd_types::ConfigMode> for ConfigMode {
+    fn from(value: tokmd_types::ConfigMode) -> Self {
+        match value {
+            tokmd_types::ConfigMode::Auto => Self::Auto,
+            tokmd_types::ConfigMode::None => Self::None,
+        }
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChildrenMode {
+    /// Merge embedded content into the parent language totals.
+    Collapse,
+    /// Show embedded languages as separate "(embedded)" rows.
+    Separate,
+}
+
+impl From<ChildrenMode> for tokmd_types::ChildrenMode {
+    fn from(value: ChildrenMode) -> Self {
+        match value {
+            ChildrenMode::Collapse => Self::Collapse,
+            ChildrenMode::Separate => Self::Separate,
+        }
+    }
+}
+
+impl From<tokmd_types::ChildrenMode> for ChildrenMode {
+    fn from(value: tokmd_types::ChildrenMode) -> Self {
+        match value {
+            tokmd_types::ChildrenMode::Collapse => Self::Collapse,
+            tokmd_types::ChildrenMode::Separate => Self::Separate,
+        }
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChildIncludeMode {
+    /// Include embedded languages as separate contributions.
+    Separate,
+    /// Ignore embedded languages.
+    ParentsOnly,
+}
+
+impl From<ChildIncludeMode> for tokmd_types::ChildIncludeMode {
+    fn from(value: ChildIncludeMode) -> Self {
+        match value {
+            ChildIncludeMode::Separate => Self::Separate,
+            ChildIncludeMode::ParentsOnly => Self::ParentsOnly,
+        }
+    }
+}
+
+impl From<tokmd_types::ChildIncludeMode> for ChildIncludeMode {
+    fn from(value: tokmd_types::ChildIncludeMode) -> Self {
+        match value {
+            tokmd_types::ChildIncludeMode::Separate => Self::Separate,
+            tokmd_types::ChildIncludeMode::ParentsOnly => Self::ParentsOnly,
+        }
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RedactMode {
+    /// Do not redact.
+    None,
+    /// Redact file paths.
+    Paths,
+    /// Redact file paths and module names.
+    All,
+}
+
+impl From<RedactMode> for tokmd_types::RedactMode {
+    fn from(value: RedactMode) -> Self {
+        match value {
+            RedactMode::None => Self::None,
+            RedactMode::Paths => Self::Paths,
+            RedactMode::All => Self::All,
+        }
+    }
+}
+
+impl From<tokmd_types::RedactMode> for RedactMode {
+    fn from(value: tokmd_types::RedactMode) -> Self {
+        match value {
+            tokmd_types::RedactMode::None => Self::None,
+            tokmd_types::RedactMode::Paths => Self::Paths,
+            tokmd_types::RedactMode::All => Self::All,
+        }
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AnalysisFormat {
+    Md,
+    Json,
+    Jsonld,
+    Xml,
+    Svg,
+    Mermaid,
+    Obj,
+    Midi,
+    Tree,
+    Html,
+}
+
+impl From<AnalysisFormat> for tokmd_types::AnalysisFormat {
+    fn from(value: AnalysisFormat) -> Self {
+        match value {
+            AnalysisFormat::Md => Self::Md,
+            AnalysisFormat::Json => Self::Json,
+            AnalysisFormat::Jsonld => Self::Jsonld,
+            AnalysisFormat::Xml => Self::Xml,
+            AnalysisFormat::Svg => Self::Svg,
+            AnalysisFormat::Mermaid => Self::Mermaid,
+            AnalysisFormat::Obj => Self::Obj,
+            AnalysisFormat::Midi => Self::Midi,
+            AnalysisFormat::Tree => Self::Tree,
+            AnalysisFormat::Html => Self::Html,
+        }
+    }
+}
+
+impl From<tokmd_types::AnalysisFormat> for AnalysisFormat {
+    fn from(value: tokmd_types::AnalysisFormat) -> Self {
+        match value {
+            tokmd_types::AnalysisFormat::Md => Self::Md,
+            tokmd_types::AnalysisFormat::Json => Self::Json,
+            tokmd_types::AnalysisFormat::Jsonld => Self::Jsonld,
+            tokmd_types::AnalysisFormat::Xml => Self::Xml,
+            tokmd_types::AnalysisFormat::Svg => Self::Svg,
+            tokmd_types::AnalysisFormat::Mermaid => Self::Mermaid,
+            tokmd_types::AnalysisFormat::Obj => Self::Obj,
+            tokmd_types::AnalysisFormat::Midi => Self::Midi,
+            tokmd_types::AnalysisFormat::Tree => Self::Tree,
+            tokmd_types::AnalysisFormat::Html => Self::Html,
+        }
+    }
+}
 
 /// tokmd — code awareness for AI contexts
 ///
@@ -1014,7 +1238,7 @@ impl From<&GlobalArgs> for tokmd_settings::ScanOptions {
     fn from(g: &GlobalArgs) -> Self {
         Self {
             excluded: g.excluded.clone(),
-            config: g.config,
+            config: g.config.into(),
             hidden: g.hidden,
             no_ignore: g.no_ignore,
             no_ignore_parent: g.no_ignore_parent,
@@ -1234,7 +1458,7 @@ mod tests {
             Profile {
                 format: Some("json".into()),
                 top: Some(10),
-                redact: Some(RedactMode::All),
+                redact: Some(tokmd_types::RedactMode::All),
                 ..Profile::default()
             },
         );
@@ -1264,7 +1488,7 @@ mod tests {
         };
         let opts: tokmd_settings::ScanOptions = (&g).into();
         assert_eq!(opts.excluded, vec!["target"]);
-        assert_eq!(opts.config, ConfigMode::None);
+        assert_eq!(opts.config, tokmd_types::ConfigMode::None);
         assert!(opts.hidden);
         assert!(opts.no_ignore);
         assert!(opts.treat_doc_strings_as_comments);

--- a/crates/tokmd/src/commands/analyze.rs
+++ b/crates/tokmd/src/commands/analyze.rs
@@ -30,7 +30,10 @@ pub(crate) fn handle(args: cli::CliAnalyzeArgs, global: &cli::GlobalArgs) -> Res
     let progress = Progress::new(!global.no_progress);
 
     let preset = args.preset.unwrap_or(cli::AnalysisPreset::Receipt);
-    let format = args.format.unwrap_or(tokmd_types::AnalysisFormat::Md);
+    let format = args
+        .format
+        .map(Into::into)
+        .unwrap_or(tokmd_types::AnalysisFormat::Md);
     let git_flag = if args.git {
         Some(true)
     } else if args.no_git {

--- a/crates/tokmd/src/commands/run.rs
+++ b/crates/tokmd/src/commands/run.rs
@@ -65,7 +65,10 @@ pub(crate) fn handle(args: cli::RunArgs, global: &cli::GlobalArgs) -> Result<()>
     );
 
     // Get redact mode - applies to scan args in all receipts (lang.json, module.json, export.jsonl)
-    let redact_mode = args.redact.unwrap_or(tokmd_types::RedactMode::None);
+    let redact_mode = args
+        .redact
+        .map(Into::into)
+        .unwrap_or(tokmd_types::RedactMode::None);
     let scan_args = format::scan_args(&args.paths, &scan_opts, Some(redact_mode));
 
     // 4. Write artifacts using tokmd-format for consistency

--- a/crates/tokmd/src/config.rs
+++ b/crates/tokmd/src/config.rs
@@ -4,6 +4,36 @@ use crate::cli;
 use clap::ValueEnum;
 use tokmd_settings::{Profile, TomlConfig, UserConfig, ViewProfile};
 
+fn parse_table_format(value: Option<&str>) -> Option<tokmd_types::TableFormat> {
+    value
+        .and_then(|s| cli::TableFormat::from_str(s, true).ok())
+        .map(Into::into)
+}
+
+fn parse_children_mode(value: Option<&str>) -> Option<tokmd_types::ChildrenMode> {
+    value
+        .and_then(|s| cli::ChildrenMode::from_str(s, true).ok())
+        .map(Into::into)
+}
+
+fn parse_child_include_mode(value: Option<&str>) -> Option<tokmd_types::ChildIncludeMode> {
+    value
+        .and_then(|s| cli::ChildIncludeMode::from_str(s, true).ok())
+        .map(Into::into)
+}
+
+fn parse_export_format(value: Option<&str>) -> Option<tokmd_types::ExportFormat> {
+    value
+        .and_then(|s| cli::ExportFormat::from_str(s, true).ok())
+        .map(Into::into)
+}
+
+fn parse_redact_mode(value: Option<&str>) -> Option<tokmd_types::RedactMode> {
+    value
+        .and_then(|s| cli::RedactMode::from_str(s, true).ok())
+        .map(Into::into)
+}
+
 /// Configuration context combining TOML config, JSON config, and resolved profile.
 ///
 /// # Example
@@ -347,12 +377,9 @@ pub fn resolve_lang(
             .unwrap_or_else(|| vec![PathBuf::from(".")]),
         format: cli_args
             .format
-            .or_else(|| {
-                profile
-                    .and_then(|p| p.format.as_deref())
-                    .and_then(|s| cli::TableFormat::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::TableFormat::Md),
+            .map(Into::into)
+            .or_else(|| parse_table_format(profile.and_then(|p| p.format.as_deref())))
+            .unwrap_or(tokmd_types::TableFormat::Md),
         top: cli_args
             .top
             .or_else(|| profile.and_then(|p| p.top))
@@ -360,12 +387,9 @@ pub fn resolve_lang(
         files: cli_args.files || profile.and_then(|p| p.files).unwrap_or(false),
         children: cli_args
             .children
-            .or_else(|| {
-                profile
-                    .and_then(|p| p.children.as_deref())
-                    .and_then(|s| cli::ChildrenMode::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ChildrenMode::Collapse),
+            .map(Into::into)
+            .or_else(|| parse_children_mode(profile.and_then(|p| p.children.as_deref())))
+            .unwrap_or(tokmd_types::ChildrenMode::Collapse),
     }
 }
 
@@ -420,22 +444,16 @@ pub fn resolve_lang_with_config(
             .unwrap_or_else(|| vec![PathBuf::from(".")]),
         format: cli_args
             .format
-            .or_else(|| {
-                resolved
-                    .format()
-                    .and_then(|s| cli::TableFormat::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::TableFormat::Md),
+            .map(Into::into)
+            .or_else(|| parse_table_format(resolved.format()))
+            .unwrap_or(tokmd_types::TableFormat::Md),
         top: cli_args.top.or(resolved.top()).unwrap_or(0),
         files: cli_args.files || resolved.files().unwrap_or(false),
         children: cli_args
             .children
-            .or_else(|| {
-                resolved
-                    .children()
-                    .and_then(|s| cli::ChildrenMode::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ChildrenMode::Collapse),
+            .map(Into::into)
+            .or_else(|| parse_children_mode(resolved.children()))
+            .unwrap_or(tokmd_types::ChildrenMode::Collapse),
     }
 }
 
@@ -477,12 +495,9 @@ pub fn resolve_module(
             .unwrap_or_else(|| vec![PathBuf::from(".")]),
         format: cli_args
             .format
-            .or_else(|| {
-                profile
-                    .and_then(|p| p.format.as_deref())
-                    .and_then(|s| cli::TableFormat::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::TableFormat::Md),
+            .map(Into::into)
+            .or_else(|| parse_table_format(profile.and_then(|p| p.format.as_deref())))
+            .unwrap_or(tokmd_types::TableFormat::Md),
         top: cli_args
             .top
             .or_else(|| profile.and_then(|p| p.top))
@@ -498,12 +513,9 @@ pub fn resolve_module(
             .unwrap_or(2),
         children: cli_args
             .children
-            .or_else(|| {
-                profile
-                    .and_then(|p| p.children.as_deref())
-                    .and_then(|s| cli::ChildIncludeMode::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ChildIncludeMode::Separate),
+            .map(Into::into)
+            .or_else(|| parse_child_include_mode(profile.and_then(|p| p.children.as_deref())))
+            .unwrap_or(tokmd_types::ChildIncludeMode::Separate),
     }
 }
 
@@ -564,12 +576,9 @@ pub fn resolve_module_with_config(
             .unwrap_or_else(|| vec![PathBuf::from(".")]),
         format: cli_args
             .format
-            .or_else(|| {
-                resolved
-                    .format()
-                    .and_then(|s| cli::TableFormat::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::TableFormat::Md),
+            .map(Into::into)
+            .or_else(|| parse_table_format(resolved.format()))
+            .unwrap_or(tokmd_types::TableFormat::Md),
         top: cli_args.top.or(resolved.top()).unwrap_or(0),
         module_roots: cli_args
             .module_roots
@@ -582,12 +591,9 @@ pub fn resolve_module_with_config(
             .unwrap_or(2),
         children: cli_args
             .children
-            .or_else(|| {
-                resolved
-                    .children()
-                    .and_then(|s| cli::ChildIncludeMode::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ChildIncludeMode::Separate),
+            .map(Into::into)
+            .or_else(|| parse_child_include_mode(resolved.children()))
+            .unwrap_or(tokmd_types::ChildIncludeMode::Separate),
     }
 }
 
@@ -630,12 +636,9 @@ pub fn resolve_export(
             .unwrap_or_else(|| vec![PathBuf::from(".")]),
         format: cli_args
             .format
-            .or_else(|| {
-                profile
-                    .and_then(|p| p.format.as_deref())
-                    .and_then(|s| cli::ExportFormat::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ExportFormat::Jsonl),
+            .map(Into::into)
+            .or_else(|| parse_export_format(profile.and_then(|p| p.format.as_deref())))
+            .unwrap_or(tokmd_types::ExportFormat::Jsonl),
         output: cli_args.output.clone(),
         module_roots: cli_args
             .module_roots
@@ -648,12 +651,9 @@ pub fn resolve_export(
             .unwrap_or(2),
         children: cli_args
             .children
-            .or_else(|| {
-                profile
-                    .and_then(|p| p.children.as_deref())
-                    .and_then(|s| cli::ChildIncludeMode::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ChildIncludeMode::Separate),
+            .map(Into::into)
+            .or_else(|| parse_child_include_mode(profile.and_then(|p| p.children.as_deref())))
+            .unwrap_or(tokmd_types::ChildIncludeMode::Separate),
         min_code: cli_args
             .min_code
             .or(profile.and_then(|p| p.min_code))
@@ -664,8 +664,9 @@ pub fn resolve_export(
             .unwrap_or(0),
         redact: cli_args
             .redact
+            .map(Into::into)
             .or(profile.and_then(|p| p.redact))
-            .unwrap_or(cli::RedactMode::None),
+            .unwrap_or(tokmd_types::RedactMode::None),
         meta: cli_args
             .meta
             .or(profile.and_then(|p| p.meta))
@@ -679,8 +680,9 @@ pub fn resolve_export(
 /// # Examples
 ///
 /// ```
-/// use tokmd::cli::{CliExportArgs, ExportFormat};
 /// use tokmd::{resolve_export_with_config, ConfigContext};
+/// use tokmd::cli::CliExportArgs;
+/// use tokmd_types::ExportFormat;
 /// use tokmd_settings::{TomlConfig, ExportConfig};
 ///
 /// // Create config with specific export format
@@ -712,7 +714,7 @@ pub fn resolve_export(
 /// // CLI arg overrides config
 /// let cli_args_override = CliExportArgs {
 ///     paths: None,
-///     format: Some(ExportFormat::Jsonl),
+///     format: Some(tokmd::cli::ExportFormat::Jsonl),
 ///     output: None,
 ///     module_roots: None,
 ///     module_depth: None,
@@ -737,18 +739,10 @@ pub fn resolve_export_with_config(
             .unwrap_or_else(|| vec![PathBuf::from(".")]),
         format: cli_args
             .format
-            .or_else(|| {
-                resolved
-                    .format()
-                    .and_then(|s| cli::ExportFormat::from_str(s, true).ok())
-            })
-            .or_else(|| {
-                resolved
-                    .toml
-                    .and_then(|t| t.export.format.as_deref())
-                    .and_then(|s| cli::ExportFormat::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ExportFormat::Jsonl),
+            .map(Into::into)
+            .or_else(|| parse_export_format(resolved.format()))
+            .or_else(|| parse_export_format(resolved.toml.and_then(|t| t.export.format.as_deref())))
+            .unwrap_or(tokmd_types::ExportFormat::Jsonl),
         output: cli_args.output.clone(),
         module_roots: cli_args
             .module_roots
@@ -761,28 +755,19 @@ pub fn resolve_export_with_config(
             .unwrap_or(2),
         children: cli_args
             .children
+            .map(Into::into)
+            .or_else(|| parse_child_include_mode(resolved.children()))
             .or_else(|| {
-                resolved
-                    .children()
-                    .and_then(|s| cli::ChildIncludeMode::from_str(s, true).ok())
+                parse_child_include_mode(resolved.toml.and_then(|t| t.export.children.as_deref()))
             })
-            .or_else(|| {
-                resolved
-                    .toml
-                    .and_then(|t| t.export.children.as_deref())
-                    .and_then(|s| cli::ChildIncludeMode::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::ChildIncludeMode::Separate),
+            .unwrap_or(tokmd_types::ChildIncludeMode::Separate),
         min_code: cli_args.min_code.or(resolved.min_code()).unwrap_or(0),
         max_rows: cli_args.max_rows.or(resolved.max_rows()).unwrap_or(0),
         redact: cli_args
             .redact
-            .or_else(|| {
-                resolved
-                    .redact()
-                    .and_then(|s| cli::RedactMode::from_str(s, true).ok())
-            })
-            .unwrap_or(cli::RedactMode::None),
+            .map(Into::into)
+            .or_else(|| parse_redact_mode(resolved.redact()))
+            .unwrap_or(tokmd_types::RedactMode::None),
         meta: cli_args.meta.or(resolved.meta()).unwrap_or(true),
         strip_prefix: cli_args.strip_prefix.clone(),
     }

--- a/crates/tokmd/tests/config_resolution.rs
+++ b/crates/tokmd/tests/config_resolution.rs
@@ -1,6 +1,7 @@
-use tokmd::cli::{CliLangArgs, TableFormat};
+use tokmd::cli::{CliLangArgs, TableFormat as CliTableFormat};
 use tokmd::resolve_lang;
 use tokmd_settings::Profile;
+use tokmd_types::TableFormat;
 
 #[test]
 fn test_resolve_lang_no_args_no_profile() {
@@ -20,7 +21,7 @@ fn test_resolve_lang_no_args_no_profile() {
 fn test_resolve_lang_cli_overrides_profile() {
     let cli = CliLangArgs {
         top: Some(50),
-        format: Some(TableFormat::Json),
+        format: Some(CliTableFormat::Json),
         ..Default::default()
     };
 
@@ -76,11 +77,12 @@ fn test_resolve_lang_partial_overrides() {
 
 #[test]
 fn test_resolve_export_cli_overrides_profile() {
-    use tokmd::cli::{CliExportArgs, ExportFormat};
+    use tokmd::cli::{CliExportArgs, ExportFormat as CliExportFormat};
     use tokmd::resolve_export;
+    use tokmd_types::ExportFormat;
 
     let cli = CliExportArgs {
-        format: Some(ExportFormat::Csv),
+        format: Some(CliExportFormat::Csv),
         min_code: Some(50),
         paths: None,
         output: None,
@@ -133,12 +135,12 @@ fn test_resolve_module_profile_overrides_default() {
 
 #[test]
 fn test_resolve_module_cli_overrides_profile_scalars() {
-    use tokmd::cli::{CliModuleArgs, TableFormat};
+    use tokmd::cli::CliModuleArgs;
     use tokmd::resolve_module;
 
     let cli = CliModuleArgs {
         paths: None,
-        format: Some(TableFormat::Tsv),
+        format: Some(CliTableFormat::Tsv),
         top: Some(100),
         module_roots: None,
         module_depth: None,
@@ -159,12 +161,13 @@ fn test_resolve_module_cli_overrides_profile_scalars() {
 
 #[test]
 fn test_resolve_export_with_config() {
-    use tokmd::cli::{CliExportArgs, ExportFormat};
+    use tokmd::cli::{CliExportArgs, ExportFormat as CliExportFormat};
     use tokmd::{ResolvedConfig, resolve_export_with_config};
     use tokmd_settings::{ExportConfig, TomlConfig};
+    use tokmd_types::ExportFormat;
 
     let cli = CliExportArgs {
-        format: Some(ExportFormat::Csv),
+        format: Some(CliExportFormat::Csv),
         min_code: None,
         paths: None,
         output: None,
@@ -197,8 +200,9 @@ fn test_resolve_export_with_config() {
 
 #[test]
 fn test_resolve_export_profile_overrides_default_format() {
-    use tokmd::cli::{CliExportArgs, ExportFormat};
+    use tokmd::cli::CliExportArgs;
     use tokmd::resolve_export;
+    use tokmd_types::ExportFormat;
 
     let cli = CliExportArgs {
         paths: None,
@@ -260,8 +264,9 @@ fn test_resolve_module_with_config() {
 
 #[test]
 fn test_resolve_export_no_args_no_profile() {
-    use tokmd::cli::{CliExportArgs, ExportFormat};
+    use tokmd::cli::CliExportArgs;
     use tokmd::resolve_export;
+    use tokmd_types::ExportFormat;
 
     let cli = CliExportArgs {
         paths: None,
@@ -306,7 +311,7 @@ fn test_resolve_module_no_args_no_profile() {
     let resolved = resolve_module(&cli, None);
 
     assert_eq!(resolved.paths[0].to_string_lossy(), ".");
-    assert_eq!(resolved.format, tokmd::cli::TableFormat::Md);
+    assert_eq!(resolved.format, TableFormat::Md);
     assert_eq!(resolved.top, 0);
     assert_eq!(
         resolved.module_roots,


### PR DESCRIPTION
## Summary
- remove the optional `clap` feature/dependency from `tokmd-types` and its lockfile entry
- add CLI-local `ValueEnum` adapter enums in `tokmd::cli` that convert to/from the pure `tokmd_types` contract enums
- add a `tokmd-types` manifest regression test and route it through the proof policy dependency-graph scope

This keeps CLI parsing ownership in `tokmd` while preserving receipt/config enum spellings and JSON schema behavior.

Closes #994.
Closes #982.

## Validation
- `cargo check -p tokmd-types --all-targets`
- `cargo check -p tokmd --all-targets`
- `cargo test -p tokmd-types manifest_stays_clap_free --verbose`
- `cargo test -p tokmd --test config_resolution --verbose`
- `cargo test -p tokmd --test cli_snapshot_golden --verbose`
- `cargo test -p tokmd --test cli_e2e --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo test -p tokmd --test schema_doc_sync --verbose`
- `cargo test -p tokmd-types --all-features`
- `cargo clippy -p tokmd-types --all-targets -- -D warnings`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask boundaries-check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo deny --all-features check`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo tree -p tokmd-types -e normal,features`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`