### PR TITLE
refactor(format): extract markdown assets renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -20,6 +20,7 @@ use std::fmt::Write;
 use tokmd_analysis_types::{AnalysisReceipt, FileStatRow};
 
 mod api_surface;
+mod assets;
 mod complexity;
 mod duplicates;
 mod effort;
@@ -401,35 +402,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(assets) = &receipt.assets {
-        out.push_str("## Assets\n\n");
-        let _ = writeln!(
-            out,
-            "- Total files: `{}`\n- Total bytes: `{}`\n",
-            assets.total_files, assets.total_bytes
-        );
-        if !assets.categories.is_empty() {
-            out.push_str("|Category|Files|Bytes|Extensions|\n");
-            out.push_str("|---|---:|---:|---|\n");
-            for row in &assets.categories {
-                let _ = writeln!(
-                    out,
-                    "|{}|{}|{}|{}|",
-                    row.category,
-                    row.files,
-                    row.bytes,
-                    row.extensions.join(", ")
-                );
-            }
-            out.push('\n');
-        }
-        if !assets.top_files.is_empty() {
-            out.push_str("|File|Bytes|Category|\n");
-            out.push_str("|---|---:|---|\n");
-            for row in &assets.top_files {
-                let _ = writeln!(out, "|{}|{}|{}|", row.path, row.bytes, row.category);
-            }
-            out.push('\n');
-        }
+        assets::render_asset_report(&mut out, assets);
     }
 
     if let Some(deps) = &receipt.deps {

--- a/crates/tokmd-format/src/analysis/markdown/assets.rs
+++ b/crates/tokmd-format/src/analysis/markdown/assets.rs
@@ -1,0 +1,40 @@
+//! Asset Markdown rendering.
+//!
+//! This module owns the asset totals, category breakdown, and top-file tables
+//! for analysis Markdown output.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::AssetReport;
+
+pub(super) fn render_asset_report(out: &mut String, assets: &AssetReport) {
+    out.push_str("## Assets\n\n");
+    let _ = writeln!(
+        out,
+        "- Total files: `{}`\n- Total bytes: `{}`\n",
+        assets.total_files, assets.total_bytes
+    );
+    if !assets.categories.is_empty() {
+        out.push_str("|Category|Files|Bytes|Extensions|\n");
+        out.push_str("|---|---:|---:|---|\n");
+        for row in &assets.categories {
+            let _ = writeln!(
+                out,
+                "|{}|{}|{}|{}|",
+                row.category,
+                row.files,
+                row.bytes,
+                row.extensions.join(", ")
+            );
+        }
+        out.push('\n');
+    }
+    if !assets.top_files.is_empty() {
+        out.push_str("|File|Bytes|Category|\n");
+        out.push_str("|---|---:|---|\n");
+        for row in &assets.top_files {
+            let _ = writeln!(out, "|{}|{}|{}|", row.path, row.bytes, row.category);
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown assets rendering into `analysis/markdown/assets.rs`
- leave `render_md` as the coordinator that delegates to the owner module
- preserve Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format --test analysis_format md_renders_assets_section --verbose`
- `cargo test -p tokmd-format --test analysis_format md_contains_assets_section --verbose`
- `cargo test -p tokmd-format --test analysis_format md_assets_after_derived_integrity --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`