### PR TITLE
refactor(cockpit): extract composition module

### DIFF
--- a/crates/tokmd-cockpit/src/composition.rs
+++ b/crates/tokmd-cockpit/src/composition.rs
@@ -1,0 +1,60 @@
+use tokmd_types::cockpit::Composition;
+
+/// Compute composition metrics.
+pub fn compute_composition<S: AsRef<str>>(files: &[S]) -> Composition {
+    let mut code = 0;
+    let mut test = 0;
+    let mut docs = 0;
+    let mut config = 0;
+
+    for file in files.iter() {
+        let path = file.as_ref().to_lowercase();
+        if path.ends_with(".rs")
+            || path.ends_with(".js")
+            || path.ends_with(".ts")
+            || path.ends_with(".py")
+        {
+            if path.contains("test") || path.contains("_spec") {
+                test += 1;
+            } else {
+                code += 1;
+            }
+        } else if path.ends_with(".md") || path.contains("/docs/") {
+            docs += 1;
+        } else if path.ends_with(".toml")
+            || path.ends_with(".json")
+            || path.ends_with(".yml")
+            || path.ends_with(".yaml")
+        {
+            config += 1;
+        }
+    }
+
+    let total = (code + test + docs + config) as f64;
+    let (code_pct, test_pct, docs_pct, config_pct) = if total > 0.0 {
+        (
+            code as f64 / total,
+            test as f64 / total,
+            docs as f64 / total,
+            config as f64 / total,
+        )
+    } else {
+        (0.0, 0.0, 0.0, 0.0)
+    };
+
+    let test_ratio = if code > 0 {
+        test as f64 / code as f64
+    } else if test > 0 {
+        1.0
+    } else {
+        0.0
+    };
+
+    Composition {
+        code_pct,
+        test_pct,
+        docs_pct,
+        config_pct,
+        test_ratio,
+    }
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -16,6 +16,7 @@
 //! * CLI argument parsing (use `tokmd::cli`)
 //! * Type definitions (use tokmd-types::cockpit)
 
+mod composition;
 pub mod determinism;
 mod display;
 #[cfg(feature = "git")]
@@ -32,6 +33,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 #[cfg(feature = "git")]
 use anyhow::{Context, bail};
+pub use composition::compute_composition;
 pub use display::{format_signed_f64, now_iso8601, round_pct, sparkline, trend_direction_label};
 #[cfg(feature = "git")]
 pub use gates::compute_determinism_gate;
@@ -238,65 +240,6 @@ fn compute_change_surface(
 // =============================================================================
 // Composition, contracts, health, risk, review plan
 // =============================================================================
-
-/// Compute composition metrics.
-pub fn compute_composition<S: AsRef<str>>(files: &[S]) -> Composition {
-    let mut code = 0;
-    let mut test = 0;
-    let mut docs = 0;
-    let mut config = 0;
-
-    for file in files.iter() {
-        let path = file.as_ref().to_lowercase();
-        if path.ends_with(".rs")
-            || path.ends_with(".js")
-            || path.ends_with(".ts")
-            || path.ends_with(".py")
-        {
-            if path.contains("test") || path.contains("_spec") {
-                test += 1;
-            } else {
-                code += 1;
-            }
-        } else if path.ends_with(".md") || path.contains("/docs/") {
-            docs += 1;
-        } else if path.ends_with(".toml")
-            || path.ends_with(".json")
-            || path.ends_with(".yml")
-            || path.ends_with(".yaml")
-        {
-            config += 1;
-        }
-    }
-
-    let total = (code + test + docs + config) as f64;
-    let (code_pct, test_pct, docs_pct, config_pct) = if total > 0.0 {
-        (
-            code as f64 / total,
-            test as f64 / total,
-            docs as f64 / total,
-            config as f64 / total,
-        )
-    } else {
-        (0.0, 0.0, 0.0, 0.0)
-    };
-
-    let test_ratio = if code > 0 {
-        test as f64 / code as f64
-    } else if test > 0 {
-        1.0
-    } else {
-        0.0
-    };
-
-    Composition {
-        code_pct,
-        test_pct,
-        docs_pct,
-        config_pct,
-        test_ratio,
-    }
-}
 
 /// Detect contract changes.
 pub fn detect_contracts<S: AsRef<str>>(files: &[S]) -> Contracts {


### PR DESCRIPTION
## Summary
- move cockpit composition metric computation into `src/composition.rs`
- keep `tokmd_cockpit::compute_composition` available through the crate-root re-export
- leave composition behavior, receipt schemas, and caller-facing APIs unchanged

## Validation
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check origin/main..HEAD`