### PR TITLE
docs: checkpoint core FFI consolidation

### DIFF
--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -60,10 +60,10 @@ fixtures:
 | Area | Current file | Approx. lines | Owner direction |
 | --- | --- | ---: | --- |
 | Content complexity | `crates/tokmd-analysis/src/content/complexity.rs` and `crates/tokmd-analysis/src/content/complexity/` | `tests/unit.rs` 1451; production owner modules <=187 | Scoring, nesting, and function-span helpers now live under owner modules; remaining work is mostly test split and aggregation cleanup |
-| Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 194; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep report aggregation in `mod.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
+| Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs` | 1500 each | Split workflow facade, FFI envelope handling, and mode dispatch without changing `run_json` |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1661; `ffi.rs` 1245; input owner 187; parse owner 257 | In-memory input decoding/path validation and strict JSON parsing now live under `ffi/`; remaining work is workflow facade, mode dispatch, and envelope handling without changing `run_json` |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -201,11 +201,19 @@ Target modules:
 crates/tokmd-core/src/
   lib.rs
   workflows/
+  ffi.rs                  # current run_json coordinator during staged split
   ffi/
-    mod.rs
-    modes.rs
-    envelope.rs
+    inputs.rs             # in-memory input decoding and path validation
+    parse.rs              # strict JSON field parsing helpers
+    mod.rs                # final coordinator once ffi.rs is split
+    modes.rs              # future mode dispatch owner
+    envelope.rs           # future response envelope owner
 ```
+
+Current checkpoint: in-memory input decoding/path validation and strict JSON
+field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`. `ffi.rs`
+still owns public `run_json`, mode dispatch, and settings construction while
+that public binding boundary remains staged.
 
 Required proof:
 
@@ -301,11 +309,10 @@ Stop and split the work if a consolidation PR:
 
 ## First Suggested PRs
 
-1. Split `tokmd-analysis-types/src/lib.rs` into DTO-family modules while
-   preserving re-exports.
-2. Continue production owner-module splits under `tokmd-analysis`, starting
-   with API surface symbol scanning and then aggregation/test cleanup where
-   useful.
+1. Continue core facade/FFI owner-module splits with mode dispatch or envelope
+   handling while preserving the public `run_json` contract.
+2. Continue production owner-module splits under `tokmd-analysis` only where
+   production seams remain broad; avoid splitting tests solely for line count.
 3. Continue CLI parser command-family splits only when clap snapshots prove
    behavior is unchanged; continue model child-language behavior only if future
    evidence shows the seam is still too broad after the row owner split.


### PR DESCRIPTION
## Summary
- checkpoint `docs/architecture-consolidation-plan.md` after the merged core FFI input and parse owner-module extractions
- update the API surface row to reflect the thin coordinator plus `report.rs` owner
- refresh the next suggested PR order toward remaining FFI facade work instead of already-completed DTO splits

## Validation
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check`

## Affected proof plan
```json
{
  "schema": "tokmd.proof_plan.v1",
  "profile": "affected",
  "changed_files": ["docs/architecture-consolidation-plan.md"],
  "commands": [
    {
      "scope": "project_truth_docs",
      "kind": "proof",
      "required": true,
      "command": "cargo xtask docs --check"
    }
  ],
  "unknown_files": []
}
```