### PR TITLE
refactor(cockpit): extract file stat module

### DIFF
--- a/crates/tokmd-cockpit/src/file_stat.rs
+++ b/crates/tokmd-cockpit/src/file_stat.rs
@@ -1,0 +1,15 @@
+//! File-level diff statistics used by cockpit metrics.
+
+/// File stat from git diff --numstat.
+#[derive(Debug, Clone)]
+pub struct FileStat {
+    pub path: String,
+    pub insertions: usize,
+    pub deletions: usize,
+}
+
+impl AsRef<str> for FileStat {
+    fn as_ref(&self) -> &str {
+        &self.path
+    }
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -22,6 +22,7 @@ mod composition;
 mod contracts;
 pub mod determinism;
 mod display;
+mod file_stat;
 #[cfg(feature = "git")]
 mod gates;
 mod health;
@@ -44,6 +45,7 @@ pub use change_surface::get_file_stats;
 pub use composition::compute_composition;
 pub use contracts::detect_contracts;
 pub use display::{format_signed_f64, now_iso8601, round_pct, sparkline, trend_direction_label};
+pub use file_stat::FileStat;
 #[cfg(feature = "git")]
 pub use gates::compute_determinism_gate;
 #[cfg(feature = "git")]
@@ -77,21 +79,6 @@ pub fn parse_proof_evidence_input(
     source_path: impl Into<std::path::PathBuf>,
 ) -> Result<ProofEvidenceInput> {
     proof_evidence::parse_proof_evidence_input(raw, source_path)
-}
-
-/// File stat from git diff --numstat.
-/// File stat from git diff --numstat.
-#[derive(Debug, Clone)]
-pub struct FileStat {
-    pub path: String,
-    pub insertions: usize,
-    pub deletions: usize,
-}
-
-impl AsRef<str> for FileStat {
-    fn as_ref(&self) -> &str {
-        &self.path
-    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- move the public `FileStat` type into a small `file_stat` owner module
- preserve the crate-root `FileStat` re-export for existing callers
- keep cockpit receipt schemas, CLI behavior, review packet output, and proof policy unchanged

## Validation
- `cargo test -p tokmd-cockpit test_filestat_as_ref --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-fix`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`