### PR TITLE
fix(model): count orphan child byte metrics

### DIFF
--- a/crates/tokmd-model/src/aggregate.rs
+++ b/crates/tokmd-model/src/aggregate.rs
@@ -69,6 +69,8 @@ pub fn create_lang_report_from_rows(
                         .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
                     entry.0.code += row.code;
                     entry.0.lines += row.lines;
+                    entry.0.bytes += row.bytes;
+                    entry.0.tokens += row.tokens;
                     entry.1.insert(row.path.as_str());
                 }
             }

--- a/crates/tokmd-model/tests/aggregate_test.rs
+++ b/crates/tokmd-model/tests/aggregate_test.rs
@@ -1,0 +1,57 @@
+use tokmd_model::create_lang_report_from_rows;
+use tokmd_types::{ChildrenMode, FileKind, FileRow};
+
+fn file_row(kind: FileKind, lang: &str, bytes: usize, tokens: usize) -> FileRow {
+    FileRow {
+        path: "docs/example.md".to_string(),
+        lang: lang.to_string(),
+        code: 100,
+        lines: 120,
+        blanks: 10,
+        comments: 10,
+        bytes,
+        tokens,
+        module: "docs".to_string(),
+        kind,
+    }
+}
+
+#[test]
+fn collapse_mode_keeps_orphan_child_bytes_and_tokens() {
+    let report = create_lang_report_from_rows(
+        &[file_row(FileKind::Child, "Rust", 500, 125)],
+        0,
+        true,
+        ChildrenMode::Collapse,
+    );
+
+    assert_eq!(report.rows.len(), 1);
+    assert_eq!(report.rows[0].lang, "Rust");
+    assert_eq!(report.rows[0].code, 100);
+    assert_eq!(report.rows[0].lines, 120);
+    assert_eq!(report.rows[0].files, 1);
+    assert_eq!(report.rows[0].bytes, 500);
+    assert_eq!(report.rows[0].tokens, 125);
+    assert_eq!(report.total.bytes, 500);
+    assert_eq!(report.total.tokens, 125);
+}
+
+#[test]
+fn separate_mode_does_not_count_child_bytes_or_tokens() {
+    let report = create_lang_report_from_rows(
+        &[file_row(FileKind::Child, "Rust", 500, 125)],
+        0,
+        true,
+        ChildrenMode::Separate,
+    );
+
+    assert_eq!(report.rows.len(), 1);
+    assert_eq!(report.rows[0].lang, "Rust (embedded)");
+    assert_eq!(report.rows[0].code, 100);
+    assert_eq!(report.rows[0].lines, 120);
+    assert_eq!(report.rows[0].files, 1);
+    assert_eq!(report.rows[0].bytes, 0);
+    assert_eq!(report.rows[0].tokens, 0);
+    assert_eq!(report.total.bytes, 0);
+    assert_eq!(report.total.tokens, 0);
+}


### PR DESCRIPTION
## Summary
- count `bytes` and `tokens` for collapse-mode child rows when no parent row exists for that path
- add focused regression tests for orphan child aggregation and separate-mode zero-byte semantics
- supersedes #1996 with a current-main keeper that excludes generated `.jules` artifacts and avoids double-counting embedded rows in separate mode

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-model --verbose`
- `cargo clippy -p tokmd-model --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo test -p tokmd-model normalize --verbose`
- `cargo test -p tokmd-scan normalize --verbose`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`