### PR TITLE
refactor(analysis): extract complexity histogram helper

### DIFF
--- a/crates/tokmd-analysis/src/complexity/histogram.rs
+++ b/crates/tokmd-analysis/src/complexity/histogram.rs
@@ -1,0 +1,37 @@
+//! Cyclomatic complexity histogram construction.
+
+use tokmd_analysis_types::{ComplexityHistogram, FileComplexity};
+
+/// Generate a histogram of cyclomatic complexity distribution.
+///
+/// Buckets files by cyclomatic complexity: 0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30+.
+///
+/// # Arguments
+/// * `files` - Slice of file complexity data
+/// * `bucket_size` - Size of each bucket (default 5)
+///
+/// # Returns
+/// A `ComplexityHistogram` with counts for each bucket
+///
+/// # Note
+/// This function is planned for integration in v1.6.0.
+pub(crate) fn generate_complexity_histogram(
+    files: &[FileComplexity],
+    bucket_size: u32,
+) -> ComplexityHistogram {
+    // 7 buckets: 0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30+
+    let num_buckets = 7;
+    let mut counts = vec![0u32; num_buckets];
+
+    for file in files {
+        let complexity = file.cyclomatic_complexity as u32;
+        let bucket = (complexity / bucket_size).min((num_buckets - 1) as u32) as usize;
+        counts[bucket] += 1;
+    }
+
+    ComplexityHistogram {
+        buckets: (0..num_buckets).map(|i| (i as u32) * bucket_size).collect(),
+        counts,
+        total: files.len() as u32,
+    }
+}

--- a/crates/tokmd-analysis/src/complexity/mod.rs
+++ b/crates/tokmd-analysis/src/complexity/mod.rs
@@ -5,7 +5,7 @@ use crate::maintainability::compute_maintainability_index;
 use anyhow::Result;
 #[cfg(test)]
 use tokmd_analysis_types::TechnicalDebtLevel;
-use tokmd_analysis_types::{ComplexityHistogram, ComplexityReport, ComplexityRisk, FileComplexity};
+use tokmd_analysis_types::{ComplexityReport, ComplexityRisk, FileComplexity};
 use tokmd_types::{ExportData, FileKind, FileRow};
 
 use tokmd_analysis_types::{AnalysisLimits, normalize_path};
@@ -13,6 +13,7 @@ use tokmd_analysis_types::{AnalysisLimits, normalize_path};
 mod debt;
 mod details;
 mod functions;
+mod histogram;
 mod risk;
 
 use debt::{average_parent_loc, compute_technical_debt_ratio};
@@ -22,6 +23,7 @@ use details::{detect_fn_spans_c_style, detect_fn_spans_python, detect_fn_spans_r
 use functions::count_functions;
 #[cfg(test)]
 use functions::{count_python_functions, count_rust_functions, is_rust_fn_start};
+pub(crate) use histogram::generate_complexity_histogram;
 use risk::{classify_risk_extended, estimate_cyclomatic};
 
 const DEFAULT_MAX_FILE_BYTES: u64 = 128 * 1024;
@@ -274,40 +276,6 @@ pub(crate) fn build_complexity_report(
         technical_debt,
         files: file_complexities,
     })
-}
-
-/// Generate a histogram of cyclomatic complexity distribution.
-///
-/// Buckets files by cyclomatic complexity: 0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30+.
-///
-/// # Arguments
-/// * `files` - Slice of file complexity data
-/// * `bucket_size` - Size of each bucket (default 5)
-///
-/// # Returns
-/// A `ComplexityHistogram` with counts for each bucket
-///
-/// # Note
-/// This function is planned for integration in v1.6.0.
-pub(crate) fn generate_complexity_histogram(
-    files: &[FileComplexity],
-    bucket_size: u32,
-) -> ComplexityHistogram {
-    // 7 buckets: 0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30+
-    let num_buckets = 7;
-    let mut counts = vec![0u32; num_buckets];
-
-    for file in files {
-        let complexity = file.cyclomatic_complexity as u32;
-        let bucket = (complexity / bucket_size).min((num_buckets - 1) as u32) as usize;
-        counts[bucket] += 1;
-    }
-
-    ComplexityHistogram {
-        buckets: (0..num_buckets).map(|i| (i as u32) * bucket_size).collect(),
-        counts,
-        total: files.len() as u32,
-    }
 }
 
 fn round_f64(val: f64, decimals: u32) -> f64 {

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Context packing | `crates/tokmd/src/context_pack.rs` | 1950 | Split selection, budgeting, rendering, and manifest helpers under `tokmd` |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` | 1702 | Split receipt DTO families while preserving re-exports |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
-| Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/risk.rs` + `complexity/debt.rs` | 631 + 301 + 343 + 78 + 69 | Keep shared complexity logic in `tokmd-analysis`, split language/source helpers |
+| Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` | 600 + 301 + 343 + 78 + 69 + 33 | Keep shared complexity logic in `tokmd-analysis`, split language/source helpers |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` | 1276 | Split command argument families while preserving clap output |
 | Model aggregation | `crates/tokmd-model/src/lib.rs` | 1159 | Split aggregation, row sorting, and child-language behavior under `tokmd-model` |
 


### PR DESCRIPTION
## Summary
- move the analysis complexity histogram builder into `complexity/histogram.rs`
- preserve `crate::complexity::generate_complexity_histogram` through the existing module surface
- update the architecture consolidation checkpoint with the new owner module split

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis --all-features complexity --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`
