### PR TITLE
docs(cockpit): define proof evidence import contract

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -634,6 +634,7 @@ paths = [
   "crates/tokmd/schemas/review-packet-evidence.schema.json",
   "crates/tokmd/schemas/review-packet-manifest.schema.json",
   "crates/tokmd/tests/cockpit_*.rs",
+  "docs/cockpit-proof-evidence.md",
   "docs/review-packet.md",
   "docs/review-map.schema.json",
   "docs/review-packet-evidence.schema.json",

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -172,6 +172,10 @@ architecture-consolidation program.
   Metrics evidence stack: tokmd is the deterministic code-intelligence and
   review-receipt producer, while evidencebus remains the schema-first evidence
   backplane for cross-tool validation, inventory, bundling, and export.
+- Cockpit proof-evidence import now has a docs-only contract in
+  `docs/cockpit-proof-evidence.md`, defining accepted proof artifacts,
+  required/advisory classification, commit freshness, rendering expectations,
+  and explicit non-goals before any CLI/API import surface is added.
 - Roadmap-era implementation notes now distinguish historical microcrate
   extraction from the current owner-module consolidation shape, so future
   architecture work starts from the actual crate graph instead of retired

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -1,0 +1,179 @@
+# Cockpit Proof Evidence Import Contract
+
+Status: proposed. No `tokmd cockpit` CLI flag or API currently imports these
+artifacts. This document defines the contract future implementation should
+follow when attaching proof-control-plane evidence to cockpit review packets.
+
+## Purpose
+
+Cockpit is the review evidence surface. The proof control plane is the proof
+router. Future cockpit proof imports should connect those systems without
+making cockpit a CI decision engine.
+
+The intended flow is:
+
+```text
+proof-plan / proof-run / executor artifacts
+  -> cockpit proof evidence import
+  -> evidence.json
+  -> review-map.json / review-map.md
+  -> comment.md
+```
+
+Imported proof evidence should help a reviewer answer:
+
+- which proof was planned for the touched scopes;
+- which proof actually ran;
+- whether the proof matched the reviewed commit;
+- whether each proof signal was required or advisory;
+- what evidence is missing, stale, unavailable, skipped, or degraded;
+- which command or artifact reproduces the claim.
+
+## Accepted Inputs
+
+Future cockpit import support may accept these artifact families:
+
+| Artifact | Role |
+| --- | --- |
+| `proof-run-summary.json` | Summary from `cargo xtask proof --run-required ...`; represents required proof commands that were executed under an explicit guard. |
+| `proof-run-observation.json` | Compact observation derived from a verified required proof-run summary; useful for routine fast-proof visibility. |
+| `proof-executor-observation.json` | Observation from scoped advisory executor artifacts, such as non-required coverage runs. |
+| `coverage-receipt.json` | Coverage artifact inventory and byte-count receipt; useful for proving a coverage artifact exists without treating coverage as required. |
+
+Inputs are optional. A missing artifact is not an error unless the caller
+explicitly requested that artifact. If an artifact is present but malformed,
+cockpit should report a clear import error or degraded evidence state rather
+than silently ignoring it.
+
+## Normalized Evidence Model
+
+Cockpit should normalize imported proof artifacts into a small internal evidence
+model before rendering packet artifacts.
+
+Each imported evidence item should preserve:
+
+- source artifact path;
+- source schema;
+- source run or workflow URL when available;
+- base ref or commit when available;
+- head ref or commit when available;
+- proof profile, such as `fast`, `affected`, `release`, or `deep`;
+- proof scope name;
+- command text or command id;
+- execution status;
+- exit code when available;
+- required/advisory classification;
+- artifact references, such as LCOV paths;
+- generated timestamp when available.
+
+Packet renderers should refer back to source artifacts using stable refs rather
+than copying large proof payloads into every packet file.
+
+Example future reference shape:
+
+```json
+{
+  "proof_refs": [
+    "proof-run-observation.json#/entries/0",
+    "proof-executor-observation.json#/entries/3"
+  ]
+}
+```
+
+## Commit Matching
+
+Imported proof is only strong evidence when it matches the change being
+reviewed. Cockpit should classify imported proof with a commit match status:
+
+| Match | Meaning |
+| --- | --- |
+| `exact` | The proof artifact's head commit equals the cockpit head commit. |
+| `partial` | The proof artifact covers a matching scope or command, but base/head metadata is incomplete or only one side matches. |
+| `stale` | The proof artifact is from a different head commit or an older source-run window. |
+| `unknown` | The proof artifact does not contain enough commit metadata to compare. |
+
+Stale or unknown proof must not be rendered as passing evidence. It may still
+be useful context, but packet outputs should show it as stale or degraded.
+
+## Required vs Advisory
+
+Cockpit should preserve the proof policy classification supplied by the proof
+artifacts.
+
+| Classification | Review-packet treatment |
+| --- | --- |
+| Required proof passed | Display as available evidence for the matching scope. |
+| Required proof failed | Display as failing evidence with the reproducing command. |
+| Required proof missing | Display as missing evidence when the touched scope expected it. |
+| Advisory proof passed | Display as available advisory evidence, not as a merge requirement. |
+| Advisory proof failed | Display as advisory failure or degraded evidence, depending on policy. |
+| Advisory proof not executed | Display as planned or skipped, not as passing. |
+
+The review packet can show required/advisory status, but cockpit must not decide
+to promote advisory proof into required proof.
+
+## Rendering Requirements
+
+When proof evidence is imported, future packet outputs should show it in the
+same evidence vocabulary used by the current review packet:
+
+- `available`
+- `missing`
+- `skipped`
+- `stale`
+- `degraded`
+- `unavailable`
+
+The information should be visible in:
+
+- `evidence.json` gate entries;
+- `review-map.json` item evidence status and `proof_refs`;
+- `review-map.md` proof lines for review-first items;
+- `comment.md` compact evidence availability text.
+
+Review map output should answer a reviewer-facing question:
+
+```text
+This PR touched tokmd_cockpit.
+Required proof passed: cockpit integration, cockpit workflow.
+Advisory coverage produced tokmd_cockpit.lcov.
+Mutation was planned but not executed.
+Diff coverage evidence is missing.
+```
+
+## Error Handling
+
+Future import behavior should distinguish:
+
+- absent optional proof artifact;
+- explicitly requested artifact that is missing;
+- malformed artifact;
+- unknown schema;
+- stale commit;
+- artifact paths that are not relative or are outside the packet root;
+- evidence artifact listed but missing on disk.
+
+Malformed or unsafe inputs should fail fast when the caller explicitly provided
+the input path. Passive discovery can instead record degraded or unavailable
+evidence.
+
+## Non-Goals
+
+- Promoting fast proof, scoped coverage, mutation, or Codecov into required
+  gates.
+- Enabling default Codecov upload.
+- Producing a merge verdict.
+- Replacing existing CI jobs or proof-policy checks.
+- Treating planned-but-not-executed proof as passing proof.
+- Treating stale or unknown-commit proof as passing proof.
+- Adding a separate `tokmd review` command.
+
+## Implementation Checklist
+
+- Add deserializable DTOs for accepted proof artifacts.
+- Keep absent imports compatible with current cockpit behavior.
+- Normalize required/advisory status before rendering.
+- Classify commit match as exact, partial, stale, or unknown.
+- Attach proof refs to review-map items without duplicating large artifacts.
+- Keep review packet schemas versioned if output shape changes.
+- Keep proof-control-plane promotion decisions outside cockpit.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -90,6 +90,11 @@ Recommended evidence availability values:
 Missing, stale, degraded, and unavailable evidence should be visible in
 `comment.md`, `evidence.json`, and `manifest.json` verdict metadata.
 
+Future cockpit proof imports should follow
+[`cockpit-proof-evidence.md`](cockpit-proof-evidence.md). Imported proof must
+preserve required/advisory classification and commit freshness, and must not
+promote advisory proof into blocking evidence.
+
 ## Manifest Requirements
 
 `manifest.json` should use schema `tokmd.review_packet_manifest.v1` and include:
@@ -189,3 +194,5 @@ that uses this packet.
 - `comment.md` remains concise enough for PR comments.
 - Existing `--format comment` and `--artifacts-dir` behavior remains compatible.
 - Action artifact upload works even when comments are disabled or unavailable.
+- Future proof evidence imports preserve required/advisory status and mark
+  stale or unknown-commit evidence explicitly.


### PR DESCRIPTION
## Summary
- add `docs/cockpit-proof-evidence.md` as the proposed cockpit proof-evidence import contract
- document accepted proof artifacts, commit freshness, required/advisory handling, rendering expectations, and non-goals
- route the new contract doc through the existing `tokmd_cockpit` proof scope so future edits are not unknown files

## Validation
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo test -p xtask --verbose`
- `cargo test -p tokmd-cockpit review_packet --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`