### PR TITLE
refactor(analysis-types): split source DTO

### DIFF
--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -30,6 +30,7 @@ mod fun;
 mod git;
 mod imports;
 mod license;
+mod source;
 mod topics;
 pub mod util;
 
@@ -72,6 +73,7 @@ pub use git::{
 };
 pub use imports::{ImportEdge, ImportReport};
 pub use license::{LicenseFinding, LicenseReport, LicenseSourceKind};
+pub use source::AnalysisSource;
 pub use topics::{TopicClouds, TopicTerm};
 pub use util::{
     AnalysisLimits, empty_file_row, is_infra_lang, is_test_path, normalize_path, normalize_root,
@@ -113,19 +115,6 @@ pub struct AnalysisReceipt {
     pub api_surface: Option<ApiSurfaceReport>,
     pub effort: Option<EffortEstimateReport>,
     pub fun: Option<FunReport>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnalysisSource {
-    pub inputs: Vec<String>,
-    pub export_path: Option<String>,
-    pub base_receipt_path: Option<String>,
-    pub export_schema_version: Option<u32>,
-    pub export_generated_at_ms: Option<u128>,
-    pub base_signature: Option<String>,
-    pub module_roots: Vec<String>,
-    pub module_depth: usize,
-    pub children: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/tokmd-analysis-types/src/source.rs
+++ b/crates/tokmd-analysis-types/src/source.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+/// Source metadata recorded in an analysis receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalysisSource {
+    pub inputs: Vec<String>,
+    pub export_path: Option<String>,
+    pub base_receipt_path: Option<String>,
+    pub export_schema_version: Option<u32>,
+    pub export_generated_at_ms: Option<u128>,
+    pub base_signature: Option<String>,
+    pub module_roots: Vec<String>,
+    pub module_depth: usize,
+    pub children: String,
+}


### PR DESCRIPTION
## Summary
- move `AnalysisSource` into `crates/tokmd-analysis-types/src/source.rs`
- preserve the root-level `tokmd_analysis_types::AnalysisSource` re-export
- keep receipt/schema behavior unchanged

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `cargo test -p tokmd-analysis --all-features analysis --verbose`
- `cargo test -p tokmd-format analysis --verbose`
- `git diff --check origin/main..HEAD`