### PR TITLE
refactor(format): extract markdown eco label renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -25,6 +25,7 @@ mod complexity;
 mod corporate_fingerprint;
 mod dependencies;
 mod duplicates;
+mod eco_label;
 mod effort;
 mod entropy;
 mod git;
@@ -359,15 +360,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     if let Some(fun) = &receipt.fun
         && let Some(label) = &fun.eco_label
     {
-        out.push_str("## Eco label\n\n");
-        let _ = writeln!(
-            out,
-            "- Label: `{}`\n- Score: `{}`\n- Bytes: `{}`\n- Notes: `{}`\n",
-            label.label,
-            fmt_f64(label.score, 1),
-            label.bytes,
-            label.notes
-        );
+        eco_label::render_eco_label(&mut out, label);
     }
 
     out

--- a/crates/tokmd-format/src/analysis/markdown/eco_label.rs
+++ b/crates/tokmd-format/src/analysis/markdown/eco_label.rs
@@ -1,0 +1,20 @@
+//! Eco label Markdown rendering.
+//!
+//! This module owns the optional fun eco-label section for analysis Markdown.
+
+use std::fmt::Write;
+
+use super::fmt_f64;
+use tokmd_analysis_types::EcoLabel;
+
+pub(super) fn render_eco_label(out: &mut String, label: &EcoLabel) {
+    out.push_str("## Eco label\n\n");
+    let _ = writeln!(
+        out,
+        "- Label: `{}`\n- Score: `{}`\n- Bytes: `{}`\n- Notes: `{}`\n",
+        label.label,
+        fmt_f64(label.score, 1),
+        label.bytes,
+        label.notes
+    );
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown eco-label rendering into `analysis/markdown/eco_label.rs`
- keep `render_md` as the section coordinator
- preserve eco-label Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format md_renders_eco_label --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`