### PR TITLE
refactor(analysis-types): split license DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -21,6 +21,7 @@ mod effort;
 mod entropy;
 pub mod findings;
 mod git;
+mod license;
 mod supply;
 mod topics;
 pub mod util;
@@ -52,6 +53,7 @@ pub use git::{
     FreshnessReport, GitReport, HotspotRow, ModuleFreshnessRow, ModuleIntentRow,
     PredictiveChurnReport, TrendClass,
 };
+pub use license::{LicenseFinding, LicenseReport, LicenseSourceKind};
 pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport};
 pub use topics::{TopicClouds, TopicTerm};
 pub use util::{
@@ -131,31 +133,6 @@ pub struct AnalysisArgsMeta {
 pub struct Archetype {
     pub kind: String,
     pub evidence: Vec<String>,
-}
-
-// -------------
-// License radar
-// -------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LicenseReport {
-    pub findings: Vec<LicenseFinding>,
-    pub effective: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LicenseFinding {
-    pub spdx: String,
-    pub confidence: f32,
-    pub source_path: String,
-    pub source_kind: LicenseSourceKind,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum LicenseSourceKind {
-    Metadata,
-    Text,
 }
 
 // -----------------

--- a/crates/tokmd-analysis-types/src/license.rs
+++ b/crates/tokmd-analysis-types/src/license.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LicenseReport {
+    pub findings: Vec<LicenseFinding>,
+    pub effective: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LicenseFinding {
+    pub spdx: String,
+    pub confidence: f32,
+    pub source_path: String,
+    pub source_kind: LicenseSourceKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LicenseSourceKind {
+    Metadata,
+    Text,
+}


### PR DESCRIPTION
## Summary
- Move license radar DTOs into `crates/tokmd-analysis-types/src/license.rs`
- Preserve root-level public re-exports for `LicenseReport`, `LicenseFinding`, and `LicenseSourceKind`
- Keep receipt/schema behavior unchanged while shrinking `lib.rs`

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features license --verbose`
- `cargo test -p tokmd-format license --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`