### PR TITLE
refactor(format): extract markdown corporate fingerprint renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -22,6 +22,7 @@ use tokmd_analysis_types::{AnalysisReceipt, FileStatRow};
 mod api_surface;
 mod assets;
 mod complexity;
+mod corporate_fingerprint;
 mod dependencies;
 mod duplicates;
 mod effort;
@@ -93,23 +94,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(fingerprint) = &receipt.corporate_fingerprint {
-        out.push_str("## Corporate fingerprint\n\n");
-        if fingerprint.domains.is_empty() {
-            out.push_str("- No commit domains detected.\n\n");
-        } else {
-            out.push_str("|Domain|Commits|Pct|\n");
-            out.push_str("|---|---:|---:|\n");
-            for row in fingerprint.domains.iter().take(10) {
-                let _ = writeln!(
-                    out,
-                    "|{}|{}|{}|",
-                    row.domain,
-                    row.commits,
-                    fmt_pct(row.pct as f64)
-                );
-            }
-            out.push('\n');
-        }
+        corporate_fingerprint::render_corporate_fingerprint(&mut out, fingerprint);
     }
 
     if let Some(churn) = &receipt.predictive_churn {

--- a/crates/tokmd-format/src/analysis/markdown/corporate_fingerprint.rs
+++ b/crates/tokmd-format/src/analysis/markdown/corporate_fingerprint.rs
@@ -1,0 +1,28 @@
+//! Corporate fingerprint Markdown rendering.
+//!
+//! This module owns commit-domain summary rendering for analysis Markdown output.
+
+use std::fmt::Write;
+
+use super::fmt_pct;
+use tokmd_analysis_types::CorporateFingerprint;
+
+pub(super) fn render_corporate_fingerprint(out: &mut String, fingerprint: &CorporateFingerprint) {
+    out.push_str("## Corporate fingerprint\n\n");
+    if fingerprint.domains.is_empty() {
+        out.push_str("- No commit domains detected.\n\n");
+    } else {
+        out.push_str("|Domain|Commits|Pct|\n");
+        out.push_str("|---|---:|---:|\n");
+        for row in fingerprint.domains.iter().take(10) {
+            let _ = writeln!(
+                out,
+                "|{}|{}|{}|",
+                row.domain,
+                row.commits,
+                fmt_pct(row.pct as f64)
+            );
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown corporate fingerprint rendering into `analysis/markdown/corporate_fingerprint.rs`
- keep `render_md` as the section coordinator
- preserve Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format --test analysis_format md_renders_corporate_fingerprint --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`