### PR TITLE
docs(cockpit): document proof-aware review workflow

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -164,6 +164,9 @@ architecture-consolidation program.
 - Hosted review-packet comments now show verifier status, manifest hash status,
   and compact proof evidence counts while keeping packet-local `comment.md`
   immutable after manifest hashing.
+- `docs/cockpit-proof-evidence.md` now includes the maintainer-facing local
+  workflow for planning proof, optionally executing guarded required proof,
+  importing proof artifacts, and verifying the review packet.
 - Cockpit `review-map.json` and `review-map.md` now surface packet-level evidence counts and item-level evidence status, so maintainers can see what proof is present or missing while deciding what to review first.
 - Cockpit review packets now keep imported proof artifacts packet-local under
   `.tokmd/review/proof/*.json`, list those artifacts in `manifest.json`, and

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -52,6 +52,68 @@ missing, malformed, or does not match the flag's expected artifact family,
 cockpit fails before rendering. Passive discovery can later record degraded
 evidence state instead of failing.
 
+## Local Review Workflow
+
+Use this workflow when you want a proof-aware packet for a local branch or a
+pull request checkout. The first command shows what proof would run without
+executing anything:
+
+```bash
+cargo xtask proof \
+  --profile affected \
+  --base origin/main \
+  --head HEAD \
+  --plan
+```
+
+When you intentionally want to execute required proof locally, use the explicit
+guard and then derive the compact observation artifact:
+
+```bash
+cargo xtask proof \
+  --profile fast \
+  --base origin/main \
+  --head HEAD \
+  --run-required \
+  --allow-local-required-execution \
+  --proof-run-summary target/proof-run/proof-run-summary.json \
+  --summary-md target/proof-run/proof-run-summary.md
+
+cargo xtask proof-run-observation \
+  --proof-run-summary target/proof-run/proof-run-summary.json \
+  --output target/proof-run/proof-run-observation.json
+```
+
+Then import the proof artifacts while writing the review packet:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --proof-run-summary target/proof-run/proof-run-summary.json \
+  --proof-observation target/proof-run/proof-run-observation.json \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+When advisory executor or coverage receipts exist, pass them too:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --executor-observation target/proof/proof-executor-observation.json \
+  --coverage-receipt target/coverage/coverage-receipt.json \
+  --review-packet-dir .tokmd/review
+```
+
+The packet remains advisory by default. Imported proof changes evidence
+visibility; it does not promote coverage, mutation, Codecov, or fast proof into
+required gates.
+
 ## Normalized Evidence Model
 
 Cockpit should normalize imported proof artifacts into a small internal evidence

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -131,6 +131,10 @@ items in `evidence.json`. Packet imports preserve required/advisory
 classification and commit freshness, and must not promote advisory proof into
 blocking evidence.
 
+For a complete local workflow that plans proof, optionally executes guarded
+required proof, imports proof artifacts, and verifies the packet, see the
+[`cockpit-proof-evidence.md` local review workflow](cockpit-proof-evidence.md#local-review-workflow).
+
 ## Manifest Requirements
 
 `manifest.json` should use schema `tokmd.review_packet_manifest.v1` and include:
@@ -246,3 +250,4 @@ that uses this packet.
 - Proof evidence imports preserve required/advisory status, mark stale or
   unknown-commit evidence explicitly, and list packet-local proof artifact
   copies in `manifest.json`.
+- Local proof-aware review workflow is documented with packet verification.


### PR DESCRIPTION
## Summary
- document the local proof-aware cockpit review packet workflow
- show proof planning, guarded required proof execution, proof-run observation, proof import, and packet verification commands
- cross-link the workflow from the review packet contract and record the checkpoint in docs/NEXT.md

## Boundaries
- docs only
- no CLI behavior changes
- no review packet schema changes
- no proof gate promotion
- no default Codecov upload

## Validation
- `cargo xtask proof --help`
- `cargo xtask proof-run-observation --help`
- `cargo xtask proof-execution-observation --help`
- `cargo xtask coverage-receipt --help`
- `cargo run -p tokmd -- cockpit --help`
- `cargo xtask docs --check`
- `cargo test -p tokmd --test docs --verbose`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-policy --check`
- `cargo test -p tokmd-cockpit review_packet --verbose`