### PR TITLE
refactor(analysis-types): split supply DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod effort;
 pub mod findings;
+mod supply;
 pub mod util;
 
 use std::collections::BTreeMap;
@@ -28,6 +29,7 @@ pub use effort::{
     EffortDeltaClassification, EffortDeltaReport, EffortDriver, EffortDriverDirection,
     EffortEstimateReport, EffortModel, EffortResults, EffortSizeBasis, EffortTagSizeRow,
 };
+pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport};
 pub use util::{
     AnalysisLimits, empty_file_row, is_infra_lang, is_test_path, normalize_path, normalize_root,
     now_ms, path_depth,
@@ -432,51 +434,6 @@ pub struct IntegrityReport {
     pub algo: String,
     pub hash: String,
     pub entries: usize,
-}
-
-// -------------
-// Asset metrics
-// -------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssetReport {
-    pub total_files: usize,
-    pub total_bytes: u64,
-    pub categories: Vec<AssetCategoryRow>,
-    pub top_files: Vec<AssetFileRow>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssetCategoryRow {
-    pub category: String,
-    pub files: usize,
-    pub bytes: u64,
-    pub extensions: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssetFileRow {
-    pub path: String,
-    pub bytes: u64,
-    pub category: String,
-    pub extension: String,
-}
-
-// -----------------
-// Dependency metrics
-// -----------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DependencyReport {
-    pub total: usize,
-    pub lockfiles: Vec<LockfileReport>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LockfileReport {
-    pub path: String,
-    pub kind: String,
-    pub dependencies: usize,
 }
 
 // ---------

--- a/crates/tokmd-analysis-types/src/supply.rs
+++ b/crates/tokmd-analysis-types/src/supply.rs
@@ -1,0 +1,43 @@
+//! Asset and dependency receipt DTOs.
+//!
+//! These supply-chain-adjacent contract types remain re-exported from the
+//! crate root to preserve existing `tokmd_analysis_types::...` names.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetReport {
+    pub total_files: usize,
+    pub total_bytes: u64,
+    pub categories: Vec<AssetCategoryRow>,
+    pub top_files: Vec<AssetFileRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetCategoryRow {
+    pub category: String,
+    pub files: usize,
+    pub bytes: u64,
+    pub extensions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetFileRow {
+    pub path: String,
+    pub bytes: u64,
+    pub category: String,
+    pub extension: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DependencyReport {
+    pub total: usize,
+    pub lockfiles: Vec<LockfileReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LockfileReport {
+    pub path: String,
+    pub kind: String,
+    pub dependencies: usize,
+}


### PR DESCRIPTION
## Summary
- move asset/dependency supply DTOs out of `tokmd-analysis-types/src/lib.rs` into a private `supply` owner module
- preserve existing root-level `tokmd_analysis_types::AssetReport`, `DependencyReport`, and related row re-exports
- keep schemas, receipt output, and publish surface unchanged

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features assets --verbose`
- `cargo test -p tokmd-format --lib analysis::tests::test_render_md_derived --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`