### PR TITLE
refactor(analysis-types): split corporate DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/corporate.rs
+++ b/crates/tokmd-analysis-types/src/corporate.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorporateFingerprint {
+    pub domains: Vec<DomainStat>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainStat {
+    pub domain: String,
+    pub commits: u32,
+    pub pct: f32,
+}

--- a/crates/tokmd-analysis-types/src/git.rs
+++ b/crates/tokmd-analysis-types/src/git.rs
@@ -2,22 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::churn::TrendClass;
 
-// ---------------------
-// Corporate fingerprint
-// ---------------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CorporateFingerprint {
-    pub domains: Vec<DomainStat>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DomainStat {
-    pub domain: String,
-    pub commits: u32,
-    pub pct: f32,
-}
-
 // ---------
 // Git report
 // ---------

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod api_surface;
 mod churn;
+mod corporate;
 mod derived;
 mod duplication;
 mod effort;
@@ -32,6 +33,7 @@ use tokmd_types::{ScanStatus, ToolInfo};
 
 pub use api_surface::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
 pub use churn::{ChurnTrend, PredictiveChurnReport, TrendClass};
+pub use corporate::{CorporateFingerprint, DomainStat};
 pub use derived::{
     BoilerplateReport, ContextWindowReport, DerivedReport, DerivedTotals, DistributionReport,
     FileStatRow, HistogramBucket, IntegrityReport, LangPurityReport, LangPurityRow, MaxFileReport,
@@ -51,8 +53,8 @@ pub use effort::{
 pub use entropy::{EntropyClass, EntropyFinding, EntropyReport};
 pub use git::{
     BusFactorRow, CodeAgeBucket, CodeAgeDistributionReport, CommitIntentCounts, CommitIntentKind,
-    CommitIntentReport, CorporateFingerprint, CouplingRow, DomainStat, FreshnessReport, GitReport,
-    HotspotRow, ModuleFreshnessRow, ModuleIntentRow,
+    CommitIntentReport, CouplingRow, FreshnessReport, GitReport, HotspotRow, ModuleFreshnessRow,
+    ModuleIntentRow,
 };
 pub use license::{LicenseFinding, LicenseReport, LicenseSourceKind};
 pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport};


### PR DESCRIPTION
## Summary
- Move corporate fingerprint DTOs into `crates/tokmd-analysis-types/src/corporate.rs`
- Preserve root-level public re-exports for `CorporateFingerprint` and `DomainStat`
- Keep git receipt/schema behavior unchanged while narrowing `git.rs` to git DTOs

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features fingerprint --verbose`
- `cargo test -p tokmd-format corporate --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`