### PR TITLE
feat(cockpit): render proof evidence in review map

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -4,8 +4,11 @@ use std::collections::BTreeSet;
 
 use serde_json::{Value, json};
 
-use crate::proof_evidence::{ProofEvidenceInput, normalize_proof_evidence};
-use crate::{CockpitReceipt, GateMeta, ReviewItem};
+use crate::proof_evidence::{
+    NormalizedProofEvidence, ProofEvidenceAvailability, ProofEvidenceInput, ProofExecutionStatus,
+    normalize_proof_evidence,
+};
+use crate::{CockpitReceipt, CommitMatch, GateMeta, ReviewItem};
 
 use super::evidence::{
     evidence_availability_optional, evidence_counts, review_packet_evidence_capabilities,
@@ -47,7 +50,7 @@ fn review_map_item(
     proof_refs: &[ReviewMapProofRef],
 ) -> Value {
     let evidence = review_map_item_evidence(item, receipt);
-    let proof_refs = review_map_item_proof_refs(item, proof_refs);
+    let proof = review_map_item_proof(item, proof_refs);
 
     json!({
         "rank": idx + 1,
@@ -61,7 +64,7 @@ fn review_map_item(
             format!("cockpit.json#/review_plan/{idx}"),
             "evidence.json#/gates",
         ],
-        "proof_refs": proof_refs,
+        "proof_refs": proof.refs,
         "evidence": {
             "status": evidence.status(),
             "present": evidence.present,
@@ -88,6 +91,7 @@ fn review_map_item(
 struct ReviewMapProofRef {
     changed_files: BTreeSet<String>,
     refs: Vec<String>,
+    line: String,
 }
 
 fn review_map_proof_refs(
@@ -114,10 +118,11 @@ fn review_map_proof_refs(
         for proof in normalized {
             let mut refs = Vec::with_capacity(1 + proof.artifact_refs.len());
             refs.push(format!("evidence.json#/proof/{proof_index}"));
-            refs.extend(proof.artifact_refs);
+            refs.extend(proof.artifact_refs.iter().cloned());
             proof_refs.push(ReviewMapProofRef {
                 changed_files: changed_files.clone(),
                 refs,
+                line: review_map_proof_line(&proof),
             });
             proof_index += 1;
         }
@@ -134,9 +139,19 @@ fn review_map_evidence_refs(has_proof: bool) -> Vec<&'static str> {
     refs
 }
 
-fn review_map_item_proof_refs(item: &ReviewItem, proof_refs: &[ReviewMapProofRef]) -> Vec<String> {
+struct ReviewMapItemProof {
+    lines: Vec<String>,
+    refs: Vec<String>,
+}
+
+fn review_map_item_proof(
+    item: &ReviewItem,
+    proof_refs: &[ReviewMapProofRef],
+) -> ReviewMapItemProof {
     let item_path = normalize_path_for_match(&item.path);
     let mut refs = BTreeSet::new();
+    let mut seen_lines = BTreeSet::new();
+    let mut lines = Vec::new();
 
     for proof_ref in proof_refs {
         if !proof_ref.changed_files.contains(&item_path) {
@@ -144,9 +159,76 @@ fn review_map_item_proof_refs(item: &ReviewItem, proof_refs: &[ReviewMapProofRef
         }
 
         refs.extend(proof_ref.refs.iter().cloned());
+        if seen_lines.insert(proof_ref.line.clone()) {
+            lines.push(proof_ref.line.clone());
+        }
     }
 
-    refs.into_iter().collect()
+    ReviewMapItemProof {
+        lines,
+        refs: refs.into_iter().collect(),
+    }
+}
+
+fn review_map_proof_line(proof: &NormalizedProofEvidence) -> String {
+    let class = if proof.required {
+        "Required"
+    } else {
+        "Advisory"
+    };
+    let scope = proof
+        .scope
+        .as_deref()
+        .unwrap_or_else(|| proof.kind.as_str());
+    let mut line = format!(
+        "{}: {} {} ({}, freshness: {})",
+        class,
+        scope,
+        execution_status_label(proof.execution_status),
+        availability_label(proof.availability),
+        commit_match_label(proof.commit_match),
+    );
+
+    if let Some(command) = proof
+        .command
+        .as_deref()
+        .filter(|command| !command.is_empty())
+    {
+        line.push_str(" - ");
+        line.push_str(command);
+    }
+
+    line
+}
+
+fn execution_status_label(status: ProofExecutionStatus) -> &'static str {
+    match status {
+        ProofExecutionStatus::Planned => "planned",
+        ProofExecutionStatus::ExecutedPassed => "passed",
+        ProofExecutionStatus::ExecutedFailed => "failed",
+        ProofExecutionStatus::NotExecuted => "not run",
+        ProofExecutionStatus::DryRun => "dry run",
+    }
+}
+
+fn availability_label(availability: ProofEvidenceAvailability) -> &'static str {
+    match availability {
+        ProofEvidenceAvailability::Available => "available",
+        ProofEvidenceAvailability::Missing => "missing",
+        ProofEvidenceAvailability::Skipped => "skipped",
+        ProofEvidenceAvailability::Stale => "stale",
+        ProofEvidenceAvailability::Degraded => "degraded",
+        ProofEvidenceAvailability::Unavailable => "unavailable",
+    }
+}
+
+fn commit_match_label(commit_match: CommitMatch) -> &'static str {
+    match commit_match {
+        CommitMatch::Exact => "exact",
+        CommitMatch::Partial => "partial",
+        CommitMatch::Stale => "stale",
+        CommitMatch::Unknown => "unknown",
+    }
 }
 
 fn normalize_path_for_match(path: &str) -> String {
@@ -222,10 +304,14 @@ fn review_priority_label(priority: u32) -> &'static str {
     }
 }
 
-pub(super) fn render_review_map_md(receipt: &CockpitReceipt) -> String {
+pub(super) fn render_review_map_md(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> String {
     use std::fmt::Write;
 
     let mut s = String::new();
+    let proof_refs = review_map_proof_refs(receipt, proof_inputs);
     let _ = writeln!(s, "# Review Map");
     let _ = writeln!(s);
     let _ = writeln!(s, "Base: `{}`", receipt.base_ref);
@@ -255,6 +341,7 @@ pub(super) fn render_review_map_md(receipt: &CockpitReceipt) -> String {
 
     for (idx, item) in receipt.review_plan.iter().enumerate() {
         let evidence = review_map_item_evidence(item, receipt);
+        let proof = review_map_item_proof(item, &proof_refs);
         let _ = writeln!(
             s,
             "{}. `{}`
@@ -280,6 +367,7 @@ pub(super) fn render_review_map_md(receipt: &CockpitReceipt) -> String {
         write_evidence_list(&mut s, "Evidence stale", &evidence.stale);
         write_evidence_list(&mut s, "Evidence skipped", &evidence.skipped);
         write_evidence_list(&mut s, "Evidence unavailable", &evidence.unavailable);
+        write_proof_block(&mut s, &proof);
         let _ = writeln!(s, "   Evidence references:");
         let _ = writeln!(s, "   - cockpit.json#/review_plan/{idx}");
         let _ = writeln!(s, "   - evidence.json#/gates");
@@ -308,4 +396,21 @@ fn write_evidence_list(s: &mut String, label: &str, gates: &[&str]) {
     }
 
     let _ = writeln!(s, "   {label}: {}", gates.join(", "));
+}
+
+fn write_proof_block(s: &mut String, proof: &ReviewMapItemProof) {
+    use std::fmt::Write;
+
+    if proof.lines.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(s, "   Proof:");
+    for line in &proof.lines {
+        let _ = writeln!(s, "   - {line}");
+    }
+    let _ = writeln!(s, "   Proof references:");
+    for reference in &proof.refs {
+        let _ = writeln!(s, "   - {reference}");
+    }
 }

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -43,7 +43,7 @@ pub fn write_review_packet_with_proof_evidence(
         serde_json::to_string_pretty(&review_packet_evidence(receipt, &packet_proof_inputs))?;
     let review_map_json =
         serde_json::to_string_pretty(&review_packet_review_map(receipt, &packet_proof_inputs))?;
-    let review_map_md = render_review_map_md(receipt);
+    let review_map_md = render_review_map_md(receipt, &packet_proof_inputs);
     let comment_md = render_review_packet_comment_md(receipt);
 
     std::fs::write(dir.join("cockpit.json"), &cockpit_json)?;

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1064,6 +1064,19 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
         items[1]["proof_refs"].as_array().unwrap().is_empty(),
         "unrelated review item must not inherit proof refs"
     );
+
+    let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    assert_eq!(
+        review_map_md.matches("   Proof:").count(),
+        1,
+        "only the matching review item should render imported proof evidence"
+    );
+    assert!(review_map_md.contains(
+        "Required: tokmd_cockpit passed (available, freshness: exact) - cargo test -p tokmd-cockpit"
+    ));
+    assert!(review_map_md.contains("   Proof references:"));
+    assert!(review_map_md.contains("evidence.json#/proof/0"));
+    assert!(review_map_md.contains("proof/proof-run-observation.json#/scopes/0"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -321,6 +321,14 @@ fn test_cockpit_review_packet_includes_imported_proof_evidence() {
             .any(|reference| reference == "proof/proof-run-observation.json#/scopes/0"),
         "review item should link to packet-local proof artifact"
     );
+
+    let review_map_md = std::fs::read_to_string(packet_dir.join("review-map.md")).unwrap();
+    assert!(review_map_md.contains(
+        "Required: tokmd_cockpit passed (available, freshness: exact) - cargo test -p tokmd-cockpit"
+    ));
+    assert!(review_map_md.contains("Proof references:"));
+    assert!(review_map_md.contains("evidence.json#/proof/0"));
+    assert!(review_map_md.contains("proof/proof-run-observation.json#/scopes/0"));
 }
 
 #[test]

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -160,7 +160,9 @@ architecture-consolidation program.
   `.tokmd/review/proof/*.json`, list those artifacts in `manifest.json`, and
   link direct changed-file matches from `review-map.json` items to
   `evidence.json#/proof/*` plus the copied source proof artifact. Review-map
-  Markdown/comment proof summaries remain future work.
+  Markdown now renders direct changed-file proof matches with required/advisory,
+  execution, availability, freshness, command, and proof-reference lines.
+  Comment proof summaries remain future work.
 - Architecture consolidation now has a current-state batch plan in
   `docs/architecture-consolidation-plan.md`, grounded in the live
   publish-surface verifier, large-file inventory, and `ci/proof.toml` scopes.

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -4,7 +4,8 @@ Status: partially implemented. `tokmd cockpit` can validate explicitly supplied
 proof artifacts, copy them into the review packet under `proof/`, and attach
 normalized imported proof items to `evidence.json` when `--review-packet-dir`
 is used. `review-map.json` can link matching review items to packet-local
-proof refs. Review-map Markdown and comment proof summaries remain future work.
+proof refs, and `review-map.md` renders matching item-level proof lines.
+Comment proof summaries remain future work.
 
 ## Purpose
 
@@ -146,7 +147,7 @@ The information should be visible in:
 
 - `evidence.json` gate entries and imported proof entries;
 - `review-map.json` item evidence status and `proof_refs`;
-- `review-map.md` proof lines for review-first items;
+- `review-map.md` item proof lines for review-first direct changed-file matches;
 - `comment.md` compact evidence availability text.
 
 Review map output should answer a reviewer-facing question:
@@ -196,5 +197,6 @@ evidence.
 - Attach imported proof entries to `evidence.json`. (done)
 - Copy supplied proof artifacts into packet-local `proof/*.json` files. (done)
 - Attach proof refs to review-map items without duplicating large artifacts. (done for `review-map.json` direct changed-file matches)
+- Render matching proof evidence in `review-map.md` without changing comment output. (done for direct changed-file matches)
 - Keep review packet schemas versioned if output shape changes.
 - Keep proof-control-plane promotion decisions outside cockpit.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -66,7 +66,7 @@ state instead of being silently assumed to have passed.
 | `evidence.json` | Evidence availability and gate status. It distinguishes passed evidence from missing, skipped, stale, degraded, or unavailable evidence. |
 | `comment.md` | PR-comment-ready summary. It stays concise and points readers to packet artifacts when hosted by CI. |
 | `review-map.json` | Machine-readable prioritized review plan with files, reasons, compact evidence status, evidence references, item-level proof references where imported proof directly matches the item path, and reproduction commands derived from `cockpit.json#/review_plan`. |
-| `review-map.md` | Human-readable review plan for artifact browsing and local review, including what to review first and which evidence is present or missing. |
+| `review-map.md` | Human-readable review plan for artifact browsing and local review, including what to review first, which evidence is present or missing, and matching proof evidence lines when imported proof directly names the item path. |
 | `proof/*.json` | Optional packet-local copies of explicitly imported proof artifacts, listed and hash-verified through `manifest.json`. |
 
 Formal JSON Schemas are published with the docs and embedded in the CLI test
@@ -147,8 +147,8 @@ evidence directly lists the item path as a changed file; scope-only or global
 proof stays packet-level until a policy-backed scope matcher exists.
 `review-map.md` is a Markdown rendering of the same ordered items, including a
 "Review First" section, evidence present/missing lines where applicable,
-evidence references, and reproduction commands for artifact browsing and local
-review.
+matching proof evidence, proof references, evidence references, and reproduction
+commands for artifact browsing and local review.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary
- render matching imported proof evidence in `review-map.md` for review items whose path is directly listed by a proof artifact
- show required/advisory class, execution result, availability, freshness, command, and packet-local proof references
- update cockpit proof-evidence/review-packet docs while leaving JSON schemas, comment output, Action behavior, proof gates, and Codecov behavior unchanged

## Validation
- `cargo test -p tokmd-cockpit scenario_write_review_packet --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`

## Boundaries
- No review-map JSON schema change
- No packet comment proof summary yet
- No proof gate promotion
- No default Codecov upload
- No merge verdict behavior