### PR TITLE
refactor(analysis-types): split entropy DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/entropy.rs
+++ b/crates/tokmd-analysis-types/src/entropy.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntropyReport {
+    pub suspects: Vec<EntropyFinding>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntropyFinding {
+    pub path: String,
+    pub module: String,
+    pub entropy_bits_per_byte: f32,
+    pub sample_bytes: u32,
+    pub class: EntropyClass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntropyClass {
+    Low,
+    Normal,
+    Suspicious,
+    High,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -18,6 +18,7 @@ mod api_surface;
 mod derived;
 mod duplication;
 mod effort;
+mod entropy;
 pub mod findings;
 mod git;
 mod supply;
@@ -44,6 +45,7 @@ pub use effort::{
     EffortDeltaClassification, EffortDeltaReport, EffortDriver, EffortDriverDirection,
     EffortEstimateReport, EffortModel, EffortResults, EffortSizeBasis, EffortTagSizeRow,
 };
+pub use entropy::{EntropyClass, EntropyFinding, EntropyReport};
 pub use git::{
     BusFactorRow, ChurnTrend, CodeAgeBucket, CodeAgeDistributionReport, CommitIntentCounts,
     CommitIntentKind, CommitIntentReport, CorporateFingerprint, CouplingRow, DomainStat,
@@ -129,33 +131,6 @@ pub struct AnalysisArgsMeta {
 pub struct Archetype {
     pub kind: String,
     pub evidence: Vec<String>,
-}
-
-// -----------------
-// Entropy profiling
-// -----------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EntropyReport {
-    pub suspects: Vec<EntropyFinding>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EntropyFinding {
-    pub path: String,
-    pub module: String,
-    pub entropy_bits_per_byte: f32,
-    pub sample_bytes: u32,
-    pub class: EntropyClass,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum EntropyClass {
-    Low,
-    Normal,
-    Suspicious,
-    High,
 }
 
 // -------------


### PR DESCRIPTION
## Summary
- Move entropy analysis DTOs into `crates/tokmd-analysis-types/src/entropy.rs`
- Preserve root-level public re-exports for `EntropyReport`, `EntropyFinding`, and `EntropyClass`
- Keep receipt/schema behavior unchanged while shrinking `lib.rs`

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features entropy --verbose`
- `cargo test -p tokmd-format entropy --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`