### PR TITLE
refactor(core): extract FFI input decoding

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -164,7 +164,11 @@ coverage = false
 [[scope]]
 name = "tokmd_core_ffi"
 kind = "rust"
-paths = ["crates/tokmd-core/src/ffi.rs", "crates/tokmd-core/tests/**"]
+paths = [
+  "crates/tokmd-core/src/ffi.rs",
+  "crates/tokmd-core/src/ffi/**",
+  "crates/tokmd-core/tests/**",
+]
 packages = ["tokmd-core"]
 proof = [
   "cargo test -p tokmd-core ffi",

--- a/crates/tokmd-core/src/ffi.rs
+++ b/crates/tokmd-core/src/ffi.rs
@@ -15,8 +15,9 @@
 //! - Missing keys use sensible defaults
 //! - Invalid values return errors (no silent fallback to defaults)
 
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde_json::Value;
+
+mod inputs;
 
 #[cfg(feature = "analysis")]
 use crate::analyze_workflow_from_inputs;
@@ -26,11 +27,10 @@ use crate::settings::{
     ExportSettings, LangSettings, ModuleSettings, RedactMode, ScanSettings,
 };
 use crate::{
-    InMemoryFile, export_workflow, export_workflow_from_inputs, lang_workflow,
-    lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
+    export_workflow, export_workflow_from_inputs, lang_workflow, lang_workflow_from_inputs,
+    module_workflow, module_workflow_from_inputs,
 };
-
-const MAX_IN_MEMORY_INPUT_PATH_BYTES: usize = 4096;
+use inputs::parse_in_memory_inputs;
 
 /// Run a tokmd operation with JSON arguments, returning JSON output.
 ///
@@ -285,179 +285,6 @@ fn parse_string_array(
             .collect(),
         Some(_) => Err(TokmdError::invalid_field(field, "an array of strings")),
     }
-}
-
-fn parse_in_memory_inputs(args: &Value) -> Result<Option<Vec<InMemoryFile>>, TokmdError> {
-    let scan_obj = args.get("scan");
-    let root_inputs = args.get("inputs").filter(|value| !value.is_null());
-    let nested_inputs = scan_obj
-        .and_then(Value::as_object)
-        .and_then(|scan| scan.get("inputs"))
-        .filter(|value| !value.is_null());
-
-    let raw_inputs = match (root_inputs, nested_inputs) {
-        (Some(_), Some(_)) => {
-            return Err(TokmdError::invalid_field(
-                "inputs",
-                "provide in-memory inputs either at the top level or under 'scan', not both",
-            ));
-        }
-        (Some(inputs), None) => inputs,
-        (None, Some(inputs)) => inputs,
-        (None, None) => return Ok(None),
-    };
-
-    let root_has_paths = args.get("paths").is_some_and(|value| !value.is_null());
-    let scan_has_paths = scan_obj
-        .and_then(Value::as_object)
-        .and_then(|scan| scan.get("paths"))
-        .is_some_and(|value| !value.is_null());
-
-    if root_has_paths || scan_has_paths {
-        return Err(TokmdError::invalid_field(
-            "paths",
-            "cannot be combined with in-memory inputs",
-        ));
-    }
-
-    let arr = raw_inputs
-        .as_array()
-        .ok_or_else(|| TokmdError::invalid_field("inputs", "an array of input objects"))?;
-    let mut inputs = Vec::with_capacity(arr.len());
-
-    for (idx, raw_input) in arr.iter().enumerate() {
-        let input = raw_input.as_object().ok_or_else(|| {
-            TokmdError::invalid_field(
-                &format!("inputs[{idx}]"),
-                "an object with 'path' and exactly one of 'text' or 'base64'",
-            )
-        })?;
-        let path = input
-            .get("path")
-            .and_then(Value::as_str)
-            .ok_or_else(|| TokmdError::invalid_field(&format!("inputs[{idx}].path"), "a string"))?
-            .to_string();
-        validate_in_memory_input_path(&path, idx)?;
-        let text = input.get("text");
-        let base64 = input.get("base64");
-
-        let bytes = match (text, base64) {
-            (Some(text), None) => text
-                .as_str()
-                .ok_or_else(|| {
-                    TokmdError::invalid_field(&format!("inputs[{idx}].text"), "a string")
-                })?
-                .as_bytes()
-                .to_vec(),
-            (None, Some(base64)) => {
-                let encoded = base64.as_str().ok_or_else(|| {
-                    TokmdError::invalid_field(&format!("inputs[{idx}].base64"), "a string")
-                })?;
-                BASE64.decode(encoded).map_err(|_| {
-                    TokmdError::invalid_field(&format!("inputs[{idx}].base64"), "valid base64")
-                })?
-            }
-            (Some(_), Some(_)) => {
-                return Err(TokmdError::invalid_field(
-                    &format!("inputs[{idx}]"),
-                    "provide exactly one of 'text' or 'base64'",
-                ));
-            }
-            (None, None) => {
-                return Err(TokmdError::invalid_field(
-                    &format!("inputs[{idx}]"),
-                    "missing content: provide exactly one of 'text' or 'base64'",
-                ));
-            }
-        };
-
-        inputs.push(InMemoryFile::new(path, bytes));
-    }
-
-    Ok(Some(inputs))
-}
-
-fn validate_in_memory_input_path(path: &str, idx: usize) -> Result<(), TokmdError> {
-    let field = format!("inputs[{idx}].path");
-
-    if path.is_empty() {
-        return Err(TokmdError::invalid_field(
-            &field,
-            "a non-empty relative file path",
-        ));
-    }
-
-    if path.len() > MAX_IN_MEMORY_INPUT_PATH_BYTES {
-        return Err(TokmdError::invalid_field(
-            &field,
-            "a relative file path no longer than 4096 bytes",
-        ));
-    }
-
-    if path.chars().any(char::is_control) {
-        return Err(TokmdError::invalid_field(
-            &field,
-            "a relative path without control characters",
-        ));
-    }
-
-    if path.starts_with('/') || path.starts_with('\\') {
-        return Err(TokmdError::invalid_field(
-            &field,
-            "a relative path, not an absolute path",
-        ));
-    }
-
-    if looks_like_windows_drive_path(path) {
-        return Err(TokmdError::invalid_field(
-            &field,
-            "a relative path without a Windows drive prefix",
-        ));
-    }
-
-    for component in std::path::Path::new(path).components() {
-        match component {
-            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
-                return Err(TokmdError::invalid_field(
-                    &field,
-                    "a relative path, not an absolute path",
-                ));
-            }
-            std::path::Component::ParentDir => {
-                return Err(TokmdError::invalid_field(
-                    &field,
-                    "a path without parent traversal (..)",
-                ));
-            }
-            std::path::Component::CurDir | std::path::Component::Normal(_) => {}
-        }
-    }
-
-    if path
-        .split(['/', '\\'])
-        .all(|segment| segment.is_empty() || segment == ".")
-    {
-        return Err(TokmdError::invalid_field(
-            &field,
-            "a path that resolves to a file",
-        ));
-    }
-
-    for segment in path.split(['/', '\\']) {
-        if segment == ".." {
-            return Err(TokmdError::invalid_field(
-                &field,
-                "a path without parent traversal (..)",
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-fn looks_like_windows_drive_path(path: &str) -> bool {
-    let bytes = path.as_bytes();
-    bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic()
 }
 
 /// Parse a ChildrenMode field strictly.
@@ -1463,7 +1290,7 @@ mod tests {
 
     #[test]
     fn in_memory_inputs_rejects_overlong_path() -> Result<(), Box<dyn std::error::Error>> {
-        let long_path = "a".repeat(MAX_IN_MEMORY_INPUT_PATH_BYTES + 1);
+        let long_path = "a".repeat(inputs::MAX_IN_MEMORY_INPUT_PATH_BYTES + 1);
         let args = serde_json::json!({
             "inputs": [{
                 "path": long_path,

--- a/crates/tokmd-core/src/ffi/inputs.rs
+++ b/crates/tokmd-core/src/ffi/inputs.rs
@@ -1,0 +1,187 @@
+//! In-memory input decoding for the FFI JSON entrypoint.
+//!
+//! This module owns the boundary between untrusted JSON input payloads and the
+//! deterministic `InMemoryFile` list consumed by core workflows.
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use serde_json::Value;
+
+use crate::InMemoryFile;
+use crate::error::TokmdError;
+
+pub(super) const MAX_IN_MEMORY_INPUT_PATH_BYTES: usize = 4096;
+
+pub(super) fn parse_in_memory_inputs(
+    args: &Value,
+) -> Result<Option<Vec<InMemoryFile>>, TokmdError> {
+    let scan_obj = args.get("scan");
+    let root_inputs = args.get("inputs").filter(|value| !value.is_null());
+    let nested_inputs = scan_obj
+        .and_then(Value::as_object)
+        .and_then(|scan| scan.get("inputs"))
+        .filter(|value| !value.is_null());
+
+    let raw_inputs = match (root_inputs, nested_inputs) {
+        (Some(_), Some(_)) => {
+            return Err(TokmdError::invalid_field(
+                "inputs",
+                "provide in-memory inputs either at the top level or under 'scan', not both",
+            ));
+        }
+        (Some(inputs), None) => inputs,
+        (None, Some(inputs)) => inputs,
+        (None, None) => return Ok(None),
+    };
+
+    let root_has_paths = args.get("paths").is_some_and(|value| !value.is_null());
+    let scan_has_paths = scan_obj
+        .and_then(Value::as_object)
+        .and_then(|scan| scan.get("paths"))
+        .is_some_and(|value| !value.is_null());
+
+    if root_has_paths || scan_has_paths {
+        return Err(TokmdError::invalid_field(
+            "paths",
+            "cannot be combined with in-memory inputs",
+        ));
+    }
+
+    let arr = raw_inputs
+        .as_array()
+        .ok_or_else(|| TokmdError::invalid_field("inputs", "an array of input objects"))?;
+    let mut inputs = Vec::with_capacity(arr.len());
+
+    for (idx, raw_input) in arr.iter().enumerate() {
+        let input = raw_input.as_object().ok_or_else(|| {
+            TokmdError::invalid_field(
+                &format!("inputs[{idx}]"),
+                "an object with 'path' and exactly one of 'text' or 'base64'",
+            )
+        })?;
+        let path = input
+            .get("path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| TokmdError::invalid_field(&format!("inputs[{idx}].path"), "a string"))?
+            .to_string();
+        validate_in_memory_input_path(&path, idx)?;
+        let text = input.get("text");
+        let base64 = input.get("base64");
+
+        let bytes = match (text, base64) {
+            (Some(text), None) => text
+                .as_str()
+                .ok_or_else(|| {
+                    TokmdError::invalid_field(&format!("inputs[{idx}].text"), "a string")
+                })?
+                .as_bytes()
+                .to_vec(),
+            (None, Some(base64)) => {
+                let encoded = base64.as_str().ok_or_else(|| {
+                    TokmdError::invalid_field(&format!("inputs[{idx}].base64"), "a string")
+                })?;
+                BASE64.decode(encoded).map_err(|_| {
+                    TokmdError::invalid_field(&format!("inputs[{idx}].base64"), "valid base64")
+                })?
+            }
+            (Some(_), Some(_)) => {
+                return Err(TokmdError::invalid_field(
+                    &format!("inputs[{idx}]"),
+                    "provide exactly one of 'text' or 'base64'",
+                ));
+            }
+            (None, None) => {
+                return Err(TokmdError::invalid_field(
+                    &format!("inputs[{idx}]"),
+                    "missing content: provide exactly one of 'text' or 'base64'",
+                ));
+            }
+        };
+
+        inputs.push(InMemoryFile::new(path, bytes));
+    }
+
+    Ok(Some(inputs))
+}
+
+fn validate_in_memory_input_path(path: &str, idx: usize) -> Result<(), TokmdError> {
+    let field = format!("inputs[{idx}].path");
+
+    if path.is_empty() {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a non-empty relative file path",
+        ));
+    }
+
+    if path.len() > MAX_IN_MEMORY_INPUT_PATH_BYTES {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a relative file path no longer than 4096 bytes",
+        ));
+    }
+
+    if path.chars().any(char::is_control) {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a relative path without control characters",
+        ));
+    }
+
+    if path.starts_with('/') || path.starts_with('\\') {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a relative path, not an absolute path",
+        ));
+    }
+
+    if looks_like_windows_drive_path(path) {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a relative path without a Windows drive prefix",
+        ));
+    }
+
+    for component in std::path::Path::new(path).components() {
+        match component {
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                return Err(TokmdError::invalid_field(
+                    &field,
+                    "a relative path, not an absolute path",
+                ));
+            }
+            std::path::Component::ParentDir => {
+                return Err(TokmdError::invalid_field(
+                    &field,
+                    "a path without parent traversal (..)",
+                ));
+            }
+            std::path::Component::CurDir | std::path::Component::Normal(_) => {}
+        }
+    }
+
+    if path
+        .split(['/', '\\'])
+        .all(|segment| segment.is_empty() || segment == ".")
+    {
+        return Err(TokmdError::invalid_field(
+            &field,
+            "a path that resolves to a file",
+        ));
+    }
+
+    for segment in path.split(['/', '\\']) {
+        if segment == ".." {
+            return Err(TokmdError::invalid_field(
+                &field,
+                "a path without parent traversal (..)",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn looks_like_windows_drive_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic()
+}


### PR DESCRIPTION
## Summary
- Move FFI in-memory input decoding and path validation into `crates/tokmd-core/src/ffi/inputs.rs`.
- Keep `ffi.rs` as the `run_json` coordinator while preserving existing FFI behavior and error semantics.
- Route `crates/tokmd-core/src/ffi/**` through the `tokmd_core_ffi` proof scope.

## Validation
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo clippy -p tokmd-core --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-artifacts-check`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`