### PR TITLE
fix(schema): sync embedded handoff schema

### DIFF
--- a/crates/tokmd/schemas/handoff.schema.json
+++ b/crates/tokmd/schemas/handoff.schema.json
@@ -21,6 +21,7 @@
     "included_files",
     "excluded_paths",
     "excluded_patterns",
+    "smart_excluded_files",
     "total_files",
     "bundled_files",
     "intelligence_preset"
@@ -65,10 +66,16 @@
     "intelligence_preset": { "type": "string" },
     "rank_by_effective": { "type": "string" },
     "fallback_reason": { "type": "string" },
+    "smart_excluded_files": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/SmartExcludedFile" }
+    },
     "excluded_by_policy": {
       "type": "array",
       "items": { "$ref": "#/definitions/PolicyExcludedFile" }
-    }
+    },
+    "token_estimation": { "$ref": "#/definitions/TokenEstimationMeta" },
+    "code_audit": { "$ref": "#/definitions/TokenAudit" }
   },
   "definitions": {
     "ToolInfo": {
@@ -153,6 +160,40 @@
       "properties": {
         "path": { "type": "string" },
         "reason": { "type": "string" }
+      }
+    },
+    "SmartExcludedFile": {
+      "type": "object",
+      "required": ["path", "reason", "tokens"],
+      "properties": {
+        "path": { "type": "string" },
+        "reason": { "type": "string" },
+        "tokens": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "TokenEstimationMeta": {
+      "type": "object",
+      "required": ["bytes_per_token_est", "bytes_per_token_low", "bytes_per_token_high", "tokens_min", "tokens_est", "tokens_max", "source_bytes"],
+      "properties": {
+        "bytes_per_token_est": { "type": "number" },
+        "bytes_per_token_low": { "type": "number" },
+        "bytes_per_token_high": { "type": "number" },
+        "tokens_min": { "type": "integer", "minimum": 0 },
+        "tokens_est": { "type": "integer", "minimum": 0 },
+        "tokens_max": { "type": "integer", "minimum": 0 },
+        "source_bytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "TokenAudit": {
+      "type": "object",
+      "required": ["output_bytes", "tokens_min", "tokens_est", "tokens_max", "overhead_bytes", "overhead_pct"],
+      "properties": {
+        "output_bytes": { "type": "integer", "minimum": 0 },
+        "tokens_min": { "type": "integer", "minimum": 0 },
+        "tokens_est": { "type": "integer", "minimum": 0 },
+        "tokens_max": { "type": "integer", "minimum": 0 },
+        "overhead_bytes": { "type": "integer", "minimum": 0 },
+        "overhead_pct": { "type": "number", "minimum": 0 }
       }
     },
     "PolicyExcludedFile": {


### PR DESCRIPTION
## Summary
- sync the embedded `crates/tokmd/schemas/handoff.schema.json` with `docs/handoff.schema.json`
- include the current handoff manifest fields for smart exclusions, token estimation metadata, and token audit metadata
- supersedes #1997 without carrying generated `.jules` artifacts

## Validation
- `git diff --no-index -- crates/tokmd/schemas/handoff.schema.json docs/handoff.schema.json`
- `cargo test -p tokmd --test schema_validation test_handoff_manifest_validates_against_schema --verbose`
- `cargo test -p tokmd --test handoff_w71 handoff_smart_excluded_files_field_present --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask docs --check`
- `cargo test -p tokmd --test schema_doc_sync --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo test -p tokmd-types schema --verbose`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`