### PR TITLE
refactor(analysis-types): split churn DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/churn.rs
+++ b/crates/tokmd-analysis-types/src/churn.rs
@@ -1,0 +1,24 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PredictiveChurnReport {
+    pub per_module: BTreeMap<String, ChurnTrend>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChurnTrend {
+    pub slope: f64,
+    pub r2: f64,
+    pub recent_change: i64,
+    pub classification: TrendClass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrendClass {
+    Rising,
+    Flat,
+    Falling,
+}

--- a/crates/tokmd-analysis-types/src/git.rs
+++ b/crates/tokmd-analysis-types/src/git.rs
@@ -1,31 +1,6 @@
-use std::collections::BTreeMap;
-
 use serde::{Deserialize, Serialize};
 
-// -----------------
-// Predictive churn
-// -----------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PredictiveChurnReport {
-    pub per_module: BTreeMap<String, ChurnTrend>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChurnTrend {
-    pub slope: f64,
-    pub r2: f64,
-    pub recent_change: i64,
-    pub classification: TrendClass,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TrendClass {
-    Rising,
-    Flat,
-    Falling,
-}
+use crate::churn::TrendClass;
 
 // ---------------------
 // Corporate fingerprint

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -15,6 +15,7 @@
 //! * File I/O operations
 
 mod api_surface;
+mod churn;
 mod derived;
 mod duplication;
 mod effort;
@@ -30,6 +31,7 @@ use serde::{Deserialize, Serialize};
 use tokmd_types::{ScanStatus, ToolInfo};
 
 pub use api_surface::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
+pub use churn::{ChurnTrend, PredictiveChurnReport, TrendClass};
 pub use derived::{
     BoilerplateReport, ContextWindowReport, DerivedReport, DerivedTotals, DistributionReport,
     FileStatRow, HistogramBucket, IntegrityReport, LangPurityReport, LangPurityRow, MaxFileReport,
@@ -48,10 +50,9 @@ pub use effort::{
 };
 pub use entropy::{EntropyClass, EntropyFinding, EntropyReport};
 pub use git::{
-    BusFactorRow, ChurnTrend, CodeAgeBucket, CodeAgeDistributionReport, CommitIntentCounts,
-    CommitIntentKind, CommitIntentReport, CorporateFingerprint, CouplingRow, DomainStat,
-    FreshnessReport, GitReport, HotspotRow, ModuleFreshnessRow, ModuleIntentRow,
-    PredictiveChurnReport, TrendClass,
+    BusFactorRow, CodeAgeBucket, CodeAgeDistributionReport, CommitIntentCounts, CommitIntentKind,
+    CommitIntentReport, CorporateFingerprint, CouplingRow, DomainStat, FreshnessReport, GitReport,
+    HotspotRow, ModuleFreshnessRow, ModuleIntentRow,
 };
 pub use license::{LicenseFinding, LicenseReport, LicenseSourceKind};
 pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport};


### PR DESCRIPTION
## Summary
- Move predictive churn DTOs into `crates/tokmd-analysis-types/src/churn.rs`
- Preserve root-level public re-exports for `PredictiveChurnReport`, `ChurnTrend`, and `TrendClass`
- Keep git receipt/schema behavior unchanged while narrowing `git.rs` to broader git DTOs

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features churn --verbose`
- `cargo test -p tokmd-format churn --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`