### PR TITLE
fix(scan): expose bounded path normalization

### DIFF
--- a/crates/tokmd-scan/src/lib.rs
+++ b/crates/tokmd-scan/src/lib.rs
@@ -655,5 +655,7 @@ pub mod walk;
 
 pub use exclude::{add_exclude_pattern, has_exclude_pattern, normalize_exclude_pattern};
 pub use math::{gini_coefficient, percentile, round_f64, safe_ratio};
-pub use path::{normalize_rel_path, normalize_slashes};
+pub use path::{
+    canonicalize_bounded_path, normalize_bounded_rel_path, normalize_rel_path, normalize_slashes,
+};
 pub use tokeignore::{InitArgs, InitProfile, init_tokeignore};

--- a/crates/tokmd-scan/src/path/mod.rs
+++ b/crates/tokmd-scan/src/path/mod.rs
@@ -6,6 +6,8 @@ mod error;
 mod tests;
 mod validated_root;
 
+use std::path::{Path, PathBuf};
+
 pub(crate) use bounded_path::{BoundedPath, normalize_bounded_relative_path};
 pub(crate) use error::{PathViolation, RootViolation};
 pub(crate) use validated_root::ValidatedRoot;
@@ -47,6 +49,12 @@ pub(crate) fn normalize_slashes_cow(path: &str) -> std::borrow::Cow<'_, str> {
 /// - converts `\` to `/`
 /// - strips all leading `./` segments
 ///
+/// This is a formatting normalizer, not a traversal validator. It intentionally
+/// preserves parent traversal segments so callers that compare already-bounded
+/// receipt paths do not silently rewrite meaning. Use [`normalize_bounded_rel_path`]
+/// or [`canonicalize_bounded_path`] before using untrusted relative paths for
+/// filesystem access.
+///
 /// # Examples
 ///
 /// ```
@@ -78,6 +86,55 @@ pub fn normalize_rel_path(path: &str) -> String {
     s.to_string()
 }
 
+/// Normalize a root-relative path and reject traversal or absolute inputs.
+///
+/// This helper performs only lexical validation. It does not touch the
+/// filesystem, so it is suitable for logical paths such as browser/in-memory
+/// inputs. Use [`canonicalize_bounded_path`] when the path must exist under a
+/// specific root.
+///
+/// # Errors
+///
+/// Returns an error when `path` is empty, absolute, resolves to only `.` segments,
+/// or contains parent traversal.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use tokmd_scan::normalize_bounded_rel_path;
+///
+/// assert_eq!(
+///     normalize_bounded_rel_path("./src/./lib.rs").unwrap(),
+///     PathBuf::from("src/lib.rs")
+/// );
+/// assert!(normalize_bounded_rel_path("../secret.txt").is_err());
+/// ```
+pub fn normalize_bounded_rel_path(path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
+    Ok(normalize_bounded_relative_path(path.as_ref())?)
+}
+
+/// Canonicalize an existing root-relative path and verify it stays under `root`.
+///
+/// This is the filesystem boundary check for untrusted relative paths. Both the
+/// root and candidate are resolved with `std::fs::canonicalize`, then the resolved
+/// candidate must remain below the resolved root. Symlinks that escape the root are
+/// rejected.
+///
+/// # Errors
+///
+/// Returns an error when `root` is empty/missing/unresolvable, when `relative` is
+/// empty/absolute/escaping/missing/unresolvable, or when symlink resolution leaves
+/// the root.
+pub fn canonicalize_bounded_path(
+    root: impl AsRef<Path>,
+    relative: impl AsRef<Path>,
+) -> anyhow::Result<PathBuf> {
+    let root = ValidatedRoot::new(root)?;
+    let bounded = BoundedPath::existing_relative(&root, relative.as_ref())?;
+    Ok(bounded.canonical().to_path_buf())
+}
+
 #[cfg(test)]
 mod normalization_tests {
     use super::*;
@@ -101,6 +158,57 @@ mod normalization_tests {
     #[test]
     fn normalize_rel_path_preserves_non_relative_prefix() {
         assert_eq!(normalize_rel_path("../src/main.rs"), "../src/main.rs");
+    }
+
+    #[test]
+    fn normalize_bounded_rel_path_rejects_parent_traversal() {
+        let err = normalize_bounded_rel_path("../src/main.rs").unwrap_err();
+
+        assert!(err.to_string().contains("parent traversal"));
+    }
+
+    #[test]
+    fn normalize_bounded_rel_path_rejects_absolute_path() {
+        let err = normalize_bounded_rel_path("/src/main.rs").unwrap_err();
+
+        assert!(err.to_string().contains("must be relative"));
+    }
+
+    #[test]
+    fn canonicalize_bounded_path_returns_canonical_child() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let child = dir.path().join("src/lib.rs");
+        std::fs::write(&child, "pub fn lib() {}\n").unwrap();
+
+        let bounded = canonicalize_bounded_path(dir.path(), "./src/lib.rs").unwrap();
+
+        assert_eq!(bounded, std::fs::canonicalize(child).unwrap());
+    }
+
+    #[test]
+    fn canonicalize_bounded_path_rejects_parent_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = canonicalize_bounded_path(dir.path(), "../secret.txt").unwrap_err();
+
+        assert!(err.to_string().contains("parent traversal"));
+    }
+
+    #[test]
+    fn canonicalize_bounded_path_rejects_symlink_escape_when_supported() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("secret.txt");
+        let link = root_dir.path().join("secret-link.txt");
+        std::fs::write(&outside_file, "secret").unwrap();
+
+        if create_file_symlink(&outside_file, &link).is_err() {
+            return;
+        }
+
+        let err = canonicalize_bounded_path(root_dir.path(), "secret-link.txt").unwrap_err();
+
+        assert!(err.to_string().contains("escapes scan root"));
     }
 
     proptest! {
@@ -129,5 +237,15 @@ mod normalization_tests {
             let twice = normalize_rel_path(&once);
             prop_assert_eq!(once, twice);
         }
+    }
+
+    #[cfg(unix)]
+    fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(src, dst)
+    }
+
+    #[cfg(windows)]
+    fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(src, dst)
     }
 }


### PR DESCRIPTION
## Summary
- Document `normalize_rel_path` as a formatting normalizer, not a traversal validator.
- Add public fallible bounded-path helpers for lexical root-relative validation and canonical root-bound filesystem resolution.
- Cover parent traversal, absolute paths, canonical child resolution, and symlink escape rejection.

Closes #776.

## Tests
- `cargo test -p tokmd-scan bounded --verbose`
- `cargo test -p tokmd-scan --lib --verbose`
- `cargo test -p tokmd-scan --doc --verbose`
- `cargo clippy -p tokmd-scan --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd-scan normalize --verbose`
- `cargo test -p tokmd-model normalize --verbose`