### PR TITLE
refactor(cockpit): extract review packet manifest

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 mod evidence;
+mod manifest;
 mod review_map;
 mod review_packet;
 

--- a/crates/tokmd-cockpit/src/render/manifest.rs
+++ b/crates/tokmd-cockpit/src/render/manifest.rs
@@ -1,0 +1,97 @@
+//! Manifest artifact construction for cockpit review packets.
+
+use serde_json::{Value, json};
+
+use crate::CockpitReceipt;
+
+use super::evidence::{review_packet_evidence_capabilities, review_packet_evidence_summary};
+
+pub(super) fn review_packet_manifest(
+    receipt: &CockpitReceipt,
+    cockpit_json: &str,
+    evidence_json: &str,
+    review_map_json: &str,
+    review_map_md: &str,
+    comment_md: &str,
+) -> Value {
+    let evidence_summary = review_packet_evidence_summary(receipt);
+    let evidence_capabilities = review_packet_evidence_capabilities(receipt);
+
+    json!({
+        "schema": "tokmd.review_packet_manifest.v1",
+        "generated_by": {
+            "name": "tokmd",
+            "version": env!("CARGO_PKG_VERSION"),
+            "mode": "cockpit",
+            "arguments": ["cockpit", "--review-packet-dir"],
+        },
+        "generated_at_ms": receipt.generated_at_ms,
+        "base_ref": receipt.base_ref,
+        "head_ref": receipt.head_ref,
+        "verdict": {
+            "status": receipt.evidence.overall_status,
+            "blocking": false,
+            "reason": "cockpit review packets are advisory by default",
+            "evidence": evidence_summary,
+        },
+        "capabilities": {
+            "evidence": evidence_capabilities,
+        },
+        "artifacts": [
+            review_packet_artifact(
+                "cockpit",
+                "cockpit.json",
+                "tokmd.cockpit_receipt.v3",
+                "application/json",
+                cockpit_json,
+            ),
+            review_packet_artifact(
+                "evidence",
+                "evidence.json",
+                "tokmd.review_packet_evidence.v1",
+                "application/json",
+                evidence_json,
+            ),
+            review_packet_artifact(
+                "review-map",
+                "review-map.json",
+                "tokmd.review_map.v1",
+                "application/json",
+                review_map_json,
+            ),
+            review_packet_artifact(
+                "review-map-md",
+                "review-map.md",
+                "markdown",
+                "text/markdown",
+                review_map_md,
+            ),
+            review_packet_artifact(
+                "comment",
+                "comment.md",
+                "markdown",
+                "text/markdown",
+                comment_md,
+            ),
+        ],
+    })
+}
+
+fn review_packet_artifact(
+    id: &str,
+    path: &str,
+    schema: &str,
+    media_type: &str,
+    content: &str,
+) -> Value {
+    json!({
+        "id": id,
+        "path": path,
+        "schema": schema,
+        "media_type": media_type,
+        "hash": {
+            "algo": "blake3",
+            "hash": blake3::hash(content.as_bytes()).to_hex().to_string(),
+        },
+    })
+}

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -3,13 +3,11 @@
 use std::path::Path;
 
 use anyhow::Result;
-use serde_json::{Value, json};
 
 use crate::CockpitReceipt;
 
-use super::evidence::{
-    review_packet_evidence, review_packet_evidence_capabilities, review_packet_evidence_summary,
-};
+use super::evidence::review_packet_evidence;
+use super::manifest::review_packet_manifest;
 use super::review_map::{render_review_map_md, review_packet_review_map};
 use super::{render_comment_md, render_json};
 
@@ -60,94 +58,4 @@ fn render_review_packet_comment_md(receipt: &CockpitReceipt) -> String {
     let _ = writeln!(s, "- [Full cockpit receipt](cockpit.json)");
     let _ = writeln!(s);
     s
-}
-
-fn review_packet_manifest(
-    receipt: &CockpitReceipt,
-    cockpit_json: &str,
-    evidence_json: &str,
-    review_map_json: &str,
-    review_map_md: &str,
-    comment_md: &str,
-) -> Value {
-    let evidence_summary = review_packet_evidence_summary(receipt);
-    let evidence_capabilities = review_packet_evidence_capabilities(receipt);
-
-    json!({
-        "schema": "tokmd.review_packet_manifest.v1",
-        "generated_by": {
-            "name": "tokmd",
-            "version": env!("CARGO_PKG_VERSION"),
-            "mode": "cockpit",
-            "arguments": ["cockpit", "--review-packet-dir"],
-        },
-        "generated_at_ms": receipt.generated_at_ms,
-        "base_ref": receipt.base_ref,
-        "head_ref": receipt.head_ref,
-        "verdict": {
-            "status": receipt.evidence.overall_status,
-            "blocking": false,
-            "reason": "cockpit review packets are advisory by default",
-            "evidence": evidence_summary,
-        },
-        "capabilities": {
-            "evidence": evidence_capabilities,
-        },
-        "artifacts": [
-            review_packet_artifact(
-                "cockpit",
-                "cockpit.json",
-                "tokmd.cockpit_receipt.v3",
-                "application/json",
-                cockpit_json,
-            ),
-            review_packet_artifact(
-                "evidence",
-                "evidence.json",
-                "tokmd.review_packet_evidence.v1",
-                "application/json",
-                evidence_json,
-            ),
-            review_packet_artifact(
-                "review-map",
-                "review-map.json",
-                "tokmd.review_map.v1",
-                "application/json",
-                review_map_json,
-            ),
-            review_packet_artifact(
-                "review-map-md",
-                "review-map.md",
-                "markdown",
-                "text/markdown",
-                review_map_md,
-            ),
-            review_packet_artifact(
-                "comment",
-                "comment.md",
-                "markdown",
-                "text/markdown",
-                comment_md,
-            ),
-        ],
-    })
-}
-
-fn review_packet_artifact(
-    id: &str,
-    path: &str,
-    schema: &str,
-    media_type: &str,
-    content: &str,
-) -> Value {
-    json!({
-        "id": id,
-        "path": path,
-        "schema": schema,
-        "media_type": media_type,
-        "hash": {
-            "algo": "blake3",
-            "hash": blake3::hash(content.as_bytes()).to_hex().to_string(),
-        },
-    })
 }


### PR DESCRIPTION
## Summary
- move cockpit review packet manifest construction and artifact hash records into `render::manifest`
- keep review packet artifact names, schemas, hashes, and output semantics unchanged
- leave packet write orchestration in `render::review_packet`

## Validation
- `cargo test -p tokmd-cockpit review_packet --verbose`
- `cargo run -p tokmd -- cockpit --base origin/main --head HEAD --review-packet-dir target/review-smoke-manifest-20260508191519`
- `cargo xtask review-packet-check --dir target/review-smoke-manifest-20260508191519`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`