### PR TITLE
test: remove scanner-like secret fixtures

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -150,6 +150,15 @@ mutation = true
 coverage = true
 
 [[scope]]
+name = "tokmd_envelope_contract"
+kind = "rust"
+paths = ["crates/tokmd-envelope/**"]
+packages = ["tokmd-envelope"]
+proof = ["cargo test -p tokmd-envelope --verbose"]
+mutation = true
+coverage = true
+
+[[scope]]
 name = "lint_policy"
 kind = "rust"
 paths = [

--- a/crates/tokmd-envelope/tests/bdd.rs
+++ b/crates/tokmd-envelope/tests/bdd.rs
@@ -146,7 +146,11 @@ fn scenario_finding_builder_chain() {
         "Possible secret",
         "File has high entropy",
     )
-    .with_location(FindingLocation::path_line_column("secrets.env", 1, 1))
+    .with_location(FindingLocation::path_line_column(
+        "finding-fixture.env",
+        1,
+        1,
+    ))
     .with_evidence(serde_json::json!({"entropy": 7.8}))
     .with_docs_url("https://docs.example.com/entropy")
     .with_fingerprint("tokmd");
@@ -157,7 +161,7 @@ fn scenario_finding_builder_chain() {
     assert_eq!(finding.severity, FindingSeverity::Error);
     assert!(finding.location.is_some());
     let loc = finding.location.as_ref().unwrap();
-    assert_eq!(loc.path, "secrets.env");
+    assert_eq!(loc.path, "finding-fixture.env");
     assert_eq!(loc.line, Some(1));
     assert_eq!(loc.column, Some(1));
     assert!(finding.evidence.is_some());

--- a/crates/tokmd-scan/tests/walk_bdd.rs
+++ b/crates/tokmd-scan/tests/walk_bdd.rs
@@ -279,7 +279,7 @@ fn hidden_files_excluded_by_gitignore_are_omitted() {
     // Given a .gitignore that explicitly ignores a hidden file
     let tmp = git_tempdir();
     std::fs::write(tmp.path().join(".gitignore"), ".secret\n").unwrap();
-    std::fs::write(tmp.path().join(".secret"), "password").unwrap();
+    std::fs::write(tmp.path().join(".secret"), "ignored fixture").unwrap();
     std::fs::write(tmp.path().join(".visible_hidden"), "visible").unwrap();
 
     // When we list files
@@ -409,7 +409,7 @@ fn file_size_for_file_in_hidden_directory() {
 #[test]
 fn file_size_for_dotfile() {
     let tmp = non_git_tempdir();
-    std::fs::write(tmp.path().join(".env"), "SECRET=abc").unwrap();
+    std::fs::write(tmp.path().join(".env"), "MODE=demo\n").unwrap();
 
     let size = file_size(tmp.path(), std::path::Path::new(".env")).unwrap();
     assert_eq!(size, 10);

--- a/crates/tokmd-scan/tests/walk_deep_w48.rs
+++ b/crates/tokmd-scan/tests/walk_deep_w48.rs
@@ -440,7 +440,7 @@ fn edge_deeply_nested_single_file() {
 #[test]
 fn edge_directory_with_only_hidden_files() {
     let dir = tempfile::tempdir().unwrap();
-    fs::write(dir.path().join(".env"), "SECRET=x").unwrap();
+    fs::write(dir.path().join(".env"), "MODE=x").unwrap();
     fs::write(dir.path().join(".config"), "key=val").unwrap();
     fs::write(dir.path().join(".gitkeep"), "").unwrap();
     let files = list_files(dir.path(), None).unwrap();

--- a/web/runner/auth.test.mjs
+++ b/web/runner/auth.test.mjs
@@ -30,9 +30,9 @@ test("session token helpers read, trim, write, and clear token values", () => {
     const storage = createMemoryStorage();
 
     assert.equal(readSessionToken(storage), "");
-    assert.equal(writeSessionToken(storage, "  ghp_example  "), "ghp_example");
-    assert.equal(storage.getItem(GITHUB_TOKEN_STORAGE_KEY), "ghp_example");
-    assert.equal(readSessionToken(storage), "ghp_example");
+    assert.equal(writeSessionToken(storage, "  test-token-example  "), "test-token-example");
+    assert.equal(storage.getItem(GITHUB_TOKEN_STORAGE_KEY), "test-token-example");
+    assert.equal(readSessionToken(storage), "test-token-example");
 
     assert.equal(writeSessionToken(storage, "   "), "");
     assert.equal(storage.getItem(GITHUB_TOKEN_STORAGE_KEY), null);
@@ -73,5 +73,5 @@ test("session token helpers tolerate unavailable storage", () => {
 test("auth mode never exposes token text", () => {
     assert.equal(authModeForToken(""), "anonymous");
     assert.equal(authModeForToken("   "), "anonymous");
-    assert.equal(authModeForToken("ghp_secret_value"), "authenticated");
+    assert.equal(authModeForToken("test-token-value"), "authenticated");
 });

--- a/web/runner/main.test.mjs
+++ b/web/runner/main.test.mjs
@@ -237,7 +237,7 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     const fetchCalls = [];
     let treeAttempts = 0;
     const storage = createMemoryStorage({
-        "tokmd.githubToken": "  ghp_saved  ",
+        "tokmd.githubToken": "  test-token-saved  ",
     });
     const harness = installBrowserHarness(t, {
         storage,
@@ -312,7 +312,7 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     const runProgressText = harness.element("[data-run-progress-text]");
     const logOutput = harness.element("[data-log]");
 
-    assert.equal(tokenInput.value, "ghp_saved");
+    assert.equal(tokenInput.value, "test-token-saved");
     assert.equal(authState.textContent, "authenticated");
     assert.equal(clearTokenButton.disabled, false);
     assert.match(harness.element("[data-worker-capabilities]").textContent, /downloads: yes/);
@@ -402,13 +402,13 @@ test("main page wires token state, retryable repo loads, cache display, and resu
     await loadRepoButton.click();
 
     assert.equal(fetchCalls.length, 1);
-    assert.equal(fetchCalls[0].authorization, "token ghp_saved");
+    assert.equal(fetchCalls[0].authorization, "token test-token-saved");
     assert.equal(retryLoadButton.disabled, false);
     assert.equal(loadProgressPanel.hidden, false);
     assert.match(loadProgressText.textContent, /Retry after 12s/);
     assert.match(loadStatusOutput.textContent, /repo load failed:/);
     assert.equal(resultOutput.textContent, secondResultBeforeRepoError);
-    assert.doesNotMatch(collectText(logOutput), /ghp_saved/);
+    assert.doesNotMatch(collectText(logOutput), /test-token-saved/);
 
     await retryLoadButton.click();
     await loadRepoButton.lastClickPromise;
@@ -440,7 +440,7 @@ test("main page marks rejected GitHub tokens without exposing token text", async
     let responseStatus = 401;
     let responseMessage = "Bad credentials";
     const storage = createMemoryStorage({
-        "tokmd.githubToken": "  ghp_rejected  ",
+        "tokmd.githubToken": "  test-token-rejected  ",
     });
     const harness = installBrowserHarness(t, {
         storage,
@@ -474,32 +474,32 @@ test("main page marks rejected GitHub tokens without exposing token text", async
     const ingestSummaryOutput = harness.element("[data-ingest-summary]");
     const logOutput = harness.element("[data-log]");
 
-    assert.equal(tokenInput.value, "ghp_rejected");
+    assert.equal(tokenInput.value, "test-token-rejected");
     assert.equal(authState.textContent, "authenticated");
     assert.equal(authState.dataset.tone, "success");
 
     await loadRepoButton.click();
 
     assert.equal(fetchCalls.length, 1);
-    assert.equal(fetchCalls[0].authorization, "token ghp_rejected");
+    assert.equal(fetchCalls[0].authorization, "token test-token-rejected");
     assert.equal(authState.textContent, "token rejected");
     assert.equal(authState.dataset.tone, "error");
     assert.equal(clearTokenButton.disabled, false);
     assert.equal(retryLoadButton.disabled, true);
     assert.match(loadStatusOutput.textContent, /GitHub rejected the supplied token/);
     assert.match(collectText(ingestSummaryOutput), /Update or clear the GitHub token/);
-    assert.doesNotMatch(collectText(logOutput), /ghp_rejected/);
+    assert.doesNotMatch(collectText(logOutput), /test-token-rejected/);
 
     responseStatus = 404;
     responseMessage = "Not Found";
     await loadRepoButton.click();
 
     assert.equal(fetchCalls.length, 2);
-    assert.equal(fetchCalls[1].authorization, "token ghp_rejected");
+    assert.equal(fetchCalls[1].authorization, "token test-token-rejected");
     assert.equal(authState.textContent, "check token/repo");
     assert.equal(authState.dataset.tone, "error");
     assert.match(loadStatusOutput.textContent, /not found for the supplied token/);
-    assert.doesNotMatch(collectText(logOutput), /ghp_rejected/);
+    assert.doesNotMatch(collectText(logOutput), /test-token-rejected/);
 
     await clearTokenButton.click();
 


### PR DESCRIPTION
## Summary
- replace scanner-like secret/password fixture literals in scan/envelope tests with neutral fixture names and content
- replace GitHub-token-shaped browser test values with generic fake token placeholders
- add a `tokmd_envelope_contract` proof-policy scope so envelope test changes stop surfacing as unknown proof-observation files
- keep behavior unchanged: gitignore, dotfile sizing, finding location, and browser auth plumbing assertions still cover the same paths

Closes #978.

## Validation
- rg -n "password|SECRET=|secrets\\.env|ghp_" crates/tokmd-scan/tests/walk_bdd.rs crates/tokmd-scan/tests/walk_deep_w48.rs crates/tokmd-envelope/tests/bdd.rs web/runner/main.test.mjs web/runner/auth.test.mjs
- cargo test -p tokmd-scan hidden_files_excluded_by_gitignore_are_omitted --verbose
- cargo test -p tokmd-scan file_size_for_dotfile --verbose
- cargo test -p tokmd-scan edge_directory_with_only_hidden_files --verbose
- cargo test -p tokmd-envelope scenario_finding_builder_chain --verbose
- npm --prefix web/runner test
- npm --prefix web/runner run check
- cargo test -p tokmd-model normalize --verbose
- cargo test -p tokmd-scan normalize --verbose
- cargo test -p tokmd-envelope --verbose
- cargo test -p xtask proof_policy --verbose
- cargo test -p xtask affected --verbose
- cargo fmt-check
- git diff --check origin/main...HEAD
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan