### PR TITLE
feat(cockpit): copy proof artifacts into review packets

### DIFF
--- a/crates/tokmd-cockpit/src/proof_evidence.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence.rs
@@ -10,7 +10,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokmd_types::cockpit::CommitMatch;
 
@@ -34,6 +34,15 @@ impl ProofEvidenceKind {
             Self::ProofRunObservation => "proof_run_observation",
             Self::ProofExecutorObservation => "proof_executor_observation",
             Self::CoverageReceipt => "coverage_receipt",
+        }
+    }
+
+    pub(crate) fn packet_file_name(self) -> &'static str {
+        match self {
+            Self::ProofRunSummary => "proof-run-summary.json",
+            Self::ProofRunObservation => "proof-run-observation.json",
+            Self::ProofExecutorObservation => "proof-executor-observation.json",
+            Self::CoverageReceipt => "coverage-receipt.json",
         }
     }
 }
@@ -448,7 +457,7 @@ pub fn parse_proof_evidence_json(raw: &str) -> Result<ProofEvidenceArtifact> {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofRunSummaryInput {
     pub schema: String,
     pub status: String,
@@ -467,7 +476,7 @@ pub struct ProofRunSummaryInput {
     pub unknown_files: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofRunExecutionGuardInput {
     pub required: bool,
     pub enabled: bool,
@@ -477,7 +486,7 @@ pub struct ProofRunExecutionGuardInput {
     pub reason: String,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofRunCountsInput {
     pub commands_total: usize,
     pub required_planned: usize,
@@ -487,7 +496,7 @@ pub struct ProofRunCountsInput {
     pub failed: usize,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofRunEntryInput {
     pub scope: String,
     pub kind: String,
@@ -499,7 +508,7 @@ pub struct ProofRunEntryInput {
     pub exit_code: Option<i32>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofRunObservationInput {
     pub schema: String,
     pub status: String,
@@ -518,14 +527,14 @@ pub struct ProofRunObservationInput {
     pub unknown_files: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofObservationGuardInput {
     pub enabled: bool,
     pub ci: bool,
     pub reason: String,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofRunObservationCountsInput {
     pub commands_total: usize,
     pub required_planned: usize,
@@ -535,7 +544,7 @@ pub struct ProofRunObservationCountsInput {
     pub failed: usize,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofObservationScopeInput {
     pub name: String,
     pub kind: String,
@@ -544,7 +553,7 @@ pub struct ProofObservationScopeInput {
     pub exit_code: Option<i64>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofExecutorObservationInput {
     pub schema: String,
     pub status: String,
@@ -565,7 +574,7 @@ pub struct ProofExecutorObservationInput {
     pub unknown_files: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofExecutorObservationCountsInput {
     pub selected: usize,
     pub executed: usize,
@@ -574,7 +583,7 @@ pub struct ProofExecutorObservationCountsInput {
     pub artifacts: usize,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProofExecutorObservationScopeInput {
     pub name: String,
     pub kind: String,
@@ -584,7 +593,7 @@ pub struct ProofExecutorObservationScopeInput {
     pub exit_code: Option<i64>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CoverageReceiptInput {
     pub schema: String,
     pub schema_version: u32,
@@ -599,7 +608,7 @@ pub struct CoverageReceiptInput {
     pub status: CoverageStatusInput,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CoverageGithubInput {
     pub run_id: Option<String>,
     pub run_attempt: Option<String>,
@@ -607,7 +616,7 @@ pub struct CoverageGithubInput {
     pub ref_name: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CoverageArtifactInput {
     pub path: String,
     pub kind: String,
@@ -615,7 +624,7 @@ pub struct CoverageArtifactInput {
     pub non_empty: bool,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CoverageStatusInput {
     pub ok: bool,
     #[serde(default)]

--- a/crates/tokmd-cockpit/src/render/manifest.rs
+++ b/crates/tokmd-cockpit/src/render/manifest.rs
@@ -13,9 +13,57 @@ pub(super) fn review_packet_manifest(
     review_map_json: &str,
     review_map_md: &str,
     comment_md: &str,
+    extra_artifacts: &[ReviewPacketArtifactContent<'_>],
 ) -> Value {
     let evidence_summary = review_packet_evidence_summary(receipt);
     let evidence_capabilities = review_packet_evidence_capabilities(receipt);
+    let mut artifacts = vec![
+        review_packet_artifact(
+            "cockpit",
+            "cockpit.json",
+            "tokmd.cockpit_receipt.v3",
+            "application/json",
+            cockpit_json,
+        ),
+        review_packet_artifact(
+            "evidence",
+            "evidence.json",
+            "tokmd.review_packet_evidence.v1",
+            "application/json",
+            evidence_json,
+        ),
+        review_packet_artifact(
+            "review-map",
+            "review-map.json",
+            "tokmd.review_map.v1",
+            "application/json",
+            review_map_json,
+        ),
+        review_packet_artifact(
+            "review-map-md",
+            "review-map.md",
+            "markdown",
+            "text/markdown",
+            review_map_md,
+        ),
+        review_packet_artifact(
+            "comment",
+            "comment.md",
+            "markdown",
+            "text/markdown",
+            comment_md,
+        ),
+    ];
+
+    artifacts.extend(extra_artifacts.iter().map(|artifact| {
+        review_packet_artifact(
+            artifact.id,
+            artifact.path,
+            artifact.schema,
+            artifact.media_type,
+            artifact.content,
+        )
+    }));
 
     json!({
         "schema": "tokmd.review_packet_manifest.v1",
@@ -37,44 +85,16 @@ pub(super) fn review_packet_manifest(
         "capabilities": {
             "evidence": evidence_capabilities,
         },
-        "artifacts": [
-            review_packet_artifact(
-                "cockpit",
-                "cockpit.json",
-                "tokmd.cockpit_receipt.v3",
-                "application/json",
-                cockpit_json,
-            ),
-            review_packet_artifact(
-                "evidence",
-                "evidence.json",
-                "tokmd.review_packet_evidence.v1",
-                "application/json",
-                evidence_json,
-            ),
-            review_packet_artifact(
-                "review-map",
-                "review-map.json",
-                "tokmd.review_map.v1",
-                "application/json",
-                review_map_json,
-            ),
-            review_packet_artifact(
-                "review-map-md",
-                "review-map.md",
-                "markdown",
-                "text/markdown",
-                review_map_md,
-            ),
-            review_packet_artifact(
-                "comment",
-                "comment.md",
-                "markdown",
-                "text/markdown",
-                comment_md,
-            ),
-        ],
+        "artifacts": artifacts,
     })
+}
+
+pub(super) struct ReviewPacketArtifactContent<'a> {
+    pub(super) id: &'a str,
+    pub(super) path: &'a str,
+    pub(super) schema: &'a str,
+    pub(super) media_type: &'a str,
+    pub(super) content: &'a str,
 }
 
 fn review_packet_artifact(

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -1,14 +1,16 @@
 //! Cockpit review packet rendering.
 
-use std::path::Path;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 
+use crate::proof_evidence::ProofEvidenceArtifact;
 use crate::{CockpitReceipt, ProofEvidenceInput};
 
 use super::comment::render_review_packet_comment_md;
 use super::evidence::review_packet_evidence;
-use super::manifest::review_packet_manifest;
+use super::manifest::{ReviewPacketArtifactContent, review_packet_manifest};
 use super::render_json;
 use super::review_map::{render_review_map_md, review_packet_review_map};
 
@@ -30,10 +32,15 @@ pub fn write_review_packet_with_proof_evidence(
     proof_evidence: &[ProofEvidenceInput],
 ) -> Result<()> {
     std::fs::create_dir_all(dir)?;
+    let proof_artifacts = packet_proof_artifacts(proof_evidence)?;
+    let packet_proof_inputs: Vec<_> = proof_artifacts
+        .iter()
+        .map(|artifact| artifact.input.clone())
+        .collect();
 
     let cockpit_json = render_json(receipt)?;
     let evidence_json =
-        serde_json::to_string_pretty(&review_packet_evidence(receipt, proof_evidence))?;
+        serde_json::to_string_pretty(&review_packet_evidence(receipt, &packet_proof_inputs))?;
     let review_map_json = serde_json::to_string_pretty(&review_packet_review_map(receipt))?;
     let review_map_md = render_review_map_md(receipt);
     let comment_md = render_review_packet_comment_md(receipt);
@@ -43,7 +50,23 @@ pub fn write_review_packet_with_proof_evidence(
     std::fs::write(dir.join("review-map.json"), &review_map_json)?;
     std::fs::write(dir.join("review-map.md"), &review_map_md)?;
     std::fs::write(dir.join("comment.md"), &comment_md)?;
+    if !proof_artifacts.is_empty() {
+        std::fs::create_dir_all(dir.join("proof"))?;
+        for artifact in &proof_artifacts {
+            std::fs::write(dir.join(&artifact.path), &artifact.content)?;
+        }
+    }
 
+    let extra_artifacts: Vec<_> = proof_artifacts
+        .iter()
+        .map(|artifact| ReviewPacketArtifactContent {
+            id: &artifact.id,
+            path: &artifact.path,
+            schema: &artifact.schema,
+            media_type: "application/json",
+            content: &artifact.content,
+        })
+        .collect();
     let manifest = review_packet_manifest(
         receipt,
         &cockpit_json,
@@ -51,6 +74,7 @@ pub fn write_review_packet_with_proof_evidence(
         &review_map_json,
         &review_map_md,
         &comment_md,
+        &extra_artifacts,
     );
     std::fs::write(
         dir.join("manifest.json"),
@@ -58,4 +82,62 @@ pub fn write_review_packet_with_proof_evidence(
     )?;
 
     Ok(())
+}
+
+struct PacketProofArtifact {
+    id: String,
+    path: String,
+    schema: String,
+    content: String,
+    input: ProofEvidenceInput,
+}
+
+fn packet_proof_artifacts(
+    proof_evidence: &[ProofEvidenceInput],
+) -> Result<Vec<PacketProofArtifact>> {
+    let mut seen_paths = BTreeSet::new();
+    let mut artifacts = Vec::new();
+
+    for input in proof_evidence {
+        let kind = input.kind();
+        let file_name = kind.packet_file_name();
+        let path = format!("proof/{file_name}");
+        if !seen_paths.insert(path.clone()) {
+            bail!("duplicate proof evidence artifact for packet path `{path}`");
+        }
+
+        artifacts.push(PacketProofArtifact {
+            id: proof_artifact_id(file_name),
+            path: path.clone(),
+            schema: input.artifact.schema().to_string(),
+            content: proof_artifact_json(input)?,
+            input: ProofEvidenceInput {
+                source_path: PathBuf::from(path),
+                artifact: input.artifact.clone(),
+            },
+        });
+    }
+
+    Ok(artifacts)
+}
+
+fn proof_artifact_id(file_name: &str) -> String {
+    file_name.trim_end_matches(".json").to_string()
+}
+
+fn proof_artifact_json(input: &ProofEvidenceInput) -> Result<String> {
+    match &input.artifact {
+        ProofEvidenceArtifact::ProofRunSummary(artifact) => {
+            Ok(serde_json::to_string_pretty(artifact)?)
+        }
+        ProofEvidenceArtifact::ProofRunObservation(artifact) => {
+            Ok(serde_json::to_string_pretty(artifact)?)
+        }
+        ProofEvidenceArtifact::ProofExecutorObservation(artifact) => {
+            Ok(serde_json::to_string_pretty(artifact)?)
+        }
+        ProofEvidenceArtifact::CoverageReceipt(artifact) => {
+            Ok(serde_json::to_string_pretty(artifact)?)
+        }
+    }
 }

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -971,7 +971,7 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
     let proof = evidence["proof"].as_array().expect("proof evidence array");
     assert_eq!(proof.len(), 1);
     assert_eq!(proof[0]["kind"], "proof_run_observation");
-    assert_eq!(proof[0]["source"], "proof-run-observation.json");
+    assert_eq!(proof[0]["source"], "proof/proof-run-observation.json");
     assert_eq!(proof[0]["source_schema"], "tokmd.proof_run_observation.v1");
     assert_eq!(proof[0]["profile"], "fast");
     assert_eq!(proof[0]["scope"], "tokmd_cockpit");
@@ -981,7 +981,16 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
     assert_eq!(proof[0]["execution_status"], "executed_passed");
     assert_eq!(proof[0]["availability"], "available");
     assert_eq!(proof[0]["commit_match"], "exact");
-    assert_eq!(proof[0]["refs"][0], "proof-run-observation.json#/scopes/0");
+    assert_eq!(
+        proof[0]["refs"][0],
+        "proof/proof-run-observation.json#/scopes/0"
+    );
+    assert!(
+        out.join("proof")
+            .join("proof-run-observation.json")
+            .exists(),
+        "imported proof artifact should be copied into the packet"
+    );
 
     let manifest: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(out.join("manifest.json")).unwrap()).unwrap();
@@ -992,6 +1001,18 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
     assert_eq!(
         manifest["verdict"]["evidence"]["details"], "evidence.json#/gates",
         "imported proof should not change gate verdict counts yet"
+    );
+    let artifacts = manifest["artifacts"]
+        .as_array()
+        .expect("manifest artifacts");
+    assert!(
+        artifacts.iter().any(|artifact| {
+            artifact["id"] == "proof-run-observation"
+                && artifact["path"] == "proof/proof-run-observation.json"
+                && artifact["schema"] == "tokmd.proof_run_observation.v1"
+                && artifact["media_type"] == "application/json"
+        }),
+        "manifest should list copied proof artifact"
     );
 }
 

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -235,7 +235,7 @@ fn test_cockpit_review_packet_includes_imported_proof_evidence() {
     let proof = evidence["proof"].as_array().expect("proof evidence array");
     assert_eq!(proof.len(), 1);
     assert_eq!(proof[0]["kind"], "proof_run_observation");
-    assert_eq!(proof[0]["source"], "proof-run-observation.json");
+    assert_eq!(proof[0]["source"], "proof/proof-run-observation.json");
     assert_eq!(proof[0]["source_schema"], "tokmd.proof_run_observation.v1");
     assert_eq!(proof[0]["profile"], "fast");
     assert_eq!(proof[0]["scope"], "tokmd_cockpit");
@@ -245,10 +245,41 @@ fn test_cockpit_review_packet_includes_imported_proof_evidence() {
     assert_eq!(proof[0]["execution_status"], "executed_passed");
     assert_eq!(proof[0]["availability"], "available");
     assert_eq!(proof[0]["commit_match"], "exact");
-    assert_eq!(proof[0]["refs"][0], "proof-run-observation.json#/scopes/0");
+    assert_eq!(
+        proof[0]["refs"][0],
+        "proof/proof-run-observation.json#/scopes/0"
+    );
     assert_eq!(
         evidence["overall_status"], baseline_evidence["overall_status"],
         "imported proof evidence must not promote or change cockpit verdicts"
+    );
+
+    let copied_proof_path = packet_dir.join("proof").join("proof-run-observation.json");
+    assert!(
+        copied_proof_path.exists(),
+        "proof artifact should be copied into the review packet"
+    );
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packet_dir.join("manifest.json")).unwrap())
+            .expect("valid manifest JSON");
+    assert_validates_against_schema(
+        REVIEW_PACKET_MANIFEST_SCHEMA_JSON,
+        &manifest,
+        "review packet manifest with proof",
+    );
+    let proof_artifact = manifest["artifacts"]
+        .as_array()
+        .expect("manifest artifacts")
+        .iter()
+        .find(|artifact| artifact["path"] == "proof/proof-run-observation.json")
+        .expect("proof artifact listed in manifest");
+    assert_eq!(proof_artifact["id"], "proof-run-observation");
+    assert_eq!(proof_artifact["schema"], "tokmd.proof_run_observation.v1");
+    let copied_bytes = std::fs::read(&copied_proof_path).unwrap();
+    assert_eq!(
+        proof_artifact["hash"]["hash"].as_str().expect("proof hash"),
+        blake3::hash(&copied_bytes).to_hex().as_str(),
+        "manifest hash should match copied proof artifact bytes"
     );
 }
 

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -1,9 +1,9 @@
 # Cockpit Proof Evidence Import Contract
 
 Status: partially implemented. `tokmd cockpit` can validate explicitly supplied
-proof artifacts and attach normalized imported proof items to
-`evidence.json` when `--review-packet-dir` is used. Review-map/comment proof
-refs and packet-local proof artifact copying remain future work.
+proof artifacts, copy them into the review packet under `proof/`, and attach
+normalized imported proof items to `evidence.json` when `--review-packet-dir`
+is used. Review-map/comment proof refs remain future work.
 
 ## Purpose
 
@@ -17,6 +17,7 @@ The intended flow is:
 proof-plan / proof-run / executor artifacts
   -> cockpit proof evidence import
   -> evidence.json
+  -> proof/*.json packet-local artifact copies
   -> review-map.json / review-map.md
   -> comment.md
 ```
@@ -55,7 +56,7 @@ model before rendering packet artifacts.
 
 Each imported evidence item should preserve:
 
-- source artifact path;
+- packet-local source artifact path;
 - source schema;
 - source run or workflow URL when available;
 - base ref or commit when available;
@@ -69,19 +70,32 @@ Each imported evidence item should preserve:
 - artifact references, such as LCOV paths;
 - generated timestamp when available.
 
-Packet renderers should refer back to source artifacts using stable refs rather
-than copying large proof payloads into every packet file.
+Packet renderers should refer back to packet-local source artifacts using
+stable refs rather than copying large proof payloads into every packet file.
 
 Example future reference shape:
 
 ```json
 {
   "proof_refs": [
-    "proof-run-observation.json#/entries/0",
-    "proof-executor-observation.json#/entries/3"
+    "proof/proof-run-observation.json#/entries/0",
+    "proof/proof-executor-observation.json#/entries/3"
   ]
 }
 ```
+
+When proof artifacts are supplied with `--review-packet-dir`, cockpit copies
+the validated JSON input into canonical packet-local names:
+
+| Kind | Packet path |
+| --- | --- |
+| proof run summary | `proof/proof-run-summary.json` |
+| proof run observation | `proof/proof-run-observation.json` |
+| proof executor observation | `proof/proof-executor-observation.json` |
+| coverage receipt | `proof/coverage-receipt.json` |
+
+These copied artifacts are listed in `manifest.json` with BLAKE3 hashes. The
+review packet verifier treats them like any other packet artifact.
 
 ## Commit Matching
 
@@ -153,7 +167,7 @@ Future import behavior should distinguish:
 - malformed artifact;
 - unknown schema;
 - stale commit;
-- artifact paths that are not relative or are outside the packet root;
+- manifest artifact paths that are not relative or are outside the packet root;
 - evidence artifact listed but missing on disk.
 
 Malformed or unsafe inputs should fail fast when the caller explicitly provided
@@ -179,6 +193,7 @@ evidence.
 - Normalize required/advisory status before rendering. (done for `evidence.json`)
 - Classify commit match as exact, partial, stale, or unknown. (done for `evidence.json`)
 - Attach imported proof entries to `evidence.json`. (done)
+- Copy supplied proof artifacts into packet-local `proof/*.json` files. (done)
 - Attach proof refs to review-map items without duplicating large artifacts.
 - Keep review packet schemas versioned if output shape changes.
 - Keep proof-control-plane promotion decisions outside cockpit.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -43,10 +43,19 @@ The review packet directory is:
   comment.md
   review-map.json
   review-map.md
+  proof/
+    proof-run-summary.json
+    proof-run-observation.json
+    proof-executor-observation.json
+    coverage-receipt.json
 ```
 
 `review-map.json` and `review-map.md` are derived from the existing cockpit
 `review_plan`. They do not add a new scoring model.
+
+The `proof/` directory is present only when explicit proof evidence artifacts
+are supplied. Missing optional proof artifacts are represented in evidence
+state instead of being silently assumed to have passed.
 
 ## Artifacts
 
@@ -58,6 +67,7 @@ The review packet directory is:
 | `comment.md` | PR-comment-ready summary. It stays concise and points readers to packet artifacts when hosted by CI. |
 | `review-map.json` | Machine-readable prioritized review plan with files, reasons, compact evidence status, evidence references, and reproduction commands derived from `cockpit.json#/review_plan`. |
 | `review-map.md` | Human-readable review plan for artifact browsing and local review, including what to review first and which evidence is present or missing. |
+| `proof/*.json` | Optional packet-local copies of explicitly imported proof artifacts, listed and hash-verified through `manifest.json`. |
 
 Formal JSON Schemas are published with the docs and embedded in the CLI test
 package:
@@ -91,10 +101,12 @@ Missing, stale, degraded, and unavailable evidence should be visible in
 `comment.md`, `evidence.json`, and `manifest.json` verdict metadata.
 
 Cockpit proof imports should follow
-[`cockpit-proof-evidence.md`](cockpit-proof-evidence.md). Current CLI support is
-validation-only for explicitly supplied proof artifacts; future packet imports
-must preserve required/advisory classification and commit freshness, and must
-not promote advisory proof into blocking evidence.
+[`cockpit-proof-evidence.md`](cockpit-proof-evidence.md). When proof artifacts
+are supplied with `--review-packet-dir`, cockpit validates them, copies them
+into canonical packet-local `proof/*.json` paths, and records normalized proof
+items in `evidence.json`. Packet imports preserve required/advisory
+classification and commit freshness, and must not promote advisory proof into
+blocking evidence.
 
 ## Manifest Requirements
 
@@ -113,7 +125,8 @@ not promote advisory proof into blocking evidence.
 
 Artifact paths in the manifest are relative to the packet directory. Hashes use
 the repo-standard BLAKE3 digest and are computed from the final bytes written
-to disk.
+to disk. Optional copied proof artifacts must also be listed in the manifest
+using packet-local relative paths such as `proof/proof-run-observation.json`.
 
 ## Review Map Requirements
 
@@ -195,5 +208,6 @@ that uses this packet.
 - `comment.md` remains concise enough for PR comments.
 - Existing `--format comment` and `--artifacts-dir` behavior remains compatible.
 - Action artifact upload works even when comments are disabled or unavailable.
-- Future proof evidence imports preserve required/advisory status and mark
-  stale or unknown-commit evidence explicitly.
+- Proof evidence imports preserve required/advisory status, mark stale or
+  unknown-commit evidence explicitly, and list packet-local proof artifact
+  copies in `manifest.json`.

--- a/xtask/src/tasks/review_packet_check.rs
+++ b/xtask/src/tasks/review_packet_check.rs
@@ -324,6 +324,36 @@ mod tests {
         assert!(msg.contains("must not be listed in manifest"), "{msg}");
     }
 
+    #[test]
+    fn nested_proof_artifact_is_hash_verified() {
+        let dir = tempdir().expect("tempdir");
+        write_valid_packet(dir.path());
+        fs::create_dir_all(dir.path().join("proof")).expect("create proof dir");
+        let proof_json = r#"{"schema":"tokmd.proof_run_observation.v1","entries":[]}"#;
+        fs::write(
+            dir.path().join("proof").join("proof-run-observation.json"),
+            proof_json,
+        )
+        .expect("write proof artifact");
+
+        let mut manifest = read_json(&dir.path().join("manifest.json"));
+        manifest["artifacts"]
+            .as_array_mut()
+            .expect("artifacts array")
+            .push(artifact(
+                "proof-run-observation",
+                "proof/proof-run-observation.json",
+                "tokmd.proof_run_observation.v1",
+                "application/json",
+                proof_json,
+            ));
+        write_json(&dir.path().join("manifest.json"), &manifest);
+
+        let report = validate_review_packet_dir(dir.path()).expect("valid packet should pass");
+
+        assert_eq!(report.artifact_count, 6);
+    }
+
     fn write_valid_packet(dir: &Path) {
         fs::create_dir_all(dir).expect("create packet dir");
 


### PR DESCRIPTION
## Summary

- copy explicitly imported cockpit proof evidence artifacts into packet-local `proof/*.json` files when `--review-packet-dir` is used
- point imported proof evidence `source`/`refs` at packet-local proof artifact paths and list those artifacts in `manifest.json` with BLAKE3 hashes
- teach `review-packet-check` tests to verify nested proof artifacts, and update the review packet/proof evidence docs

## Non-goals

- no review-map or comment proof rendering yet
- no proof gate promotion, Codecov upload change, or merge verdict behavior
- no default cockpit stdout or `--artifacts-dir` behavior change

## Validation

- `cargo test -p tokmd-cockpit scenario_write_review_packet --verbose`
- `cargo test -p tokmd-cockpit proof_evidence --verbose`
- `cargo test -p tokmd --test cockpit_integration proof_evidence --verbose`
- `cargo test -p xtask review_packet --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo test -p tokmd --test schema_validation review_packet --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`