### PR TITLE
docs: sync active version examples

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -944,10 +944,12 @@ paths = [
   "docs/design.md",
   "docs/evidencebus-integration.md",
   "docs/implementation-plan.md",
+  "docs/install.md",
   "docs/adr/**",
   "docs/audits/**",
   "docs/progress-events.md",
   "docs/requirements.md",
+  "docs/sensor-report-v1.md",
   "docs/specification.md",
 ]
 proof = ["cargo xtask docs --check"]

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -117,7 +117,7 @@ Every receipt includes:
 | `generated_at_ms` | `integer` | Unix timestamp (milliseconds) when the scan ran. |
 | `tool` | `object` | Information about the tool version. |
 | `tool.name` | `string` | Always `"tokmd"`. |
-| `tool.version` | `string` | The version of tokmd used (e.g., `"1.10.0"`). |
+| `tool.version` | `string` | The version of tokmd used (e.g., `"1.11.0"`). |
 | `mode` | `string` | One of `"lang"`, `"module"`, `"export"`, `"analysis"`, or `"cockpit"`. |
 | `status` | `string` | Scan status: `"complete"` or `"partial"`. |
 | `warnings` | `array` | Array of warning strings generated during the scan. |
@@ -150,7 +150,7 @@ Produced by `tokmd --format json` or `tokmd lang --format json`.
 {
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.10.0" },
+  "tool": { "name": "tokmd", "version": "1.11.0" },
   "mode": "lang",
   "status": "complete",
   "warnings": [],
@@ -231,7 +231,7 @@ Produced by `tokmd module --format json`.
 {
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.10.0" },
+  "tool": { "name": "tokmd", "version": "1.11.0" },
   "mode": "module",
   "status": "complete",
   "warnings": [],
@@ -314,7 +314,7 @@ JSONL output consists of a **Meta Record** (first line) followed by **Data Rows*
   "type": "meta",
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.10.0" },
+  "tool": { "name": "tokmd", "version": "1.11.0" },
   "mode": "export",
   "status": "complete",
   "warnings": [],
@@ -358,7 +358,7 @@ When using `--format json`, the output is a single JSON object:
 {
   "schema_version": 2,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.10.0" },
+  "tool": { "name": "tokmd", "version": "1.11.0" },
   "mode": "export",
   "status": "complete",
   "warnings": [],
@@ -448,7 +448,7 @@ Analysis receipts contain derived metrics and optional enrichments. All sections
 {
   "schema_version": 9,
   "generated_at_ms": 1706350000000,
-  "tool": { "name": "tokmd", "version": "1.10.0" },
+  "tool": { "name": "tokmd", "version": "1.11.0" },
   "mode": "analysis",
   "status": "complete",
   "warnings": [],
@@ -806,7 +806,7 @@ The ecosystem envelope provides a standardized JSON format for multi-sensor inte
   "schema": "sensor.report.v1",
   "tool": {
     "name": "tokmd",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "mode": "cockpit"
   },
   "generated_at": "2024-01-27T10:30:00Z",

--- a/docs/design.md
+++ b/docs/design.md
@@ -72,7 +72,7 @@ Every JSON receipt includes:
 {
   "schema_version": 2,
   "tool": "tokmd",
-  "tool_version": "1.10.0",
+  "tool_version": "1.11.0",
   "generated_at_ms": 1706886000000,
   "mode": "lang",
   "scan": { ... },

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -22,7 +22,7 @@ jobs:
 
       - uses: EffortlessMetrics/tokmd@v1
         with:
-          version: '1.10.0'
+          version: '1.11.0'
           paths: .
           artifact: 'true'
           comment: 'true'
@@ -35,23 +35,23 @@ There are two version choices in every workflow:
 | Setting | Meaning | Example |
 | :------ | :------ | :------ |
 | Action ref | Which repository ref GitHub uses for `action.yml` | `EffortlessMetrics/tokmd@v1` |
-| `version` input | Which released `tokmd` binary the Action downloads | `version: '1.10.0'` |
+| `version` input | Which released `tokmd` binary the Action downloads | `version: '1.11.0'` |
 
 Use stable workflows like this:
 
 ```yaml
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     paths: .
 ```
 
 For release-candidate smoke tests, pin both the Action ref and the downloaded binary:
 
 ```yaml
-- uses: EffortlessMetrics/tokmd@v1.10.0-rc.1
+- uses: EffortlessMetrics/tokmd@v1.11.0-rc.1
   with:
-    version: '1.10.0-rc.1'
+    version: '1.11.0-rc.1'
     paths: .
 ```
 
@@ -59,9 +59,9 @@ If `version` does not start with `v`, the Action prepends it before downloading 
 
 | `version` input | Release tag |
 | :-------------- | :---------- |
-| `1.10.0` | `v1.10.0` |
-| `v1.10.0` | `v1.10.0` |
-| `1.10.0-rc.1` | `v1.10.0-rc.1` |
+| `1.11.0` | `v1.11.0` |
+| `v1.11.0` | `v1.11.0` |
+| `1.11.0-rc.1` | `v1.11.0-rc.1` |
 
 ## Inputs
 
@@ -219,7 +219,7 @@ For `cockpit` and `sensor` in external pull request workflows, prefer full histo
 
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     mode: cockpit
     head: HEAD
     artifact: 'true'
@@ -291,7 +291,7 @@ Supported binary assets:
 
 When `checksums.txt` exists on the release, the Action verifies the downloaded binary before running it.
 
-Stable release tags update the `v1` major tag. Release-candidate tags such as `v1.10.0-rc.1` are prereleases, do not become the latest release, and do not move `v1`.
+Stable release tags update the `v1` major tag. Release-candidate tags such as `v1.11.0-rc.1` are prereleases, do not become the latest release, and do not move `v1`.
 
 ## Examples
 
@@ -300,7 +300,7 @@ Stable release tags update the `v1` major tag. Release-candidate tags such as `v
 ```yaml
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     paths: .
     artifact: 'true'
     comment: 'true'
@@ -321,7 +321,7 @@ Stable release tags update the `v1` major tag. Release-candidate tags such as `v
 
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     mode: gate
     paths: .
     artifact: 'true'
@@ -337,7 +337,7 @@ Stable release tags update the `v1` major tag. Release-candidate tags such as `v
 
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     mode: cockpit
     head: HEAD
     artifact: 'true'
@@ -353,7 +353,7 @@ Stable release tags update the `v1` major tag. Release-candidate tags such as `v
 
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     mode: sensor
     head: HEAD
     artifact: 'true'
@@ -365,7 +365,7 @@ Stable release tags update the `v1` major tag. Release-candidate tags such as `v
 ```yaml
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     mode: baseline
     paths: .
     artifact: 'true'

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,7 +28,7 @@ Use the root composite Action when you want CI receipts, PR summaries, artifacts
 ```yaml
 - uses: EffortlessMetrics/tokmd@v1
   with:
-    version: '1.10.0'
+    version: '1.11.0'
     paths: .
 ```
 

--- a/docs/sensor-report-v1.md
+++ b/docs/sensor-report-v1.md
@@ -47,7 +47,7 @@ The formal JSON Schema is available at:
   "schema": "sensor.report.v1",
   "tool": {
     "name": "tokmd",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "mode": "cockpit"
   },
   "generated_at": "2026-02-07T12:00:00Z",
@@ -117,7 +117,7 @@ The formal JSON Schema is available at:
 ```json
 {
   "name": "tokmd",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "mode": "cockpit"
 }
 ```


### PR DESCRIPTION
## Summary
- update active docs examples from `1.10.0` to the current `1.11.0` workspace version
- map `docs/install.md` and `docs/sensor-report-v1.md` into the existing `project_truth_docs` proof scope so affected discovery stays strict
- supersedes the active-docs portion of #1999 without carrying generated `.jules` run artifacts or unrelated root scratch cleanup

## Validation
- `rg "1\\.10\\.0" docs/SCHEMA.md docs/design.md docs/github-action.md docs/install.md docs/sensor-report-v1.md`
- `cargo xtask version-consistency`
- `cargo xtask docs --check`
- `cargo test -p tokmd --test schema_doc_sync --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo test -p tokmd --test docs --verbose`
- `cargo test -p tokmd-analysis-types --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`