### PR TITLE
docs: audit vendored home unsafe usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "fuzz",
     "xtask",
 ]
+exclude = ["vendor/home-0.5.12"]
 default-members = [
     "crates/tokmd",
     "crates/tokmd-analysis",

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -59,6 +59,21 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "vendored_home_patch"
+kind = "rust"
+paths = [
+  "Cargo.toml",
+  "vendor/home-0.5.12/**",
+]
+proof = [
+  "cargo tree -i home --edges normal",
+  "cargo test --manifest-path vendor/home-0.5.12/Cargo.toml --verbose",
+]
+reason = "The patched `home` crate is vendored to supply tokmd's non-Unix/non-Windows fallback while preserving the upstream Windows implementation."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "fuzz_harnesses"
 kind = "rust"
 paths = [

--- a/vendor/home-0.5.12/README.tokmd.md
+++ b/vendor/home-0.5.12/README.tokmd.md
@@ -1,0 +1,17 @@
+# tokmd vendor note for `home` 0.5.12
+
+tokmd patches `home` through the workspace `[patch.crates-io]` entry because
+the dependency reaches tokmd through `tokei -> etcetera`, and upstream `home`
+0.5.12 does not provide a non-Unix/non-Windows fallback.
+
+The functional local delta is intentionally small:
+
+- `src/lib.rs` adds `#[cfg(not(any(unix, windows)))] home_dir_inner() -> None`.
+- `src/windows.rs` keeps the upstream Windows API behavior and adds tokmd audit
+  comments around the existing unsafe FFI blocks.
+
+The unsafe Windows code is third-party FFI from `home` 0.5.12. It calls
+`SHGetKnownFolderPath`, reads the returned NUL-terminated UTF-16 buffer, and
+frees it with `CoTaskMemFree`. Do not make logic changes here casually; refresh
+from the upstream crate and reapply the small tokmd fallback if a newer upstream
+release removes the need for this vendor patch.

--- a/vendor/home-0.5.12/src/windows.rs
+++ b/vendor/home-0.5.12/src/windows.rs
@@ -18,6 +18,13 @@ pub fn home_dir_inner() -> Option<PathBuf> {
 
 #[cfg(not(target_vendor = "uwp"))]
 fn home_dir_crt() -> Option<PathBuf> {
+    // SAFETY: `SHGetKnownFolderPath` initializes `path` to a
+    // `CoTaskMemFree`-owned, NUL-terminated UTF-16 buffer when it returns
+    // `S_OK`. This code only reads up to the terminator reported by `wcslen`,
+    // converts that slice immediately, and frees the allocation with
+    // `CoTaskMemFree` on both success and failure paths. The implementation is
+    // vendored from `home` 0.5.12; tokmd's local patch only adds the
+    // non-Unix/non-Windows fallback documented in `README.tokmd.md`.
     unsafe {
         let mut path = ptr::null_mut();
         match SHGetKnownFolderPath(
@@ -62,6 +69,8 @@ mod tests {
     fn test_with_without() {
         let olduserprofile = env::var_os("USERPROFILE").unwrap();
 
+        // SAFETY: this vendored crate has a single Windows test that mutates
+        // process environment variables to exercise `home_dir_inner`.
         unsafe {
             env::remove_var("HOME");
             env::remove_var("USERPROFILE");
@@ -71,11 +80,13 @@ mod tests {
 
         let home = Path::new(r"C:\Users\foo tar baz");
 
+        // SAFETY: see the test-level environment mutation note above.
         unsafe {
             env::set_var("HOME", home.as_os_str());
         }
         assert_ne!(home_dir_inner().as_ref().map(Deref::deref), Some(home));
 
+        // SAFETY: see the test-level environment mutation note above.
         unsafe {
             env::set_var("USERPROFILE", home.as_os_str());
         }


### PR DESCRIPTION
## Summary

- Document the local `home` 0.5.12 vendor patch and the upstream delta tokmd carries for the non-Unix/non-Windows fallback.
- Add safety notes around the vendored Windows FFI and test-only environment mutation unsafe blocks without changing behavior.
- Exclude the vendored crate from the workspace so it can be tested directly, and add a `vendored_home_patch` proof scope.

Closes #980.

## Validation

- `cargo test --manifest-path vendor/home-0.5.12/Cargo.toml --verbose`
- `cargo tree -i home --edges normal`
- `cargo xtask proof-policy --check`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask boundaries-check`
- `cargo xtask publish-surface --json`
- `cargo test -p tokmd-types manifest_stays_clap_free --verbose`
- `cargo test -p xtask lint_policy --verbose`
- `cargo test -p xtask clippy_exceptions --verbose`
- `cargo xtask check-lint-policy`
- `cargo xtask check-clippy-exceptions`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo deny --all-features check`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`
