### PR TITLE
refactor(analysis-types): split fun DTOs

### DIFF
--- a/crates/tokmd-analysis-types/src/fun.rs
+++ b/crates/tokmd-analysis-types/src/fun.rs
@@ -1,0 +1,19 @@
+//! Fun and novelty analysis receipt DTOs.
+//!
+//! These contract types remain re-exported from the crate root to preserve
+//! existing `tokmd_analysis_types::...` names.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunReport {
+    pub eco_label: Option<EcoLabel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EcoLabel {
+    pub score: f64,
+    pub label: String,
+    pub bytes: u64,
+    pub notes: String,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -25,6 +25,7 @@ mod duplication;
 mod effort;
 mod entropy;
 pub mod findings;
+mod fun;
 mod git;
 mod imports;
 mod license;
@@ -61,6 +62,7 @@ pub use effort::{
     EffortEstimateReport, EffortModel, EffortResults, EffortSizeBasis, EffortTagSizeRow,
 };
 pub use entropy::{EntropyClass, EntropyFinding, EntropyReport};
+pub use fun::{EcoLabel, FunReport};
 pub use git::{
     BusFactorRow, CodeAgeBucket, CodeAgeDistributionReport, CommitIntentCounts, CommitIntentKind,
     CommitIntentReport, CouplingRow, FreshnessReport, GitReport, HotspotRow, ModuleFreshnessRow,
@@ -444,23 +446,6 @@ fn chrono_timestamp_iso8601(ms: u128) -> String {
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
         y, m, d, hour, min, sec, millis
     )
-}
-
-// ---------
-// Fun stuff
-// ---------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FunReport {
-    pub eco_label: Option<EcoLabel>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EcoLabel {
-    pub score: f64,
-    pub label: String,
-    pub bytes: u64,
-    pub notes: String,
 }
 
 // =========================


### PR DESCRIPTION
## Summary
- move `FunReport` and `EcoLabel` into `crates/tokmd-analysis-types/src/fun.rs`
- preserve root-level `tokmd_analysis_types::{FunReport, EcoLabel}` re-exports
- leave analysis receipt schema, serde fields, renderer behavior, and proof policy unchanged

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features fun --verbose`
- `cargo test -p tokmd-format fun --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`