### PR TITLE
refactor(format): extract markdown topics renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -32,6 +32,7 @@ mod git;
 mod imports;
 mod license;
 mod predictive_churn;
+mod topics;
 
 /// Render an [`AnalysisReceipt`] to a Markdown string.
 ///
@@ -60,31 +61,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(topics) = &receipt.topics {
-        out.push_str("## Topics\n\n");
-        if !topics.overall.is_empty() {
-            let _ = writeln!(
-                out,
-                "- Overall: `{}`",
-                topics
-                    .overall
-                    .iter()
-                    .map(|t| t.term.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-        }
-        for (module, terms) in &topics.per_module {
-            if terms.is_empty() {
-                continue;
-            }
-            let line = terms
-                .iter()
-                .map(|t| t.term.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let _ = writeln!(out, "- `{}`: {}", module, line);
-        }
-        out.push('\n');
+        topics::render_topic_clouds(&mut out, topics);
     }
 
     if let Some(entropy) = &receipt.entropy {

--- a/crates/tokmd-format/src/analysis/markdown/topics.rs
+++ b/crates/tokmd-format/src/analysis/markdown/topics.rs
@@ -1,0 +1,35 @@
+//! Topic cloud Markdown rendering.
+//!
+//! This module owns overall and per-module topic list rendering.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::TopicClouds;
+
+pub(super) fn render_topic_clouds(out: &mut String, topics: &TopicClouds) {
+    out.push_str("## Topics\n\n");
+    if !topics.overall.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Overall: `{}`",
+            topics
+                .overall
+                .iter()
+                .map(|t| t.term.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    for (module, terms) in &topics.per_module {
+        if terms.is_empty() {
+            continue;
+        }
+        let line = terms
+            .iter()
+            .map(|t| t.term.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(out, "- `{}`: {}", module, line);
+    }
+    out.push('\n');
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown topic-cloud rendering into `analysis/markdown/topics.rs`
- keep `render_md` as the section coordinator
- preserve topic Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format md_renders_topics_section --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`