### PR TITLE
fix(git): harden subprocess helper environment

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -665,9 +665,9 @@ paths = [
 ]
 packages = ["tokmd-git", "tokmd-scan", "tokmd"]
 proof = [
-  "cargo test -p tokmd-git git_cmd_removes_repo_shaping_env_overrides --verbose",
-  "cargo test -p tokmd-scan git_cmd_removes_repo_shaping_env_overrides --verbose",
-  "cargo test -p tokmd git_cmd_removes_repo_shaping_env_overrides --verbose",
+  "cargo test -p tokmd-git git_cmd_removes --verbose",
+  "cargo test -p tokmd-scan git_cmd_removes --verbose",
+  "cargo test -p tokmd git_cmd_removes --verbose",
 ]
 mutation = true
 coverage = true

--- a/crates/tokmd-git/src/lib.rs
+++ b/crates/tokmd-git/src/lib.rs
@@ -23,6 +23,7 @@ use anyhow::{Context, Result};
 pub use tokmd_types::CommitIntentKind;
 
 const GIT_REPO_SHAPING_ENV: &[&str] = &[
+    // Repository and object-store overrides.
     "GIT_DIR",
     "GIT_WORK_TREE",
     "GIT_INDEX_FILE",
@@ -30,13 +31,21 @@ const GIT_REPO_SHAPING_ENV: &[&str] = &[
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
     "GIT_COMMON_DIR",
     "GIT_CEILING_DIRECTORIES",
+    // Git hooks that can execute helper programs from ambient environment.
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+    "GIT_ASKPASS",
+    "GIT_PAGER",
+    "GIT_EDITOR",
+    "GIT_PROXY_COMMAND",
+    "GIT_EXTERNAL_DIFF",
 ];
 
 /// Create a `Command` for git with process-environment isolation.
 ///
-/// Strips repo, worktree, index, object-store, and discovery overrides so
-/// inherited environment variables cannot bypass the explicit `-C` path used
-/// by functions in this crate.
+/// Strips repo, worktree, index, object-store, discovery, and execution helper
+/// overrides so inherited environment variables cannot bypass the explicit
+/// `-C` path used by functions in this crate or launch ambient helper programs.
 pub fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
     for name in GIT_REPO_SHAPING_ENV {
@@ -465,6 +474,30 @@ mod tests {
 
         for name in GIT_REPO_SHAPING_ENV {
             assert!(removed.contains(*name), "missing env_remove for {name}");
+        }
+    }
+
+    #[test]
+    fn git_cmd_removes_execution_helper_env_overrides() {
+        let removed: BTreeSet<_> = git_cmd()
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect();
+
+        for name in [
+            "GIT_SSH",
+            "GIT_SSH_COMMAND",
+            "GIT_ASKPASS",
+            "GIT_PAGER",
+            "GIT_EDITOR",
+            "GIT_PROXY_COMMAND",
+            "GIT_EXTERNAL_DIFF",
+        ] {
+            assert!(
+                removed.contains(name),
+                "missing execution env_remove for {name}"
+            );
         }
     }
 

--- a/crates/tokmd-scan/src/walk/mod.rs
+++ b/crates/tokmd-scan/src/walk/mod.rs
@@ -23,6 +23,7 @@ use tokmd_io_port::MemFs;
 use crate::path::{BoundedPath, PathViolation, ValidatedRoot, normalize_bounded_relative_path};
 
 const GIT_REPO_SHAPING_ENV: &[&str] = &[
+    // Repository and object-store overrides.
     "GIT_DIR",
     "GIT_WORK_TREE",
     "GIT_INDEX_FILE",
@@ -30,6 +31,14 @@ const GIT_REPO_SHAPING_ENV: &[&str] = &[
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
     "GIT_COMMON_DIR",
     "GIT_CEILING_DIRECTORIES",
+    // Git hooks that can execute helper programs from ambient environment.
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+    "GIT_ASKPASS",
+    "GIT_PAGER",
+    "GIT_EDITOR",
+    "GIT_PROXY_COMMAND",
+    "GIT_EXTERNAL_DIFF",
 ];
 
 #[derive(Debug, Clone)]
@@ -271,6 +280,30 @@ mod tests {
 
         for name in GIT_REPO_SHAPING_ENV {
             assert!(removed.contains(*name), "missing env_remove for {name}");
+        }
+    }
+
+    #[test]
+    fn git_cmd_removes_execution_helper_env_overrides() {
+        let removed: BTreeSet<_> = git_cmd()
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect();
+
+        for name in [
+            "GIT_SSH",
+            "GIT_SSH_COMMAND",
+            "GIT_ASKPASS",
+            "GIT_PAGER",
+            "GIT_EDITOR",
+            "GIT_PROXY_COMMAND",
+            "GIT_EXTERNAL_DIFF",
+        ] {
+            assert!(
+                removed.contains(name),
+                "missing execution env_remove for {name}"
+            );
         }
     }
 

--- a/crates/tokmd/src/git_support.rs
+++ b/crates/tokmd/src/git_support.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 
 const GIT_REPO_SHAPING_ENV: &[&str] = &[
+    // Repository and object-store overrides.
     "GIT_DIR",
     "GIT_WORK_TREE",
     "GIT_INDEX_FILE",
@@ -8,9 +9,17 @@ const GIT_REPO_SHAPING_ENV: &[&str] = &[
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
     "GIT_COMMON_DIR",
     "GIT_CEILING_DIRECTORIES",
+    // Git hooks that can execute helper programs from ambient environment.
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+    "GIT_ASKPASS",
+    "GIT_PAGER",
+    "GIT_EDITOR",
+    "GIT_PROXY_COMMAND",
+    "GIT_EXTERNAL_DIFF",
 ];
 
-/// Create a `git` command without inheriting repo-shaping overrides.
+/// Create a `git` command without inheriting repo or execution-shaping overrides.
 pub(crate) fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
     for name in GIT_REPO_SHAPING_ENV {
@@ -34,6 +43,30 @@ mod tests {
 
         for name in GIT_REPO_SHAPING_ENV {
             assert!(removed.contains(*name), "missing env_remove for {name}");
+        }
+    }
+
+    #[test]
+    fn git_cmd_removes_execution_helper_env_overrides() {
+        let removed: BTreeSet<_> = git_cmd()
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect();
+
+        for name in [
+            "GIT_SSH",
+            "GIT_SSH_COMMAND",
+            "GIT_ASKPASS",
+            "GIT_PAGER",
+            "GIT_EDITOR",
+            "GIT_PROXY_COMMAND",
+            "GIT_EXTERNAL_DIFF",
+        ] {
+            assert!(
+                removed.contains(name),
+                "missing execution env_remove for {name}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- harden all current repo-owned Git subprocess wrappers against ambient Git execution-helper environment overrides
- add negative tests for `GIT_SSH`, `GIT_SSH_COMMAND`, `GIT_ASKPASS`, `GIT_PAGER`, `GIT_EDITOR`, `GIT_PROXY_COMMAND`, and `GIT_EXTERNAL_DIFF`
- widen the `git_subprocess_boundary` proof scope to route the full `git_cmd_removes` test family

Synthesized from draft #1992, which covered only part of the boundary. This keeper applies the same guardrail to `tokmd`, `tokmd-git`, and `tokmd-scan` without changing CLI behavior, proof gate promotion, Codecov upload, or receipt schemas.

## Trust boundary
Repo-owned Git subprocess execution must not inherit ambient environment variables that can redirect repository/object-store discovery or launch external helper programs. The wrappers still run `git`, but now explicitly remove both repository-shaping and execution-helper Git variables before callers add arguments/current directories.

## Validation
- `cargo test -p tokmd-git git_cmd_removes --verbose`
- `cargo test -p tokmd-scan git_cmd_removes --verbose`
- `cargo test -p tokmd git_cmd_removes --verbose`
- `cargo clippy -p tokmd-git -p tokmd-scan -p tokmd --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`
