### PR TITLE
refactor(analysis-types): split archetype DTO

### DIFF
--- a/crates/tokmd-analysis-types/src/archetype.rs
+++ b/crates/tokmd-analysis-types/src/archetype.rs
@@ -1,0 +1,12 @@
+//! Project archetype analysis receipt DTOs.
+//!
+//! These contract types remain re-exported from the crate root to preserve
+//! existing `tokmd_analysis_types::...` names.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Archetype {
+    pub kind: String,
+    pub evidence: Vec<String>,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -15,6 +15,7 @@
 //! * File I/O operations
 
 mod api_surface;
+mod archetype;
 mod assets;
 mod churn;
 mod complexity;
@@ -36,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use tokmd_types::{ScanStatus, ToolInfo};
 
 pub use api_surface::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
+pub use archetype::Archetype;
 pub use assets::{AssetCategoryRow, AssetFileRow, AssetReport};
 pub use churn::{ChurnTrend, PredictiveChurnReport, TrendClass};
 pub use complexity::{
@@ -138,16 +140,6 @@ pub struct AnalysisArgsMeta {
     pub max_commit_files: Option<usize>,
     pub max_file_bytes: Option<u64>,
     pub import_granularity: String,
-}
-
-// ---------------
-// Project context
-// ---------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Archetype {
-    pub kind: String,
-    pub evidence: Vec<String>,
 }
 
 // -------------------


### PR DESCRIPTION
## Summary
- move `Archetype` into `crates/tokmd-analysis-types/src/archetype.rs`
- preserve the root-level `tokmd_analysis_types::Archetype` re-export
- leave analysis receipt schema, serde fields, renderer behavior, and proof policy unchanged

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --all-features archetype --verbose`
- `cargo test -p tokmd-format archetype --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `git diff --check origin/main..HEAD`