### PR TITLE
refactor(format): extract markdown imports renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -24,6 +24,7 @@ mod complexity;
 mod duplicates;
 mod effort;
 mod git;
+mod imports;
 
 /// Render an [`AnalysisReceipt`] to a Markdown string.
 ///
@@ -449,16 +450,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(imports) = &receipt.imports {
-        out.push_str("## Imports\n\n");
-        let _ = writeln!(out, "- Granularity: `{}`\n", imports.granularity);
-        if !imports.edges.is_empty() {
-            out.push_str("|From|To|Count|\n");
-            out.push_str("|---|---|---:|\n");
-            for row in imports.edges.iter().take(20) {
-                let _ = writeln!(out, "|{}|{}|{}|", row.from, row.to, row.count);
-            }
-            out.push('\n');
-        }
+        imports::render_import_report(&mut out, imports);
     }
 
     if let Some(dup) = &receipt.dup {

--- a/crates/tokmd-format/src/analysis/markdown/imports.rs
+++ b/crates/tokmd-format/src/analysis/markdown/imports.rs
@@ -1,0 +1,21 @@
+//! Import graph Markdown rendering.
+//!
+//! This module owns the imports section and its truncated edge table for
+//! analysis Markdown output.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::ImportReport;
+
+pub(super) fn render_import_report(out: &mut String, imports: &ImportReport) {
+    out.push_str("## Imports\n\n");
+    let _ = writeln!(out, "- Granularity: `{}`\n", imports.granularity);
+    if !imports.edges.is_empty() {
+        out.push_str("|From|To|Count|\n");
+        out.push_str("|---|---|---:|\n");
+        for row in imports.edges.iter().take(20) {
+            let _ = writeln!(out, "|{}|{}|{}|", row.from, row.to, row.count);
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown imports rendering into nalysis/markdown/imports.rs
- leave ender_md as the coordinator that delegates to the owner module
- preserve Markdown output, schemas, and CLI behavior

## Validation
- cargo test -p tokmd-format --test analysis_format md_renders_imports_section --verbose
- cargo test -p tokmd-format --test analysis_format md_imports_section --verbose
- cargo test -p tokmd-format --test analysis_format --verbose
- cargo test -p tokmd-format --test analysis_html --verbose
- cargo clippy -p tokmd-format --all-targets -- -D warnings
- cargo fmt-check
- cargo xtask proof-policy --check
- cargo xtask docs --check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan