### PR TITLE
refactor(cockpit): move file stat tests to owner module

### DIFF
--- a/crates/tokmd-cockpit/src/file_stat.rs
+++ b/crates/tokmd-cockpit/src/file_stat.rs
@@ -13,3 +13,19 @@ impl AsRef<str> for FileStat {
         &self.path
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filestat_as_ref() {
+        let stat = FileStat {
+            path: "src/main.rs".to_string(),
+            insertions: 10,
+            deletions: 5,
+        };
+        let s: &str = stat.as_ref();
+        assert_eq!(s, "src/main.rs");
+    }
+}

--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -213,17 +213,4 @@ fn branchy(x: i32) -> i32 {
         assert_eq!(analysis.total_complexity, 4);
         assert_eq!(analysis.max_complexity, 4);
     }
-
-    // ---- FileStat AsRef ----
-
-    #[test]
-    fn test_filestat_as_ref() {
-        let stat = FileStat {
-            path: "src/main.rs".to_string(),
-            insertions: 10,
-            deletions: 5,
-        };
-        let s: &str = stat.as_ref();
-        assert_eq!(s, "src/main.rs");
-    }
 }


### PR DESCRIPTION
## Summary
- move the FileStat AsRef unit test from the crate root into file_stat.rs
- leave the public FileStat export and cockpit behavior unchanged
- keep lib.rs focused on remaining root-level Rust complexity regression coverage

## Validation
- cargo fmt-fix
- cargo test -p tokmd-cockpit test_filestat_as_ref --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo fmt-check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- git diff --check