### PR TITLE
docs: sync AST roadmap and Jules indexes

### DIFF
--- a/.jules/friction/open/compat-wasm-pack-args.md
+++ b/.jules/friction/open/compat-wasm-pack-args.md
@@ -1,0 +1,21 @@
+# Friction Item
+
+id: compat-wasm-pack-args
+persona: compat
+style: builder
+shard: bindings-targets
+status: open
+
+## Problem
+`wasm-pack test` argument placement is easy to get wrong when future runs need to pass Cargo feature flags or profile flags through to wasm test builds.
+
+## Evidence
+- A compat-targets investigation found no repository bug in the wasm, Python, or Node binding matrix.
+- The only durable friction was command syntax confusion around where `wasm-pack test` expects feature-related arguments.
+
+## Why it matters
+Future compatibility runs should not convert external command-line friction into fake tokmd code changes.
+
+## Done when
+- [ ] The bindings-targets runbook documents the exact `wasm-pack test` feature-argument form used by tokmd.
+- [ ] Future compat prompts can distinguish external runner syntax friction from a repository feature-interaction bug.

--- a/.jules/index/generated/FRICTION_ROLLUP.md
+++ b/.jules/index/generated/FRICTION_ROLLUP.md
@@ -5,6 +5,7 @@ It rolls up active friction metadata from `.jules/friction/open/`.
 
 | ID | Persona | Style | Shard | Status | Summary |
 |---|---|---|---|---|---|
+| `compat-wasm-pack-args` | compat | builder | bindings-targets | open | `wasm-pack test` argument placement is easy to get wrong when future runs need to pass Cargo feature flags or profile flags through to wasm test builds. |
 | `fuzz_toolchain_blocker` | fuzzer | prover | interfaces | open | `cargo fuzz` is not a reliable local gate in the current agent environments. Repeated runs hit either missing nightly-toolchain support in sandboxed Linux environments or sanitizer/LLVM link failures on Windows/MSVC before the target starts. |
 | `librarian_doctest_git_dependency` | librarian | prover | core-pipeline | open | The `cockpit_workflow` public API doctest is marked as `no_run` and skipping validation because it implicitly requires an active Git repository to execute (it fails with `not inside a git repository` when executed normally). |
 | `steward-release-clean-state` | steward | stabilizer | tooling-governance | open | A prompt (`steward_release`) requested finding release/governance improvements (e.g. publish-plan drift, changelog mismatch), but all checks pass cleanly. |

--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -17,10 +17,11 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `cartographer_roadmap_design_1` | cartographer | builder | tooling-governance | in-progress | 0 | live |
 | `compat_interfaces_matrix_01` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `d657338a-caa9-4ccf-93a1-4733ada7154c` | Gatekeeper | Unknown | quality | completed | 0 | live |
+| `fuzzer_input_hardening_1` | Fuzzer 🌪️ | Prover | interfaces | in-progress | 1 | live |
 | `gatekeeper_contracts` | Gatekeeper | Builder | tooling-governance | in-progress | 6 | live |
 | `invariant_model_analysis` | invariant | prover | analysis-stack | success | 0 | live |
 | `librarian_api_doctests` | Librarian | Prover | interfaces | in-progress | 0 | live |
-| `librarian_docs_examples` | librarian | Builder | tooling-governance | in-progress | 1 | live |
+| `librarian_docs_examples` | Librarian 📚 | Builder | tooling-governance | success | 0 | live |
 | `palette_runtime_dx_interfaces` | Palette 🎨 | Builder | interfaces | in-progress | 0 | live |
 | `run-specsmith-1` | Specsmith | Builder | analysis-stack | in-progress | 3 | live |
 | `run_perf_cockpit_entry` | Unknown | Unknown | Unknown | in-progress | 0 | live |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,8 +218,6 @@ Stable release following `v1.10.0-rc.1` validation.
 ### Added
 
 - Near-duplicate detection enricher (`tokmd-analysis-near-dup`), commit intent classification, and focused microcrate extraction.
-- Planned v4.0.0 milestone for Adze AST integration in roadmap.
-
 ### Fixed
 
 - `cargo xtask publish` now handles HTTP 429 rate-limit responses from crates.io by parsing the `retry-after` timestamp, sleeping until the cooldown expires, and retrying automatically instead of failing hard. This prevents partial releases when publishing many crates in sequence.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,8 +40,7 @@ context for humans, machines, CI, and agents.
 | **v1.10.0** | ✅ Complete | Stable CI control plane, trust hardening, WASM truth, Action release, and proof stability. |
 | **v1.11.0** | ✅ Complete | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
-| **v3.0.0** | 🔭 Long-term | Tree-sitter AST integration (requires significant R&D).      |
-| **v4.0.0** | 🔭 Long-term | Adze AST integration.      |
+| **v3.0.0** | 🚧 Active (Shadow) | Tree-sitter AST foundation in-tree behind feature flag. |
 
 ---
 
@@ -668,8 +667,8 @@ _Goal: Accurate parsing for precise metrics. This is a significant undertaking r
 
 #### J. Tree-sitter AST Parsing
 
-- Feature-gated AST foundation defined by ADR-0008
-- Rust-first owner module under `tokmd-analysis` before any public parser crate
+- ✅ Feature-gated AST foundation defined by ADR-0008 (landed behind `ast` feature)
+- ✅ Rust-first owner module under `tokmd-analysis` before any public parser crate
 - Shadow comparison artifacts for heuristic-vs-AST function, import, and control-flow evidence
 - Later language-specific complexity rules only after deterministic shadow evidence
 - Public receipt/schema changes only after schema review and migration policy

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -445,9 +445,9 @@ authenticated fetch.
 
 ---
 
-## Phase 7: Tree-sitter Integration (v3.0 — Long-term)
+## Phase 7: Tree-sitter Integration (v3.0 — Shadow Mode Active)
 
-**Goal**: Accurate parsing for precise metrics. This is a significant R&D effort requiring multi-language grammar integration, cross-platform build toolchains, and extensive correctness validation. Intentionally deferred well beyond v2.x.
+**Goal**: Accurate parsing for precise metrics. This is a significant R&D effort requiring multi-language grammar integration, cross-platform build toolchains, and extensive correctness validation. Intentionally deferred well beyond v2.x for full default integration, but foundation shadow work has begun.
 
 ADR-0008 defines the rollout boundary: AST work starts as a feature-gated,
 Rust-first owner module with deterministic shadow comparison artifacts. It must


### PR DESCRIPTION
## Summary
- update roadmap and implementation-plan wording for the in-tree Tree-sitter AST shadow foundation
- remove the stale Adze roadmap/changelog note
- add a concise Jules friction item for wasm-pack feature-argument syntax and regenerate Jules indexes

## Supersedes
- Supersedes #2003 for AST roadmap drift without generated run artifacts.
- Supersedes #2002 for the durable compat friction note without raw exploratory transcript files.
- Supersedes #2000 for Jules index freshness without changing existing friction item style.

## Validation
- cargo xtask jules-index --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask version-consistency
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json
- cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json
- cargo fmt-check
- cargo xtask publish-surface --json --verify-publish
- git diff --check origin/main..HEAD