### PR TITLE
test(cli): cover health analyze BDD

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -256,12 +256,14 @@ paths = [
   "crates/tokmd-analysis/tests/orchestrator.rs",
   "crates/tokmd/src/commands/analyze.rs",
   "crates/tokmd/tests/analyze_integration.rs",
+  "crates/tokmd/tests/bdd_analyze_scenarios_w50.rs",
 ]
 packages = ["tokmd-analysis", "tokmd"]
 proof = [
   "cargo test -p tokmd-analysis --all-features orchestration --verbose",
   "cargo test -p tokmd-analysis --all-features feature --verbose",
   "cargo test -p tokmd --test analyze_integration --verbose",
+  "cargo test -p tokmd --test bdd_analyze_scenarios_w50 --verbose",
 ]
 mutation = true
 coverage = true

--- a/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
@@ -239,3 +239,36 @@ fn given_project_when_analyze_estimate_then_effort_model_present() {
         .expect("effort drivers should be an array");
     assert!(!drivers.is_empty(), "effort should have drivers");
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 9: Health preset includes TODO tags and complexity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_analyze_health_then_todo_and_complexity_present() {
+    // Given: a project with source files
+    // When: I analyze with `health` preset and JSON format
+    let output = tokmd_cmd()
+        .args(["analyze", ".", "--preset", "health", "--format", "json"])
+        .output()
+        .expect("failed to execute tokmd analyze --preset health");
+
+    // Then: complexity metrics and TODO density are present
+    assert!(
+        output.status.success(),
+        "analyze should succeed: {:?}",
+        output.status
+    );
+    let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+    let json: Value = serde_json::from_str(&stdout).expect("output should be valid JSON");
+
+    assert_eq!(json["mode"], "analysis", "mode should be 'analysis'");
+    assert!(
+        json.get("complexity").is_some(),
+        "should have complexity section"
+    );
+    assert!(
+        json["derived"].get("todo").is_some(),
+        "should have derived.todo section"
+    );
+}


### PR DESCRIPTION
## Summary
- add a BDD-style CLI regression for `tokmd analyze . --preset health --format json`
- assert the health receipt exposes both `complexity` and `derived.todo`
- route `bdd_analyze_scenarios_w50.rs` through the `analysis_orchestration` proof scope so affected planning has no unknown files

This is a synthesized keeper from #1904. The generated draft identified a useful CLI coverage gap, but also included `submission.sh` and left the new BDD test unscoped for affected proof planning. This PR carries the current test and proof-policy mapping only.

## Validation
- `cargo test -p tokmd --test bdd_analyze_scenarios_w50 given_project_when_analyze_health_then_todo_and_complexity_present --verbose`
- `cargo test -p tokmd --test bdd_analyze_scenarios_w50 --verbose`
- `cargo test -p tokmd --test analyze_integration --verbose`
- `cargo test -p tokmd-analysis --all-features orchestration --verbose`
- `cargo test -p tokmd-analysis --all-features feature --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `git diff --check origin/main..HEAD`