### PR TITLE
refactor(cockpit): extract review map renderer

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -12,6 +12,7 @@ use crate::{
     trend_direction_label,
 };
 
+mod review_map;
 mod review_packet;
 
 pub use review_packet::write_review_packet;

--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -1,0 +1,228 @@
+//! Review-map artifact rendering for cockpit review packets.
+
+use serde_json::{Value, json};
+
+use crate::{CockpitReceipt, GateMeta, ReviewItem};
+
+use super::review_packet::{
+    evidence_availability_optional, evidence_counts, review_packet_evidence_capabilities,
+    review_packet_evidence_gate_specs, review_packet_evidence_summary,
+};
+
+pub(super) fn review_packet_review_map(receipt: &CockpitReceipt) -> Value {
+    let items: Vec<_> = receipt
+        .review_plan
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| review_map_item(idx, item, receipt))
+        .collect();
+
+    json!({
+        "schema": "tokmd.review_map.v1",
+        "base_ref": receipt.base_ref,
+        "head_ref": receipt.head_ref,
+        "source": "cockpit.review_plan",
+        "evidence": {
+            "summary": review_packet_evidence_summary(receipt),
+            "groups": review_packet_evidence_capabilities(receipt),
+            "refs": ["evidence.json#/gates"],
+        },
+        "item_count": items.len(),
+        "items": items,
+    })
+}
+
+fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> Value {
+    let evidence = review_map_item_evidence(item, receipt);
+
+    json!({
+        "rank": idx + 1,
+        "path": &item.path,
+        "priority": item.priority,
+        "priority_label": review_priority_label(item.priority),
+        "reason": &item.reason,
+        "complexity": item.complexity,
+        "lines_changed": item.lines_changed,
+        "evidence_refs": [
+            format!("cockpit.json#/review_plan/{idx}"),
+            "evidence.json#/gates",
+        ],
+        "evidence": {
+            "status": evidence.status(),
+            "present": evidence.present,
+            "missing": evidence.missing,
+            "degraded": evidence.degraded,
+            "stale": evidence.stale,
+            "skipped": evidence.skipped,
+            "unavailable": evidence.unavailable,
+            "refs": ["evidence.json#/gates"],
+        },
+        "reproduce": [
+            format!(
+                "tokmd cockpit --base {} --head {} --format json",
+                receipt.base_ref, receipt.head_ref
+            ),
+            format!(
+                "tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review",
+                receipt.base_ref, receipt.head_ref
+            ),
+        ],
+    })
+}
+
+#[derive(Default)]
+struct ReviewMapItemEvidence {
+    present: Vec<&'static str>,
+    missing: Vec<&'static str>,
+    degraded: Vec<&'static str>,
+    stale: Vec<&'static str>,
+    skipped: Vec<&'static str>,
+    unavailable: Vec<&'static str>,
+}
+
+impl ReviewMapItemEvidence {
+    fn status(&self) -> &'static str {
+        if !self.missing.is_empty() {
+            "missing"
+        } else if !self.stale.is_empty() {
+            "stale"
+        } else if !self.degraded.is_empty() {
+            "degraded"
+        } else if !self.present.is_empty() {
+            "available"
+        } else if !self.skipped.is_empty() {
+            "skipped"
+        } else {
+            "unavailable"
+        }
+    }
+}
+
+fn review_map_item_evidence(item: &ReviewItem, receipt: &CockpitReceipt) -> ReviewMapItemEvidence {
+    let mut evidence = ReviewMapItemEvidence::default();
+
+    for (id, meta) in review_packet_evidence_gate_specs(receipt) {
+        if !evidence_gate_applies_to_item(meta, item) {
+            continue;
+        }
+
+        match evidence_availability_optional(meta) {
+            "available" => evidence.present.push(id),
+            "missing" => evidence.missing.push(id),
+            "degraded" => evidence.degraded.push(id),
+            "stale" => evidence.stale.push(id),
+            "skipped" => evidence.skipped.push(id),
+            "unavailable" => evidence.unavailable.push(id),
+            _ => {}
+        }
+    }
+
+    evidence
+}
+
+fn evidence_gate_applies_to_item(meta: Option<&GateMeta>, item: &ReviewItem) -> bool {
+    let Some(meta) = meta else {
+        return false;
+    };
+
+    let is_global = meta.scope.relevant.is_empty() && meta.scope.tested.is_empty();
+    is_global
+        || meta.scope.relevant.iter().any(|path| path == &item.path)
+        || meta.scope.tested.iter().any(|path| path == &item.path)
+}
+
+fn review_priority_label(priority: u32) -> &'static str {
+    match priority {
+        1 => "highest",
+        2 => "medium",
+        _ => "low",
+    }
+}
+
+pub(super) fn render_review_map_md(receipt: &CockpitReceipt) -> String {
+    use std::fmt::Write;
+
+    let mut s = String::new();
+    let _ = writeln!(s, "# Review Map");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "Base: `{}`", receipt.base_ref);
+    let _ = writeln!(s, "Head: `{}`", receipt.head_ref);
+    let _ = writeln!(s);
+
+    let evidence = evidence_counts(receipt);
+    let _ = writeln!(
+        s,
+        "Evidence overview: {} available, {} degraded, {} stale, {} skipped, {} unavailable, {} missing.",
+        evidence.available,
+        evidence.degraded,
+        evidence.stale,
+        evidence.skipped,
+        evidence.unavailable,
+        evidence.missing,
+    );
+    let _ = writeln!(s);
+
+    if receipt.review_plan.is_empty() {
+        let _ = writeln!(s, "No prioritized files were identified.");
+        return s;
+    }
+
+    let _ = writeln!(s, "## Review First");
+    let _ = writeln!(s);
+
+    for (idx, item) in receipt.review_plan.iter().enumerate() {
+        let evidence = review_map_item_evidence(item, receipt);
+        let _ = writeln!(
+            s,
+            "{}. `{}`
+   Priority: {} ({})
+   Why it matters: {}",
+            idx + 1,
+            item.path,
+            item.priority,
+            review_priority_label(item.priority),
+            item.reason
+        );
+
+        if let Some(lines_changed) = item.lines_changed {
+            let _ = writeln!(s, "   Lines changed: {lines_changed}");
+        }
+        if let Some(complexity) = item.complexity {
+            let _ = writeln!(s, "   Review complexity: {complexity}/5");
+        }
+        let _ = writeln!(s, "   Evidence status: {}", evidence.status());
+        write_evidence_list(&mut s, "Evidence present", &evidence.present);
+        write_evidence_list(&mut s, "Evidence missing", &evidence.missing);
+        write_evidence_list(&mut s, "Evidence degraded", &evidence.degraded);
+        write_evidence_list(&mut s, "Evidence stale", &evidence.stale);
+        write_evidence_list(&mut s, "Evidence skipped", &evidence.skipped);
+        write_evidence_list(&mut s, "Evidence unavailable", &evidence.unavailable);
+        let _ = writeln!(s, "   Evidence references:");
+        let _ = writeln!(s, "   - cockpit.json#/review_plan/{idx}");
+        let _ = writeln!(s, "   - evidence.json#/gates");
+        let _ = writeln!(s, "   Reproduce:");
+        let _ = writeln!(
+            s,
+            "   - `tokmd cockpit --base {} --head {} --format json`",
+            receipt.base_ref, receipt.head_ref
+        );
+        let _ = writeln!(
+            s,
+            "   - `tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review`",
+            receipt.base_ref, receipt.head_ref
+        );
+        let _ = writeln!(s);
+    }
+
+    s
+}
+
+fn write_evidence_list(s: &mut String, label: &str, gates: &[&str]) {
+    use std::fmt::Write;
+
+    if gates.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(s, "   {label}: {}", gates.join(", "));
+}

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -5,8 +5,9 @@ use std::path::Path;
 use anyhow::Result;
 use serde_json::{Value, json};
 
-use crate::{CockpitReceipt, CommitMatch, GateMeta, GateStatus, ReviewItem};
+use crate::{CockpitReceipt, CommitMatch, GateMeta, GateStatus};
 
+use super::review_map::{render_review_map_md, review_packet_review_map};
 use super::{render_comment_md, render_json};
 
 /// Write review packet artifacts to directory.
@@ -163,7 +164,7 @@ fn review_packet_evidence(receipt: &CockpitReceipt) -> Value {
     })
 }
 
-fn review_packet_evidence_summary(receipt: &CockpitReceipt) -> Value {
+pub(super) fn review_packet_evidence_summary(receipt: &CockpitReceipt) -> Value {
     let counts = evidence_counts(receipt);
 
     json!({
@@ -212,7 +213,7 @@ pub(super) fn evidence_counts(receipt: &CockpitReceipt) -> EvidenceAvailabilityC
     counts
 }
 
-fn review_packet_evidence_capabilities(receipt: &CockpitReceipt) -> Value {
+pub(super) fn review_packet_evidence_capabilities(receipt: &CockpitReceipt) -> Value {
     let mut available = Vec::new();
     let mut degraded = Vec::new();
     let mut stale = Vec::new();
@@ -243,7 +244,7 @@ fn review_packet_evidence_capabilities(receipt: &CockpitReceipt) -> Value {
     })
 }
 
-fn review_packet_evidence_gate_specs(
+pub(super) fn review_packet_evidence_gate_specs(
     receipt: &CockpitReceipt,
 ) -> [(&'static str, Option<&GateMeta>); 6] {
     [
@@ -277,224 +278,6 @@ fn review_packet_evidence_gate_specs(
             receipt.evidence.complexity.as_ref().map(|gate| &gate.meta),
         ),
     ]
-}
-
-fn review_packet_review_map(receipt: &CockpitReceipt) -> Value {
-    let items: Vec<_> = receipt
-        .review_plan
-        .iter()
-        .enumerate()
-        .map(|(idx, item)| review_map_item(idx, item, receipt))
-        .collect();
-
-    json!({
-        "schema": "tokmd.review_map.v1",
-        "base_ref": receipt.base_ref,
-        "head_ref": receipt.head_ref,
-        "source": "cockpit.review_plan",
-        "evidence": {
-            "summary": review_packet_evidence_summary(receipt),
-            "groups": review_packet_evidence_capabilities(receipt),
-            "refs": ["evidence.json#/gates"],
-        },
-        "item_count": items.len(),
-        "items": items,
-    })
-}
-
-fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> Value {
-    let evidence = review_map_item_evidence(item, receipt);
-
-    json!({
-        "rank": idx + 1,
-        "path": &item.path,
-        "priority": item.priority,
-        "priority_label": review_priority_label(item.priority),
-        "reason": &item.reason,
-        "complexity": item.complexity,
-        "lines_changed": item.lines_changed,
-        "evidence_refs": [
-            format!("cockpit.json#/review_plan/{idx}"),
-            "evidence.json#/gates",
-        ],
-        "evidence": {
-            "status": evidence.status(),
-            "present": evidence.present,
-            "missing": evidence.missing,
-            "degraded": evidence.degraded,
-            "stale": evidence.stale,
-            "skipped": evidence.skipped,
-            "unavailable": evidence.unavailable,
-            "refs": ["evidence.json#/gates"],
-        },
-        "reproduce": [
-            format!(
-                "tokmd cockpit --base {} --head {} --format json",
-                receipt.base_ref, receipt.head_ref
-            ),
-            format!(
-                "tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review",
-                receipt.base_ref, receipt.head_ref
-            ),
-        ],
-    })
-}
-
-#[derive(Default)]
-struct ReviewMapItemEvidence {
-    present: Vec<&'static str>,
-    missing: Vec<&'static str>,
-    degraded: Vec<&'static str>,
-    stale: Vec<&'static str>,
-    skipped: Vec<&'static str>,
-    unavailable: Vec<&'static str>,
-}
-
-impl ReviewMapItemEvidence {
-    fn status(&self) -> &'static str {
-        if !self.missing.is_empty() {
-            "missing"
-        } else if !self.stale.is_empty() {
-            "stale"
-        } else if !self.degraded.is_empty() {
-            "degraded"
-        } else if !self.present.is_empty() {
-            "available"
-        } else if !self.skipped.is_empty() {
-            "skipped"
-        } else {
-            "unavailable"
-        }
-    }
-}
-
-fn review_map_item_evidence(item: &ReviewItem, receipt: &CockpitReceipt) -> ReviewMapItemEvidence {
-    let mut evidence = ReviewMapItemEvidence::default();
-
-    for (id, meta) in review_packet_evidence_gate_specs(receipt) {
-        if !evidence_gate_applies_to_item(meta, item) {
-            continue;
-        }
-
-        match evidence_availability_optional(meta) {
-            "available" => evidence.present.push(id),
-            "missing" => evidence.missing.push(id),
-            "degraded" => evidence.degraded.push(id),
-            "stale" => evidence.stale.push(id),
-            "skipped" => evidence.skipped.push(id),
-            "unavailable" => evidence.unavailable.push(id),
-            _ => {}
-        }
-    }
-
-    evidence
-}
-
-fn evidence_gate_applies_to_item(meta: Option<&GateMeta>, item: &ReviewItem) -> bool {
-    let Some(meta) = meta else {
-        return false;
-    };
-
-    let is_global = meta.scope.relevant.is_empty() && meta.scope.tested.is_empty();
-    is_global
-        || meta.scope.relevant.iter().any(|path| path == &item.path)
-        || meta.scope.tested.iter().any(|path| path == &item.path)
-}
-
-fn review_priority_label(priority: u32) -> &'static str {
-    match priority {
-        1 => "highest",
-        2 => "medium",
-        _ => "low",
-    }
-}
-
-fn render_review_map_md(receipt: &CockpitReceipt) -> String {
-    use std::fmt::Write;
-
-    let mut s = String::new();
-    let _ = writeln!(s, "# Review Map");
-    let _ = writeln!(s);
-    let _ = writeln!(s, "Base: `{}`", receipt.base_ref);
-    let _ = writeln!(s, "Head: `{}`", receipt.head_ref);
-    let _ = writeln!(s);
-
-    let evidence = evidence_counts(receipt);
-    let _ = writeln!(
-        s,
-        "Evidence overview: {} available, {} degraded, {} stale, {} skipped, {} unavailable, {} missing.",
-        evidence.available,
-        evidence.degraded,
-        evidence.stale,
-        evidence.skipped,
-        evidence.unavailable,
-        evidence.missing,
-    );
-    let _ = writeln!(s);
-
-    if receipt.review_plan.is_empty() {
-        let _ = writeln!(s, "No prioritized files were identified.");
-        return s;
-    }
-
-    let _ = writeln!(s, "## Review First");
-    let _ = writeln!(s);
-
-    for (idx, item) in receipt.review_plan.iter().enumerate() {
-        let evidence = review_map_item_evidence(item, receipt);
-        let _ = writeln!(
-            s,
-            "{}. `{}`
-   Priority: {} ({})
-   Why it matters: {}",
-            idx + 1,
-            item.path,
-            item.priority,
-            review_priority_label(item.priority),
-            item.reason
-        );
-
-        if let Some(lines_changed) = item.lines_changed {
-            let _ = writeln!(s, "   Lines changed: {lines_changed}");
-        }
-        if let Some(complexity) = item.complexity {
-            let _ = writeln!(s, "   Review complexity: {complexity}/5");
-        }
-        let _ = writeln!(s, "   Evidence status: {}", evidence.status());
-        write_evidence_list(&mut s, "Evidence present", &evidence.present);
-        write_evidence_list(&mut s, "Evidence missing", &evidence.missing);
-        write_evidence_list(&mut s, "Evidence degraded", &evidence.degraded);
-        write_evidence_list(&mut s, "Evidence stale", &evidence.stale);
-        write_evidence_list(&mut s, "Evidence skipped", &evidence.skipped);
-        write_evidence_list(&mut s, "Evidence unavailable", &evidence.unavailable);
-        let _ = writeln!(s, "   Evidence references:");
-        let _ = writeln!(s, "   - cockpit.json#/review_plan/{idx}");
-        let _ = writeln!(s, "   - evidence.json#/gates");
-        let _ = writeln!(s, "   Reproduce:");
-        let _ = writeln!(
-            s,
-            "   - `tokmd cockpit --base {} --head {} --format json`",
-            receipt.base_ref, receipt.head_ref
-        );
-        let _ = writeln!(
-            s,
-            "   - `tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review`",
-            receipt.base_ref, receipt.head_ref
-        );
-        let _ = writeln!(s);
-    }
-
-    s
-}
-
-fn write_evidence_list(s: &mut String, label: &str, gates: &[&str]) {
-    use std::fmt::Write;
-
-    if gates.is_empty() {
-        return;
-    }
-
-    let _ = writeln!(s, "   {label}: {}", gates.join(", "));
 }
 
 fn evidence_gate(id: &str, meta: Option<&GateMeta>) -> Value {
@@ -553,7 +336,7 @@ fn evidence_availability(meta: &GateMeta) -> &'static str {
     }
 }
 
-fn evidence_availability_optional(meta: Option<&GateMeta>) -> &'static str {
+pub(super) fn evidence_availability_optional(meta: Option<&GateMeta>) -> &'static str {
     match meta {
         Some(meta) => evidence_availability(meta),
         None => "unavailable",


### PR DESCRIPTION
## Summary
- move cockpit review-map JSON and Markdown rendering into `render::review_map`
- keep review packet artifact names, schemas, hashes, and output semantics unchanged
- leave evidence and manifest ownership in `render::review_packet` for later narrow splits

## Validation
- `cargo test -p tokmd-cockpit review_packet --verbose`
- `cargo run -p tokmd -- cockpit --base origin/main --head HEAD --review-packet-dir target/review-smoke-review-map-20260508185139`
- `cargo xtask review-packet-check --dir target/review-smoke-review-map-20260508185139`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`