### PR TITLE
refactor(format): extract markdown license renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -28,6 +28,7 @@ mod effort;
 mod entropy;
 mod git;
 mod imports;
+mod license;
 
 /// Render an [`AnalysisReceipt`] to a Markdown string.
 ///
@@ -88,26 +89,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(license) = &receipt.license {
-        out.push_str("## License radar\n\n");
-        if let Some(effective) = &license.effective {
-            let _ = writeln!(out, "- Effective: `{}`", effective);
-        }
-        out.push_str("- Heuristic detection; not legal advice.\n\n");
-        if !license.findings.is_empty() {
-            out.push_str("|SPDX|Confidence|Source|Kind|\n");
-            out.push_str("|---|---:|---|---|\n");
-            for row in license.findings.iter().take(10) {
-                let _ = writeln!(
-                    out,
-                    "|{}|{}|{}|{:?}|",
-                    row.spdx,
-                    fmt_f64(row.confidence as f64, 2),
-                    row.source_path,
-                    row.source_kind
-                );
-            }
-            out.push('\n');
-        }
+        license::render_license_report(&mut out, license);
     }
 
     if let Some(fingerprint) = &receipt.corporate_fingerprint {

--- a/crates/tokmd-format/src/analysis/markdown/license.rs
+++ b/crates/tokmd-format/src/analysis/markdown/license.rs
@@ -1,0 +1,32 @@
+//! License Markdown rendering.
+//!
+//! This module owns license radar summary and finding table rendering for
+//! analysis Markdown output.
+
+use std::fmt::Write;
+
+use super::fmt_f64;
+use tokmd_analysis_types::LicenseReport;
+
+pub(super) fn render_license_report(out: &mut String, license: &LicenseReport) {
+    out.push_str("## License radar\n\n");
+    if let Some(effective) = &license.effective {
+        let _ = writeln!(out, "- Effective: `{}`", effective);
+    }
+    out.push_str("- Heuristic detection; not legal advice.\n\n");
+    if !license.findings.is_empty() {
+        out.push_str("|SPDX|Confidence|Source|Kind|\n");
+        out.push_str("|---|---:|---|---|\n");
+        for row in license.findings.iter().take(10) {
+            let _ = writeln!(
+                out,
+                "|{}|{}|{}|{:?}|",
+                row.spdx,
+                fmt_f64(row.confidence as f64, 2),
+                row.source_path,
+                row.source_kind
+            );
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown license radar rendering into `analysis/markdown/license.rs`
- keep `render_md` as the section coordinator
- preserve Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format --test analysis_format md_renders_license_section --verbose`
- `cargo test -p tokmd-format --test analysis_format md_contains_license_section --verbose`
- `cargo test -p tokmd-format --test analysis_format md_license_multiple_findings --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`