### PR TITLE
test(cli): cover all parser subcommands

### DIFF
--- a/crates/tokmd/tests/cli_parser_properties.rs
+++ b/crates/tokmd/tests/cli_parser_properties.rs
@@ -3,9 +3,50 @@
 //! Verifies that the clap parser (`tokmd::cli::Cli`) never panics
 //! when fed arbitrary string arguments.
 
-use clap::Parser;
+use std::collections::BTreeSet;
+
+use clap::{CommandFactory, Parser};
 use proptest::prelude::*;
 use tokmd::cli::Cli;
+
+const PARSER_SUBCOMMANDS: &[&str] = &[
+    "lang",
+    "module",
+    "export",
+    "analyze",
+    "badge",
+    "init",
+    "completions",
+    "run",
+    "diff",
+    "context",
+    "check-ignore",
+    "tools",
+    "gate",
+    "cockpit",
+    "baseline",
+    "handoff",
+    "sensor",
+];
+
+fn parser_subcommands() -> impl Strategy<Value = &'static str> {
+    prop::sample::select(PARSER_SUBCOMMANDS.to_vec())
+}
+
+#[test]
+fn parser_subcommand_property_list_matches_clap_surface() {
+    let command = Cli::command();
+    let actual: BTreeSet<String> = command
+        .get_subcommands()
+        .map(|subcommand| subcommand.get_name().to_owned())
+        .collect();
+    let listed: BTreeSet<String> = PARSER_SUBCOMMANDS
+        .iter()
+        .map(|subcommand| (*subcommand).to_owned())
+        .collect();
+
+    assert_eq!(listed, actual);
+}
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(1000))]
@@ -21,17 +62,7 @@ proptest! {
 
     #[test]
     fn cli_parser_never_panics_on_subcommand_with_arbitrary_args(
-        subcmd in prop_oneof![
-            Just("lang"),
-            Just("module"),
-            Just("export"),
-            Just("diff"),
-            Just("version"),
-            Just("analyze"),
-            Just("cockpit"),
-            Just("context"),
-            Just("handoff"),
-        ],
+        subcmd in parser_subcommands(),
         args in prop::collection::vec("\\PC{0,30}", 0..20)
     ) {
         let mut iter_args = vec!["tokmd".to_string(), subcmd.to_string()];


### PR DESCRIPTION
## Summary
- Expand the CLI parser proptest to sample every actual clap subcommand.
- Add a guard test that compares the property subcommand list against `Cli::command()` so future command additions cannot silently fall out of coverage.
- Synthesize the useful test-only part of draft #2001 without the generated `.jules` run artifacts.

## Behavior
- Test-only change.
- No CLI output, schema, proof policy, Action, gate promotion, or Codecov changes.

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd --test cli_parser_properties --verbose`
- `cargo test -p tokmd --test cli_snapshot_golden --verbose`
- `cargo clippy -p tokmd --test cli_parser_properties -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo test -p tokmd --test cli_e2e --verbose`
- `cargo test -p tokmd --test config_resolution --verbose`