### PR TITLE
bolt: optimize path normalization hot-paths ⚡

### DIFF
--- a/.jules/runs/bolt_core_pipeline_refactorer/decision.md
+++ b/.jules/runs/bolt_core_pipeline_refactorer/decision.md
@@ -1,0 +1,17 @@
+## Options Considered
+
+### Option A: String allocation reduction in path normalization (recommended)
+- **What it is:** The path normalizers `tokmd_model::normalize_path` and `tokmd_scan::path::normalize_rel_path` currently perform unnecessary allocations when stripping `./` segments by unconditionally calling `.to_string()` or `.into_owned()` on path slices that haven't structurally mutated (other than being sliced). Option A fixes this by returning the slice converted to a string only when the length actually changes, avoiding allocation for already-normalized paths. It also includes optimizing `is_absolute_pattern` to avoid parsing into a `Path` if string-based checks succeed.
+- **Why it fits:** The `core-pipeline` shard's `tokmd-scan` and `tokmd-model` heavily process files and paths during tree traversal. These normalization functions sit in the hot-path. Benchmarks show a significant performance win by reducing allocations.
+- **Trade-offs:**
+  - Structure: Minor logic adjustments to handle lifetimes and ownership properly.
+  - Velocity: Extremely fast refactor that avoids structural breaks while fixing actual measured hotspots.
+  - Governance: Zero behavior changes. Retains deterministic normalization guarantees.
+
+### Option B: Replace `BTreeMap` with `HashMap` in `tokmd-model` aggregation
+- **What it is:** Swap tree maps for hash maps in `tokmd_model` for aggregation stages.
+- **Why it fits:** Hash maps typically provide better insertion and lookup performance.
+- **Trade-offs:** Breaks determinism and violates the shard's anti-drift constraint to preserve output determinism unless explicitly justified.
+
+## Decision
+I have chosen **Option A**. The benchmark clearly proves that avoiding unconditional string cloning and string ownership parsing in normalization fast paths yields a solid performance win (~10% improvement in `normalize_rel_path` and `is_absolute_pattern`) without altering API semantics or structural outputs.

--- a/.jules/runs/bolt_core_pipeline_refactorer/envelope.json
+++ b/.jules/runs/bolt_core_pipeline_refactorer/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "bolt_core_pipeline_refactorer",
+  "persona": "Bolt ⚡",
+  "style": "Refactorer",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "perf-proof",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/bolt_core_pipeline_refactorer/pr_body.md
+++ b/.jules/runs/bolt_core_pipeline_refactorer/pr_body.md
@@ -1,0 +1,54 @@
+## 💡 Summary
+Optimized hot-path path normalization across `tokmd-scan` and `tokmd-model` to reduce unnecessary string cloning and parsing overhead.
+
+## 🎯 Why
+During path traversal and metric accumulation, path normalization is a very hot execution path. Unconditional string allocation `.into_owned()` and path parsing `Path::new()` add hidden overhead when checking patterns or standardizing relative paths. The refactor avoids this overhead by using string slice offsets and short-circuit byte scans.
+
+## 🔎 Evidence
+Benchmarks show an ~20% improvement in `normalize_path`, ~10% improvement in `normalize_rel_path`, and ~55% improvement in `is_absolute_pattern` checks:
+- `crates/tokmd-scan/src/lib.rs` (`is_absolute_pattern`)
+- `crates/tokmd-scan/src/path/mod.rs` (`normalize_rel_path`)
+- `crates/tokmd-model/src/lib.rs` (`normalize_path`)
+
+## 🧭 Options considered
+### Option A (recommended)
+- **What it is:** The path normalizers `tokmd_model::normalize_path` and `tokmd_scan::path::normalize_rel_path` currently perform unnecessary allocations when stripping `./` segments by unconditionally calling `.to_string()` or `.into_owned()` on path slices that haven't structurally mutated. Option A fixes this by returning the slice converted to a string only when the length actually changes, avoiding allocation for already-normalized paths. It also includes optimizing `is_absolute_pattern` to avoid parsing into a `Path` if string-based checks succeed.
+- **Why it fits:** The `core-pipeline` shard's `tokmd-scan` and `tokmd-model` heavily process files and paths during tree traversal. These normalization functions sit in the hot-path. Benchmarks show a significant performance win by reducing allocations.
+- **Trade-offs:** Structure is slightly more verbose to handle lifetimes, but velocity is preserved, and governance determinism is strictly maintained.
+
+### Option B
+- **What it is:** Swap `BTreeMap` for `HashMap` in `tokmd_model` for aggregation stages.
+- **When to choose it instead:** When insertion/lookup performance is critically bottlenecking and deterministic iteration order is not required.
+- **Trade-offs:** Breaks determinism and violates the shard's anti-drift constraint to preserve output determinism unless explicitly justified.
+
+## ✅ Decision
+I have chosen **Option A**. The benchmark clearly proves that avoiding unconditional string cloning and string ownership parsing in normalization fast paths yields a solid performance win (~10-50% improvements) without altering API semantics or structural outputs.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-scan/src/lib.rs`: Moved `Path::new(pattern).is_absolute()` to the end of the short-circuiting OR expression in `is_absolute_pattern`.
+- `crates/tokmd-scan/src/path/mod.rs`: Optimized string allocation in `normalize_rel_path`.
+- `crates/tokmd-model/src/lib.rs`: Overhauled the prefix-stripping fallback path in `normalize_path` to utilize prefix slice offsetting without allocating intermediate strings or pushing slashes.
+
+## 🧪 Verification receipts
+```text
+{"command": "rustc benches_normalize_path.rs -O && ./benches_normalize_path", "output": "Original: 335.478232ms (len: 35000000)\nOptimized: 267.37771ms (len: 35000000)"}
+{"command": "rustc benches2.rs -O && ./benches2", "output": "Original normalize_rel_path: 165.514888ms (len: 53000000)\nOptimized normalize_rel_path: 148.717563ms (len: 53000000)"}
+{"command": "rustc benches3.rs -O && ./benches3", "output": "Original is_absolute_pattern: 7.712177ms (true: 2000000)\nOptimized is_absolute_pattern: 3.442905ms (true: 2000000)"}
+```
+
+## 🧭 Telemetry
+- Change shape: Internal structural refactoring for path allocations.
+- Blast radius: `tokmd-scan` and `tokmd-model` internals; fully covered by deterministic test suites.
+- Risk class: Low - logic only reduces internal string clones and avoids full object parsing via early-returns. Behavior semantics are identical.
+- Rollback: Revert the PR.
+- Gates run: `cargo test -p tokmd-model -p tokmd-scan`, `perf-proof` custom benches.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/bolt_core_pipeline_refactorer/envelope.json`
+- `.jules/runs/bolt_core_pipeline_refactorer/decision.md`
+- `.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl`
+- `.jules/runs/bolt_core_pipeline_refactorer/result.json`
+- `.jules/runs/bolt_core_pipeline_refactorer/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl
+++ b/.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl
@@ -1,0 +1,3 @@
+{"command": "rustc benches_normalize_path.rs -O && ./benches_normalize_path", "output": "Original: 335.478232ms (len: 35000000)\nOptimized: 267.37771ms (len: 35000000)"}
+{"command": "rustc benches2.rs -O && ./benches2", "output": "Original normalize_rel_path: 165.514888ms (len: 53000000)\nOptimized normalize_rel_path: 148.717563ms (len: 53000000)"}
+{"command": "rustc benches3.rs -O && ./benches3", "output": "Original is_absolute_pattern: 7.712177ms (true: 2000000)\nOptimized is_absolute_pattern: 3.442905ms (true: 2000000)"}

--- a/.jules/runs/bolt_core_pipeline_refactorer/result.json
+++ b/.jules/runs/bolt_core_pipeline_refactorer/result.json
@@ -1,0 +1,9 @@
+{
+  "status": "success",
+  "patch_type": "code",
+  "affected_paths": [
+    "crates/tokmd-scan/src/lib.rs",
+    "crates/tokmd-scan/src/path/mod.rs",
+    "crates/tokmd-model/src/lib.rs"
+  ]
+}

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -810,22 +810,24 @@ pub fn normalize_path(path: &Path, strip_prefix: Option<&Path>) -> String {
             }
         } else {
             // Slow path: avoid string allocation if not replacing
-            let pfx: Cow<str> = if needs_replace {
+            if needs_replace {
                 let mut pfx = p_cow_stripped.replace('\\', "/");
                 if needs_slash {
                     pfx.push('/');
                 }
-                Cow::Owned(pfx)
+                if slice.starts_with(&pfx) {
+                    slice = &slice[pfx.len()..];
+                }
             } else if needs_slash {
-                let mut pfx = p_cow_stripped.into_owned();
-                pfx.push('/');
-                Cow::Owned(pfx)
+                // To avoid allocation here when it doesn't match:
+                // We know it needs a slash. So it must match p_cow_stripped + '/'
+                if slice.starts_with(p_cow_stripped.as_ref()) && slice[p_cow_stripped.len()..].starts_with('/') {
+                    slice = &slice[p_cow_stripped.len() + 1..];
+                }
             } else {
-                p_cow_stripped.clone()
-            };
-
-            if slice.starts_with(pfx.as_ref()) {
-                slice = &slice[pfx.len()..];
+                if slice.starts_with(p_cow_stripped.as_ref()) {
+                    slice = &slice[p_cow_stripped.len()..];
+                }
             }
         }
     }

--- a/crates/tokmd-scan/src/lib.rs
+++ b/crates/tokmd-scan/src/lib.rs
@@ -259,11 +259,10 @@ fn ignored_patterns(args: &ScanOptions, roots: &[ValidatedRoot]) -> Vec<String> 
 }
 
 fn is_absolute_pattern(pattern: &str) -> bool {
-    let path = Path::new(pattern);
-    path.is_absolute()
-        || pattern.starts_with('/')
+    pattern.starts_with('/')
         || pattern.starts_with('\\')
         || pattern.as_bytes().get(1).is_some_and(|byte| *byte == b':')
+        || Path::new(pattern).is_absolute()
 }
 
 fn normalize_relative_ignore_pattern(pattern: &str) -> String {

--- a/crates/tokmd-scan/src/path/mod.rs
+++ b/crates/tokmd-scan/src/path/mod.rs
@@ -83,7 +83,11 @@ pub fn normalize_rel_path(path: &str) -> String {
     while let Some(rest) = s.strip_prefix("./") {
         s = rest;
     }
-    s.to_string()
+    if s.len() == normalized.len() {
+        normalized.into_owned()
+    } else {
+        s.to_string()
+    }
 }
 
 /// Normalize a root-relative path and reject traversal or absolute inputs.


### PR DESCRIPTION
## 💡 Summary
Optimized hot-path path normalization across `tokmd-scan` and `tokmd-model` to reduce unnecessary string cloning and parsing overhead.

## 🎯 Why
During path traversal and metric accumulation, path normalization is a very hot execution path. Unconditional string allocation `.into_owned()` and path parsing `Path::new()` add hidden overhead when checking patterns or standardizing relative paths. The refactor avoids this overhead by using string slice offsets and short-circuit byte scans.

## 🔎 Evidence
Benchmarks show an ~20% improvement in `normalize_path`, ~10% improvement in `normalize_rel_path`, and ~55% improvement in `is_absolute_pattern` checks:
- `crates/tokmd-scan/src/lib.rs` (`is_absolute_pattern`)
- `crates/tokmd-scan/src/path/mod.rs` (`normalize_rel_path`)
- `crates/tokmd-model/src/lib.rs` (`normalize_path`)

## 🧭 Options considered
### Option A (recommended)
- **What it is:** The path normalizers `tokmd_model::normalize_path` and `tokmd_scan::path::normalize_rel_path` currently perform unnecessary allocations when stripping `./` segments by unconditionally calling `.to_string()` or `.into_owned()` on path slices that haven't structurally mutated. Option A fixes this by returning the slice converted to a string only when the length actually changes, avoiding allocation for already-normalized paths. It also includes optimizing `is_absolute_pattern` to avoid parsing into a `Path` if string-based checks succeed.
- **Why it fits:** The `core-pipeline` shard's `tokmd-scan` and `tokmd-model` heavily process files and paths during tree traversal. These normalization functions sit in the hot-path. Benchmarks show a significant performance win by reducing allocations.
- **Trade-offs:** Structure is slightly more verbose to handle lifetimes, but velocity is preserved, and governance determinism is strictly maintained.

### Option B
- **What it is:** Swap `BTreeMap` for `HashMap` in `tokmd_model` for aggregation stages.
- **When to choose it instead:** When insertion/lookup performance is critically bottlenecking and deterministic iteration order is not required.
- **Trade-offs:** Breaks determinism and violates the shard's anti-drift constraint to preserve output determinism unless explicitly justified.

## ✅ Decision
I have chosen **Option A**. The benchmark clearly proves that avoiding unconditional string cloning and string ownership parsing in normalization fast paths yields a solid performance win (~10-50% improvements) without altering API semantics or structural outputs.

## 🧱 Changes made (SRP)
- `crates/tokmd-scan/src/lib.rs`: Moved `Path::new(pattern).is_absolute()` to the end of the short-circuiting OR expression in `is_absolute_pattern`.
- `crates/tokmd-scan/src/path/mod.rs`: Optimized string allocation in `normalize_rel_path`.
- `crates/tokmd-model/src/lib.rs`: Overhauled the prefix-stripping fallback path in `normalize_path` to utilize prefix slice offsetting without allocating intermediate strings or pushing slashes.

## 🧪 Verification receipts
```text
{"command": "rustc benches_normalize_path.rs -O && ./benches_normalize_path", "output": "Original: 335.478232ms (len: 35000000)\nOptimized: 267.37771ms (len: 35000000)"}
{"command": "rustc benches2.rs -O && ./benches2", "output": "Original normalize_rel_path: 165.514888ms (len: 53000000)\nOptimized normalize_rel_path: 148.717563ms (len: 53000000)"}
{"command": "rustc benches3.rs -O && ./benches3", "output": "Original is_absolute_pattern: 7.712177ms (true: 2000000)\nOptimized is_absolute_pattern: 3.442905ms (true: 2000000)"}
```

## 🧭 Telemetry
- Change shape: Internal structural refactoring for path allocations.
- Blast radius: `tokmd-scan` and `tokmd-model` internals; fully covered by deterministic test suites.
- Risk class: Low - logic only reduces internal string clones and avoids full object parsing via early-returns. Behavior semantics are identical.
- Rollback: Revert the PR.
- Gates run: `cargo test -p tokmd-model -p tokmd-scan`, `perf-proof` custom benches.

## 🗂️ .jules artifacts
- `.jules/runs/bolt_core_pipeline_refactorer/envelope.json`
- `.jules/runs/bolt_core_pipeline_refactorer/decision.md`
- `.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl`
- `.jules/runs/bolt_core_pipeline_refactorer/result.json`
- `.jules/runs/bolt_core_pipeline_refactorer/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [17763201603792274405](https://jules.google.com/task/17763201603792274405) started by @EffortlessSteven*