### PR TITLE
refactor(analysis): extract content complexity shared helpers

### DIFF
--- a/crates/tokmd-analysis/src/content/complexity.rs
+++ b/crates/tokmd-analysis/src/content/complexity.rs
@@ -40,6 +40,7 @@ mod cognitive;
 mod cyclomatic;
 mod functions;
 mod nesting;
+mod shared;
 
 #[allow(unused_imports)]
 pub use cognitive::{CognitiveComplexity, HighCognitiveFunction, estimate_cognitive_complexity};
@@ -53,48 +54,6 @@ pub use functions::{FunctionMetrics, analyze_functions};
 // though current callers only use `analyze_nesting_depth` directly.
 #[allow(unused_imports)]
 pub use nesting::{NestingAnalysis, analyze_nesting_depth};
-
-/// Get the indentation level (number of leading whitespace characters).
-fn get_indent(line: &str) -> usize {
-    line.len() - line.trim_start().len()
-}
-
-/// Check if line is a comment.
-fn is_comment_line(trimmed: &str, lang: &str) -> bool {
-    match lang {
-        "python" | "py" => trimmed.starts_with('#'),
-        _ => {
-            trimmed.starts_with("//")
-                || trimmed.starts_with("/*")
-                || trimmed.starts_with('*')
-                || trimmed.starts_with("*/")
-        }
-    }
-}
-
-/// Count occurrences of keyword ensuring it's a word boundary.
-fn count_keyword(line: &str, keyword: &str) -> usize {
-    let mut count = 0;
-    let mut pos = 0;
-
-    while let Some(idx) = line[pos..].find(keyword) {
-        let abs_pos = pos + idx;
-        // Check it's at word boundary (not part of larger identifier)
-        let before_ok = abs_pos == 0
-            || !line[..abs_pos]
-                .chars()
-                .last()
-                .map(|c| c.is_alphanumeric() || c == '_')
-                .unwrap_or(false);
-
-        if before_ok {
-            count += 1;
-        }
-        pos = abs_pos + keyword.len();
-    }
-
-    count
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/tokmd-analysis/src/content/complexity/cognitive.rs
+++ b/crates/tokmd-analysis/src/content/complexity/cognitive.rs
@@ -3,7 +3,7 @@
 //! This module owns nesting-aware cognitive scoring while sharing function span
 //! detection and low-level source predicates with the parent complexity module.
 
-use super::{count_keyword, functions, is_comment_line};
+use super::{functions, shared::count_keyword, shared::is_comment_line};
 
 /// Result of cognitive complexity analysis.
 ///

--- a/crates/tokmd-analysis/src/content/complexity/cyclomatic.rs
+++ b/crates/tokmd-analysis/src/content/complexity/cyclomatic.rs
@@ -3,7 +3,7 @@
 //! This module owns decision-point scoring while sharing function span
 //! detection and low-level source predicates with the parent complexity module.
 
-use super::{count_keyword, functions, is_comment_line};
+use super::{functions, shared::count_keyword, shared::is_comment_line};
 
 /// Result of cyclomatic complexity analysis.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/tokmd-analysis/src/content/complexity/functions.rs
+++ b/crates/tokmd-analysis/src/content/complexity/functions.rs
@@ -6,7 +6,7 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use super::get_indent;
+use super::shared::get_indent;
 
 /// Metrics about functions in a source file.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/tokmd-analysis/src/content/complexity/nesting.rs
+++ b/crates/tokmd-analysis/src/content/complexity/nesting.rs
@@ -3,7 +3,7 @@
 //! This module owns brace- and indentation-based nesting depth heuristics used
 //! by the content complexity analyzer.
 
-use super::{get_indent, is_comment_line};
+use super::{shared::get_indent, shared::is_comment_line};
 
 /// Result of nesting depth analysis.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/tokmd-analysis/src/content/complexity/shared.rs
+++ b/crates/tokmd-analysis/src/content/complexity/shared.rs
@@ -1,0 +1,43 @@
+//! Shared source-text predicates for content complexity analysis.
+
+/// Get the indentation level (number of leading whitespace characters).
+pub(super) fn get_indent(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// Check if line is a comment.
+pub(super) fn is_comment_line(trimmed: &str, lang: &str) -> bool {
+    match lang {
+        "python" | "py" => trimmed.starts_with('#'),
+        _ => {
+            trimmed.starts_with("//")
+                || trimmed.starts_with("/*")
+                || trimmed.starts_with('*')
+                || trimmed.starts_with("*/")
+        }
+    }
+}
+
+/// Count occurrences of keyword ensuring it's a word boundary.
+pub(super) fn count_keyword(line: &str, keyword: &str) -> usize {
+    let mut count = 0;
+    let mut pos = 0;
+
+    while let Some(idx) = line[pos..].find(keyword) {
+        let abs_pos = pos + idx;
+        // Check it's at word boundary (not part of larger identifier)
+        let before_ok = abs_pos == 0
+            || !line[..abs_pos]
+                .chars()
+                .last()
+                .map(|c| c.is_alphanumeric() || c == '_')
+                .unwrap_or(false);
+
+        if before_ok {
+            count += 1;
+        }
+        pos = abs_pos + keyword.len();
+    }
+
+    count
+}

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -59,7 +59,7 @@ fixtures:
 
 | Area | Current file | Approx. lines | Owner direction |
 | --- | --- | ---: | --- |
-| Content complexity | `crates/tokmd-analysis/src/content/complexity.rs` and `crates/tokmd-analysis/src/content/complexity/` | 1415 + 396 + 285 + 260 + 156 | Continue splitting detection, scoring, nesting, aggregation, and tests under `content::complexity` |
+| Content complexity | `crates/tokmd-analysis/src/content/complexity.rs` and `crates/tokmd-analysis/src/content/complexity/` | 1378 + 396 + 285 + 260 + 156 + 37 | Continue splitting detection, scoring, nesting, shared predicates, aggregation, and tests under `content::complexity` |
 | Context packing | `crates/tokmd/src/context_pack.rs` | 1950 | Split selection, budgeting, rendering, and manifest helpers under `tokmd` |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` | 1702 | Split receipt DTO families while preserving re-exports |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |


### PR DESCRIPTION
## Summary

- move shared content-complexity source predicates into `content::complexity::shared`
- update cognitive, cyclomatic, function-span, and nesting modules to use the shared owner
- update the architecture consolidation checkpoint for the new content complexity module

## Validation

- `cargo fmt-check`
- `cargo test -p tokmd-analysis --all-features complexity --verbose`
- `cargo test -p tokmd-analysis --all-features assets --verbose`
- `cargo test -p tokmd-analysis --all-features content --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`