### PR TITLE
refactor(analysis-types): split dependency DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/dependencies.rs
+++ b/crates/tokmd-analysis-types/src/dependencies.rs
@@ -1,0 +1,19 @@
+//! Dependency receipt DTOs.
+//!
+//! These supply-chain-adjacent contract types remain re-exported from the
+//! crate root to preserve existing `tokmd_analysis_types::...` names.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DependencyReport {
+    pub total: usize,
+    pub lockfiles: Vec<LockfileReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LockfileReport {
+    pub path: String,
+    pub kind: String,
+    pub dependencies: usize,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -17,6 +17,7 @@
 mod api_surface;
 mod churn;
 mod corporate;
+mod dependencies;
 mod derived;
 mod duplication;
 mod effort;
@@ -34,6 +35,7 @@ use tokmd_types::{ScanStatus, ToolInfo};
 pub use api_surface::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
 pub use churn::{ChurnTrend, PredictiveChurnReport, TrendClass};
 pub use corporate::{CorporateFingerprint, DomainStat};
+pub use dependencies::{DependencyReport, LockfileReport};
 pub use derived::{
     BoilerplateReport, ContextWindowReport, DerivedReport, DerivedTotals, DistributionReport,
     FileStatRow, HistogramBucket, IntegrityReport, LangPurityReport, LangPurityRow, MaxFileReport,
@@ -57,7 +59,7 @@ pub use git::{
     ModuleIntentRow,
 };
 pub use license::{LicenseFinding, LicenseReport, LicenseSourceKind};
-pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport, DependencyReport, LockfileReport};
+pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport};
 pub use topics::{TopicClouds, TopicTerm};
 pub use util::{
     AnalysisLimits, empty_file_row, is_infra_lang, is_test_path, normalize_path, normalize_root,

--- a/crates/tokmd-analysis-types/src/supply.rs
+++ b/crates/tokmd-analysis-types/src/supply.rs
@@ -1,7 +1,7 @@
-//! Asset and dependency receipt DTOs.
+//! Asset receipt DTOs.
 //!
-//! These supply-chain-adjacent contract types remain re-exported from the
-//! crate root to preserve existing `tokmd_analysis_types::...` names.
+//! These supply-chain-adjacent contract types remain re-exported from the crate
+//! root to preserve existing `tokmd_analysis_types::...` names.
 
 use serde::{Deserialize, Serialize};
 
@@ -27,17 +27,4 @@ pub struct AssetFileRow {
     pub bytes: u64,
     pub category: String,
     pub extension: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DependencyReport {
-    pub total: usize,
-    pub lockfiles: Vec<LockfileReport>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LockfileReport {
-    pub path: String,
-    pub kind: String,
-    pub dependencies: usize,
 }


### PR DESCRIPTION
## Summary
- Move dependency DTOs into `crates/tokmd-analysis-types/src/dependencies.rs`
- Preserve root-level public re-exports for `DependencyReport` and `LockfileReport`
- Leave asset DTO ownership in `supply.rs` for a later narrow split

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features dependency --verbose`
- `cargo test -p tokmd-format deps --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`