### PR TITLE
refactor(format): extract markdown archetype renderer

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown.rs
+++ b/crates/tokmd-format/src/analysis/markdown.rs
@@ -20,6 +20,7 @@ use std::fmt::Write;
 use tokmd_analysis_types::{AnalysisReceipt, FileStatRow};
 
 mod api_surface;
+mod archetype;
 mod assets;
 mod complexity;
 mod corporate_fingerprint;
@@ -49,12 +50,7 @@ pub fn render_md(receipt: &AnalysisReceipt) -> String {
     }
 
     if let Some(archetype) = &receipt.archetype {
-        out.push_str("## Archetype\n\n");
-        let _ = writeln!(out, "- Kind: `{}`", archetype.kind);
-        if !archetype.evidence.is_empty() {
-            let _ = writeln!(out, "- Evidence: `{}`", archetype.evidence.join("`, `"));
-        }
-        out.push('\n');
+        archetype::render_archetype(&mut out, archetype);
     }
 
     if let Some(topics) = &receipt.topics {

--- a/crates/tokmd-format/src/analysis/markdown/archetype.rs
+++ b/crates/tokmd-format/src/analysis/markdown/archetype.rs
@@ -1,0 +1,16 @@
+//! Archetype Markdown rendering.
+//!
+//! This module owns the optional project archetype classification section.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::Archetype;
+
+pub(super) fn render_archetype(out: &mut String, archetype: &Archetype) {
+    out.push_str("## Archetype\n\n");
+    let _ = writeln!(out, "- Kind: `{}`", archetype.kind);
+    if !archetype.evidence.is_empty() {
+        let _ = writeln!(out, "- Evidence: `{}`", archetype.evidence.join("`, `"));
+    }
+    out.push('\n');
+}


### PR DESCRIPTION
## Summary
- move analysis Markdown archetype rendering into `analysis/markdown/archetype.rs`
- keep `render_md` as the section coordinator
- preserve archetype Markdown output, schemas, and CLI behavior

## Validation
- `cargo test -p tokmd-format md_renders_archetype_section --verbose`
- `cargo test -p tokmd-format --test analysis_format --verbose`
- `cargo test -p tokmd-format --test analysis_html --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`