### PR TITLE
refactor(cockpit): extract change surface module

### DIFF
--- a/crates/tokmd-cockpit/src/change_surface.rs
+++ b/crates/tokmd-cockpit/src/change_surface.rs
@@ -1,0 +1,108 @@
+//! Git diff file-stat collection and change-surface metrics.
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use tokmd_types::cockpit::ChangeSurface;
+
+use crate::FileStat;
+
+/// Get file stats for changed files.
+pub fn get_file_stats(
+    repo_root: &Path,
+    base: &str,
+    head: &str,
+    range_mode: tokmd_git::GitRangeMode,
+) -> Result<Vec<FileStat>> {
+    let range = range_mode.format(base, head);
+    let output = tokmd_git::git_cmd()
+        .arg("-C")
+        .arg(repo_root)
+        .args(["diff", "--numstat", &range])
+        .output()
+        .context("Failed to run git diff --numstat")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git diff --numstat failed: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut stats = Vec::new();
+
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() == 3 {
+            let insertions = parts[0].parse().unwrap_or(0);
+            let deletions = parts[1].parse().unwrap_or(0);
+            let path = parts[2].to_string();
+            stats.push(FileStat {
+                path,
+                insertions,
+                deletions,
+            });
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Compute change surface metrics.
+pub(crate) fn compute_change_surface(
+    repo_root: &Path,
+    base: &str,
+    head: &str,
+    file_stats: &[FileStat],
+    range_mode: tokmd_git::GitRangeMode,
+) -> Result<ChangeSurface> {
+    let range = range_mode.format(base, head);
+    let output = tokmd_git::git_cmd()
+        .arg("-C")
+        .arg(repo_root)
+        .args(["rev-list", "--count", &range])
+        .output()
+        .context("Failed to run git rev-list --count")?;
+
+    let commits = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0);
+
+    let files_changed = file_stats.len();
+    let insertions = file_stats.iter().map(|s| s.insertions).sum();
+    let deletions = file_stats.iter().map(|s| s.deletions).sum();
+    let net_lines = (insertions as i64) - (deletions as i64);
+
+    let churn_velocity = if commits > 0 {
+        (insertions + deletions) as f64 / commits as f64
+    } else {
+        0.0
+    };
+
+    // Simple change concentration: what % of changes are in top 20% of files.
+    let mut changes: Vec<usize> = file_stats
+        .iter()
+        .map(|s| s.insertions + s.deletions)
+        .collect();
+    changes.sort_unstable_by(|a, b| b.cmp(a));
+
+    let top_count = (files_changed as f64 * 0.2).ceil() as usize;
+    let total_changes: usize = changes.iter().sum();
+    let top_changes: usize = changes.iter().take(top_count).sum();
+
+    let change_concentration = if total_changes > 0 {
+        top_changes as f64 / total_changes as f64
+    } else {
+        0.0
+    };
+
+    Ok(ChangeSurface {
+        commits,
+        files_changed,
+        insertions,
+        deletions,
+        net_lines,
+        churn_velocity,
+        change_concentration,
+    })
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -16,6 +16,8 @@
 //! * CLI argument parsing (use `tokmd::cli`)
 //! * Type definitions (use tokmd-types::cockpit)
 
+#[cfg(feature = "git")]
+mod change_surface;
 mod composition;
 mod contracts;
 pub mod determinism;
@@ -36,7 +38,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 #[cfg(feature = "git")]
-use anyhow::{Context, bail};
+use change_surface::compute_change_surface;
+#[cfg(feature = "git")]
+pub use change_surface::get_file_stats;
 pub use composition::compute_composition;
 pub use contracts::detect_contracts;
 pub use display::{format_signed_f64, now_iso8601, round_pct, sparkline, trend_direction_label};
@@ -154,112 +158,6 @@ pub fn compute_cockpit(
         evidence,
         review_plan,
         trend: None, // Populated by caller if --baseline is provided
-    })
-}
-
-// =============================================================================
-// File stats and change surface
-// =============================================================================
-
-/// Get file stats for changed files.
-#[cfg(feature = "git")]
-pub fn get_file_stats(
-    repo_root: &Path,
-    base: &str,
-    head: &str,
-    range_mode: tokmd_git::GitRangeMode,
-) -> Result<Vec<FileStat>> {
-    let range = range_mode.format(base, head);
-    let output = tokmd_git::git_cmd()
-        .arg("-C")
-        .arg(repo_root)
-        .args(["diff", "--numstat", &range])
-        .output()
-        .context("Failed to run git diff --numstat")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("git diff --numstat failed: {}", stderr.trim());
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut stats = Vec::new();
-
-    for line in stdout.lines() {
-        let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() == 3 {
-            let insertions = parts[0].parse().unwrap_or(0);
-            let deletions = parts[1].parse().unwrap_or(0);
-            let path = parts[2].to_string();
-            stats.push(FileStat {
-                path,
-                insertions,
-                deletions,
-            });
-        }
-    }
-
-    Ok(stats)
-}
-
-/// Compute change surface metrics.
-#[cfg(feature = "git")]
-fn compute_change_surface(
-    repo_root: &Path,
-    base: &str,
-    head: &str,
-    file_stats: &[FileStat],
-    range_mode: tokmd_git::GitRangeMode,
-) -> Result<ChangeSurface> {
-    let range = range_mode.format(base, head);
-    let output = tokmd_git::git_cmd()
-        .arg("-C")
-        .arg(repo_root)
-        .args(["rev-list", "--count", &range])
-        .output()
-        .context("Failed to run git rev-list --count")?;
-
-    let commits = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap_or(0);
-
-    let files_changed = file_stats.len();
-    let insertions = file_stats.iter().map(|s| s.insertions).sum();
-    let deletions = file_stats.iter().map(|s| s.deletions).sum();
-    let net_lines = (insertions as i64) - (deletions as i64);
-
-    let churn_velocity = if commits > 0 {
-        (insertions + deletions) as f64 / commits as f64
-    } else {
-        0.0
-    };
-
-    // Simple change concentration: what % of changes are in top 20% of files
-    let mut changes: Vec<usize> = file_stats
-        .iter()
-        .map(|s| s.insertions + s.deletions)
-        .collect();
-    changes.sort_unstable_by(|a, b| b.cmp(a));
-
-    let top_count = (files_changed as f64 * 0.2).ceil() as usize;
-    let total_changes: usize = changes.iter().sum();
-    let top_changes: usize = changes.iter().take(top_count).sum();
-
-    let change_concentration = if total_changes > 0 {
-        top_changes as f64 / total_changes as f64
-    } else {
-        0.0
-    };
-
-    Ok(ChangeSurface {
-        commits,
-        files_changed,
-        insertions,
-        deletions,
-        net_lines,
-        churn_velocity,
-        change_concentration,
     })
 }
 


### PR DESCRIPTION
## Summary
- move git-backed file-stat collection and change-surface metrics into `tokmd-cockpit::change_surface`
- preserve the public `get_file_stats` export and existing `compute_cockpit` wiring
- keep cockpit schemas, CLI behavior, review packet output, and proof policy unchanged

## Validation
- `cargo test -p tokmd-cockpit get_file_stats_ignores_inherited_git_env_overrides --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`