### PR TITLE
refactor(cli): extract analyze parser args

### DIFF
--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -20,8 +20,12 @@ pub use crate::tool_schema::ToolSchemaFormat;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 
+mod analysis;
 mod context;
 
+pub use analysis::{
+    AnalysisPreset, CliAnalyzeArgs, EffortLayer, EffortModelKind, ImportGranularity, NearDupScope,
+};
 pub use context::{
     CliContextArgs, ContextOutput, ContextStrategy, HandoffArgs, HandoffPreset, ValueMetric,
 };
@@ -585,121 +589,6 @@ pub struct CliExportArgs {
 }
 
 #[derive(Args, Debug, Clone)]
-pub struct CliAnalyzeArgs {
-    /// Inputs to analyze (run dir, receipt.json, export.jsonl, or paths).
-    #[arg(value_name = "INPUT", default_value = ".")]
-    pub inputs: Vec<PathBuf>,
-
-    /// Analysis preset to run [default: receipt].
-    #[arg(long, value_enum)]
-    pub preset: Option<AnalysisPreset>,
-
-    /// Output format [default: md].
-    #[arg(long, value_enum)]
-    pub format: Option<AnalysisFormat>,
-
-    /// Context window size (tokens) for utilization bars.
-    #[arg(long)]
-    pub window: Option<usize>,
-
-    /// Force-enable git-based metrics.
-    #[arg(long, action = clap::ArgAction::SetTrue, conflicts_with = "no_git")]
-    pub git: bool,
-
-    /// Disable git-based metrics.
-    #[arg(long = "no-git", action = clap::ArgAction::SetTrue, conflicts_with = "git")]
-    pub no_git: bool,
-
-    /// Output directory for analysis artifacts.
-    #[arg(long)]
-    pub output_dir: Option<PathBuf>,
-
-    /// Limit how many files are walked for asset/deps/content scans.
-    #[arg(long)]
-    pub max_files: Option<usize>,
-
-    /// Limit total bytes read during content scans.
-    #[arg(long)]
-    pub max_bytes: Option<u64>,
-
-    /// Limit bytes per file during content scans.
-    #[arg(long)]
-    pub max_file_bytes: Option<u64>,
-
-    /// Limit how many commits are scanned for git metrics.
-    #[arg(long)]
-    pub max_commits: Option<usize>,
-
-    /// Limit files per commit when scanning git history.
-    #[arg(long)]
-    pub max_commit_files: Option<usize>,
-
-    /// Import graph granularity [default: module].
-    #[arg(long, value_enum)]
-    pub granularity: Option<ImportGranularity>,
-
-    /// Effort model for estimate calculations [default: cocomo81-basic].
-    #[arg(long)]
-    pub effort_model: Option<EffortModelKind>,
-
-    /// Effort layer for report detail [default: full].
-    #[arg(long)]
-    pub effort_layer: Option<EffortLayer>,
-
-    /// Base reference for effort delta computation.
-    #[arg(long = "effort-base-ref")]
-    pub effort_base_ref: Option<String>,
-
-    /// Head reference for effort delta computation.
-    #[arg(long = "effort-head-ref")]
-    pub effort_head_ref: Option<String>,
-
-    /// Enable Monte Carlo simulation for effort estimation.
-    #[arg(long)]
-    pub monte_carlo: bool,
-
-    /// Monte Carlo iterations when effort estimation is enabled [default: 10000].
-    #[arg(long = "mc-iterations")]
-    pub mc_iterations: Option<usize>,
-
-    /// Monte Carlo seed for deterministic effort estimation.
-    #[arg(long = "mc-seed")]
-    pub mc_seed: Option<u64>,
-
-    /// Include function-level complexity details in output.
-    #[arg(long)]
-    pub detail_functions: bool,
-
-    /// Enable near-duplicate file detection (opt-in).
-    #[arg(long)]
-    pub near_dup: bool,
-
-    /// Near-duplicate similarity threshold (0.0–1.0) [default: 0.80].
-    #[arg(long, default_value = "0.80")]
-    pub near_dup_threshold: f64,
-
-    /// Maximum files to analyze for near-duplicates [default: 2000].
-    #[arg(long, default_value = "2000")]
-    pub near_dup_max_files: usize,
-
-    /// Near-duplicate comparison scope [default: module].
-    #[arg(long, value_enum)]
-    pub near_dup_scope: Option<NearDupScope>,
-
-    /// Maximum near-duplicate pairs to emit (truncation guardrail) [default: 10000].
-    #[arg(long, default_value = "10000")]
-    pub near_dup_max_pairs: usize,
-
-    /// Exclude files matching this glob pattern from near-duplicate analysis. Repeatable.
-    #[arg(long, value_name = "GLOB")]
-    pub near_dup_exclude: Vec<String>,
-
-    /// Explain a metric or finding key and exit.
-    #[arg(long, value_name = "KEY")]
-    pub explain: Option<String>,
-}
-
-#[derive(Args, Debug, Clone)]
 pub struct BadgeArgs {
     /// Inputs to analyze (run dir, receipt.json, export.jsonl, or paths).
     #[arg(value_name = "INPUT", default_value = ".")]
@@ -755,46 +644,6 @@ pub struct InitArgs {
     /// Skip interactive wizard and use defaults.
     #[arg(long)]
     pub non_interactive: bool,
-}
-
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum AnalysisPreset {
-    Receipt,
-    Estimate,
-    Health,
-    Risk,
-    Supply,
-    Architecture,
-    Topics,
-    Security,
-    Identity,
-    Git,
-    Deep,
-    Fun,
-}
-
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum ImportGranularity {
-    Module,
-    File,
-}
-
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum EffortModelKind {
-    Cocomo81Basic,
-    Cocomo2Early,
-    Ensemble,
-}
-
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum EffortLayer {
-    Headline,
-    Why,
-    Full,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1019,18 +868,6 @@ pub enum SensorFormat {
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
-pub enum NearDupScope {
-    /// Compare files within the same module.
-    #[default]
-    Module,
-    /// Compare files within the same language.
-    Lang,
-    /// Compare all files globally.
-    Global,
-}
-
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
 pub enum DiffRangeMode {
     /// Two-dot syntax (A..B) - direct diff between commits.
     #[default]
@@ -1149,28 +986,6 @@ mod tests {
 
     // ── Enum serde roundtrips ─────────────────────────────────────────
     #[test]
-    fn analysis_preset_serde_roundtrip() {
-        for variant in [
-            AnalysisPreset::Receipt,
-            AnalysisPreset::Estimate,
-            AnalysisPreset::Health,
-            AnalysisPreset::Risk,
-            AnalysisPreset::Supply,
-            AnalysisPreset::Architecture,
-            AnalysisPreset::Topics,
-            AnalysisPreset::Security,
-            AnalysisPreset::Identity,
-            AnalysisPreset::Git,
-            AnalysisPreset::Deep,
-            AnalysisPreset::Fun,
-        ] {
-            let json = serde_json::to_string(&variant).unwrap();
-            let back: AnalysisPreset = serde_json::from_str(&json).unwrap();
-            assert_eq!(back, variant);
-        }
-    }
-
-    #[test]
     fn diff_format_default_is_md() {
         assert_eq!(DiffFormat::default(), DiffFormat::Md);
     }
@@ -1225,28 +1040,11 @@ mod tests {
     }
 
     #[test]
-    fn near_dup_scope_default_is_module() {
-        assert_eq!(NearDupScope::default(), NearDupScope::Module);
-    }
-
-    #[test]
     fn diff_range_mode_default_is_two_dot() {
         assert_eq!(DiffRangeMode::default(), DiffRangeMode::TwoDot);
     }
 
     // ── Serde naming ──────────────────────────────────────────────────
-    #[test]
-    fn analysis_preset_uses_kebab_case() {
-        assert_eq!(
-            serde_json::to_string(&AnalysisPreset::Receipt).unwrap(),
-            "\"receipt\""
-        );
-        assert_eq!(
-            serde_json::to_string(&AnalysisPreset::Deep).unwrap(),
-            "\"deep\""
-        );
-    }
-
     #[test]
     fn context_strategy_uses_kebab_case() {
         assert_eq!(

--- a/crates/tokmd/src/cli/parser/analysis.rs
+++ b/crates/tokmd/src/cli/parser/analysis.rs
@@ -1,0 +1,217 @@
+use std::path::PathBuf;
+
+use clap::{Args, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+use super::AnalysisFormat;
+
+#[derive(Args, Debug, Clone)]
+pub struct CliAnalyzeArgs {
+    /// Inputs to analyze (run dir, receipt.json, export.jsonl, or paths).
+    #[arg(value_name = "INPUT", default_value = ".")]
+    pub inputs: Vec<PathBuf>,
+
+    /// Analysis preset to run [default: receipt].
+    #[arg(long, value_enum)]
+    pub preset: Option<AnalysisPreset>,
+
+    /// Output format [default: md].
+    #[arg(long, value_enum)]
+    pub format: Option<AnalysisFormat>,
+
+    /// Context window size (tokens) for utilization bars.
+    #[arg(long)]
+    pub window: Option<usize>,
+
+    /// Force-enable git-based metrics.
+    #[arg(long, action = clap::ArgAction::SetTrue, conflicts_with = "no_git")]
+    pub git: bool,
+
+    /// Disable git-based metrics.
+    #[arg(long = "no-git", action = clap::ArgAction::SetTrue, conflicts_with = "git")]
+    pub no_git: bool,
+
+    /// Output directory for analysis artifacts.
+    #[arg(long)]
+    pub output_dir: Option<PathBuf>,
+
+    /// Limit how many files are walked for asset/deps/content scans.
+    #[arg(long)]
+    pub max_files: Option<usize>,
+
+    /// Limit total bytes read during content scans.
+    #[arg(long)]
+    pub max_bytes: Option<u64>,
+
+    /// Limit bytes per file during content scans.
+    #[arg(long)]
+    pub max_file_bytes: Option<u64>,
+
+    /// Limit how many commits are scanned for git metrics.
+    #[arg(long)]
+    pub max_commits: Option<usize>,
+
+    /// Limit files per commit when scanning git history.
+    #[arg(long)]
+    pub max_commit_files: Option<usize>,
+
+    /// Import graph granularity [default: module].
+    #[arg(long, value_enum)]
+    pub granularity: Option<ImportGranularity>,
+
+    /// Effort model for estimate calculations [default: cocomo81-basic].
+    #[arg(long)]
+    pub effort_model: Option<EffortModelKind>,
+
+    /// Effort layer for report detail [default: full].
+    #[arg(long)]
+    pub effort_layer: Option<EffortLayer>,
+
+    /// Base reference for effort delta computation.
+    #[arg(long = "effort-base-ref")]
+    pub effort_base_ref: Option<String>,
+
+    /// Head reference for effort delta computation.
+    #[arg(long = "effort-head-ref")]
+    pub effort_head_ref: Option<String>,
+
+    /// Enable Monte Carlo simulation for effort estimation.
+    #[arg(long)]
+    pub monte_carlo: bool,
+
+    /// Monte Carlo iterations when effort estimation is enabled [default: 10000].
+    #[arg(long = "mc-iterations")]
+    pub mc_iterations: Option<usize>,
+
+    /// Monte Carlo seed for deterministic effort estimation.
+    #[arg(long = "mc-seed")]
+    pub mc_seed: Option<u64>,
+
+    /// Include function-level complexity details in output.
+    #[arg(long)]
+    pub detail_functions: bool,
+
+    /// Enable near-duplicate file detection (opt-in).
+    #[arg(long)]
+    pub near_dup: bool,
+
+    /// Near-duplicate similarity threshold (0.0–1.0) [default: 0.80].
+    #[arg(long, default_value = "0.80")]
+    pub near_dup_threshold: f64,
+
+    /// Maximum files to analyze for near-duplicates [default: 2000].
+    #[arg(long, default_value = "2000")]
+    pub near_dup_max_files: usize,
+
+    /// Near-duplicate comparison scope [default: module].
+    #[arg(long, value_enum)]
+    pub near_dup_scope: Option<NearDupScope>,
+
+    /// Maximum near-duplicate pairs to emit (truncation guardrail) [default: 10000].
+    #[arg(long, default_value = "10000")]
+    pub near_dup_max_pairs: usize,
+
+    /// Exclude files matching this glob pattern from near-duplicate analysis. Repeatable.
+    #[arg(long, value_name = "GLOB")]
+    pub near_dup_exclude: Vec<String>,
+
+    /// Explain a metric or finding key and exit.
+    #[arg(long, value_name = "KEY")]
+    pub explain: Option<String>,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AnalysisPreset {
+    Receipt,
+    Estimate,
+    Health,
+    Risk,
+    Supply,
+    Architecture,
+    Topics,
+    Security,
+    Identity,
+    Git,
+    Deep,
+    Fun,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ImportGranularity {
+    Module,
+    File,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EffortModelKind {
+    Cocomo81Basic,
+    Cocomo2Early,
+    Ensemble,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EffortLayer {
+    Headline,
+    Why,
+    Full,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum NearDupScope {
+    /// Compare files within the same module.
+    #[default]
+    Module,
+    /// Compare files within the same language.
+    Lang,
+    /// Compare all files globally.
+    Global,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn analysis_preset_serde_roundtrip() {
+        for variant in [
+            AnalysisPreset::Receipt,
+            AnalysisPreset::Estimate,
+            AnalysisPreset::Health,
+            AnalysisPreset::Risk,
+            AnalysisPreset::Supply,
+            AnalysisPreset::Architecture,
+            AnalysisPreset::Topics,
+            AnalysisPreset::Security,
+            AnalysisPreset::Identity,
+            AnalysisPreset::Git,
+            AnalysisPreset::Deep,
+            AnalysisPreset::Fun,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: AnalysisPreset = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn analysis_preset_uses_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&AnalysisPreset::Receipt).unwrap(),
+            "\"receipt\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AnalysisPreset::Deep).unwrap(),
+            "\"deep\""
+        );
+    }
+
+    #[test]
+    fn near_dup_scope_default_is_module() {
+        assert_eq!(NearDupScope::default(), NearDupScope::Module);
+    }
+}

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -61,11 +61,11 @@ fixtures:
 | --- | --- | ---: | --- |
 | Content complexity | `crates/tokmd-analysis/src/content/complexity.rs` and `crates/tokmd-analysis/src/content/complexity/` | `tests/unit.rs` 1451; production owner modules <=187 | Scoring, nesting, and function-span helpers now live under owner modules; remaining work is mostly test split and aggregation cleanup |
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 194; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep report aggregation in `mod.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
-| Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; reassess CLI parser or model aggregation as the next pressure point; keep context/handoff proof scoped |
+| Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
-| CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1327; context/handoff parser owner 208 | Context and handoff argument families now live under `parser/context.rs`; continue command-family splits only when clap snapshots prove behavior is unchanged |
+| CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1125; analyze parser owner 217; context/handoff parser owner 208 | Context, handoff, and analyze argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
 
 ## Batch Order
@@ -306,9 +306,9 @@ Stop and split the work if a consolidation PR:
 2. Continue production owner-module splits under `tokmd-analysis`, starting
    with API surface symbol scanning and then aggregation/test cleanup where
    useful.
-3. Reassess CLI parser or analysis owner modules next; continue model
-   child-language behavior only if future evidence shows the seam is still too
-   broad after the row owner split.
+3. Continue CLI parser command-family splits only when clap snapshots prove
+   behavior is unchanged; continue model child-language behavior only if future
+   evidence shows the seam is still too broad after the row owner split.
 
 Each PR should include the affected proof-plan output in the PR body and should
 leave `publish-surface --verify-publish` green when public exports or


### PR DESCRIPTION
## Summary
- Extract `CliAnalyzeArgs` and analyze-specific parser enums into `crates/tokmd/src/cli/parser/analysis.rs`.
- Preserve the existing `tokmd::cli::*` re-export surface and CLI behavior.
- Refresh the architecture consolidation checkpoint with the new CLI parser owner-module counts.

## Validation
- `cargo test -p tokmd analysis_preset_serde_roundtrip --verbose`
- `cargo test -p tokmd --test cli_snapshot_golden --verbose`
- `cargo test -p tokmd --test cli_e2e --verbose`
- `cargo test -p tokmd --test completions_integration --verbose`
- `cargo test -p tokmd --lib --verbose`
- `cargo test -p tokmd --test config_resolution --verbose`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`
- `cargo xtask publish-surface --json --verify-publish`