### PR TITLE
docs: align crate/module boundary wording

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -174,6 +174,15 @@ mutation = true
 coverage = true
 
 [[scope]]
+name = "tokmd_python_binding"
+kind = "rust"
+paths = ["crates/tokmd-python/**"]
+packages = ["tokmd-python"]
+proof = ["cargo check -p tokmd-python --all-targets"]
+mutation = false
+coverage = false
+
+[[scope]]
 name = "lint_policy"
 kind = "rust"
 paths = [
@@ -572,6 +581,21 @@ proof = [
   "cargo test -p tokmd --test config_resolution --verbose",
 ]
 mutation = true
+coverage = true
+
+[[scope]]
+name = "tokmd_pipeline_integration"
+kind = "rust"
+paths = [
+  "crates/tokmd/tests/cross_crate_integration_w50.rs",
+  "crates/tokmd/tests/full_pipeline_w55.rs",
+]
+packages = ["tokmd"]
+proof = [
+  "cargo test -p tokmd --test cross_crate_integration_w50 --verbose",
+  "cargo test -p tokmd --test full_pipeline_w55 --verbose",
+]
+mutation = false
 coverage = true
 
 [[scope]]

--- a/crates/tokmd-analysis/src/lib.rs
+++ b/crates/tokmd-analysis/src/lib.rs
@@ -9,7 +9,7 @@
 //! * Analysis orchestration and module coordination
 //! * Derived metric computation
 //! * Preset-based feature inclusion
-//! * Enricher orchestration and adapters (delegated to microcrates)
+//! * Enricher orchestration and adapters (delegated to owner modules)
 //!
 //! ## What does NOT belong here
 //! * Output formatting (use tokmd-format::analysis)

--- a/crates/tokmd-io-port/Cargo.toml
+++ b/crates/tokmd-io-port/Cargo.toml
@@ -7,7 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 description = "I/O port traits for host-abstracted file access, enabling WASM targets."
 readme = "README.md"
-keywords = ["io", "wasm", "abstraction", "filesystem", "microcrate"]
+keywords = ["io", "wasm", "abstraction", "filesystem", "adapter"]
 categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-io-port"
 

--- a/crates/tokmd-python/src/lib.rs
+++ b/crates/tokmd-python/src/lib.rs
@@ -227,7 +227,7 @@ fn run_with_json_module(
     // valid &str. The core FFI receives only valid, owned data.
     let result_json = py.detach(move || tokmd_core::ffi::run_json(mode, &args_json));
 
-    // Parse/extract with the shared FFI-envelope microcrate, then convert to PyObject.
+    // Parse/extract with the shared FFI-envelope contract crate, then convert to PyObject.
     //
     // Rationale: The envelope extraction handles the "ok": true/false protocol.
     // Success returns the `data` field, failure returns a TokmdError.

--- a/crates/tokmd/tests/cross_crate_integration_w50.rs
+++ b/crates/tokmd/tests/cross_crate_integration_w50.rs
@@ -1,5 +1,5 @@
 //! Cross-crate integration tests verifying complete data flow through the
-//! tiered microcrate architecture: types → scan → model → format → analysis.
+//! tiered crate/module architecture: types → scan → model → format → analysis.
 
 mod common;
 

--- a/crates/tokmd/tests/full_pipeline_w55.rs
+++ b/crates/tokmd/tests/full_pipeline_w55.rs
@@ -2,7 +2,7 @@
 
 //! Cross-crate full-pipeline integration tests (W55).
 //!
-//! Exercises the complete data-flow across the tiered microcrate architecture:
+//! Exercises the complete data flow across the tiered crate/module architecture:
 //! types → scan → model → format → analysis, including CLI round-trips.
 
 mod common;


### PR DESCRIPTION
## Summary
- Replace stale microcrate wording in analysis, Python binding, and cross-crate pipeline comments with the accepted crate/module boundary language.
- Remove `microcrate` from the public `tokmd-io-port` crate keywords.
- Add proof-policy scopes for Python bindings and full-pipeline integration tests so the affected planner routes those paths instead of reporting them as unknown.

## Validation
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo check -p tokmd-io-port --all-targets`
- `cargo publish -p tokmd-io-port --locked --dry-run --no-verify --allow-dirty`
- `cargo check -p tokmd-python --all-targets`
- `cargo test -p tokmd --test cross_crate_integration_w50 --verbose`
- `cargo test -p tokmd --test full_pipeline_w55 --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask publish-surface --json`
- `git diff --check origin/main..HEAD`