### PR TITLE
refactor(format): extract markdown entropy renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -25,6 +25,7 @@ mod complexity;
 mod dependencies;
 mod duplicates;
 mod effort;
+mod entropy;
 mod git;
 mod imports;
 
@@ -83,25 +84,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(entropy) = &receipt.entropy {
-        out.push_str("## Entropy profiling\n\n");
-        if entropy.suspects.is_empty() {
-            out.push_str("- No entropy outliers detected.\n\n");
-        } else {
-            out.push_str("|Path|Module|Entropy|Sample bytes|Class|\n");
-            out.push_str("|---|---|---:|---:|---|\n");
-            for row in entropy.suspects.iter().take(10) {
-                let _ = writeln!(
-                    out,
-                    "|{}|{}|{}|{}|{:?}|",
-                    row.path,
-                    row.module,
-                    fmt_f64(row.entropy_bits_per_byte as f64, 2),
-                    row.sample_bytes,
-                    row.class
-                );
-            }
-            out.push('\n');
-        }
+        entropy::render_entropy_report(&mut out, entropy);
     }
 
     if let Some(license) = &receipt.license {

--- a/crates/tokmd-format/src/analysis/markdown/entropy.rs
+++ b/crates/tokmd-format/src/analysis/markdown/entropy.rs
@@ -1,0 +1,30 @@
+//! Entropy Markdown rendering.
+//!
+//! This module owns entropy outlier table rendering for analysis Markdown output.
+
+use std::fmt::Write;
+
+use super::fmt_f64;
+use tokmd_analysis_types::EntropyReport;
+
+pub(super) fn render_entropy_report(out: &mut String, entropy: &EntropyReport) {
+    out.push_str("## Entropy profiling\n\n");
+    if entropy.suspects.is_empty() {
+        out.push_str("- No entropy outliers detected.\n\n");
+    } else {
+        out.push_str("|Path|Module|Entropy|Sample bytes|Class|\n");
+        out.push_str("|---|---|---:|---:|---|\n");
+        for row in entropy.suspects.iter().take(10) {
+            let _ = writeln!(
+                out,
+                "|{}|{}|{}|{}|{:?}|",
+                row.path,
+                row.module,
+                fmt_f64(row.entropy_bits_per_byte as f64, 2),
+                row.sample_bytes,
+                row.class
+            );
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown entropy rendering into `analysis/markdown/entropy.rs`
- keep `render_md` as the section coordinator
- preserve Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format --test analysis_format md_renders_entropy_section_with_suspects --verbose`
- `cargo test -p tokmd-format --test analysis_format md_renders_entropy_section_no_suspects --verbose`
- `cargo test -p tokmd-format --test analysis_format md_large_entropy_truncates_to_ten --verbose`
- `cargo test -p tokmd-format --test analysis_format md_contains_entropy_section --verbose`
- `cargo test -p tokmd-format --test analysis_format md_no_entropy_section --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`