### PR TITLE
refactor(cockpit): extract code health module

### DIFF
--- a/crates/tokmd-cockpit/src/health.rs
+++ b/crates/tokmd-cockpit/src/health.rs
@@ -1,0 +1,71 @@
+//! Code-health metric computation for cockpit receipts.
+
+use crate::FileStat;
+use tokmd_types::cockpit::{
+    CodeHealth, ComplexityIndicator, Contracts, HealthWarning, WarningType,
+};
+
+/// Compute code health metrics.
+pub fn compute_code_health(file_stats: &[FileStat], contracts: &Contracts) -> CodeHealth {
+    let mut large_files_touched = 0;
+    let mut total_lines = 0;
+
+    for stat in file_stats {
+        let lines = stat.insertions + stat.deletions;
+        if lines > 500 {
+            large_files_touched += 1;
+        }
+        total_lines += lines;
+    }
+
+    let avg_file_size = if !file_stats.is_empty() {
+        total_lines / file_stats.len()
+    } else {
+        0
+    };
+
+    let complexity_indicator = if large_files_touched > 5 {
+        ComplexityIndicator::Critical
+    } else if large_files_touched > 2 {
+        ComplexityIndicator::High
+    } else if large_files_touched > 0 {
+        ComplexityIndicator::Medium
+    } else {
+        ComplexityIndicator::Low
+    };
+
+    let mut warnings = Vec::new();
+    for stat in file_stats {
+        if stat.insertions + stat.deletions > 500 {
+            warnings.push(HealthWarning {
+                path: stat.path.clone(),
+                warning_type: WarningType::LargeFile,
+                message: "Large file touched".to_string(),
+            });
+        }
+    }
+
+    let mut score: u32 = 100;
+    score = score.saturating_sub((large_files_touched * 10) as u32);
+    if contracts.breaking_indicators > 0 {
+        score = score.saturating_sub(20);
+    }
+
+    let grade = match score {
+        90..=100 => "A",
+        80..=89 => "B",
+        70..=79 => "C",
+        60..=69 => "D",
+        _ => "F",
+    }
+    .to_string();
+
+    CodeHealth {
+        score,
+        grade,
+        large_files_touched,
+        avg_file_size,
+        complexity_indicator,
+        warnings,
+    }
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -22,6 +22,7 @@ pub mod determinism;
 mod display;
 #[cfg(feature = "git")]
 mod gates;
+mod health;
 mod proof_evidence;
 pub mod render;
 mod review_plan;
@@ -42,6 +43,7 @@ pub use display::{format_signed_f64, now_iso8601, round_pct, sparkline, trend_di
 pub use gates::compute_determinism_gate;
 #[cfg(feature = "git")]
 use gates::compute_evidence;
+pub use health::compute_code_health;
 pub use proof_evidence::{ProofEvidenceInput, ProofEvidenceKind};
 pub use review_plan::generate_review_plan;
 #[cfg(all(test, feature = "git"))]
@@ -260,71 +262,6 @@ fn compute_change_surface(
 // =============================================================================
 // Composition, contracts, health, risk, review plan
 // =============================================================================
-
-/// Compute code health metrics.
-pub fn compute_code_health(file_stats: &[FileStat], contracts: &Contracts) -> CodeHealth {
-    let mut large_files_touched = 0;
-    let mut total_lines = 0;
-
-    for stat in file_stats {
-        let lines = stat.insertions + stat.deletions;
-        if lines > 500 {
-            large_files_touched += 1;
-        }
-        total_lines += lines;
-    }
-
-    let avg_file_size = if !file_stats.is_empty() {
-        total_lines / file_stats.len()
-    } else {
-        0
-    };
-
-    let complexity_indicator = if large_files_touched > 5 {
-        ComplexityIndicator::Critical
-    } else if large_files_touched > 2 {
-        ComplexityIndicator::High
-    } else if large_files_touched > 0 {
-        ComplexityIndicator::Medium
-    } else {
-        ComplexityIndicator::Low
-    };
-
-    let mut warnings = Vec::new();
-    for stat in file_stats {
-        if stat.insertions + stat.deletions > 500 {
-            warnings.push(HealthWarning {
-                path: stat.path.clone(),
-                warning_type: WarningType::LargeFile,
-                message: "Large file touched".to_string(),
-            });
-        }
-    }
-
-    let mut score: u32 = 100;
-    score = score.saturating_sub((large_files_touched * 10) as u32);
-    if contracts.breaking_indicators > 0 {
-        score = score.saturating_sub(20);
-    }
-
-    let grade = match score {
-        90..=100 => "A",
-        80..=89 => "B",
-        70..=79 => "C",
-        60..=69 => "D",
-        _ => "F",
-    }
-    .to_string();
-
-    CodeHealth {
-        score,
-        grade,
-        large_files_touched,
-        avg_file_size,
-        complexity_indicator,
-        warnings,
-    }
-}
 
 fn compute_risk_from_iter<I>(_contracts: &Contracts, health: &CodeHealth, file_stats: I) -> Risk
 where


### PR DESCRIPTION
## Summary
- move `compute_code_health` out of `lib.rs` into a dedicated `health` owner module
- preserve the existing public `compute_code_health` export and cockpit receipt semantics
- keep schemas, CLI behavior, proof policy, and review packet output unchanged

## Validation
- `cargo check -p tokmd-cockpit --all-targets`
- `cargo test -p tokmd-cockpit test_code_health --lib --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`