### PR TITLE
refactor(analysis-types): split asset DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/assets.rs
+++ b/crates/tokmd-analysis-types/src/assets.rs
@@ -1,7 +1,7 @@
 //! Asset receipt DTOs.
 //!
-//! These supply-chain-adjacent contract types remain re-exported from the crate
-//! root to preserve existing `tokmd_analysis_types::...` names.
+//! These contract types remain re-exported from the crate root to preserve
+//! existing `tokmd_analysis_types::...` names.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -15,6 +15,7 @@
 //! * File I/O operations
 
 mod api_surface;
+mod assets;
 mod churn;
 mod corporate;
 mod dependencies;
@@ -25,7 +26,6 @@ mod entropy;
 pub mod findings;
 mod git;
 mod license;
-mod supply;
 mod topics;
 pub mod util;
 
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 use tokmd_types::{ScanStatus, ToolInfo};
 
 pub use api_surface::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
+pub use assets::{AssetCategoryRow, AssetFileRow, AssetReport};
 pub use churn::{ChurnTrend, PredictiveChurnReport, TrendClass};
 pub use corporate::{CorporateFingerprint, DomainStat};
 pub use dependencies::{DependencyReport, LockfileReport};
@@ -59,7 +60,6 @@ pub use git::{
     ModuleIntentRow,
 };
 pub use license::{LicenseFinding, LicenseReport, LicenseSourceKind};
-pub use supply::{AssetCategoryRow, AssetFileRow, AssetReport};
 pub use topics::{TopicClouds, TopicTerm};
 pub use util::{
     AnalysisLimits, empty_file_row, is_infra_lang, is_test_path, normalize_path, normalize_root,


### PR DESCRIPTION
## Summary
- Move asset DTOs from `supply.rs` into `crates/tokmd-analysis-types/src/assets.rs`
- Preserve root-level public re-exports for `AssetReport`, `AssetCategoryRow`, and `AssetFileRow`
- Remove the now-empty private `supply` owner module without changing receipt/schema behavior

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features assets --verbose`
- `cargo test -p tokmd-format assets --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`