### PR TITLE
feat(cockpit): summarize proof evidence in packet comment

### DIFF
--- a/crates/tokmd-cockpit/src/render/comment.rs
+++ b/crates/tokmd-cockpit/src/render/comment.rs
@@ -1,6 +1,10 @@
 //! PR comment rendering for cockpit receipts and review packets.
 
-use crate::{CockpitReceipt, GateStatus, RiskLevel};
+use crate::proof_evidence::{
+    ProofEvidenceAvailability, ProofEvidenceInput, ProofExecutionStatus,
+    normalize_proof_evidence_inputs,
+};
+use crate::{CockpitReceipt, CommitMatch, GateStatus, RiskLevel};
 
 use super::evidence::evidence_counts;
 
@@ -156,14 +160,141 @@ pub fn render_comment_md(receipt: &CockpitReceipt) -> String {
     s
 }
 
-pub(super) fn render_review_packet_comment_md(receipt: &CockpitReceipt) -> String {
+pub(super) fn render_review_packet_comment_md(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> String {
     use std::fmt::Write;
 
     let mut s = render_comment_md(receipt);
+    write_proof_evidence_summary(&mut s, receipt, proof_inputs);
     let _ = writeln!(s, "**Review packet artifacts**:");
     let _ = writeln!(s, "- [Evidence gates](evidence.json)");
     let _ = writeln!(s, "- [Review map](review-map.md)");
     let _ = writeln!(s, "- [Full cockpit receipt](cockpit.json)");
     let _ = writeln!(s);
     s
+}
+
+#[derive(Default)]
+struct ProofCommentCounts {
+    total: usize,
+    required_passed: usize,
+    required_failed: usize,
+    required_missing: usize,
+    advisory_available: usize,
+    advisory_missing: usize,
+    exact: usize,
+    partial: usize,
+    stale: usize,
+    unknown: usize,
+    not_run: usize,
+    degraded: usize,
+    skipped: usize,
+    unavailable: usize,
+}
+
+fn write_proof_evidence_summary(
+    s: &mut String,
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) {
+    use std::fmt::Write;
+
+    let counts = proof_comment_counts(receipt, proof_inputs);
+    if counts.total == 0 {
+        return;
+    }
+
+    let _ = writeln!(s, "**Proof evidence**:");
+    let _ = writeln!(
+        s,
+        "- Required proof: {} passed, {} failed, {} missing",
+        counts.required_passed, counts.required_failed, counts.required_missing,
+    );
+    let _ = writeln!(
+        s,
+        "- Advisory proof: {} available, {} missing",
+        counts.advisory_available, counts.advisory_missing,
+    );
+    let _ = writeln!(
+        s,
+        "- Proof freshness: {} exact, {} partial, {} stale, {} unknown",
+        counts.exact, counts.partial, counts.stale, counts.unknown,
+    );
+    if counts.not_run > 0 {
+        let _ = writeln!(s, "- Not run: {}", counts.not_run);
+    }
+    if counts.degraded > 0 || counts.skipped > 0 || counts.unavailable > 0 {
+        let _ = writeln!(
+            s,
+            "- Other proof state: {} degraded, {} skipped, {} unavailable",
+            counts.degraded, counts.skipped, counts.unavailable,
+        );
+    }
+    let _ = writeln!(s);
+}
+
+fn proof_comment_counts(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> ProofCommentCounts {
+    let mut counts = ProofCommentCounts::default();
+
+    for item in normalize_proof_evidence_inputs(
+        proof_inputs,
+        Some(&receipt.base_ref),
+        Some(&receipt.head_ref),
+    ) {
+        counts.total += 1;
+
+        match item.commit_match {
+            CommitMatch::Exact => counts.exact += 1,
+            CommitMatch::Partial => counts.partial += 1,
+            CommitMatch::Stale => counts.stale += 1,
+            CommitMatch::Unknown => counts.unknown += 1,
+        }
+
+        match item.availability {
+            ProofEvidenceAvailability::Degraded => counts.degraded += 1,
+            ProofEvidenceAvailability::Skipped => counts.skipped += 1,
+            ProofEvidenceAvailability::Unavailable => counts.unavailable += 1,
+            _ => {}
+        }
+
+        if matches!(
+            item.execution_status,
+            ProofExecutionStatus::Planned | ProofExecutionStatus::NotExecuted
+        ) {
+            counts.not_run += 1;
+        }
+
+        if item.required {
+            if item.execution_status == ProofExecutionStatus::ExecutedPassed
+                && item.availability == ProofEvidenceAvailability::Available
+            {
+                counts.required_passed += 1;
+            } else if item.execution_status == ProofExecutionStatus::ExecutedFailed {
+                counts.required_failed += 1;
+            } else if matches!(
+                item.availability,
+                ProofEvidenceAvailability::Missing | ProofEvidenceAvailability::Unavailable
+            ) {
+                counts.required_missing += 1;
+            }
+        }
+
+        if item.advisory {
+            if item.availability == ProofEvidenceAvailability::Available {
+                counts.advisory_available += 1;
+            } else if matches!(
+                item.availability,
+                ProofEvidenceAvailability::Missing | ProofEvidenceAvailability::Unavailable
+            ) {
+                counts.advisory_missing += 1;
+            }
+        }
+    }
+
+    counts
 }

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -44,7 +44,7 @@ pub fn write_review_packet_with_proof_evidence(
     let review_map_json =
         serde_json::to_string_pretty(&review_packet_review_map(receipt, &packet_proof_inputs))?;
     let review_map_md = render_review_map_md(receipt, &packet_proof_inputs);
-    let comment_md = render_review_packet_comment_md(receipt);
+    let comment_md = render_review_packet_comment_md(receipt, &packet_proof_inputs);
 
     std::fs::write(dir.join("cockpit.json"), &cockpit_json)?;
     std::fs::write(dir.join("evidence.json"), &evidence_json)?;

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -921,6 +921,7 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert!(comment_md.contains("1 available"));
     assert!(comment_md.contains("4 unavailable"));
     assert!(comment_md.contains("1 missing"));
+    assert!(!comment_md.contains("Proof evidence"));
     assert!(comment_md.contains("Review packet artifacts"));
     assert!(comment_md.contains("[Evidence gates](evidence.json)"));
     assert!(comment_md.contains("[Review map](review-map.md)"));
@@ -1077,6 +1078,12 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
     assert!(review_map_md.contains("   Proof references:"));
     assert!(review_map_md.contains("evidence.json#/proof/0"));
     assert!(review_map_md.contains("proof/proof-run-observation.json#/scopes/0"));
+
+    let comment_md = std::fs::read_to_string(out.join("comment.md")).unwrap();
+    assert!(comment_md.contains("Proof evidence"));
+    assert!(comment_md.contains("Required proof: 1 passed, 0 failed, 0 missing"));
+    assert!(comment_md.contains("Advisory proof: 0 available, 0 missing"));
+    assert!(comment_md.contains("Proof freshness: 1 exact, 0 partial, 0 stale, 0 unknown"));
 }
 
 // ===========================================================================

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -329,6 +329,12 @@ fn test_cockpit_review_packet_includes_imported_proof_evidence() {
     assert!(review_map_md.contains("Proof references:"));
     assert!(review_map_md.contains("evidence.json#/proof/0"));
     assert!(review_map_md.contains("proof/proof-run-observation.json#/scopes/0"));
+
+    let comment_md = std::fs::read_to_string(packet_dir.join("comment.md")).unwrap();
+    assert!(comment_md.contains("Proof evidence"));
+    assert!(comment_md.contains("Required proof: 1 passed, 0 failed, 0 missing"));
+    assert!(comment_md.contains("Advisory proof: 0 available, 0 missing"));
+    assert!(comment_md.contains("Proof freshness: 1 exact, 0 partial, 0 stale, 0 unknown"));
 }
 
 #[test]

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -162,7 +162,8 @@ architecture-consolidation program.
   `evidence.json#/proof/*` plus the copied source proof artifact. Review-map
   Markdown now renders direct changed-file proof matches with required/advisory,
   execution, availability, freshness, command, and proof-reference lines.
-  Comment proof summaries remain future work.
+  Packet-local `comment.md` now includes compact proof evidence totals for
+  required/advisory proof and freshness without listing raw command output.
 - Architecture consolidation now has a current-state batch plan in
   `docs/architecture-consolidation-plan.md`, grounded in the live
   publish-surface verifier, large-file inventory, and `ci/proof.toml` scopes.

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -5,7 +5,8 @@ proof artifacts, copy them into the review packet under `proof/`, and attach
 normalized imported proof items to `evidence.json` when `--review-packet-dir`
 is used. `review-map.json` can link matching review items to packet-local
 proof refs, and `review-map.md` renders matching item-level proof lines.
-Comment proof summaries remain future work.
+`comment.md` includes compact proof evidence totals for required/advisory proof
+and freshness.
 
 ## Purpose
 
@@ -148,7 +149,7 @@ The information should be visible in:
 - `evidence.json` gate entries and imported proof entries;
 - `review-map.json` item evidence status and `proof_refs`;
 - `review-map.md` item proof lines for review-first direct changed-file matches;
-- `comment.md` compact evidence availability text.
+- `comment.md` compact evidence availability and proof evidence totals.
 
 Review map output should answer a reviewer-facing question:
 
@@ -197,6 +198,7 @@ evidence.
 - Attach imported proof entries to `evidence.json`. (done)
 - Copy supplied proof artifacts into packet-local `proof/*.json` files. (done)
 - Attach proof refs to review-map items without duplicating large artifacts. (done for `review-map.json` direct changed-file matches)
-- Render matching proof evidence in `review-map.md` without changing comment output. (done for direct changed-file matches)
+- Render matching proof evidence in `review-map.md` without changing JSON schemas. (done for direct changed-file matches)
+- Render compact proof evidence totals in `comment.md` without listing raw commands. (done)
 - Keep review packet schemas versioned if output shape changes.
 - Keep proof-control-plane promotion decisions outside cockpit.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -64,7 +64,7 @@ state instead of being silently assumed to have passed.
 | `manifest.json` | Packet index with schema name, generated-by metadata, base/head refs, artifact paths, hashes, and verdict metadata. |
 | `cockpit.json` | Full `CockpitReceipt` JSON. This is the same receipt produced by `tokmd cockpit --format json`. |
 | `evidence.json` | Evidence availability and gate status. It distinguishes passed evidence from missing, skipped, stale, degraded, or unavailable evidence. |
-| `comment.md` | PR-comment-ready summary. It stays concise and points readers to packet artifacts when hosted by CI. |
+| `comment.md` | PR-comment-ready summary. It stays concise, summarizes evidence/proof availability, and points readers to packet artifacts when hosted by CI. |
 | `review-map.json` | Machine-readable prioritized review plan with files, reasons, compact evidence status, evidence references, item-level proof references where imported proof directly matches the item path, and reproduction commands derived from `cockpit.json#/review_plan`. |
 | `review-map.md` | Human-readable review plan for artifact browsing and local review, including what to review first, which evidence is present or missing, and matching proof evidence lines when imported proof directly names the item path. |
 | `proof/*.json` | Optional packet-local copies of explicitly imported proof artifacts, listed and hash-verified through `manifest.json`. |
@@ -99,6 +99,9 @@ Recommended evidence availability values:
 
 Missing, stale, degraded, and unavailable evidence should be visible in
 `comment.md`, `evidence.json`, and `manifest.json` verdict metadata.
+When explicit proof artifacts are imported, `comment.md` also summarizes
+required proof, advisory proof, and freshness counts without listing raw
+commands.
 
 Cockpit proof imports should follow
 [`cockpit-proof-evidence.md`](cockpit-proof-evidence.md). When proof artifacts


### PR DESCRIPTION
## Summary
- add compact proof-evidence totals to packet-local `comment.md` when explicit proof artifacts are imported
- keep the public `tokmd cockpit --format comment` output and review packet JSON artifacts unchanged
- document that comment proof summaries report required/advisory/freshness counts without raw command spam

## Boundaries
- no review packet JSON or schema changes
- no Action behavior changes
- no proof gate promotion
- no default Codecov upload
- no merge verdict behavior

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit scenario_write_review_packet --verbose`
- `cargo test -p tokmd --test cockpit_integration proof_evidence --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`