### PR TITLE
feat(action): show review packet verification status

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -395,6 +395,10 @@ jobs:
             echo "::error::review packet comment.md should remain manifest-hashed packet content"
             exit 1
           fi
+          if grep -q 'Review packet verification' .tokmd/review/comment.md; then
+            echo "::error::review packet comment.md should not include hosted verifier status"
+            exit 1
+          fi
           if [ ! -f tokmd-review-packet-comment.md ]; then
             echo "::error::hosted review packet comment copy not generated"
             exit 1
@@ -403,6 +407,10 @@ jobs:
           grep -q 'Workflow run:' tokmd-review-packet-comment.md
           grep -q 'Artifact: `tokmd-receipts`' tokmd-review-packet-comment.md
           grep -q 'Packet path: `.tokmd/review`' tokmd-review-packet-comment.md
+          grep -q 'Review packet verification' tokmd-review-packet-comment.md
+          grep -q 'Review packet: verified' tokmd-review-packet-comment.md
+          grep -q 'Manifest hashes: valid' tokmd-review-packet-comment.md
+          grep -q 'Proof evidence: 0 available, 0 missing, 0 stale' tokmd-review-packet-comment.md
           if [ ! -f target/tokmd/review-packet-check.json ]; then
             echo "::error::review packet verifier receipt not generated"
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -438,6 +438,59 @@ runs:
 
         echo "receipt=$receipt_rel" >> "$GITHUB_OUTPUT"
 
+    - name: Append Review Packet Verification Status
+      if: steps.review_packet_comment.outputs['comment-file'] != '' && steps.review_packet_check.outputs.receipt != ''
+      shell: bash
+      env:
+        COMMENT_FILE: ${{ steps.review_packet_comment.outputs['comment-file'] }}
+        REVIEW_PACKET_DIR: ${{ steps.generate.outputs['review-packet'] }}
+        REVIEW_PACKET_CHECK: ${{ steps.review_packet_check.outputs.receipt }}
+      run: |
+        set -euo pipefail
+
+        python - <<'PY'
+        import json
+        import os
+        from pathlib import Path
+
+        comment_path = Path(os.environ["COMMENT_FILE"])
+        review_packet_dir = Path(os.environ["REVIEW_PACKET_DIR"])
+        check_path = Path(os.environ["REVIEW_PACKET_CHECK"])
+
+        with check_path.open(encoding="utf-8") as f:
+            check = json.load(f)
+        with (review_packet_dir / "evidence.json").open(encoding="utf-8") as f:
+            evidence = json.load(f)
+
+        proof_items = evidence.get("proof") or []
+
+        def available(item):
+            return item.get("availability") == "available"
+
+        def missing(item):
+            return item.get("availability") in {"missing", "unavailable"}
+
+        available_count = sum(1 for item in proof_items if available(item))
+        missing_count = sum(1 for item in proof_items if missing(item))
+        stale_count = sum(
+            1
+            for item in proof_items
+            if item.get("availability") == "stale" or item.get("commit_match") == "stale"
+        )
+
+        status = "verified" if check.get("ok") is True else "failed"
+        hash_status = "valid" if check.get("hashes_verified") == check.get("artifact_count") else "incomplete"
+
+        with comment_path.open("a", encoding="utf-8") as f:
+            f.write("\n**Review packet verification**:\n")
+            f.write(f"- Review packet: {status}\n")
+            f.write(f"- Verified artifacts: {check.get('artifact_count', 0)}\n")
+            f.write(f"- Manifest hashes: {hash_status}\n")
+            f.write(
+                f"- Proof evidence: {available_count} available, {missing_count} missing, {stale_count} stale\n"
+            )
+        PY
+
     - name: Upload Artifact
       if: inputs.artifact == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -161,6 +161,9 @@ architecture-consolidation program.
 - The composite Action now writes `target/tokmd/review-packet-check.json` for
   cockpit review packets after preparing the hosted comment copy and uploads it
   with `tokmd-receipts` when artifact upload is enabled.
+- Hosted review-packet comments now show verifier status, manifest hash status,
+  and compact proof evidence counts while keeping packet-local `comment.md`
+  immutable after manifest hashing.
 - Cockpit `review-map.json` and `review-map.md` now surface packet-level evidence counts and item-level evidence status, so maintainers can see what proof is present or missing while deciding what to review first.
 - Cockpit review packets now keep imported proof artifacts packet-local under
   `.tokmd/review/proof/*.json`, list those artifacts in `manifest.json`, and

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -140,6 +140,9 @@ The Action verifies the packet after preparing the hosted comment copy and
 writes `target/tokmd/review-packet-check.json`. That verifier receipt records
 the checked schemas, packet-local artifact paths, and BLAKE3 hash verification
 counts, and is uploaded with `tokmd-receipts` when artifact upload is enabled.
+The hosted comment copy also includes a compact verifier status and proof
+evidence count summary. The packet-local `.tokmd/review/comment.md` is still
+not mutated.
 
 ### `sensor`
 
@@ -195,7 +198,9 @@ posting the pull request comment. With `artifact: 'true'`, the block points
 reviewers to the workflow run and `tokmd-receipts` artifact that contains the
 full `.tokmd/review/` directory. With artifact upload disabled, the comment
 states that the packet was generated locally in the workflow workspace but not
-uploaded. The packet-local `comment.md` is not mutated after generation.
+uploaded. After packet verification, the hosted copy also shows whether the
+packet was verified, whether manifest hashes were valid, and compact proof
+evidence counts. The packet-local `comment.md` is not mutated after generation.
 
 ## Checkout Guidance
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -208,7 +208,9 @@ After preparing the hosted comment copy, the Action runs
 target/tokmd/review-packet-check.json`. The verifier receipt is uploaded with
 `tokmd-receipts` when artifact upload is enabled. It is intentionally outside
 the packet manifest because it verifies the final packet instead of being part
-of the packet itself.
+of the packet itself. The hosted comment copy includes the verification status,
+manifest hash status, and compact proof evidence counts; packet-local
+`comment.md` remains unchanged.
 
 Action inputs build on the cockpit surface first:
 


### PR DESCRIPTION
## Summary
- append review packet verifier status to the hosted review-packet comment copy
- summarize manifest hash status and compact proof evidence counts without touching packet-local `.tokmd/review/comment.md`
- extend the Action self-test to prove verifier status appears only in the hosted comment copy

## Boundaries
- no `tokmd cockpit` output changes
- no review packet JSON/schema changes
- no proof gate promotion
- no default Codecov upload
- no merge verdict behavior

## Validation
- Python YAML parse for `action.yml` and `.github/workflows/test-action.yml`
- extracted Action run-script smoke for the verifier-status Python block
- `cargo xtask docs --check`
- `cargo test -p tokmd --test docs --verbose`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-policy --check`