### PR TITLE
refactor(cockpit): extract risk module

### DIFF
--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -26,6 +26,7 @@ mod health;
 mod proof_evidence;
 pub mod render;
 mod review_plan;
+mod risk;
 #[cfg(feature = "git")]
 mod supply_chain;
 mod trend;
@@ -46,6 +47,9 @@ use gates::compute_evidence;
 pub use health::compute_code_health;
 pub use proof_evidence::{ProofEvidenceInput, ProofEvidenceKind};
 pub use review_plan::generate_review_plan;
+pub use risk::compute_risk;
+#[cfg(feature = "git")]
+use risk::compute_risk_owned;
 #[cfg(all(test, feature = "git"))]
 use tokmd_analysis::source_complexity::analyze_rust_function_complexity;
 pub use trend::{compute_complexity_trend, compute_metric_trend, load_and_compute_trend};
@@ -257,67 +261,6 @@ fn compute_change_surface(
         churn_velocity,
         change_concentration,
     })
-}
-
-// =============================================================================
-// Composition, contracts, health, risk, review plan
-// =============================================================================
-
-fn compute_risk_from_iter<I>(_contracts: &Contracts, health: &CodeHealth, file_stats: I) -> Risk
-where
-    I: IntoIterator<Item = String>,
-{
-    let mut hotspots_touched = Vec::new();
-    let bus_factor_warnings = Vec::new();
-
-    for path in file_stats {
-        hotspots_touched.push(path);
-    }
-
-    let score = (hotspots_touched.len() * 15 + (100 - health.score) as usize).min(100) as u32;
-
-    let level = match score {
-        0..=20 => RiskLevel::Low,
-        21..=50 => RiskLevel::Medium,
-        51..=80 => RiskLevel::High,
-        _ => RiskLevel::Critical,
-    };
-
-    Risk {
-        hotspots_touched,
-        bus_factor_warnings,
-        level,
-        score,
-    }
-}
-
-/// Compute risk metrics for borrowed file stats.
-pub fn compute_risk(file_stats: &[FileStat], contracts: &Contracts, health: &CodeHealth) -> Risk {
-    compute_risk_from_iter(
-        contracts,
-        health,
-        file_stats
-            .iter()
-            .filter(|stat| stat.insertions + stat.deletions > 300)
-            .map(|stat| stat.path.clone()),
-    )
-}
-
-/// Internal fast path used by cockpit assembly when it already owns the stats.
-#[cfg(feature = "git")]
-fn compute_risk_owned(
-    file_stats: Vec<FileStat>,
-    contracts: &Contracts,
-    health: &CodeHealth,
-) -> Risk {
-    compute_risk_from_iter(
-        contracts,
-        health,
-        file_stats
-            .into_iter()
-            .filter(|stat| stat.insertions + stat.deletions > 300)
-            .map(|stat| stat.path),
-    )
 }
 
 #[cfg(test)]

--- a/crates/tokmd-cockpit/src/risk.rs
+++ b/crates/tokmd-cockpit/src/risk.rs
@@ -1,0 +1,61 @@
+//! Risk metric computation for cockpit receipts.
+
+use crate::FileStat;
+use tokmd_types::cockpit::{CodeHealth, Contracts, Risk, RiskLevel};
+
+fn compute_risk_from_iter<I>(_contracts: &Contracts, health: &CodeHealth, file_stats: I) -> Risk
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut hotspots_touched = Vec::new();
+    let bus_factor_warnings = Vec::new();
+
+    for path in file_stats {
+        hotspots_touched.push(path);
+    }
+
+    let score = (hotspots_touched.len() * 15 + (100 - health.score) as usize).min(100) as u32;
+
+    let level = match score {
+        0..=20 => RiskLevel::Low,
+        21..=50 => RiskLevel::Medium,
+        51..=80 => RiskLevel::High,
+        _ => RiskLevel::Critical,
+    };
+
+    Risk {
+        hotspots_touched,
+        bus_factor_warnings,
+        level,
+        score,
+    }
+}
+
+/// Compute risk metrics for borrowed file stats.
+pub fn compute_risk(file_stats: &[FileStat], contracts: &Contracts, health: &CodeHealth) -> Risk {
+    compute_risk_from_iter(
+        contracts,
+        health,
+        file_stats
+            .iter()
+            .filter(|stat| stat.insertions + stat.deletions > 300)
+            .map(|stat| stat.path.clone()),
+    )
+}
+
+/// Internal fast path used by cockpit assembly when it already owns the stats.
+#[cfg(feature = "git")]
+pub(crate) fn compute_risk_owned(
+    file_stats: Vec<FileStat>,
+    contracts: &Contracts,
+    health: &CodeHealth,
+) -> Risk {
+    compute_risk_from_iter(
+        contracts,
+        health,
+        file_stats
+            .into_iter()
+            .filter(|stat| stat.insertions + stat.deletions > 300)
+            .map(|stat| stat.path),
+    )
+}


### PR DESCRIPTION
## Summary
- move cockpit risk scoring helpers out of `lib.rs` into a dedicated `risk` owner module
- preserve the public `compute_risk` export and the internal owned fast path used by cockpit assembly
- keep receipt schemas, CLI behavior, review packet output, and proof policy unchanged

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit test_risk --lib --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`