### PR TITLE
refactor(core): extract FFI settings parsers

### DIFF
--- a/crates/tokmd-core/src/ffi.rs
+++ b/crates/tokmd-core/src/ffi.rs
@@ -19,25 +19,19 @@ use serde_json::Value;
 
 mod inputs;
 mod parse;
+mod settings_parse;
 
 #[cfg(feature = "analysis")]
 use crate::analyze_workflow_from_inputs;
 use crate::error::{ResponseEnvelope, TokmdError};
-use crate::settings::{
-    AnalyzeSettings, ChildIncludeMode, ChildrenMode, ConfigMode, DiffSettings, ExportFormat,
-    ExportSettings, LangSettings, ModuleSettings, RedactMode, ScanSettings,
-};
 use crate::{
     export_workflow, export_workflow_from_inputs, lang_workflow, lang_workflow_from_inputs,
     module_workflow, module_workflow_from_inputs,
 };
 use inputs::parse_in_memory_inputs;
-use parse::{
-    parse_analyze_preset, parse_bool, parse_child_include_mode, parse_children_mode,
-    parse_config_mode, parse_effort_layer, parse_effort_model, parse_export_format,
-    parse_import_granularity, parse_optional_bool, parse_optional_redact_mode,
-    parse_optional_string, parse_optional_u64, parse_optional_usize, parse_redact_mode,
-    parse_required_string, parse_string, parse_string_array, parse_usize, scan_arg_object,
+use settings_parse::{
+    parse_diff_settings, parse_export_settings, parse_lang_settings, parse_module_settings,
+    parse_scan_settings,
 };
 
 /// Run a tokmd operation with JSON arguments, returning JSON output.
@@ -126,7 +120,7 @@ fn run_json_inner(mode: &str, args_json: &str) -> Result<Value, TokmdError> {
         "analyze" => {
             #[cfg(feature = "analysis")]
             {
-                let settings = parse_analyze_settings(&args)?;
+                let settings = settings_parse::parse_analyze_settings(&args)?;
                 let receipt = if let Some(inputs) = inputs.as_deref() {
                     analyze_workflow_from_inputs(inputs, &scan.options, &settings)?
                 } else {
@@ -144,7 +138,7 @@ fn run_json_inner(mode: &str, args_json: &str) -> Result<Value, TokmdError> {
         "cockpit" => {
             #[cfg(feature = "cockpit")]
             {
-                let settings = parse_cockpit_settings(&args)?;
+                let settings = settings_parse::parse_cockpit_settings(&args)?;
                 let receipt = crate::cockpit_workflow(&settings)?;
                 Ok(serde_json::to_value(receipt)?)
             }
@@ -179,146 +173,6 @@ fn run_json_inner(mode: &str, args_json: &str) -> Result<Value, TokmdError> {
     }
 }
 
-// ============================================================================
-// Settings parsers
-// ============================================================================
-
-fn parse_scan_settings(args: &Value) -> Result<ScanSettings, TokmdError> {
-    // Use nested object if present, otherwise use root
-    let obj = scan_arg_object(args);
-
-    Ok(ScanSettings {
-        paths: parse_string_array(obj, "paths", vec![".".to_string()])?,
-        options: crate::settings::ScanOptions {
-            excluded: parse_string_array(obj, "excluded", vec![])?,
-            config: parse_config_mode(obj, ConfigMode::Auto)?,
-            hidden: parse_bool(obj, "hidden", false)?,
-            no_ignore: parse_bool(obj, "no_ignore", false)?,
-            no_ignore_parent: parse_bool(obj, "no_ignore_parent", false)?,
-            no_ignore_dot: parse_bool(obj, "no_ignore_dot", false)?,
-            no_ignore_vcs: parse_bool(obj, "no_ignore_vcs", false)?,
-            treat_doc_strings_as_comments: parse_bool(obj, "treat_doc_strings_as_comments", false)?,
-        },
-    })
-}
-
-fn parse_lang_settings(args: &Value) -> Result<LangSettings, TokmdError> {
-    // Use nested object if present, otherwise use root
-    let obj = args.get("lang").unwrap_or(args);
-
-    Ok(LangSettings {
-        top: parse_usize(obj, "top", 0)?,
-        files: parse_bool(obj, "files", false)?,
-        children: parse_children_mode(obj, ChildrenMode::Collapse)?,
-        redact: parse_optional_redact_mode(obj)?,
-    })
-}
-
-fn parse_module_settings(args: &Value) -> Result<ModuleSettings, TokmdError> {
-    // Use nested object if present, otherwise use root
-    let obj = args.get("module").unwrap_or(args);
-
-    Ok(ModuleSettings {
-        top: parse_usize(obj, "top", 0)?,
-        module_roots: parse_string_array(
-            obj,
-            "module_roots",
-            vec!["crates".to_string(), "packages".to_string()],
-        )?,
-        module_depth: parse_usize(obj, "module_depth", 2)?,
-        children: parse_child_include_mode(obj, ChildIncludeMode::Separate)?,
-        redact: parse_optional_redact_mode(obj)?,
-    })
-}
-
-fn parse_export_settings(args: &Value) -> Result<ExportSettings, TokmdError> {
-    // Use nested object if present, otherwise use root
-    let obj = args.get("export").unwrap_or(args);
-
-    Ok(ExportSettings {
-        format: parse_export_format(obj, ExportFormat::Jsonl)?,
-        module_roots: parse_string_array(
-            obj,
-            "module_roots",
-            vec!["crates".to_string(), "packages".to_string()],
-        )?,
-        module_depth: parse_usize(obj, "module_depth", 2)?,
-        children: parse_child_include_mode(obj, ChildIncludeMode::Separate)?,
-        min_code: parse_usize(obj, "min_code", 0)?,
-        max_rows: parse_usize(obj, "max_rows", 0)?,
-        redact: parse_redact_mode(obj, RedactMode::None)?,
-        meta: parse_bool(obj, "meta", true)?,
-        strip_prefix: parse_optional_string(obj, "strip_prefix")?,
-    })
-}
-
-#[allow(dead_code)]
-fn parse_analyze_settings(args: &Value) -> Result<AnalyzeSettings, TokmdError> {
-    // Use nested object if present, otherwise use root
-    let obj = args.get("analyze").unwrap_or(args);
-
-    let effort_base_ref = parse_optional_string(obj, "effort_base_ref")?;
-    let effort_head_ref = parse_optional_string(obj, "effort_head_ref")?;
-    if (effort_base_ref.is_some() && effort_head_ref.is_none())
-        || (effort_base_ref.is_none() && effort_head_ref.is_some())
-    {
-        return Err(TokmdError::invalid_field(
-            "effort_base_ref/effort_head_ref",
-            "both effort_base_ref and effort_head_ref must be provided together",
-        ));
-    }
-    if let Some(iterations) = parse_optional_usize(obj, "effort_mc_iterations")?
-        && iterations == 0
-    {
-        return Err(TokmdError::invalid_field(
-            "effort_mc_iterations",
-            "must be greater than 0",
-        ));
-    }
-
-    Ok(AnalyzeSettings {
-        preset: parse_analyze_preset(obj, "receipt")?,
-        window: parse_optional_usize(obj, "window")?,
-        git: parse_optional_bool(obj, "git")?,
-        max_files: parse_optional_usize(obj, "max_files")?,
-        max_bytes: parse_optional_u64(obj, "max_bytes")?,
-        max_file_bytes: parse_optional_u64(obj, "max_file_bytes")?,
-        max_commits: parse_optional_usize(obj, "max_commits")?,
-        max_commit_files: parse_optional_usize(obj, "max_commit_files")?,
-        granularity: parse_import_granularity(obj, "module")?,
-        effort_base_ref,
-        effort_head_ref,
-        effort_model: parse_effort_model(obj, "effort_model")?,
-        effort_layer: parse_effort_layer(obj, "effort_layer")?,
-        effort_monte_carlo: parse_optional_bool(obj, "effort_monte_carlo")?,
-        effort_mc_iterations: parse_optional_usize(obj, "effort_mc_iterations")?,
-        effort_mc_seed: parse_optional_u64(obj, "effort_mc_seed")?,
-    })
-}
-
-#[allow(dead_code)]
-fn parse_cockpit_settings(args: &Value) -> Result<crate::settings::CockpitSettings, TokmdError> {
-    // Use nested object if present, otherwise use root
-    let obj = args.get("cockpit").unwrap_or(args);
-
-    Ok(crate::settings::CockpitSettings {
-        base: parse_string(obj, "base", "main")?,
-        head: parse_string(obj, "head", "HEAD")?,
-        range_mode: parse_string(obj, "range_mode", "two-dot")?,
-        baseline: parse_optional_string(obj, "baseline")?,
-    })
-}
-
-fn parse_diff_settings(args: &Value) -> Result<DiffSettings, TokmdError> {
-    // Use nested object if present, otherwise use root
-    let obj = args.get("diff").unwrap_or(args);
-
-    let from = parse_required_string(obj, "from")?;
-    let to = parse_required_string(obj, "to")?;
-
-    Ok(DiffSettings { from, to })
-}
-
 /// Get the tokmd version string.
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -331,6 +185,9 @@ pub fn schema_version() -> u32 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "analysis")]
+    use super::settings_parse::parse_analyze_settings;
+    use super::settings_parse::parse_cockpit_settings;
     use super::*;
 
     #[test]

--- a/crates/tokmd-core/src/ffi/settings_parse.rs
+++ b/crates/tokmd-core/src/ffi/settings_parse.rs
@@ -1,0 +1,150 @@
+//! Mode-specific settings construction for the FFI entrypoint.
+//!
+//! This module composes primitive strict JSON parsers into the settings objects
+//! consumed by `run_json` mode dispatch.
+
+use serde_json::Value;
+
+use super::parse::{
+    parse_analyze_preset, parse_bool, parse_child_include_mode, parse_children_mode,
+    parse_config_mode, parse_effort_layer, parse_effort_model, parse_export_format,
+    parse_import_granularity, parse_optional_bool, parse_optional_redact_mode,
+    parse_optional_string, parse_optional_u64, parse_optional_usize, parse_redact_mode,
+    parse_required_string, parse_string, parse_string_array, parse_usize, scan_arg_object,
+};
+use crate::error::TokmdError;
+use crate::settings::{
+    AnalyzeSettings, ChildIncludeMode, ChildrenMode, ConfigMode, DiffSettings, ExportFormat,
+    ExportSettings, LangSettings, ModuleSettings, RedactMode, ScanSettings,
+};
+
+pub(super) fn parse_scan_settings(args: &Value) -> Result<ScanSettings, TokmdError> {
+    let obj = scan_arg_object(args);
+
+    Ok(ScanSettings {
+        paths: parse_string_array(obj, "paths", vec![".".to_string()])?,
+        options: crate::settings::ScanOptions {
+            excluded: parse_string_array(obj, "excluded", vec![])?,
+            config: parse_config_mode(obj, ConfigMode::Auto)?,
+            hidden: parse_bool(obj, "hidden", false)?,
+            no_ignore: parse_bool(obj, "no_ignore", false)?,
+            no_ignore_parent: parse_bool(obj, "no_ignore_parent", false)?,
+            no_ignore_dot: parse_bool(obj, "no_ignore_dot", false)?,
+            no_ignore_vcs: parse_bool(obj, "no_ignore_vcs", false)?,
+            treat_doc_strings_as_comments: parse_bool(obj, "treat_doc_strings_as_comments", false)?,
+        },
+    })
+}
+
+pub(super) fn parse_lang_settings(args: &Value) -> Result<LangSettings, TokmdError> {
+    let obj = args.get("lang").unwrap_or(args);
+
+    Ok(LangSettings {
+        top: parse_usize(obj, "top", 0)?,
+        files: parse_bool(obj, "files", false)?,
+        children: parse_children_mode(obj, ChildrenMode::Collapse)?,
+        redact: parse_optional_redact_mode(obj)?,
+    })
+}
+
+pub(super) fn parse_module_settings(args: &Value) -> Result<ModuleSettings, TokmdError> {
+    let obj = args.get("module").unwrap_or(args);
+
+    Ok(ModuleSettings {
+        top: parse_usize(obj, "top", 0)?,
+        module_roots: parse_string_array(
+            obj,
+            "module_roots",
+            vec!["crates".to_string(), "packages".to_string()],
+        )?,
+        module_depth: parse_usize(obj, "module_depth", 2)?,
+        children: parse_child_include_mode(obj, ChildIncludeMode::Separate)?,
+        redact: parse_optional_redact_mode(obj)?,
+    })
+}
+
+pub(super) fn parse_export_settings(args: &Value) -> Result<ExportSettings, TokmdError> {
+    let obj = args.get("export").unwrap_or(args);
+
+    Ok(ExportSettings {
+        format: parse_export_format(obj, ExportFormat::Jsonl)?,
+        module_roots: parse_string_array(
+            obj,
+            "module_roots",
+            vec!["crates".to_string(), "packages".to_string()],
+        )?,
+        module_depth: parse_usize(obj, "module_depth", 2)?,
+        children: parse_child_include_mode(obj, ChildIncludeMode::Separate)?,
+        min_code: parse_usize(obj, "min_code", 0)?,
+        max_rows: parse_usize(obj, "max_rows", 0)?,
+        redact: parse_redact_mode(obj, RedactMode::None)?,
+        meta: parse_bool(obj, "meta", true)?,
+        strip_prefix: parse_optional_string(obj, "strip_prefix")?,
+    })
+}
+
+#[allow(dead_code)]
+pub(super) fn parse_analyze_settings(args: &Value) -> Result<AnalyzeSettings, TokmdError> {
+    let obj = args.get("analyze").unwrap_or(args);
+
+    let effort_base_ref = parse_optional_string(obj, "effort_base_ref")?;
+    let effort_head_ref = parse_optional_string(obj, "effort_head_ref")?;
+    if (effort_base_ref.is_some() && effort_head_ref.is_none())
+        || (effort_base_ref.is_none() && effort_head_ref.is_some())
+    {
+        return Err(TokmdError::invalid_field(
+            "effort_base_ref/effort_head_ref",
+            "both effort_base_ref and effort_head_ref must be provided together",
+        ));
+    }
+    if let Some(iterations) = parse_optional_usize(obj, "effort_mc_iterations")?
+        && iterations == 0
+    {
+        return Err(TokmdError::invalid_field(
+            "effort_mc_iterations",
+            "must be greater than 0",
+        ));
+    }
+
+    Ok(AnalyzeSettings {
+        preset: parse_analyze_preset(obj, "receipt")?,
+        window: parse_optional_usize(obj, "window")?,
+        git: parse_optional_bool(obj, "git")?,
+        max_files: parse_optional_usize(obj, "max_files")?,
+        max_bytes: parse_optional_u64(obj, "max_bytes")?,
+        max_file_bytes: parse_optional_u64(obj, "max_file_bytes")?,
+        max_commits: parse_optional_usize(obj, "max_commits")?,
+        max_commit_files: parse_optional_usize(obj, "max_commit_files")?,
+        granularity: parse_import_granularity(obj, "module")?,
+        effort_base_ref,
+        effort_head_ref,
+        effort_model: parse_effort_model(obj, "effort_model")?,
+        effort_layer: parse_effort_layer(obj, "effort_layer")?,
+        effort_monte_carlo: parse_optional_bool(obj, "effort_monte_carlo")?,
+        effort_mc_iterations: parse_optional_usize(obj, "effort_mc_iterations")?,
+        effort_mc_seed: parse_optional_u64(obj, "effort_mc_seed")?,
+    })
+}
+
+#[allow(dead_code)]
+pub(super) fn parse_cockpit_settings(
+    args: &Value,
+) -> Result<crate::settings::CockpitSettings, TokmdError> {
+    let obj = args.get("cockpit").unwrap_or(args);
+
+    Ok(crate::settings::CockpitSettings {
+        base: parse_string(obj, "base", "main")?,
+        head: parse_string(obj, "head", "HEAD")?,
+        range_mode: parse_string(obj, "range_mode", "two-dot")?,
+        baseline: parse_optional_string(obj, "baseline")?,
+    })
+}
+
+pub(super) fn parse_diff_settings(args: &Value) -> Result<DiffSettings, TokmdError> {
+    let obj = args.get("diff").unwrap_or(args);
+
+    let from = parse_required_string(obj, "from")?;
+    let to = parse_required_string(obj, "to")?;
+
+    Ok(DiffSettings { from, to })
+}

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1661; `ffi.rs` 1245; input owner 187; parse owner 257 | In-memory input decoding/path validation and strict JSON parsing now live under `ffi/`; remaining work is workflow facade, mode dispatch, and envelope handling without changing `run_json` |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1661; `ffi.rs` 1101; input owner 187; parse owner 257; settings parser owner 150 | In-memory input decoding/path validation, strict JSON parsing, and FFI settings construction now live under `ffi/`; remaining work is workflow facade, mode dispatch, and envelope handling without changing `run_json` |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -205,15 +205,17 @@ crates/tokmd-core/src/
   ffi/
     inputs.rs             # in-memory input decoding and path validation
     parse.rs              # strict JSON field parsing helpers
+    settings_parse.rs     # mode-specific settings construction
     mod.rs                # final coordinator once ffi.rs is split
     modes.rs              # future mode dispatch owner
     envelope.rs           # future response envelope owner
 ```
 
 Current checkpoint: in-memory input decoding/path validation and strict JSON
-field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`. `ffi.rs`
-still owns public `run_json`, mode dispatch, and settings construction while
-that public binding boundary remains staged.
+field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`, and
+mode-specific settings construction has moved into `ffi/settings_parse.rs`.
+`ffi.rs` still owns public `run_json` and mode dispatch while that public
+binding boundary remains staged.
 
 Required proof:
 


### PR DESCRIPTION
## Summary
- extract FFI mode-specific settings construction into `ffi/settings_parse.rs`
- keep `ffi.rs` as the public `run_json` and mode-dispatch coordinator
- update the architecture consolidation checkpoint for the current FFI owner modules

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --all-features ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo clippy -p tokmd-core --all-targets --all-features -- -D warnings`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask proof-artifacts-check`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check origin/main..HEAD`

## Affected proof plan
```json
{
  "schema": "tokmd.proof_plan.v1",
  "profile": "affected",
  "changed_files": [
    "crates/tokmd-core/src/ffi.rs",
    "crates/tokmd-core/src/ffi/settings_parse.rs",
    "docs/architecture-consolidation-plan.md"
  ],
  "commands": [
    { "scope": "project_truth_docs", "kind": "proof", "required": true, "command": "cargo xtask docs --check" },
    { "scope": "tokmd_core_ffi", "kind": "proof", "required": true, "command": "cargo test -p tokmd-core --test ffi_parity_w53" },
    { "scope": "tokmd_core_ffi", "kind": "proof", "required": true, "command": "cargo test -p tokmd-core ffi" },
    { "scope": "tokmd_core_ffi", "kind": "coverage", "required": false, "command": "cargo llvm-cov -p tokmd-core --all-features --lcov --output-path target/proof/coverage/tokmd_core_ffi.lcov" },
    { "scope": "tokmd_core_ffi", "kind": "mutation", "required": false, "command": "cargo mutants --file crates/tokmd-core/src/ffi.rs --timeout 300" },
    { "scope": "tokmd_core_ffi", "kind": "mutation", "required": false, "command": "cargo mutants --file crates/tokmd-core/src/ffi/settings_parse.rs --timeout 300" }
  ],
  "unknown_files": []
}
```

## CI follow-up
The first hosted run exposed an all-features lib-test import gap around `parse_analyze_settings`. This branch now imports that helper inside the feature-gated test module and has local `--all-features` coverage for the failing path.