### PR TITLE
refactor(core): extract FFI mode dispatch

### DIFF
--- a/crates/tokmd-core/src/ffi.rs
+++ b/crates/tokmd-core/src/ffi.rs
@@ -18,21 +18,14 @@
 use serde_json::Value;
 
 mod inputs;
+mod modes;
 mod parse;
 mod settings_parse;
 
-#[cfg(feature = "analysis")]
-use crate::analyze_workflow_from_inputs;
 use crate::error::{ResponseEnvelope, TokmdError};
-use crate::{
-    export_workflow, export_workflow_from_inputs, lang_workflow, lang_workflow_from_inputs,
-    module_workflow, module_workflow_from_inputs,
-};
 use inputs::parse_in_memory_inputs;
-use settings_parse::{
-    parse_diff_settings, parse_export_settings, parse_lang_settings, parse_module_settings,
-    parse_scan_settings,
-};
+use modes::run_mode;
+use settings_parse::parse_scan_settings;
 
 /// Run a tokmd operation with JSON arguments, returning JSON output.
 ///
@@ -89,88 +82,7 @@ fn run_json_inner(mode: &str, args_json: &str) -> Result<Value, TokmdError> {
     // Extract scan settings (shared by all modes)
     let scan = parse_scan_settings(&args)?;
 
-    match mode {
-        "lang" => {
-            let settings = parse_lang_settings(&args)?;
-            let receipt = if let Some(inputs) = inputs.as_deref() {
-                lang_workflow_from_inputs(inputs, &scan.options, &settings)?
-            } else {
-                lang_workflow(&scan, &settings)?
-            };
-            Ok(serde_json::to_value(receipt)?)
-        }
-        "module" => {
-            let settings = parse_module_settings(&args)?;
-            let receipt = if let Some(inputs) = inputs.as_deref() {
-                module_workflow_from_inputs(inputs, &scan.options, &settings)?
-            } else {
-                module_workflow(&scan, &settings)?
-            };
-            Ok(serde_json::to_value(receipt)?)
-        }
-        "export" => {
-            let settings = parse_export_settings(&args)?;
-            let receipt = if let Some(inputs) = inputs.as_deref() {
-                export_workflow_from_inputs(inputs, &scan.options, &settings)?
-            } else {
-                export_workflow(&scan, &settings)?
-            };
-            Ok(serde_json::to_value(receipt)?)
-        }
-        "analyze" => {
-            #[cfg(feature = "analysis")]
-            {
-                let settings = settings_parse::parse_analyze_settings(&args)?;
-                let receipt = if let Some(inputs) = inputs.as_deref() {
-                    analyze_workflow_from_inputs(inputs, &scan.options, &settings)?
-                } else {
-                    crate::analyze_workflow(&scan, &settings)?
-                };
-                Ok(serde_json::to_value(receipt)?)
-            }
-            #[cfg(not(feature = "analysis"))]
-            {
-                Err(TokmdError::not_implemented(
-                    "analyze mode requires 'analysis' feature: enable in Cargo.toml or use CLI",
-                ))
-            }
-        }
-        "cockpit" => {
-            #[cfg(feature = "cockpit")]
-            {
-                let settings = settings_parse::parse_cockpit_settings(&args)?;
-                let receipt = crate::cockpit_workflow(&settings)?;
-                Ok(serde_json::to_value(receipt)?)
-            }
-            #[cfg(not(feature = "cockpit"))]
-            {
-                Err(TokmdError::not_implemented(
-                    "cockpit mode requires 'cockpit' feature: enable in Cargo.toml or use CLI",
-                ))
-            }
-        }
-        "diff" => {
-            let settings = parse_diff_settings(&args)?;
-            let receipt = crate::diff_workflow(&settings)?;
-            Ok(serde_json::to_value(receipt)?)
-        }
-        "version" => {
-            #[cfg(feature = "analysis")]
-            let version_info = serde_json::json!({
-                "version": env!("CARGO_PKG_VERSION"),
-                "schema_version": tokmd_types::SCHEMA_VERSION,
-                "analysis_schema_version": tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION,
-            });
-            #[cfg(not(feature = "analysis"))]
-            let version_info = serde_json::json!({
-                "version": env!("CARGO_PKG_VERSION"),
-                "schema_version": tokmd_types::SCHEMA_VERSION,
-                "analysis_schema_version": serde_json::Value::Null,
-            });
-            Ok(version_info)
-        }
-        _ => Err(TokmdError::unknown_mode(mode)),
-    }
+    run_mode(mode, &args, &scan, inputs.as_deref())
 }
 
 /// Get the tokmd version string.
@@ -188,6 +100,9 @@ mod tests {
     #[cfg(feature = "analysis")]
     use super::settings_parse::parse_analyze_settings;
     use super::settings_parse::parse_cockpit_settings;
+    use super::settings_parse::{
+        parse_export_settings, parse_lang_settings, parse_module_settings,
+    };
     use super::*;
 
     #[test]

--- a/crates/tokmd-core/src/ffi/modes.rs
+++ b/crates/tokmd-core/src/ffi/modes.rs
@@ -1,0 +1,149 @@
+//! FFI mode dispatch for the JSON entrypoint.
+//!
+//! This module owns the binding-facing mode switch while `ffi.rs` keeps the
+//! public `run_json` envelope boundary.
+
+use serde_json::Value;
+
+#[cfg(feature = "analysis")]
+use super::settings_parse::parse_analyze_settings;
+#[cfg(feature = "cockpit")]
+use super::settings_parse::parse_cockpit_settings;
+use super::settings_parse::{
+    parse_diff_settings, parse_export_settings, parse_lang_settings, parse_module_settings,
+};
+#[cfg(feature = "cockpit")]
+use crate::cockpit_workflow;
+use crate::error::TokmdError;
+use crate::settings::ScanSettings;
+use crate::{
+    InMemoryFile, export_workflow, export_workflow_from_inputs, lang_workflow,
+    lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
+};
+#[cfg(feature = "analysis")]
+use crate::{analyze_workflow, analyze_workflow_from_inputs};
+
+pub(super) fn run_mode(
+    mode: &str,
+    args: &Value,
+    scan: &ScanSettings,
+    inputs: Option<&[InMemoryFile]>,
+) -> Result<Value, TokmdError> {
+    match mode {
+        "lang" => run_lang(args, scan, inputs),
+        "module" => run_module(args, scan, inputs),
+        "export" => run_export(args, scan, inputs),
+        "analyze" => run_analyze(args, scan, inputs),
+        "cockpit" => run_cockpit(args),
+        "diff" => run_diff(args),
+        "version" => Ok(version_info()),
+        _ => Err(TokmdError::unknown_mode(mode)),
+    }
+}
+
+fn run_lang(
+    args: &Value,
+    scan: &ScanSettings,
+    inputs: Option<&[InMemoryFile]>,
+) -> Result<Value, TokmdError> {
+    let settings = parse_lang_settings(args)?;
+    let receipt = if let Some(inputs) = inputs {
+        lang_workflow_from_inputs(inputs, &scan.options, &settings)?
+    } else {
+        lang_workflow(scan, &settings)?
+    };
+    Ok(serde_json::to_value(receipt)?)
+}
+
+fn run_module(
+    args: &Value,
+    scan: &ScanSettings,
+    inputs: Option<&[InMemoryFile]>,
+) -> Result<Value, TokmdError> {
+    let settings = parse_module_settings(args)?;
+    let receipt = if let Some(inputs) = inputs {
+        module_workflow_from_inputs(inputs, &scan.options, &settings)?
+    } else {
+        module_workflow(scan, &settings)?
+    };
+    Ok(serde_json::to_value(receipt)?)
+}
+
+fn run_export(
+    args: &Value,
+    scan: &ScanSettings,
+    inputs: Option<&[InMemoryFile]>,
+) -> Result<Value, TokmdError> {
+    let settings = parse_export_settings(args)?;
+    let receipt = if let Some(inputs) = inputs {
+        export_workflow_from_inputs(inputs, &scan.options, &settings)?
+    } else {
+        export_workflow(scan, &settings)?
+    };
+    Ok(serde_json::to_value(receipt)?)
+}
+
+#[cfg(feature = "analysis")]
+fn run_analyze(
+    args: &Value,
+    scan: &ScanSettings,
+    inputs: Option<&[InMemoryFile]>,
+) -> Result<Value, TokmdError> {
+    let settings = parse_analyze_settings(args)?;
+    let receipt = if let Some(inputs) = inputs {
+        analyze_workflow_from_inputs(inputs, &scan.options, &settings)?
+    } else {
+        analyze_workflow(scan, &settings)?
+    };
+    Ok(serde_json::to_value(receipt)?)
+}
+
+#[cfg(not(feature = "analysis"))]
+fn run_analyze(
+    _args: &Value,
+    _scan: &ScanSettings,
+    _inputs: Option<&[InMemoryFile]>,
+) -> Result<Value, TokmdError> {
+    Err(TokmdError::not_implemented(
+        "analyze mode requires 'analysis' feature: enable in Cargo.toml or use CLI",
+    ))
+}
+
+#[cfg(feature = "cockpit")]
+fn run_cockpit(args: &Value) -> Result<Value, TokmdError> {
+    let settings = parse_cockpit_settings(args)?;
+    let receipt = cockpit_workflow(&settings)?;
+    Ok(serde_json::to_value(receipt)?)
+}
+
+#[cfg(not(feature = "cockpit"))]
+fn run_cockpit(_args: &Value) -> Result<Value, TokmdError> {
+    Err(TokmdError::not_implemented(
+        "cockpit mode requires 'cockpit' feature: enable in Cargo.toml or use CLI",
+    ))
+}
+
+fn run_diff(args: &Value) -> Result<Value, TokmdError> {
+    let settings = parse_diff_settings(args)?;
+    let receipt = crate::diff_workflow(&settings)?;
+    Ok(serde_json::to_value(receipt)?)
+}
+
+fn version_info() -> Value {
+    #[cfg(feature = "analysis")]
+    {
+        serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "schema_version": tokmd_types::SCHEMA_VERSION,
+            "analysis_schema_version": tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION,
+        })
+    }
+    #[cfg(not(feature = "analysis"))]
+    {
+        serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "schema_version": tokmd_types::SCHEMA_VERSION,
+            "analysis_schema_version": serde_json::Value::Null,
+        })
+    }
+}

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1661; `ffi.rs` 1101; input owner 187; parse owner 257; settings parser owner 150 | In-memory input decoding/path validation, strict JSON parsing, and FFI settings construction now live under `ffi/`; remaining work is workflow facade, mode dispatch, and envelope handling without changing `run_json` |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1661; `ffi.rs` 1017; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | In-memory input decoding/path validation, strict JSON parsing, FFI settings construction, and mode dispatch now live under `ffi/`; remaining work is workflow facade and envelope handling without changing `run_json` |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -201,21 +201,22 @@ Target modules:
 crates/tokmd-core/src/
   lib.rs
   workflows/
-  ffi.rs                  # current run_json coordinator during staged split
+  ffi.rs                  # public run_json coordinator during staged split
   ffi/
     inputs.rs             # in-memory input decoding and path validation
     parse.rs              # strict JSON field parsing helpers
     settings_parse.rs     # mode-specific settings construction
     mod.rs                # final coordinator once ffi.rs is split
-    modes.rs              # future mode dispatch owner
+    modes.rs              # mode dispatch owner
     envelope.rs           # future response envelope owner
 ```
 
 Current checkpoint: in-memory input decoding/path validation and strict JSON
 field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`, and
 mode-specific settings construction has moved into `ffi/settings_parse.rs`.
-`ffi.rs` still owns public `run_json` and mode dispatch while that public
-binding boundary remains staged.
+Mode dispatch has moved into `ffi/modes.rs`. `ffi.rs` still owns public
+`run_json` and the response-envelope boundary while that public binding
+boundary remains staged.
 
 Required proof:
 


### PR DESCRIPTION
## Summary
- move FFI mode dispatch from `ffi.rs` into `ffi/modes.rs`
- keep public `run_json` envelope handling in `ffi.rs`
- update the architecture consolidation checkpoint for the new FFI owner module

## Validation
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --all-features ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo clippy -p tokmd-core --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask proof-artifacts-check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`