### PR TITLE
refactor(analysis): extract content cyclomatic scoring

### DIFF
--- a/crates/tokmd-analysis/src/content/complexity/cyclomatic.rs
+++ b/crates/tokmd-analysis/src/content/complexity/cyclomatic.rs
@@ -3,7 +3,9 @@
 //! This module owns decision-point scoring while sharing function span
 //! detection and low-level source predicates with the parent complexity module.
 
-use super::{functions, shared::count_keyword, shared::is_comment_line};
+mod scoring;
+
+use super::functions;
 
 /// Result of cyclomatic complexity analysis.
 #[derive(Debug, Clone, PartialEq)]
@@ -106,7 +108,7 @@ pub fn estimate_cyclomatic_complexity(content: &str, language: &str) -> Cyclomat
     for span in &spans {
         let func_name = functions::extract_function_name(&lines, span.start_line, &lang);
         let func_lines: Vec<&str> = lines[span.start_line..=span.end_line].to_vec();
-        let cc = calculate_cyclomatic_complexity(&func_lines, &lang);
+        let cc = scoring::calculate_cyclomatic_complexity(&func_lines, &lang);
         complexities.push((func_name, span.start_line + 1, cc)); // 1-indexed line
     }
 
@@ -136,159 +138,4 @@ pub fn estimate_cyclomatic_complexity(content: &str, language: &str) -> Cyclomat
         high_complexity_functions,
         function_count,
     }
-}
-
-/// Calculate cyclomatic complexity for function lines.
-fn calculate_cyclomatic_complexity(lines: &[&str], lang: &str) -> usize {
-    let mut complexity = 1; // Base complexity
-
-    for line in lines {
-        let trimmed = line.trim();
-
-        // Skip comments
-        if is_comment_line(trimmed, lang) {
-            continue;
-        }
-
-        // Count decision points based on language
-        complexity += count_decision_points(trimmed, lang);
-    }
-
-    complexity
-}
-
-/// Count decision points in a line based on language.
-fn count_decision_points(line: &str, lang: &str) -> usize {
-    let mut count = 0;
-
-    match lang {
-        "rust" | "rs" => {
-            // Count else if first, then standalone if (avoiding double-count)
-            let else_if_count = count_keyword(line, "else if ");
-            count += else_if_count;
-            count += count_standalone_if(line, else_if_count);
-            count += count_keyword(line, "match ");
-            count += count_keyword(line, "for ");
-            count += count_keyword(line, "while ");
-            count += count_keyword(line, "loop ");
-            count += line.matches("&&").count();
-            count += line.matches("||").count();
-            count += count_rust_try_op(line);
-            count += line.matches("=>").count(); // Match arms
-        }
-        "python" | "py" => {
-            count += count_keyword(line, "if ");
-            count += count_keyword(line, "elif ");
-            count += count_keyword(line, "for ");
-            count += count_keyword(line, "while ");
-            count += count_keyword(line, "except ");
-            count += count_keyword(line, "except:");
-            count += line.matches(" and ").count();
-            count += line.matches(" or ").count();
-        }
-        "javascript" | "js" | "typescript" | "ts" | "jsx" | "tsx" => {
-            // Count else if first, then standalone if (avoiding double-count)
-            let else_if_count = count_keyword(line, "else if ") + count_keyword(line, "else if(");
-            count += else_if_count;
-            count += count_standalone_if_js(line, else_if_count);
-            count += count_keyword(line, "switch ");
-            count += count_keyword(line, "switch(");
-            count += count_keyword(line, "for ");
-            count += count_keyword(line, "for(");
-            count += count_keyword(line, "while ");
-            count += count_keyword(line, "while(");
-            count += count_keyword(line, "catch ");
-            count += count_keyword(line, "catch(");
-            count += count_keyword(line, "case ");
-            count += line.matches("&&").count();
-            count += line.matches("||").count();
-            count += count_ternary_op(line);
-        }
-        "go" => {
-            // Count else if first, then standalone if (avoiding double-count)
-            let else_if_count = count_keyword(line, "else if ");
-            count += else_if_count;
-            count += count_standalone_if(line, else_if_count);
-            count += count_keyword(line, "switch ");
-            count += count_keyword(line, "select ");
-            count += count_keyword(line, "for ");
-            count += count_keyword(line, "case ");
-            count += line.matches("&&").count();
-            count += line.matches("||").count();
-        }
-        _ => {}
-    }
-
-    count
-}
-
-/// Count standalone `if ` occurrences, excluding those that are part of `else if `.
-fn count_standalone_if(line: &str, else_if_count: usize) -> usize {
-    let total_if = count_keyword(line, "if ");
-    // Subtract the if's that are part of else if
-    total_if.saturating_sub(else_if_count)
-}
-
-/// Count standalone `if` occurrences in JS (handles both `if ` and `if(`).
-fn count_standalone_if_js(line: &str, else_if_count: usize) -> usize {
-    let total_if = count_keyword(line, "if ") + count_keyword(line, "if(");
-    // Subtract the if's that are part of else if
-    total_if.saturating_sub(else_if_count)
-}
-
-/// Count Rust try operator `?` (at expression end).
-fn count_rust_try_op(line: &str) -> usize {
-    let mut count = 0;
-    let chars: Vec<char> = line.chars().collect();
-
-    for (i, &ch) in chars.iter().enumerate() {
-        if ch == '?' {
-            let prev = if i > 0 { chars.get(i - 1) } else { None };
-            let next = chars.get(i + 1);
-
-            // Exclude format specifiers like {:?} or {:#?}
-            // These have ? preceded by : or #
-            if prev == Some(&':') || prev == Some(&'#') {
-                continue;
-            }
-
-            // Try operator is ? followed by end-of-expression characters
-            let is_try = next.is_none()
-                || matches!(
-                    next,
-                    Some(';') | Some(')') | Some('}') | Some(',') | Some(' ')
-                );
-            // Exclude ?. (optional chaining)
-            let is_optional_chain = next == Some(&'.');
-
-            if is_try && !is_optional_chain {
-                count += 1;
-            }
-        }
-    }
-
-    count
-}
-
-/// Count ternary operators in JS/TS.
-fn count_ternary_op(line: &str) -> usize {
-    let mut count = 0;
-    let chars: Vec<char> = line.chars().collect();
-
-    for (i, &ch) in chars.iter().enumerate() {
-        if ch == '?' {
-            let next = chars.get(i + 1);
-            // Ternary: ? not followed by . (optional chain) or at end
-            let is_optional_chain = next == Some(&'.');
-            let at_end = next.is_none() || matches!(next, Some(';') | Some(')'));
-            // Check there's a : somewhere after
-            let has_colon = line[i..].contains(':');
-
-            if !is_optional_chain && !at_end && has_colon {
-                count += 1;
-            }
-        }
-    }
-
-    count
 }

--- a/crates/tokmd-analysis/src/content/complexity/cyclomatic/scoring.rs
+++ b/crates/tokmd-analysis/src/content/complexity/cyclomatic/scoring.rs
@@ -1,0 +1,145 @@
+//! Cyclomatic decision-point scoring helpers.
+
+use super::super::shared::{count_keyword, is_comment_line};
+
+/// Calculate cyclomatic complexity for function lines.
+pub(super) fn calculate_cyclomatic_complexity(lines: &[&str], lang: &str) -> usize {
+    let mut complexity = 1; // Base complexity
+
+    for line in lines {
+        let trimmed = line.trim();
+
+        if is_comment_line(trimmed, lang) {
+            continue;
+        }
+
+        complexity += count_decision_points(trimmed, lang);
+    }
+
+    complexity
+}
+
+/// Count decision points in a line based on language.
+fn count_decision_points(line: &str, lang: &str) -> usize {
+    let mut count = 0;
+
+    match lang {
+        "rust" | "rs" => {
+            let else_if_count = count_keyword(line, "else if ");
+            count += else_if_count;
+            count += count_standalone_if(line, else_if_count);
+            count += count_keyword(line, "match ");
+            count += count_keyword(line, "for ");
+            count += count_keyword(line, "while ");
+            count += count_keyword(line, "loop ");
+            count += line.matches("&&").count();
+            count += line.matches("||").count();
+            count += count_rust_try_op(line);
+            count += line.matches("=>").count();
+        }
+        "python" | "py" => {
+            count += count_keyword(line, "if ");
+            count += count_keyword(line, "elif ");
+            count += count_keyword(line, "for ");
+            count += count_keyword(line, "while ");
+            count += count_keyword(line, "except ");
+            count += count_keyword(line, "except:");
+            count += line.matches(" and ").count();
+            count += line.matches(" or ").count();
+        }
+        "javascript" | "js" | "typescript" | "ts" | "jsx" | "tsx" => {
+            let else_if_count = count_keyword(line, "else if ") + count_keyword(line, "else if(");
+            count += else_if_count;
+            count += count_standalone_if_js(line, else_if_count);
+            count += count_keyword(line, "switch ");
+            count += count_keyword(line, "switch(");
+            count += count_keyword(line, "for ");
+            count += count_keyword(line, "for(");
+            count += count_keyword(line, "while ");
+            count += count_keyword(line, "while(");
+            count += count_keyword(line, "catch ");
+            count += count_keyword(line, "catch(");
+            count += count_keyword(line, "case ");
+            count += line.matches("&&").count();
+            count += line.matches("||").count();
+            count += count_ternary_op(line);
+        }
+        "go" => {
+            let else_if_count = count_keyword(line, "else if ");
+            count += else_if_count;
+            count += count_standalone_if(line, else_if_count);
+            count += count_keyword(line, "switch ");
+            count += count_keyword(line, "select ");
+            count += count_keyword(line, "for ");
+            count += count_keyword(line, "case ");
+            count += line.matches("&&").count();
+            count += line.matches("||").count();
+        }
+        _ => {}
+    }
+
+    count
+}
+
+/// Count standalone `if ` occurrences, excluding those that are part of `else if `.
+fn count_standalone_if(line: &str, else_if_count: usize) -> usize {
+    let total_if = count_keyword(line, "if ");
+    total_if.saturating_sub(else_if_count)
+}
+
+/// Count standalone `if` occurrences in JS, handling both `if ` and `if(`.
+fn count_standalone_if_js(line: &str, else_if_count: usize) -> usize {
+    let total_if = count_keyword(line, "if ") + count_keyword(line, "if(");
+    total_if.saturating_sub(else_if_count)
+}
+
+/// Count Rust try operator `?` at expression end.
+fn count_rust_try_op(line: &str) -> usize {
+    let mut count = 0;
+    let chars: Vec<char> = line.chars().collect();
+
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch == '?' {
+            let prev = if i > 0 { chars.get(i - 1) } else { None };
+            let next = chars.get(i + 1);
+
+            if prev == Some(&':') || prev == Some(&'#') {
+                continue;
+            }
+
+            let is_try = next.is_none()
+                || matches!(
+                    next,
+                    Some(';') | Some(')') | Some('}') | Some(',') | Some(' ')
+                );
+            let is_optional_chain = next == Some(&'.');
+
+            if is_try && !is_optional_chain {
+                count += 1;
+            }
+        }
+    }
+
+    count
+}
+
+/// Count ternary operators in JS/TS.
+fn count_ternary_op(line: &str) -> usize {
+    let mut count = 0;
+    let chars: Vec<char> = line.chars().collect();
+
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch == '?' {
+            let next = chars.get(i + 1);
+            let is_optional_chain = next == Some(&'.');
+            let at_end = next.is_none() || matches!(next, Some(';') | Some(')'));
+            let has_colon = line[i..].contains(':');
+
+            if !is_optional_chain && !at_end && has_colon {
+                count += 1;
+            }
+        }
+    }
+
+    count
+}


### PR DESCRIPTION
## Summary
- move cyclomatic decision-point scoring helpers into `content::complexity::cyclomatic::scoring`
- keep `cyclomatic.rs` focused on the public estimator/result types and function-span orchestration
- preserve content complexity behavior, schemas, CLI output, and proof policy

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-analysis --all-features complexity --verbose`
- `cargo test -p tokmd-analysis --all-features content --verbose`
- `cargo test -p tokmd-analysis --all-features assets --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`