### PR TITLE
docs(cockpit): clarify proof evidence import flags

### DIFF
--- a/crates/tokmd-cockpit/src/lib.rs
+++ b/crates/tokmd-cockpit/src/lib.rs
@@ -65,8 +65,8 @@ pub const COMPLEXITY_THRESHOLD: u32 = 15;
 
 /// Parse a proof-control-plane evidence artifact and return its artifact family.
 ///
-/// This is intentionally validation-only for now: cockpit can accept explicit
-/// proof evidence inputs without changing review packet output semantics.
+/// The CLI uses this lightweight classifier to validate that proof-evidence
+/// flags point at the expected artifact family before packet rendering.
 pub fn proof_evidence_kind(raw: &str) -> Result<ProofEvidenceKind> {
     proof_evidence::proof_evidence_kind(raw)
 }

--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -1039,19 +1039,19 @@ pub struct CockpitArgs {
     #[arg(long, value_name = "PATH")]
     pub baseline: Option<std::path::PathBuf>,
 
-    /// Validate a required proof-run summary artifact before rendering.
+    /// Import required proof-run summary evidence into review packets.
     #[arg(long, value_name = "PATH")]
     pub proof_run_summary: Option<std::path::PathBuf>,
 
-    /// Validate a proof-run observation artifact before rendering.
+    /// Import proof-run observation evidence into review packets.
     #[arg(long, value_name = "PATH")]
     pub proof_observation: Option<std::path::PathBuf>,
 
-    /// Validate a proof-executor observation artifact before rendering.
+    /// Import proof-executor observation evidence into review packets.
     #[arg(long, value_name = "PATH")]
     pub executor_observation: Option<std::path::PathBuf>,
 
-    /// Validate a coverage receipt artifact before rendering.
+    /// Import coverage receipt evidence into review packets.
     #[arg(long, value_name = "PATH")]
     pub coverage_receipt: Option<std::path::PathBuf>,
 

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -1268,19 +1268,19 @@ Options:
           When provided, cockpit will compute delta metrics showing how the current state compares to the baseline.
 
       --proof-run-summary <PATH>
-          Validate a required proof-run summary artifact before rendering
+          Import required proof-run summary evidence into review packets
 
       --proof-observation <PATH>
-          Validate a proof-run observation artifact before rendering
+          Import proof-run observation evidence into review packets
 
       --executor-observation <PATH>
-          Validate a proof-executor observation artifact before rendering
+          Import proof-executor observation evidence into review packets
 
       --no-progress
           Disable progress spinners
 
       --coverage-receipt <PATH>
-          Validate a coverage receipt artifact before rendering
+          Import coverage receipt evidence into review packets
 
       --diff-range <DIFF_RANGE>
           Diff range syntax: two-dot (default) or three-dot
@@ -1318,10 +1318,10 @@ Options:
 | `--artifacts-dir <DIR>` | In standard cockpit mode, write `cockpit.json`, `report.json`, and `comment.md` to a directory. | `(none)` |
 | `--review-packet-dir <DIR>` | Write review packet artifacts (`manifest.json`, `cockpit.json`, `evidence.json`, `review-map.json`, `review-map.md`, `comment.md`) to a directory. | `(none)` |
 | `--baseline <PATH>` | Path to baseline receipt for trend comparison. | `(none)` |
-| `--proof-run-summary <PATH>` | Validate a required proof-run summary artifact before rendering. | `(none)` |
-| `--proof-observation <PATH>` | Validate a proof-run observation artifact before rendering. | `(none)` |
-| `--executor-observation <PATH>` | Validate a proof-executor observation artifact before rendering. | `(none)` |
-| `--coverage-receipt <PATH>` | Validate a coverage receipt artifact before rendering. | `(none)` |
+| `--proof-run-summary <PATH>` | Import required proof-run summary evidence into review packets. | `(none)` |
+| `--proof-observation <PATH>` | Import proof-run observation evidence into review packets. | `(none)` |
+| `--executor-observation <PATH>` | Import proof-executor observation evidence into review packets. | `(none)` |
+| `--coverage-receipt <PATH>` | Import coverage receipt evidence into review packets. | `(none)` |
 | `--diff-range <MODE>` | Diff range syntax: `two-dot` or `three-dot`. | `two-dot` |
 | `--sensor-mode` | Run in sensor mode for CI integration (see below). | `false` |
 | `--no-progress` | Disable progress spinners. | `false` |


### PR DESCRIPTION
## Summary
- update cockpit proof-evidence flag help to describe importing evidence into review packets
- refresh docs/reference-cli.md help and option table
- remove stale tokmd-cockpit classifier docs that implied proof inputs never affect packet output

## Validation
- cargo xtask docs --check
- cargo test -p tokmd --test cockpit_integration test_cockpit_help --verbose
- cargo fmt-check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p tokmd --test cli_e2e --verbose
- cargo test -p tokmd --test cli_snapshot_golden --verbose
- cargo test -p tokmd --test config_resolution --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo clippy -p tokmd-cockpit -p tokmd --all-targets -- -D warnings
- git diff origin/main..HEAD --check

No behavior, schema, packet, Action, proof-policy, Codecov, or gate-promotion changes.