### PR TITLE
refactor(analysis-types): split api surface DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/api_surface.rs
+++ b/crates/tokmd-analysis-types/src/api_surface.rs
@@ -1,0 +1,66 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Public API surface analysis report.
+///
+/// Computes public export ratios per language and module by scanning
+/// source files for exported symbols (pub fn, export function, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiSurfaceReport {
+    /// Total items discovered across all languages.
+    pub total_items: usize,
+    /// Items with public visibility.
+    pub public_items: usize,
+    /// Items with internal/private visibility.
+    pub internal_items: usize,
+    /// Ratio of public to total items (0.0-1.0).
+    pub public_ratio: f64,
+    /// Ratio of documented public items (0.0-1.0).
+    pub documented_ratio: f64,
+    /// Per-language breakdown.
+    pub by_language: BTreeMap<String, LangApiSurface>,
+    /// Per-module breakdown.
+    pub by_module: Vec<ModuleApiRow>,
+    /// Top exporters (files with most public items).
+    pub top_exporters: Vec<ApiExportItem>,
+}
+
+/// Per-language API surface breakdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LangApiSurface {
+    /// Total items in this language.
+    pub total_items: usize,
+    /// Public items in this language.
+    pub public_items: usize,
+    /// Internal items in this language.
+    pub internal_items: usize,
+    /// Public ratio for this language.
+    pub public_ratio: f64,
+}
+
+/// Per-module API surface row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleApiRow {
+    /// Module path.
+    pub module: String,
+    /// Total items in this module.
+    pub total_items: usize,
+    /// Public items in this module.
+    pub public_items: usize,
+    /// Public ratio for this module.
+    pub public_ratio: f64,
+}
+
+/// A file that exports many public items.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiExportItem {
+    /// File path.
+    pub path: String,
+    /// Language of the file.
+    pub lang: String,
+    /// Number of public items exported.
+    pub public_items: usize,
+    /// Total items in the file.
+    pub total_items: usize,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -14,6 +14,7 @@
 //! * Formatting logic (use tokmd-format::analysis)
 //! * File I/O operations
 
+mod api_surface;
 mod derived;
 mod duplication;
 mod effort;
@@ -27,6 +28,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use tokmd_types::{ScanStatus, ToolInfo};
 
+pub use api_surface::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
 pub use derived::{
     BoilerplateReport, ContextWindowReport, DerivedReport, DerivedTotals, DistributionReport,
     FileStatRow, HistogramBucket, IntegrityReport, LangPurityReport, LangPurityRow, MaxFileReport,
@@ -732,73 +734,6 @@ fn chrono_timestamp_iso8601(ms: u128) -> String {
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
         y, m, d, hour, min, sec, millis
     )
-}
-
-// -------------------
-// API Surface metrics
-// -------------------
-
-/// Public API surface analysis report.
-///
-/// Computes public export ratios per language and module by scanning
-/// source files for exported symbols (pub fn, export function, etc.).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ApiSurfaceReport {
-    /// Total items discovered across all languages.
-    pub total_items: usize,
-    /// Items with public visibility.
-    pub public_items: usize,
-    /// Items with internal/private visibility.
-    pub internal_items: usize,
-    /// Ratio of public to total items (0.0-1.0).
-    pub public_ratio: f64,
-    /// Ratio of documented public items (0.0-1.0).
-    pub documented_ratio: f64,
-    /// Per-language breakdown.
-    pub by_language: BTreeMap<String, LangApiSurface>,
-    /// Per-module breakdown.
-    pub by_module: Vec<ModuleApiRow>,
-    /// Top exporters (files with most public items).
-    pub top_exporters: Vec<ApiExportItem>,
-}
-
-/// Per-language API surface breakdown.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LangApiSurface {
-    /// Total items in this language.
-    pub total_items: usize,
-    /// Public items in this language.
-    pub public_items: usize,
-    /// Internal items in this language.
-    pub internal_items: usize,
-    /// Public ratio for this language.
-    pub public_ratio: f64,
-}
-
-/// Per-module API surface row.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModuleApiRow {
-    /// Module path.
-    pub module: String,
-    /// Total items in this module.
-    pub total_items: usize,
-    /// Public items in this module.
-    pub public_items: usize,
-    /// Public ratio for this module.
-    pub public_ratio: f64,
-}
-
-/// A file that exports many public items.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ApiExportItem {
-    /// File path.
-    pub path: String,
-    /// Language of the file.
-    pub lang: String,
-    /// Number of public items exported.
-    pub public_items: usize,
-    /// Total items in the file.
-    pub total_items: usize,
 }
 
 // ---------


### PR DESCRIPTION
## Summary
- Move API surface analysis DTOs into `crates/tokmd-analysis-types/src/api_surface.rs`
- Preserve root-level public re-exports for `ApiSurfaceReport`, `LangApiSurface`, `ModuleApiRow`, and `ApiExportItem`
- Keep receipt/schema behavior unchanged while shrinking `lib.rs`

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features api_surface --verbose`
- `cargo test -p tokmd-format api_surface --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`