### PR TITLE
refactor(cockpit): extract proof evidence model

### DIFF
--- a/crates/tokmd-cockpit/src/proof_evidence.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence.rs
@@ -10,10 +10,10 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use tokmd_types::cockpit::CommitMatch;
 
 mod artifacts;
 mod inputs;
+mod model;
 mod normalize;
 
 pub(crate) use artifacts::ProofEvidenceArtifact;
@@ -23,107 +23,9 @@ use artifacts::{
     COVERAGE_RECEIPT_SCHEMA, PROOF_EXECUTOR_OBSERVATION_SCHEMA, PROOF_RUN_OBSERVATION_SCHEMA,
     PROOF_RUN_SUMMARY_SCHEMA,
 };
+pub(crate) use model::{NormalizedProofEvidence, ProofEvidenceAvailability, ProofExecutionStatus};
+pub use model::{ProofEvidenceInput, ProofEvidenceKind};
 pub(crate) use normalize::{normalize_proof_evidence, normalize_proof_evidence_inputs};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProofEvidenceKind {
-    ProofRunSummary,
-    ProofRunObservation,
-    ProofExecutorObservation,
-    CoverageReceipt,
-}
-
-impl ProofEvidenceKind {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ProofRunSummary => "proof_run_summary",
-            Self::ProofRunObservation => "proof_run_observation",
-            Self::ProofExecutorObservation => "proof_executor_observation",
-            Self::CoverageReceipt => "coverage_receipt",
-        }
-    }
-
-    pub(crate) fn packet_file_name(self) -> &'static str {
-        match self {
-            Self::ProofRunSummary => "proof-run-summary.json",
-            Self::ProofRunObservation => "proof-run-observation.json",
-            Self::ProofExecutorObservation => "proof-executor-observation.json",
-            Self::CoverageReceipt => "coverage-receipt.json",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProofEvidenceAvailability {
-    Available,
-    Missing,
-    Skipped,
-    Stale,
-    Degraded,
-    Unavailable,
-}
-
-impl ProofEvidenceAvailability {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Available => "available",
-            Self::Missing => "missing",
-            Self::Skipped => "skipped",
-            Self::Stale => "stale",
-            Self::Degraded => "degraded",
-            Self::Unavailable => "unavailable",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProofExecutionStatus {
-    Planned,
-    ExecutedPassed,
-    ExecutedFailed,
-    NotExecuted,
-    DryRun,
-}
-
-impl ProofExecutionStatus {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Planned => "planned",
-            Self::ExecutedPassed => "executed_passed",
-            Self::ExecutedFailed => "executed_failed",
-            Self::NotExecuted => "not_executed",
-            Self::DryRun => "dry_run",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct NormalizedProofEvidence {
-    pub source_path: PathBuf,
-    pub source_schema: String,
-    pub kind: ProofEvidenceKind,
-    pub profile: Option<String>,
-    pub scope: Option<String>,
-    pub command: Option<String>,
-    pub required: bool,
-    pub advisory: bool,
-    pub execution_status: ProofExecutionStatus,
-    pub availability: ProofEvidenceAvailability,
-    pub commit_match: CommitMatch,
-    pub artifact_refs: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProofEvidenceInput {
-    pub source_path: PathBuf,
-    pub artifact: ProofEvidenceArtifact,
-}
-
-impl ProofEvidenceInput {
-    pub fn kind(&self) -> ProofEvidenceKind {
-        self.artifact.kind()
-    }
-}
 
 pub fn proof_evidence_kind(raw: &str) -> Result<ProofEvidenceKind> {
     parse_proof_evidence_json(raw).map(|artifact| artifact.kind())
@@ -144,6 +46,7 @@ pub fn parse_proof_evidence_input(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokmd_types::cockpit::CommitMatch;
 
     fn parse_value(value: serde_json::Value) -> ProofEvidenceArtifact {
         parse_proof_evidence_json(&value.to_string()).expect("parse proof evidence")

--- a/crates/tokmd-cockpit/src/proof_evidence/artifacts.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/artifacts.rs
@@ -3,11 +3,11 @@
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-use super::ProofEvidenceKind;
 use super::inputs::{
     CoverageReceiptInput, ProofExecutorObservationInput, ProofRunObservationInput,
     ProofRunSummaryInput,
 };
+use super::model::ProofEvidenceKind;
 
 pub(super) const PROOF_RUN_SUMMARY_SCHEMA: &str = "tokmd.proof_run_summary.v1";
 pub(super) const PROOF_RUN_OBSERVATION_SCHEMA: &str = "tokmd.proof_run_observation.v1";

--- a/crates/tokmd-cockpit/src/proof_evidence/model.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/model.rs
@@ -1,0 +1,107 @@
+//! Normalized proof evidence model shared by cockpit renderers.
+
+use std::path::PathBuf;
+
+use tokmd_types::cockpit::CommitMatch;
+
+use super::artifacts::ProofEvidenceArtifact;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofEvidenceKind {
+    ProofRunSummary,
+    ProofRunObservation,
+    ProofExecutorObservation,
+    CoverageReceipt,
+}
+
+impl ProofEvidenceKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ProofRunSummary => "proof_run_summary",
+            Self::ProofRunObservation => "proof_run_observation",
+            Self::ProofExecutorObservation => "proof_executor_observation",
+            Self::CoverageReceipt => "coverage_receipt",
+        }
+    }
+
+    pub(crate) fn packet_file_name(self) -> &'static str {
+        match self {
+            Self::ProofRunSummary => "proof-run-summary.json",
+            Self::ProofRunObservation => "proof-run-observation.json",
+            Self::ProofExecutorObservation => "proof-executor-observation.json",
+            Self::CoverageReceipt => "coverage-receipt.json",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProofEvidenceAvailability {
+    Available,
+    Missing,
+    Skipped,
+    Stale,
+    Degraded,
+    Unavailable,
+}
+
+impl ProofEvidenceAvailability {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::Missing => "missing",
+            Self::Skipped => "skipped",
+            Self::Stale => "stale",
+            Self::Degraded => "degraded",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProofExecutionStatus {
+    Planned,
+    ExecutedPassed,
+    ExecutedFailed,
+    NotExecuted,
+    DryRun,
+}
+
+impl ProofExecutionStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Planned => "planned",
+            Self::ExecutedPassed => "executed_passed",
+            Self::ExecutedFailed => "executed_failed",
+            Self::NotExecuted => "not_executed",
+            Self::DryRun => "dry_run",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NormalizedProofEvidence {
+    pub source_path: PathBuf,
+    pub source_schema: String,
+    pub kind: ProofEvidenceKind,
+    pub profile: Option<String>,
+    pub scope: Option<String>,
+    pub command: Option<String>,
+    pub required: bool,
+    pub advisory: bool,
+    pub execution_status: ProofExecutionStatus,
+    pub availability: ProofEvidenceAvailability,
+    pub commit_match: CommitMatch,
+    pub artifact_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofEvidenceInput {
+    pub source_path: PathBuf,
+    pub artifact: ProofEvidenceArtifact,
+}
+
+impl ProofEvidenceInput {
+    pub fn kind(&self) -> ProofEvidenceKind {
+        self.artifact.kind()
+    }
+}

--- a/crates/tokmd-cockpit/src/proof_evidence/normalize.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/normalize.rs
@@ -6,7 +6,7 @@ use tokmd_types::cockpit::CommitMatch;
 
 use super::artifacts::ProofEvidenceArtifact;
 use super::inputs::{CoverageReceiptInput, ProofRunEntryInput};
-use super::{
+use super::model::{
     NormalizedProofEvidence, ProofEvidenceAvailability, ProofEvidenceInput, ProofEvidenceKind,
     ProofExecutionStatus,
 };


### PR DESCRIPTION
## Summary
- move proof evidence model types into `proof_evidence/model.rs`
- keep existing `ProofEvidenceInput` / `ProofEvidenceKind` public re-exports stable
- update artifact and normalization modules to import the model from its owner module

## Validation
- `cargo check -p tokmd-cockpit --all-targets`
- `cargo test -p tokmd-cockpit proof_evidence --lib --verbose`
- `cargo test -p tokmd-cockpit --test bdd scenario_write_review_packet_includes_imported_proof_evidence --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check origin/main..HEAD`

No schema, CLI, review packet output, proof gate, or Codecov behavior changes.