### PR TITLE
refactor(analysis-types): split args DTO

### DIFF
--- a/crates/tokmd-analysis-types/src/args.rs
+++ b/crates/tokmd-analysis-types/src/args.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+/// Command argument metadata recorded in an analysis receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalysisArgsMeta {
+    pub preset: String,
+    pub format: String,
+    pub window_tokens: Option<usize>,
+    pub git: Option<bool>,
+    pub max_files: Option<usize>,
+    pub max_bytes: Option<u64>,
+    pub max_commits: Option<usize>,
+    pub max_commit_files: Option<usize>,
+    pub max_file_bytes: Option<u64>,
+    pub import_granularity: String,
+}

--- a/crates/tokmd-analysis-types/src/lib.rs
+++ b/crates/tokmd-analysis-types/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod api_surface;
 mod archetype;
+mod args;
 mod assets;
 mod churn;
 mod complexity;
@@ -39,6 +40,7 @@ use tokmd_types::{ScanStatus, ToolInfo};
 
 pub use api_surface::{ApiExportItem, ApiSurfaceReport, LangApiSurface, ModuleApiRow};
 pub use archetype::Archetype;
+pub use args::AnalysisArgsMeta;
 pub use assets::{AssetCategoryRow, AssetFileRow, AssetReport};
 pub use churn::{ChurnTrend, PredictiveChurnReport, TrendClass};
 pub use complexity::{
@@ -115,20 +117,6 @@ pub struct AnalysisReceipt {
     pub api_surface: Option<ApiSurfaceReport>,
     pub effort: Option<EffortEstimateReport>,
     pub fun: Option<FunReport>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnalysisArgsMeta {
-    pub preset: String,
-    pub format: String,
-    pub window_tokens: Option<usize>,
-    pub git: Option<bool>,
-    pub max_files: Option<usize>,
-    pub max_bytes: Option<u64>,
-    pub max_commits: Option<usize>,
-    pub max_commit_files: Option<usize>,
-    pub max_file_bytes: Option<u64>,
-    pub import_granularity: String,
 }
 
 // -------------------


### PR DESCRIPTION
## Summary
- move `AnalysisArgsMeta` into `crates/tokmd-analysis-types/src/args.rs`
- preserve the root-level `tokmd_analysis_types::AnalysisArgsMeta` re-export
- keep receipt/schema behavior unchanged

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo test -p tokmd-types schema --verbose`
- `cargo test -p tokmd-analysis --all-features analysis --verbose`
- `cargo test -p tokmd-format analysis --verbose`
- `git diff --check origin/main..HEAD`