### PR TITLE
refactor(format): extract markdown dependencies renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -22,6 +22,7 @@ use tokmd_analysis_types::{AnalysisReceipt, FileStatRow};
 mod api_surface;
 mod assets;
 mod complexity;
+mod dependencies;
 mod duplicates;
 mod effort;
 mod git;
@@ -406,16 +407,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(deps) = &receipt.deps {
-        out.push_str("## Dependencies\n\n");
-        let _ = writeln!(out, "- Total: `{}`\n", deps.total);
-        if !deps.lockfiles.is_empty() {
-            out.push_str("|Lockfile|Kind|Dependencies|\n");
-            out.push_str("|---|---|---:|\n");
-            for row in &deps.lockfiles {
-                let _ = writeln!(out, "|{}|{}|{}|", row.path, row.kind, row.dependencies);
-            }
-            out.push('\n');
-        }
+        dependencies::render_dependency_report(&mut out, deps);
     }
 
     if let Some(git) = &receipt.git {

--- a/crates/tokmd-format/src/analysis/markdown/dependencies.rs
+++ b/crates/tokmd-format/src/analysis/markdown/dependencies.rs
@@ -1,0 +1,21 @@
+//! Dependency Markdown rendering.
+//!
+//! This module owns dependency totals and lockfile rows for analysis Markdown
+//! output.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DependencyReport;
+
+pub(super) fn render_dependency_report(out: &mut String, deps: &DependencyReport) {
+    out.push_str("## Dependencies\n\n");
+    let _ = writeln!(out, "- Total: `{}`\n", deps.total);
+    if !deps.lockfiles.is_empty() {
+        out.push_str("|Lockfile|Kind|Dependencies|\n");
+        out.push_str("|---|---|---:|\n");
+        for row in &deps.lockfiles {
+            let _ = writeln!(out, "|{}|{}|{}|", row.path, row.kind, row.dependencies);
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown dependency rendering into `analysis/markdown/dependencies.rs`
- keep `render_md` as the section coordinator
- preserve Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format --test analysis_format md_renders_deps_section --verbose`
- `cargo test -p tokmd-format --test analysis_format md_contains_deps_section --verbose`
- `cargo test -p tokmd-format --test analysis_format md_no_deps_section --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`