### PR TITLE
refactor(analysis-types): split topics DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -21,9 +21,8 @@ mod effort;
 pub mod findings;
 mod git;
 mod supply;
+mod topics;
 pub mod util;
-
-use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use tokmd_types::{ScanStatus, ToolInfo};
@@ -52,6 +51,7 @@ pub use git::{
     PredictiveChurnReport, TrendClass,
 };
 pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport};
+pub use topics::{TopicClouds, TopicTerm};
 pub use util::{
     AnalysisLimits, empty_file_row, is_infra_lang, is_test_path, normalize_path, normalize_root,
     now_ms, path_depth,
@@ -129,24 +129,6 @@ pub struct AnalysisArgsMeta {
 pub struct Archetype {
     pub kind: String,
     pub evidence: Vec<String>,
-}
-
-// -----------------
-// Semantic topics
-// -----------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TopicClouds {
-    pub per_module: BTreeMap<String, Vec<TopicTerm>>,
-    pub overall: Vec<TopicTerm>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TopicTerm {
-    pub term: String,
-    pub score: f64,
-    pub tf: u32,
-    pub df: u32,
 }
 
 // -----------------

--- a/crates/tokmd-analysis-types/src/topics.rs
+++ b/crates/tokmd-analysis-types/src/topics.rs
@@ -1,0 +1,17 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicClouds {
+    pub per_module: BTreeMap<String, Vec<TopicTerm>>,
+    pub overall: Vec<TopicTerm>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicTerm {
+    pub term: String,
+    pub score: f64,
+    pub tf: u32,
+    pub df: u32,
+}


### PR DESCRIPTION
## Summary
- Move semantic topic analysis DTOs into `crates/tokmd-analysis-types/src/topics.rs`
- Preserve root-level public re-exports for `TopicClouds` and `TopicTerm`
- Keep receipt/schema behavior unchanged while shrinking `lib.rs`

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features topics --verbose`
- `cargo test -p tokmd-format topics --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`