### PR TITLE
feat(action): upload review packet verifier receipt

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-review-packet-comment.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
+        run: rm -rf tokmd-summary.md tokmd-review-packet-comment.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd target/tokmd/review-packet-check.json
 
       - name: Set up Rust for local review packet binary
         uses: dtolnay/rust-toolchain@stable
@@ -403,11 +403,19 @@ jobs:
           grep -q 'Workflow run:' tokmd-review-packet-comment.md
           grep -q 'Artifact: `tokmd-receipts`' tokmd-review-packet-comment.md
           grep -q 'Packet path: `.tokmd/review`' tokmd-review-packet-comment.md
+          if [ ! -f target/tokmd/review-packet-check.json ]; then
+            echo "::error::review packet verifier receipt not generated"
+            exit 1
+          fi
+          grep -q '"schema": "tokmd.review_packet_check.v1"' target/tokmd/review-packet-check.json
+          grep -q '"ok": true' target/tokmd/review-packet-check.json
+          grep -q '"hashes_verified": 5' target/tokmd/review-packet-check.json
+          grep -q '"path": "comment.md"' target/tokmd/review-packet-check.json
           cargo xtask review-packet-check --dir .tokmd/review
 
       - name: Clean generated files
         shell: bash
-        run: rm -rf tokmd-summary.md tokmd-review-packet-comment.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd
+        run: rm -rf tokmd-summary.md tokmd-review-packet-comment.md tokmd-receipt.* tokmd-gate-verdict.json tokmd-cockpit-report.json tokmd-sensor-report.json tokmd-baseline.json tokmd.toml comment.md extras .tokmd target/tokmd/review-packet-check.json
 
       - name: Run cockpit mode with inferred pull request base
         id: cockpit_inferred_base

--- a/action.yml
+++ b/action.yml
@@ -410,6 +410,34 @@ runs:
 
         echo "comment-file=$comment_file" >> "$GITHUB_OUTPUT"
 
+    - name: Verify Review Packet
+      id: review_packet_check
+      if: steps.generate.outputs['review-packet'] != ''
+      shell: bash
+      env:
+        REVIEW_PACKET_DIR: ${{ steps.generate.outputs['review-packet'] }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        case "$REVIEW_PACKET_DIR" in
+          /*) packet_dir="$REVIEW_PACKET_DIR" ;;
+          *) packet_dir="$GITHUB_WORKSPACE/$REVIEW_PACKET_DIR" ;;
+        esac
+
+        receipt_rel="target/tokmd/review-packet-check.json"
+        receipt_file="$GITHUB_WORKSPACE/$receipt_rel"
+        mkdir -p "$(dirname "$receipt_file")"
+
+        cargo run \
+          --manifest-path "$ACTION_PATH/Cargo.toml" \
+          -p xtask -- \
+          review-packet-check \
+          --dir "$packet_dir" \
+          --json "$receipt_file"
+
+        echo "receipt=$receipt_rel" >> "$GITHUB_OUTPUT"
+
     - name: Upload Artifact
       if: inputs.artifact == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -422,6 +450,7 @@ runs:
           ${{ steps.generate.outputs['cockpit-report'] }}
           ${{ steps.generate.outputs['review-packet'] }}
           ${{ steps.review_packet_comment.outputs['comment-file'] }}
+          ${{ steps.review_packet_check.outputs.receipt }}
           ${{ steps.generate.outputs['sensor-report'] }}
           ${{ steps.generate.outputs['baseline-report'] }}
           extras/

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -158,6 +158,9 @@ architecture-consolidation program.
 - `cargo xtask review-packet-check --dir <dir> --json <path>` now emits a
   `tokmd.review_packet_check.v1` verifier receipt with schema, artifact, hash,
   and packet-local path evidence for CI upload or downstream inspection.
+- The composite Action now writes `target/tokmd/review-packet-check.json` for
+  cockpit review packets after preparing the hosted comment copy and uploads it
+  with `tokmd-receipts` when artifact upload is enabled.
 - Cockpit `review-map.json` and `review-map.md` now surface packet-level evidence counts and item-level evidence status, so maintainers can see what proof is present or missing while deciding what to review first.
 - Cockpit review packets now keep imported proof artifacts packet-local under
   `.tokmd/review/proof/*.json`, list those artifacts in `manifest.json`, and

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -136,6 +136,11 @@ name, and the packet path. The packet's own `comment.md` remains unchanged so
 `manifest.json` hashes stay valid, while pull request comments still point to
 hosted artifacts.
 
+The Action verifies the packet after preparing the hosted comment copy and
+writes `target/tokmd/review-packet-check.json`. That verifier receipt records
+the checked schemas, packet-local artifact paths, and BLAKE3 hash verification
+counts, and is uploaded with `tokmd-receipts` when artifact upload is enabled.
+
 ### `sensor`
 
 Runs `tokmd sensor --format json` and writes:
@@ -163,6 +168,7 @@ Artifact candidates include:
 - `tokmd-gate-verdict.json`
 - `tokmd-cockpit-report.json`
 - `tokmd-review-packet-comment.md`
+- `target/tokmd/review-packet-check.json`
 - `.tokmd/review`
 - `tokmd-sensor-report.json`
 - `tokmd-baseline.json`

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -203,6 +203,13 @@ the `tokmd-receipts` artifact, and the packet path. With artifact upload
 disabled, it states that the packet was not uploaded. The packet-local
 `comment.md` is not mutated after `manifest.json` hashes are written.
 
+After preparing the hosted comment copy, the Action runs
+`cargo xtask review-packet-check --dir .tokmd/review --json
+target/tokmd/review-packet-check.json`. The verifier receipt is uploaded with
+`tokmd-receipts` when artifact upload is enabled. It is intentionally outside
+the packet manifest because it verifies the final packet instead of being part
+of the packet itself.
+
 Action inputs build on the cockpit surface first:
 
 ```yaml


### PR DESCRIPTION
## Summary
- verify cockpit review packets in the composite Action after preparing the hosted comment copy
- write `target/tokmd/review-packet-check.json` with `tokmd.review_packet_check.v1` verifier evidence
- upload the verifier receipt with `tokmd-receipts` and assert it in the Action self-test

## Boundaries
- no `tokmd cockpit` output changes
- no review packet JSON/schema changes
- no proof gate promotion
- no default Codecov upload
- no merge verdict behavior

## Validation
- Python YAML parse for `action.yml` and `.github/workflows/test-action.yml`
- `cargo xtask docs --check`
- `cargo test -p tokmd --test docs --verbose`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-policy --check`
- `cargo test -p tokmd-cockpit review_packet --verbose`