### PR TITLE
chore(ci): sync lane whitelist with current jobs

### DIFF
--- a/docs/ci/default-pr-gate.md
+++ b/docs/ci/default-pr-gate.md
@@ -33,29 +33,37 @@ green `CI (Required)` row provided the lanes that *did* run all passed.
 
 ## Default-PR LEM after the slimming
 
-Roughly (per PR 02's `inventory.md`, with cache normalised in PR 09):
+Roughly (per `docs/ci/inventory.md`, with advisory proof/cockpit lanes now
+included in the inventory):
 
 ```text
 msrv_check                   5
 quality_gate                 8
 proof_policy                 3
 affected_proof_plan          4
+ci_detect_risk_packs         1
+fast_proof_run_advisory      5
 feature_boundaries          10
 typos                        1
 cargo_deny                   4
 version_consistency          2
 docs_check                   4
-build (Linux only)          12   (matrix Linux entry)
+build_test_linux            12
 publish_surface              8
+ci_lane_whitelist            3
+pr_cockpit_report            3
+no_panic_family              3
+pr_plan_advisory             1
+ripr_advisory                2
+scoped_coverage_executor_non_required 12
 ci_required                  1
                           ----
-                            62   default PR (was ~203)
+                            92   default PR (was ~203)
 ```
 
-PR 11 will add a `ripr` advisory at ~2 LEM in place of the demoted
-mutation lane, leaving the default ordinary PR around 64 LEM — within
-the `elevated` band on first roll-out, with PR 12's risk-pack routing
-designed to bring this further down for narrow PRs.
+That remains below the hard override ceiling, but it is intentionally reported
+as high-cost while the advisory proof executor and proof-run observation lanes
+collect real timing evidence.
 
 ## Anti-patterns
 

--- a/docs/ci/inventory.md
+++ b/docs/ci/inventory.md
@@ -1,6 +1,6 @@
 # tokmd CI inventory snapshot
 
-Snapshot of CI lanes as of 2026-05-07. Generated as the human-readable
+Snapshot of CI lanes as of 2026-05-09. Generated as the human-readable
 companion to `policy/ci-lane-whitelist.toml`. Update on rollout PRs.
 
 ## Frontdoor (cheap default)
@@ -11,23 +11,33 @@ companion to `policy/ci-lane-whitelist.toml`. Update on rollout PRs.
 | `quality_gate` | Quality Gate | ubuntu | 8 | `cargo xtask gate --check`. |
 | `proof_policy` | Proof Policy | ubuntu | 3 | `cargo xtask proof-policy --check`. |
 | `affected_proof_plan` | Affected Proof Plan | ubuntu | 4 | Wrapped by PR 08 PR Plan. |
+| `ci_detect_risk_packs` | Detect risk packs | ubuntu | 1 | Workflow path classifier. |
+| `fast_proof_run_advisory` | Fast Proof Run (Advisory) | ubuntu | 5 | Advisory fast proof observation. |
 | `feature_boundaries` | Feature Boundaries | ubuntu | 10 | Analysis feature/module boundaries. |
 | `typos` | Typos | ubuntu | 1 | crate-ci/typos. |
 | `cargo_deny` | Cargo Deny | ubuntu | 4 | Advisories + licenses. |
 | `version_consistency` | Version consistency | ubuntu | 2 | Release metadata alignment. |
 | `docs_check` | Docs Check | ubuntu | 4 | `cargo xtask docs --check`. |
+| `build_test_linux` | Build & Test (Linux) | ubuntu | 12 | Linux all-features tests. |
+| `publish_surface` | Publish Surface | ubuntu | 8 | Publish-surface dry-run checks. |
+| `ci_lane_whitelist` | CI Lane Whitelist | ubuntu | 3 | Advisory CI policy inventory. |
+| `pr_cockpit_report` | PR Cockpit Report | ubuntu | 3 | PR cockpit metrics report. |
+| `no_panic_family` | No-panic Family | ubuntu | 3 | Panic-family policy checker. |
+| `pr_plan_advisory` | PR Plan (advisory) | ubuntu | 1 | LEM-aware PR plan. |
+| `ripr_advisory` | ripr (advisory) | ubuntu | 2 | Static oracle-gap signal. |
+| `scoped_coverage_executor_non_required` | Scoped Coverage Executor (Non-Required) | ubuntu | 12 | Advisory proof executor. |
 | `ci_required` | CI (Required) | ubuntu | 1 | Aggregator. |
 
-## Expensive default — needs exception during rollout
+## Risk-gated / expensive lanes
 
-| Lane ID | Job | Runner | Base LEM | Exception |
-|---------|-----|--------|----------|-----------|
-| `build_test_linux_windows` | Build & Test | mixed | 40 | `ci_exception_windows_full_test_default` |
-| `wasm_compile_test` | Wasm Compile & Test | ubuntu | 25 | `ci_exception_wasm_default` |
-| `nix_pr_package_gate` | Nix PR Package Gate | ubuntu | 35 | `ci_exception_nix_default` |
-| `mutation_required` | Mutation Testing (Required) | ubuntu | 45 | `ci_exception_mutation_default` |
-| `proptest_smoke` | Proptest Smoke | ubuntu | 8 | (no exception; fits frontdoor band) |
-| `publish_surface` | Publish Surface | ubuntu | 8 | (no exception; cheap dry-run) |
+| Lane ID | Job | Runner | Base LEM | Trigger |
+|---------|-----|--------|----------|---------|
+| `build_test_windows` | Build & Test (Windows) | Windows | 20 | push, `windows`, `full-ci`, or Windows path risk. |
+| `wasm_compile_test` | Wasm Compile & Test | ubuntu | 25 | push, `wasm`, `full-ci`, or WASM path risk. |
+| `nix_pr_package_gate` | Nix PR Package Gate | ubuntu | 35 | push, `nix`, `release-check`, `full-ci`, or release path risk. |
+| `mutation_required` | Mutation Testing | ubuntu | 45 | push, `mutation`, or `full-ci`. |
+| `proptest_smoke` | Proptest Smoke | ubuntu | 8 | push, `property-tests`, `full-ci`, or core-receipts path risk. |
+| `rust_coverage` | Codecov Coverage | ubuntu | 30 | push, workflow dispatch, `coverage`, or `full-ci`. |
 
 ## Push / main-only
 
@@ -42,21 +52,25 @@ msrv_check                  5
 quality_gate                8
 proof_policy                3
 affected_proof_plan         4
+ci_detect_risk_packs        1
+fast_proof_run_advisory     5
 feature_boundaries         10
 typos                       1
 cargo_deny                  4
 version_consistency         2
 docs_check                  4
-build_test_linux_windows   40
-wasm_compile_test          25
-nix_pr_package_gate        35
-mutation_required          45
-proptest_smoke              8
+build_test_linux           12
 publish_surface             8
+ci_lane_whitelist           3
+pr_cockpit_report           3
+no_panic_family             3
+pr_plan_advisory            1
+ripr_advisory               2
+scoped_coverage_executor_non_required  12
 ci_required                 1
                           ----
-                           203  (high-cost / override band)
+                            92  (high-cost band; below hard override ceiling)
 ```
 
-PR 10–12 demote the bottom block to risk-pack routing. The target frontdoor
-band drops to roughly 30–40 LEM for an ordinary Rust-only PR.
+Expensive Windows, WASM, Nix, mutation, proptest, and coverage lanes are now
+label, path-risk, push, or dispatch routed instead of ordinary PR defaults.

--- a/docs/ci/learned-estimates.md
+++ b/docs/ci/learned-estimates.md
@@ -20,12 +20,12 @@ Each lane in `lanes_selected` now has:
 
 ```json
 {
-  "id": "build_test_linux_windows",
-  "estimated_lem": 38,
+  "id": "build_test_linux",
+  "estimated_lem": 12,
   "estimate_source": "learned-p50",
-  "learned_p50_lem": 33.0,
-  "learned_p90_lem": 41.5,
-  "learned_p95_lem": 44.2,
+  "learned_p50_lem": 10.5,
+  "learned_p90_lem": 14.0,
+  "learned_p95_lem": 16.0,
   ...
 }
 ```

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -108,9 +108,49 @@ evidence = [
   "target/proof/executor-manifest.json",
 ]
 allowed_triggers = ["pull_request"]
-duplicate_of     = ["future:pr_plan"]
+duplicate_of     = ["pr_plan_advisory"]
 review_after     = "2026-06-07"
 expires          = "2026-08-07"
+
+[[lane]]
+id               = "ci_detect_risk_packs"
+workflow         = ".github/workflows/ci.yml"
+job              = "Detect risk packs"
+kind             = "planner"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 1
+owner            = "release/ci"
+intent           = "Classify changed paths into risk packs for conditional CI routing."
+failure_mode     = "Risk-gated jobs skip changes that should have selected them."
+proof_obligation = "Run the workflow path classifier and expose risk-pack outputs."
+evidence         = ["job outputs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = ["affected_proof_plan"]
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "fast_proof_run_advisory"
+workflow         = ".github/workflows/ci.yml"
+job              = "Fast Proof Run (Advisory)"
+kind             = "proof"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = false
+runner           = "ubuntu_latest"
+base_lem         = 5
+owner            = "proof"
+intent           = "Run the fast proof profile on PRs as advisory observation evidence."
+failure_mode     = "Fast proof-run regressions lose visibility before required promotion decisions."
+proof_obligation = "Run cargo xtask proof --profile fast --run-required --allow-ci-required-execution."
+evidence         = ["target/proof-run/proof-run-summary.json", "target/proof-run/proof-run-observation.json"]
+allowed_triggers = ["pull_request"]
+duplicate_of     = ["proof_policy", "affected_proof_plan"]
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
 
 [[lane]]
 id               = "feature_boundaries"
@@ -213,33 +253,49 @@ review_after     = "2026-06-07"
 expires          = "2026-11-07"
 
 # -----------------------------------------------------------------------
-# Expensive default-PR lanes (transition exceptions in
-# policy/ci-whitelist-exceptions.toml)
+# Build and risk-gated CI lanes
 # -----------------------------------------------------------------------
 
 [[lane]]
-id                     = "build_test_linux_windows"
-workflow               = ".github/workflows/ci.yml"
-job                    = "Build & Test"
-kind                   = "rust"
-tier                   = "frontdoor"
-default_pr             = true
-blocking               = true
-runner                 = "mixed"
-runners_used           = ["ubuntu_latest", "windows_latest"]
-base_lem               = 40
-owner                  = "core/build"
-intent                 = "Run full all-features tests on Ubuntu and Windows."
-failure_mode           = "All-features test failure or Windows-specific failure reaches main."
-proof_obligation       = "Run cargo test --all-features on Linux and Windows."
-evidence               = ["job logs"]
-allowed_triggers       = ["pull_request", "push"]
-expensive              = true
-expensive_reason       = "Windows doubles Linux-equivalent cost and all-features is broad."
-default_pr_exception   = "ci_exception_windows_full_test_default"
-duplicate_of           = ["quality_gate"]
-review_after           = "2026-06-07"
-expires                = "2026-08-07"
+id               = "build_test_linux"
+workflow         = ".github/workflows/ci.yml"
+job              = "Build & Test (Linux)"
+kind             = "rust"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 12
+owner            = "core/build"
+intent           = "Run full all-features tests on Ubuntu."
+failure_mode     = "All-features Linux test failure reaches main."
+proof_obligation = "Run cargo test --all-features on Linux."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = ["quality_gate"]
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "build_test_windows"
+workflow         = ".github/workflows/ci.yml"
+job              = "Build & Test (Windows)"
+kind             = "rust"
+tier             = "risk-gated"
+default_pr       = false
+blocking         = true
+runner           = "windows_latest"
+base_lem         = 20
+owner            = "platform/windows"
+intent           = "Run full all-features tests on Windows for pushes, labels, and Windows-relevant PRs."
+failure_mode     = "Windows-specific test failure reaches main."
+proof_obligation = "Run cargo test --all-features on Windows."
+evidence         = ["job logs"]
+allowed_triggers = ["pull_request", "push"]
+expensive        = true
+duplicate_of     = ["build_test_linux"]
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
 
 [[lane]]
 id                     = "wasm_compile_test"
@@ -247,7 +303,7 @@ workflow               = ".github/workflows/ci.yml"
 job                    = "Wasm Compile & Test"
 kind                   = "wasm"
 tier                   = "risk-gated"
-default_pr             = true
+default_pr             = false
 blocking               = true
 runner                 = "ubuntu_latest"
 base_lem               = 25
@@ -258,10 +314,9 @@ proof_obligation       = "Check tokmd-scan/core/wasm for wasm32, run wasm-pack t
 evidence               = ["job logs"]
 allowed_triggers       = ["pull_request", "push"]
 expensive              = true
-default_pr_exception   = "ci_exception_wasm_default"
 duplicate_of           = []
 review_after           = "2026-06-07"
-expires                = "2026-08-07"
+expires                = "2026-11-07"
 
 [[lane]]
 id                     = "nix_pr_package_gate"
@@ -269,7 +324,7 @@ workflow               = ".github/workflows/ci.yml"
 job                    = "Nix PR Package Gate"
 kind                   = "packaging"
 tier                   = "deep"
-default_pr             = true
+default_pr             = false
 blocking               = true
 runner                 = "ubuntu_latest"
 base_lem               = 35
@@ -280,32 +335,30 @@ proof_obligation       = "Run nix flake check --no-build and nix build .#tokmd."
 evidence               = ["job logs"]
 allowed_triggers       = ["pull_request", "push"]
 expensive              = true
-default_pr_exception   = "ci_exception_nix_default"
 duplicate_of           = ["publish_surface"]
 review_after           = "2026-06-07"
-expires                = "2026-08-07"
+expires                = "2026-11-07"
 
 [[lane]]
 id                     = "mutation_required"
 workflow               = ".github/workflows/ci.yml"
-job                    = "Mutation Testing (Required)"
+job                    = "Mutation Testing"
 kind                   = "mutation"
 tier                   = "deep"
-default_pr             = true
+default_pr             = false
 blocking               = true
 runner                 = "ubuntu_latest"
 base_lem               = 45
 owner                  = "testing/oracle"
-intent                 = "Run runtime mutation testing on changed production Rust files."
+intent                 = "Run runtime mutation testing on changed production Rust files for pushes and opted-in PRs."
 failure_mode           = "Changed code is covered but tests do not kill concrete mutants."
 proof_obligation       = "Run cargo-mutants on changed production Rust files."
 evidence               = ["mutants.out artifacts"]
-allowed_triggers       = ["pull_request"]
+allowed_triggers       = ["pull_request", "push"]
 expensive              = true
-default_pr_exception   = "ci_exception_mutation_default"
-duplicate_of           = ["future:ripr_advisory"]
+duplicate_of           = ["ripr_advisory"]
 review_after           = "2026-06-07"
-expires                = "2026-08-07"
+expires                = "2026-11-07"
 
 [[lane]]
 id                     = "proptest_smoke"
@@ -313,7 +366,7 @@ workflow               = ".github/workflows/ci.yml"
 job                    = "Proptest Smoke"
 kind                   = "property"
 tier                   = "risk-gated"
-default_pr             = true
+default_pr             = false
 blocking               = true
 runner                 = "ubuntu_latest"
 base_lem               = 8
@@ -424,9 +477,69 @@ review_after     = "2026-06-07"
 expires          = "2026-11-07"
 
 [[lane]]
+id               = "no_panic_family"
+workflow         = ".github/workflows/no-panic-policy.yml"
+job              = "No-panic Family"
+kind             = "policy"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 3
+owner            = "core/policy"
+intent           = "Verify the panic-family allowlist and stale-entry policy."
+failure_mode     = "Schema, stale-entry, or expired panic-family policy drift reaches main."
+proof_obligation = "Run cargo xtask check-no-panic-family --json."
+evidence         = ["target/tokmd/reports/no-panic-report.json"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = ["quality_gate"]
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "pr_plan_advisory"
+workflow         = ".github/workflows/pr-plan.yml"
+job              = "PR Plan (advisory)"
+kind             = "planner"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = false
+runner           = "ubuntu_latest"
+base_lem         = 1
+owner            = "release/ci"
+intent           = "Publish the LEM-aware advisory PR plan for reviewers."
+failure_mode     = "Reviewers lose the planned proof/cost view for ordinary PRs."
+proof_obligation = "Run cargo xtask ci-plan --enforce and upload pr-plan artifacts."
+evidence         = ["target/ci-plan.json", "target/ci-plan.md"]
+allowed_triggers = ["pull_request"]
+duplicate_of     = ["ci_detect_risk_packs"]
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
+id               = "ripr_advisory"
+workflow         = ".github/workflows/ripr.yml"
+job              = "ripr (advisory)"
+kind             = "analysis"
+tier             = "frontdoor"
+default_pr       = true
+blocking         = false
+runner           = "ubuntu_latest"
+base_lem         = 2
+owner            = "testing/oracle"
+intent           = "Run static mutation-shaped oracle-gap analysis as advisory PR evidence."
+failure_mode     = "Reviewers lose cheap oracle-gap signal on changed production Rust files."
+proof_obligation = "Run ripr or the advisory placeholder and upload the ripr report."
+evidence         = ["target/ripr/ripr.json", "target/ripr/ripr.md", "target/ripr/ripr.sarif"]
+allowed_triggers = ["pull_request", "push"]
+duplicate_of     = ["mutation_required"]
+review_after     = "2026-06-07"
+expires          = "2026-11-07"
+
+[[lane]]
 id               = "rust_coverage"
 workflow         = ".github/workflows/coverage.yml"
-job              = "Rust coverage"
+job              = "Codecov Coverage"
 kind             = "coverage"
 tier             = "deep"
 default_pr       = false
@@ -434,9 +547,9 @@ blocking         = false
 runner           = "ubuntu_latest"
 base_lem         = 30
 owner            = "testing/oracle"
-intent           = "Generate Rust coverage report for the workspace."
+intent           = "Generate Rust coverage report for the workspace and upload to Codecov when configured."
 failure_mode     = "Coverage drift goes unnoticed because no other lane measures it."
-proof_obligation = "Run cargo llvm-cov on the workspace."
+proof_obligation = "Run cargo llvm-cov on the workspace; upload to Codecov when CODECOV_TOKEN is available."
 evidence         = ["lcov / codecov upload"]
 allowed_triggers = ["pull_request", "push", "workflow_dispatch"]
 expensive        = true

--- a/policy/ci-risk-packs.toml
+++ b/policy/ci-risk-packs.toml
@@ -27,7 +27,7 @@ paths = [
   "crates/tokmd-format/**",
 ]
 lanes = ["rust_fast_gate", "proof_policy", "ripr"]
-deep_lanes = ["build_test_linux_windows", "proptest_smoke"]
+deep_lanes = ["build_test_windows", "proptest_smoke"]
 
 [risk_pack.analysis]
 description = "Risk, effort, complexity, duplication, git, API-surface reports."
@@ -57,7 +57,7 @@ paths = [
   "crates/tokmd-scan/**",
 ]
 lanes = ["rust_fast_gate", "ripr"]
-deep_lanes = ["build_test_linux_windows"]
+deep_lanes = ["build_test_windows"]
 
 [risk_pack.wasm]
 description = "WASM/browser runner and web capability surface."
@@ -90,7 +90,7 @@ paths = [
   ".github/workflows/**",
 ]
 lanes = ["proof_policy", "quality_gate", "ci_lane_whitelist"]
-deep_lanes = ["build_test_linux_windows"]
+deep_lanes = ["build_test_windows"]
 
 [risk_pack.docs]
 description = "Documentation-only changes."

--- a/policy/ci-whitelist-exceptions.toml
+++ b/policy/ci-whitelist-exceptions.toml
@@ -9,50 +9,5 @@ status = "active"
 # and an expiry. Expired exceptions are surfaced by the lane whitelist
 # linter (PR 03).
 
-[[exception]]
-id           = "ci_exception_mutation_default"
-kind         = "expensive_default_pr_lane"
-lane         = "mutation_required"
-allowed      = true
-owner        = "testing/oracle"
-issue        = "TODO"
-reason       = "Runtime mutation is currently required on PRs. Replace ordinary PR default with ripr advisory plus label/main/nightly mutation after baseline review."
-created      = "2026-05-07"
-review_after = "2026-06-07"
-expires      = "2026-08-07"
-
-[[exception]]
-id           = "ci_exception_wasm_default"
-kind         = "expensive_default_pr_lane"
-lane         = "wasm_compile_test"
-allowed      = true
-owner        = "wasm"
-issue        = "TODO"
-reason       = "WASM/browser runner is important but should route only on WASM/web/capability changes after PR Plan lands."
-created      = "2026-05-07"
-review_after = "2026-06-07"
-expires      = "2026-08-07"
-
-[[exception]]
-id           = "ci_exception_nix_default"
-kind         = "expensive_default_pr_lane"
-lane         = "nix_pr_package_gate"
-allowed      = true
-owner        = "release/nix"
-issue        = "TODO"
-reason       = "Nix package proof is currently required; move to release/main/label once publish-surface and package risk packs are wired."
-created      = "2026-05-07"
-review_after = "2026-06-07"
-expires      = "2026-08-07"
-
-[[exception]]
-id           = "ci_exception_windows_full_test_default"
-kind         = "expensive_default_pr_lane"
-lane         = "build_test_linux_windows"
-allowed      = true
-owner        = "platform/windows"
-issue        = "TODO"
-reason       = "Windows currently runs full all-features test matrix. Retain temporarily until Windows risk pack separates path/platform checks from every Rust PR."
-created      = "2026-05-07"
-review_after = "2026-06-07"
-expires      = "2026-08-07"
+# No active exceptions. Expensive lanes now run on push, explicit labels,
+# or risk-pack routing instead of ordinary PR defaults.


### PR DESCRIPTION
## Summary
- split the stale combined build/test whitelist entry into current Linux default and Windows risk-gated jobs
- add missing current CI/advisory job entries for risk detection, fast proof, no-panic, PR Plan, and ripr
- update mutation and Codecov job names/triggers, retire the old TODO exception placeholders, and sync CI inventory docs

This supersedes draft #1891 with a narrower keeper: it fixes workflow inventory drift without blanket-flipping ordinary PR lanes out of the planner.

## Validation
- `cargo xtask ci-lane-whitelist --strict --report-dir target/tokmd/reports`
- `cargo xtask ci-plan --base origin/main --head HEAD --labels-json '[]' --enforce` (reports 92 LEM high-cost warning, below the 125 hard ceiling)
- `cargo test -p xtask ci_lane_whitelist --verbose`
- `cargo test -p xtask ci_plan --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`