### PR TITLE
test(model): cover env split-string flags

### DIFF
--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -1251,6 +1251,14 @@ mod tests {
             env_interpreter_token(vec!["-S", "-i", "python"].into_iter()),
             Some("python")
         );
+        assert_eq!(
+            env_interpreter_token(vec!["--split-string", "python"].into_iter()),
+            Some("python")
+        );
+        assert_eq!(
+            env_interpreter_token(vec!["--ignore-environment", "python"].into_iter()),
+            Some("python")
+        );
 
         // Skip flags with next argument
         assert_eq!(


### PR DESCRIPTION
## Summary
- add direct coverage for env `--split-string` and `--ignore-environment` parser flags
- keep the change test-only and preserve existing shebang/interpreter behavior

This is a synthesized keeper from #1899. The generated draft found a real coverage gap, but its `.jules` mutation receipts were stale/mixed, so this PR carries only the current proof-improvement patch.

## Validation
- `cargo test -p tokmd-model test_env_interpreter_token --verbose`
- `cargo test -p tokmd-model --verbose`
- `cargo test -p tokmd-model normalize --verbose`
- `cargo test -p tokmd-scan normalize --verbose`
- `cargo clippy -p tokmd-model --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`