### PR TITLE
refactor(format): extract analysis tree renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/mod.rs
+++ b/crates/tokmd-format/src/analysis/mod.rs
@@ -38,6 +38,7 @@ mod jsonld;
 mod markdown;
 mod mermaid;
 mod svg;
+mod tree;
 mod xml;
 
 pub enum RenderedOutput {
@@ -55,21 +56,13 @@ pub fn render(receipt: &AnalysisReceipt, format: AnalysisFormat) -> Result<Rende
         AnalysisFormat::Mermaid => Ok(RenderedOutput::Text(mermaid::render(receipt))),
         AnalysisFormat::Obj => Ok(RenderedOutput::Text(render_obj(receipt)?)),
         AnalysisFormat::Midi => Ok(RenderedOutput::Binary(render_midi(receipt)?)),
-        AnalysisFormat::Tree => Ok(RenderedOutput::Text(render_tree(receipt))),
+        AnalysisFormat::Tree => Ok(RenderedOutput::Text(tree::render(receipt))),
         AnalysisFormat::Html => Ok(RenderedOutput::Text(render_html(receipt))),
     }
 }
 
 fn render_md(receipt: &AnalysisReceipt) -> String {
     markdown::render_md(receipt)
-}
-
-fn render_tree(receipt: &AnalysisReceipt) -> String {
-    receipt
-        .derived
-        .as_ref()
-        .and_then(|d| d.tree.clone())
-        .unwrap_or_else(|| "(tree unavailable)".to_string())
 }
 
 // --- fun enabled impls ---
@@ -494,7 +487,7 @@ mod tests {
     fn test_render_tree() {
         let mut receipt = minimal_receipt();
         receipt.derived = Some(sample_derived());
-        let result = render_tree(&receipt);
+        let result = tree::render(&receipt);
         assert_eq!(result, "test-tree");
     }
 
@@ -502,7 +495,7 @@ mod tests {
     #[test]
     fn test_render_tree_no_derived() {
         let receipt = minimal_receipt();
-        let result = render_tree(&receipt);
+        let result = tree::render(&receipt);
         assert_eq!(result, "(tree unavailable)");
     }
 
@@ -513,7 +506,7 @@ mod tests {
         let mut derived = sample_derived();
         derived.tree = None;
         receipt.derived = Some(derived);
-        let result = render_tree(&receipt);
+        let result = tree::render(&receipt);
         assert_eq!(result, "(tree unavailable)");
     }
 

--- a/crates/tokmd-format/src/analysis/tree.rs
+++ b/crates/tokmd-format/src/analysis/tree.rs
@@ -1,0 +1,14 @@
+//! Tree rendering for analysis receipts.
+//!
+//! This module owns the `AnalysisFormat::Tree` projection and preserves the
+//! existing fallback when no derived tree is present.
+
+use tokmd_analysis_types::AnalysisReceipt;
+
+pub(super) fn render(receipt: &AnalysisReceipt) -> String {
+    receipt
+        .derived
+        .as_ref()
+        .and_then(|d| d.tree.clone())
+        .unwrap_or_else(|| "(tree unavailable)".to_string())
+}


### PR DESCRIPTION
## Summary
- move analysis tree rendering from `analysis/mod.rs` into `analysis/tree.rs`
- keep `AnalysisFormat::Tree` dispatch and output semantics unchanged
- leave schemas, proof policy, CLI behavior, and cockpit/review packet behavior unchanged

## Verification
- `cargo fmt-fix`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`