### PR TITLE
refactor(cockpit): move risk tests to owner module

### DIFF
--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -160,41 +160,6 @@ mod tests {
         }
     }
 
-    // ---- compute_risk ----
-
-    #[test]
-    fn test_risk_no_hotspots() {
-        let stats = vec![make_stat("src/main.rs", 10, 5)];
-        let contracts = Contracts {
-            api_changed: false,
-            cli_changed: false,
-            schema_changed: false,
-            breaking_indicators: 0,
-        };
-        let health = compute_code_health(&stats, &contracts);
-        let risk = compute_risk(&stats, &contracts, &health);
-        assert_eq!(risk.level, RiskLevel::Low);
-        assert!(risk.hotspots_touched.is_empty());
-    }
-
-    #[test]
-    fn test_risk_with_hotspots() {
-        let stats = vec![
-            make_stat("src/huge.rs", 200, 200), // >300 lines total
-            make_stat("src/big.rs", 200, 200),  // >300 lines total
-        ];
-        let contracts = Contracts {
-            api_changed: false,
-            cli_changed: false,
-            schema_changed: false,
-            breaking_indicators: 0,
-        };
-        let health = compute_code_health(&stats, &contracts);
-        let risk = compute_risk(&stats, &contracts, &health);
-        assert!(!risk.hotspots_touched.is_empty());
-        assert!(risk.score > 0);
-    }
-
     // ---- generate_review_plan ----
 
     #[test]

--- a/crates/tokmd-cockpit/src/risk.rs
+++ b/crates/tokmd-cockpit/src/risk.rs
@@ -59,3 +59,50 @@ pub(crate) fn compute_risk_owned(
             .map(|stat| stat.path),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::compute_code_health;
+
+    fn make_stat(path: &str, insertions: usize, deletions: usize) -> FileStat {
+        FileStat {
+            path: path.to_string(),
+            insertions,
+            deletions,
+        }
+    }
+
+    #[test]
+    fn test_risk_no_hotspots() {
+        let stats = vec![make_stat("src/main.rs", 10, 5)];
+        let contracts = Contracts {
+            api_changed: false,
+            cli_changed: false,
+            schema_changed: false,
+            breaking_indicators: 0,
+        };
+        let health = compute_code_health(&stats, &contracts);
+        let risk = compute_risk(&stats, &contracts, &health);
+        assert_eq!(risk.level, RiskLevel::Low);
+        assert!(risk.hotspots_touched.is_empty());
+    }
+
+    #[test]
+    fn test_risk_with_hotspots() {
+        let stats = vec![
+            make_stat("src/huge.rs", 200, 200), // >300 lines total
+            make_stat("src/big.rs", 200, 200),  // >300 lines total
+        ];
+        let contracts = Contracts {
+            api_changed: false,
+            cli_changed: false,
+            schema_changed: false,
+            breaking_indicators: 0,
+        };
+        let health = compute_code_health(&stats, &contracts);
+        let risk = compute_risk(&stats, &contracts, &health);
+        assert!(!risk.hotspots_touched.is_empty());
+        assert!(risk.score > 0);
+    }
+}


### PR DESCRIPTION
## Summary

- Move risk unit tests from the cockpit crate root into the `risk` owner module.
- Leave the crate-root `make_stat` helper in place because review-plan tests still use it.
- Preserve production logic, schemas, CLI behavior, review packet output, and proof policy behavior.

## Validation

- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit test_risk --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`