### PR TITLE
refactor(format): extract markdown inputs renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -30,6 +30,7 @@ mod effort;
 mod entropy;
 mod git;
 mod imports;
+mod inputs;
 mod license;
 mod predictive_churn;
 mod topics;
@@ -44,11 +45,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     let _ = writeln!(out, "Preset: `{}`\n", receipt.args.preset);
 
     if !receipt.source.inputs.is_empty() {
-        out.push_str("## Inputs\n\n");
-        for input in &receipt.source.inputs {
-            let _ = writeln!(out, "- `{}`", input);
-        }
-        out.push('\n');
+        inputs::render_inputs(&mut out, &receipt.source.inputs);
     }
 
     if let Some(archetype) = &receipt.archetype {

--- a/crates/tokmd-format/src/analysis/markdown/inputs.rs
+++ b/crates/tokmd-format/src/analysis/markdown/inputs.rs
@@ -1,0 +1,13 @@
+//! Analysis input Markdown rendering.
+//!
+//! This module owns the caller-provided analysis input list section.
+
+use std::fmt::Write;
+
+pub(super) fn render_inputs(out: &mut String, inputs: &[String]) {
+    out.push_str("## Inputs\n\n");
+    for input in inputs {
+        let _ = writeln!(out, "- `{}`", input);
+    }
+    out.push('\n');
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown input-list rendering into `analysis/markdown/inputs.rs`
- keep `render_md` as the section coordinator
- preserve input Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format md_multiple_inputs_listed --verbose`
- `cargo test -p tokmd-format md_no_inputs_skips_section --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`