### PR TITLE
refactor(format): extract markdown predictive churn renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -30,6 +30,7 @@ mod entropy;
 mod git;
 mod imports;
 mod license;
+mod predictive_churn;
 
 /// Render an [`AnalysisReceipt`] to a Markdown string.
 ///
@@ -98,32 +99,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(churn) = &receipt.predictive_churn {
-        out.push_str("## Predictive churn\n\n");
-        let mut rows: Vec<_> = churn.per_module.iter().collect();
-        rows.sort_by(|a, b| {
-            b.1.slope
-                .partial_cmp(&a.1.slope)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| a.0.cmp(b.0))
-        });
-        if rows.is_empty() {
-            out.push_str("- No churn signals detected.\n\n");
-        } else {
-            out.push_str("|Module|Slope|R²|Recent change|Class|\n");
-            out.push_str("|---|---:|---:|---:|---|\n");
-            for (module, trend) in rows.into_iter().take(10) {
-                let _ = writeln!(
-                    out,
-                    "|{}|{}|{}|{}|{:?}|",
-                    module,
-                    fmt_f64(trend.slope, 4),
-                    fmt_f64(trend.r2, 2),
-                    trend.recent_change,
-                    trend.classification
-                );
-            }
-            out.push('\n');
-        }
+        predictive_churn::render_predictive_churn(&mut out, churn);
     }
 
     if let Some(derived) = &receipt.derived {

--- a/crates/tokmd-format/src/analysis/markdown/predictive_churn.rs
+++ b/crates/tokmd-format/src/analysis/markdown/predictive_churn.rs
@@ -1,0 +1,37 @@
+//! Predictive churn Markdown rendering.
+//!
+//! This module owns predictive churn table ordering and empty-state rendering.
+
+use std::fmt::Write;
+
+use super::fmt_f64;
+use tokmd_analysis_types::PredictiveChurnReport;
+
+pub(super) fn render_predictive_churn(out: &mut String, churn: &PredictiveChurnReport) {
+    out.push_str("## Predictive churn\n\n");
+    let mut rows: Vec<_> = churn.per_module.iter().collect();
+    rows.sort_by(|a, b| {
+        b.1.slope
+            .partial_cmp(&a.1.slope)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(b.0))
+    });
+    if rows.is_empty() {
+        out.push_str("- No churn signals detected.\n\n");
+    } else {
+        out.push_str("|Module|Slope|R²|Recent change|Class|\n");
+        out.push_str("|---|---:|---:|---:|---|\n");
+        for (module, trend) in rows.into_iter().take(10) {
+            let _ = writeln!(
+                out,
+                "|{}|{}|{}|{}|{:?}|",
+                module,
+                fmt_f64(trend.slope, 4),
+                fmt_f64(trend.r2, 2),
+                trend.recent_change,
+                trend.classification
+            );
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown predictive churn rendering into `analysis/markdown/predictive_churn.rs`
- keep `render_md` as the section coordinator
- preserve predictive churn ordering, empty-state text, Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format md_renders_predictive_churn --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`