### PR TITLE
refactor(context): extract bundle manifest writer

### DIFF
--- a/crates/tokmd/src/commands/context.rs
+++ b/crates/tokmd/src/commands/context.rs
@@ -1,17 +1,15 @@
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli;
-use anyhow::{Context, Result, bail};
-use blake3::Hasher;
+use anyhow::{Context, Result};
 use tokmd_model as model;
 use tokmd_scan as scan;
 use tokmd_scan::{add_exclude_pattern, normalize_exclude_pattern};
 use tokmd_types::{
-    ArtifactEntry, ArtifactHash, CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION,
-    ContextBundleManifest, ContextExcludedPath, ContextFileRow, ContextLogRecord, ContextReceipt,
+    CONTEXT_SCHEMA_VERSION, ContextExcludedPath, ContextFileRow, ContextLogRecord, ContextReceipt,
     SCHEMA_VERSION, ToolInfo,
 };
 
@@ -151,7 +149,7 @@ pub(crate) fn handle(args: cli::CliContextArgs, global: &cli::GlobalArgs) -> Res
     // Write output and get total bytes written
     let total_bytes = if let Some(ref bundle_dir) = args.bundle_dir {
         // Handle bundle directory mode - streams directly to files
-        write_bundle_directory(
+        context_pack::write_bundle_directory(
             bundle_dir,
             &args,
             selected,
@@ -386,168 +384,6 @@ fn write_output_file(path: &Path, content: &str, force: bool) -> Result<()> {
     Ok(())
 }
 
-/// Write bundle to a directory with manifest.
-/// Streams bundle.txt directly to avoid memory blowup.
-/// Returns the total bytes of bundle.txt (the main output).
-#[allow(clippy::too_many_arguments)]
-fn write_bundle_directory(
-    dir: &Path,
-    args: &cli::CliContextArgs,
-    selected: &[ContextFileRow],
-    budget: usize,
-    used_tokens: usize,
-    utilization: f64,
-    force: bool,
-    excluded_paths: &[ContextExcludedPath],
-    excluded_patterns: &[String],
-    select_result: &context_pack::SelectResult,
-) -> Result<usize> {
-    // Check if directory exists and is non-empty
-    if dir.exists() {
-        let is_empty = dir
-            .read_dir()
-            .map(|mut entries| entries.next().is_none())
-            .unwrap_or(false);
-        if !is_empty && !force {
-            bail!(
-                "Bundle directory is not empty: {}. Use --force to overwrite.",
-                dir.display()
-            );
-        }
-    } else {
-        fs::create_dir_all(dir)
-            .with_context(|| format!("Failed to create bundle directory: {}", dir.display()))?;
-    }
-
-    let now_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-
-    // Compute token estimation from selected file bytes
-    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
-    let token_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
-
-    // Write receipt.json
-    let receipt_path = dir.join("receipt.json");
-    let receipt = ContextReceipt {
-        schema_version: CONTEXT_SCHEMA_VERSION,
-        generated_at_ms: now_ms,
-        tool: ToolInfo::current(),
-        mode: "context".to_string(),
-        budget_tokens: budget,
-        used_tokens,
-        utilization_pct: utilization,
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
-        file_count: selected.len(),
-        files: selected.to_vec(),
-        rank_by_effective: if select_result.fallback_reason.is_some() {
-            Some(select_result.rank_by_effective.clone())
-        } else {
-            None
-        },
-        fallback_reason: select_result.fallback_reason.clone(),
-        excluded_by_policy: select_result.excluded_by_policy.clone(),
-        token_estimation: Some(token_estimation),
-        bundle_audit: None, // Populated below after bundle is written
-    };
-    // Write initial receipt.json (bundle_audit populated after bundle is written)
-    let initial_receipt_json = serde_json::to_string_pretty(&receipt)?;
-    fs::write(&receipt_path, &initial_receipt_json)
-        .with_context(|| format!("Failed to write receipt: {}", receipt_path.display()))?;
-
-    // Write bundle.txt (concatenated content) - stream directly to file
-    let bundle_path = dir.join("bundle.txt");
-    let bundle_file = File::create(&bundle_path)
-        .with_context(|| format!("Failed to create bundle file: {}", bundle_path.display()))?;
-    let mut counter = context_pack::CountingWriter::new(bundle_file);
-    context_pack::write_bundle_output(&mut counter, selected, args.compress)?;
-    counter.flush()?;
-    let bundle_bytes = counter.bytes() as usize;
-    let bundle_hash = hash_file(&bundle_path)?;
-
-    // Deferred write: rewrite receipt.json with bundle audit
-    let receipt_audit =
-        tokmd_types::TokenAudit::from_output(bundle_bytes as u64, total_file_bytes as u64);
-    let mut receipt = receipt;
-    receipt.bundle_audit = Some(receipt_audit);
-    let receipt_json = serde_json::to_string_pretty(&receipt)?;
-    fs::write(&receipt_path, &receipt_json)
-        .with_context(|| format!("Failed to rewrite receipt: {}", receipt_path.display()))?;
-
-    // Build artifacts list
-    let artifacts = vec![
-        ArtifactEntry {
-            name: "manifest".to_string(),
-            path: "manifest.json".to_string(),
-            description: "Context bundle manifest".to_string(),
-            bytes: 0, // Self-referential hash omitted
-            hash: None,
-        },
-        ArtifactEntry {
-            name: "receipt".to_string(),
-            path: "receipt.json".to_string(),
-            description: "Context selection receipt".to_string(),
-            bytes: receipt_json.len() as u64,
-            hash: None,
-        },
-        ArtifactEntry {
-            name: "bundle".to_string(),
-            path: "bundle.txt".to_string(),
-            description: "Token-budgeted code bundle".to_string(),
-            bytes: bundle_bytes as u64,
-            hash: Some(ArtifactHash {
-                algo: "blake3".to_string(),
-                hash: bundle_hash,
-            }),
-        },
-    ];
-
-    // Write manifest.json (authoritative index)
-    let manifest_path = dir.join("manifest.json");
-    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
-    let bundle_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
-    let bundle_audit =
-        tokmd_types::TokenAudit::from_output(bundle_bytes as u64, total_file_bytes as u64);
-    let manifest = ContextBundleManifest {
-        schema_version: CONTEXT_BUNDLE_SCHEMA_VERSION,
-        generated_at_ms: now_ms,
-        tool: ToolInfo::current(),
-        mode: "context_bundle".to_string(),
-        budget_tokens: budget,
-        used_tokens,
-        utilization_pct: utilization,
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
-        file_count: selected.len(),
-        bundle_bytes,
-        artifacts,
-        included_files: selected.to_vec(),
-        excluded_paths: excluded_paths.to_vec(),
-        excluded_patterns: excluded_patterns.to_vec(),
-        rank_by_effective: if select_result.fallback_reason.is_some() {
-            Some(select_result.rank_by_effective.clone())
-        } else {
-            None
-        },
-        fallback_reason: select_result.fallback_reason.clone(),
-        excluded_by_policy: select_result.excluded_by_policy.clone(),
-        token_estimation: Some(bundle_estimation),
-        bundle_audit: Some(bundle_audit),
-    };
-    let manifest_json = serde_json::to_string_pretty(&manifest)?;
-    fs::write(&manifest_path, &manifest_json)
-        .with_context(|| format!("Failed to write manifest: {}", manifest_path.display()))?;
-
-    eprintln!("Wrote bundle to {}", dir.display());
-    eprintln!("  - receipt.json ({} bytes)", receipt_json.len());
-    eprintln!("  - bundle.txt ({} bytes)", bundle_bytes);
-    eprintln!("  - manifest.json ({} bytes)", manifest_json.len());
-
-    Ok(bundle_bytes)
-}
-
 fn add_excluded_path(
     root: &Path,
     path: Option<&PathBuf>,
@@ -569,21 +405,6 @@ fn add_excluded_path(
             reason: reason.to_string(),
         });
     }
-}
-
-fn hash_file(path: &Path) -> Result<String> {
-    let mut file =
-        File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
-    let mut hasher = Hasher::new();
-    let mut buf = [0u8; 8 * 1024];
-    loop {
-        let n = file.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    Ok(hasher.finalize().to_hex().to_string())
 }
 
 /// Append a log record to a JSONL file.

--- a/crates/tokmd/src/context_pack.rs
+++ b/crates/tokmd/src/context_pack.rs
@@ -1,9 +1,11 @@
 //! Context packing helpers for LLM context window optimization.
 
 mod budget;
+mod manifest;
 mod render;
 mod select;
 
 pub(crate) use budget::parse_budget;
+pub(crate) use manifest::write_bundle_directory;
 pub(crate) use render::{CountingWriter, format_list_output, write_bundle_output, write_head_tail};
 pub(crate) use select::{SelectOptions, SelectResult, select_files_with_options};

--- a/crates/tokmd/src/context_pack/manifest.rs
+++ b/crates/tokmd/src/context_pack/manifest.rs
@@ -1,0 +1,195 @@
+//! Context bundle directory receipt and manifest writing.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use blake3::Hasher;
+use tokmd_types::{
+    ArtifactEntry, ArtifactHash, CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION,
+    ContextBundleManifest, ContextExcludedPath, ContextFileRow, ContextReceipt, ToolInfo,
+};
+
+use crate::cli;
+
+use super::{CountingWriter, SelectResult, write_bundle_output};
+
+/// Write bundle to a directory with manifest.
+///
+/// Streams bundle.txt directly to avoid memory blowup and returns the total
+/// bytes of bundle.txt (the main output).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn write_bundle_directory(
+    dir: &Path,
+    args: &cli::CliContextArgs,
+    selected: &[ContextFileRow],
+    budget: usize,
+    used_tokens: usize,
+    utilization: f64,
+    force: bool,
+    excluded_paths: &[ContextExcludedPath],
+    excluded_patterns: &[String],
+    select_result: &SelectResult,
+) -> Result<usize> {
+    // Check if directory exists and is non-empty.
+    if dir.exists() {
+        let is_empty = dir
+            .read_dir()
+            .map(|mut entries| entries.next().is_none())
+            .unwrap_or(false);
+        if !is_empty && !force {
+            bail!(
+                "Bundle directory is not empty: {}. Use --force to overwrite.",
+                dir.display()
+            );
+        }
+    } else {
+        fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create bundle directory: {}", dir.display()))?;
+    }
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+
+    // Compute token estimation from selected file bytes.
+    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
+    let token_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
+
+    // Write receipt.json.
+    let receipt_path = dir.join("receipt.json");
+    let receipt = ContextReceipt {
+        schema_version: CONTEXT_SCHEMA_VERSION,
+        generated_at_ms: now_ms,
+        tool: ToolInfo::current(),
+        mode: "context".to_string(),
+        budget_tokens: budget,
+        used_tokens,
+        utilization_pct: utilization,
+        strategy: format!("{:?}", args.strategy).to_lowercase(),
+        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
+        file_count: selected.len(),
+        files: selected.to_vec(),
+        rank_by_effective: if select_result.fallback_reason.is_some() {
+            Some(select_result.rank_by_effective.clone())
+        } else {
+            None
+        },
+        fallback_reason: select_result.fallback_reason.clone(),
+        excluded_by_policy: select_result.excluded_by_policy.clone(),
+        token_estimation: Some(token_estimation),
+        bundle_audit: None,
+    };
+    // Write initial receipt.json (bundle_audit populated after bundle is written).
+    let initial_receipt_json = serde_json::to_string_pretty(&receipt)?;
+    fs::write(&receipt_path, &initial_receipt_json)
+        .with_context(|| format!("Failed to write receipt: {}", receipt_path.display()))?;
+
+    // Write bundle.txt (concatenated content) - stream directly to file.
+    let bundle_path = dir.join("bundle.txt");
+    let bundle_file = File::create(&bundle_path)
+        .with_context(|| format!("Failed to create bundle file: {}", bundle_path.display()))?;
+    let mut counter = CountingWriter::new(bundle_file);
+    write_bundle_output(&mut counter, selected, args.compress)?;
+    counter.flush()?;
+    let bundle_bytes = counter.bytes() as usize;
+    let bundle_hash = hash_file(&bundle_path)?;
+
+    // Deferred write: rewrite receipt.json with bundle audit.
+    let receipt_audit =
+        tokmd_types::TokenAudit::from_output(bundle_bytes as u64, total_file_bytes as u64);
+    let mut receipt = receipt;
+    receipt.bundle_audit = Some(receipt_audit);
+    let receipt_json = serde_json::to_string_pretty(&receipt)?;
+    fs::write(&receipt_path, &receipt_json)
+        .with_context(|| format!("Failed to rewrite receipt: {}", receipt_path.display()))?;
+
+    // Build artifacts list.
+    let artifacts = vec![
+        ArtifactEntry {
+            name: "manifest".to_string(),
+            path: "manifest.json".to_string(),
+            description: "Context bundle manifest".to_string(),
+            bytes: 0,
+            hash: None,
+        },
+        ArtifactEntry {
+            name: "receipt".to_string(),
+            path: "receipt.json".to_string(),
+            description: "Context selection receipt".to_string(),
+            bytes: receipt_json.len() as u64,
+            hash: None,
+        },
+        ArtifactEntry {
+            name: "bundle".to_string(),
+            path: "bundle.txt".to_string(),
+            description: "Token-budgeted code bundle".to_string(),
+            bytes: bundle_bytes as u64,
+            hash: Some(ArtifactHash {
+                algo: "blake3".to_string(),
+                hash: bundle_hash,
+            }),
+        },
+    ];
+
+    // Write manifest.json (authoritative index).
+    let manifest_path = dir.join("manifest.json");
+    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
+    let bundle_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
+    let bundle_audit =
+        tokmd_types::TokenAudit::from_output(bundle_bytes as u64, total_file_bytes as u64);
+    let manifest = ContextBundleManifest {
+        schema_version: CONTEXT_BUNDLE_SCHEMA_VERSION,
+        generated_at_ms: now_ms,
+        tool: ToolInfo::current(),
+        mode: "context_bundle".to_string(),
+        budget_tokens: budget,
+        used_tokens,
+        utilization_pct: utilization,
+        strategy: format!("{:?}", args.strategy).to_lowercase(),
+        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
+        file_count: selected.len(),
+        bundle_bytes,
+        artifacts,
+        included_files: selected.to_vec(),
+        excluded_paths: excluded_paths.to_vec(),
+        excluded_patterns: excluded_patterns.to_vec(),
+        rank_by_effective: if select_result.fallback_reason.is_some() {
+            Some(select_result.rank_by_effective.clone())
+        } else {
+            None
+        },
+        fallback_reason: select_result.fallback_reason.clone(),
+        excluded_by_policy: select_result.excluded_by_policy.clone(),
+        token_estimation: Some(bundle_estimation),
+        bundle_audit: Some(bundle_audit),
+    };
+    let manifest_json = serde_json::to_string_pretty(&manifest)?;
+    fs::write(&manifest_path, &manifest_json)
+        .with_context(|| format!("Failed to write manifest: {}", manifest_path.display()))?;
+
+    eprintln!("Wrote bundle to {}", dir.display());
+    eprintln!("  - receipt.json ({} bytes)", receipt_json.len());
+    eprintln!("  - bundle.txt ({} bytes)", bundle_bytes);
+    eprintln!("  - manifest.json ({} bytes)", manifest_json.len());
+
+    Ok(bundle_bytes)
+}
+
+fn hash_file(path: &Path) -> Result<String> {
+    let mut file =
+        File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
+    let mut hasher = Hasher::new();
+    let mut buf = [0u8; 8 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -61,7 +61,7 @@ fixtures:
 | --- | --- | ---: | --- |
 | Content complexity | `crates/tokmd-analysis/src/content/complexity.rs` and `crates/tokmd-analysis/src/content/complexity/` | `tests/unit.rs` 1451; production owner modules <=187 | Scoring, nesting, and function-span helpers now live under owner modules; remaining work is mostly test split and aggregation cleanup |
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 230; symbol scanner 385; symbol tests 449 | Keep report aggregation in `mod.rs`, source scanning and scanner tests under `symbols`, and leave large integration tests under `api_surface/tests` |
-| Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 9; selection submodule/tests 1684; render submodule 204; budget parser/tests 200; context command 602 | Budget parsing, file selection, and bundle text rendering now live in owner modules; continue splitting manifest helpers under `tokmd`; keep context/handoff proof scoped |
+| Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 11; selection submodule/tests 1896; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 423 | Budget parsing, file selection, bundle text rendering, and context bundle manifest writing now live in owner modules; reassess remaining command orchestration before moving to the next pressure point; keep context/handoff proof scoped |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
@@ -233,6 +233,7 @@ crates/tokmd/src/
     budget.rs
     select.rs
     render.rs
+    manifest.rs
   cli/
     parser/
       mod.rs
@@ -304,8 +305,8 @@ Stop and split the work if a consolidation PR:
 2. Continue production owner-module splits under `tokmd-analysis`, starting
    with API surface symbol scanning and then aggregation/test cleanup where
    useful.
-3. Split `crates/tokmd/src/context_pack.rs` into selection, budgeting,
-   rendering, and manifest helpers under `tokmd`.
+3. Reassess the remaining context command orchestration now that selection,
+   budgeting, rendering, and manifest helpers live under `tokmd`.
 
 Each PR should include the affected proof-plan output in the PR body and should
 leave `publish-surface --verify-publish` green when public exports or


### PR DESCRIPTION
## Summary
- move context bundle directory receipt/manifest writing into `context_pack::manifest`
- keep `commands/context.rs` focused on CLI orchestration, output destination handling, and JSON/list/bundle routing
- update the architecture consolidation checkpoint now that context selection, rendering, and manifest helpers are owner modules

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd context_pack --verbose`
- `cargo test -p tokmd context --verbose`
- `cargo test -p tokmd handoff --verbose`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask publish-surface --json --verify-publish` (after commit; pre-commit run correctly hit the dirty-tree package guard)
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo test -p tokmd --test cli_e2e --verbose`
- `cargo test -p tokmd --test cli_snapshot_golden --verbose`
- `cargo test -p tokmd --test config_resolution --verbose`
- `cargo test -p tokmd --test context_e2e --verbose`
- `cargo test -p tokmd --test context_handoff_deep --verbose`
- `cargo test -p tokmd --test handoff_integration --verbose`
- `git diff --check origin/main..HEAD`

Affected scopes: `project_truth_docs`, `tokmd_cli`, `tokmd_context_handoff`; unknown files: none.