### PR TITLE
fix(action): keep review packet comment immutable

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
+        run: rm -rf tokmd-summary.md tokmd-review-packet-comment.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
 
       - name: Set up Rust for local review packet binary
         uses: dtolnay/rust-toolchain@stable
@@ -391,14 +391,22 @@ jobs:
           done
           grep -q '"schema": "tokmd.review_packet_manifest.v1"' .tokmd/review/manifest.json
           grep -q '"schema": "tokmd.review_map.v1"' .tokmd/review/review-map.json
-          grep -q 'Hosted packet' .tokmd/review/comment.md
-          grep -q 'Workflow run:' .tokmd/review/comment.md
-          grep -q 'Artifact: `tokmd-receipts`' .tokmd/review/comment.md
-          grep -q 'Packet path: `.tokmd/review`' .tokmd/review/comment.md
+          if grep -q 'Hosted packet' .tokmd/review/comment.md; then
+            echo "::error::review packet comment.md should remain manifest-hashed packet content"
+            exit 1
+          fi
+          if [ ! -f tokmd-review-packet-comment.md ]; then
+            echo "::error::hosted review packet comment copy not generated"
+            exit 1
+          fi
+          grep -q 'Hosted packet' tokmd-review-packet-comment.md
+          grep -q 'Workflow run:' tokmd-review-packet-comment.md
+          grep -q 'Artifact: `tokmd-receipts`' tokmd-review-packet-comment.md
+          grep -q 'Packet path: `.tokmd/review`' tokmd-review-packet-comment.md
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
+        run: rm -rf tokmd-summary.md tokmd-review-packet-comment.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
 
       - name: Run cockpit mode with inferred pull request base
         id: cockpit_inferred_base

--- a/action.yml
+++ b/action.yml
@@ -376,7 +376,8 @@ runs:
           echo "command-status=$command_status"
         } >> "$GITHUB_OUTPUT"
 
-    - name: Annotate Review Packet Comment
+    - name: Prepare Review Packet Comment
+      id: review_packet_comment
       if: steps.generate.outputs['review-packet'] != '' && steps.generate.outputs.summary != ''
       shell: bash
       env:
@@ -392,6 +393,9 @@ runs:
           exit 0
         fi
 
+        comment_file="tokmd-review-packet-comment.md"
+        cp "$SUMMARY_FILE" "$comment_file"
+
         {
           echo
           echo "**Hosted packet**:"
@@ -402,7 +406,9 @@ runs:
             echo "- Workflow artifact upload: disabled"
           fi
           echo "- Packet path: \`$REVIEW_PACKET_DIR\`"
-        } >> "$SUMMARY_FILE"
+        } >> "$comment_file"
+
+        echo "comment-file=$comment_file" >> "$GITHUB_OUTPUT"
 
     - name: Upload Artifact
       if: inputs.artifact == 'true'
@@ -415,6 +421,7 @@ runs:
           ${{ steps.generate.outputs['gate-verdict'] }}
           ${{ steps.generate.outputs['cockpit-report'] }}
           ${{ steps.generate.outputs['review-packet'] }}
+          ${{ steps.review_packet_comment.outputs['comment-file'] }}
           ${{ steps.generate.outputs['sensor-report'] }}
           ${{ steps.generate.outputs['baseline-report'] }}
           extras/
@@ -423,7 +430,7 @@ runs:
       if: inputs.comment == 'true' && github.event_name == 'pull_request' && steps.generate.outputs.summary != ''
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
       with:
-        file-path: ${{ steps.generate.outputs.summary }}
+        file-path: ${{ steps.review_packet_comment.outputs['comment-file'] || steps.generate.outputs.summary }}
         comment_tag: tokmd-summary
 
     - name: Publish workflow summary

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -152,7 +152,8 @@ architecture-consolidation program.
 - Proof-control-plane status: routine PR observations continue under the two-command default. There is no active promotion slice for a required gate, default Codecov upload, or larger command-limit default.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
-- The composite Action now appends hosted packet metadata to review-packet comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.
+- The composite Action now adds hosted packet metadata to review-packet PR comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.
+- The composite Action now prepares hosted review-packet comments in `tokmd-review-packet-comment.md` instead of mutating `.tokmd/review/comment.md`, preserving `manifest.json` hashes for packet-local artifacts while keeping hosted PR comments useful.
 - Cockpit's Rust complexity gate now delegates function-scoped source analysis
   to `tokmd-analysis::source_complexity` instead of owning a duplicate parser.
   The `else if` double-count is fixed as a correctness improvement; impact

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -126,13 +126,15 @@ If `base` is omitted, the Action infers a repository-aware base ref. Set `base` 
 
 When `review-packet: 'true'`, cockpit mode also runs with
 `--review-packet-dir .tokmd/review`. The `review-packet` output points to that
-directory, and the `summary` output points to `.tokmd/review/comment.md` so the
-existing `comment` input can post the packet summary on pull requests.
+directory, and the `summary` output points to the packet-local
+`.tokmd/review/comment.md`.
 
-When artifact upload is enabled, the Action also appends hosted packet metadata
-to `.tokmd/review/comment.md`: the workflow run URL, the `tokmd-receipts`
-artifact name, and the packet path. This keeps pull request comments useful even
-though the packet's local file links are artifact-relative.
+When artifact upload is enabled, the Action also prepares
+`tokmd-review-packet-comment.md` from `.tokmd/review/comment.md` and appends
+hosted packet metadata: the workflow run URL, the `tokmd-receipts` artifact
+name, and the packet path. The packet's own `comment.md` remains unchanged so
+`manifest.json` hashes stay valid, while pull request comments still point to
+hosted artifacts.
 
 ### `sensor`
 
@@ -160,6 +162,7 @@ Artifact candidates include:
 - `tokmd-receipt.*`
 - `tokmd-gate-verdict.json`
 - `tokmd-cockpit-report.json`
+- `tokmd-review-packet-comment.md`
 - `.tokmd/review`
 - `tokmd-sensor-report.json`
 - `tokmd-baseline.json`
@@ -178,14 +181,15 @@ permissions:
 
 Commenting only runs on `pull_request` events. Set `comment: 'false'` for scheduled jobs, push jobs, private smoke tests, or workflows where comments are not desired.
 
-The default flow comments with `tokmd-summary.md`. `sensor` comments with `comment.md`. JSON-only modes such as `gate`, `cockpit`, and `baseline` normally leave the `summary` output empty. `cockpit` with `review-packet: 'true'` comments with `.tokmd/review/comment.md`.
+The default flow comments with `tokmd-summary.md`. `sensor` comments with `comment.md`. JSON-only modes such as `gate`, `cockpit`, and `baseline` normally leave the `summary` output empty. `cockpit` with `review-packet: 'true'` comments with the packet summary, using `tokmd-review-packet-comment.md` when hosted packet metadata is added.
 
-For cockpit review packets, the Action appends a short hosted-packet block to
-that comment before posting it. With `artifact: 'true'`, the block points
+For cockpit review packets, the Action copies `.tokmd/review/comment.md` to
+`tokmd-review-packet-comment.md` and appends a short hosted-packet block before
+posting the pull request comment. With `artifact: 'true'`, the block points
 reviewers to the workflow run and `tokmd-receipts` artifact that contains the
 full `.tokmd/review/` directory. With artifact upload disabled, the comment
 states that the packet was generated locally in the workflow workspace but not
-uploaded.
+uploaded. The packet-local `comment.md` is not mutated after generation.
 
 ## Checkout Guidance
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -147,11 +147,13 @@ The Action uploads the packet as an artifact when `artifact: 'true'` and
 `review-packet: 'true'` are both set. Comment posting remains fork-safe and is
 not required for packet generation.
 
-When the composite Action generates a review packet, it appends a hosted-packet
-block to `.tokmd/review/comment.md` before artifact upload and PR commenting.
-With artifact upload enabled, that block points to the workflow run, the
-`tokmd-receipts` artifact, and the packet path. With artifact upload disabled,
-it states that the packet was not uploaded.
+When the composite Action generates a review packet, it copies
+`.tokmd/review/comment.md` to `tokmd-review-packet-comment.md` and appends a
+hosted-packet block to that comment copy before artifact upload and PR
+commenting. With artifact upload enabled, that block points to the workflow run,
+the `tokmd-receipts` artifact, and the packet path. With artifact upload
+disabled, it states that the packet was not uploaded. The packet-local
+`comment.md` is not mutated after `manifest.json` hashes are written.
 
 Action inputs build on the cockpit surface first:
 


### PR DESCRIPTION
## Summary
- keep `.tokmd/review/comment.md` immutable after `tokmd cockpit --review-packet-dir` writes the packet
- prepare hosted PR comment metadata in `tokmd-review-packet-comment.md` instead of mutating a manifest-hashed packet artifact
- update Action self-test and docs to distinguish packet-local comments from hosted PR comments

## Why
The review packet manifest hashes `comment.md`. Mutating that file in the Action after packet generation can make `manifest.json` stale. This preserves the packet contract while keeping hosted comments useful.

## Validation
- `python -c "import yaml; yaml.safe_load(open('action.yml', encoding='utf-8')); yaml.safe_load(open('.github/workflows/test-action.yml', encoding='utf-8')); print('yaml ok')"`
- `git diff --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd --test docs --verbose`
- `cargo test -p xtask --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

Note: `ruby` and `actionlint` are not installed in this local Windows environment; PyYAML parsing covered YAML syntax locally and the hosted Action self-test covers composite Action behavior.