### PR TITLE
refactor(cockpit): extract artifact writers

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -2,13 +2,11 @@
 //!
 //! Provides JSON, Markdown, sections, comment, and review packet output formats.
 
-use std::path::Path;
-
 use anyhow::{Context, Result};
-use tokmd_envelope::{SensorReport, ToolMeta, Verdict};
 
-use crate::{CockpitReceipt, GateStatus, now_iso8601};
+use crate::CockpitReceipt;
 
+mod artifacts;
 mod comment;
 mod evidence;
 mod manifest;
@@ -17,6 +15,9 @@ mod review_map;
 mod review_packet;
 mod sections;
 
+pub use artifacts::write_artifacts;
+#[cfg(feature = "git")]
+pub use artifacts::write_sensor_artifacts;
 pub use comment::render_comment_md;
 pub use markdown::render_markdown;
 pub use review_packet::{write_review_packet, write_review_packet_with_proof_evidence};
@@ -25,79 +26,4 @@ pub use sections::render_sections;
 /// Render receipt as JSON.
 pub fn render_json(receipt: &CockpitReceipt) -> Result<String> {
     serde_json::to_string_pretty(receipt).context("Failed to serialize receipt to JSON")
-}
-
-/// Write artifacts to directory.
-pub fn write_artifacts(dir: &Path, receipt: &CockpitReceipt) -> Result<()> {
-    std::fs::create_dir_all(dir)?;
-
-    // Write cockpit.json (full receipt)
-    let json = render_json(receipt)?;
-    std::fs::write(dir.join("cockpit.json"), json)?;
-
-    // Write report.json (sensor report envelope)
-    let verdict = match receipt.evidence.overall_status {
-        GateStatus::Pass => Verdict::Pass,
-        GateStatus::Fail => Verdict::Fail,
-        GateStatus::Warn => Verdict::Warn,
-        GateStatus::Skipped => Verdict::Skip,
-        GateStatus::Pending => Verdict::Pending,
-    };
-
-    let report = SensorReport::new(
-        ToolMeta::tokmd(env!("CARGO_PKG_VERSION"), "cockpit"),
-        now_iso8601(),
-        verdict,
-        format!(
-            "{} files changed, +{}/-{}, health {}/100, risk {} in {}..{}",
-            receipt.change_surface.files_changed,
-            receipt.change_surface.insertions,
-            receipt.change_surface.deletions,
-            receipt.code_health.score,
-            receipt.risk.level,
-            receipt.base_ref,
-            receipt.head_ref
-        ),
-    );
-
-    let report_json = serde_json::to_string_pretty(&report)?;
-    std::fs::write(dir.join("report.json"), report_json)?;
-
-    // Write comment.md (markdown summary)
-    let comment_md = render_comment_md(receipt);
-    std::fs::write(dir.join("comment.md"), comment_md)?;
-
-    Ok(())
-}
-
-/// Write sensor artifacts.
-#[cfg(feature = "git")]
-pub fn write_sensor_artifacts(
-    dir: &Path,
-    receipt: &CockpitReceipt,
-    base: &str,
-    head: &str,
-) -> Result<()> {
-    std::fs::create_dir_all(dir)?;
-
-    // Build sensor report
-    let verdict = match receipt.evidence.overall_status {
-        GateStatus::Pass => Verdict::Pass,
-        GateStatus::Fail => Verdict::Fail,
-        GateStatus::Warn => Verdict::Warn,
-        GateStatus::Skipped => Verdict::Skip,
-        GateStatus::Pending => Verdict::Pending,
-    };
-
-    let report = SensorReport::new(
-        ToolMeta::tokmd(env!("CARGO_PKG_VERSION"), "cockpit"),
-        now_iso8601(),
-        verdict,
-        format!("Cockpit run for {}..{}", base, head),
-    );
-
-    let json = serde_json::to_string_pretty(&report)?;
-    std::fs::write(dir.join("report.json"), json)?;
-
-    Ok(())
 }

--- a/crates/tokmd-cockpit/src/render/artifacts.rs
+++ b/crates/tokmd-cockpit/src/render/artifacts.rs
@@ -1,0 +1,85 @@
+//! Artifact writers for cockpit receipt outputs.
+
+use std::path::Path;
+
+use anyhow::Result;
+use tokmd_envelope::{SensorReport, ToolMeta, Verdict};
+
+use crate::{CockpitReceipt, GateStatus, now_iso8601};
+
+use super::{render_comment_md, render_json};
+
+/// Write artifacts to directory.
+pub fn write_artifacts(dir: &Path, receipt: &CockpitReceipt) -> Result<()> {
+    std::fs::create_dir_all(dir)?;
+
+    // Write cockpit.json (full receipt)
+    let json = render_json(receipt)?;
+    std::fs::write(dir.join("cockpit.json"), json)?;
+
+    // Write report.json (sensor report envelope)
+    let verdict = match receipt.evidence.overall_status {
+        GateStatus::Pass => Verdict::Pass,
+        GateStatus::Fail => Verdict::Fail,
+        GateStatus::Warn => Verdict::Warn,
+        GateStatus::Skipped => Verdict::Skip,
+        GateStatus::Pending => Verdict::Pending,
+    };
+
+    let report = SensorReport::new(
+        ToolMeta::tokmd(env!("CARGO_PKG_VERSION"), "cockpit"),
+        now_iso8601(),
+        verdict,
+        format!(
+            "{} files changed, +{}/-{}, health {}/100, risk {} in {}..{}",
+            receipt.change_surface.files_changed,
+            receipt.change_surface.insertions,
+            receipt.change_surface.deletions,
+            receipt.code_health.score,
+            receipt.risk.level,
+            receipt.base_ref,
+            receipt.head_ref
+        ),
+    );
+
+    let report_json = serde_json::to_string_pretty(&report)?;
+    std::fs::write(dir.join("report.json"), report_json)?;
+
+    // Write comment.md (markdown summary)
+    let comment_md = render_comment_md(receipt);
+    std::fs::write(dir.join("comment.md"), comment_md)?;
+
+    Ok(())
+}
+
+/// Write sensor artifacts.
+#[cfg(feature = "git")]
+pub fn write_sensor_artifacts(
+    dir: &Path,
+    receipt: &CockpitReceipt,
+    base: &str,
+    head: &str,
+) -> Result<()> {
+    std::fs::create_dir_all(dir)?;
+
+    // Build sensor report
+    let verdict = match receipt.evidence.overall_status {
+        GateStatus::Pass => Verdict::Pass,
+        GateStatus::Fail => Verdict::Fail,
+        GateStatus::Warn => Verdict::Warn,
+        GateStatus::Skipped => Verdict::Skip,
+        GateStatus::Pending => Verdict::Pending,
+    };
+
+    let report = SensorReport::new(
+        ToolMeta::tokmd(env!("CARGO_PKG_VERSION"), "cockpit"),
+        now_iso8601(),
+        verdict,
+        format!("Cockpit run for {}..{}", base, head),
+    );
+
+    let json = serde_json::to_string_pretty(&report)?;
+    std::fs::write(dir.join("report.json"), json)?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- move cockpit artifact writers from `render.rs` into `render/artifacts.rs`
- keep `write_artifacts` and feature-gated `write_sensor_artifacts` re-exported from `tokmd_cockpit::render`
- leave artifact contents, receipt schemas, review packet output, CLI behavior, and proof policy unchanged

## Verification
- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo run -p tokmd -- cockpit --base origin/main --head HEAD --review-packet-dir target/review-smoke-artifacts --format json`
- `cargo xtask review-packet-check --dir target/review-smoke-artifacts`
- `git diff --check`

## Notes
Behavior-preserving architecture consolidation only. No schema, Action, CLI, proof-gate, Codecov, AST, or review-command changes.