### PR TITLE
refactor(cockpit): extract contract detection module

### DIFF
--- a/crates/tokmd-cockpit/src/contracts.rs
+++ b/crates/tokmd-cockpit/src/contracts.rs
@@ -1,0 +1,40 @@
+//! Contract-change detection for cockpit receipts.
+
+use tokmd_types::cockpit::Contracts;
+
+/// Detect contract changes.
+pub fn detect_contracts<S: AsRef<str>>(files: &[S]) -> Contracts {
+    let mut api_changed = false;
+    let mut cli_changed = false;
+    let mut schema_changed = false;
+    let mut breaking_indicators = 0;
+
+    for file in files.iter() {
+        if file.as_ref().ends_with("lib.rs") || file.as_ref().ends_with("mod.rs") {
+            api_changed = true;
+        }
+        if file.as_ref().contains("crates/tokmd/src/commands/")
+            || file.as_ref().contains("crates/tokmd/src/cli/")
+            || file.as_ref() == "crates/tokmd/src/config.rs"
+        {
+            cli_changed = true;
+        }
+        if file.as_ref() == "docs/schema.json" || file.as_ref() == "docs/SCHEMA.md" {
+            schema_changed = true;
+        }
+    }
+
+    if api_changed {
+        breaking_indicators += 1;
+    }
+    if schema_changed {
+        breaking_indicators += 1;
+    }
+
+    Contracts {
+        api_changed,
+        cli_changed,
+        schema_changed,
+        breaking_indicators,
+    }
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -17,6 +17,7 @@
 //! * Type definitions (use tokmd-types::cockpit)
 
 mod composition;
+mod contracts;
 pub mod determinism;
 mod display;
 #[cfg(feature = "git")]
@@ -35,6 +36,7 @@ use anyhow::Result;
 #[cfg(feature = "git")]
 use anyhow::{Context, bail};
 pub use composition::compute_composition;
+pub use contracts::detect_contracts;
 pub use display::{format_signed_f64, now_iso8601, round_pct, sparkline, trend_direction_label};
 #[cfg(feature = "git")]
 pub use gates::compute_determinism_gate;
@@ -258,43 +260,6 @@ fn compute_change_surface(
 // =============================================================================
 // Composition, contracts, health, risk, review plan
 // =============================================================================
-
-/// Detect contract changes.
-pub fn detect_contracts<S: AsRef<str>>(files: &[S]) -> Contracts {
-    let mut api_changed = false;
-    let mut cli_changed = false;
-    let mut schema_changed = false;
-    let mut breaking_indicators = 0;
-
-    for file in files.iter() {
-        if file.as_ref().ends_with("lib.rs") || file.as_ref().ends_with("mod.rs") {
-            api_changed = true;
-        }
-        if file.as_ref().contains("crates/tokmd/src/commands/")
-            || file.as_ref().contains("crates/tokmd/src/cli/")
-            || file.as_ref() == "crates/tokmd/src/config.rs"
-        {
-            cli_changed = true;
-        }
-        if file.as_ref() == "docs/schema.json" || file.as_ref() == "docs/SCHEMA.md" {
-            schema_changed = true;
-        }
-    }
-
-    if api_changed {
-        breaking_indicators += 1;
-    }
-    if schema_changed {
-        breaking_indicators += 1;
-    }
-
-    Contracts {
-        api_changed,
-        cli_changed,
-        schema_changed,
-        breaking_indicators,
-    }
-}
 
 /// Compute code health metrics.
 pub fn compute_code_health(file_stats: &[FileStat], contracts: &Contracts) -> CodeHealth {


### PR DESCRIPTION
## Summary
- move cockpit contract-change detection into a dedicated `contracts` owner module
- preserve the existing `detect_contracts` public export and receipt semantics
- keep schemas, CLI behavior, proof policy, and review packet output unchanged

## Validation
- `cargo check -p tokmd-cockpit --all-targets`
- `cargo test -p tokmd-cockpit test_detect_contracts --lib --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`