### PR TITLE
feat(cockpit): validate proof evidence inputs

### DIFF
--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -40,6 +40,7 @@ pub use display::{format_signed_f64, now_iso8601, round_pct, sparkline, trend_di
 pub use gates::compute_determinism_gate;
 #[cfg(feature = "git")]
 use gates::compute_evidence;
+pub use proof_evidence::ProofEvidenceKind;
 pub use review_plan::generate_review_plan;
 #[cfg(all(test, feature = "git"))]
 use tokmd_analysis::source_complexity::analyze_rust_function_complexity;
@@ -49,6 +50,14 @@ pub use tokmd_types::cockpit::*;
 
 /// Cyclomatic complexity threshold for high complexity.
 pub const COMPLEXITY_THRESHOLD: u32 = 15;
+
+/// Parse a proof-control-plane evidence artifact and return its artifact family.
+///
+/// This is intentionally validation-only for now: cockpit can accept explicit
+/// proof evidence inputs without changing review packet output semantics.
+pub fn proof_evidence_kind(raw: &str) -> Result<ProofEvidenceKind> {
+    proof_evidence::proof_evidence_kind(raw)
+}
 
 /// File stat from git diff --numstat.
 /// File stat from git diff --numstat.

--- a/crates/tokmd-cockpit/src/proof_evidence.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence.rs
@@ -15,6 +15,14 @@ const PROOF_RUN_OBSERVATION_SCHEMA: &str = "tokmd.proof_run_observation.v1";
 const PROOF_EXECUTOR_OBSERVATION_SCHEMA: &str = "tokmd.proof_executor_observation.v1";
 const COVERAGE_RECEIPT_SCHEMA: &str = "tokmd.coverage_receipt.v1";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofEvidenceKind {
+    ProofRunSummary,
+    ProofRunObservation,
+    ProofExecutorObservation,
+    CoverageReceipt,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProofEvidenceArtifact {
     ProofRunSummary(ProofRunSummaryInput),
@@ -24,6 +32,15 @@ pub enum ProofEvidenceArtifact {
 }
 
 impl ProofEvidenceArtifact {
+    pub fn kind(&self) -> ProofEvidenceKind {
+        match self {
+            Self::ProofRunSummary(_) => ProofEvidenceKind::ProofRunSummary,
+            Self::ProofRunObservation(_) => ProofEvidenceKind::ProofRunObservation,
+            Self::ProofExecutorObservation(_) => ProofEvidenceKind::ProofExecutorObservation,
+            Self::CoverageReceipt(_) => ProofEvidenceKind::CoverageReceipt,
+        }
+    }
+
     pub fn schema(&self) -> &str {
         match self {
             Self::ProofRunSummary(artifact) => &artifact.schema,
@@ -50,6 +67,10 @@ impl ProofEvidenceArtifact {
             Self::CoverageReceipt(artifact) => Some(&artifact.sha),
         }
     }
+}
+
+pub fn proof_evidence_kind(raw: &str) -> Result<ProofEvidenceKind> {
+    parse_proof_evidence_json(raw).map(|artifact| artifact.kind())
 }
 
 pub fn parse_proof_evidence_json(raw: &str) -> Result<ProofEvidenceArtifact> {
@@ -309,6 +330,27 @@ mod tests {
         assert_eq!(summary.profile, "fast");
         assert_eq!(summary.entries[0].scope, "tokmd_cockpit");
         assert_eq!(summary.entries[0].exit_code, Some(0));
+    }
+
+    #[test]
+    fn reports_proof_evidence_kind() {
+        let kind = proof_evidence_kind(
+            r#"{
+  "schema": "tokmd.coverage_receipt.v1",
+  "schema_version": 1,
+  "repo": "EffortlessMetrics/tokmd",
+  "lane": "scoped",
+  "flag": "tokmd_cockpit",
+  "workflow": "Coverage",
+  "sha": "abc123",
+  "github": {},
+  "artifacts": [],
+  "status": { "ok": true, "missing": [], "empty": [] }
+}"#,
+        )
+        .expect("parse coverage receipt kind");
+
+        assert_eq!(kind, ProofEvidenceKind::CoverageReceipt);
     }
 
     #[test]

--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -1039,6 +1039,22 @@ pub struct CockpitArgs {
     #[arg(long, value_name = "PATH")]
     pub baseline: Option<std::path::PathBuf>,
 
+    /// Validate a required proof-run summary artifact before rendering.
+    #[arg(long, value_name = "PATH")]
+    pub proof_run_summary: Option<std::path::PathBuf>,
+
+    /// Validate a proof-run observation artifact before rendering.
+    #[arg(long, value_name = "PATH")]
+    pub proof_observation: Option<std::path::PathBuf>,
+
+    /// Validate a proof-executor observation artifact before rendering.
+    #[arg(long, value_name = "PATH")]
+    pub executor_observation: Option<std::path::PathBuf>,
+
+    /// Validate a coverage receipt artifact before rendering.
+    #[arg(long, value_name = "PATH")]
+    pub coverage_receipt: Option<std::path::PathBuf>,
+
     /// Diff range syntax: two-dot (default) or three-dot.
     #[arg(long, value_enum, default_value_t = DiffRangeMode::TwoDot)]
     pub diff_range: DiffRangeMode,

--- a/crates/tokmd/src/commands/cockpit.rs
+++ b/crates/tokmd/src/commands/cockpit.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "git")]
 use std::io::Write;
 #[cfg(feature = "git")]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::cli;
 #[cfg(feature = "git")]
@@ -38,6 +38,7 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
         let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
         let repo_root = tokmd_git::repo_root(&cwd)
             .ok_or_else(|| anyhow::anyhow!("not inside a git repository"))?;
+        validate_proof_evidence_inputs(&args)?;
 
         let range_mode = match args.diff_range {
             cli::DiffRangeMode::TwoDot => tokmd_git::GitRangeMode::TwoDot,
@@ -115,6 +116,67 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
 
         Ok(())
     }
+}
+
+#[cfg(feature = "git")]
+fn validate_proof_evidence_inputs(args: &cli::CockpitArgs) -> Result<()> {
+    let inputs = [
+        (
+            "--proof-run-summary",
+            args.proof_run_summary.as_deref(),
+            tokmd_cockpit::ProofEvidenceKind::ProofRunSummary,
+        ),
+        (
+            "--proof-observation",
+            args.proof_observation.as_deref(),
+            tokmd_cockpit::ProofEvidenceKind::ProofRunObservation,
+        ),
+        (
+            "--executor-observation",
+            args.executor_observation.as_deref(),
+            tokmd_cockpit::ProofEvidenceKind::ProofExecutorObservation,
+        ),
+        (
+            "--coverage-receipt",
+            args.coverage_receipt.as_deref(),
+            tokmd_cockpit::ProofEvidenceKind::CoverageReceipt,
+        ),
+    ];
+
+    for (flag, path, expected_kind) in inputs {
+        if let Some(path) = path {
+            validate_proof_evidence_input(flag, path, expected_kind)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "git")]
+fn validate_proof_evidence_input(
+    flag: &str,
+    path: &Path,
+    expected_kind: tokmd_cockpit::ProofEvidenceKind,
+) -> Result<()> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {flag} proof evidence at {}", path.display()))?;
+    let actual_kind = tokmd_cockpit::proof_evidence_kind(&raw).with_context(|| {
+        format!(
+            "failed to parse {flag} proof evidence at {}",
+            path.display()
+        )
+    })?;
+
+    if actual_kind != expected_kind {
+        bail!(
+            "{flag} expected {:?} evidence at {}, found {:?}",
+            expected_kind,
+            path.display(),
+            actual_kind
+        );
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -5,7 +5,7 @@ mod common;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use tempfile::tempdir;
+use tempfile::{TempDir, tempdir};
 
 fn tokmd_cmd() -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
@@ -39,6 +39,89 @@ fn assert_validates_against_schema(schema_json: &str, instance: &serde_json::Val
     }
 }
 
+fn basic_cockpit_repo() -> Option<TempDir> {
+    if !common::git_available() {
+        eprintln!("Skipping: git not available");
+        return None;
+    }
+
+    let dir = tempdir().unwrap();
+    if !common::init_git_repo(dir.path()) {
+        eprintln!("Skipping: git init failed");
+        return None;
+    }
+
+    std::fs::write(dir.path().join("lib.rs"), "fn main() {}").unwrap();
+    if !common::git_add_commit(dir.path(), "Initial commit") {
+        eprintln!("Skipping: git commit failed");
+        return None;
+    }
+
+    let status = std::process::Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(dir.path())
+        .status();
+    if !status.map(|s| s.success()).unwrap_or(false) {
+        eprintln!("Skipping: feature branch checkout failed");
+        return None;
+    }
+
+    std::fs::write(dir.path().join("new.rs"), "fn new() {}").unwrap();
+    if !common::git_add_commit(dir.path(), "Add new file") {
+        eprintln!("Skipping: second commit failed");
+        return None;
+    }
+
+    Some(dir)
+}
+
+const PROOF_RUN_OBSERVATION_JSON: &str = r#"{
+  "schema": "tokmd.proof_run_observation.v1",
+  "status": "passed",
+  "execution_status": "executed",
+  "profile": "fast",
+  "base": "origin/main",
+  "head": "abc123",
+  "ok": true,
+  "execution_guard": {
+    "enabled": true,
+    "ci": true,
+    "reason": "required proof-run summary verified"
+  },
+  "counts": {
+    "commands_total": 1,
+    "required_planned": 1,
+    "advisory_skipped": 0,
+    "executed": 1,
+    "passed": 1,
+    "failed": 0
+  },
+  "scopes": [
+    {
+      "name": "tokmd_cockpit",
+      "kind": "test",
+      "command": "cargo test -p tokmd-cockpit",
+      "status": "passed",
+      "exit_code": 0
+    }
+  ],
+  "changed_files": ["crates/tokmd-cockpit/src/lib.rs"],
+  "unknown_files": []
+}"#;
+
+const COVERAGE_RECEIPT_JSON: &str = r#"{
+  "schema": "tokmd.coverage_receipt.v1",
+  "schema_version": 1,
+  "repo": "EffortlessMetrics/tokmd",
+  "lane": "scoped",
+  "flag": "tokmd_cockpit",
+  "workflow": "Coverage",
+  "sha": "abc123",
+  "github": {},
+  "artifacts": [],
+  "status": { "ok": true, "missing": [], "empty": [] }
+}"#;
+
 #[test]
 fn test_cockpit_help() {
     // Given: The cockpit command exists
@@ -52,7 +135,98 @@ fn test_cockpit_help() {
         .stdout(predicate::str::contains("--base"))
         .stdout(predicate::str::contains("--head"))
         .stdout(predicate::str::contains("--format"))
+        .stdout(predicate::str::contains("--proof-run-summary"))
+        .stdout(predicate::str::contains("--proof-observation"))
+        .stdout(predicate::str::contains("--executor-observation"))
+        .stdout(predicate::str::contains("--coverage-receipt"))
         .stdout(predicate::str::contains("--output"));
+}
+
+#[test]
+fn test_cockpit_accepts_valid_proof_observation_input_without_receipt_change() {
+    let Some(dir) = basic_cockpit_repo() else {
+        return;
+    };
+    let proof_path = dir.path().join("proof-run-observation.json");
+    std::fs::write(&proof_path, PROOF_RUN_OBSERVATION_JSON).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    let output = cmd
+        .current_dir(dir.path())
+        .arg("cockpit")
+        .arg("--base")
+        .arg("main")
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--format")
+        .arg("json")
+        .arg("--proof-observation")
+        .arg(&proof_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "cockpit should accept valid proof observation input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid cockpit JSON");
+    assert!(json.get("schema_version").is_some());
+    assert!(json.get("review_plan").is_some());
+}
+
+#[test]
+fn test_cockpit_rejects_unknown_proof_evidence_schema() {
+    let Some(dir) = basic_cockpit_repo() else {
+        return;
+    };
+    let proof_path = dir.path().join("unknown-proof.json");
+    std::fs::write(&proof_path, r#"{ "schema": "tokmd.unknown.v1" }"#).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .arg("cockpit")
+        .arg("--base")
+        .arg("main")
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--proof-observation")
+        .arg(&proof_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "failed to parse --proof-observation proof evidence",
+        ))
+        .stderr(predicate::str::contains(
+            "unsupported proof evidence schema",
+        ));
+}
+
+#[test]
+fn test_cockpit_rejects_mismatched_proof_evidence_kind() {
+    let Some(dir) = basic_cockpit_repo() else {
+        return;
+    };
+    let proof_path = dir.path().join("coverage-receipt.json");
+    std::fs::write(&proof_path, COVERAGE_RECEIPT_JSON).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .arg("cockpit")
+        .arg("--base")
+        .arg("main")
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--proof-observation")
+        .arg(&proof_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--proof-observation expected ProofRunObservation evidence",
+        ))
+        .stderr(predicate::str::contains("found CoverageReceipt"));
 }
 
 #[test]

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -1,8 +1,10 @@
 # Cockpit Proof Evidence Import Contract
 
-Status: proposed. No `tokmd cockpit` CLI flag or API currently imports these
-artifacts. This document defines the contract future implementation should
-follow when attaching proof-control-plane evidence to cockpit review packets.
+Status: partially implemented. `tokmd cockpit` can validate explicitly supplied
+proof artifacts through validation-only flags, but it does not yet attach
+imported proof evidence to review packet outputs. This document defines the
+contract future implementation should follow when attaching proof-control-plane
+evidence to cockpit review packets.
 
 ## Purpose
 
@@ -31,19 +33,21 @@ Imported proof evidence should help a reviewer answer:
 
 ## Accepted Inputs
 
-Future cockpit import support may accept these artifact families:
+Cockpit accepts these artifact families for validation. Future import support
+may normalize the same artifacts into review packet evidence:
 
-| Artifact | Role |
+| Artifact | CLI flag | Role |
 | --- | --- |
-| `proof-run-summary.json` | Summary from `cargo xtask proof --run-required ...`; represents required proof commands that were executed under an explicit guard. |
-| `proof-run-observation.json` | Compact observation derived from a verified required proof-run summary; useful for routine fast-proof visibility. |
-| `proof-executor-observation.json` | Observation from scoped advisory executor artifacts, such as non-required coverage runs. |
-| `coverage-receipt.json` | Coverage artifact inventory and byte-count receipt; useful for proving a coverage artifact exists without treating coverage as required. |
+| `proof-run-summary.json` | `--proof-run-summary <PATH>` | Summary from `cargo xtask proof --run-required ...`; represents required proof commands that were executed under an explicit guard. |
+| `proof-run-observation.json` | `--proof-observation <PATH>` | Compact observation derived from a verified required proof-run summary; useful for routine fast-proof visibility. |
+| `proof-executor-observation.json` | `--executor-observation <PATH>` | Observation from scoped advisory executor artifacts, such as non-required coverage runs. |
+| `coverage-receipt.json` | `--coverage-receipt <PATH>` | Coverage artifact inventory and byte-count receipt; useful for proving a coverage artifact exists without treating coverage as required. |
 
 Inputs are optional. A missing artifact is not an error unless the caller
-explicitly requested that artifact. If an artifact is present but malformed,
-cockpit should report a clear import error or degraded evidence state rather
-than silently ignoring it.
+explicitly requested that artifact. When an explicitly supplied artifact is
+missing, malformed, or does not match the flag's expected artifact family,
+cockpit fails before rendering. Passive discovery can later record degraded
+evidence state instead of failing.
 
 ## Normalized Evidence Model
 
@@ -170,8 +174,9 @@ evidence.
 
 ## Implementation Checklist
 
-- Add deserializable DTOs for accepted proof artifacts.
-- Keep absent imports compatible with current cockpit behavior.
+- Add deserializable DTOs for accepted proof artifacts. (done)
+- Validate explicit proof artifact inputs without changing receipt output. (done)
+- Keep absent imports compatible with current cockpit behavior. (done)
 - Normalize required/advisory status before rendering.
 - Classify commit match as exact, partial, stale, or unknown.
 - Attach proof refs to review-map items without duplicating large artifacts.

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -1267,6 +1267,21 @@ Options:
 
           When provided, cockpit will compute delta metrics showing how the current state compares to the baseline.
 
+      --proof-run-summary <PATH>
+          Validate a required proof-run summary artifact before rendering
+
+      --proof-observation <PATH>
+          Validate a proof-run observation artifact before rendering
+
+      --executor-observation <PATH>
+          Validate a proof-executor observation artifact before rendering
+
+      --no-progress
+          Disable progress spinners
+
+      --coverage-receipt <PATH>
+          Validate a coverage receipt artifact before rendering
+
       --diff-range <DIFF_RANGE>
           Diff range syntax: two-dot (default) or three-dot
 
@@ -1280,9 +1295,6 @@ Options:
           Run in sensor mode for CI integration.
 
           When enabled: - Writes only sensor.report.v1 envelope to artifacts_dir/report.json - Exits 0 if receipt written successfully (verdict in envelope instead of exit code)
-
-      --no-progress
-          Disable progress spinners
 
       --profile <PROFILE>
           Configuration profile to use (e.g., "llm_safe", "ci")
@@ -1304,7 +1316,12 @@ Options:
 | `--format <FORMAT>` | Output format: `json`, `md`, `sections`. | `json` |
 | `--output <PATH>` | Write output to file instead of stdout. | `(stdout)` |
 | `--artifacts-dir <DIR>` | In standard cockpit mode, write `cockpit.json`, `report.json`, and `comment.md` to a directory. | `(none)` |
+| `--review-packet-dir <DIR>` | Write review packet artifacts (`manifest.json`, `cockpit.json`, `evidence.json`, `review-map.json`, `review-map.md`, `comment.md`) to a directory. | `(none)` |
 | `--baseline <PATH>` | Path to baseline receipt for trend comparison. | `(none)` |
+| `--proof-run-summary <PATH>` | Validate a required proof-run summary artifact before rendering. | `(none)` |
+| `--proof-observation <PATH>` | Validate a proof-run observation artifact before rendering. | `(none)` |
+| `--executor-observation <PATH>` | Validate a proof-executor observation artifact before rendering. | `(none)` |
+| `--coverage-receipt <PATH>` | Validate a coverage receipt artifact before rendering. | `(none)` |
 | `--diff-range <MODE>` | Diff range syntax: `two-dot` or `three-dot`. | `two-dot` |
 | `--sensor-mode` | Run in sensor mode for CI integration (see below). | `false` |
 | `--no-progress` | Disable progress spinners. | `false` |

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -90,10 +90,11 @@ Recommended evidence availability values:
 Missing, stale, degraded, and unavailable evidence should be visible in
 `comment.md`, `evidence.json`, and `manifest.json` verdict metadata.
 
-Future cockpit proof imports should follow
-[`cockpit-proof-evidence.md`](cockpit-proof-evidence.md). Imported proof must
-preserve required/advisory classification and commit freshness, and must not
-promote advisory proof into blocking evidence.
+Cockpit proof imports should follow
+[`cockpit-proof-evidence.md`](cockpit-proof-evidence.md). Current CLI support is
+validation-only for explicitly supplied proof artifacts; future packet imports
+must preserve required/advisory classification and commit freshness, and must
+not promote advisory proof into blocking evidence.
 
 ## Manifest Requirements
 


### PR DESCRIPTION
## Summary
- add validation-only cockpit proof evidence inputs for proof-run summaries, proof-run observations, proof-executor observations, and coverage receipts
- expose a small proof evidence kind parser from `tokmd-cockpit` for CLI-side validation without changing cockpit receipt or review packet output semantics
- document the partial proof evidence import state and update generated CLI reference/help coverage

## Validation
- `cargo test -p tokmd-cockpit proof_evidence --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo test -p tokmd --test cli_e2e --test cli_snapshot_golden --test config_resolution --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check origin/main...HEAD`

## Notes
- This does not import proof evidence into review packet artifacts yet.
- This does not promote any proof-control-plane gates, Codecov uploads, mutation, or coverage evidence to required.