### PR TITLE
feat(cockpit): link proof evidence from review map

### DIFF
--- a/crates/tokmd-cockpit/src/proof_evidence.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence.rs
@@ -163,6 +163,15 @@ impl ProofEvidenceArtifact {
             Self::CoverageReceipt(artifact) => Some(&artifact.sha),
         }
     }
+
+    pub(crate) fn changed_files(&self) -> &[String] {
+        match self {
+            Self::ProofRunSummary(artifact) => &artifact.changed_files,
+            Self::ProofRunObservation(artifact) => &artifact.changed_files,
+            Self::ProofExecutorObservation(artifact) => &artifact.changed_files,
+            Self::CoverageReceipt(_) => &[],
+        }
+    }
 }
 
 pub fn proof_evidence_kind(raw: &str) -> Result<ProofEvidenceKind> {

--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -1,7 +1,10 @@
 //! Review-map artifact rendering for cockpit review packets.
 
+use std::collections::BTreeSet;
+
 use serde_json::{Value, json};
 
+use crate::proof_evidence::{ProofEvidenceInput, normalize_proof_evidence};
 use crate::{CockpitReceipt, GateMeta, ReviewItem};
 
 use super::evidence::{
@@ -9,12 +12,17 @@ use super::evidence::{
     review_packet_evidence_gate_specs, review_packet_evidence_summary,
 };
 
-pub(super) fn review_packet_review_map(receipt: &CockpitReceipt) -> Value {
+pub(super) fn review_packet_review_map(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> Value {
+    let proof_refs = review_map_proof_refs(receipt, proof_inputs);
+    let evidence_refs = review_map_evidence_refs(!proof_refs.is_empty());
     let items: Vec<_> = receipt
         .review_plan
         .iter()
         .enumerate()
-        .map(|(idx, item)| review_map_item(idx, item, receipt))
+        .map(|(idx, item)| review_map_item(idx, item, receipt, &proof_refs))
         .collect();
 
     json!({
@@ -25,15 +33,21 @@ pub(super) fn review_packet_review_map(receipt: &CockpitReceipt) -> Value {
         "evidence": {
             "summary": review_packet_evidence_summary(receipt),
             "groups": review_packet_evidence_capabilities(receipt),
-            "refs": ["evidence.json#/gates"],
+            "refs": evidence_refs,
         },
         "item_count": items.len(),
         "items": items,
     })
 }
 
-fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> Value {
+fn review_map_item(
+    idx: usize,
+    item: &ReviewItem,
+    receipt: &CockpitReceipt,
+    proof_refs: &[ReviewMapProofRef],
+) -> Value {
     let evidence = review_map_item_evidence(item, receipt);
+    let proof_refs = review_map_item_proof_refs(item, proof_refs);
 
     json!({
         "rank": idx + 1,
@@ -47,6 +61,7 @@ fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> V
             format!("cockpit.json#/review_plan/{idx}"),
             "evidence.json#/gates",
         ],
+        "proof_refs": proof_refs,
         "evidence": {
             "status": evidence.status(),
             "present": evidence.present,
@@ -68,6 +83,74 @@ fn review_map_item(idx: usize, item: &ReviewItem, receipt: &CockpitReceipt) -> V
             ),
         ],
     })
+}
+
+struct ReviewMapProofRef {
+    changed_files: BTreeSet<String>,
+    refs: Vec<String>,
+}
+
+fn review_map_proof_refs(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> Vec<ReviewMapProofRef> {
+    let mut proof_refs = Vec::new();
+    let mut proof_index = 0;
+
+    for input in proof_inputs {
+        let changed_files = input
+            .artifact
+            .changed_files()
+            .iter()
+            .map(|path| normalize_path_for_match(path))
+            .collect::<BTreeSet<_>>();
+        let normalized = normalize_proof_evidence(
+            &input.artifact,
+            input.source_path.clone(),
+            Some(&receipt.base_ref),
+            Some(&receipt.head_ref),
+        );
+
+        for proof in normalized {
+            let mut refs = Vec::with_capacity(1 + proof.artifact_refs.len());
+            refs.push(format!("evidence.json#/proof/{proof_index}"));
+            refs.extend(proof.artifact_refs);
+            proof_refs.push(ReviewMapProofRef {
+                changed_files: changed_files.clone(),
+                refs,
+            });
+            proof_index += 1;
+        }
+    }
+
+    proof_refs
+}
+
+fn review_map_evidence_refs(has_proof: bool) -> Vec<&'static str> {
+    let mut refs = vec!["evidence.json#/gates"];
+    if has_proof {
+        refs.push("evidence.json#/proof");
+    }
+    refs
+}
+
+fn review_map_item_proof_refs(item: &ReviewItem, proof_refs: &[ReviewMapProofRef]) -> Vec<String> {
+    let item_path = normalize_path_for_match(&item.path);
+    let mut refs = BTreeSet::new();
+
+    for proof_ref in proof_refs {
+        if !proof_ref.changed_files.contains(&item_path) {
+            continue;
+        }
+
+        refs.extend(proof_ref.refs.iter().cloned());
+    }
+
+    refs.into_iter().collect()
+}
+
+fn normalize_path_for_match(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 #[derive(Default)]

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -41,7 +41,8 @@ pub fn write_review_packet_with_proof_evidence(
     let cockpit_json = render_json(receipt)?;
     let evidence_json =
         serde_json::to_string_pretty(&review_packet_evidence(receipt, &packet_proof_inputs))?;
-    let review_map_json = serde_json::to_string_pretty(&review_packet_review_map(receipt))?;
+    let review_map_json =
+        serde_json::to_string_pretty(&review_packet_review_map(receipt, &packet_proof_inputs))?;
     let review_map_md = render_review_map_md(receipt);
     let comment_md = render_review_packet_comment_md(receipt);
 

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -889,6 +889,13 @@ fn scenario_write_review_packet_creates_contract_files() {
         review_map["items"][0]["evidence"]["missing"][0],
         "diff_coverage"
     );
+    assert!(
+        review_map["items"][0]["proof_refs"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "review-map item proof refs should stay empty when no proof evidence is imported"
+    );
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("# Review Map"));
@@ -923,7 +930,23 @@ fn scenario_write_review_packet_creates_contract_files() {
 #[test]
 fn scenario_write_review_packet_includes_imported_proof_evidence() {
     let dir = tempfile::tempdir().unwrap();
-    let receipt = minimal_receipt();
+    let mut receipt = minimal_receipt();
+    receipt.review_plan = vec![
+        ReviewItem {
+            path: "crates/tokmd-cockpit/src/lib.rs".to_string(),
+            reason: "Cockpit proof-aware review packet changed".to_string(),
+            priority: 1,
+            complexity: Some(3),
+            lines_changed: Some(12),
+        },
+        ReviewItem {
+            path: "unrelated.rs".to_string(),
+            reason: "Unrelated changed file".to_string(),
+            priority: 3,
+            complexity: None,
+            lines_changed: Some(1),
+        },
+    ];
     let out = dir.path().join("review");
     let proof = tokmd_cockpit::parse_proof_evidence_input(
         r#"{
@@ -1013,6 +1036,33 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
                 && artifact["media_type"] == "application/json"
         }),
         "manifest should list copied proof artifact"
+    );
+
+    let review_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
+            .unwrap();
+    let items = review_map["items"].as_array().expect("review-map items");
+    assert_eq!(items.len(), 2);
+    assert!(
+        review_map["evidence"]["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference == "evidence.json#/proof"),
+        "packet-level review-map evidence refs should link to imported proof evidence"
+    );
+    assert_eq!(items[0]["path"], "crates/tokmd-cockpit/src/lib.rs");
+    assert_eq!(
+        items[0]["proof_refs"][0], "evidence.json#/proof/0",
+        "matching review item should link to normalized proof evidence"
+    );
+    assert_eq!(
+        items[0]["proof_refs"][1], "proof/proof-run-observation.json#/scopes/0",
+        "matching review item should link to packet-local source proof artifact"
+    );
+    assert!(
+        items[1]["proof_refs"].as_array().unwrap().is_empty(),
+        "unrelated review item must not inherit proof refs"
     );
 }
 

--- a/crates/tokmd/schemas/review-map.schema.json
+++ b/crates/tokmd/schemas/review-map.schema.json
@@ -155,6 +155,10 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "proof_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
         "evidence": { "$ref": "#/definitions/reviewMapItemEvidence" },
         "reproduce": {
           "type": "array",

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -182,8 +182,12 @@ fn test_cockpit_review_packet_includes_imported_proof_evidence() {
     let Some(dir) = basic_cockpit_repo() else {
         return;
     };
-    let proof_json =
-        PROOF_RUN_OBSERVATION_JSON.replace("\"head\": \"abc123\"", "\"head\": \"HEAD\"");
+    let proof_json = PROOF_RUN_OBSERVATION_JSON
+        .replace("\"head\": \"abc123\"", "\"head\": \"HEAD\"")
+        .replace(
+            "\"changed_files\": [\"crates/tokmd-cockpit/src/lib.rs\"]",
+            "\"changed_files\": [\"new.rs\"]",
+        );
     std::fs::write(dir.path().join("proof-run-observation.json"), proof_json).unwrap();
     let baseline_packet_dir = dir.path().join(".tokmd").join("review-baseline");
     let packet_dir = dir.path().join(".tokmd").join("review");
@@ -280,6 +284,42 @@ fn test_cockpit_review_packet_includes_imported_proof_evidence() {
         proof_artifact["hash"]["hash"].as_str().expect("proof hash"),
         blake3::hash(&copied_bytes).to_hex().as_str(),
         "manifest hash should match copied proof artifact bytes"
+    );
+
+    let review_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packet_dir.join("review-map.json")).unwrap())
+            .expect("valid review map JSON");
+    assert_validates_against_schema(
+        REVIEW_MAP_SCHEMA_JSON,
+        &review_map,
+        "review map with proof refs",
+    );
+    assert!(
+        review_map["evidence"]["refs"]
+            .as_array()
+            .expect("review-map evidence refs")
+            .iter()
+            .any(|reference| reference == "evidence.json#/proof"),
+        "review map should expose packet-level proof evidence refs"
+    );
+    let item = review_map["items"]
+        .as_array()
+        .expect("review-map items")
+        .iter()
+        .find(|item| item["path"] == "new.rs")
+        .expect("new.rs review item");
+    let proof_refs = item["proof_refs"].as_array().expect("proof refs array");
+    assert!(
+        proof_refs
+            .iter()
+            .any(|reference| reference == "evidence.json#/proof/0"),
+        "review item should link to normalized proof evidence"
+    );
+    assert!(
+        proof_refs
+            .iter()
+            .any(|reference| reference == "proof/proof-run-observation.json#/scopes/0"),
+        "review item should link to packet-local proof artifact"
     );
 }
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -156,6 +156,11 @@ architecture-consolidation program.
 - The composite Action now prepares hosted review-packet comments in `tokmd-review-packet-comment.md` instead of mutating `.tokmd/review/comment.md`, preserving `manifest.json` hashes for packet-local artifacts while keeping hosted PR comments useful.
 - The composite Action self-test now runs `cargo xtask review-packet-check --dir .tokmd/review` after preparing the hosted comment copy, proving Action-hosted metadata does not drift packet-local manifest hashes.
 - Cockpit `review-map.json` and `review-map.md` now surface packet-level evidence counts and item-level evidence status, so maintainers can see what proof is present or missing while deciding what to review first.
+- Cockpit review packets now keep imported proof artifacts packet-local under
+  `.tokmd/review/proof/*.json`, list those artifacts in `manifest.json`, and
+  link direct changed-file matches from `review-map.json` items to
+  `evidence.json#/proof/*` plus the copied source proof artifact. Review-map
+  Markdown/comment proof summaries remain future work.
 - Architecture consolidation now has a current-state batch plan in
   `docs/architecture-consolidation-plan.md`, grounded in the live
   publish-surface verifier, large-file inventory, and `ci/proof.toml` scopes.

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -3,7 +3,8 @@
 Status: partially implemented. `tokmd cockpit` can validate explicitly supplied
 proof artifacts, copy them into the review packet under `proof/`, and attach
 normalized imported proof items to `evidence.json` when `--review-packet-dir`
-is used. Review-map/comment proof refs remain future work.
+is used. `review-map.json` can link matching review items to packet-local
+proof refs. Review-map Markdown and comment proof summaries remain future work.
 
 ## Purpose
 
@@ -194,6 +195,6 @@ evidence.
 - Classify commit match as exact, partial, stale, or unknown. (done for `evidence.json`)
 - Attach imported proof entries to `evidence.json`. (done)
 - Copy supplied proof artifacts into packet-local `proof/*.json` files. (done)
-- Attach proof refs to review-map items without duplicating large artifacts.
+- Attach proof refs to review-map items without duplicating large artifacts. (done for `review-map.json` direct changed-file matches)
 - Keep review packet schemas versioned if output shape changes.
 - Keep proof-control-plane promotion decisions outside cockpit.

--- a/docs/review-map.schema.json
+++ b/docs/review-map.schema.json
@@ -155,6 +155,10 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "proof_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
         "evidence": { "$ref": "#/definitions/reviewMapItemEvidence" },
         "reproduce": {
           "type": "array",

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -65,7 +65,7 @@ state instead of being silently assumed to have passed.
 | `cockpit.json` | Full `CockpitReceipt` JSON. This is the same receipt produced by `tokmd cockpit --format json`. |
 | `evidence.json` | Evidence availability and gate status. It distinguishes passed evidence from missing, skipped, stale, degraded, or unavailable evidence. |
 | `comment.md` | PR-comment-ready summary. It stays concise and points readers to packet artifacts when hosted by CI. |
-| `review-map.json` | Machine-readable prioritized review plan with files, reasons, compact evidence status, evidence references, and reproduction commands derived from `cockpit.json#/review_plan`. |
+| `review-map.json` | Machine-readable prioritized review plan with files, reasons, compact evidence status, evidence references, item-level proof references where imported proof directly matches the item path, and reproduction commands derived from `cockpit.json#/review_plan`. |
 | `review-map.md` | Human-readable review plan for artifact browsing and local review, including what to review first and which evidence is present or missing. |
 | `proof/*.json` | Optional packet-local copies of explicitly imported proof artifacts, listed and hash-verified through `manifest.json`. |
 
@@ -141,11 +141,14 @@ using packet-local relative paths such as `proof/proof-run-observation.json`.
 The map may also include a packet-level evidence summary copied from the same
 availability buckets as `manifest.json`. Each item includes rank, path,
 priority, priority label, reason, optional complexity, optional lines changed,
-compact item-level evidence status, evidence references, and reproduction
-commands. `review-map.md` is a Markdown rendering of the same ordered items,
-including a "Review First" section, evidence present/missing lines where
-applicable, evidence references, and reproduction commands for artifact
-browsing and local review.
+compact item-level evidence status, evidence references, optional `proof_refs`,
+and reproduction commands. Proof refs are added only when imported proof
+evidence directly lists the item path as a changed file; scope-only or global
+proof stays packet-level until a policy-backed scope matcher exists.
+`review-map.md` is a Markdown rendering of the same ordered items, including a
+"Review First" section, evidence present/missing lines where applicable,
+evidence references, and reproduction commands for artifact browsing and local
+review.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

- add `proof_refs` to review-map JSON items when imported proof evidence directly lists the review item path in `changed_files`
- expose packet-level `evidence.json#/proof` refs from `review-map.json` when proof evidence is imported
- update review-map schemas and cockpit proof-evidence docs to keep Markdown/comment proof summaries explicitly future work

## Boundaries

- no review-map Markdown proof rendering
- no comment proof summary changes
- no proof gate promotion, Codecov upload change, or merge verdict behavior
- no broad proof scope matching; scope-only/global proof remains packet-level until policy-backed matching exists

## Validation

- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit scenario_write_review_packet --verbose`
- `cargo test -p tokmd --test cockpit_integration proof_evidence --verbose`
- `cargo test -p tokmd --test schema_validation review_packet --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`