### PR TITLE
refactor(cockpit): move composition tests to owner module

### DIFF
--- a/crates/tokmd-cockpit/src/composition.rs
+++ b/crates/tokmd-cockpit/src/composition.rs
@@ -58,3 +58,65 @@ pub fn compute_composition<S: AsRef<str>>(files: &[S]) -> Composition {
         test_ratio,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_composition_mixed_files() {
+        let files = vec![
+            "src/main.rs",
+            "src/lib.rs",
+            "tests/test_main.rs",
+            "README.md",
+            "Cargo.toml",
+        ];
+        let comp = compute_composition(&files);
+        assert!(comp.code_pct > 0.0);
+        assert!(comp.test_pct > 0.0);
+        assert!(comp.docs_pct > 0.0);
+        assert!(comp.config_pct > 0.0);
+    }
+
+    #[test]
+    fn test_composition_empty_input() {
+        let files: Vec<&str> = vec![];
+        let comp = compute_composition(&files);
+        assert_eq!(comp.code_pct, 0.0);
+        assert_eq!(comp.test_pct, 0.0);
+        assert_eq!(comp.test_ratio, 0.0);
+    }
+
+    #[test]
+    fn test_composition_only_code() {
+        let files = vec!["src/main.rs", "src/lib.rs"];
+        let comp = compute_composition(&files);
+        assert_eq!(comp.code_pct, 1.0);
+        assert_eq!(comp.test_pct, 0.0);
+        assert_eq!(comp.test_ratio, 0.0);
+    }
+
+    #[test]
+    fn test_composition_test_ratio() {
+        let files = vec![
+            "src/main.rs",
+            "src/lib.rs",
+            "tests/test_main.rs",
+            "tests/test_lib.rs",
+        ];
+        let comp = compute_composition(&files);
+        // 2 code files, 2 test files -> ratio = 1.0
+        assert_eq!(comp.test_ratio, 1.0);
+    }
+
+    #[test]
+    fn test_composition_only_tests() {
+        let files = vec!["tests/test_main.rs", "tests/test_lib.rs"];
+        let comp = compute_composition(&files);
+        assert_eq!(comp.code_pct, 0.0);
+        assert_eq!(comp.test_pct, 1.0);
+        // No code files, but tests exist -> test_ratio = 1.0
+        assert_eq!(comp.test_ratio, 1.0);
+    }
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -152,65 +152,6 @@ pub fn compute_cockpit(
 mod tests {
     use super::*;
 
-    // ---- compute_composition ----
-
-    #[test]
-    fn test_composition_mixed_files() {
-        let files = vec![
-            "src/main.rs",
-            "src/lib.rs",
-            "tests/test_main.rs",
-            "README.md",
-            "Cargo.toml",
-        ];
-        let comp = compute_composition(&files);
-        assert!(comp.code_pct > 0.0);
-        assert!(comp.test_pct > 0.0);
-        assert!(comp.docs_pct > 0.0);
-        assert!(comp.config_pct > 0.0);
-    }
-
-    #[test]
-    fn test_composition_empty_input() {
-        let files: Vec<&str> = vec![];
-        let comp = compute_composition(&files);
-        assert_eq!(comp.code_pct, 0.0);
-        assert_eq!(comp.test_pct, 0.0);
-        assert_eq!(comp.test_ratio, 0.0);
-    }
-
-    #[test]
-    fn test_composition_only_code() {
-        let files = vec!["src/main.rs", "src/lib.rs"];
-        let comp = compute_composition(&files);
-        assert_eq!(comp.code_pct, 1.0);
-        assert_eq!(comp.test_pct, 0.0);
-        assert_eq!(comp.test_ratio, 0.0);
-    }
-
-    #[test]
-    fn test_composition_test_ratio() {
-        let files = vec![
-            "src/main.rs",
-            "src/lib.rs",
-            "tests/test_main.rs",
-            "tests/test_lib.rs",
-        ];
-        let comp = compute_composition(&files);
-        // 2 code files, 2 test files → ratio = 1.0
-        assert_eq!(comp.test_ratio, 1.0);
-    }
-
-    #[test]
-    fn test_composition_only_tests() {
-        let files = vec!["tests/test_main.rs", "tests/test_lib.rs"];
-        let comp = compute_composition(&files);
-        assert_eq!(comp.code_pct, 0.0);
-        assert_eq!(comp.test_pct, 1.0);
-        // No code files, but tests exist → test_ratio = 1.0
-        assert_eq!(comp.test_ratio, 1.0);
-    }
-
     // ---- detect_contracts ----
 
     #[test]


### PR DESCRIPTION
## Summary
- move composition unit tests from the cockpit crate root into the composition owner module
- leave production code, exports, schemas, packet output, and CLI behavior unchanged

## Validation
- cargo fmt-fix
- cargo test -p tokmd-cockpit test_composition --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo fmt-check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- git diff --check origin/main..HEAD