### PR TITLE
refactor(cockpit): extract review packet comment renderer

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -8,15 +8,16 @@ use anyhow::{Context, Result};
 use tokmd_envelope::{SensorReport, ToolMeta, Verdict};
 
 use crate::{
-    CockpitReceipt, GateStatus, RiskLevel, format_signed_f64, now_iso8601, sparkline,
-    trend_direction_label,
+    CockpitReceipt, GateStatus, format_signed_f64, now_iso8601, sparkline, trend_direction_label,
 };
 
+mod comment;
 mod evidence;
 mod manifest;
 mod review_map;
 mod review_packet;
 
+pub use comment::render_comment_md;
 pub use review_packet::write_review_packet;
 
 /// Render receipt as JSON.
@@ -428,158 +429,6 @@ pub fn render_sections(receipt: &CockpitReceipt) -> String {
     let _ = writeln!(s);
     let _ = writeln!(s, "Full receipt data available in JSON format.");
     let _ = writeln!(s);
-
-    s
-}
-
-/// Render comment.md for PR comments.
-pub fn render_comment_md(receipt: &CockpitReceipt) -> String {
-    use std::fmt::Write;
-    let mut s = String::new();
-
-    // Summary bullet points
-    let _ = writeln!(s, "## Glass Cockpit Summary");
-    let _ = writeln!(s);
-    let _ = writeln!(
-        s,
-        "- **{} files changed**, +{}/-{}",
-        receipt.change_surface.files_changed,
-        receipt.change_surface.insertions,
-        receipt.change_surface.deletions
-    );
-    let _ = writeln!(
-        s,
-        "- **Health**: {}/100 ({})",
-        receipt.code_health.score, receipt.code_health.grade
-    );
-    let _ = writeln!(
-        s,
-        "- **Risk**: {} ({}/100)",
-        receipt.risk.level, receipt.risk.score
-    );
-    let _ = writeln!(s);
-
-    // Contract changes
-    if receipt.contracts.api_changed
-        || receipt.contracts.cli_changed
-        || receipt.contracts.schema_changed
-    {
-        let _ = writeln!(s, "**Contract changes**:");
-        if receipt.contracts.api_changed {
-            let _ = writeln!(s, "- API contract changed");
-        }
-        if receipt.contracts.cli_changed {
-            let _ = writeln!(s, "- CLI contract changed");
-        }
-        if receipt.contracts.schema_changed {
-            let _ = writeln!(s, "- Schema contract changed");
-        }
-        if receipt.contracts.breaking_indicators > 0 {
-            let _ = writeln!(
-                s,
-                "- {} breaking indicator(s)",
-                receipt.contracts.breaking_indicators
-            );
-        }
-        let _ = writeln!(s);
-    }
-
-    // Evidence gates
-    let _ = writeln!(
-        s,
-        "**Evidence gates**: {:?}",
-        receipt.evidence.overall_status
-    );
-    let availability = evidence::evidence_counts(receipt);
-    let _ = writeln!(
-        s,
-        "- **Evidence availability**: {} available, {} degraded, {} stale, {} skipped, {} unavailable, {} missing",
-        availability.available,
-        availability.degraded,
-        availability.stale,
-        availability.skipped,
-        availability.unavailable,
-        availability.missing,
-    );
-    if !receipt.evidence.mutation.survivors.is_empty() {
-        let _ = writeln!(
-            s,
-            "- Mutation: {} survivors detected",
-            receipt.evidence.mutation.survivors.len()
-        );
-    }
-    if let Some(ref dc) = receipt.evidence.diff_coverage {
-        let _ = writeln!(s, "- Diff coverage: {:.1}%", dc.coverage_pct * 100.0);
-    }
-    if let Some(ref contracts) = receipt.evidence.contracts
-        && contracts.failures > 0
-    {
-        let _ = writeln!(s, "- Contracts: {} sub-gate(s) failed", contracts.failures);
-    }
-    if let Some(ref sc) = receipt.evidence.supply_chain
-        && !sc.vulnerabilities.is_empty()
-    {
-        let _ = writeln!(
-            s,
-            "- Supply chain: {} vulnerability/vulnerabilities",
-            sc.vulnerabilities.len()
-        );
-    }
-    if let Some(ref cx) = receipt.evidence.complexity
-        && cx.threshold_exceeded
-    {
-        let _ = writeln!(
-            s,
-            "- Complexity: threshold exceeded (max cyclomatic: {})",
-            cx.max_cyclomatic
-        );
-    }
-    let _ = writeln!(s);
-
-    // Suggested next steps for PR authors and reviewers.
-    let _ = writeln!(s, "**Next steps**:");
-    match receipt.evidence.overall_status {
-        GateStatus::Fail => {
-            let _ = writeln!(s, "- [ ] Address failing evidence gates before merge");
-        }
-        GateStatus::Warn => {
-            let _ = writeln!(
-                s,
-                "- [ ] Review warning evidence gates and capture risk acceptance"
-            );
-        }
-        GateStatus::Pass => {
-            let _ = writeln!(s, "- [ ] Proceed with reviewer sign-off");
-        }
-        GateStatus::Skipped | GateStatus::Pending => {
-            let _ = writeln!(
-                s,
-                "- [ ] Capture missing or pending evidence before relying on this packet"
-            );
-        }
-    }
-    if receipt.contracts.breaking_indicators > 0 {
-        let _ = writeln!(s, "- [ ] Confirm breaking changes are documented");
-    }
-    if matches!(receipt.risk.level, RiskLevel::High | RiskLevel::Critical) {
-        let _ = writeln!(s, "- [ ] Add a domain reviewer for high-risk files");
-    }
-    let _ = writeln!(s);
-
-    // Review plan (priority items only)
-    let priority_items: Vec<_> = receipt
-        .review_plan
-        .iter()
-        .filter(|item| item.priority <= 2)
-        .collect();
-
-    if !priority_items.is_empty() {
-        let _ = writeln!(s, "**Priority review items**:");
-        for item in priority_items {
-            let _ = writeln!(s, "- {} ({})", item.path, item.reason);
-        }
-        let _ = writeln!(s);
-    }
 
     s
 }

--- a/crates/tokmd-cockpit/src/render/comment.rs
+++ b/crates/tokmd-cockpit/src/render/comment.rs
@@ -1,0 +1,169 @@
+//! PR comment rendering for cockpit receipts and review packets.
+
+use crate::{CockpitReceipt, GateStatus, RiskLevel};
+
+use super::evidence::evidence_counts;
+
+/// Render comment.md for PR comments.
+pub fn render_comment_md(receipt: &CockpitReceipt) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+
+    // Summary bullet points
+    let _ = writeln!(s, "## Glass Cockpit Summary");
+    let _ = writeln!(s);
+    let _ = writeln!(
+        s,
+        "- **{} files changed**, +{}/-{}",
+        receipt.change_surface.files_changed,
+        receipt.change_surface.insertions,
+        receipt.change_surface.deletions
+    );
+    let _ = writeln!(
+        s,
+        "- **Health**: {}/100 ({})",
+        receipt.code_health.score, receipt.code_health.grade
+    );
+    let _ = writeln!(
+        s,
+        "- **Risk**: {} ({}/100)",
+        receipt.risk.level, receipt.risk.score
+    );
+    let _ = writeln!(s);
+
+    // Contract changes
+    if receipt.contracts.api_changed
+        || receipt.contracts.cli_changed
+        || receipt.contracts.schema_changed
+    {
+        let _ = writeln!(s, "**Contract changes**:");
+        if receipt.contracts.api_changed {
+            let _ = writeln!(s, "- API contract changed");
+        }
+        if receipt.contracts.cli_changed {
+            let _ = writeln!(s, "- CLI contract changed");
+        }
+        if receipt.contracts.schema_changed {
+            let _ = writeln!(s, "- Schema contract changed");
+        }
+        if receipt.contracts.breaking_indicators > 0 {
+            let _ = writeln!(
+                s,
+                "- {} breaking indicator(s)",
+                receipt.contracts.breaking_indicators
+            );
+        }
+        let _ = writeln!(s);
+    }
+
+    // Evidence gates
+    let _ = writeln!(
+        s,
+        "**Evidence gates**: {:?}",
+        receipt.evidence.overall_status
+    );
+    let availability = evidence_counts(receipt);
+    let _ = writeln!(
+        s,
+        "- **Evidence availability**: {} available, {} degraded, {} stale, {} skipped, {} unavailable, {} missing",
+        availability.available,
+        availability.degraded,
+        availability.stale,
+        availability.skipped,
+        availability.unavailable,
+        availability.missing,
+    );
+    if !receipt.evidence.mutation.survivors.is_empty() {
+        let _ = writeln!(
+            s,
+            "- Mutation: {} survivors detected",
+            receipt.evidence.mutation.survivors.len()
+        );
+    }
+    if let Some(ref dc) = receipt.evidence.diff_coverage {
+        let _ = writeln!(s, "- Diff coverage: {:.1}%", dc.coverage_pct * 100.0);
+    }
+    if let Some(ref contracts) = receipt.evidence.contracts
+        && contracts.failures > 0
+    {
+        let _ = writeln!(s, "- Contracts: {} sub-gate(s) failed", contracts.failures);
+    }
+    if let Some(ref sc) = receipt.evidence.supply_chain
+        && !sc.vulnerabilities.is_empty()
+    {
+        let _ = writeln!(
+            s,
+            "- Supply chain: {} vulnerability/vulnerabilities",
+            sc.vulnerabilities.len()
+        );
+    }
+    if let Some(ref cx) = receipt.evidence.complexity
+        && cx.threshold_exceeded
+    {
+        let _ = writeln!(
+            s,
+            "- Complexity: threshold exceeded (max cyclomatic: {})",
+            cx.max_cyclomatic
+        );
+    }
+    let _ = writeln!(s);
+
+    // Suggested next steps for PR authors and reviewers.
+    let _ = writeln!(s, "**Next steps**:");
+    match receipt.evidence.overall_status {
+        GateStatus::Fail => {
+            let _ = writeln!(s, "- [ ] Address failing evidence gates before merge");
+        }
+        GateStatus::Warn => {
+            let _ = writeln!(
+                s,
+                "- [ ] Review warning evidence gates and capture risk acceptance"
+            );
+        }
+        GateStatus::Pass => {
+            let _ = writeln!(s, "- [ ] Proceed with reviewer sign-off");
+        }
+        GateStatus::Skipped | GateStatus::Pending => {
+            let _ = writeln!(
+                s,
+                "- [ ] Capture missing or pending evidence before relying on this packet"
+            );
+        }
+    }
+    if receipt.contracts.breaking_indicators > 0 {
+        let _ = writeln!(s, "- [ ] Confirm breaking changes are documented");
+    }
+    if matches!(receipt.risk.level, RiskLevel::High | RiskLevel::Critical) {
+        let _ = writeln!(s, "- [ ] Add a domain reviewer for high-risk files");
+    }
+    let _ = writeln!(s);
+
+    // Review plan (priority items only)
+    let priority_items: Vec<_> = receipt
+        .review_plan
+        .iter()
+        .filter(|item| item.priority <= 2)
+        .collect();
+
+    if !priority_items.is_empty() {
+        let _ = writeln!(s, "**Priority review items**:");
+        for item in priority_items {
+            let _ = writeln!(s, "- {} ({})", item.path, item.reason);
+        }
+        let _ = writeln!(s);
+    }
+
+    s
+}
+
+pub(super) fn render_review_packet_comment_md(receipt: &CockpitReceipt) -> String {
+    use std::fmt::Write;
+
+    let mut s = render_comment_md(receipt);
+    let _ = writeln!(s, "**Review packet artifacts**:");
+    let _ = writeln!(s, "- [Evidence gates](evidence.json)");
+    let _ = writeln!(s, "- [Review map](review-map.md)");
+    let _ = writeln!(s, "- [Full cockpit receipt](cockpit.json)");
+    let _ = writeln!(s);
+    s
+}

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -6,10 +6,11 @@ use anyhow::Result;
 
 use crate::CockpitReceipt;
 
+use super::comment::render_review_packet_comment_md;
 use super::evidence::review_packet_evidence;
 use super::manifest::review_packet_manifest;
+use super::render_json;
 use super::review_map::{render_review_map_md, review_packet_review_map};
-use super::{render_comment_md, render_json};
 
 /// Write review packet artifacts to directory.
 ///
@@ -46,16 +47,4 @@ pub fn write_review_packet(dir: &Path, receipt: &CockpitReceipt) -> Result<()> {
     )?;
 
     Ok(())
-}
-
-fn render_review_packet_comment_md(receipt: &CockpitReceipt) -> String {
-    use std::fmt::Write;
-
-    let mut s = render_comment_md(receipt);
-    let _ = writeln!(s, "**Review packet artifacts**:");
-    let _ = writeln!(s, "- [Evidence gates](evidence.json)");
-    let _ = writeln!(s, "- [Review map](review-map.md)");
-    let _ = writeln!(s, "- [Full cockpit receipt](cockpit.json)");
-    let _ = writeln!(s);
-    s
 }


### PR DESCRIPTION
## Summary
- move cockpit PR comment rendering into `render::comment`
- keep the public `render_comment_md` surface re-exported from `render`
- keep review-packet artifact names, schemas, hashes, and comment output semantics unchanged

## Validation
- `cargo test -p tokmd-cockpit review_packet --verbose`
- `cargo run -p tokmd -- cockpit --base origin/main --head HEAD --review-packet-dir target/review-smoke-comment-20260508192834`
- `cargo xtask review-packet-check --dir target/review-smoke-comment-20260508192834`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`