### PR TITLE
cartographer: fix factual drift in ROADMAP and implementation plan 🗺️

### DIFF
--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -10,14 +10,12 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `36cec87d-2836-42ed-9ae1-33dbf2702319` | Librarian | Explorer | docs | completed | 3 | live |
 | `37581ca1` | Sentinel | Stabilizer | core-pipeline | in-progress | 0 | live |
 | `archivist_jules` | Archivist | Builder | workspace-wide | in-progress | 2 | live |
-| `auditor_bindings_manifests` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `bolt-run-001` | Bolt | Refactorer | core-pipeline | in-progress | 0 | live |
-| `bolt_analysis_stack_builder` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `cartographer_roadmap_design` | Cartographer | Builder | tooling-governance | in-progress | 3 | live |
-| `cartographer_roadmap_design_1` | cartographer | builder | tooling-governance | success | 0 | live |
-| `compat_interfaces_matrix_01` | Unknown | Unknown | Unknown | in-progress | 0 | live |
+| `cartographer_roadmap_design_1` | cartographer | builder | tooling-governance | in-progress | 0 | live |
 | `d657338a-caa9-4ccf-93a1-4733ada7154c` | Gatekeeper | Unknown | quality | completed | 0 | live |
 | `gatekeeper_contracts` | Gatekeeper | Builder | tooling-governance | in-progress | 6 | live |
+| `invariant_model_analysis` | invariant | prover | analysis-stack | success | 0 | live |
 | `librarian_api_doctests` | Librarian | Prover | interfaces | in-progress | 0 | live |
 | `librarian_docs_examples` | librarian | Builder | tooling-governance | in-progress | 1 | live |
 | `palette_runtime_dx_interfaces` | Palette 🎨 | Builder | interfaces | in-progress | 0 | live |

--- a/.jules/runs/cartographer_roadmap_design_1/decision.md
+++ b/.jules/runs/cartographer_roadmap_design_1/decision.md
@@ -1,22 +1,85 @@
-# Decision
+# Cartographer Decision: ROADMAP & Docs Alignment with AST Reality
 
-## Option A (recommended)
-Update `docs/requirements.md` to fix factual drift regarding `Analysis receipts` schema version. It currently states "Schema v5" while `docs/design.md`, `docs/architecture.md`, and the codebase itself (`crates/tokmd-analysis-types/src/lib.rs`) state it's `ANALYSIS_SCHEMA_VERSION = 9`.
+## Context
+The prompt requires finding and fixing factual drift between shipped reality and roadmap/design/requirements docs, specifically optimizing for "useful, aligned, evidence-backed work per prompt" and treating it as a Rust-first shard.
 
-- **What it is**: Updating the `Receipt Contracts` section in `docs/requirements.md` to list `Analysis receipts` as `Schema v9` instead of `Schema v5`.
-- **Why it fits this repo and shard**: Aligning documentation with the actual implementation is the Cartographer persona's primary goal. The "tooling-governance" shard covers `docs/**`, and fixing this schema version inconsistency is directly in scope.
-- **Trade-offs**:
-  - **Structure**: High alignment. It removes contradictory schema claims across design docs.
-  - **Velocity**: Fast to execute.
-  - **Governance**: Ensures requirements docs aren't misleading developers about contract versions.
+Upon analyzing the documentation and codebase:
+1. `ROADMAP.md` and `docs/implementation-plan.md` still state that Tree-sitter AST parsing is part of the v3.0 / Phase 7 "Long-term" goals and explicitly assert that "Default full AST analysis — tokmd remains heuristic-first until feature-gated AST shadow evidence justifies public receipt/schema changes" (and similarly throughout the docs).
+2. Furthermore, in `ROADMAP.md`, `v4.0.0` is designated for `Adze AST integration.`
+3. Meanwhile, `crates/tokmd-analysis/src/ast/rust.rs` already contains a partial implementation of Tree-sitter integration behind the `ast` feature flag, as defined in `ADR-0008` (which is marked as "proposed", yet the code is actively merged and feature-gated in `Cargo.toml`).
 
-## Option B
-Update `docs/requirements.md` to just point to `docs/design.md` for schema versions.
+The drift here isn't that AST is fully rolled out, but rather that the AST foundation (ADR-0008) is partially shipped in code (`crates/tokmd-analysis/Cargo.toml` has `ast = [...]`, `src/ast/rust.rs` uses `tree-sitter`, and `NEXT.md` acknowledges "The Rust AST shadow scaffold now uses optional `tree-sitter`"). However, `ROADMAP.md` under "Completed Milestones" fails to mention this work landing in the recent v1.x milestones, despite `NEXT.md` stating "The Rust AST shadow scaffold now uses optional tree-sitter".
 
-- **What it is**: Removing the specific schema version numbers from `docs/requirements.md` and adding a link to `docs/design.md` where the definitive list is kept.
-- **When to choose it instead**: If we want a single source of truth for schema versions to avoid future drift.
-- **Trade-offs**:
-  - Decreases the immediate readability of the requirements document. It's often useful to state current expectations in requirements.
+Wait, `ROADMAP.md` says:
+```markdown
+| **v3.0.0** | 🔭 Long-term | Tree-sitter AST integration (requires significant R&D).      |
+| **v4.0.0** | 🔭 Long-term | Adze AST integration.      |
+```
+And under Phase 7 in `docs/implementation-plan.md`:
+```markdown
+- [x] Evaluate Tree-sitter Rust grammar availability and dependency footprint for a first shadow slice
+- [x] Add feature-gated `tokmd-analysis::ast` owner module
+- [x] Parse initial Rust function landmarks
+```
+So `docs/implementation-plan.md` IS up to date with the checkboxes!
+But `ROADMAP.md`'s Status Summary and Completed Milestones don't mention that the feature-gated shadow scaffold landed, which is significant R&D that is already in tree.
 
-## Decision
-I will proceed with **Option A**. The requirements document outlines what the system *must* do, and stating the current schema version there is standard practice. Updating it to `v9` fixes the immediate factual drift while keeping the document informative.
+Let's look for a better target: "roadmap/design/requirements drift from shipped reality" or "missing explanation of a real architectural/design choice" or "stale implementation-plan sections that mislead contributors".
+
+Let's check `ROADMAP.md` Completed Milestones for v1.11.0:
+```markdown
+| **v1.11.0** | ✅ Complete | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
+```
+Is `tokmd cockpit` review-packet hardening missing from ROADMAP?
+`NEXT.md` says:
+```
+The active product lane is cockpit review-packet hardening. Improve cockpit as the PR-review evidence surface before adding any separate `tokmd review` command. After the review packet/action surface is stable, move into the architecture-consolidation program.
+```
+In `ROADMAP.md`, `v1.11.0` is complete. What is next in ROADMAP?
+```markdown
+## Future Horizons
+
+### v2.0 — Platform Evolution
+
+#### A. AI Agent Integration & MCP Server Mode
+```
+
+What about architecture consolidation or review packet hardening? They are missing from `ROADMAP.md` entirely. In `ROADMAP.md`, there's no mention of the architecture consolidation program or cockpit review-packet hardening in the Future Horizons.
+
+Let's review `docs/implementation-plan.md`.
+
+Looking at `NEXT.md` vs `docs/implementation-plan.md` and `ROADMAP.md`:
+`NEXT.md` specifies: "The active product lane is cockpit review-packet hardening. Improve cockpit as the PR-review evidence surface before adding any separate `tokmd review` command. After the review packet/action surface is stable, move into the architecture-consolidation program."
+
+However, `ROADMAP.md` completely misses the "cockpit review-packet hardening" and "architecture-consolidation" phases, jumping straight to "v2.0 MCP Server Mode". `docs/implementation-plan.md` similarly has Phase 5c (Browser Runtime Polish) and then Phase 6 (MCP Server Mode), completely skipping the active product lane and architecture-consolidation program mentioned in `NEXT.md`.
+
+In `docs/implementation-plan.md`, Phase 5c (v1.11.0) is marked as complete in `ROADMAP.md` but not in `implementation-plan.md` header (it lacks the `✅ Complete` badge).
+Wait, `NEXT.md` says: "The v1.11 browser runtime polish lane is closed on main: cache semantics, worker and repo-load progress, retry/rate-limit guidance, authenticated fetch UX, loaded-bundle capability filtering, and local browser file input are all implemented."
+
+So `docs/implementation-plan.md` is slightly stale on v1.11.0 being complete, and both `ROADMAP.md` and `docs/implementation-plan.md` are missing the current active product lanes described in `NEXT.md`:
+1. Cockpit review-packet hardening (improve cockpit as PR-review evidence surface).
+2. Architecture consolidation program (collapsing implementation microcrates into SRP modules).
+
+Let's check `docs/implementation-plan.md` for "architecture-consolidation" or "cockpit".
+
+So the factual drift between shipped reality / NEXT directives and the roadmap/design docs is:
+1. `docs/implementation-plan.md` still lists `Phase 5c: Browser Runtime Polish (v1.11.0)` as incomplete (missing `✅ Complete` in header), even though it is closed on main according to `NEXT.md` and `ROADMAP.md` Completed Milestones.
+2. `ROADMAP.md` and `docs/implementation-plan.md` both skip the current active program ("cockpit review-packet hardening" and "architecture-consolidation") mandated by `NEXT.md`.
+3. `ROADMAP.md` does not list the architecture consolidation or cockpit review-packet hardening under `Future Horizons`. It just jumps to v2.0 Platform Evolution.
+4. Also `ROADMAP.md` has `| **v1.11.0** | ✅ Complete | Browser runtime polish...` but it's not marked `✅ Complete` in the implementation-plan phase heading.
+
+Let's fix this factual drift.
+
+### Option A (recommended)
+Update `docs/implementation-plan.md` and `ROADMAP.md` to reflect the active product lane:
+- Mark `Phase 5c: Browser Runtime Polish (v1.11.0)` as `✅ Complete` in `docs/implementation-plan.md`.
+- Insert a new section in `ROADMAP.md` (e.g. `v1.12.0 — Cockpit Review-Packet Hardening & Architecture Consolidation`) under `Future Horizons` before `v2.0` to reflect the directives in `NEXT.md`.
+- Insert a new Phase (e.g., `Phase 5d` or `Phase 6`) in `docs/implementation-plan.md` for `Cockpit Review-Packet Hardening` and `Architecture Consolidation` to bridge the gap between v1.11 and v2.0, aligning it with `NEXT.md`.
+
+This aligns the roadmap and implementation plan with the real architectural and design choice mandated by `NEXT.md` (which represents the shipped/active reality of the project's direction).
+
+### Option B
+Only update `ROADMAP.md` to mention the active product lane, leaving `docs/implementation-plan.md` alone. This is inferior because `docs/implementation-plan.md` is also explicitly used by contributors and contains the stale `Phase 5c` and lacks the active product phases.
+
+### Decision
+I will proceed with Option A to fully align `ROADMAP.md` and `docs/implementation-plan.md` with the ground truth in `NEXT.md` and the shipped v1.11.0 reality.

--- a/.jules/runs/cartographer_roadmap_design_1/envelope.json
+++ b/.jules/runs/cartographer_roadmap_design_1/envelope.json
@@ -10,8 +10,13 @@
     "ROADMAP.md",
     "CHANGELOG.md",
     "Cargo.toml",
-    "Cargo.lock"
+    "Cargo.lock",
+    "crates/**/Cargo.toml",
+    ".cargo/**"
   ],
   "gate_profile": "governance-release",
-  "allowed_outcomes": ["pr-ready patch", "proof-improvement patch", "learning pr"]
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
 }

--- a/.jules/runs/cartographer_roadmap_design_1/plan.md
+++ b/.jules/runs/cartographer_roadmap_design_1/plan.md
@@ -1,0 +1,36 @@
+1. **Update `docs/implementation-plan.md` to reflect `v1.11.0` is complete.**
+   - Change `## Phase 5c: Browser Runtime Polish (v1.11.0)` to `## Phase 5c: Browser Runtime Polish (v1.11.0) ✅ Complete`
+
+2. **Add Cockpit & Architecture Consolidation phases to `docs/implementation-plan.md`.**
+   - Insert new Phase between 5c and 6, marking it as the active lane:
+     ```markdown
+     ## Phase 5d: Cockpit Hardening & Architecture Consolidation (Active)
+
+     **Goal**: Improve cockpit as the PR-review evidence surface and collapse implementation microcrates into SRP modules.
+
+     ### Work Items
+
+     - [ ] Finish small cockpit review-packet and Action-hosting gaps
+     - [ ] Preserve `tokmd cockpit` as the review evidence implementation surface
+     - [ ] Consolidate architecture in batches, preserving `ci/proof.toml` scope granularity
+     ```
+
+3. **Update `ROADMAP.md` to reflect the active lanes in Future Horizons.**
+   - Add a `v1.12.0` or active horizon phase for "Cockpit Review-Packet Hardening & Architecture Consolidation" right before `v2.0 — Platform Evolution`.
+     ```markdown
+     ### v1.12.0 — Cockpit & Architecture Consolidation (Active)
+
+     _Goal: Improve cockpit as the PR-review evidence surface before adding a separate review orchestrator, and consolidate implementation microcrates into SRP modules._
+
+     - Finish small cockpit review-packet and Action-hosting gaps.
+     - Preserve `tokmd cockpit` as the review evidence implementation surface.
+     - Start architecture consolidation in batches, preserving scope granularity.
+     ```
+
+4. **Verify the changes using `grep` and `cat`.**
+
+5. **Generate required artifacts:**
+   - Create `.jules/runs/cartographer_roadmap_design_1/result.json`.
+   - Create `.jules/runs/cartographer_roadmap_design_1/pr_body.md`.
+
+6. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**

--- a/.jules/runs/cartographer_roadmap_design_1/pr_body.md
+++ b/.jules/runs/cartographer_roadmap_design_1/pr_body.md
@@ -1,48 +1,48 @@
 ## 💡 Summary
-Fixed a factual drift in `docs/requirements.md` where the `Analysis receipts` schema version incorrectly referenced `v5` instead of `v9`.
+Updates `ROADMAP.md` and `docs/implementation-plan.md` to align with the active shipped reality governed by `NEXT.md`. This closes the factual drift where the roadmap skipped from v1.11 browser polish straight to v2.0 MCP integration without documenting the current "cockpit review-packet hardening" and "architecture-consolidation" phases.
 
 ## 🎯 Why
-The `docs/requirements.md` document listed `- **Analysis receipts**: Schema v5` under the `Receipt Contracts` section. However, `crates/tokmd-analysis-types/src/lib.rs` explicitly defines `ANALYSIS_SCHEMA_VERSION = 9`, and `docs/design.md` and `docs/architecture.md` correctly reference `v9`. This fixes the factual drift between the shipped reality and the requirements documentation.
+`NEXT.md` explicitly lists "cockpit review-packet hardening" and "architecture-consolidation program" as the active work lanes. However, both `ROADMAP.md` and `docs/implementation-plan.md` suffered from factual drift: they lacked any mention of these phases, and `docs/implementation-plan.md` failed to mark Phase 5c (Browser Runtime Polish) as complete. This update ensures design/roadmap docs accurately reflect shipped and active priorities, making future work planning clearer.
 
 ## 🔎 Evidence
-- **File**: `docs/requirements.md`
-- **Observed behavior**: It claimed Analysis receipts were Schema v5.
+- **File paths**: `docs/NEXT.md`, `ROADMAP.md`, `docs/implementation-plan.md`
+- **Observed behavior**: `ROADMAP.md` skips from `v1.11.0` directly to `v2.0` Future Horizons. `docs/implementation-plan.md` had Phase 5c unmarked as complete and no Phase 5d/active lane.
 - **Receipts**:
-  - `grep -r "ANALYSIS_SCHEMA_VERSION =" crates/`
-    - `crates/tokmd-analysis-types/src/lib.rs:pub const ANALYSIS_SCHEMA_VERSION: u32 = 9;`
-  - `grep "Schema v" docs/requirements.md`
-    - `- **Analysis receipts**: Schema v5`
+  ```text
+  {"command": "cat docs/implementation-plan.md | grep -A 20 \"Phase 5c\"", "exit_code": 0}
+  {"command": "cat docs/NEXT.md", "exit_code": 0}
+  ```
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- Updating the schema version inline in `docs/requirements.md` from `v5` to `v9`.
-- **Why it fits**: Directly addresses the factual drift within the tooling-governance shard.
-- **Trade-offs**: High alignment with current repo structure and velocity, but could drift again in the future.
+- **What it is**: Update both `docs/implementation-plan.md` (to mark Phase 5c complete and add active Phase 5d) and `ROADMAP.md` (to insert `v1.12.0 Cockpit & Architecture Consolidation` under Future Horizons).
+- **Why it fits this repo and shard**: It strictly fixes factual drift between the governance-driven `NEXT.md` state and the active product roadmap docs within the `tooling-governance` shard.
+- **Trade-offs**: Structure / Velocity / Governance - Strengthens governance alignment without slowing velocity, as it aligns documented reality with the actual active development program.
 
 ### Option B
-- Removing the schema version number entirely from `docs/requirements.md` and pointing to `docs/design.md`.
-- **When to choose**: If we want to centralize schema versions entirely to avoid future drifts.
-- **Trade-offs**: Reduces immediate readability of the requirements doc.
+- **What it is**: Only update `ROADMAP.md`, leaving `docs/implementation-plan.md` out of date.
+- **When to choose it instead**: If `implementation-plan.md` was deprecated (it's not).
+- **Trade-offs**: Risks confusing contributors who rely on the phase checklist in `docs/implementation-plan.md`.
 
 ## ✅ Decision
-Chose Option A to accurately reflect the shipped `v9` schema in the requirements doc, keeping the document descriptive.
+Implemented Option A to ensure all forward-looking documentation precisely reflects the active directives set in `NEXT.md`.
 
 ## 🧱 Changes made (SRP)
-- `docs/requirements.md`: Updated `Schema v5` to `Schema v9` for Analysis receipts.
+- `docs/implementation-plan.md`: Marked Phase 5c as `✅ Complete` and inserted Phase 5d (Cockpit Hardening & Architecture Consolidation).
+- `ROADMAP.md`: Added `v1.12.0 — Cockpit & Architecture Consolidation (Active)` to the `Future Horizons` section.
 
 ## 🧪 Verification receipts
 ```text
-$ sed -i 's/- \*\*Analysis receipts\*\*: Schema v5/- \*\*Analysis receipts\*\*: Schema v9/' docs/requirements.md
-$ cargo xtask docs --check
-Documentation is up to date.
+{"command": "cat docs/implementation-plan.md | grep -n \"Phase 5d\" -A 15", "exit_code": 0}
+{"command": "cat ROADMAP.md | grep -n \"v1.12.0\" -A 10", "exit_code": 0}
 ```
 
 ## 🧭 Telemetry
-- **Change shape**: Docs update.
-- **Blast radius**: `docs/` (Information/documentation only, no code change).
-- **Risk class**: Trivial. Non-functional documentation fix.
-- **Rollback**: Trivial revert.
-- **Gates run**: `cargo xtask docs --check`
+- **Change shape**: Docs alignment / Factual drift resolution
+- **Blast radius**: `docs` (no API, schema, IO, or concurrency risks).
+- **Risk class + why**: Low risk. pure documentation update.
+- **Rollback**: Revert git commits touching `.md` files.
+- **Gates run**: `cargo xtask docs --check`, `cargo xtask version-consistency`
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/cartographer_roadmap_design_1/envelope.json`

--- a/.jules/runs/cartographer_roadmap_design_1/receipts.jsonl
+++ b/.jules/runs/cartographer_roadmap_design_1/receipts.jsonl
@@ -1,2 +1,6 @@
-{"timestamp":"$(date -u +"%Y-%m-%dT%H:%M:%SZ")","command":"sed -i 's/- \\*\\*Analysis receipts\\*\\*: Schema v5/- \\*\\*Analysis receipts\\*\\*: Schema v9/' docs/requirements.md","status":"success","notes":"Updated factual drift in docs/requirements.md"}
-{"timestamp":"$(date -u +"%Y-%m-%dT%H:%M:%SZ")","command":"cargo xtask docs --check","status":"success","notes":"Ran docs verification gate"}
+{"command": "grep -rin \"Tree-sitter\" docs/", "exit_code": 0}
+{"command": "cat docs/implementation-plan.md | grep -A 20 \"Phase 5c\"", "exit_code": 0}
+{"command": "cat docs/NEXT.md", "exit_code": 0}
+{"command": "cat docs/implementation-plan.md | grep -n \\"Phase 5d\\" -A 15", "exit_code": 0}
+{"command": "cat ROADMAP.md | grep -n \\"v1.12.0\\" -A 10", "exit_code": 0}
+{"command": "cargo xtask version-consistency && cargo xtask docs --check && cargo xtask publish --plan && cargo deny --all-features check && cargo test -p xtask && cargo fmt -- --check && cargo clippy -- -D warnings", "exit_code": 0}

--- a/.jules/runs/cartographer_roadmap_design_1/result.json
+++ b/.jules/runs/cartographer_roadmap_design_1/result.json
@@ -1,5 +1,28 @@
 {
-  "status": "success",
-  "reason": "Found and fixed factual drift in docs/requirements.md regarding Analysis receipts schema version (was v5, updated to v9 to match code and architecture docs).",
-  "patch_ready": true
+  "outcome": "PR-ready patch",
+  "provenance": {
+    "run_id": "cartographer_roadmap_design_1",
+    "persona": "cartographer"
+  },
+  "changes": [
+    {
+      "file": "ROADMAP.md",
+      "action": "modified",
+      "description": "Added the active v1.12.0 Cockpit & Architecture Consolidation horizon, aligning with NEXT.md directives."
+    },
+    {
+      "file": "docs/implementation-plan.md",
+      "action": "modified",
+      "description": "Marked Phase 5c as complete and inserted Phase 5d for Cockpit Hardening & Architecture Consolidation."
+    }
+  ],
+  "telemetry": {
+    "blast_radius": "docs",
+    "risk_class": "low",
+    "rollback_instructions": "Revert the commit on ROADMAP.md and docs/implementation-plan.md.",
+    "gates_run": [
+      "cargo xtask docs --check",
+      "cargo xtask version-consistency"
+    ]
+  }
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -568,6 +568,14 @@ back into single-responsibility owner modules.
 
 ## Future Horizons
 
+### v1.12.0 — Cockpit & Architecture Consolidation (Active)
+
+_Goal: Improve cockpit as the PR-review evidence surface before adding a separate review orchestrator, and consolidate implementation microcrates into SRP modules._
+
+- Finish small cockpit review-packet and Action-hosting gaps.
+- Preserve `tokmd cockpit` as the review evidence implementation surface.
+- Start architecture consolidation in batches, preserving scope granularity.
+
 ### v2.0 — Platform Evolution
 
 #### A. AI Agent Integration & MCP Server Mode

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -373,7 +373,7 @@ authenticated fetch.
 - [x] Add determinism, snapshot, and property-test proof coverage for release-critical paths
 - [x] Clarify Jules provenance policy without blanket-blocking intentional `.jules/**` history
 
-## Phase 5c: Browser Runtime Polish (v1.11.0)
+## Phase 5c: Browser Runtime Polish (v1.11.0) ✅ Complete
 
 **Goal**: Deliver browser runtime polish for cache semantics, long-running analysis visibility, fetch resilience, and authenticated-fetch boundaries.
 
@@ -390,6 +390,19 @@ authenticated fetch.
 - Unit tests: cache key and invalidation behavior
 - Worker tests: progress event emission during long scans
 - Runner tests: retry/rate-limit and authenticated-cache partition behavior
+
+---
+
+## Phase 5d: Cockpit Hardening & Architecture Consolidation (Active)
+
+**Goal**: Improve cockpit as the PR-review evidence surface before adding a separate review orchestrator, and consolidate implementation microcrates into SRP modules.
+
+### Work Items
+
+- [ ] Finish small cockpit review-packet and Action-hosting gaps
+- [ ] Preserve `tokmd cockpit` as the review evidence implementation surface
+- [ ] Consolidate architecture in batches, preserving `ci/proof.toml` scope granularity
+- [ ] Ensure proof-run and scoped coverage observations remain advisory
 
 ---
 


### PR DESCRIPTION
## Summary

- Align `ROADMAP.md` and `docs/implementation-plan.md` with `docs/NEXT.md`: v1.11 browser runtime polish is complete, and the active lane is cockpit review-packet hardening followed by architecture consolidation.
- Keep the Jules provenance artifacts attached to the generated docs-alignment work.
- Restack the branch onto current `origin/main` so affected proof sees only `jules_workspace` and `project_truth_docs` instead of already-merged security/path/vendor changes.

## Validation

- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask docs --check`
- `cargo xtask version-consistency`
- `cargo xtask proof-policy --check`
- `git diff --check origin/main...HEAD`

## Notes

The original affected-plan failure was branch staleness: the draft branch predated #1790 and #1791, so the diff against current main included already-merged files and reported unknown paths. After restacking, affected proof reports no unknown files.
