### PR TITLE
docs: clarify tokmd evidence stack boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 [![License](https://img.shields.io/crates/l/tokmd)](https://crates.io/crates/tokmd)
 [![Downloads](https://img.shields.io/crates/d/tokmd)](https://crates.io/crates/tokmd)
 
-`tokmd` turns a source tree into stable Markdown and JSON artifacts: language and module summaries, file receipts, analysis reports, diffs, policy gates, baselines, sensor reports, and LLM-ready context bundles.
+`tokmd` is the fast deterministic code-intelligence instrument in the Effortless
+Metrics evidence stack. It turns a source tree into stable Markdown and JSON
+artifacts: language and module summaries, file receipts, analysis reports,
+diffs, policy gates, baselines, sensor reports, and LLM-ready context bundles.
 
 Use it from the CLI first; wire the same surfaces into CI when you want automated receipts, comments, and gates.
 
@@ -84,6 +87,11 @@ Raw LOC output is easy to generate and hard to reuse.
 CI needs artifacts and gates. Review workflows need stable before/after surfaces. LLM workflows need bounded context instead of pasted terminal output.
 
 `tokmd` makes repository shape repeatable, diffable, and machine-readable.
+
+In the wider Effortless Metrics stack, `tokmd` produces code evidence.
+`evidencebus` carries and inventories evidence from `tokmd`, `mergecode`, CI
+sensors, gates, and other producers. `tokmd` stays useful on its own while
+remaining a focused producer rather than the whole evidence backplane.
 
 ## What It Looks Like
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,10 @@ This document outlines the evolution of `tokmd` and the path forward.
 
 ## Vision
 
-`tokmd` is a **lightweight code intelligence tool** that transforms repository scans into actionable insights for humans, machines, and LLMs.
+`tokmd` is the **fast deterministic code-intelligence instrument** in the
+Effortless Metrics evidence stack. It transforms repository scans into
+actionable code receipts, review surfaces, proof-routing inputs, and LLM-ready
+context for humans, machines, CI, and agents.
 
 - **Receipt-Grade**: Outputs are deterministic, versioned, and safe for automated pipelines.
 - **Analysis-Ready**: Rich derived metrics, git integration, and semantic analysis.

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -693,6 +693,8 @@ name = "project_truth_docs"
 kind = "non_rust"
 paths = [
   "ROADMAP.md",
+  "tokmd-role.md",
+  "docs/PRODUCT.md",
   "docs/NOW.md",
   "docs/architecture.md",
   "docs/design.md",

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -163,6 +163,10 @@ architecture-consolidation program.
   ownership model: analysis rendering lives in `tokmd-format`, review evidence
   in `tokmd-cockpit`, and implementation details should stay as SRP owner
   modules unless they are durable public surfaces.
+- Product truth docs now distinguish tokmd's role from the wider Effortless
+  Metrics evidence stack: tokmd is the deterministic code-intelligence and
+  review-receipt producer, while evidencebus remains the schema-first evidence
+  backplane for cross-tool validation, inventory, bundling, and export.
 - Roadmap-era implementation notes now distinguish historical microcrate
   extraction from the current owner-module consolidation shape, so future
   architecture work starts from the actual crate graph instead of retired

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -6,7 +6,10 @@
 
 **tokmd transforms code scans into actionable intelligence: receipts for automation, metrics for understanding, and signals for decision-making.**
 
-It is not just a counter. It is a **lightweight code intelligence tool** that converts raw counts into trusted artifacts and derived insights.
+It is not just a counter. It is the **fast deterministic code-intelligence and
+review-receipt engine** in the Effortless Metrics evidence stack. It converts
+raw counts into trusted code artifacts and derived insights without trying to
+own the whole evidence transport layer.
 
 ## The Problems We Solve
 
@@ -61,6 +64,13 @@ Analysis provides information, not judgments:
 *   "File changed 47 times" — not "This is a problem file"
 *   Users interpret signals in their context.
 
+### 6. Code Evidence, Not The Backplane
+`tokmd` produces deterministic code evidence. It does not own the universal
+evidence bundle, merge verdict, or multi-tool inventory. In the wider Effortless
+Metrics stack, `evidencebus` is the schema-first backplane that validates,
+bundles, inventories, and exports evidence from `tokmd`, `mergecode`, CI
+sensors, gates, perf tools, and other producers.
+
 ## Safety Posture
 
 **"If you wouldn't email it, don't paste."**
@@ -107,7 +117,9 @@ Analysis provides information, not judgments:
 `tokmd` explicitly does **not**:
 *   Format or lint code (use rustfmt, eslint)
 *   Implement vulnerability detection (tokmd delegates to cargo-audit/npm audit but does not maintain its own advisory database)
-*   Execute tests (use cargo test, pytest)
+*   Replace test runners (proof planning may route `cargo test`, pytest, or
+    coverage commands, but those tools remain the source of build/test truth)
+*   Own the evidence transport backplane or global merge decision
 *   Parse AST deeply (uses heuristics, not full parsers)
 *   Score or rank developers
 *   Provide absolute quality judgments

--- a/docs/design.md
+++ b/docs/design.md
@@ -82,7 +82,10 @@ Every JSON receipt includes:
 }
 ```
 
-tokmd is a **sensor**: it produces receipts, not orchestration. External directors can aggregate tokmd receipts with other tools.
+tokmd is a **code-evidence producer**: it produces receipts, review packets,
+proof-routing inputs, and context bundles, not the whole evidence backplane.
+External directors and `evidencebus` can aggregate tokmd receipts with evidence
+from `mergecode`, CI sensors, gates, perf tools, and other producers.
 
 ### Schema Versioning
 

--- a/tokmd-role.md
+++ b/tokmd-role.md
@@ -1,12 +1,15 @@
 # tokmd responsibilities
 
-tokmd is the **Change Surface + Repo Intelligence** sensor in the sensors → receipts → cockpit stack.
+tokmd is the **Change Surface + Repo Intelligence** instrument in the
+Effortless Metrics evidence stack.
 
 It exists to answer one reviewer / LLM question well:
 
 > “What changed, where is risk concentrated, and what should I look at first?”
 
-tokmd stays useful standalone. It integrates with the cockpit via **artifacts + receipts**, not by becoming a director.
+tokmd stays useful standalone. It integrates with cockpit, `evidencebus`, and
+other directors via **artifacts + receipts**, not by becoming the director or
+evidence backplane.
 
 ---
 
@@ -45,8 +48,15 @@ tokmd stays useful standalone. It integrates with the cockpit via **artifacts + 
 - does not decide the global merge verdict
 - does not post PR comments via network APIs
 
+**Not the evidence backplane**
+- does not validate or inventory every tool's evidence packet
+- does not own cross-tool bundle export
+- does not replace `evidencebus`
+
 **Not build truth**
-- does not run tests/coverage/clippy/bench
+- does not replace tests/coverage/clippy/bench as sources of truth
+- proof planning may route or observe those commands, but the native tools
+  produce the build evidence
 - does not map build artifacts onto diffs (covguard/lintdiff/perfgate do that)
 
 **Not machine truth**
@@ -204,15 +214,19 @@ Both `tokmd context` and `tokmd handoff` must consume the same plan to prevent d
 
 ## Interactions with the rest of the stack
 
-tokmd complements the other sensors:
+tokmd complements the other evidence producers and transport layers:
 
+- evidencebus: schema-first evidence backplane for validation, inventory,
+  bundling, and export
+- mergecode: deeper AST and semantic graph intelligence
 - builddiag / depguard / diffguard: enforce repo/diff policy contracts
 - covguard / lintdiff / perfgate: consume build outputs and map truth onto diffs
 - env-check: validates machine state
 - buildfix: applies allowlisted fixes from receipts
 - cockpitctl: ingests receipts and renders one merge surface
 
-tokmd does not replace any of these. It provides the missing “context” slice that makes the cockpit readable.
+tokmd does not replace any of these. It provides the code lens and review
+receipt slice that makes the wider evidence stack readable.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify tokmd's product role as the fast deterministic code-intelligence and review-receipt producer in the Effortless Metrics evidence stack
- document the boundary with `evidencebus` as the cross-tool evidence backplane and `mergecode` as the deeper semantic/AST producer
- route `docs/PRODUCT.md` and `tokmd-role.md` through the existing project truth docs proof scope

## Validation
- `cargo xtask docs --check`
- `cargo test -p xtask docs --verbose`
- `cargo xtask proof-policy --check`
- `cargo test -p xtask proof_policy --verbose`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask --verbose`
