### PR TITLE
refactor(analysis-types): split git DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/git.rs
+++ b/crates/tokmd-analysis-types/src/git.rs
@@ -1,0 +1,198 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+// -----------------
+// Predictive churn
+// -----------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PredictiveChurnReport {
+    pub per_module: BTreeMap<String, ChurnTrend>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChurnTrend {
+    pub slope: f64,
+    pub r2: f64,
+    pub recent_change: i64,
+    pub classification: TrendClass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrendClass {
+    Rising,
+    Flat,
+    Falling,
+}
+
+// ---------------------
+// Corporate fingerprint
+// ---------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorporateFingerprint {
+    pub domains: Vec<DomainStat>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainStat {
+    pub domain: String,
+    pub commits: u32,
+    pub pct: f32,
+}
+
+// ---------
+// Git report
+// ---------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitReport {
+    pub commits_scanned: usize,
+    pub files_seen: usize,
+    pub hotspots: Vec<HotspotRow>,
+    pub bus_factor: Vec<BusFactorRow>,
+    pub freshness: FreshnessReport,
+    pub coupling: Vec<CouplingRow>,
+    /// Code age bucket distribution plus recent refresh trend.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub age_distribution: Option<CodeAgeDistributionReport>,
+    /// Commit intent classification (feat/fix/refactor/etc.).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent: Option<CommitIntentReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HotspotRow {
+    pub path: String,
+    pub commits: usize,
+    pub lines: usize,
+    pub score: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusFactorRow {
+    pub module: String,
+    pub authors: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FreshnessReport {
+    pub threshold_days: usize,
+    pub stale_files: usize,
+    pub total_files: usize,
+    pub stale_pct: f64,
+    pub by_module: Vec<ModuleFreshnessRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleFreshnessRow {
+    pub module: String,
+    pub avg_days: f64,
+    pub p90_days: f64,
+    pub stale_pct: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CouplingRow {
+    pub left: String,
+    pub right: String,
+    pub count: usize,
+    /// Jaccard similarity: count / (n_left + n_right - count). Range (0.0, 1.0].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jaccard: Option<f64>,
+    /// Lift: (count * N) / (n_left * n_right), where N = commits_considered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lift: Option<f64>,
+    /// Commits touching left module (within commits_considered universe).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub n_left: Option<usize>,
+    /// Commits touching right module (within commits_considered universe).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub n_right: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeAgeDistributionReport {
+    pub buckets: Vec<CodeAgeBucket>,
+    pub recent_refreshes: usize,
+    pub prior_refreshes: usize,
+    pub refresh_trend: TrendClass,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeAgeBucket {
+    pub label: String,
+    pub min_days: usize,
+    pub max_days: Option<usize>,
+    pub files: usize,
+    pub pct: f64,
+}
+
+// --------------------------
+// Commit intent classification
+// --------------------------
+
+// Re-export from tokmd-types (Tier 0) so existing consumers keep working.
+pub use tokmd_types::CommitIntentKind;
+
+/// Overall commit intent classification report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitIntentReport {
+    /// Aggregate counts across all scanned commits.
+    pub overall: CommitIntentCounts,
+    /// Per-module intent breakdown.
+    pub by_module: Vec<ModuleIntentRow>,
+    /// Percentage of commits classified as "other" (unrecognized).
+    pub unknown_pct: f64,
+    /// Corrective ratio: (fix + revert) / total. Range [0.0, 1.0].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corrective_ratio: Option<f64>,
+}
+
+/// Counts per intent kind.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommitIntentCounts {
+    pub feat: usize,
+    pub fix: usize,
+    pub refactor: usize,
+    pub docs: usize,
+    pub test: usize,
+    pub chore: usize,
+    pub ci: usize,
+    pub build: usize,
+    pub perf: usize,
+    pub style: usize,
+    pub revert: usize,
+    pub other: usize,
+    pub total: usize,
+}
+
+impl CommitIntentCounts {
+    /// Increment the count for a given intent kind.
+    pub fn increment(&mut self, kind: CommitIntentKind) {
+        match kind {
+            CommitIntentKind::Feat => self.feat += 1,
+            CommitIntentKind::Fix => self.fix += 1,
+            CommitIntentKind::Refactor => self.refactor += 1,
+            CommitIntentKind::Docs => self.docs += 1,
+            CommitIntentKind::Test => self.test += 1,
+            CommitIntentKind::Chore => self.chore += 1,
+            CommitIntentKind::Ci => self.ci += 1,
+            CommitIntentKind::Build => self.build += 1,
+            CommitIntentKind::Perf => self.perf += 1,
+            CommitIntentKind::Style => self.style += 1,
+            CommitIntentKind::Revert => self.revert += 1,
+            CommitIntentKind::Other => self.other += 1,
+        }
+        self.total += 1;
+    }
+}
+
+/// Per-module intent breakdown row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleIntentRow {
+    pub module: String,
+    pub counts: CommitIntentCounts,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -17,6 +17,7 @@
 mod derived;
 mod effort;
 pub mod findings;
+mod git;
 mod supply;
 pub mod util;
 
@@ -35,6 +36,12 @@ pub use effort::{
     CocomoReport, EffortAssumptions, EffortConfidence, EffortConfidenceLevel,
     EffortDeltaClassification, EffortDeltaReport, EffortDriver, EffortDriverDirection,
     EffortEstimateReport, EffortModel, EffortResults, EffortSizeBasis, EffortTagSizeRow,
+};
+pub use git::{
+    BusFactorRow, ChurnTrend, CodeAgeBucket, CodeAgeDistributionReport, CommitIntentCounts,
+    CommitIntentKind, CommitIntentReport, CorporateFingerprint, CouplingRow, DomainStat,
+    FreshnessReport, GitReport, HotspotRow, ModuleFreshnessRow, ModuleIntentRow,
+    PredictiveChurnReport, TrendClass,
 };
 pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport};
 pub use util::{
@@ -161,47 +168,6 @@ pub enum EntropyClass {
     High,
 }
 
-// -----------------
-// Predictive churn
-// -----------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PredictiveChurnReport {
-    pub per_module: BTreeMap<String, ChurnTrend>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChurnTrend {
-    pub slope: f64,
-    pub r2: f64,
-    pub recent_change: i64,
-    pub classification: TrendClass,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TrendClass {
-    Rising,
-    Flat,
-    Falling,
-}
-
-// ---------------------
-// Corporate fingerprint
-// ---------------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CorporateFingerprint {
-    pub domains: Vec<DomainStat>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DomainStat {
-    pub domain: String,
-    pub commits: u32,
-    pub pct: f32,
-}
-
 // -------------
 // License radar
 // -------------
@@ -225,160 +191,6 @@ pub struct LicenseFinding {
 pub enum LicenseSourceKind {
     Metadata,
     Text,
-}
-
-// ---------
-// Git report
-// ---------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GitReport {
-    pub commits_scanned: usize,
-    pub files_seen: usize,
-    pub hotspots: Vec<HotspotRow>,
-    pub bus_factor: Vec<BusFactorRow>,
-    pub freshness: FreshnessReport,
-    pub coupling: Vec<CouplingRow>,
-    /// Code age bucket distribution plus recent refresh trend.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub age_distribution: Option<CodeAgeDistributionReport>,
-    /// Commit intent classification (feat/fix/refactor/etc.).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub intent: Option<CommitIntentReport>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HotspotRow {
-    pub path: String,
-    pub commits: usize,
-    pub lines: usize,
-    pub score: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BusFactorRow {
-    pub module: String,
-    pub authors: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FreshnessReport {
-    pub threshold_days: usize,
-    pub stale_files: usize,
-    pub total_files: usize,
-    pub stale_pct: f64,
-    pub by_module: Vec<ModuleFreshnessRow>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModuleFreshnessRow {
-    pub module: String,
-    pub avg_days: f64,
-    pub p90_days: f64,
-    pub stale_pct: f64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CouplingRow {
-    pub left: String,
-    pub right: String,
-    pub count: usize,
-    /// Jaccard similarity: count / (n_left + n_right - count). Range (0.0, 1.0].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub jaccard: Option<f64>,
-    /// Lift: (count * N) / (n_left * n_right), where N = commits_considered.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lift: Option<f64>,
-    /// Commits touching left module (within commits_considered universe).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub n_left: Option<usize>,
-    /// Commits touching right module (within commits_considered universe).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub n_right: Option<usize>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CodeAgeDistributionReport {
-    pub buckets: Vec<CodeAgeBucket>,
-    pub recent_refreshes: usize,
-    pub prior_refreshes: usize,
-    pub refresh_trend: TrendClass,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CodeAgeBucket {
-    pub label: String,
-    pub min_days: usize,
-    pub max_days: Option<usize>,
-    pub files: usize,
-    pub pct: f64,
-}
-
-// --------------------------
-// Commit intent classification
-// --------------------------
-
-// Re-export from tokmd-types (Tier 0) so existing consumers keep working.
-pub use tokmd_types::CommitIntentKind;
-
-/// Overall commit intent classification report.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommitIntentReport {
-    /// Aggregate counts across all scanned commits.
-    pub overall: CommitIntentCounts,
-    /// Per-module intent breakdown.
-    pub by_module: Vec<ModuleIntentRow>,
-    /// Percentage of commits classified as "other" (unrecognized).
-    pub unknown_pct: f64,
-    /// Corrective ratio: (fix + revert) / total. Range [0.0, 1.0].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub corrective_ratio: Option<f64>,
-}
-
-/// Counts per intent kind.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct CommitIntentCounts {
-    pub feat: usize,
-    pub fix: usize,
-    pub refactor: usize,
-    pub docs: usize,
-    pub test: usize,
-    pub chore: usize,
-    pub ci: usize,
-    pub build: usize,
-    pub perf: usize,
-    pub style: usize,
-    pub revert: usize,
-    pub other: usize,
-    pub total: usize,
-}
-
-impl CommitIntentCounts {
-    /// Increment the count for a given intent kind.
-    pub fn increment(&mut self, kind: CommitIntentKind) {
-        match kind {
-            CommitIntentKind::Feat => self.feat += 1,
-            CommitIntentKind::Fix => self.fix += 1,
-            CommitIntentKind::Refactor => self.refactor += 1,
-            CommitIntentKind::Docs => self.docs += 1,
-            CommitIntentKind::Test => self.test += 1,
-            CommitIntentKind::Chore => self.chore += 1,
-            CommitIntentKind::Ci => self.ci += 1,
-            CommitIntentKind::Build => self.build += 1,
-            CommitIntentKind::Perf => self.perf += 1,
-            CommitIntentKind::Style => self.style += 1,
-            CommitIntentKind::Revert => self.revert += 1,
-            CommitIntentKind::Other => self.other += 1,
-        }
-        self.total += 1;
-    }
-}
-
-/// Per-module intent breakdown row.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModuleIntentRow {
-    pub module: String,
-    pub counts: CommitIntentCounts,
 }
 
 // ----------------------------


### PR DESCRIPTION
## Summary
- Move the git-derived analysis DTO family into `crates/tokmd-analysis-types/src/git.rs`
- Preserve the existing root-level public re-exports for churn, git report, code age, and commit intent types
- Keep receipt/schema behavior unchanged while shrinking `lib.rs`

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features git --verbose`
- `cargo test -p tokmd-format --lib test_render_md_git --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`