### PR TITLE
refactor(analysis-types): split import DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/imports.rs
+++ b/crates/tokmd-analysis-types/src/imports.rs
@@ -1,0 +1,19 @@
+//! Import graph receipt DTOs.
+//!
+//! These contract types remain re-exported from the crate root to preserve
+//! existing `tokmd_analysis_types::...` names.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportReport {
+    pub granularity: String,
+    pub edges: Vec<ImportEdge>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportEdge {
+    pub from: String,
+    pub to: String,
+    pub count: usize,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -25,6 +25,7 @@ mod effort;
 mod entropy;
 pub mod findings;
 mod git;
+mod imports;
 mod license;
 mod topics;
 pub mod util;
@@ -59,6 +60,7 @@ pub use git::{
     CommitIntentReport, CouplingRow, FreshnessReport, GitReport, HotspotRow, ModuleFreshnessRow,
     ModuleIntentRow,
 };
+pub use imports::{ImportEdge, ImportReport};
 pub use license::{LicenseFinding, LicenseReport, LicenseSourceKind};
 pub use topics::{TopicClouds, TopicTerm};
 pub use util::{
@@ -138,23 +140,6 @@ pub struct AnalysisArgsMeta {
 pub struct Archetype {
     pub kind: String,
     pub evidence: Vec<String>,
-}
-
-// -----------------
-// Import graph info
-// -----------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImportReport {
-    pub granularity: String,
-    pub edges: Vec<ImportEdge>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImportEdge {
-    pub from: String,
-    pub to: String,
-    pub count: usize,
 }
 
 // -------------------


### PR DESCRIPTION
## Summary
- Move import DTOs into `crates/tokmd-analysis-types/src/imports.rs`
- Preserve root-level public re-exports for `ImportReport` and `ImportEdge`
- Leave receipt/schema and renderer behavior unchanged

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features imports --verbose`
- `cargo test -p tokmd-format imports --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`