### PR TITLE
refactor(cockpit): extract section renderer

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -15,103 +15,16 @@ mod manifest;
 mod markdown;
 mod review_map;
 mod review_packet;
+mod sections;
 
 pub use comment::render_comment_md;
 pub use markdown::render_markdown;
 pub use review_packet::{write_review_packet, write_review_packet_with_proof_evidence};
+pub use sections::render_sections;
 
 /// Render receipt as JSON.
 pub fn render_json(receipt: &CockpitReceipt) -> Result<String> {
     serde_json::to_string_pretty(receipt).context("Failed to serialize receipt to JSON")
-}
-
-/// Render receipt as sectioned output.
-pub fn render_sections(receipt: &CockpitReceipt) -> String {
-    use std::fmt::Write;
-    let mut s = String::new();
-
-    let _ = writeln!(s, "<!-- SECTION:COCKPIT -->");
-    let _ = writeln!(s);
-    let _ = writeln!(s, "## Glass Cockpit");
-    let _ = writeln!(s);
-    let _ = writeln!(s, "**Base**: {}", receipt.base_ref);
-    let _ = writeln!(s, "**Head**: {}", receipt.head_ref);
-    let _ = writeln!(s);
-    let _ = writeln!(s, "**Change Surface**:");
-    let _ = writeln!(s, "- Files: {}", receipt.change_surface.files_changed);
-    let _ = writeln!(s, "- Insertions: {}", receipt.change_surface.insertions);
-    let _ = writeln!(s, "- Deletions: {}", receipt.change_surface.deletions);
-    let _ = writeln!(s);
-    let _ = writeln!(s, "**Composition**:");
-    let _ = writeln!(s, "- Code: {:.1}%", receipt.composition.code_pct * 100.0);
-    let _ = writeln!(s, "- Test: {:.1}%", receipt.composition.test_pct * 100.0);
-    let _ = writeln!(s, "- Docs: {:.1}%", receipt.composition.docs_pct * 100.0);
-    let _ = writeln!(
-        s,
-        "- Config: {:.1}%",
-        receipt.composition.config_pct * 100.0
-    );
-    let _ = writeln!(s);
-    let _ = writeln!(s, "**Contracts**:");
-    let _ = writeln!(
-        s,
-        "- API: {}",
-        if receipt.contracts.api_changed {
-            "Yes"
-        } else {
-            "No"
-        }
-    );
-    let _ = writeln!(
-        s,
-        "- CLI: {}",
-        if receipt.contracts.cli_changed {
-            "Yes"
-        } else {
-            "No"
-        }
-    );
-    let _ = writeln!(
-        s,
-        "- Schema: {}",
-        if receipt.contracts.schema_changed {
-            "Yes"
-        } else {
-            "No"
-        }
-    );
-    let _ = writeln!(s);
-    let _ = writeln!(
-        s,
-        "**Health**: {}/100 ({})",
-        receipt.code_health.score, receipt.code_health.grade
-    );
-    let _ = writeln!(
-        s,
-        "**Risk**: {} ({}/100)",
-        receipt.risk.level, receipt.risk.score
-    );
-    let _ = writeln!(s);
-    let _ = writeln!(s, "<!-- SECTION:REVIEW_PLAN -->");
-    let _ = writeln!(s);
-    let _ = writeln!(s, "## Review Plan");
-    let _ = writeln!(s);
-    if receipt.review_plan.is_empty() {
-        let _ = writeln!(s, "No review items.");
-    } else {
-        for item in &receipt.review_plan {
-            let _ = writeln!(s, "- {} (priority: {})", item.path, item.priority);
-        }
-    }
-    let _ = writeln!(s);
-    let _ = writeln!(s, "<!-- SECTION:RECEIPTS -->");
-    let _ = writeln!(s);
-    let _ = writeln!(s, "## Receipts");
-    let _ = writeln!(s);
-    let _ = writeln!(s, "Full receipt data available in JSON format.");
-    let _ = writeln!(s);
-
-    s
 }
 
 /// Write artifacts to directory.

--- a/crates/tokmd-cockpit/src/render/sections.rs
+++ b/crates/tokmd-cockpit/src/render/sections.rs
@@ -1,0 +1,93 @@
+//! Section-marker Markdown rendering for cockpit receipts.
+
+use std::fmt::Write;
+
+use crate::CockpitReceipt;
+
+/// Render receipt as sectioned output.
+pub fn render_sections(receipt: &CockpitReceipt) -> String {
+    let mut s = String::new();
+
+    let _ = writeln!(s, "<!-- SECTION:COCKPIT -->");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "## Glass Cockpit");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "**Base**: {}", receipt.base_ref);
+    let _ = writeln!(s, "**Head**: {}", receipt.head_ref);
+    let _ = writeln!(s);
+    let _ = writeln!(s, "**Change Surface**:");
+    let _ = writeln!(s, "- Files: {}", receipt.change_surface.files_changed);
+    let _ = writeln!(s, "- Insertions: {}", receipt.change_surface.insertions);
+    let _ = writeln!(s, "- Deletions: {}", receipt.change_surface.deletions);
+    let _ = writeln!(s);
+    let _ = writeln!(s, "**Composition**:");
+    let _ = writeln!(s, "- Code: {:.1}%", receipt.composition.code_pct * 100.0);
+    let _ = writeln!(s, "- Test: {:.1}%", receipt.composition.test_pct * 100.0);
+    let _ = writeln!(s, "- Docs: {:.1}%", receipt.composition.docs_pct * 100.0);
+    let _ = writeln!(
+        s,
+        "- Config: {:.1}%",
+        receipt.composition.config_pct * 100.0
+    );
+    let _ = writeln!(s);
+    let _ = writeln!(s, "**Contracts**:");
+    let _ = writeln!(
+        s,
+        "- API: {}",
+        if receipt.contracts.api_changed {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    let _ = writeln!(
+        s,
+        "- CLI: {}",
+        if receipt.contracts.cli_changed {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    let _ = writeln!(
+        s,
+        "- Schema: {}",
+        if receipt.contracts.schema_changed {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    let _ = writeln!(s);
+    let _ = writeln!(
+        s,
+        "**Health**: {}/100 ({})",
+        receipt.code_health.score, receipt.code_health.grade
+    );
+    let _ = writeln!(
+        s,
+        "**Risk**: {} ({}/100)",
+        receipt.risk.level, receipt.risk.score
+    );
+    let _ = writeln!(s);
+    let _ = writeln!(s, "<!-- SECTION:REVIEW_PLAN -->");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "## Review Plan");
+    let _ = writeln!(s);
+    if receipt.review_plan.is_empty() {
+        let _ = writeln!(s, "No review items.");
+    } else {
+        for item in &receipt.review_plan {
+            let _ = writeln!(s, "- {} (priority: {})", item.path, item.priority);
+        }
+    }
+    let _ = writeln!(s);
+    let _ = writeln!(s, "<!-- SECTION:RECEIPTS -->");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "## Receipts");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "Full receipt data available in JSON format.");
+    let _ = writeln!(s);
+
+    s
+}


### PR DESCRIPTION
## Summary
- move the section-marker cockpit renderer from `render.rs` into `render/sections.rs`
- keep `tokmd_cockpit::render::render_sections` re-exported from the same public module
- leave receipt schemas, review packet output, CLI behavior, proof policy, and gate behavior unchanged

## Verification
- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo run -p tokmd -- cockpit --base origin/main --head HEAD --review-packet-dir target/review-smoke-sections --format json`
- `cargo xtask review-packet-check --dir target/review-smoke-sections`
- `git diff --check`

## Notes
Behavior-preserving architecture consolidation only. No schema, Action, CLI, proof-gate, Codecov, AST, or review-command changes.