### PR TITLE
refactor(analysis): extract complexity summary helper

### DIFF
--- a/crates/tokmd-analysis/src/complexity/debt.rs
+++ b/crates/tokmd-analysis/src/complexity/debt.rs
@@ -3,7 +3,7 @@
 use tokmd_analysis_types::{FileComplexity, TechnicalDebtLevel, TechnicalDebtRatio};
 use tokmd_types::{ExportData, FileKind};
 
-use super::round_f64;
+use super::math::round_f64;
 
 const TECHNICAL_DEBT_LOW_THRESHOLD: f64 = 30.0;
 const TECHNICAL_DEBT_MODERATE_THRESHOLD: f64 = 60.0;

--- a/crates/tokmd-analysis/src/complexity/math.rs
+++ b/crates/tokmd-analysis/src/complexity/math.rs
@@ -1,0 +1,6 @@
+//! Shared numeric helpers for complexity analysis.
+
+pub(super) fn round_f64(val: f64, decimals: u32) -> f64 {
+    let factor = 10f64.powi(decimals as i32);
+    (val * factor).round() / factor
+}

--- a/crates/tokmd-analysis/src/complexity/mod.rs
+++ b/crates/tokmd-analysis/src/complexity/mod.rs
@@ -4,8 +4,10 @@ use std::path::{Path, PathBuf};
 use crate::maintainability::compute_maintainability_index;
 use anyhow::Result;
 #[cfg(test)]
+use tokmd_analysis_types::ComplexityRisk;
+#[cfg(test)]
 use tokmd_analysis_types::TechnicalDebtLevel;
-use tokmd_analysis_types::{ComplexityReport, ComplexityRisk, FileComplexity};
+use tokmd_analysis_types::{ComplexityReport, FileComplexity};
 use tokmd_types::{ExportData, FileKind, FileRow};
 
 use tokmd_analysis_types::{AnalysisLimits, normalize_path};
@@ -15,7 +17,9 @@ mod details;
 mod functions;
 mod histogram;
 mod language;
+mod math;
 mod risk;
+mod summary;
 
 use debt::{average_parent_loc, compute_technical_debt_ratio};
 use details::extract_function_details;
@@ -27,6 +31,7 @@ use functions::{count_python_functions, count_rust_functions, is_rust_fn_start};
 pub(crate) use histogram::generate_complexity_histogram;
 use language::{is_complexity_lang, map_language_for_complexity};
 use risk::{classify_risk_extended, estimate_cyclomatic};
+use summary::summarize_file_complexities;
 
 const DEFAULT_MAX_FILE_BYTES: u64 = 128 * 1024;
 const MAX_COMPLEXITY_FILES: usize = 100;
@@ -133,92 +138,18 @@ pub(crate) fn build_complexity_report(
     });
 
     // Compute aggregates before truncating
-    let total_functions: usize = file_complexities.iter().map(|f| f.function_count).sum();
-    let file_count = file_complexities.len();
-
-    let avg_function_length = if total_functions == 0 {
-        0.0
-    } else {
-        let total_max_len: usize = file_complexities
-            .iter()
-            .map(|f| f.max_function_length)
-            .sum();
-        round_f64(total_max_len as f64 / file_count as f64, 2)
-    };
-
-    let max_function_length = file_complexities
-        .iter()
-        .map(|f| f.max_function_length)
-        .max()
-        .unwrap_or(0);
-
-    let avg_cyclomatic = if file_count == 0 {
-        0.0
-    } else {
-        let total_cyclo: usize = file_complexities
-            .iter()
-            .map(|f| f.cyclomatic_complexity)
-            .sum();
-        round_f64(total_cyclo as f64 / file_count as f64, 2)
-    };
-
-    let max_cyclomatic = file_complexities
-        .iter()
-        .map(|f| f.cyclomatic_complexity)
-        .max()
-        .unwrap_or(0);
-
-    // Compute cognitive complexity aggregates
-    let cognitive_values: Vec<usize> = file_complexities
-        .iter()
-        .filter_map(|f| f.cognitive_complexity)
-        .collect();
-    let (avg_cognitive, max_cognitive) = if cognitive_values.is_empty() {
-        (None, None)
-    } else {
-        let total: usize = cognitive_values.iter().sum();
-        let max = cognitive_values.iter().copied().max().unwrap_or(0);
-        (
-            Some(round_f64(total as f64 / cognitive_values.len() as f64, 2)),
-            Some(max),
-        )
-    };
-
-    // Compute nesting depth aggregates
-    let nesting_values: Vec<usize> = file_complexities
-        .iter()
-        .filter_map(|f| f.max_nesting)
-        .collect();
-    let (avg_nesting_depth, max_nesting_depth) = if nesting_values.is_empty() {
-        (None, None)
-    } else {
-        let total: usize = nesting_values.iter().sum();
-        let max = nesting_values.iter().copied().max().unwrap_or(0);
-        (
-            Some(round_f64(total as f64 / nesting_values.len() as f64, 2)),
-            Some(max),
-        )
-    };
-
-    let high_risk_files = file_complexities
-        .iter()
-        .filter(|f| {
-            matches!(
-                f.risk_level,
-                ComplexityRisk::High | ComplexityRisk::Critical
-            )
-        })
-        .count();
+    let summary = summarize_file_complexities(&file_complexities);
 
     // Generate histogram from all files before truncating
     let histogram = generate_complexity_histogram(&file_complexities, 5);
 
     // Compute maintainability index
-    let maintainability_index = if file_count == 0 {
+    let maintainability_index = if file_complexities.is_empty() {
         None
     } else {
-        average_parent_loc(export)
-            .and_then(|avg_loc| compute_maintainability_index(avg_cyclomatic, avg_loc, None))
+        average_parent_loc(export).and_then(|avg_loc| {
+            compute_maintainability_index(summary.avg_cyclomatic, avg_loc, None)
+        })
     };
     let technical_debt = compute_technical_debt_ratio(export, &file_complexities);
 
@@ -226,27 +157,22 @@ pub(crate) fn build_complexity_report(
     file_complexities.truncate(MAX_COMPLEXITY_FILES);
 
     Ok(ComplexityReport {
-        total_functions,
-        avg_function_length,
-        max_function_length,
-        avg_cyclomatic,
-        max_cyclomatic,
-        avg_cognitive,
-        max_cognitive,
-        avg_nesting_depth,
-        max_nesting_depth,
-        high_risk_files,
+        total_functions: summary.total_functions,
+        avg_function_length: summary.avg_function_length,
+        max_function_length: summary.max_function_length,
+        avg_cyclomatic: summary.avg_cyclomatic,
+        max_cyclomatic: summary.max_cyclomatic,
+        avg_cognitive: summary.avg_cognitive,
+        max_cognitive: summary.max_cognitive,
+        avg_nesting_depth: summary.avg_nesting_depth,
+        max_nesting_depth: summary.max_nesting_depth,
+        high_risk_files: summary.high_risk_files,
         histogram: Some(histogram),
         halstead: None, // Populated when halstead feature is enabled
         maintainability_index,
         technical_debt,
         files: file_complexities,
     })
-}
-
-fn round_f64(val: f64, decimals: u32) -> f64 {
-    let factor = 10f64.powi(decimals as i32);
-    (val * factor).round() / factor
 }
 
 #[cfg(test)]

--- a/crates/tokmd-analysis/src/complexity/summary.rs
+++ b/crates/tokmd-analysis/src/complexity/summary.rs
@@ -1,0 +1,158 @@
+//! Aggregate summary calculations for complexity reports.
+
+use tokmd_analysis_types::{ComplexityRisk, FileComplexity};
+
+use super::math::round_f64;
+
+pub(super) struct ComplexitySummary {
+    pub(super) total_functions: usize,
+    pub(super) avg_function_length: f64,
+    pub(super) max_function_length: usize,
+    pub(super) avg_cyclomatic: f64,
+    pub(super) max_cyclomatic: usize,
+    pub(super) avg_cognitive: Option<f64>,
+    pub(super) max_cognitive: Option<usize>,
+    pub(super) avg_nesting_depth: Option<f64>,
+    pub(super) max_nesting_depth: Option<usize>,
+    pub(super) high_risk_files: usize,
+}
+
+pub(super) fn summarize_file_complexities(files: &[FileComplexity]) -> ComplexitySummary {
+    let total_functions: usize = files.iter().map(|f| f.function_count).sum();
+    let file_count = files.len();
+
+    let avg_function_length = if total_functions == 0 {
+        0.0
+    } else {
+        let total_max_len: usize = files.iter().map(|f| f.max_function_length).sum();
+        round_f64(total_max_len as f64 / file_count as f64, 2)
+    };
+
+    let max_function_length = files
+        .iter()
+        .map(|f| f.max_function_length)
+        .max()
+        .unwrap_or(0);
+
+    let avg_cyclomatic = if file_count == 0 {
+        0.0
+    } else {
+        let total_cyclo: usize = files.iter().map(|f| f.cyclomatic_complexity).sum();
+        round_f64(total_cyclo as f64 / file_count as f64, 2)
+    };
+
+    let max_cyclomatic = files
+        .iter()
+        .map(|f| f.cyclomatic_complexity)
+        .max()
+        .unwrap_or(0);
+
+    let cognitive_values: Vec<usize> = files
+        .iter()
+        .filter_map(|f| f.cognitive_complexity)
+        .collect();
+    let (avg_cognitive, max_cognitive) = summarize_optional_values(&cognitive_values);
+
+    let nesting_values: Vec<usize> = files.iter().filter_map(|f| f.max_nesting).collect();
+    let (avg_nesting_depth, max_nesting_depth) = summarize_optional_values(&nesting_values);
+
+    let high_risk_files = files
+        .iter()
+        .filter(|f| {
+            matches!(
+                f.risk_level,
+                ComplexityRisk::High | ComplexityRisk::Critical
+            )
+        })
+        .count();
+
+    ComplexitySummary {
+        total_functions,
+        avg_function_length,
+        max_function_length,
+        avg_cyclomatic,
+        max_cyclomatic,
+        avg_cognitive,
+        max_cognitive,
+        avg_nesting_depth,
+        max_nesting_depth,
+        high_risk_files,
+    }
+}
+
+fn summarize_optional_values(values: &[usize]) -> (Option<f64>, Option<usize>) {
+    if values.is_empty() {
+        (None, None)
+    } else {
+        let total: usize = values.iter().sum();
+        let max = values.iter().copied().max().unwrap_or(0);
+        (
+            Some(round_f64(total as f64 / values.len() as f64, 2)),
+            Some(max),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(
+        function_count: usize,
+        max_function_length: usize,
+        cyclomatic_complexity: usize,
+        cognitive_complexity: Option<usize>,
+        max_nesting: Option<usize>,
+        risk_level: ComplexityRisk,
+    ) -> FileComplexity {
+        FileComplexity {
+            path: "src/lib.rs".to_string(),
+            module: "src".to_string(),
+            function_count,
+            max_function_length,
+            cyclomatic_complexity,
+            cognitive_complexity,
+            max_nesting,
+            risk_level,
+            functions: None,
+        }
+    }
+
+    #[test]
+    fn empty_input_produces_zero_summary() {
+        let summary = summarize_file_complexities(&[]);
+
+        assert_eq!(summary.total_functions, 0);
+        assert_eq!(summary.avg_function_length, 0.0);
+        assert_eq!(summary.max_function_length, 0);
+        assert_eq!(summary.avg_cyclomatic, 0.0);
+        assert_eq!(summary.max_cyclomatic, 0);
+        assert_eq!(summary.avg_cognitive, None);
+        assert_eq!(summary.max_cognitive, None);
+        assert_eq!(summary.avg_nesting_depth, None);
+        assert_eq!(summary.max_nesting_depth, None);
+        assert_eq!(summary.high_risk_files, 0);
+    }
+
+    #[test]
+    fn summarizes_file_complexity_aggregates() {
+        let files = vec![
+            file(2, 10, 3, Some(4), Some(2), ComplexityRisk::Low),
+            file(4, 21, 8, Some(9), Some(5), ComplexityRisk::High),
+            file(0, 0, 1, None, None, ComplexityRisk::Critical),
+        ];
+
+        let summary = summarize_file_complexities(&files);
+
+        assert_eq!(summary.total_functions, 6);
+        assert_eq!(summary.avg_function_length, 10.33);
+        assert_eq!(summary.max_function_length, 21);
+        assert_eq!(summary.avg_cyclomatic, 4.0);
+        assert_eq!(summary.max_cyclomatic, 8);
+        assert_eq!(summary.avg_cognitive, Some(6.5));
+        assert_eq!(summary.max_cognitive, Some(9));
+        assert_eq!(summary.avg_nesting_depth, Some(3.5));
+        assert_eq!(summary.max_nesting_depth, Some(5));
+        assert_eq!(summary.high_risk_files, 2);
+    }
+}

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Context packing | `crates/tokmd/src/context_pack.rs` | 1950 | Split selection, budgeting, rendering, and manifest helpers under `tokmd` |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` | 1702 | Split receipt DTO families while preserving re-exports |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
-| Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` | 568 + 301 + 343 + 78 + 69 + 33 + 35 | Keep shared complexity logic in `tokmd-analysis`, split language/source helpers |
+| Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` | 502 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` | 1276 | Split command argument families while preserving clap output |
 | Model aggregation | `crates/tokmd-model/src/lib.rs` | 1159 | Split aggregation, row sorting, and child-language behavior under `tokmd-model` |
 


### PR DESCRIPTION
## Summary

- move complexity aggregate summary calculation into `complexity::summary`
- move shared rounding into `complexity::math` so debt and summary do not depend on the coordinator
- update the architecture consolidation checkpoint for the new complexity owner modules

## Validation

- `cargo fmt-check`
- `cargo test -p tokmd-analysis --all-features complexity --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`