### PR TITLE
refactor(context): extract output helpers

### DIFF
--- a/crates/tokmd/src/commands/context.rs
+++ b/crates/tokmd/src/commands/context.rs
@@ -1,17 +1,11 @@
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use tokmd_model as model;
 use tokmd_scan as scan;
 use tokmd_scan::{add_exclude_pattern, normalize_exclude_pattern};
-use tokmd_types::{
-    CONTEXT_SCHEMA_VERSION, ContextExcludedPath, ContextFileRow, ContextLogRecord, ContextReceipt,
-    SCHEMA_VERSION, ToolInfo,
-};
+use tokmd_types::ContextExcludedPath;
 
 use crate::context_pack;
 use crate::progress::Progress;
@@ -144,7 +138,7 @@ pub(crate) fn handle(args: cli::CliContextArgs, global: &cli::GlobalArgs) -> Res
     progress.finish_and_clear();
 
     // Determine output destination for logging
-    let output_destination = determine_output_destination(&args);
+    let output_destination = context_pack::determine_output_destination(&args);
 
     // Write output and get total bytes written
     let total_bytes = if let Some(ref bundle_dir) = args.bundle_dir {
@@ -164,7 +158,7 @@ pub(crate) fn handle(args: cli::CliContextArgs, global: &cli::GlobalArgs) -> Res
     } else {
         // For bundle output mode, stream directly to destination
         // For list/json output modes, build string (small outputs)
-        write_to_destination(
+        context_pack::write_to_destination(
             &args,
             selected,
             budget,
@@ -185,202 +179,18 @@ pub(crate) fn handle(args: cli::CliContextArgs, global: &cli::GlobalArgs) -> Res
 
     // Handle log append
     if let Some(ref log_path) = args.log {
-        let log_record = ContextLogRecord {
-            schema_version: SCHEMA_VERSION,
-            generated_at_ms: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis(),
-            tool: ToolInfo::current(),
-            budget_tokens: budget,
+        context_pack::append_context_log_record(
+            log_path,
+            &args,
+            budget,
             used_tokens,
-            utilization_pct: utilization,
-            strategy: format!("{:?}", args.strategy).to_lowercase(),
-            rank_by: format!("{:?}", args.rank_by).to_lowercase(),
-            file_count: selected.len(),
+            utilization,
+            selected.len(),
             total_bytes,
             output_destination,
-        };
-        append_log_record(log_path, &log_record)?;
+        )?;
     }
 
-    Ok(())
-}
-
-/// Determine the output destination string for logging.
-fn determine_output_destination(args: &cli::CliContextArgs) -> String {
-    if let Some(ref bundle_dir) = args.bundle_dir {
-        format!("bundle:{}", bundle_dir.display())
-    } else if let Some(ref out_path) = args.output {
-        format!("file:{}", out_path.display())
-    } else {
-        "stdout".to_string()
-    }
-}
-
-/// Write output to destination and return total bytes written.
-/// For bundle output, streams directly to avoid memory blowup.
-/// For list/json output, builds string first (small outputs).
-fn write_to_destination(
-    args: &cli::CliContextArgs,
-    selected: &[ContextFileRow],
-    budget: usize,
-    used_tokens: usize,
-    utilization: f64,
-    select_result: &context_pack::SelectResult,
-) -> Result<usize> {
-    match args.output_mode {
-        cli::ContextOutput::Bundle => {
-            // Stream bundle output directly to destination
-            write_bundle_to_destination(args, selected)
-        }
-        cli::ContextOutput::List | cli::ContextOutput::Json => {
-            // Build string for list/json (small outputs)
-            let content = match args.output_mode {
-                cli::ContextOutput::List => context_pack::format_list_output(
-                    selected,
-                    budget,
-                    used_tokens,
-                    utilization,
-                    args.strategy,
-                ),
-                cli::ContextOutput::Json => format_json_output(
-                    selected,
-                    budget,
-                    used_tokens,
-                    utilization,
-                    args,
-                    select_result,
-                )?,
-                cli::ContextOutput::Bundle => unreachable!(),
-            };
-            let total_bytes = content.len();
-
-            if let Some(ref out_path) = args.output {
-                write_output_file(out_path, &content, args.force)?;
-            } else {
-                print!("{}", content);
-            }
-
-            Ok(total_bytes)
-        }
-    }
-}
-
-/// Write bundle output directly to destination (file or stdout).
-/// Streams content to avoid loading entire bundle into memory.
-fn write_bundle_to_destination(
-    args: &cli::CliContextArgs,
-    selected: &[ContextFileRow],
-) -> Result<usize> {
-    if let Some(ref out_path) = args.output {
-        // Open file with proper semantics: create_new fails if exists (unless --force)
-        let file = if args.force {
-            OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(out_path)
-        } else {
-            OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(out_path)
-        }
-        .with_context(|| {
-            if !args.force && out_path.exists() {
-                format!(
-                    "Output file already exists: {}. Use --force to overwrite.",
-                    out_path.display()
-                )
-            } else {
-                format!("Failed to create output file: {}", out_path.display())
-            }
-        })?;
-
-        let mut counter = context_pack::CountingWriter::new(file);
-        context_pack::write_bundle_output(&mut counter, selected, args.compress)?;
-        counter.flush()?;
-
-        let bytes = counter.bytes() as usize;
-        eprintln!("Wrote {}", out_path.display());
-        Ok(bytes)
-    } else {
-        // Stream to stdout
-        let stdout = std::io::stdout();
-        let mut counter = context_pack::CountingWriter::new(stdout.lock());
-        context_pack::write_bundle_output(&mut counter, selected, args.compress)?;
-        counter.flush()?;
-        Ok(counter.bytes() as usize)
-    }
-}
-
-/// Format JSON receipt output.
-fn format_json_output(
-    selected: &[ContextFileRow],
-    budget: usize,
-    used_tokens: usize,
-    utilization: f64,
-    args: &cli::CliContextArgs,
-    select_result: &context_pack::SelectResult,
-) -> Result<String> {
-    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
-    let token_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
-    let receipt = ContextReceipt {
-        schema_version: CONTEXT_SCHEMA_VERSION,
-        generated_at_ms: SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis(),
-        tool: ToolInfo::current(),
-        mode: "context".to_string(),
-        budget_tokens: budget,
-        used_tokens,
-        utilization_pct: utilization,
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
-        file_count: selected.len(),
-        files: selected.to_vec(),
-        rank_by_effective: if select_result.fallback_reason.is_some() {
-            Some(select_result.rank_by_effective.clone())
-        } else {
-            None
-        },
-        fallback_reason: select_result.fallback_reason.clone(),
-        excluded_by_policy: select_result.excluded_by_policy.clone(),
-        token_estimation: Some(token_estimation),
-        bundle_audit: None,
-    };
-    let json = serde_json::to_string_pretty(&receipt)?;
-    Ok(format!("{}\n", json))
-}
-
-/// Write output to a file, checking for existence unless force is true.
-fn write_output_file(path: &Path, content: &str, force: bool) -> Result<()> {
-    // Open file with proper semantics: create_new fails if exists (unless --force)
-    let mut file = if force {
-        OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)
-    } else {
-        OpenOptions::new().write(true).create_new(true).open(path)
-    }
-    .with_context(|| {
-        if !force && path.exists() {
-            format!(
-                "Output file already exists: {}. Use --force to overwrite.",
-                path.display()
-            )
-        } else {
-            format!("Failed to write output file: {}", path.display())
-        }
-    })?;
-
-    file.write_all(content.as_bytes())
-        .with_context(|| format!("Failed to write output file: {}", path.display()))?;
-    eprintln!("Wrote {}", path.display());
     Ok(())
 }
 
@@ -405,19 +215,4 @@ fn add_excluded_path(
             reason: reason.to_string(),
         });
     }
-}
-
-/// Append a log record to a JSONL file.
-fn append_log_record(path: &Path, record: &ContextLogRecord) -> Result<()> {
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("Failed to open log file: {}", path.display()))?;
-
-    let json = serde_json::to_string(record)?;
-    writeln!(file, "{}", json)
-        .with_context(|| format!("Failed to append to log file: {}", path.display()))?;
-
-    Ok(())
 }

--- a/crates/tokmd/src/context_pack.rs
+++ b/crates/tokmd/src/context_pack.rs
@@ -2,10 +2,14 @@
 
 mod budget;
 mod manifest;
+mod output;
 mod render;
 mod select;
 
 pub(crate) use budget::parse_budget;
 pub(crate) use manifest::write_bundle_directory;
+pub(crate) use output::{
+    append_context_log_record, determine_output_destination, write_to_destination,
+};
 pub(crate) use render::{CountingWriter, format_list_output, write_bundle_output, write_head_tail};
 pub(crate) use select::{SelectOptions, SelectResult, select_files_with_options};

--- a/crates/tokmd/src/context_pack/output.rs
+++ b/crates/tokmd/src/context_pack/output.rs
@@ -1,0 +1,224 @@
+//! Context command output destination and log writing helpers.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use tokmd_types::{
+    CONTEXT_SCHEMA_VERSION, ContextFileRow, ContextLogRecord, ContextReceipt, SCHEMA_VERSION,
+    ToolInfo,
+};
+
+use crate::cli;
+
+use super::{CountingWriter, SelectResult, format_list_output, write_bundle_output};
+
+/// Determine the output destination string for context logging.
+pub(crate) fn determine_output_destination(args: &cli::CliContextArgs) -> String {
+    if let Some(ref bundle_dir) = args.bundle_dir {
+        format!("bundle:{}", bundle_dir.display())
+    } else if let Some(ref out_path) = args.output {
+        format!("file:{}", out_path.display())
+    } else {
+        "stdout".to_string()
+    }
+}
+
+/// Write context output to its configured destination and return bytes written.
+///
+/// Bundle output streams directly to avoid memory blowup. List and JSON output
+/// are built first because they are bounded receipt-like outputs.
+pub(crate) fn write_to_destination(
+    args: &cli::CliContextArgs,
+    selected: &[ContextFileRow],
+    budget: usize,
+    used_tokens: usize,
+    utilization: f64,
+    select_result: &SelectResult,
+) -> Result<usize> {
+    match args.output_mode {
+        cli::ContextOutput::Bundle => write_bundle_to_destination(args, selected),
+        cli::ContextOutput::List | cli::ContextOutput::Json => {
+            let content = match args.output_mode {
+                cli::ContextOutput::List => {
+                    format_list_output(selected, budget, used_tokens, utilization, args.strategy)
+                }
+                cli::ContextOutput::Json => format_json_output(
+                    selected,
+                    budget,
+                    used_tokens,
+                    utilization,
+                    args,
+                    select_result,
+                )?,
+                cli::ContextOutput::Bundle => unreachable!(),
+            };
+            let total_bytes = content.len();
+
+            if let Some(ref out_path) = args.output {
+                write_output_file(out_path, &content, args.force)?;
+            } else {
+                print!("{content}");
+            }
+
+            Ok(total_bytes)
+        }
+    }
+}
+
+/// Append a context JSONL log record.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn append_context_log_record(
+    path: &Path,
+    args: &cli::CliContextArgs,
+    budget: usize,
+    used_tokens: usize,
+    utilization: f64,
+    file_count: usize,
+    total_bytes: usize,
+    output_destination: String,
+) -> Result<()> {
+    let log_record = ContextLogRecord {
+        schema_version: SCHEMA_VERSION,
+        generated_at_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+        tool: ToolInfo::current(),
+        budget_tokens: budget,
+        used_tokens,
+        utilization_pct: utilization,
+        strategy: format!("{:?}", args.strategy).to_lowercase(),
+        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
+        file_count,
+        total_bytes,
+        output_destination,
+    };
+    append_log_record(path, &log_record)
+}
+
+fn write_bundle_to_destination(
+    args: &cli::CliContextArgs,
+    selected: &[ContextFileRow],
+) -> Result<usize> {
+    if let Some(ref out_path) = args.output {
+        let file = if args.force {
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(out_path)
+        } else {
+            OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(out_path)
+        }
+        .with_context(|| {
+            if !args.force && out_path.exists() {
+                format!(
+                    "Output file already exists: {}. Use --force to overwrite.",
+                    out_path.display()
+                )
+            } else {
+                format!("Failed to create output file: {}", out_path.display())
+            }
+        })?;
+
+        let mut counter = CountingWriter::new(file);
+        write_bundle_output(&mut counter, selected, args.compress)?;
+        counter.flush()?;
+
+        let bytes = counter.bytes() as usize;
+        eprintln!("Wrote {}", out_path.display());
+        Ok(bytes)
+    } else {
+        let stdout = std::io::stdout();
+        let mut counter = CountingWriter::new(stdout.lock());
+        write_bundle_output(&mut counter, selected, args.compress)?;
+        counter.flush()?;
+        Ok(counter.bytes() as usize)
+    }
+}
+
+fn format_json_output(
+    selected: &[ContextFileRow],
+    budget: usize,
+    used_tokens: usize,
+    utilization: f64,
+    args: &cli::CliContextArgs,
+    select_result: &SelectResult,
+) -> Result<String> {
+    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
+    let token_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
+    let receipt = ContextReceipt {
+        schema_version: CONTEXT_SCHEMA_VERSION,
+        generated_at_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+        tool: ToolInfo::current(),
+        mode: "context".to_string(),
+        budget_tokens: budget,
+        used_tokens,
+        utilization_pct: utilization,
+        strategy: format!("{:?}", args.strategy).to_lowercase(),
+        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
+        file_count: selected.len(),
+        files: selected.to_vec(),
+        rank_by_effective: if select_result.fallback_reason.is_some() {
+            Some(select_result.rank_by_effective.clone())
+        } else {
+            None
+        },
+        fallback_reason: select_result.fallback_reason.clone(),
+        excluded_by_policy: select_result.excluded_by_policy.clone(),
+        token_estimation: Some(token_estimation),
+        bundle_audit: None,
+    };
+    let json = serde_json::to_string_pretty(&receipt)?;
+    Ok(format!("{json}\n"))
+}
+
+fn write_output_file(path: &Path, content: &str, force: bool) -> Result<()> {
+    let mut file = if force {
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+    } else {
+        OpenOptions::new().write(true).create_new(true).open(path)
+    }
+    .with_context(|| {
+        if !force && path.exists() {
+            format!(
+                "Output file already exists: {}. Use --force to overwrite.",
+                path.display()
+            )
+        } else {
+            format!("Failed to write output file: {}", path.display())
+        }
+    })?;
+
+    file.write_all(content.as_bytes())
+        .with_context(|| format!("Failed to write output file: {}", path.display()))?;
+    eprintln!("Wrote {}", path.display());
+    Ok(())
+}
+
+fn append_log_record(path: &Path, record: &ContextLogRecord) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("Failed to open log file: {}", path.display()))?;
+
+    let json = serde_json::to_string(record)?;
+    writeln!(file, "{json}")
+        .with_context(|| format!("Failed to append to log file: {}", path.display()))?;
+
+    Ok(())
+}

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -61,7 +61,7 @@ fixtures:
 | --- | --- | ---: | --- |
 | Content complexity | `crates/tokmd-analysis/src/content/complexity.rs` and `crates/tokmd-analysis/src/content/complexity/` | `tests/unit.rs` 1451; production owner modules <=187 | Scoring, nesting, and function-span helpers now live under owner modules; remaining work is mostly test split and aggregation cleanup |
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 230; symbol scanner 385; symbol tests 449 | Keep report aggregation in `mod.rs`, source scanning and scanner tests under `symbols`, and leave large integration tests under `api_surface/tests` |
-| Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 11; selection submodule/tests 1896; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 423 | Budget parsing, file selection, bundle text rendering, and context bundle manifest writing now live in owner modules; reassess remaining command orchestration before moving to the next pressure point; keep context/handoff proof scoped |
+| Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; reassess CLI parser or model aggregation as the next pressure point; keep context/handoff proof scoped |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
@@ -234,6 +234,7 @@ crates/tokmd/src/
     select.rs
     render.rs
     manifest.rs
+    output.rs
   cli/
     parser/
       mod.rs
@@ -305,8 +306,8 @@ Stop and split the work if a consolidation PR:
 2. Continue production owner-module splits under `tokmd-analysis`, starting
    with API surface symbol scanning and then aggregation/test cleanup where
    useful.
-3. Reassess the remaining context command orchestration now that selection,
-   budgeting, rendering, and manifest helpers live under `tokmd`.
+3. Reassess CLI parser and model aggregation now that context selection,
+   budgeting, rendering, manifest, and output helpers live under `tokmd`.
 
 Each PR should include the affected proof-plan output in the PR body and should
 leave `publish-surface --verify-publish` green when public exports or


### PR DESCRIPTION
## Summary
- move context single-output and JSONL log writing into `context_pack/output.rs`
- keep `commands/context.rs` focused on scan setup, selection orchestration, bundle-dir writing, and log dispatch
- update the architecture consolidation checkpoint to show context output/log ownership under `tokmd`

## Affected proof
- `project_truth_docs`: `docs/architecture-consolidation-plan.md`
- `tokmd_cli`: `crates/tokmd/src/commands/context.rs`
- `tokmd_context_handoff`: `crates/tokmd/src/commands/context.rs`, `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/output.rs`
- unknown files: none

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd context_pack --verbose`
- `cargo test -p tokmd context --verbose`
- `cargo test -p tokmd --test context_e2e --verbose`
- `cargo test -p tokmd --test context_handoff_deep --verbose`
- `cargo test -p tokmd --test handoff_integration --verbose`
- `cargo test -p tokmd --test cli_e2e --verbose`
- `cargo test -p tokmd --test cli_snapshot_golden --verbose`
- `cargo test -p tokmd --test config_resolution --verbose`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`
