### PR TITLE
refactor(model): extract row sorting helpers

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -635,6 +635,7 @@ kind = "rust"
 paths = [
   "crates/tokmd-model/src/lib.rs",
   "crates/tokmd-model/src/module_key/**",
+  "crates/tokmd-model/src/sorting.rs",
   "crates/tokmd-model/tests/**",
   "crates/tokmd-scan/src/lib.rs",
   "crates/tokmd-scan/src/path/**",

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -22,8 +22,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 pub mod module_key;
+mod sorting;
 
 use crate::module_key::module_key_from_normalized;
+use crate::sorting::{sort_file_rows, sort_lang_rows, sort_module_rows};
 use tokei::{CodeStats, Config, LanguageType, Languages};
 use tokmd_types::{
     ChildIncludeMode, ChildrenMode, ExportData, FileKind, FileRow, LangReport, LangRow,
@@ -644,18 +646,6 @@ pub fn create_export_data_from_rows(
     }
 }
 
-fn sort_lang_rows(rows: &mut [LangRow]) {
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
-}
-
-fn sort_module_rows(rows: &mut [ModuleRow]) {
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
-}
-
-fn sort_file_rows(rows: &mut [FileRow]) {
-    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.path.cmp(&b.path)));
-}
-
 /// Collect per-file contributions, optionally including embedded language reports.
 ///
 /// This returns one row per (path, lang, kind), aggregated if tokei produced multiple
@@ -1146,90 +1136,6 @@ mod tests {
         assert_eq!(metrics_from_byte_len(12), (12, 3));
         assert_eq!(metrics_from_byte_len(15), (15, 3));
         assert_eq!(metrics_from_bytes(b"hello world!"), (12, 3));
-    }
-
-    fn test_lang_row(lang: &str, code: usize) -> LangRow {
-        LangRow {
-            lang: lang.to_string(),
-            code,
-            lines: code + 20,
-            files: 2,
-            bytes: code * 4,
-            tokens: code,
-            avg_lines: avg(code + 20, 2),
-        }
-    }
-
-    fn test_module_row(module: &str, code: usize) -> ModuleRow {
-        ModuleRow {
-            module: module.to_string(),
-            code,
-            lines: code + 20,
-            files: 2,
-            bytes: code * 4,
-            tokens: code,
-            avg_lines: avg(code + 20, 2),
-        }
-    }
-
-    fn test_file_row(path: &str, code: usize) -> FileRow {
-        FileRow {
-            path: path.to_string(),
-            module: "src".to_string(),
-            lang: "Rust".to_string(),
-            kind: FileKind::Parent,
-            code,
-            comments: 10,
-            blanks: 5,
-            lines: code + 15,
-            bytes: code * 4,
-            tokens: code,
-        }
-    }
-
-    #[test]
-    fn sort_lang_rows_orders_code_desc_then_name() {
-        let mut rows = vec![
-            test_lang_row("Zeta", 100),
-            test_lang_row("Rust", 300),
-            test_lang_row("Alpha", 100),
-        ];
-
-        sort_lang_rows(&mut rows);
-
-        assert_eq!(rows[0].lang, "Rust");
-        assert_eq!(rows[1].lang, "Alpha");
-        assert_eq!(rows[2].lang, "Zeta");
-    }
-
-    #[test]
-    fn sort_module_rows_orders_code_desc_then_module() {
-        let mut rows = vec![
-            test_module_row("src/zeta", 100),
-            test_module_row("src/core", 300),
-            test_module_row("src/alpha", 100),
-        ];
-
-        sort_module_rows(&mut rows);
-
-        assert_eq!(rows[0].module, "src/core");
-        assert_eq!(rows[1].module, "src/alpha");
-        assert_eq!(rows[2].module, "src/zeta");
-    }
-
-    #[test]
-    fn sort_file_rows_orders_code_desc_then_path() {
-        let mut rows = vec![
-            test_file_row("src/zeta.rs", 100),
-            test_file_row("src/core.rs", 300),
-            test_file_row("src/alpha.rs", 100),
-        ];
-
-        sort_file_rows(&mut rows);
-
-        assert_eq!(rows[0].path, "src/core.rs");
-        assert_eq!(rows[1].path, "src/alpha.rs");
-        assert_eq!(rows[2].path, "src/zeta.rs");
     }
 
     #[test]

--- a/crates/tokmd-model/src/sorting.rs
+++ b/crates/tokmd-model/src/sorting.rs
@@ -1,0 +1,108 @@
+//! Deterministic row sorting helpers for model receipts.
+
+use tokmd_types::{FileRow, LangRow, ModuleRow};
+
+pub(crate) fn sort_lang_rows(rows: &mut [LangRow]) {
+    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.lang.cmp(&b.lang)));
+}
+
+pub(crate) fn sort_module_rows(rows: &mut [ModuleRow]) {
+    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
+}
+
+pub(crate) fn sort_file_rows(rows: &mut [FileRow]) {
+    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.path.cmp(&b.path)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokmd_types::FileKind;
+
+    fn lang_row(lang: &str, code: usize) -> LangRow {
+        LangRow {
+            lang: lang.to_string(),
+            code,
+            lines: code,
+            files: 1,
+            bytes: 0,
+            tokens: 0,
+            avg_lines: code,
+        }
+    }
+
+    fn module_row(module: &str, code: usize) -> ModuleRow {
+        ModuleRow {
+            module: module.to_string(),
+            code,
+            lines: code,
+            files: 1,
+            bytes: 0,
+            tokens: 0,
+            avg_lines: code,
+        }
+    }
+
+    fn file_row(path: &str, code: usize) -> FileRow {
+        FileRow {
+            path: path.to_string(),
+            module: "(root)".to_string(),
+            lang: "Rust".to_string(),
+            kind: FileKind::Parent,
+            code,
+            comments: 0,
+            blanks: 0,
+            lines: code,
+            bytes: 0,
+            tokens: 0,
+        }
+    }
+
+    #[test]
+    fn lang_rows_sort_by_code_desc_then_name() {
+        let mut rows = vec![
+            lang_row("TypeScript", 10),
+            lang_row("Rust", 20),
+            lang_row("Python", 10),
+        ];
+
+        sort_lang_rows(&mut rows);
+
+        assert_eq!(
+            rows.into_iter().map(|row| row.lang).collect::<Vec<_>>(),
+            ["Rust", "Python", "TypeScript"]
+        );
+    }
+
+    #[test]
+    fn module_rows_sort_by_code_desc_then_name() {
+        let mut rows = vec![
+            module_row("web", 12),
+            module_row("crates", 20),
+            module_row("docs", 12),
+        ];
+
+        sort_module_rows(&mut rows);
+
+        assert_eq!(
+            rows.into_iter().map(|row| row.module).collect::<Vec<_>>(),
+            ["crates", "docs", "web"]
+        );
+    }
+
+    #[test]
+    fn file_rows_sort_by_code_desc_then_path() {
+        let mut rows = vec![
+            file_row("src/z.rs", 8),
+            file_row("src/a.rs", 8),
+            file_row("src/lib.rs", 20),
+        ];
+
+        sort_file_rows(&mut rows);
+
+        assert_eq!(
+            rows.into_iter().map(|row| row.path).collect::<Vec<_>>(),
+            ["src/lib.rs", "src/a.rs", "src/z.rs"]
+        );
+    }
+}

--- a/crates/tokmd-model/tests/snapshots/snapshots__file_rows_parents_only.snap
+++ b/crates/tokmd-model/tests/snapshots/snapshots__file_rows_parents_only.snap
@@ -19,5 +19,13 @@ expression: redacted
     "lines_eq_sum": true,
     "module": "<root>",
     "path": "crates/tokmd-model/src/module_key/mod.rs"
+  },
+  {
+    "code_gt_zero": true,
+    "kind": "Parent",
+    "lang": "Rust",
+    "lines_eq_sum": true,
+    "module": "<root>",
+    "path": "crates/tokmd-model/src/sorting.rs"
   }
 ]

--- a/crates/tokmd-model/tests/snapshots/snapshots__file_rows_separate.snap
+++ b/crates/tokmd-model/tests/snapshots/snapshots__file_rows_separate.snap
@@ -35,5 +35,21 @@ expression: redacted
     "lines_eq_sum": true,
     "module": "<root>",
     "path": "crates/tokmd-model/src/module_key/mod.rs"
+  },
+  {
+    "code_gt_zero": false,
+    "kind": "Child",
+    "lang": "Markdown",
+    "lines_eq_sum": true,
+    "module": "<root>",
+    "path": "crates/tokmd-model/src/sorting.rs"
+  },
+  {
+    "code_gt_zero": true,
+    "kind": "Parent",
+    "lang": "Rust",
+    "lines_eq_sum": true,
+    "module": "<root>",
+    "path": "crates/tokmd-model/src/sorting.rs"
   }
 ]

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -66,7 +66,7 @@ fixtures:
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` | 1276 | Split command argument families while preserving clap output |
-| Model aggregation | `crates/tokmd-model/src/lib.rs` | 1159 | Split aggregation, row sorting, and child-language behavior under `tokmd-model` |
+| Model aggregation | `crates/tokmd-model/src/lib.rs` and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 1224; sorting owner/tests 107 | Row sorting now lives in an owner module; remaining work is aggregation/report builders and child-language behavior under `tokmd-model` |
 
 ## Batch Order
 
@@ -306,8 +306,8 @@ Stop and split the work if a consolidation PR:
 2. Continue production owner-module splits under `tokmd-analysis`, starting
    with API surface symbol scanning and then aggregation/test cleanup where
    useful.
-3. Reassess CLI parser and model aggregation now that context selection,
-   budgeting, rendering, manifest, and output helpers live under `tokmd`.
+3. Continue model aggregation with aggregation/report builders or child-language
+   behavior only after the sorting owner split is validated.
 
 Each PR should include the affected proof-plan output in the PR body and should
 leave `publish-surface --verify-publish` green when public exports or


### PR DESCRIPTION
## Summary
- move deterministic `LangRow`, `ModuleRow`, and `FileRow` ordering helpers into `tokmd-model::sorting`
- keep the helpers crate-private and preserve report/export sorting semantics
- update model self-scan snapshots for the new `sorting.rs` source file
- update `ci/proof.toml` so the new owner module stays covered by affected proof routing
- refresh the architecture consolidation checkpoint for the model sorting split

## Affected proof
- `model_scan_path_normalization`: `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/sorting.rs`, model snapshots
- `project_truth_docs`: `docs/architecture-consolidation-plan.md`
- `proof_control_plane`: `ci/proof.toml`
- unknown files: none

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-model sort --lib --verbose`
- `cargo test -p tokmd-model --test snapshots --verbose`
- `cargo test -p tokmd-model --test from_rows_api_w78 --verbose`
- `cargo test -p tokmd-model --verbose`
- `cargo test -p tokmd-scan normalize --verbose`
- `cargo test -p tokmd --test integration --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo clippy -p tokmd-model --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`
