### PR TITLE
test(analysis-types): cover determinism baseline roundtrip

### DIFF
--- a/crates/tokmd-analysis-types/src/baseline/determinism.rs
+++ b/crates/tokmd-analysis-types/src/baseline/determinism.rs
@@ -22,3 +22,38 @@ pub struct DeterminismBaseline {
     /// Hash of Cargo.lock if present (Rust projects).
     pub cargo_lock_hash: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn determinism_baseline_roundtrips_through_json(
+            baseline_version in any::<u32>(),
+            generated_at in "[a-zA-Z0-9:.-]{10,40}",
+            build_hash in "[a-f0-9]{40}",
+            source_hash in "[a-f0-9]{40}",
+            cargo_lock_hash in proptest::option::of("[a-f0-9]{40}"),
+        ) {
+            let baseline = DeterminismBaseline {
+                baseline_version,
+                generated_at,
+                build_hash,
+                source_hash,
+                cargo_lock_hash,
+            };
+
+            let json = serde_json::to_string(&baseline).expect("serialize determinism baseline");
+            let parsed: DeterminismBaseline =
+                serde_json::from_str(&json).expect("deserialize determinism baseline");
+
+            prop_assert_eq!(baseline.baseline_version, parsed.baseline_version);
+            prop_assert_eq!(&baseline.generated_at, &parsed.generated_at);
+            prop_assert_eq!(&baseline.build_hash, &parsed.build_hash);
+            prop_assert_eq!(&baseline.source_hash, &parsed.source_hash);
+            prop_assert_eq!(&baseline.cargo_lock_hash, &parsed.cargo_lock_hash);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a property test for `DeterminismBaseline` JSON roundtripping
- preserve DTO fields, serde names, schemas, and public re-exports
- supersedes #1998 with a current-main keeper that excludes generated run artifacts

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-analysis-types --lib baseline::determinism --verbose`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo clippy -p tokmd-analysis-types --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo test -p tokmd-analysis-types baseline --verbose`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`