### PR TITLE
refactor(analysis): extract complexity language helpers

### DIFF
--- a/crates/tokmd-analysis/src/complexity/language.rs
+++ b/crates/tokmd-analysis/src/complexity/language.rs
@@ -1,0 +1,37 @@
+//! Language compatibility helpers for complexity analysis.
+
+/// Map language strings to complexity-compatible names.
+pub(super) fn map_language_for_complexity(lang: &str) -> &str {
+    match lang.to_lowercase().as_str() {
+        "rust" => "rust",
+        "javascript" | "jsx" => "javascript",
+        "typescript" | "tsx" => "typescript",
+        "python" => "python",
+        "go" => "go",
+        "c" => "c",
+        "c++" | "cpp" => "c++",
+        "java" => "java",
+        "c#" | "csharp" => "c#",
+        "php" => "php",
+        "ruby" => "ruby",
+        _ => lang,
+    }
+}
+
+/// Languages that support complexity analysis.
+pub(super) fn is_complexity_lang(lang: &str) -> bool {
+    matches!(
+        lang.to_lowercase().as_str(),
+        "rust"
+            | "javascript"
+            | "typescript"
+            | "python"
+            | "go"
+            | "c"
+            | "c++"
+            | "java"
+            | "c#"
+            | "php"
+            | "ruby"
+    )
+}

--- a/crates/tokmd-analysis/src/complexity/mod.rs
+++ b/crates/tokmd-analysis/src/complexity/mod.rs
@@ -14,6 +14,7 @@ mod debt;
 mod details;
 mod functions;
 mod histogram;
+mod language;
 mod risk;
 
 use debt::{average_parent_loc, compute_technical_debt_ratio};
@@ -24,50 +25,15 @@ use functions::count_functions;
 #[cfg(test)]
 use functions::{count_python_functions, count_rust_functions, is_rust_fn_start};
 pub(crate) use histogram::generate_complexity_histogram;
+use language::{is_complexity_lang, map_language_for_complexity};
 use risk::{classify_risk_extended, estimate_cyclomatic};
 
 const DEFAULT_MAX_FILE_BYTES: u64 = 128 * 1024;
 const MAX_COMPLEXITY_FILES: usize = 100;
 
-/// Map language strings to complexity-compatible names.
-fn map_language_for_complexity(lang: &str) -> &str {
-    match lang.to_lowercase().as_str() {
-        "rust" => "rust",
-        "javascript" | "jsx" => "javascript",
-        "typescript" | "tsx" => "typescript",
-        "python" => "python",
-        "go" => "go",
-        "c" => "c",
-        "c++" | "cpp" => "c++",
-        "java" => "java",
-        "c#" | "csharp" => "c#",
-        "php" => "php",
-        "ruby" => "ruby",
-        _ => lang,
-    }
-}
-
 #[cfg(test)]
 #[path = "tests.rs"]
 mod moved_tests;
-
-/// Languages that support complexity analysis.
-fn is_complexity_lang(lang: &str) -> bool {
-    matches!(
-        lang.to_lowercase().as_str(),
-        "rust"
-            | "javascript"
-            | "typescript"
-            | "python"
-            | "go"
-            | "c"
-            | "c++"
-            | "java"
-            | "c#"
-            | "php"
-            | "ruby"
-    )
-}
 
 /// Build a complexity report by analyzing function counts, lengths, cyclomatic and cognitive complexity.
 pub(crate) fn build_complexity_report(

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Context packing | `crates/tokmd/src/context_pack.rs` | 1950 | Split selection, budgeting, rendering, and manifest helpers under `tokmd` |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` | 1702 | Split receipt DTO families while preserving re-exports |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
-| Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` | 600 + 301 + 343 + 78 + 69 + 33 | Keep shared complexity logic in `tokmd-analysis`, split language/source helpers |
+| Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` | 568 + 301 + 343 + 78 + 69 + 33 + 35 | Keep shared complexity logic in `tokmd-analysis`, split language/source helpers |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` | 1276 | Split command argument families while preserving clap output |
 | Model aggregation | `crates/tokmd-model/src/lib.rs` | 1159 | Split aggregation, row sorting, and child-language behavior under `tokmd-model` |
 


### PR DESCRIPTION
## Summary
- move complexity language compatibility helpers into `complexity/language.rs`
- keep report construction and function-detail extraction behavior unchanged
- update the architecture consolidation checkpoint with the new owner module split

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-analysis --all-features complexity --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`
