### PR TITLE
test(cockpit): validate review packet schemas

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -600,8 +600,14 @@ paths = [
   "crates/tokmd-types/src/cockpit.rs",
   "crates/tokmd-types/tests/cockpit_tests.rs",
   "crates/tokmd/src/commands/cockpit.rs",
+  "crates/tokmd/schemas/review-map.schema.json",
+  "crates/tokmd/schemas/review-packet-evidence.schema.json",
+  "crates/tokmd/schemas/review-packet-manifest.schema.json",
   "crates/tokmd/tests/cockpit_*.rs",
   "docs/review-packet.md",
+  "docs/review-map.schema.json",
+  "docs/review-packet-evidence.schema.json",
+  "docs/review-packet-manifest.schema.json",
   "docs/tokmd-in-cockpit.md",
 ]
 packages = ["tokmd-cockpit", "tokmd-core", "tokmd-types", "tokmd"]
@@ -790,6 +796,9 @@ paths = [
   "docs/baseline.schema.json",
   "docs/handoff.schema.json",
   "docs/handoff-schema.md",
+  "docs/review-map.schema.json",
+  "docs/review-packet-evidence.schema.json",
+  "docs/review-packet-manifest.schema.json",
   "docs/schema.json",
   "docs/requirements.md",
 ]

--- a/crates/tokmd/schemas/review-map.schema.json
+++ b/crates/tokmd/schemas/review-map.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://effortlessmetrics.dev/tokmd/schemas/review-map.schema.json",
+  "title": "tokmd Review Map",
+  "description": "Schema for .tokmd/review/review-map.json emitted by tokmd cockpit --review-packet-dir.",
+  "type": "object",
+  "required": ["schema", "base_ref", "head_ref", "source", "item_count", "items"],
+  "properties": {
+    "schema": { "type": "string", "const": "tokmd.review_map.v1" },
+    "base_ref": { "type": "string", "minLength": 1 },
+    "head_ref": { "type": "string", "minLength": 1 },
+    "source": { "type": "string", "const": "cockpit.review_plan" },
+    "item_count": { "type": "integer", "minimum": 0 },
+    "items": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/reviewMapItem" }
+    }
+  },
+  "definitions": {
+    "reviewMapItem": {
+      "type": "object",
+      "required": [
+        "rank",
+        "path",
+        "priority",
+        "priority_label",
+        "reason",
+        "complexity",
+        "lines_changed",
+        "evidence_refs",
+        "reproduce"
+      ],
+      "properties": {
+        "rank": { "type": "integer", "minimum": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "priority": { "type": "integer", "minimum": 0 },
+        "priority_label": {
+          "type": "string",
+          "enum": ["highest", "medium", "low"]
+        },
+        "reason": { "type": "string", "minLength": 1 },
+        "complexity": {
+          "anyOf": [
+            { "type": "integer", "minimum": 1, "maximum": 5 },
+            { "type": "null" }
+          ]
+        },
+        "lines_changed": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "reproduce": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/crates/tokmd/schemas/review-packet-evidence.schema.json
+++ b/crates/tokmd/schemas/review-packet-evidence.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://effortlessmetrics.dev/tokmd/schemas/review-packet-evidence.schema.json",
+  "title": "tokmd Review Packet Evidence",
+  "description": "Schema for .tokmd/review/evidence.json emitted by tokmd cockpit --review-packet-dir.",
+  "type": "object",
+  "required": ["schema", "overall_status", "base_ref", "head_ref", "gates"],
+  "properties": {
+    "schema": { "type": "string", "const": "tokmd.review_packet_evidence.v1" },
+    "overall_status": { "$ref": "#/definitions/gateStatus" },
+    "base_ref": { "type": "string", "minLength": 1 },
+    "head_ref": { "type": "string", "minLength": 1 },
+    "gates": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/evidenceGate" }
+    }
+  },
+  "definitions": {
+    "evidenceGate": {
+      "type": "object",
+      "required": [
+        "id",
+        "status",
+        "availability",
+        "source",
+        "commit_match",
+        "scope",
+        "evidence_commit",
+        "evidence_generated_at_ms"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "status": {
+          "type": "string",
+          "enum": ["pass", "warn", "fail", "skipped", "pending", "unavailable"]
+        },
+        "availability": { "$ref": "#/definitions/availability" },
+        "source": {
+          "anyOf": [
+            { "type": "string", "enum": ["ci_artifact", "cached", "ran_local"] },
+            { "type": "null" }
+          ]
+        },
+        "commit_match": {
+          "anyOf": [
+            { "type": "string", "enum": ["exact", "partial", "stale", "unknown"] },
+            { "type": "null" }
+          ]
+        },
+        "scope": { "$ref": "#/definitions/scopeCoverage" },
+        "evidence_commit": {
+          "anyOf": [{ "type": "string" }, { "type": "null" }]
+        },
+        "evidence_generated_at_ms": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "scopeCoverage": {
+      "type": "object",
+      "required": ["relevant", "tested", "ratio", "lines_relevant", "lines_tested"],
+      "properties": {
+        "relevant": { "$ref": "#/definitions/stringList" },
+        "tested": { "$ref": "#/definitions/stringList" },
+        "ratio": { "type": "number", "minimum": 0 },
+        "lines_relevant": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "lines_tested": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "stringList": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "availability": {
+      "type": "string",
+      "enum": ["available", "missing", "skipped", "stale", "degraded", "unavailable"]
+    },
+    "gateStatus": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail", "skipped", "pending"]
+    }
+  }
+}

--- a/crates/tokmd/schemas/review-packet-manifest.schema.json
+++ b/crates/tokmd/schemas/review-packet-manifest.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://effortlessmetrics.dev/tokmd/schemas/review-packet-manifest.schema.json",
+  "title": "tokmd Review Packet Manifest",
+  "description": "Schema for .tokmd/review/manifest.json emitted by tokmd cockpit --review-packet-dir.",
+  "type": "object",
+  "required": [
+    "schema",
+    "generated_by",
+    "generated_at_ms",
+    "base_ref",
+    "head_ref",
+    "verdict",
+    "capabilities",
+    "artifacts"
+  ],
+  "properties": {
+    "schema": { "type": "string", "const": "tokmd.review_packet_manifest.v1" },
+    "generated_by": { "$ref": "#/definitions/generatedBy" },
+    "generated_at_ms": { "type": "integer", "minimum": 0 },
+    "base_ref": { "type": "string", "minLength": 1 },
+    "head_ref": { "type": "string", "minLength": 1 },
+    "verdict": { "$ref": "#/definitions/verdict" },
+    "capabilities": { "$ref": "#/definitions/capabilities" },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/artifact" }
+    }
+  },
+  "definitions": {
+    "generatedBy": {
+      "type": "object",
+      "required": ["name", "version", "mode", "arguments"],
+      "properties": {
+        "name": { "type": "string", "const": "tokmd" },
+        "version": { "type": "string", "minLength": 1 },
+        "mode": { "type": "string", "const": "cockpit" },
+        "arguments": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "verdict": {
+      "type": "object",
+      "required": ["status", "blocking", "reason", "evidence"],
+      "properties": {
+        "status": { "$ref": "#/definitions/gateStatus" },
+        "blocking": { "type": "boolean" },
+        "reason": { "type": "string", "minLength": 1 },
+        "evidence": { "$ref": "#/definitions/evidenceSummary" }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "required": ["evidence"],
+      "properties": {
+        "evidence": { "$ref": "#/definitions/evidenceCapabilityGroups" }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["id", "path", "schema", "media_type", "hash"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "not": { "pattern": "^([A-Za-z]:|/|\\\\)" }
+        },
+        "schema": { "type": "string", "minLength": 1 },
+        "media_type": { "type": "string", "minLength": 1 },
+        "hash": { "$ref": "#/definitions/artifactHash" }
+      }
+    },
+    "artifactHash": {
+      "type": "object",
+      "required": ["algo", "hash"],
+      "properties": {
+        "algo": { "type": "string", "const": "blake3" },
+        "hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "evidenceSummary": {
+      "type": "object",
+      "required": [
+        "details",
+        "total_gates",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "total_gates": { "type": "integer", "minimum": 0 },
+        "available": { "type": "integer", "minimum": 0 },
+        "degraded": { "type": "integer", "minimum": 0 },
+        "stale": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "unavailable": { "type": "integer", "minimum": 0 },
+        "missing": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "evidenceCapabilityGroups": {
+      "type": "object",
+      "required": [
+        "details",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "available": { "$ref": "#/definitions/stringList" },
+        "degraded": { "$ref": "#/definitions/stringList" },
+        "stale": { "$ref": "#/definitions/stringList" },
+        "skipped": { "$ref": "#/definitions/stringList" },
+        "unavailable": { "$ref": "#/definitions/stringList" },
+        "missing": { "$ref": "#/definitions/stringList" }
+      }
+    },
+    "stringList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "gateStatus": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail", "skipped", "pending"]
+    }
+  }
+}

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -13,6 +13,32 @@ fn tokmd_cmd() -> Command {
     cmd
 }
 
+const REVIEW_PACKET_MANIFEST_SCHEMA_JSON: &str =
+    include_str!("../schemas/review-packet-manifest.schema.json");
+const REVIEW_PACKET_EVIDENCE_SCHEMA_JSON: &str =
+    include_str!("../schemas/review-packet-evidence.schema.json");
+const REVIEW_MAP_SCHEMA_JSON: &str = include_str!("../schemas/review-map.schema.json");
+
+fn assert_validates_against_schema(schema_json: &str, instance: &serde_json::Value, label: &str) {
+    let schema: serde_json::Value =
+        serde_json::from_str(schema_json).unwrap_or_else(|err| panic!("{label} schema: {err}"));
+    let validator = jsonschema::validator_for(&schema)
+        .unwrap_or_else(|err| panic!("{label} schema should compile: {err}"));
+
+    if !validator.is_valid(instance) {
+        let errors: Vec<String> = validator
+            .iter_errors(instance)
+            .map(|err| format!("{} at {}", err, err.instance_path()))
+            .collect();
+        panic!(
+            "{label} did not validate against schema:\n{}\n\nInstance:\n{}",
+            errors.join("\n"),
+            serde_json::to_string_pretty(instance)
+                .expect("failed to serialize invalid schema instance")
+        );
+    }
+}
+
 #[test]
 fn test_cockpit_help() {
     // Given: The cockpit command exists
@@ -534,6 +560,11 @@ fn test_cockpit_review_packet_dir() {
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(packet_dir.join("manifest.json")).unwrap())
             .expect("valid manifest JSON");
+    assert_validates_against_schema(
+        REVIEW_PACKET_MANIFEST_SCHEMA_JSON,
+        &manifest,
+        "review packet manifest",
+    );
     assert_eq!(manifest["schema"], "tokmd.review_packet_manifest.v1");
     assert_eq!(
         manifest["capabilities"]["evidence"]["details"],
@@ -606,6 +637,11 @@ fn test_cockpit_review_packet_dir() {
     let evidence: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(packet_dir.join("evidence.json")).unwrap())
             .expect("valid evidence JSON");
+    assert_validates_against_schema(
+        REVIEW_PACKET_EVIDENCE_SCHEMA_JSON,
+        &evidence,
+        "review packet evidence",
+    );
     assert_eq!(evidence["schema"], "tokmd.review_packet_evidence.v1");
     let gates = evidence["gates"].as_array().expect("evidence gates array");
     assert!(
@@ -629,6 +665,7 @@ fn test_cockpit_review_packet_dir() {
     let review_map: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(packet_dir.join("review-map.json")).unwrap())
             .expect("valid review map JSON");
+    assert_validates_against_schema(REVIEW_MAP_SCHEMA_JSON, &review_map, "review map");
     assert_eq!(review_map["schema"], "tokmd.review_map.v1");
     let items = review_map["items"].as_array().expect("review map items");
     assert_eq!(review_map["item_count"], items.len() as u64);

--- a/crates/tokmd/tests/schema_validation.rs
+++ b/crates/tokmd/tests/schema_validation.rs
@@ -23,6 +23,17 @@ const HANDOFF_SCHEMA_JSON: &str = include_str!("../schemas/handoff.schema.json")
 /// Embedded JSON schema for sensor.report.v1 envelope (from schemas/sensor.report.v1.schema.json)
 const SENSOR_REPORT_SCHEMA_JSON: &str = include_str!("../schemas/sensor.report.v1.schema.json");
 
+/// Embedded JSON schema for review packet manifests
+const REVIEW_PACKET_MANIFEST_SCHEMA_JSON: &str =
+    include_str!("../schemas/review-packet-manifest.schema.json");
+
+/// Embedded JSON schema for review packet evidence
+const REVIEW_PACKET_EVIDENCE_SCHEMA_JSON: &str =
+    include_str!("../schemas/review-packet-evidence.schema.json");
+
+/// Embedded JSON schema for review maps
+const REVIEW_MAP_SCHEMA_JSON: &str = include_str!("../schemas/review-map.schema.json");
+
 /// Load the JSON schema from embedded content
 fn load_schema() -> Result<Value> {
     serde_json::from_str(SCHEMA_JSON).context("Failed to parse embedded schema.json")
@@ -38,6 +49,13 @@ fn load_handoff_schema() -> Result<Value> {
 fn load_sensor_report_schema() -> Result<Value> {
     serde_json::from_str(SENSOR_REPORT_SCHEMA_JSON)
         .context("Failed to parse embedded sensor.report.v1.schema.json")
+}
+
+fn compile_schema(schema_json: &str, name: &str) -> Result<jsonschema::Validator> {
+    let schema: Value = serde_json::from_str(schema_json)
+        .with_context(|| format!("Failed to parse embedded {name}"))?;
+    jsonschema::validator_for(&schema)
+        .map_err(|e| anyhow::anyhow!("Failed to compile {name}: {}", e))
 }
 
 /// Build a validator for a specific definition in the schema
@@ -375,6 +393,52 @@ fn test_schema_copies_in_sync() {
         embedded, docs,
         "crates/tokmd/schemas/schema.json and docs/schema.json have diverged — update both copies"
     );
+}
+
+#[test]
+fn test_review_packet_schema_copies_in_sync() -> Result<()> {
+    for (schema_name, embedded) in [
+        (
+            "review-packet-manifest.schema.json",
+            REVIEW_PACKET_MANIFEST_SCHEMA_JSON,
+        ),
+        (
+            "review-packet-evidence.schema.json",
+            REVIEW_PACKET_EVIDENCE_SCHEMA_JSON,
+        ),
+        ("review-map.schema.json", REVIEW_MAP_SCHEMA_JSON),
+    ] {
+        let docs_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs")
+            .join(schema_name);
+        let docs_schema = std::fs::read_to_string(&docs_path)
+            .with_context(|| format!("read {}", docs_path.display()))?;
+
+        let embedded: Value = serde_json::from_str(&embedded.replace("\r\n", "\n"))
+            .with_context(|| format!("embedded {schema_name} should be valid JSON"))?;
+        let docs: Value = serde_json::from_str(&docs_schema.replace("\r\n", "\n"))
+            .with_context(|| format!("docs/{schema_name} should be valid JSON"))?;
+        assert_eq!(
+            embedded, docs,
+            "crates/tokmd/schemas/{schema_name} and docs/{schema_name} have diverged"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_review_packet_schemas_are_valid_json_schema() -> Result<()> {
+    compile_schema(
+        REVIEW_PACKET_MANIFEST_SCHEMA_JSON,
+        "review-packet-manifest.schema.json",
+    )?;
+    compile_schema(
+        REVIEW_PACKET_EVIDENCE_SCHEMA_JSON,
+        "review-packet-evidence.schema.json",
+    )?;
+    compile_schema(REVIEW_MAP_SCHEMA_JSON, "review-map.schema.json")?;
+    Ok(())
 }
 
 #[test]

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,7 +1,11 @@
 # tokmd Receipt Schema
 
-> **Note**: Core/analysis receipts are defined in [schema.json](schema.json).  
+> **Note**: Core/analysis receipts are defined in [schema.json](schema.json).
 > Handoff manifests are defined in [handoff.schema.json](handoff.schema.json).
+> Cockpit review packet sidecars are defined in
+> [review-packet-manifest.schema.json](review-packet-manifest.schema.json),
+> [review-packet-evidence.schema.json](review-packet-evidence.schema.json), and
+> [review-map.schema.json](review-map.schema.json).
 
 `tokmd` produces structured JSON outputs called "receipts". These schemas are stable and intended for machine consumption.
 

--- a/docs/review-map.schema.json
+++ b/docs/review-map.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://effortlessmetrics.dev/tokmd/schemas/review-map.schema.json",
+  "title": "tokmd Review Map",
+  "description": "Schema for .tokmd/review/review-map.json emitted by tokmd cockpit --review-packet-dir.",
+  "type": "object",
+  "required": ["schema", "base_ref", "head_ref", "source", "item_count", "items"],
+  "properties": {
+    "schema": { "type": "string", "const": "tokmd.review_map.v1" },
+    "base_ref": { "type": "string", "minLength": 1 },
+    "head_ref": { "type": "string", "minLength": 1 },
+    "source": { "type": "string", "const": "cockpit.review_plan" },
+    "item_count": { "type": "integer", "minimum": 0 },
+    "items": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/reviewMapItem" }
+    }
+  },
+  "definitions": {
+    "reviewMapItem": {
+      "type": "object",
+      "required": [
+        "rank",
+        "path",
+        "priority",
+        "priority_label",
+        "reason",
+        "complexity",
+        "lines_changed",
+        "evidence_refs",
+        "reproduce"
+      ],
+      "properties": {
+        "rank": { "type": "integer", "minimum": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "priority": { "type": "integer", "minimum": 0 },
+        "priority_label": {
+          "type": "string",
+          "enum": ["highest", "medium", "low"]
+        },
+        "reason": { "type": "string", "minLength": 1 },
+        "complexity": {
+          "anyOf": [
+            { "type": "integer", "minimum": 1, "maximum": 5 },
+            { "type": "null" }
+          ]
+        },
+        "lines_changed": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "reproduce": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/docs/review-packet-evidence.schema.json
+++ b/docs/review-packet-evidence.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://effortlessmetrics.dev/tokmd/schemas/review-packet-evidence.schema.json",
+  "title": "tokmd Review Packet Evidence",
+  "description": "Schema for .tokmd/review/evidence.json emitted by tokmd cockpit --review-packet-dir.",
+  "type": "object",
+  "required": ["schema", "overall_status", "base_ref", "head_ref", "gates"],
+  "properties": {
+    "schema": { "type": "string", "const": "tokmd.review_packet_evidence.v1" },
+    "overall_status": { "$ref": "#/definitions/gateStatus" },
+    "base_ref": { "type": "string", "minLength": 1 },
+    "head_ref": { "type": "string", "minLength": 1 },
+    "gates": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/evidenceGate" }
+    }
+  },
+  "definitions": {
+    "evidenceGate": {
+      "type": "object",
+      "required": [
+        "id",
+        "status",
+        "availability",
+        "source",
+        "commit_match",
+        "scope",
+        "evidence_commit",
+        "evidence_generated_at_ms"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "status": {
+          "type": "string",
+          "enum": ["pass", "warn", "fail", "skipped", "pending", "unavailable"]
+        },
+        "availability": { "$ref": "#/definitions/availability" },
+        "source": {
+          "anyOf": [
+            { "type": "string", "enum": ["ci_artifact", "cached", "ran_local"] },
+            { "type": "null" }
+          ]
+        },
+        "commit_match": {
+          "anyOf": [
+            { "type": "string", "enum": ["exact", "partial", "stale", "unknown"] },
+            { "type": "null" }
+          ]
+        },
+        "scope": { "$ref": "#/definitions/scopeCoverage" },
+        "evidence_commit": {
+          "anyOf": [{ "type": "string" }, { "type": "null" }]
+        },
+        "evidence_generated_at_ms": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "scopeCoverage": {
+      "type": "object",
+      "required": ["relevant", "tested", "ratio", "lines_relevant", "lines_tested"],
+      "properties": {
+        "relevant": { "$ref": "#/definitions/stringList" },
+        "tested": { "$ref": "#/definitions/stringList" },
+        "ratio": { "type": "number", "minimum": 0 },
+        "lines_relevant": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "lines_tested": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "stringList": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "availability": {
+      "type": "string",
+      "enum": ["available", "missing", "skipped", "stale", "degraded", "unavailable"]
+    },
+    "gateStatus": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail", "skipped", "pending"]
+    }
+  }
+}

--- a/docs/review-packet-manifest.schema.json
+++ b/docs/review-packet-manifest.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://effortlessmetrics.dev/tokmd/schemas/review-packet-manifest.schema.json",
+  "title": "tokmd Review Packet Manifest",
+  "description": "Schema for .tokmd/review/manifest.json emitted by tokmd cockpit --review-packet-dir.",
+  "type": "object",
+  "required": [
+    "schema",
+    "generated_by",
+    "generated_at_ms",
+    "base_ref",
+    "head_ref",
+    "verdict",
+    "capabilities",
+    "artifacts"
+  ],
+  "properties": {
+    "schema": { "type": "string", "const": "tokmd.review_packet_manifest.v1" },
+    "generated_by": { "$ref": "#/definitions/generatedBy" },
+    "generated_at_ms": { "type": "integer", "minimum": 0 },
+    "base_ref": { "type": "string", "minLength": 1 },
+    "head_ref": { "type": "string", "minLength": 1 },
+    "verdict": { "$ref": "#/definitions/verdict" },
+    "capabilities": { "$ref": "#/definitions/capabilities" },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/artifact" }
+    }
+  },
+  "definitions": {
+    "generatedBy": {
+      "type": "object",
+      "required": ["name", "version", "mode", "arguments"],
+      "properties": {
+        "name": { "type": "string", "const": "tokmd" },
+        "version": { "type": "string", "minLength": 1 },
+        "mode": { "type": "string", "const": "cockpit" },
+        "arguments": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "verdict": {
+      "type": "object",
+      "required": ["status", "blocking", "reason", "evidence"],
+      "properties": {
+        "status": { "$ref": "#/definitions/gateStatus" },
+        "blocking": { "type": "boolean" },
+        "reason": { "type": "string", "minLength": 1 },
+        "evidence": { "$ref": "#/definitions/evidenceSummary" }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "required": ["evidence"],
+      "properties": {
+        "evidence": { "$ref": "#/definitions/evidenceCapabilityGroups" }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["id", "path", "schema", "media_type", "hash"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "not": { "pattern": "^([A-Za-z]:|/|\\\\)" }
+        },
+        "schema": { "type": "string", "minLength": 1 },
+        "media_type": { "type": "string", "minLength": 1 },
+        "hash": { "$ref": "#/definitions/artifactHash" }
+      }
+    },
+    "artifactHash": {
+      "type": "object",
+      "required": ["algo", "hash"],
+      "properties": {
+        "algo": { "type": "string", "const": "blake3" },
+        "hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "evidenceSummary": {
+      "type": "object",
+      "required": [
+        "details",
+        "total_gates",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "total_gates": { "type": "integer", "minimum": 0 },
+        "available": { "type": "integer", "minimum": 0 },
+        "degraded": { "type": "integer", "minimum": 0 },
+        "stale": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "unavailable": { "type": "integer", "minimum": 0 },
+        "missing": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "evidenceCapabilityGroups": {
+      "type": "object",
+      "required": [
+        "details",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "available": { "$ref": "#/definitions/stringList" },
+        "degraded": { "$ref": "#/definitions/stringList" },
+        "stale": { "$ref": "#/definitions/stringList" },
+        "skipped": { "$ref": "#/definitions/stringList" },
+        "unavailable": { "$ref": "#/definitions/stringList" },
+        "missing": { "$ref": "#/definitions/stringList" }
+      }
+    },
+    "stringList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "gateStatus": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail", "skipped", "pending"]
+    }
+  }
+}

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -59,6 +59,13 @@ The review packet directory is:
 | `review-map.json` | Machine-readable prioritized review plan with files, reasons, evidence references, and reproduction commands derived from `cockpit.json#/review_plan`. |
 | `review-map.md` | Human-readable review plan for artifact browsing and local review. |
 
+Formal JSON Schemas are published with the docs and embedded in the CLI test
+package:
+
+- [`review-packet-manifest.schema.json`](review-packet-manifest.schema.json)
+- [`review-packet-evidence.schema.json`](review-packet-evidence.schema.json)
+- [`review-map.schema.json`](review-map.schema.json)
+
 ## Evidence Semantics
 
 Packet consumers must not treat unavailable evidence as passing evidence.


### PR DESCRIPTION
## Summary
- Add formal Draft 7 schemas for cockpit review-packet manifest, evidence, and review-map artifacts.
- Embed matching schema copies in `crates/tokmd/schemas` and assert docs/embedded copies stay in sync.
- Validate generated `tokmd cockpit --review-packet-dir` artifacts against the schemas and route schema files through the cockpit/schema proof scopes.

## Validation
- `cargo test -p tokmd --test schema_validation review_packet --verbose`
- `cargo test -p tokmd --test cockpit_integration test_cockpit_review_packet_dir --verbose`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo clippy -p tokmd --test cockpit_integration --test schema_validation -- -D warnings`
- `cargo test -p tokmd --test schema_doc_sync --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-types schema --verbose`
- `cargo test -p tokmd-analysis-types --verbose`