### PR TITLE
feat(cockpit): attach proof evidence to packet evidence

### DIFF
--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -40,7 +40,7 @@ pub use display::{format_signed_f64, now_iso8601, round_pct, sparkline, trend_di
 pub use gates::compute_determinism_gate;
 #[cfg(feature = "git")]
 use gates::compute_evidence;
-pub use proof_evidence::ProofEvidenceKind;
+pub use proof_evidence::{ProofEvidenceInput, ProofEvidenceKind};
 pub use review_plan::generate_review_plan;
 #[cfg(all(test, feature = "git"))]
 use tokmd_analysis::source_complexity::analyze_rust_function_complexity;
@@ -57,6 +57,14 @@ pub const COMPLEXITY_THRESHOLD: u32 = 15;
 /// proof evidence inputs without changing review packet output semantics.
 pub fn proof_evidence_kind(raw: &str) -> Result<ProofEvidenceKind> {
     proof_evidence::proof_evidence_kind(raw)
+}
+
+/// Parse a proof-control-plane evidence artifact with its source path.
+pub fn parse_proof_evidence_input(
+    raw: &str,
+    source_path: impl Into<std::path::PathBuf>,
+) -> Result<ProofEvidenceInput> {
+    proof_evidence::parse_proof_evidence_input(raw, source_path)
 }
 
 /// File stat from git diff --numstat.

--- a/crates/tokmd-cockpit/src/proof_evidence.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence.rs
@@ -1,8 +1,9 @@
 //! Deserializable proof-control-plane evidence artifacts.
 //!
-//! Cockpit does not import these artifacts into review packets yet. This module
-//! locks the accepted input shapes so future packet wiring can classify proof
-//! evidence without duplicating the `xtask` JSON contracts.
+//! Cockpit imports these artifacts into review packet evidence when callers
+//! explicitly provide them. This module locks the accepted input shapes so
+//! packet wiring can classify proof evidence without duplicating the `xtask`
+//! JSON contracts.
 
 #![allow(dead_code)]
 
@@ -26,6 +27,17 @@ pub enum ProofEvidenceKind {
     CoverageReceipt,
 }
 
+impl ProofEvidenceKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ProofRunSummary => "proof_run_summary",
+            Self::ProofRunObservation => "proof_run_observation",
+            Self::ProofExecutorObservation => "proof_executor_observation",
+            Self::CoverageReceipt => "coverage_receipt",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProofEvidenceAvailability {
     Available,
@@ -36,6 +48,19 @@ pub(crate) enum ProofEvidenceAvailability {
     Unavailable,
 }
 
+impl ProofEvidenceAvailability {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::Missing => "missing",
+            Self::Skipped => "skipped",
+            Self::Stale => "stale",
+            Self::Degraded => "degraded",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProofExecutionStatus {
     Planned,
@@ -43,6 +68,18 @@ pub(crate) enum ProofExecutionStatus {
     ExecutedFailed,
     NotExecuted,
     DryRun,
+}
+
+impl ProofExecutionStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Planned => "planned",
+            Self::ExecutedPassed => "executed_passed",
+            Self::ExecutedFailed => "executed_failed",
+            Self::NotExecuted => "not_executed",
+            Self::DryRun => "dry_run",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -67,6 +104,18 @@ pub enum ProofEvidenceArtifact {
     ProofRunObservation(ProofRunObservationInput),
     ProofExecutorObservation(ProofExecutorObservationInput),
     CoverageReceipt(CoverageReceiptInput),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofEvidenceInput {
+    pub source_path: PathBuf,
+    pub artifact: ProofEvidenceArtifact,
+}
+
+impl ProofEvidenceInput {
+    pub fn kind(&self) -> ProofEvidenceKind {
+        self.artifact.kind()
+    }
 }
 
 impl ProofEvidenceArtifact {
@@ -109,6 +158,36 @@ impl ProofEvidenceArtifact {
 
 pub fn proof_evidence_kind(raw: &str) -> Result<ProofEvidenceKind> {
     parse_proof_evidence_json(raw).map(|artifact| artifact.kind())
+}
+
+pub fn parse_proof_evidence_input(
+    raw: &str,
+    source_path: impl Into<PathBuf>,
+) -> Result<ProofEvidenceInput> {
+    let artifact = parse_proof_evidence_json(raw)?;
+
+    Ok(ProofEvidenceInput {
+        source_path: source_path.into(),
+        artifact,
+    })
+}
+
+pub(crate) fn normalize_proof_evidence_inputs(
+    inputs: &[ProofEvidenceInput],
+    cockpit_base: Option<&str>,
+    cockpit_head: Option<&str>,
+) -> Vec<NormalizedProofEvidence> {
+    inputs
+        .iter()
+        .flat_map(|input| {
+            normalize_proof_evidence(
+                &input.artifact,
+                input.source_path.clone(),
+                cockpit_base,
+                cockpit_head,
+            )
+        })
+        .collect()
 }
 
 pub(crate) fn normalize_proof_evidence(

--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -18,7 +18,7 @@ mod review_map;
 mod review_packet;
 
 pub use comment::render_comment_md;
-pub use review_packet::write_review_packet;
+pub use review_packet::{write_review_packet, write_review_packet_with_proof_evidence};
 
 /// Render receipt as JSON.
 pub fn render_json(receipt: &CockpitReceipt) -> Result<String> {

--- a/crates/tokmd-cockpit/src/render/evidence.rs
+++ b/crates/tokmd-cockpit/src/render/evidence.rs
@@ -2,21 +2,65 @@
 
 use serde_json::{Value, json};
 
+use crate::proof_evidence::{ProofEvidenceInput, normalize_proof_evidence_inputs};
 use crate::{CockpitReceipt, CommitMatch, GateMeta, GateStatus};
 
-pub(super) fn review_packet_evidence(receipt: &CockpitReceipt) -> Value {
+pub(super) fn review_packet_evidence(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> Value {
     let gates: Vec<_> = review_packet_evidence_gate_specs(receipt)
         .into_iter()
         .map(|(id, meta)| evidence_gate(id, meta))
         .collect();
 
-    json!({
+    let mut evidence = json!({
         "schema": "tokmd.review_packet_evidence.v1",
         "overall_status": receipt.evidence.overall_status,
         "base_ref": receipt.base_ref,
         "head_ref": receipt.head_ref,
         "gates": gates,
+    });
+
+    let proof = review_packet_proof_evidence(receipt, proof_inputs);
+    if !proof.is_empty() {
+        evidence["proof"] = Value::Array(proof);
+    }
+
+    evidence
+}
+
+fn review_packet_proof_evidence(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> Vec<Value> {
+    normalize_proof_evidence_inputs(
+        proof_inputs,
+        Some(&receipt.base_ref),
+        Some(&receipt.head_ref),
+    )
+    .into_iter()
+    .map(|item| {
+        json!({
+            "kind": item.kind.as_str(),
+            "source": normalize_path_for_output(&item.source_path),
+            "source_schema": item.source_schema,
+            "profile": item.profile,
+            "scope": item.scope,
+            "command": item.command,
+            "required": item.required,
+            "advisory": item.advisory,
+            "execution_status": item.execution_status.as_str(),
+            "availability": item.availability.as_str(),
+            "commit_match": item.commit_match,
+            "refs": item.artifact_refs,
+        })
     })
+    .collect()
+}
+
+fn normalize_path_for_output(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 pub(super) fn review_packet_evidence_summary(receipt: &CockpitReceipt) -> Value {

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use crate::CockpitReceipt;
+use crate::{CockpitReceipt, ProofEvidenceInput};
 
 use super::comment::render_review_packet_comment_md;
 use super::evidence::review_packet_evidence;
@@ -19,10 +19,21 @@ use super::review_map::{render_review_map_md, review_packet_review_map};
 /// integrations keep their shipped `cockpit.json` / `report.json` /
 /// `comment.md` artifact shape until they opt into packet emission.
 pub fn write_review_packet(dir: &Path, receipt: &CockpitReceipt) -> Result<()> {
+    write_review_packet_with_proof_evidence(dir, receipt, &[])
+}
+
+/// Write review packet artifacts and include imported proof evidence in
+/// `evidence.json`.
+pub fn write_review_packet_with_proof_evidence(
+    dir: &Path,
+    receipt: &CockpitReceipt,
+    proof_evidence: &[ProofEvidenceInput],
+) -> Result<()> {
     std::fs::create_dir_all(dir)?;
 
     let cockpit_json = render_json(receipt)?;
-    let evidence_json = serde_json::to_string_pretty(&review_packet_evidence(receipt))?;
+    let evidence_json =
+        serde_json::to_string_pretty(&review_packet_evidence(receipt, proof_evidence))?;
     let review_map_json = serde_json::to_string_pretty(&review_packet_review_map(receipt))?;
     let review_map_md = render_review_map_md(receipt);
     let comment_md = render_review_packet_comment_md(receipt);

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -857,6 +857,10 @@ fn scenario_write_review_packet_creates_contract_files() {
             .len(),
         0
     );
+    assert!(
+        evidence.get("proof").is_none(),
+        "packets without proof inputs should preserve the current evidence shape"
+    );
 
     let review_map: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
@@ -914,6 +918,81 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert!(comment_md.contains("[Evidence gates](evidence.json)"));
     assert!(comment_md.contains("[Review map](review-map.md)"));
     assert!(comment_md.contains("[Full cockpit receipt](cockpit.json)"));
+}
+
+#[test]
+fn scenario_write_review_packet_includes_imported_proof_evidence() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = minimal_receipt();
+    let out = dir.path().join("review");
+    let proof = tokmd_cockpit::parse_proof_evidence_input(
+        r#"{
+  "schema": "tokmd.proof_run_observation.v1",
+  "status": "passed",
+  "execution_status": "executed",
+  "profile": "fast",
+  "base": "main",
+  "head": "feature",
+  "ok": true,
+  "execution_guard": {
+    "enabled": true,
+    "ci": true,
+    "reason": "required proof-run summary verified"
+  },
+  "counts": {
+    "commands_total": 1,
+    "required_planned": 1,
+    "advisory_skipped": 0,
+    "executed": 1,
+    "passed": 1,
+    "failed": 0
+  },
+  "scopes": [
+    {
+      "name": "tokmd_cockpit",
+      "kind": "test",
+      "command": "cargo test -p tokmd-cockpit",
+      "status": "passed",
+      "exit_code": 0
+    }
+  ],
+  "changed_files": ["crates/tokmd-cockpit/src/lib.rs"],
+  "unknown_files": []
+}"#,
+        "proof-run-observation.json",
+    )
+    .unwrap();
+
+    tokmd_cockpit::render::write_review_packet_with_proof_evidence(&out, &receipt, &[proof])
+        .unwrap();
+
+    let evidence: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("evidence.json")).unwrap()).unwrap();
+    let proof = evidence["proof"].as_array().expect("proof evidence array");
+    assert_eq!(proof.len(), 1);
+    assert_eq!(proof[0]["kind"], "proof_run_observation");
+    assert_eq!(proof[0]["source"], "proof-run-observation.json");
+    assert_eq!(proof[0]["source_schema"], "tokmd.proof_run_observation.v1");
+    assert_eq!(proof[0]["profile"], "fast");
+    assert_eq!(proof[0]["scope"], "tokmd_cockpit");
+    assert_eq!(proof[0]["command"], "cargo test -p tokmd-cockpit");
+    assert_eq!(proof[0]["required"], true);
+    assert_eq!(proof[0]["advisory"], false);
+    assert_eq!(proof[0]["execution_status"], "executed_passed");
+    assert_eq!(proof[0]["availability"], "available");
+    assert_eq!(proof[0]["commit_match"], "exact");
+    assert_eq!(proof[0]["refs"][0], "proof-run-observation.json#/scopes/0");
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("manifest.json")).unwrap()).unwrap();
+    assert_eq!(
+        manifest["verdict"]["reason"],
+        "cockpit review packets are advisory by default"
+    );
+    assert_eq!(
+        manifest["verdict"]["evidence"]["details"], "evidence.json#/gates",
+        "imported proof should not change gate verdict counts yet"
+    );
 }
 
 // ===========================================================================

--- a/crates/tokmd/schemas/review-packet-evidence.schema.json
+++ b/crates/tokmd/schemas/review-packet-evidence.schema.json
@@ -13,6 +13,10 @@
     "gates": {
       "type": "array",
       "items": { "$ref": "#/definitions/evidenceGate" }
+    },
+    "proof": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/proofEvidence" }
     }
   },
   "definitions": {
@@ -56,6 +60,66 @@
             { "type": "integer", "minimum": 0 },
             { "type": "null" }
           ]
+        }
+      }
+    },
+    "proofEvidence": {
+      "type": "object",
+      "required": [
+        "kind",
+        "source",
+        "source_schema",
+        "profile",
+        "scope",
+        "command",
+        "required",
+        "advisory",
+        "execution_status",
+        "availability",
+        "commit_match",
+        "refs"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "proof_run_summary",
+            "proof_run_observation",
+            "proof_executor_observation",
+            "coverage_receipt"
+          ]
+        },
+        "source": { "type": "string", "minLength": 1 },
+        "source_schema": { "type": "string", "minLength": 1 },
+        "profile": {
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "scope": {
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "command": {
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "required": { "type": "boolean" },
+        "advisory": { "type": "boolean" },
+        "execution_status": {
+          "type": "string",
+          "enum": [
+            "planned",
+            "executed_passed",
+            "executed_failed",
+            "not_executed",
+            "dry_run"
+          ]
+        },
+        "availability": { "$ref": "#/definitions/availability" },
+        "commit_match": {
+          "type": "string",
+          "enum": ["exact", "partial", "stale", "unknown"]
+        },
+        "refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
         }
       }
     },

--- a/crates/tokmd/src/commands/cockpit.rs
+++ b/crates/tokmd/src/commands/cockpit.rs
@@ -38,7 +38,7 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
         let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
         let repo_root = tokmd_git::repo_root(&cwd)
             .ok_or_else(|| anyhow::anyhow!("not inside a git repository"))?;
-        validate_proof_evidence_inputs(&args)?;
+        let proof_evidence_inputs = load_proof_evidence_inputs(&args)?;
 
         let range_mode = match args.diff_range {
             cli::DiffRangeMode::TwoDot => tokmd_git::GitRangeMode::TwoDot,
@@ -102,7 +102,11 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
             tokmd_cockpit::render::write_artifacts(artifacts_dir, &receipt)?;
         }
         if let Some(review_packet_dir) = &args.review_packet_dir {
-            tokmd_cockpit::render::write_review_packet(review_packet_dir, &receipt)?;
+            tokmd_cockpit::render::write_review_packet_with_proof_evidence(
+                review_packet_dir,
+                &receipt,
+                &proof_evidence_inputs,
+            )?;
         }
 
         if let Some(output_path) = &args.output {
@@ -119,7 +123,9 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
 }
 
 #[cfg(feature = "git")]
-fn validate_proof_evidence_inputs(args: &cli::CockpitArgs) -> Result<()> {
+fn load_proof_evidence_inputs(
+    args: &cli::CockpitArgs,
+) -> Result<Vec<tokmd_cockpit::ProofEvidenceInput>> {
     let inputs = [
         (
             "--proof-run-summary",
@@ -143,29 +149,31 @@ fn validate_proof_evidence_inputs(args: &cli::CockpitArgs) -> Result<()> {
         ),
     ];
 
+    let mut loaded = Vec::new();
     for (flag, path, expected_kind) in inputs {
         if let Some(path) = path {
-            validate_proof_evidence_input(flag, path, expected_kind)?;
+            loaded.push(load_proof_evidence_input(flag, path, expected_kind)?);
         }
     }
 
-    Ok(())
+    Ok(loaded)
 }
 
 #[cfg(feature = "git")]
-fn validate_proof_evidence_input(
+fn load_proof_evidence_input(
     flag: &str,
     path: &Path,
     expected_kind: tokmd_cockpit::ProofEvidenceKind,
-) -> Result<()> {
+) -> Result<tokmd_cockpit::ProofEvidenceInput> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {flag} proof evidence at {}", path.display()))?;
-    let actual_kind = tokmd_cockpit::proof_evidence_kind(&raw).with_context(|| {
+    let input = tokmd_cockpit::parse_proof_evidence_input(&raw, path).with_context(|| {
         format!(
             "failed to parse {flag} proof evidence at {}",
             path.display()
         )
     })?;
+    let actual_kind = input.kind();
 
     if actual_kind != expected_kind {
         bail!(
@@ -176,7 +184,7 @@ fn validate_proof_evidence_input(
         );
     }
 
-    Ok(())
+    Ok(input)
 }
 
 #[cfg(test)]

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -178,6 +178,81 @@ fn test_cockpit_accepts_valid_proof_observation_input_without_receipt_change() {
 }
 
 #[test]
+fn test_cockpit_review_packet_includes_imported_proof_evidence() {
+    let Some(dir) = basic_cockpit_repo() else {
+        return;
+    };
+    let proof_json =
+        PROOF_RUN_OBSERVATION_JSON.replace("\"head\": \"abc123\"", "\"head\": \"HEAD\"");
+    std::fs::write(dir.path().join("proof-run-observation.json"), proof_json).unwrap();
+    let baseline_packet_dir = dir.path().join(".tokmd").join("review-baseline");
+    let packet_dir = dir.path().join(".tokmd").join("review");
+
+    let mut baseline_cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    baseline_cmd
+        .current_dir(dir.path())
+        .arg("cockpit")
+        .arg("--base")
+        .arg("main")
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--review-packet-dir")
+        .arg(&baseline_packet_dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .arg("cockpit")
+        .arg("--base")
+        .arg("main")
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--proof-observation")
+        .arg("proof-run-observation.json")
+        .arg("--review-packet-dir")
+        .arg(&packet_dir)
+        .assert()
+        .success();
+
+    let evidence: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packet_dir.join("evidence.json")).unwrap())
+            .expect("valid evidence JSON");
+    let baseline_evidence: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(baseline_packet_dir.join("evidence.json")).unwrap(),
+    )
+    .expect("valid baseline evidence JSON");
+    assert!(
+        baseline_evidence.get("proof").is_none(),
+        "proof evidence should stay absent when no proof artifacts are provided"
+    );
+    assert_validates_against_schema(
+        REVIEW_PACKET_EVIDENCE_SCHEMA_JSON,
+        &evidence,
+        "review packet evidence with proof",
+    );
+
+    let proof = evidence["proof"].as_array().expect("proof evidence array");
+    assert_eq!(proof.len(), 1);
+    assert_eq!(proof[0]["kind"], "proof_run_observation");
+    assert_eq!(proof[0]["source"], "proof-run-observation.json");
+    assert_eq!(proof[0]["source_schema"], "tokmd.proof_run_observation.v1");
+    assert_eq!(proof[0]["profile"], "fast");
+    assert_eq!(proof[0]["scope"], "tokmd_cockpit");
+    assert_eq!(proof[0]["command"], "cargo test -p tokmd-cockpit");
+    assert_eq!(proof[0]["required"], true);
+    assert_eq!(proof[0]["advisory"], false);
+    assert_eq!(proof[0]["execution_status"], "executed_passed");
+    assert_eq!(proof[0]["availability"], "available");
+    assert_eq!(proof[0]["commit_match"], "exact");
+    assert_eq!(proof[0]["refs"][0], "proof-run-observation.json#/scopes/0");
+    assert_eq!(
+        evidence["overall_status"], baseline_evidence["overall_status"],
+        "imported proof evidence must not promote or change cockpit verdicts"
+    );
+}
+
+#[test]
 fn test_cockpit_rejects_unknown_proof_evidence_schema() {
     let Some(dir) = basic_cockpit_repo() else {
         return;

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -1,10 +1,9 @@
 # Cockpit Proof Evidence Import Contract
 
 Status: partially implemented. `tokmd cockpit` can validate explicitly supplied
-proof artifacts through validation-only flags, but it does not yet attach
-imported proof evidence to review packet outputs. This document defines the
-contract future implementation should follow when attaching proof-control-plane
-evidence to cockpit review packets.
+proof artifacts and attach normalized imported proof items to
+`evidence.json` when `--review-packet-dir` is used. Review-map/comment proof
+refs and packet-local proof artifact copying remain future work.
 
 ## Purpose
 
@@ -130,7 +129,7 @@ same evidence vocabulary used by the current review packet:
 
 The information should be visible in:
 
-- `evidence.json` gate entries;
+- `evidence.json` gate entries and imported proof entries;
 - `review-map.json` item evidence status and `proof_refs`;
 - `review-map.md` proof lines for review-first items;
 - `comment.md` compact evidence availability text.
@@ -177,8 +176,9 @@ evidence.
 - Add deserializable DTOs for accepted proof artifacts. (done)
 - Validate explicit proof artifact inputs without changing receipt output. (done)
 - Keep absent imports compatible with current cockpit behavior. (done)
-- Normalize required/advisory status before rendering.
-- Classify commit match as exact, partial, stale, or unknown.
+- Normalize required/advisory status before rendering. (done for `evidence.json`)
+- Classify commit match as exact, partial, stale, or unknown. (done for `evidence.json`)
+- Attach imported proof entries to `evidence.json`. (done)
 - Attach proof refs to review-map items without duplicating large artifacts.
 - Keep review packet schemas versioned if output shape changes.
 - Keep proof-control-plane promotion decisions outside cockpit.

--- a/docs/review-packet-evidence.schema.json
+++ b/docs/review-packet-evidence.schema.json
@@ -13,6 +13,10 @@
     "gates": {
       "type": "array",
       "items": { "$ref": "#/definitions/evidenceGate" }
+    },
+    "proof": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/proofEvidence" }
     }
   },
   "definitions": {
@@ -56,6 +60,66 @@
             { "type": "integer", "minimum": 0 },
             { "type": "null" }
           ]
+        }
+      }
+    },
+    "proofEvidence": {
+      "type": "object",
+      "required": [
+        "kind",
+        "source",
+        "source_schema",
+        "profile",
+        "scope",
+        "command",
+        "required",
+        "advisory",
+        "execution_status",
+        "availability",
+        "commit_match",
+        "refs"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "proof_run_summary",
+            "proof_run_observation",
+            "proof_executor_observation",
+            "coverage_receipt"
+          ]
+        },
+        "source": { "type": "string", "minLength": 1 },
+        "source_schema": { "type": "string", "minLength": 1 },
+        "profile": {
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "scope": {
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "command": {
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "required": { "type": "boolean" },
+        "advisory": { "type": "boolean" },
+        "execution_status": {
+          "type": "string",
+          "enum": [
+            "planned",
+            "executed_passed",
+            "executed_failed",
+            "not_executed",
+            "dry_run"
+          ]
+        },
+        "availability": { "$ref": "#/definitions/availability" },
+        "commit_match": {
+          "type": "string",
+          "enum": ["exact", "partial", "stale", "unknown"]
+        },
+        "refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
         }
       }
     },


### PR DESCRIPTION
## Summary
- attach explicitly supplied cockpit proof artifacts to review packet `evidence.json` as normalized proof records
- preserve current packet behavior when no proof artifacts are supplied and keep imported proof out of gate verdict counts
- update review packet evidence schemas and the proof evidence contract doc for the additive `proof` section

## Validation
- cargo test -p tokmd-cockpit scenario_write_review_packet --verbose
- cargo test -p tokmd --test cockpit_integration proof_evidence --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo xtask proof-policy --check
- cargo test -p tokmd --test schema_validation review_packet --verbose
- cargo xtask docs --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan

## Boundaries
- no review map/comment proof rendering yet
- no packet-local proof artifact copying yet
- no proof gate promotion or Codecov upload behavior changes