### PR TITLE
feat(cockpit): surface evidence status in review map

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -292,12 +292,19 @@ fn review_packet_review_map(receipt: &CockpitReceipt) -> Value {
         "base_ref": receipt.base_ref,
         "head_ref": receipt.head_ref,
         "source": "cockpit.review_plan",
+        "evidence": {
+            "summary": review_packet_evidence_summary(receipt),
+            "groups": review_packet_evidence_capabilities(receipt),
+            "refs": ["evidence.json#/gates"],
+        },
         "item_count": items.len(),
         "items": items,
     })
 }
 
 fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> Value {
+    let evidence = review_map_item_evidence(item, receipt);
+
     json!({
         "rank": idx + 1,
         "path": &item.path,
@@ -310,6 +317,16 @@ fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> V
             format!("cockpit.json#/review_plan/{idx}"),
             "evidence.json#/gates",
         ],
+        "evidence": {
+            "status": evidence.status(),
+            "present": evidence.present,
+            "missing": evidence.missing,
+            "degraded": evidence.degraded,
+            "stale": evidence.stale,
+            "skipped": evidence.skipped,
+            "unavailable": evidence.unavailable,
+            "refs": ["evidence.json#/gates"],
+        },
         "reproduce": [
             format!(
                 "tokmd cockpit --base {} --head {} --format json",
@@ -321,6 +338,67 @@ fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> V
             ),
         ],
     })
+}
+
+#[derive(Default)]
+struct ReviewMapItemEvidence {
+    present: Vec<&'static str>,
+    missing: Vec<&'static str>,
+    degraded: Vec<&'static str>,
+    stale: Vec<&'static str>,
+    skipped: Vec<&'static str>,
+    unavailable: Vec<&'static str>,
+}
+
+impl ReviewMapItemEvidence {
+    fn status(&self) -> &'static str {
+        if !self.missing.is_empty() {
+            "missing"
+        } else if !self.stale.is_empty() {
+            "stale"
+        } else if !self.degraded.is_empty() {
+            "degraded"
+        } else if !self.present.is_empty() {
+            "available"
+        } else if !self.skipped.is_empty() {
+            "skipped"
+        } else {
+            "unavailable"
+        }
+    }
+}
+
+fn review_map_item_evidence(item: &ReviewItem, receipt: &CockpitReceipt) -> ReviewMapItemEvidence {
+    let mut evidence = ReviewMapItemEvidence::default();
+
+    for (id, meta) in review_packet_evidence_gate_specs(receipt) {
+        if !evidence_gate_applies_to_item(meta, item) {
+            continue;
+        }
+
+        match evidence_availability_optional(meta) {
+            "available" => evidence.present.push(id),
+            "missing" => evidence.missing.push(id),
+            "degraded" => evidence.degraded.push(id),
+            "stale" => evidence.stale.push(id),
+            "skipped" => evidence.skipped.push(id),
+            "unavailable" => evidence.unavailable.push(id),
+            _ => {}
+        }
+    }
+
+    evidence
+}
+
+fn evidence_gate_applies_to_item(meta: Option<&GateMeta>, item: &ReviewItem) -> bool {
+    let Some(meta) = meta else {
+        return false;
+    };
+
+    let is_global = meta.scope.relevant.is_empty() && meta.scope.tested.is_empty();
+    is_global
+        || meta.scope.relevant.iter().any(|path| path == &item.path)
+        || meta.scope.tested.iter().any(|path| path == &item.path)
 }
 
 fn review_priority_label(priority: u32) -> &'static str {
@@ -341,17 +419,34 @@ fn render_review_map_md(receipt: &CockpitReceipt) -> String {
     let _ = writeln!(s, "Head: `{}`", receipt.head_ref);
     let _ = writeln!(s);
 
+    let evidence = evidence_counts(receipt);
+    let _ = writeln!(
+        s,
+        "Evidence overview: {} available, {} degraded, {} stale, {} skipped, {} unavailable, {} missing.",
+        evidence.available,
+        evidence.degraded,
+        evidence.stale,
+        evidence.skipped,
+        evidence.unavailable,
+        evidence.missing,
+    );
+    let _ = writeln!(s);
+
     if receipt.review_plan.is_empty() {
         let _ = writeln!(s, "No prioritized files were identified.");
         return s;
     }
 
+    let _ = writeln!(s, "## Review First");
+    let _ = writeln!(s);
+
     for (idx, item) in receipt.review_plan.iter().enumerate() {
+        let evidence = review_map_item_evidence(item, receipt);
         let _ = writeln!(
             s,
             "{}. `{}`
    Priority: {} ({})
-   Reason: {}",
+   Why it matters: {}",
             idx + 1,
             item.path,
             item.priority,
@@ -365,6 +460,13 @@ fn render_review_map_md(receipt: &CockpitReceipt) -> String {
         if let Some(complexity) = item.complexity {
             let _ = writeln!(s, "   Review complexity: {complexity}/5");
         }
+        let _ = writeln!(s, "   Evidence status: {}", evidence.status());
+        write_evidence_list(&mut s, "Evidence present", &evidence.present);
+        write_evidence_list(&mut s, "Evidence missing", &evidence.missing);
+        write_evidence_list(&mut s, "Evidence degraded", &evidence.degraded);
+        write_evidence_list(&mut s, "Evidence stale", &evidence.stale);
+        write_evidence_list(&mut s, "Evidence skipped", &evidence.skipped);
+        write_evidence_list(&mut s, "Evidence unavailable", &evidence.unavailable);
         let _ = writeln!(s, "   Evidence references:");
         let _ = writeln!(s, "   - cockpit.json#/review_plan/{idx}");
         let _ = writeln!(s, "   - evidence.json#/gates");
@@ -383,6 +485,16 @@ fn render_review_map_md(receipt: &CockpitReceipt) -> String {
     }
 
     s
+}
+
+fn write_evidence_list(s: &mut String, label: &str, gates: &[&str]) {
+    use std::fmt::Write;
+
+    if gates.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(s, "   {label}: {}", gates.join(", "));
 }
 
 fn evidence_gate(id: &str, meta: Option<&GateMeta>) -> Value {

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -862,16 +862,39 @@ fn scenario_write_review_packet_creates_contract_files() {
         serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
             .unwrap();
     assert_eq!(review_map["schema"], "tokmd.review_map.v1");
+    assert_eq!(
+        review_map["evidence"]["summary"]["details"],
+        "evidence.json#/gates"
+    );
+    assert_eq!(review_map["evidence"]["summary"]["available"], 1);
+    assert_eq!(review_map["evidence"]["summary"]["missing"], 1);
+    assert_eq!(review_map["evidence"]["groups"]["available"][0], "mutation");
+    assert_eq!(
+        review_map["evidence"]["groups"]["missing"][0],
+        "diff_coverage"
+    );
     assert_eq!(review_map["item_count"], 1);
     assert_eq!(review_map["items"][0]["path"], "src/lib.rs");
     assert_eq!(
         review_map["items"][0]["evidence_refs"][0],
         "cockpit.json#/review_plan/0"
     );
+    assert_eq!(review_map["items"][0]["evidence"]["status"], "missing");
+    assert_eq!(review_map["items"][0]["evidence"]["present"][0], "mutation");
+    assert_eq!(
+        review_map["items"][0]["evidence"]["missing"][0],
+        "diff_coverage"
+    );
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("# Review Map"));
+    assert!(review_map_md.contains("Evidence overview: 1 available"));
+    assert!(review_map_md.contains("## Review First"));
     assert!(review_map_md.contains("`src/lib.rs`"));
+    assert!(review_map_md.contains("Why it matters: Large changed file"));
+    assert!(review_map_md.contains("Evidence status: missing"));
+    assert!(review_map_md.contains("Evidence present: mutation"));
+    assert!(review_map_md.contains("Evidence missing: diff_coverage"));
     assert!(review_map_md.contains("Evidence references:"));
     assert!(review_map_md.contains("cockpit.json#/review_plan/0"));
     assert!(review_map_md.contains("evidence.json#/gates"));

--- a/crates/tokmd/schemas/review-map.schema.json
+++ b/crates/tokmd/schemas/review-map.schema.json
@@ -10,6 +10,7 @@
     "base_ref": { "type": "string", "minLength": 1 },
     "head_ref": { "type": "string", "minLength": 1 },
     "source": { "type": "string", "const": "cockpit.review_plan" },
+    "evidence": { "$ref": "#/definitions/reviewMapEvidence" },
     "item_count": { "type": "integer", "minimum": 0 },
     "items": {
       "type": "array",
@@ -17,6 +18,104 @@
     }
   },
   "definitions": {
+    "reviewMapEvidence": {
+      "type": "object",
+      "required": ["summary", "groups", "refs"],
+      "properties": {
+        "summary": { "$ref": "#/definitions/evidenceSummary" },
+        "groups": { "$ref": "#/definitions/evidenceGroups" },
+        "refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "evidenceSummary": {
+      "type": "object",
+      "required": [
+        "details",
+        "total_gates",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "total_gates": { "type": "integer", "minimum": 0 },
+        "available": { "type": "integer", "minimum": 0 },
+        "degraded": { "type": "integer", "minimum": 0 },
+        "stale": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "unavailable": { "type": "integer", "minimum": 0 },
+        "missing": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "evidenceGroups": {
+      "type": "object",
+      "required": [
+        "details",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "available": { "$ref": "#/definitions/evidenceGateIds" },
+        "degraded": { "$ref": "#/definitions/evidenceGateIds" },
+        "stale": { "$ref": "#/definitions/evidenceGateIds" },
+        "skipped": { "$ref": "#/definitions/evidenceGateIds" },
+        "unavailable": { "$ref": "#/definitions/evidenceGateIds" },
+        "missing": { "$ref": "#/definitions/evidenceGateIds" }
+      }
+    },
+    "evidenceGateIds": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "reviewMapItemEvidence": {
+      "type": "object",
+      "required": [
+        "status",
+        "present",
+        "missing",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "refs"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "available",
+            "missing",
+            "degraded",
+            "stale",
+            "skipped",
+            "unavailable"
+          ]
+        },
+        "present": { "$ref": "#/definitions/evidenceGateIds" },
+        "missing": { "$ref": "#/definitions/evidenceGateIds" },
+        "degraded": { "$ref": "#/definitions/evidenceGateIds" },
+        "stale": { "$ref": "#/definitions/evidenceGateIds" },
+        "skipped": { "$ref": "#/definitions/evidenceGateIds" },
+        "unavailable": { "$ref": "#/definitions/evidenceGateIds" },
+        "refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "reviewMapItem": {
       "type": "object",
       "required": [
@@ -56,6 +155,7 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "evidence": { "$ref": "#/definitions/reviewMapItemEvidence" },
         "reproduce": {
           "type": "array",
           "minItems": 1,

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -667,11 +667,40 @@ fn test_cockpit_review_packet_dir() {
             .expect("valid review map JSON");
     assert_validates_against_schema(REVIEW_MAP_SCHEMA_JSON, &review_map, "review map");
     assert_eq!(review_map["schema"], "tokmd.review_map.v1");
+    assert_eq!(
+        review_map["evidence"]["summary"]["details"],
+        "evidence.json#/gates"
+    );
+    assert!(
+        review_map["evidence"]["summary"]["unavailable"]
+            .as_u64()
+            .unwrap()
+            > 0,
+        "review map should summarize packet-level unavailable evidence"
+    );
+    assert!(
+        review_map["evidence"]["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference == "evidence.json#/gates"),
+        "review map should link back to evidence gates"
+    );
     let items = review_map["items"].as_array().expect("review map items");
     assert_eq!(review_map["item_count"], items.len() as u64);
+    assert!(
+        items
+            .iter()
+            .all(|item| item["evidence"]["status"].is_string()),
+        "each review-map item should expose compact evidence status"
+    );
 
     let review_map_md = std::fs::read_to_string(packet_dir.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("# Review Map"));
+    assert!(review_map_md.contains("Evidence overview:"));
+    assert!(review_map_md.contains("## Review First"));
+    assert!(review_map_md.contains("Why it matters:"));
+    assert!(review_map_md.contains("Evidence status:"));
     assert!(review_map_md.contains("Evidence references:"));
     assert!(review_map_md.contains("cockpit.json#/review_plan/0"));
     assert!(review_map_md.contains("evidence.json#/gates"));

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -155,6 +155,7 @@ architecture-consolidation program.
 - The composite Action now adds hosted packet metadata to review-packet PR comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.
 - The composite Action now prepares hosted review-packet comments in `tokmd-review-packet-comment.md` instead of mutating `.tokmd/review/comment.md`, preserving `manifest.json` hashes for packet-local artifacts while keeping hosted PR comments useful.
 - The composite Action self-test now runs `cargo xtask review-packet-check --dir .tokmd/review` after preparing the hosted comment copy, proving Action-hosted metadata does not drift packet-local manifest hashes.
+- Cockpit `review-map.json` and `review-map.md` now surface packet-level evidence counts and item-level evidence status, so maintainers can see what proof is present or missing while deciding what to review first.
 - Cockpit's Rust complexity gate now delegates function-scoped source analysis
   to `tokmd-analysis::source_complexity` instead of owning a duplicate parser.
   The `else if` double-count is fixed as a correctness improvement; impact

--- a/docs/review-map.schema.json
+++ b/docs/review-map.schema.json
@@ -10,6 +10,7 @@
     "base_ref": { "type": "string", "minLength": 1 },
     "head_ref": { "type": "string", "minLength": 1 },
     "source": { "type": "string", "const": "cockpit.review_plan" },
+    "evidence": { "$ref": "#/definitions/reviewMapEvidence" },
     "item_count": { "type": "integer", "minimum": 0 },
     "items": {
       "type": "array",
@@ -17,6 +18,104 @@
     }
   },
   "definitions": {
+    "reviewMapEvidence": {
+      "type": "object",
+      "required": ["summary", "groups", "refs"],
+      "properties": {
+        "summary": { "$ref": "#/definitions/evidenceSummary" },
+        "groups": { "$ref": "#/definitions/evidenceGroups" },
+        "refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "evidenceSummary": {
+      "type": "object",
+      "required": [
+        "details",
+        "total_gates",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "total_gates": { "type": "integer", "minimum": 0 },
+        "available": { "type": "integer", "minimum": 0 },
+        "degraded": { "type": "integer", "minimum": 0 },
+        "stale": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "unavailable": { "type": "integer", "minimum": 0 },
+        "missing": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "evidenceGroups": {
+      "type": "object",
+      "required": [
+        "details",
+        "available",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "missing"
+      ],
+      "properties": {
+        "details": { "type": "string", "const": "evidence.json#/gates" },
+        "available": { "$ref": "#/definitions/evidenceGateIds" },
+        "degraded": { "$ref": "#/definitions/evidenceGateIds" },
+        "stale": { "$ref": "#/definitions/evidenceGateIds" },
+        "skipped": { "$ref": "#/definitions/evidenceGateIds" },
+        "unavailable": { "$ref": "#/definitions/evidenceGateIds" },
+        "missing": { "$ref": "#/definitions/evidenceGateIds" }
+      }
+    },
+    "evidenceGateIds": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "reviewMapItemEvidence": {
+      "type": "object",
+      "required": [
+        "status",
+        "present",
+        "missing",
+        "degraded",
+        "stale",
+        "skipped",
+        "unavailable",
+        "refs"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "available",
+            "missing",
+            "degraded",
+            "stale",
+            "skipped",
+            "unavailable"
+          ]
+        },
+        "present": { "$ref": "#/definitions/evidenceGateIds" },
+        "missing": { "$ref": "#/definitions/evidenceGateIds" },
+        "degraded": { "$ref": "#/definitions/evidenceGateIds" },
+        "stale": { "$ref": "#/definitions/evidenceGateIds" },
+        "skipped": { "$ref": "#/definitions/evidenceGateIds" },
+        "unavailable": { "$ref": "#/definitions/evidenceGateIds" },
+        "refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "reviewMapItem": {
       "type": "object",
       "required": [
@@ -56,6 +155,7 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "evidence": { "$ref": "#/definitions/reviewMapItemEvidence" },
         "reproduce": {
           "type": "array",
           "minItems": 1,

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -56,8 +56,8 @@ The review packet directory is:
 | `cockpit.json` | Full `CockpitReceipt` JSON. This is the same receipt produced by `tokmd cockpit --format json`. |
 | `evidence.json` | Evidence availability and gate status. It distinguishes passed evidence from missing, skipped, stale, degraded, or unavailable evidence. |
 | `comment.md` | PR-comment-ready summary. It stays concise and points readers to packet artifacts when hosted by CI. |
-| `review-map.json` | Machine-readable prioritized review plan with files, reasons, evidence references, and reproduction commands derived from `cockpit.json#/review_plan`. |
-| `review-map.md` | Human-readable review plan for artifact browsing and local review. |
+| `review-map.json` | Machine-readable prioritized review plan with files, reasons, compact evidence status, evidence references, and reproduction commands derived from `cockpit.json#/review_plan`. |
+| `review-map.md` | Human-readable review plan for artifact browsing and local review, including what to review first and which evidence is present or missing. |
 
 Formal JSON Schemas are published with the docs and embedded in the CLI test
 package:
@@ -119,10 +119,13 @@ to disk.
 - `item_count`
 - `items` sorted in cockpit review-plan order
 
-Each item includes rank, path, priority, priority label, reason, optional
-complexity, optional lines changed, evidence references, and reproduction
+The map may also include a packet-level evidence summary copied from the same
+availability buckets as `manifest.json`. Each item includes rank, path,
+priority, priority label, reason, optional complexity, optional lines changed,
+compact item-level evidence status, evidence references, and reproduction
 commands. `review-map.md` is a Markdown rendering of the same ordered items,
-including the evidence references and reproduction commands for artifact
+including a "Review First" section, evidence present/missing lines where
+applicable, evidence references, and reproduction commands for artifact
 browsing and local review.
 
 ## Exit Codes


### PR DESCRIPTION
## Summary
- Add packet-level evidence summary/groups/refs to `review-map.json` so the review map can point back to `evidence.json`.
- Add compact item-level evidence status, present/missing/degraded/stale/skipped/unavailable buckets, and evidence refs for each review-map item.
- Update `review-map.md`, review-map schemas, cockpit packet docs, and focused tests without changing `tokmd cockpit` receipt semantics or promoting proof gates.

## Validation
- `cargo test -p tokmd-cockpit scenario_write_review_packet_creates_contract_files --verbose`
- `cargo test -p tokmd --test cockpit_integration test_cockpit_review_packet_dir --verbose`
- `cargo test -p tokmd --test schema_validation test_review_packet --verbose`
- `cargo test -p xtask review_packet --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd --test schema_doc_sync --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo test -p tokmd-types schema --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p xtask --verbose`
- `cargo run -p tokmd -- cockpit --base origin/main --head HEAD --review-packet-dir target/review-map-smoke-evidence-status`
- `cargo xtask review-packet-check --dir target/review-map-smoke-evidence-status`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`

Note: local untracked `.playwright-mcp/` was present before push and was left untouched.