### PR TITLE
fix(cockpit): delegate Rust complexity analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "time",
+ "tokmd-analysis",
  "tokmd-analysis-types",
  "tokmd-envelope",
  "tokmd-git",

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -268,6 +268,7 @@ kind = "rust"
 paths = [
   "crates/tokmd-analysis/src/complexity/**",
   "crates/tokmd-analysis/src/content/complexity.rs",
+  "crates/tokmd-analysis/src/source_complexity.rs",
 ]
 packages = ["tokmd-analysis"]
 proof = ["cargo test -p tokmd-analysis --all-features complexity --verbose"]

--- a/crates/tokmd-analysis/src/lib.rs
+++ b/crates/tokmd-analysis/src/lib.rs
@@ -52,6 +52,7 @@ mod license;
 mod maintainability;
 #[cfg(feature = "content")]
 mod near_dup;
+pub mod source_complexity;
 #[cfg(feature = "topics")]
 mod topics;
 mod util;

--- a/crates/tokmd-analysis/src/source_complexity.rs
+++ b/crates/tokmd-analysis/src/source_complexity.rs
@@ -1,0 +1,384 @@
+//! Source-level complexity helpers shared by review-oriented surfaces.
+//!
+//! These helpers are intentionally lightweight and heuristic. They preserve
+//! function-scoped Rust complexity for cockpit review gates without pulling in
+//! the full analysis preset pipeline or changing receipt schemas.
+
+/// Summary of function-scoped Rust complexity for one source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RustFunctionComplexitySummary {
+    /// Total cyclomatic complexity across all detected functions.
+    pub total_complexity: u32,
+    /// Maximum complexity of any single detected function.
+    pub max_complexity: u32,
+    /// Number of functions detected in the source file.
+    pub function_count: usize,
+    /// Maximum detected function length in lines.
+    pub max_function_length: usize,
+}
+
+/// Testable source analyzer seam for review and gate callers.
+pub trait SourceAnalyzer {
+    /// Analyze function-scoped Rust complexity for one source file.
+    fn analyze_rust(&self, content: &str) -> RustFunctionComplexitySummary;
+}
+
+/// Heuristic Rust analyzer used by cockpit review gates.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RustAnalyzer;
+
+impl SourceAnalyzer for RustAnalyzer {
+    fn analyze_rust(&self, content: &str) -> RustFunctionComplexitySummary {
+        analyze_rust_function_complexity(content)
+    }
+}
+
+/// Analyze function-scoped cyclomatic complexity of Rust source code.
+///
+/// The keyword list intentionally omits `else if`: an `else if` branch already
+/// contains `if`, and counting both terms double-counts a single decision.
+pub fn analyze_rust_function_complexity(content: &str) -> RustFunctionComplexitySummary {
+    let mut total_complexity: u32 = 0;
+    let mut max_complexity: u32 = 0;
+    let mut function_count: usize = 0;
+    let mut max_function_length: usize = 0;
+
+    let mut in_function = false;
+    let mut brace_depth: i32 = 0;
+    let mut function_brace_depth: i32 = 0;
+    let mut function_start_line: usize = 0;
+    let mut current_complexity: u32 = 1;
+    let mut mask = RustCodeMask::default();
+
+    for (line_idx, line) in content.lines().enumerate() {
+        let code_line = mask.code_only_line(line);
+        let trimmed = code_line.trim();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let is_fn_start = !in_function && is_rust_fn_start(trimmed);
+
+        if is_fn_start {
+            in_function = true;
+            function_start_line = line_idx;
+            function_brace_depth = brace_depth;
+            current_complexity = 1;
+        }
+
+        for c in code_line.chars() {
+            if c == '{' {
+                brace_depth += 1;
+            } else if c == '}' {
+                brace_depth -= 1;
+                if in_function && brace_depth == function_brace_depth {
+                    let function_length = line_idx - function_start_line + 1;
+                    max_function_length = max_function_length.max(function_length);
+                    total_complexity += current_complexity;
+                    max_complexity = max_complexity.max(current_complexity);
+                    function_count += 1;
+                    in_function = false;
+                    current_complexity = 1;
+                }
+            }
+        }
+
+        if in_function {
+            for kw in ["if ", "while ", "for ", "loop ", "match ", "&&", "||", "?"] {
+                let mut search_line = trimmed;
+                while let Some(pos) = search_line.find(kw) {
+                    current_complexity += 1;
+                    search_line = &search_line[pos + kw.len()..];
+                }
+            }
+
+            current_complexity += trimmed.matches("=>").count() as u32;
+        }
+    }
+
+    if in_function {
+        function_count += 1;
+        total_complexity += current_complexity;
+        max_complexity = max_complexity.max(current_complexity);
+    }
+
+    RustFunctionComplexitySummary {
+        total_complexity,
+        max_complexity,
+        function_count,
+        max_function_length,
+    }
+}
+
+fn is_rust_fn_start(trimmed: &str) -> bool {
+    let Some(fn_pos) = trimmed.find("fn ") else {
+        return false;
+    };
+
+    let mut rest = trimmed[..fn_pos].trim();
+    if rest.is_empty() {
+        return true;
+    }
+
+    while !rest.is_empty() {
+        rest = rest.trim_start();
+        if rest.is_empty() {
+            break;
+        }
+        if rest.starts_with("pub(") {
+            let Some(close) = rest.find(')') else {
+                return false;
+            };
+            rest = &rest[close + 1..];
+        } else if let Some(next) = rest.strip_prefix("pub") {
+            rest = next;
+        } else if let Some(next) = rest.strip_prefix("async") {
+            rest = next;
+        } else if let Some(next) = rest.strip_prefix("unsafe") {
+            rest = next;
+        } else if let Some(next) = rest.strip_prefix("const") {
+            rest = next;
+        } else if rest.starts_with("extern") {
+            rest = rest["extern".len()..].trim_start();
+            if rest.starts_with('"') {
+                let Some(close) = rest[1..].find('"') else {
+                    return false;
+                };
+                rest = &rest[close + 2..];
+            }
+        } else {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Masks Rust source spans that should not contribute to complexity.
+#[derive(Default)]
+struct RustCodeMask {
+    in_string: bool,
+    in_char: bool,
+    block_comment_depth: usize,
+    raw_string_hashes: Option<usize>,
+}
+
+impl RustCodeMask {
+    fn code_only_line(&mut self, line: &str) -> String {
+        let chars: Vec<char> = line.chars().collect();
+        let mut code = String::with_capacity(line.len());
+        let mut i = 0;
+
+        while i < chars.len() {
+            if let Some(hashes) = self.raw_string_hashes {
+                if raw_string_closes_at(&chars, i, hashes) {
+                    self.raw_string_hashes = None;
+                    i += 1 + hashes;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+
+            if self.block_comment_depth > 0 {
+                if starts_pair(&chars, i, '/', '*') {
+                    self.block_comment_depth += 1;
+                    i += 2;
+                    continue;
+                }
+                if starts_pair(&chars, i, '*', '/') {
+                    self.block_comment_depth -= 1;
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+                continue;
+            }
+
+            if !self.in_string && !self.in_char {
+                if starts_pair(&chars, i, '/', '/') {
+                    break;
+                }
+                if starts_pair(&chars, i, '/', '*') {
+                    self.block_comment_depth = 1;
+                    i += 2;
+                    continue;
+                }
+                if let Some((opening_len, hashes)) = raw_string_opens_at(&chars, i) {
+                    self.raw_string_hashes = Some(hashes);
+                    i += opening_len;
+                    continue;
+                }
+            }
+
+            let c = chars[i];
+
+            if !self.in_char && c == '"' && !is_escaped(&chars, i) {
+                self.in_string = !self.in_string;
+                i += 1;
+                continue;
+            }
+
+            if !self.in_string && c == '\'' && !is_escaped(&chars, i) {
+                if self.in_char {
+                    self.in_char = false;
+                    i += 1;
+                    continue;
+                }
+                if starts_char_literal(&chars, i) {
+                    self.in_char = true;
+                    i += 1;
+                    continue;
+                }
+            }
+
+            if self.in_string || self.in_char {
+                i += 1;
+                continue;
+            }
+
+            code.push(c);
+            i += 1;
+        }
+
+        code
+    }
+}
+
+fn starts_pair(chars: &[char], i: usize, first: char, second: char) -> bool {
+    chars.get(i) == Some(&first) && chars.get(i + 1) == Some(&second)
+}
+
+fn is_escaped(chars: &[char], i: usize) -> bool {
+    if i == 0 {
+        return false;
+    }
+
+    let mut slash_count = 0;
+    let mut cursor = i;
+    while cursor > 0 && chars[cursor - 1] == '\\' {
+        slash_count += 1;
+        cursor -= 1;
+    }
+    slash_count % 2 == 1
+}
+
+fn starts_char_literal(chars: &[char], i: usize) -> bool {
+    matches!(
+        (chars.get(i + 1), chars.get(i + 2), chars.get(i + 3)),
+        (Some('\\'), Some(_), Some('\'')) | (Some(_), Some('\''), _)
+    )
+}
+
+fn raw_string_opens_at(chars: &[char], i: usize) -> Option<(usize, usize)> {
+    let mut cursor = match (chars.get(i), chars.get(i + 1)) {
+        (Some('b'), Some('r')) => i + 2,
+        (Some('r'), _) => i + 1,
+        _ => return None,
+    };
+
+    let hash_start = cursor;
+    while chars.get(cursor) == Some(&'#') {
+        cursor += 1;
+    }
+
+    if chars.get(cursor) == Some(&'"') {
+        let hashes = cursor - hash_start;
+        Some((cursor - i + 1, hashes))
+    } else {
+        None
+    }
+}
+
+fn raw_string_closes_at(chars: &[char], i: usize, hashes: usize) -> bool {
+    chars.get(i) == Some(&'"') && (0..hashes).all(|offset| chars.get(i + 1 + offset) == Some(&'#'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RustAnalyzer, SourceAnalyzer, analyze_rust_function_complexity};
+
+    #[test]
+    fn rust_complexity_counts_else_if_once() {
+        let analysis = analyze_rust_function_complexity(
+            r#"
+fn branchy(x: i32) -> i32 {
+    if x > 0 {
+        1
+    } else if x < 0 {
+        -1
+    } else if x == 0 {
+        0
+    } else {
+        42
+    }
+}
+"#,
+        );
+
+        assert_eq!(analysis.function_count, 1);
+        assert_eq!(analysis.total_complexity, 4);
+        assert_eq!(analysis.max_complexity, 4);
+    }
+
+    #[test]
+    fn rust_complexity_ignores_decisions_in_strings_and_comments() {
+        let analysis = analyze_rust_function_complexity(
+            r###"
+fn only_real_branch(flag: bool) {
+    let _normal = "if while for loop match && || ? => { }";
+    let _raw = r##"if while for loop match && || ? => { }"##;
+    let _char = '?';
+    /* if outer /* while nested */ match ignored => */
+    if flag {
+        println!("ok"); // else if ignored && ||
+    }
+}
+"###,
+        );
+
+        assert_eq!(analysis.function_count, 1);
+        assert_eq!(analysis.total_complexity, 2);
+        assert_eq!(analysis.max_complexity, 2);
+    }
+
+    #[test]
+    fn rust_complexity_counts_match_arms() {
+        let analysis = analyze_rust_function_complexity(
+            r#"
+fn classify(x: i32) -> i32 {
+    match x {
+        0 => 0,
+        1 => 1,
+        _ => 2,
+    }
+}
+"#,
+        );
+
+        assert_eq!(analysis.function_count, 1);
+        assert_eq!(analysis.max_complexity, 5);
+    }
+
+    #[test]
+    fn rust_analyzer_trait_delegates_to_function_scoped_analysis() {
+        let analyzer = RustAnalyzer;
+        let analysis = analyzer.analyze_rust(
+            r#"
+fn first() {
+    if true {}
+}
+
+fn second() {
+    while false {}
+    for _ in 0..1 {}
+}
+"#,
+        );
+
+        assert_eq!(analysis.function_count, 2);
+        assert_eq!(analysis.total_complexity, 5);
+        assert_eq!(analysis.max_complexity, 3);
+    }
+}

--- a/crates/tokmd-cockpit/Cargo.toml
+++ b/crates/tokmd-cockpit/Cargo.toml
@@ -22,6 +22,7 @@ ignore = "0.4.23"
 serde.workspace = true
 serde_json.workspace = true
 time = { version = "0.3.41", features = ["formatting"] }
+tokmd-analysis = { path = "../tokmd-analysis", version = "1.10.0", default-features = false }
 tokmd-analysis-types.workspace = true
 tokmd-envelope.workspace = true
 tokmd-types.workspace = true
@@ -33,4 +34,3 @@ tokmd-git = { workspace = true, optional = true }
 insta = { workspace = true }
 proptest.workspace = true
 tempfile.workspace = true
-

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -31,6 +31,8 @@ use anyhow::Result;
 use anyhow::{Context, bail};
 #[cfg(feature = "git")]
 use serde::Deserialize;
+#[cfg(feature = "git")]
+use tokmd_analysis::source_complexity::analyze_rust_function_complexity;
 
 // Re-export types from tokmd_types::cockpit for convenience
 pub use tokmd_types::cockpit::*;
@@ -1266,7 +1268,7 @@ fn compute_complexity_gate(
         }
 
         if let Ok(content) = std::fs::read_to_string(&full_path) {
-            let analysis = analyze_rust_complexity(&content);
+            let analysis = analyze_rust_function_complexity(&content);
             files_analyzed += 1;
             total_complexity += analysis.total_complexity as u64;
             max_cyclomatic = max_cyclomatic.max(analysis.max_complexity);
@@ -1332,270 +1334,6 @@ fn compute_complexity_gate(
         max_cyclomatic,
         threshold_exceeded,
     }))
-}
-
-/// Results from analyzing a Rust file's complexity.
-#[cfg(feature = "git")]
-struct ComplexityAnalysis {
-    /// Total cyclomatic complexity across all functions.
-    total_complexity: u32,
-    /// Maximum complexity of any single function.
-    max_complexity: u32,
-    /// Number of functions found.
-    function_count: usize,
-    /// Maximum function length in lines.
-    max_function_length: usize,
-}
-
-/// Masks Rust source spans that should not contribute to cockpit complexity.
-#[cfg(feature = "git")]
-#[derive(Default)]
-struct RustCodeMask {
-    in_string: bool,
-    in_char: bool,
-    block_comment_depth: usize,
-    raw_string_hashes: Option<usize>,
-}
-
-#[cfg(feature = "git")]
-impl RustCodeMask {
-    fn code_only_line(&mut self, line: &str) -> String {
-        let chars: Vec<char> = line.chars().collect();
-        let mut code = String::with_capacity(line.len());
-        let mut i = 0;
-
-        while i < chars.len() {
-            if let Some(hashes) = self.raw_string_hashes {
-                if raw_string_closes_at(&chars, i, hashes) {
-                    self.raw_string_hashes = None;
-                    i += 1 + hashes;
-                } else {
-                    i += 1;
-                }
-                continue;
-            }
-
-            if self.block_comment_depth > 0 {
-                if starts_pair(&chars, i, '/', '*') {
-                    self.block_comment_depth += 1;
-                    i += 2;
-                    continue;
-                }
-                if starts_pair(&chars, i, '*', '/') {
-                    self.block_comment_depth -= 1;
-                    i += 2;
-                    continue;
-                }
-                i += 1;
-                continue;
-            }
-
-            if !self.in_string && !self.in_char {
-                if starts_pair(&chars, i, '/', '/') {
-                    break;
-                }
-                if starts_pair(&chars, i, '/', '*') {
-                    self.block_comment_depth = 1;
-                    i += 2;
-                    continue;
-                }
-                if let Some((opening_len, hashes)) = raw_string_opens_at(&chars, i) {
-                    self.raw_string_hashes = Some(hashes);
-                    i += opening_len;
-                    continue;
-                }
-            }
-
-            let c = chars[i];
-
-            if !self.in_char && c == '"' && !is_escaped(&chars, i) {
-                self.in_string = !self.in_string;
-                i += 1;
-                continue;
-            }
-
-            if !self.in_string && c == '\'' && !is_escaped(&chars, i) {
-                if self.in_char {
-                    self.in_char = false;
-                    i += 1;
-                    continue;
-                }
-                if starts_char_literal(&chars, i) {
-                    self.in_char = true;
-                    i += 1;
-                    continue;
-                }
-            }
-
-            if self.in_string || self.in_char {
-                i += 1;
-                continue;
-            }
-
-            code.push(c);
-            i += 1;
-        }
-
-        code
-    }
-}
-
-#[cfg(feature = "git")]
-fn starts_pair(chars: &[char], i: usize, first: char, second: char) -> bool {
-    chars.get(i) == Some(&first) && chars.get(i + 1) == Some(&second)
-}
-
-#[cfg(feature = "git")]
-fn is_escaped(chars: &[char], i: usize) -> bool {
-    if i == 0 {
-        return false;
-    }
-
-    let mut slash_count = 0;
-    let mut cursor = i;
-    while cursor > 0 && chars[cursor - 1] == '\\' {
-        slash_count += 1;
-        cursor -= 1;
-    }
-    slash_count % 2 == 1
-}
-
-#[cfg(feature = "git")]
-fn starts_char_literal(chars: &[char], i: usize) -> bool {
-    matches!(
-        (chars.get(i + 1), chars.get(i + 2), chars.get(i + 3)),
-        (Some('\\'), Some(_), Some('\'')) | (Some(_), Some('\''), _)
-    )
-}
-
-#[cfg(feature = "git")]
-fn raw_string_opens_at(chars: &[char], i: usize) -> Option<(usize, usize)> {
-    let mut cursor = match (chars.get(i), chars.get(i + 1)) {
-        (Some('b'), Some('r')) => i + 2,
-        (Some('r'), _) => i + 1,
-        _ => return None,
-    };
-
-    let hash_start = cursor;
-    while chars.get(cursor) == Some(&'#') {
-        cursor += 1;
-    }
-
-    if chars.get(cursor) == Some(&'"') {
-        let hashes = cursor - hash_start;
-        Some((cursor - i + 1, hashes))
-    } else {
-        None
-    }
-}
-
-#[cfg(feature = "git")]
-fn raw_string_closes_at(chars: &[char], i: usize, hashes: usize) -> bool {
-    chars.get(i) == Some(&'"') && (0..hashes).all(|offset| chars.get(i + 1 + offset) == Some(&'#'))
-}
-
-/// Analyze the cyclomatic complexity of Rust source code.
-/// Uses a simple heuristic approach counting decision points.
-#[cfg(feature = "git")]
-fn analyze_rust_complexity(content: &str) -> ComplexityAnalysis {
-    let mut total_complexity: u32 = 0;
-    let mut max_complexity: u32 = 0;
-    let mut function_count: usize = 0;
-    let mut max_function_length: usize = 0;
-
-    let mut in_function = false;
-    let mut brace_depth: i32 = 0;
-    let mut function_brace_depth: i32 = 0; // Depth when function started
-    let mut function_start_line: usize = 0;
-    let mut current_complexity: u32 = 1; // Start at 1 for the function itself
-    let mut mask = RustCodeMask::default();
-
-    for (line_idx, line) in content.lines().enumerate() {
-        let code_line = mask.code_only_line(line);
-        let trimmed = code_line.trim();
-
-        // Skip empty lines
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        // Check for function start BEFORE processing braces
-        // (so we can track the starting brace depth correctly)
-        let is_fn_start = !in_function
-            && (trimmed.starts_with("fn ")
-                || trimmed.starts_with("pub fn ")
-                || trimmed.starts_with("pub(crate) fn ")
-                || trimmed.starts_with("pub(super) fn ")
-                || trimmed.starts_with("async fn ")
-                || trimmed.starts_with("pub async fn ")
-                || trimmed.starts_with("const fn ")
-                || trimmed.starts_with("pub const fn ")
-                || trimmed.starts_with("unsafe fn ")
-                || trimmed.starts_with("pub unsafe fn "));
-
-        if is_fn_start {
-            in_function = true;
-            function_start_line = line_idx;
-            function_brace_depth = brace_depth;
-            current_complexity = 1;
-        }
-
-        for c in code_line.chars() {
-            // Track brace depth
-            if c == '{' {
-                brace_depth += 1;
-            } else if c == '}' {
-                brace_depth -= 1;
-                if in_function && brace_depth == function_brace_depth {
-                    // End of function
-                    let function_length = line_idx - function_start_line + 1;
-                    max_function_length = max_function_length.max(function_length);
-                    total_complexity += current_complexity;
-                    max_complexity = max_complexity.max(current_complexity);
-                    function_count += 1;
-                    in_function = false;
-                    current_complexity = 1;
-                }
-            }
-        }
-
-        // Count decision points for complexity (only inside functions)
-        if in_function {
-            // Count control flow keywords
-            let keywords = [
-                "if ", "else if ", "while ", "for ", "loop ", "match ", "&&", "||", "?",
-            ];
-            for kw in &keywords {
-                // Count occurrences of each keyword
-                let mut search_line = trimmed;
-                while let Some(pos) = search_line.find(kw) {
-                    current_complexity += 1;
-                    search_line = &search_line[pos + kw.len()..];
-                }
-            }
-
-            // Count match arms (each => in a match adds complexity)
-            if trimmed.contains("=>") && !trimmed.starts_with("//") {
-                // Count number of => in the line
-                let arrow_count = trimmed.matches("=>").count();
-                current_complexity += arrow_count as u32;
-            }
-        }
-    }
-
-    // Handle case where file ends without closing brace
-    if in_function {
-        function_count += 1;
-        total_complexity += current_complexity;
-        max_complexity = max_complexity.max(current_complexity);
-    }
-
-    ComplexityAnalysis {
-        total_complexity,
-        max_complexity,
-        function_count,
-        max_function_length,
-    }
 }
 
 /// Check if a file is a relevant Rust source file for mutation testing.
@@ -2776,7 +2514,7 @@ mod tests {
     #[test]
     #[cfg(feature = "git")]
     fn test_rust_complexity_ignores_decisions_in_strings_and_comments() {
-        let analysis = analyze_rust_complexity(
+        let analysis = analyze_rust_function_complexity(
             r###"
 fn only_real_branch(flag: bool) {
     let _normal = "if while for loop match && || ? => { }";
@@ -2798,7 +2536,7 @@ fn only_real_branch(flag: bool) {
     #[test]
     #[cfg(feature = "git")]
     fn test_rust_complexity_counts_code_before_trailing_comment() {
-        let analysis = analyze_rust_complexity(
+        let analysis = analyze_rust_function_complexity(
             r#"
 fn branch_before_comment(flag: bool) {
     if flag { return; } // if ignored && ||
@@ -2809,6 +2547,30 @@ fn branch_before_comment(flag: bool) {
         assert_eq!(analysis.function_count, 1);
         assert_eq!(analysis.total_complexity, 2);
         assert_eq!(analysis.max_complexity, 2);
+    }
+
+    #[test]
+    #[cfg(feature = "git")]
+    fn test_rust_complexity_counts_else_if_once() {
+        let analysis = analyze_rust_function_complexity(
+            r#"
+fn branchy(x: i32) -> i32 {
+    if x > 0 {
+        1
+    } else if x < 0 {
+        -1
+    } else if x == 0 {
+        0
+    } else {
+        42
+    }
+}
+"#,
+        );
+
+        assert_eq!(analysis.function_count, 1);
+        assert_eq!(analysis.total_complexity, 4);
+        assert_eq!(analysis.max_complexity, 4);
     }
 
     // ---- flush_uncovered_hunks ----

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -153,6 +153,11 @@ architecture-consolidation program.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
 - The composite Action now appends hosted packet metadata to review-packet comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.
+- Cockpit's Rust complexity gate now delegates function-scoped source analysis
+  to `tokmd-analysis::source_complexity` instead of owning a duplicate parser.
+  The `else if` double-count is fixed as a correctness improvement; impact
+  analysis over 183 current relevant Rust source files found 52 files near the
+  10-20 complexity range and 0 files flipping from fail to pass at threshold 15.
 - Agent-facing architecture docs now reflect the current crate-and-module
   ownership model: analysis rendering lives in `tokmd-format`, review evidence
   in `tokmd-cockpit`, and implementation details should stay as SRP owner


### PR DESCRIPTION
## Summary

- Move cockpit's function-scoped Rust complexity heuristic into `tokmd-analysis::source_complexity`.
- Make `tokmd-cockpit` delegate its complexity gate to that shared helper with `tokmd-analysis` default features disabled.
- Fix the `else if` double-count in the shared helper and keep masking for strings, chars, raw strings, line comments, and nested block comments.
- Route the new helper through the `analysis_complexity` proof scope and record the cockpit checkpoint in `docs/NEXT.md`.

## Impact analysis

Local impact scan over current relevant Rust source files:

- Files analyzed: 183
- Files with old or new max complexity in the 10-20 range: 52
- Files flipping from failing to passing at threshold 15: 0

The gate behavior change removes a known overcount without changing receipt schemas or default analysis output.

Closes #999.

## Validation

- `cargo check -p tokmd-analysis --no-default-features --all-targets`
- `cargo check -p tokmd-cockpit --all-targets`
- `cargo test -p tokmd-analysis --no-default-features source_complexity --verbose`
- `cargo test -p tokmd-cockpit rust_complexity --verbose`
- `cargo test -p tokmd-analysis --all-features complexity --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo clippy -p tokmd-analysis --all-targets -- -D warnings`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask boundaries-check`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo deny --all-features check`
- `cargo test -p tokmd --test analyze_integration --verbose`
- `cargo test -p tokmd-analysis --all-features feature --verbose`
- `cargo test -p tokmd-analysis --all-features orchestration --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo test -p tokmd-types manifest_stays_clap_free --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`