### PR TITLE
refactor(cockpit): extract rust source gate helper

### DIFF
--- a/crates/tokmd-cockpit/src/gates.rs
+++ b/crates/tokmd-cockpit/src/gates.rs
@@ -8,6 +8,7 @@ mod contracts;
 mod determinism_gate;
 mod diff_coverage;
 mod mutation;
+mod rust_source;
 
 use complexity::compute_complexity_gate;
 use contracts::compute_contract_gate;
@@ -114,33 +115,4 @@ fn compute_overall_status(
     } else {
         GateStatus::Pass
     }
-}
-
-/// Check if a file is a relevant Rust source file for mutation testing.
-/// Excludes test files, fuzz targets, etc.
-#[cfg(feature = "git")]
-pub(super) fn is_relevant_rust_source(path: &str) -> bool {
-    let path_lower = path.to_lowercase();
-
-    // Must be a .rs file
-    if !path_lower.ends_with(".rs") {
-        return false;
-    }
-
-    // Exclude test directories
-    if path_lower.contains("/tests/") || path_lower.starts_with("tests/") {
-        return false;
-    }
-
-    // Exclude test files
-    if path_lower.ends_with("_test.rs") || path_lower.ends_with("_tests.rs") {
-        return false;
-    }
-
-    // Exclude fuzz targets
-    if path_lower.contains("/fuzz/") || path_lower.starts_with("fuzz/") {
-        return false;
-    }
-
-    true
 }

--- a/crates/tokmd-cockpit/src/gates/complexity.rs
+++ b/crates/tokmd-cockpit/src/gates/complexity.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use tokmd_analysis::source_complexity::analyze_rust_function_complexity;
 use tokmd_types::cockpit::*;
 
-use super::is_relevant_rust_source;
+use super::rust_source::is_relevant_rust_source;
 use crate::{COMPLEXITY_THRESHOLD, FileStat, round_pct};
 
 /// Compute complexity gate.

--- a/crates/tokmd-cockpit/src/gates/mutation.rs
+++ b/crates/tokmd-cockpit/src/gates/mutation.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use tokmd_types::cockpit::*;
 
-use super::is_relevant_rust_source;
+use super::rust_source::is_relevant_rust_source;
 use crate::FileStat;
 
 /// Get the current HEAD commit hash.

--- a/crates/tokmd-cockpit/src/gates/rust_source.rs
+++ b/crates/tokmd-cockpit/src/gates/rust_source.rs
@@ -1,0 +1,28 @@
+/// Check if a file is a relevant Rust source file for mutation testing.
+/// Excludes test files, fuzz targets, etc.
+#[cfg(feature = "git")]
+pub(super) fn is_relevant_rust_source(path: &str) -> bool {
+    let path_lower = path.to_lowercase();
+
+    // Must be a .rs file
+    if !path_lower.ends_with(".rs") {
+        return false;
+    }
+
+    // Exclude test directories
+    if path_lower.contains("/tests/") || path_lower.starts_with("tests/") {
+        return false;
+    }
+
+    // Exclude test files
+    if path_lower.ends_with("_test.rs") || path_lower.ends_with("_tests.rs") {
+        return false;
+    }
+
+    // Exclude fuzz targets
+    if path_lower.contains("/fuzz/") || path_lower.starts_with("fuzz/") {
+        return false;
+    }
+
+    true
+}


### PR DESCRIPTION
## Summary
- move the shared cockpit Rust-source relevance predicate into `gates::rust_source`
- update mutation and complexity gates to import the helper from the owner module
- keep cockpit gate behavior and public API unchanged

## Validation
- `cargo test -p tokmd-cockpit --lib --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo check -p tokmd-cockpit --no-default-features` (passes with pre-existing unused `anyhow::Result` warning)
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`