### PR TITLE
refactor(cockpit): move contract tests to owner module

### DIFF
--- a/crates/tokmd-cockpit/src/contracts.rs
+++ b/crates/tokmd-cockpit/src/contracts.rs
@@ -38,3 +38,58 @@ pub fn detect_contracts<S: AsRef<str>>(files: &[S]) -> Contracts {
         breaking_indicators,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_contracts_api() {
+        let files = vec!["crates/tokmd-types/src/lib.rs"];
+        let contracts = detect_contracts(&files);
+        assert!(contracts.api_changed);
+        assert!(!contracts.cli_changed);
+        assert!(!contracts.schema_changed);
+        assert_eq!(contracts.breaking_indicators, 1);
+    }
+
+    #[test]
+    fn test_detect_contracts_cli() {
+        let files = vec!["crates/tokmd/src/commands/lang.rs"];
+        let contracts = detect_contracts(&files);
+        assert!(!contracts.api_changed);
+        assert!(contracts.cli_changed);
+    }
+
+    #[test]
+    fn test_detect_contracts_schema() {
+        let files = vec!["docs/schema.json"];
+        let contracts = detect_contracts(&files);
+        assert!(contracts.schema_changed);
+        assert_eq!(contracts.breaking_indicators, 1);
+    }
+
+    #[test]
+    fn test_detect_contracts_none() {
+        let files = vec!["README.md", "src/utils.rs"];
+        let contracts = detect_contracts(&files);
+        assert!(!contracts.api_changed);
+        assert!(!contracts.cli_changed);
+        assert!(!contracts.schema_changed);
+        assert_eq!(contracts.breaking_indicators, 0);
+    }
+
+    #[test]
+    fn test_detect_contracts_all() {
+        let files = vec![
+            "crates/tokmd-types/src/lib.rs",
+            "crates/tokmd/src/commands/lang.rs",
+            "docs/schema.json",
+        ];
+        let contracts = detect_contracts(&files);
+        assert!(contracts.api_changed);
+        assert!(contracts.cli_changed);
+        assert!(contracts.schema_changed);
+        assert_eq!(contracts.breaking_indicators, 2); // api + schema
+    }
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -152,58 +152,6 @@ pub fn compute_cockpit(
 mod tests {
     use super::*;
 
-    // ---- detect_contracts ----
-
-    #[test]
-    fn test_detect_contracts_api() {
-        let files = vec!["crates/tokmd-types/src/lib.rs"];
-        let contracts = detect_contracts(&files);
-        assert!(contracts.api_changed);
-        assert!(!contracts.cli_changed);
-        assert!(!contracts.schema_changed);
-        assert_eq!(contracts.breaking_indicators, 1);
-    }
-
-    #[test]
-    fn test_detect_contracts_cli() {
-        let files = vec!["crates/tokmd/src/commands/lang.rs"];
-        let contracts = detect_contracts(&files);
-        assert!(!contracts.api_changed);
-        assert!(contracts.cli_changed);
-    }
-
-    #[test]
-    fn test_detect_contracts_schema() {
-        let files = vec!["docs/schema.json"];
-        let contracts = detect_contracts(&files);
-        assert!(contracts.schema_changed);
-        assert_eq!(contracts.breaking_indicators, 1);
-    }
-
-    #[test]
-    fn test_detect_contracts_none() {
-        let files = vec!["README.md", "src/utils.rs"];
-        let contracts = detect_contracts(&files);
-        assert!(!contracts.api_changed);
-        assert!(!contracts.cli_changed);
-        assert!(!contracts.schema_changed);
-        assert_eq!(contracts.breaking_indicators, 0);
-    }
-
-    #[test]
-    fn test_detect_contracts_all() {
-        let files = vec![
-            "crates/tokmd-types/src/lib.rs",
-            "crates/tokmd/src/commands/lang.rs",
-            "docs/schema.json",
-        ];
-        let contracts = detect_contracts(&files);
-        assert!(contracts.api_changed);
-        assert!(contracts.cli_changed);
-        assert!(contracts.schema_changed);
-        assert_eq!(contracts.breaking_indicators, 2); // api + schema
-    }
-
     // ---- compute_code_health ----
 
     fn make_stat(path: &str, insertions: usize, deletions: usize) -> FileStat {


### PR DESCRIPTION
## Summary
- move contract-detection unit tests from the cockpit crate root into the contracts owner module
- leave production logic, exports, schemas, packet output, and CLI behavior unchanged

## Validation
- cargo fmt-fix
- cargo test -p tokmd-cockpit test_detect_contracts --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo fmt-check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- git diff --check