### PR TITLE
refactor(cockpit): extract determinism gate module

### DIFF
--- a/crates/tokmd-cockpit/src/gates.rs
+++ b/crates/tokmd-cockpit/src/gates.rs
@@ -1,10 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::Result;
 use tokmd_types::cockpit::*;
 
 mod complexity;
 mod contracts;
+mod determinism_gate;
 mod diff_coverage;
 mod mutation;
 
@@ -14,8 +15,9 @@ use diff_coverage::compute_diff_coverage_gate;
 use mutation::compute_mutation_gate;
 
 use crate::FileStat;
-use crate::determinism;
 use crate::supply_chain::compute_supply_chain_gate;
+
+pub use determinism_gate::compute_determinism_gate;
 
 // =============================================================================
 // Evidence computation
@@ -112,132 +114,6 @@ fn compute_overall_status(
     } else {
         GateStatus::Pass
     }
-}
-
-// =============================================================================
-// Determinism gate
-// =============================================================================
-
-/// Compute determinism gate.
-/// Compares expected source hash (from baseline) with a fresh hash of the repo.
-#[cfg(feature = "git")]
-pub fn compute_determinism_gate(
-    repo_root: &Path,
-    baseline_path: Option<&Path>,
-) -> Result<Option<DeterminismGate>> {
-    use tokmd_analysis_types::ComplexityBaseline;
-
-    fn short16(s: &str) -> &str {
-        s.get(..16).unwrap_or(s)
-    }
-
-    // Resolve baseline: explicit path or default location
-    let resolved_path = match baseline_path {
-        Some(p) => p.to_path_buf(),
-        None => repo_root.join(".tokmd/baseline.json"),
-    };
-
-    // If no baseline file exists, skip the gate
-    if !resolved_path.exists() {
-        return Ok(None);
-    }
-
-    // Parse baseline
-    let content = std::fs::read_to_string(&resolved_path)
-        .with_context(|| format!("failed to read baseline at {}", resolved_path.display()))?;
-    let json: serde_json::Value = serde_json::from_str(&content).with_context(|| {
-        format!(
-            "failed to parse baseline JSON at {}",
-            resolved_path.display()
-        )
-    })?;
-    let baseline: ComplexityBaseline = match serde_json::from_value(json.clone()) {
-        Ok(parsed) => parsed,
-        Err(_) => {
-            // Allow cockpit receipts for trend comparison; determinism data is unavailable there.
-            let mode = json
-                .get("mode")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default();
-            if mode == "cockpit" {
-                return Ok(None);
-            }
-            bail!(
-                "baseline JSON at {} is not a ComplexityBaseline (and not a cockpit receipt)",
-                resolved_path.display()
-            );
-        }
-    };
-
-    // If baseline has no determinism section, skip the gate
-    let det = match &baseline.determinism {
-        Some(d) => d,
-        None => return Ok(None),
-    };
-
-    // Recompute current source hash by walking the repo, excluding the baseline file itself
-    let baseline_rel = resolved_path
-        .strip_prefix(repo_root)
-        .ok()
-        .map(|p| p.to_string_lossy().replace('\\', "/"));
-    let exclude: Vec<&str> = baseline_rel.as_deref().into_iter().collect();
-    let actual_hash = determinism::hash_files_from_walk(repo_root, &exclude)?;
-    let expected_hash = &det.source_hash;
-
-    let mut differences = Vec::new();
-
-    if actual_hash != *expected_hash {
-        differences.push(format!(
-            "source hash mismatch: expected {}, got {}",
-            short16(expected_hash),
-            short16(&actual_hash),
-        ));
-    }
-
-    // Check Cargo.lock hash if baseline had one
-    if let Some(expected_lock) = &det.cargo_lock_hash {
-        let actual_lock = determinism::hash_cargo_lock(repo_root)?;
-        match actual_lock {
-            Some(ref actual) if actual != expected_lock => {
-                differences.push(format!(
-                    "Cargo.lock hash mismatch: expected {}, got {}",
-                    short16(expected_lock),
-                    short16(actual),
-                ));
-            }
-            None => {
-                differences.push("Cargo.lock missing (was present in baseline)".to_string());
-            }
-            _ => {}
-        }
-    }
-
-    let status = if differences.is_empty() {
-        GateStatus::Pass
-    } else {
-        GateStatus::Warn
-    };
-
-    Ok(Some(DeterminismGate {
-        meta: GateMeta {
-            status,
-            source: EvidenceSource::RanLocal,
-            commit_match: CommitMatch::Unknown,
-            scope: ScopeCoverage {
-                relevant: vec!["source files".to_string()],
-                tested: vec!["source files".to_string()],
-                ratio: 1.0,
-                lines_relevant: None,
-                lines_tested: None,
-            },
-            evidence_commit: None,
-            evidence_generated_at_ms: None,
-        },
-        expected_hash: Some(expected_hash.clone()),
-        actual_hash: Some(actual_hash),
-        algo: "blake3".to_string(),
-        differences,
-    }))
 }
 
 /// Check if a file is a relevant Rust source file for mutation testing.

--- a/crates/tokmd-cockpit/src/gates/determinism_gate.rs
+++ b/crates/tokmd-cockpit/src/gates/determinism_gate.rs
@@ -1,0 +1,128 @@
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use tokmd_types::cockpit::*;
+
+use crate::determinism;
+
+/// Compute determinism gate.
+/// Compares expected source hash (from baseline) with a fresh hash of the repo.
+#[cfg(feature = "git")]
+pub fn compute_determinism_gate(
+    repo_root: &Path,
+    baseline_path: Option<&Path>,
+) -> Result<Option<DeterminismGate>> {
+    use tokmd_analysis_types::ComplexityBaseline;
+
+    fn short16(s: &str) -> &str {
+        s.get(..16).unwrap_or(s)
+    }
+
+    // Resolve baseline: explicit path or default location
+    let resolved_path = match baseline_path {
+        Some(p) => p.to_path_buf(),
+        None => repo_root.join(".tokmd/baseline.json"),
+    };
+
+    // If no baseline file exists, skip the gate
+    if !resolved_path.exists() {
+        return Ok(None);
+    }
+
+    // Parse baseline
+    let content = std::fs::read_to_string(&resolved_path)
+        .with_context(|| format!("failed to read baseline at {}", resolved_path.display()))?;
+    let json: serde_json::Value = serde_json::from_str(&content).with_context(|| {
+        format!(
+            "failed to parse baseline JSON at {}",
+            resolved_path.display()
+        )
+    })?;
+    let baseline: ComplexityBaseline = match serde_json::from_value(json.clone()) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            // Allow cockpit receipts for trend comparison; determinism data is unavailable there.
+            let mode = json
+                .get("mode")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            if mode == "cockpit" {
+                return Ok(None);
+            }
+            bail!(
+                "baseline JSON at {} is not a ComplexityBaseline (and not a cockpit receipt)",
+                resolved_path.display()
+            );
+        }
+    };
+
+    // If baseline has no determinism section, skip the gate
+    let det = match &baseline.determinism {
+        Some(d) => d,
+        None => return Ok(None),
+    };
+
+    // Recompute current source hash by walking the repo, excluding the baseline file itself
+    let baseline_rel = resolved_path
+        .strip_prefix(repo_root)
+        .ok()
+        .map(|p| p.to_string_lossy().replace('\\', "/"));
+    let exclude: Vec<&str> = baseline_rel.as_deref().into_iter().collect();
+    let actual_hash = determinism::hash_files_from_walk(repo_root, &exclude)?;
+    let expected_hash = &det.source_hash;
+
+    let mut differences = Vec::new();
+
+    if actual_hash != *expected_hash {
+        differences.push(format!(
+            "source hash mismatch: expected {}, got {}",
+            short16(expected_hash),
+            short16(&actual_hash),
+        ));
+    }
+
+    // Check Cargo.lock hash if baseline had one
+    if let Some(expected_lock) = &det.cargo_lock_hash {
+        let actual_lock = determinism::hash_cargo_lock(repo_root)?;
+        match actual_lock {
+            Some(ref actual) if actual != expected_lock => {
+                differences.push(format!(
+                    "Cargo.lock hash mismatch: expected {}, got {}",
+                    short16(expected_lock),
+                    short16(actual),
+                ));
+            }
+            None => {
+                differences.push("Cargo.lock missing (was present in baseline)".to_string());
+            }
+            _ => {}
+        }
+    }
+
+    let status = if differences.is_empty() {
+        GateStatus::Pass
+    } else {
+        GateStatus::Warn
+    };
+
+    Ok(Some(DeterminismGate {
+        meta: GateMeta {
+            status,
+            source: EvidenceSource::RanLocal,
+            commit_match: CommitMatch::Unknown,
+            scope: ScopeCoverage {
+                relevant: vec!["source files".to_string()],
+                tested: vec!["source files".to_string()],
+                ratio: 1.0,
+                lines_relevant: None,
+                lines_tested: None,
+            },
+            evidence_commit: None,
+            evidence_generated_at_ms: None,
+        },
+        expected_hash: Some(expected_hash.clone()),
+        actual_hash: Some(actual_hash),
+        algo: "blake3".to_string(),
+        differences,
+    }))
+}


### PR DESCRIPTION
## Summary
- move cockpit determinism gate computation into `gates::determinism_gate`
- preserve the existing `gates::compute_determinism_gate` public re-export
- keep cockpit output semantics unchanged while shrinking the gate orchestrator module

## Validation
- `cargo test -p tokmd-cockpit --lib --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo check -p tokmd-cockpit --no-default-features`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`