### PR TITLE
refactor(core): extract FFI parsing helpers

### DIFF
--- a/crates/tokmd-core/src/ffi.rs
+++ b/crates/tokmd-core/src/ffi.rs
@@ -18,6 +18,7 @@
 use serde_json::Value;
 
 mod inputs;
+mod parse;
 
 #[cfg(feature = "analysis")]
 use crate::analyze_workflow_from_inputs;
@@ -31,6 +32,13 @@ use crate::{
     module_workflow, module_workflow_from_inputs,
 };
 use inputs::parse_in_memory_inputs;
+use parse::{
+    parse_analyze_preset, parse_bool, parse_child_include_mode, parse_children_mode,
+    parse_config_mode, parse_effort_layer, parse_effort_model, parse_export_format,
+    parse_import_granularity, parse_optional_bool, parse_optional_redact_mode,
+    parse_optional_string, parse_optional_u64, parse_optional_usize, parse_redact_mode,
+    parse_required_string, parse_string, parse_string_array, parse_usize, scan_arg_object,
+};
 
 /// Run a tokmd operation with JSON arguments, returning JSON output.
 ///
@@ -168,243 +176,6 @@ fn run_json_inner(mode: &str, args_json: &str) -> Result<Value, TokmdError> {
             Ok(version_info)
         }
         _ => Err(TokmdError::unknown_mode(mode)),
-    }
-}
-
-fn scan_arg_object(args: &Value) -> &Value {
-    args.get("scan").unwrap_or(args)
-}
-
-// ============================================================================
-// Strict parsing helpers
-// ============================================================================
-
-/// Parse a boolean field strictly: missing/null -> default, non-bool -> error.
-fn parse_bool(args: &Value, field: &str, default: bool) -> Result<bool, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(default),
-        Some(v) => v
-            .as_bool()
-            .ok_or_else(|| TokmdError::invalid_field(field, "a boolean (true or false)")),
-    }
-}
-
-/// Parse a usize field strictly: missing/null -> default, non-number -> error.
-fn parse_usize(args: &Value, field: &str, default: usize) -> Result<usize, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(default),
-        Some(v) => v
-            .as_u64()
-            .map(|n| n as usize)
-            .ok_or_else(|| TokmdError::invalid_field(field, "a non-negative integer")),
-    }
-}
-
-/// Parse a u64 field strictly: missing/null -> None, non-number -> error.
-fn parse_optional_u64(args: &Value, field: &str) -> Result<Option<u64>, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(None),
-        Some(v) => v
-            .as_u64()
-            .map(Some)
-            .ok_or_else(|| TokmdError::invalid_field(field, "a non-negative integer")),
-    }
-}
-
-/// Parse an optional usize field strictly: missing/null -> None, non-number -> error.
-fn parse_optional_usize(args: &Value, field: &str) -> Result<Option<usize>, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(None),
-        Some(v) => v
-            .as_u64()
-            .map(|n| Some(n as usize))
-            .ok_or_else(|| TokmdError::invalid_field(field, "a non-negative integer")),
-    }
-}
-
-/// Parse an optional bool field strictly: missing/null -> None, non-bool -> error.
-fn parse_optional_bool(args: &Value, field: &str) -> Result<Option<bool>, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(None),
-        Some(v) => v
-            .as_bool()
-            .map(Some)
-            .ok_or_else(|| TokmdError::invalid_field(field, "a boolean (true or false)")),
-    }
-}
-
-/// Parse an optional string field strictly: missing/null -> None, non-string -> error.
-fn parse_optional_string(args: &Value, field: &str) -> Result<Option<String>, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(None),
-        Some(v) => v
-            .as_str()
-            .map(|s| Some(s.to_string()))
-            .ok_or_else(|| TokmdError::invalid_field(field, "a string")),
-    }
-}
-
-/// Parse a string field strictly: missing/null -> default, non-string -> error.
-fn parse_string(args: &Value, field: &str, default: &str) -> Result<String, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(default.to_string()),
-        Some(v) => v
-            .as_str()
-            .map(|s| s.to_string())
-            .ok_or_else(|| TokmdError::invalid_field(field, "a string")),
-    }
-}
-
-/// Parse a required string field strictly: missing/null -> error, non-string -> error.
-fn parse_required_string(args: &Value, field: &str) -> Result<String, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Err(TokmdError::invalid_field(field, "required but missing")),
-        Some(v) => v
-            .as_str()
-            .map(String::from)
-            .ok_or_else(|| TokmdError::invalid_field(field, "a string")),
-    }
-}
-
-/// Parse a string array field strictly: missing/null -> default, invalid -> error.
-fn parse_string_array(
-    args: &Value,
-    field: &str,
-    default: Vec<String>,
-) -> Result<Vec<String>, TokmdError> {
-    match args.get(field) {
-        None | Some(Value::Null) => Ok(default),
-        Some(Value::Array(arr)) => arr
-            .iter()
-            .enumerate()
-            .map(|(i, v)| {
-                v.as_str().map(String::from).ok_or_else(|| {
-                    TokmdError::invalid_field(&format!("{}[{}]", field, i), "a string")
-                })
-            })
-            .collect(),
-        Some(_) => Err(TokmdError::invalid_field(field, "an array of strings")),
-    }
-}
-
-/// Parse a ChildrenMode field strictly.
-fn parse_children_mode(args: &Value, default: ChildrenMode) -> Result<ChildrenMode, TokmdError> {
-    match args.get("children") {
-        None => Ok(default),
-        Some(v) => serde_json::from_value::<ChildrenMode>(v.clone())
-            .map_err(|_| TokmdError::invalid_field("children", "'collapse' or 'separate'")),
-    }
-}
-
-/// Parse a ChildIncludeMode field strictly.
-fn parse_child_include_mode(
-    args: &Value,
-    default: ChildIncludeMode,
-) -> Result<ChildIncludeMode, TokmdError> {
-    match args.get("children") {
-        None => Ok(default),
-        Some(v) => serde_json::from_value::<ChildIncludeMode>(v.clone())
-            .map_err(|_| TokmdError::invalid_field("children", "'separate' or 'parents-only'")),
-    }
-}
-
-/// Parse a RedactMode field strictly.
-fn parse_redact_mode(args: &Value, default: RedactMode) -> Result<RedactMode, TokmdError> {
-    match args.get("redact") {
-        None => Ok(default),
-        Some(v) => serde_json::from_value::<RedactMode>(v.clone())
-            .map_err(|_| TokmdError::invalid_field("redact", "'none', 'paths', or 'all'")),
-    }
-}
-
-/// Parse an effort model from a string: missing/null -> None, unsupported values -> error.
-fn parse_effort_model(args: &Value, field: &str) -> Result<Option<String>, TokmdError> {
-    match parse_optional_string(args, field)? {
-        None => Ok(None),
-        Some(value) => {
-            let normalized = value.trim().to_ascii_lowercase();
-            match normalized.as_str() {
-                "cocomo81-basic" => Ok(Some(normalized)),
-                "cocomo2-early" | "ensemble" => Err(TokmdError::invalid_field(
-                    field,
-                    "only 'cocomo81-basic' is currently supported",
-                )),
-                _ => Err(TokmdError::invalid_field(field, "'cocomo81-basic'")),
-            }
-        }
-    }
-}
-
-/// Parse an effort layer from a string: missing/null -> None, unsupported values -> error.
-fn parse_effort_layer(args: &Value, field: &str) -> Result<Option<String>, TokmdError> {
-    match parse_optional_string(args, field)? {
-        None => Ok(None),
-        Some(value) => {
-            let normalized = value.trim().to_ascii_lowercase();
-            match normalized.as_str() {
-                "headline" | "why" | "full" => Ok(Some(normalized)),
-                _ => Err(TokmdError::invalid_field(
-                    field,
-                    "'headline', 'why', or 'full'",
-                )),
-            }
-        }
-    }
-}
-
-/// Parse an optional RedactMode field strictly.
-fn parse_optional_redact_mode(args: &Value) -> Result<Option<RedactMode>, TokmdError> {
-    match args.get("redact") {
-        None => Ok(None),
-        Some(v) => serde_json::from_value::<RedactMode>(v.clone())
-            .map(Some)
-            .map_err(|_| TokmdError::invalid_field("redact", "'none', 'paths', or 'all'")),
-    }
-}
-
-/// Parse a ConfigMode field strictly.
-fn parse_config_mode(args: &Value, default: ConfigMode) -> Result<ConfigMode, TokmdError> {
-    match args.get("config") {
-        None => Ok(default),
-        Some(v) => serde_json::from_value::<ConfigMode>(v.clone())
-            .map_err(|_| TokmdError::invalid_field("config", "'auto' or 'none'")),
-    }
-}
-
-/// Parse an ExportFormat field strictly.
-fn parse_export_format(args: &Value, default: ExportFormat) -> Result<ExportFormat, TokmdError> {
-    match args.get("format") {
-        None => Ok(default),
-        Some(v) => serde_json::from_value::<ExportFormat>(v.clone()).map_err(|_| {
-            TokmdError::invalid_field("format", "'csv', 'jsonl', 'json', or 'cyclonedx'")
-        }),
-    }
-}
-
-/// Parse and validate analyze preset names.
-fn parse_analyze_preset(args: &Value, default: &str) -> Result<String, TokmdError> {
-    let preset = parse_string(args, "preset", default)?;
-    let normalized = preset.trim().to_ascii_lowercase();
-    match normalized.as_str() {
-        "receipt" | "estimate" | "health" | "risk" | "supply" | "architecture" | "topics"
-        | "security" | "identity" | "git" | "deep" | "fun" => Ok(normalized),
-        _ => Err(TokmdError::invalid_field(
-            "preset",
-            "'receipt', 'estimate', 'health', 'risk', 'supply', 'architecture', 'topics', 'security', 'identity', 'git', 'deep', or 'fun'",
-        )),
-    }
-}
-
-/// Parse and validate import graph granularity.
-fn parse_import_granularity(args: &Value, default: &str) -> Result<String, TokmdError> {
-    let granularity = parse_string(args, "granularity", default)?;
-    let normalized = granularity.trim().to_ascii_lowercase();
-    match normalized.as_str() {
-        "module" | "file" => Ok(normalized),
-        _ => Err(TokmdError::invalid_field(
-            "granularity",
-            "'module' or 'file'",
-        )),
     }
 }
 

--- a/crates/tokmd-core/src/ffi/parse.rs
+++ b/crates/tokmd-core/src/ffi/parse.rs
@@ -1,0 +1,257 @@
+//! Strict JSON argument parsing helpers for the FFI entrypoint.
+//!
+//! This module owns primitive field decoding and enum/string validation. The
+//! parent module composes these helpers into mode-specific settings.
+
+use serde_json::Value;
+
+use crate::error::TokmdError;
+use crate::settings::{ChildIncludeMode, ChildrenMode, ConfigMode, ExportFormat, RedactMode};
+
+pub(super) fn scan_arg_object(args: &Value) -> &Value {
+    args.get("scan").unwrap_or(args)
+}
+
+/// Parse a boolean field strictly: missing/null -> default, non-bool -> error.
+pub(super) fn parse_bool(args: &Value, field: &str, default: bool) -> Result<bool, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(default),
+        Some(v) => v
+            .as_bool()
+            .ok_or_else(|| TokmdError::invalid_field(field, "a boolean (true or false)")),
+    }
+}
+
+/// Parse a usize field strictly: missing/null -> default, non-number -> error.
+pub(super) fn parse_usize(args: &Value, field: &str, default: usize) -> Result<usize, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(default),
+        Some(v) => v
+            .as_u64()
+            .map(|n| n as usize)
+            .ok_or_else(|| TokmdError::invalid_field(field, "a non-negative integer")),
+    }
+}
+
+/// Parse a u64 field strictly: missing/null -> None, non-number -> error.
+pub(super) fn parse_optional_u64(args: &Value, field: &str) -> Result<Option<u64>, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_u64()
+            .map(Some)
+            .ok_or_else(|| TokmdError::invalid_field(field, "a non-negative integer")),
+    }
+}
+
+/// Parse an optional usize field strictly: missing/null -> None, non-number -> error.
+pub(super) fn parse_optional_usize(args: &Value, field: &str) -> Result<Option<usize>, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_u64()
+            .map(|n| Some(n as usize))
+            .ok_or_else(|| TokmdError::invalid_field(field, "a non-negative integer")),
+    }
+}
+
+/// Parse an optional bool field strictly: missing/null -> None, non-bool -> error.
+pub(super) fn parse_optional_bool(args: &Value, field: &str) -> Result<Option<bool>, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_bool()
+            .map(Some)
+            .ok_or_else(|| TokmdError::invalid_field(field, "a boolean (true or false)")),
+    }
+}
+
+/// Parse an optional string field strictly: missing/null -> None, non-string -> error.
+pub(super) fn parse_optional_string(
+    args: &Value,
+    field: &str,
+) -> Result<Option<String>, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_str()
+            .map(|s| Some(s.to_string()))
+            .ok_or_else(|| TokmdError::invalid_field(field, "a string")),
+    }
+}
+
+/// Parse a string field strictly: missing/null -> default, non-string -> error.
+pub(super) fn parse_string(args: &Value, field: &str, default: &str) -> Result<String, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(default.to_string()),
+        Some(v) => v
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| TokmdError::invalid_field(field, "a string")),
+    }
+}
+
+/// Parse a required string field strictly: missing/null -> error, non-string -> error.
+pub(super) fn parse_required_string(args: &Value, field: &str) -> Result<String, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Err(TokmdError::invalid_field(field, "required but missing")),
+        Some(v) => v
+            .as_str()
+            .map(String::from)
+            .ok_or_else(|| TokmdError::invalid_field(field, "a string")),
+    }
+}
+
+/// Parse a string array field strictly: missing/null -> default, invalid -> error.
+pub(super) fn parse_string_array(
+    args: &Value,
+    field: &str,
+    default: Vec<String>,
+) -> Result<Vec<String>, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                v.as_str().map(String::from).ok_or_else(|| {
+                    TokmdError::invalid_field(&format!("{}[{}]", field, i), "a string")
+                })
+            })
+            .collect(),
+        Some(_) => Err(TokmdError::invalid_field(field, "an array of strings")),
+    }
+}
+
+/// Parse a ChildrenMode field strictly.
+pub(super) fn parse_children_mode(
+    args: &Value,
+    default: ChildrenMode,
+) -> Result<ChildrenMode, TokmdError> {
+    match args.get("children") {
+        None => Ok(default),
+        Some(v) => serde_json::from_value::<ChildrenMode>(v.clone())
+            .map_err(|_| TokmdError::invalid_field("children", "'collapse' or 'separate'")),
+    }
+}
+
+/// Parse a ChildIncludeMode field strictly.
+pub(super) fn parse_child_include_mode(
+    args: &Value,
+    default: ChildIncludeMode,
+) -> Result<ChildIncludeMode, TokmdError> {
+    match args.get("children") {
+        None => Ok(default),
+        Some(v) => serde_json::from_value::<ChildIncludeMode>(v.clone())
+            .map_err(|_| TokmdError::invalid_field("children", "'separate' or 'parents-only'")),
+    }
+}
+
+/// Parse a RedactMode field strictly.
+pub(super) fn parse_redact_mode(
+    args: &Value,
+    default: RedactMode,
+) -> Result<RedactMode, TokmdError> {
+    match args.get("redact") {
+        None => Ok(default),
+        Some(v) => serde_json::from_value::<RedactMode>(v.clone())
+            .map_err(|_| TokmdError::invalid_field("redact", "'none', 'paths', or 'all'")),
+    }
+}
+
+/// Parse an effort model from a string: missing/null -> None, unsupported values -> error.
+pub(super) fn parse_effort_model(args: &Value, field: &str) -> Result<Option<String>, TokmdError> {
+    match parse_optional_string(args, field)? {
+        None => Ok(None),
+        Some(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "cocomo81-basic" => Ok(Some(normalized)),
+                "cocomo2-early" | "ensemble" => Err(TokmdError::invalid_field(
+                    field,
+                    "only 'cocomo81-basic' is currently supported",
+                )),
+                _ => Err(TokmdError::invalid_field(field, "'cocomo81-basic'")),
+            }
+        }
+    }
+}
+
+/// Parse an effort layer from a string: missing/null -> None, unsupported values -> error.
+pub(super) fn parse_effort_layer(args: &Value, field: &str) -> Result<Option<String>, TokmdError> {
+    match parse_optional_string(args, field)? {
+        None => Ok(None),
+        Some(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "headline" | "why" | "full" => Ok(Some(normalized)),
+                _ => Err(TokmdError::invalid_field(
+                    field,
+                    "'headline', 'why', or 'full'",
+                )),
+            }
+        }
+    }
+}
+
+/// Parse an optional RedactMode field strictly.
+pub(super) fn parse_optional_redact_mode(args: &Value) -> Result<Option<RedactMode>, TokmdError> {
+    match args.get("redact") {
+        None => Ok(None),
+        Some(v) => serde_json::from_value::<RedactMode>(v.clone())
+            .map(Some)
+            .map_err(|_| TokmdError::invalid_field("redact", "'none', 'paths', or 'all'")),
+    }
+}
+
+/// Parse a ConfigMode field strictly.
+pub(super) fn parse_config_mode(
+    args: &Value,
+    default: ConfigMode,
+) -> Result<ConfigMode, TokmdError> {
+    match args.get("config") {
+        None => Ok(default),
+        Some(v) => serde_json::from_value::<ConfigMode>(v.clone())
+            .map_err(|_| TokmdError::invalid_field("config", "'auto' or 'none'")),
+    }
+}
+
+/// Parse an ExportFormat field strictly.
+pub(super) fn parse_export_format(
+    args: &Value,
+    default: ExportFormat,
+) -> Result<ExportFormat, TokmdError> {
+    match args.get("format") {
+        None => Ok(default),
+        Some(v) => serde_json::from_value::<ExportFormat>(v.clone()).map_err(|_| {
+            TokmdError::invalid_field("format", "'csv', 'jsonl', 'json', or 'cyclonedx'")
+        }),
+    }
+}
+
+/// Parse and validate analyze preset names.
+pub(super) fn parse_analyze_preset(args: &Value, default: &str) -> Result<String, TokmdError> {
+    let preset = parse_string(args, "preset", default)?;
+    let normalized = preset.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "receipt" | "estimate" | "health" | "risk" | "supply" | "architecture" | "topics"
+        | "security" | "identity" | "git" | "deep" | "fun" => Ok(normalized),
+        _ => Err(TokmdError::invalid_field(
+            "preset",
+            "'receipt', 'estimate', 'health', 'risk', 'supply', 'architecture', 'topics', 'security', 'identity', 'git', 'deep', or 'fun'",
+        )),
+    }
+}
+
+/// Parse and validate import graph granularity.
+pub(super) fn parse_import_granularity(args: &Value, default: &str) -> Result<String, TokmdError> {
+    let granularity = parse_string(args, "granularity", default)?;
+    let normalized = granularity.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "module" | "file" => Ok(normalized),
+        _ => Err(TokmdError::invalid_field(
+            "granularity",
+            "'module' or 'file'",
+        )),
+    }
+}


### PR DESCRIPTION
## Summary
- Move strict FFI JSON parsing helpers into `crates/tokmd-core/src/ffi/parse.rs`.
- Keep `ffi.rs` focused on `run_json`, mode dispatch, and mode-specific settings construction.
- Preserve FFI behavior, schemas, proof policy, and public API surface.

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo clippy -p tokmd-core --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask docs --check`
- `git diff --check origin/main..HEAD`