### PR TITLE
test(action): verify review packet manifest integrity

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -403,6 +403,7 @@ jobs:
           grep -q 'Workflow run:' tokmd-review-packet-comment.md
           grep -q 'Artifact: `tokmd-receipts`' tokmd-review-packet-comment.md
           grep -q 'Packet path: `.tokmd/review`' tokmd-review-packet-comment.md
+          cargo xtask review-packet-check --dir .tokmd/review
 
       - name: Clean generated files
         shell: bash

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -154,6 +154,7 @@ architecture-consolidation program.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
 - The composite Action now adds hosted packet metadata to review-packet PR comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.
 - The composite Action now prepares hosted review-packet comments in `tokmd-review-packet-comment.md` instead of mutating `.tokmd/review/comment.md`, preserving `manifest.json` hashes for packet-local artifacts while keeping hosted PR comments useful.
+- The composite Action self-test now runs `cargo xtask review-packet-check --dir .tokmd/review` after preparing the hosted comment copy, proving Action-hosted metadata does not drift packet-local manifest hashes.
 - Cockpit's Rust complexity gate now delegates function-scoped source analysis
   to `tokmd-analysis::source_complexity` instead of owning a duplicate parser.
   The `else if` double-count is fixed as a correctness improvement; impact


### PR DESCRIPTION
## Summary
- run `cargo xtask review-packet-check --dir .tokmd/review` inside the composite Action review-packet self-test after the hosted comment copy is prepared
- record the Action-hosting integrity checkpoint in `docs/NEXT.md`

## Validation
- `python` + PyYAML parsed `.github/workflows/test-action.yml` and `action.yml`
- `cargo test -p xtask review_packet --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo test -p tokmd --test docs --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `git diff --check origin/main..HEAD`

## Notes
- Ruby was not installed locally, so YAML parsing used PyYAML instead.
- No product Action behavior or `tokmd cockpit` output semantics changed.