### PR TITLE
refactor(core): extract language workflow owner

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -165,12 +165,15 @@ coverage = false
 name = "tokmd_core_ffi"
 kind = "rust"
 paths = [
+  "crates/tokmd-core/src/lib.rs",
   "crates/tokmd-core/src/ffi.rs",
   "crates/tokmd-core/src/ffi/**",
+  "crates/tokmd-core/src/workflows/**",
   "crates/tokmd-core/tests/**",
 ]
 packages = ["tokmd-core"]
 proof = [
+  "cargo test -p tokmd-core lang_workflow --verbose",
   "cargo test -p tokmd-core ffi",
   "cargo test -p tokmd-core --test ffi_parity_w53",
 ]

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -65,8 +65,10 @@ pub mod context_policy;
 pub mod error;
 pub mod ffi;
 pub mod settings;
+mod workflows;
 pub use tokmd_scan::InMemoryFile;
 pub use tokmd_types as types;
+pub use workflows::{lang_workflow, lang_workflow_from_inputs};
 
 use settings::{DiffSettings, ExportSettings, LangSettings, ModuleSettings, ScanSettings};
 use tokmd_format::scan_args;
@@ -94,82 +96,6 @@ fn now_ms() -> u128 {
 // =============================================================================
 // Settings-based workflows (new API for bindings)
 // =============================================================================
-
-/// Runs the language summary workflow with pure settings types.
-///
-/// This is the binding-friendly API that doesn't require Clap types.
-///
-/// # Arguments
-///
-/// * `scan` - Scan settings (paths, exclusions, etc.)
-/// * `lang` - Language-specific settings (top N, files, etc.)
-///
-/// # Returns
-///
-/// A `LangReceipt` containing the language summary.
-///
-/// # Example
-///
-/// ```rust
-/// use std::fs;
-///
-/// use tokmd_core::{
-///     lang_workflow,
-///     settings::{LangSettings, ScanSettings},
-/// };
-///
-/// let tmp = tempfile::tempdir().expect("tempdir");
-/// fs::write(tmp.path().join("main.rs"), "fn main() {}").expect("write fixture");
-///
-/// let scan = ScanSettings::for_paths(vec![tmp.path().to_string_lossy().into_owned()]);
-/// let lang = LangSettings::default();
-///
-/// let receipt = lang_workflow(&scan, &lang).expect("language scan");
-/// assert_eq!(receipt.report.rows.len(), 1);
-/// ```
-pub fn lang_workflow(scan: &ScanSettings, lang: &LangSettings) -> Result<LangReceipt> {
-    let scan_opts = settings_to_scan_options(scan);
-    let paths = scan_paths_or_current_dir(scan);
-
-    // Scan
-    let languages = tokmd_scan::scan(&paths, &scan_opts)?;
-
-    // Model
-    let report = tokmd_model::create_lang_report(&languages, lang.top, lang.files, lang.children);
-
-    Ok(build_lang_receipt(&paths, &scan_opts, lang, report))
-}
-
-/// Runs the language summary workflow for ordered in-memory inputs.
-///
-/// # Example
-///
-/// ```rust
-/// use tokmd_core::{
-///     InMemoryFile, lang_workflow_from_inputs,
-///     settings::{LangSettings, ScanOptions},
-/// };
-///
-/// let inputs = vec![InMemoryFile::new("src/main.rs", b"fn main() {}".to_vec())];
-/// let scan_opts = ScanOptions::default();
-/// let lang = LangSettings::default();
-///
-/// let receipt = lang_workflow_from_inputs(&inputs, &scan_opts, &lang).expect("Scan failed");
-/// assert_eq!(receipt.report.rows.len(), 1);
-/// ```
-pub fn lang_workflow_from_inputs(
-    inputs: &[InMemoryFile],
-    scan_opts: &ScanOptions,
-    lang: &LangSettings,
-) -> Result<LangReceipt> {
-    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
-    let (paths, rows) =
-        collect_pure_in_memory_rows(inputs, &scan_opts, &[], 1, ChildIncludeMode::Separate)?;
-    let report =
-        tokmd_model::create_lang_report_from_rows(&rows, lang.top, lang.files, lang.children);
-
-    Ok(build_lang_receipt(&paths, &scan_opts, lang, report))
-}
 
 /// Runs the module summary workflow with pure settings types.
 ///

--- a/crates/tokmd-core/src/workflows/lang.rs
+++ b/crates/tokmd-core/src/workflows/lang.rs
@@ -1,0 +1,84 @@
+//! Language summary workflow facade.
+
+use anyhow::Result;
+use tokmd_settings::ScanOptions;
+use tokmd_types::{ChildIncludeMode, LangReceipt};
+
+use crate::settings::{LangSettings, ScanSettings};
+use crate::{
+    InMemoryFile, build_lang_receipt, collect_pure_in_memory_rows,
+    deterministic_in_memory_scan_options, scan_paths_or_current_dir, settings_to_scan_options,
+};
+
+/// Runs the language summary workflow with pure settings types.
+///
+/// This is the binding-friendly API that doesn't require Clap types.
+///
+/// # Arguments
+///
+/// * `scan` - Scan settings (paths, exclusions, etc.)
+/// * `lang` - Language-specific settings (top N, files, etc.)
+///
+/// # Returns
+///
+/// A `LangReceipt` containing the language summary.
+///
+/// # Example
+///
+/// ```rust
+/// use std::fs;
+///
+/// use tokmd_core::{
+///     lang_workflow,
+///     settings::{LangSettings, ScanSettings},
+/// };
+///
+/// let tmp = tempfile::tempdir().expect("tempdir");
+/// fs::write(tmp.path().join("main.rs"), "fn main() {}").expect("write fixture");
+///
+/// let scan = ScanSettings::for_paths(vec![tmp.path().to_string_lossy().into_owned()]);
+/// let lang = LangSettings::default();
+///
+/// let receipt = lang_workflow(&scan, &lang).expect("language scan");
+/// assert_eq!(receipt.report.rows.len(), 1);
+/// ```
+pub fn lang_workflow(scan: &ScanSettings, lang: &LangSettings) -> Result<LangReceipt> {
+    let scan_opts = settings_to_scan_options(scan);
+    let paths = scan_paths_or_current_dir(scan);
+
+    let languages = tokmd_scan::scan(&paths, &scan_opts)?;
+    let report = tokmd_model::create_lang_report(&languages, lang.top, lang.files, lang.children);
+
+    Ok(build_lang_receipt(&paths, &scan_opts, lang, report))
+}
+
+/// Runs the language summary workflow for ordered in-memory inputs.
+///
+/// # Example
+///
+/// ```rust
+/// use tokmd_core::{
+///     InMemoryFile, lang_workflow_from_inputs,
+///     settings::{LangSettings, ScanOptions},
+/// };
+///
+/// let inputs = vec![InMemoryFile::new("src/main.rs", b"fn main() {}".to_vec())];
+/// let scan_opts = ScanOptions::default();
+/// let lang = LangSettings::default();
+///
+/// let receipt = lang_workflow_from_inputs(&inputs, &scan_opts, &lang).expect("Scan failed");
+/// assert_eq!(receipt.report.rows.len(), 1);
+/// ```
+pub fn lang_workflow_from_inputs(
+    inputs: &[InMemoryFile],
+    scan_opts: &ScanOptions,
+    lang: &LangSettings,
+) -> Result<LangReceipt> {
+    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
+    let (paths, rows) =
+        collect_pure_in_memory_rows(inputs, &scan_opts, &[], 1, ChildIncludeMode::Separate)?;
+    let report =
+        tokmd_model::create_lang_report_from_rows(&rows, lang.top, lang.files, lang.children);
+
+    Ok(build_lang_receipt(&paths, &scan_opts, lang, report))
+}

--- a/crates/tokmd-core/src/workflows/mod.rs
+++ b/crates/tokmd-core/src/workflows/mod.rs
@@ -1,0 +1,5 @@
+//! Public workflow facade owner modules.
+
+mod lang;
+
+pub use lang::{lang_workflow, lang_workflow_from_inputs};

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1661; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | In-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion now live under `ffi/`; remaining work is workflow facade without changing `run_json` |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1587; workflow coordinator 5; language workflow owner 84; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language workflow facade now lives under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is module/export/diff/analysis/cockpit workflow facade without changing public APIs |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -201,6 +201,7 @@ Target modules:
 crates/tokmd-core/src/
   lib.rs
   workflows/
+    lang.rs               # language workflow owner
   ffi.rs                  # public run_json coordinator during staged split
   ffi/
     inputs.rs             # in-memory input decoding and path validation
@@ -215,8 +216,12 @@ Current checkpoint: in-memory input decoding/path validation and strict JSON
 field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`, and
 mode-specific settings construction has moved into `ffi/settings_parse.rs`.
 Mode dispatch has moved into `ffi/modes.rs`, and response-envelope conversion
-has moved into `ffi/envelope.rs`. `ffi.rs` still owns public `run_json` while
-that public binding boundary remains staged.
+has moved into `ffi/envelope.rs`. Language workflow construction has moved into
+`workflows/lang.rs` while the root `tokmd_core::lang_workflow` and
+`tokmd_core::lang_workflow_from_inputs` exports remain stable. `ffi.rs` still
+owns public `run_json` while that public binding boundary remains staged, and
+`lib.rs` still owns the remaining module/export/diff/analyze/cockpit workflow
+facade helpers.
 
 Required proof:
 
@@ -312,8 +317,9 @@ Stop and split the work if a consolidation PR:
 
 ## First Suggested PRs
 
-1. Continue core facade/FFI owner-module splits with mode dispatch or envelope
-   handling while preserving the public `run_json` contract.
+1. Continue core facade owner-module splits with the remaining workflow
+   families while preserving the root-level public exports and binding
+   contracts.
 2. Continue production owner-module splits under `tokmd-analysis` only where
    production seams remain broad; avoid splitting tests solely for line count.
 3. Continue CLI parser command-family splits only when clap snapshots prove


### PR DESCRIPTION
## Summary
- Move the public language workflow pair into `crates/tokmd-core/src/workflows/lang.rs`.
- Preserve the root-level `tokmd_core::lang_workflow` and `tokmd_core::lang_workflow_from_inputs` exports.
- Extend the `tokmd_core_ffi` proof scope so the new workflow owner paths stay routed by affected planning.
- Update the architecture consolidation checkpoint with the new core workflow owner module.

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-core lang_workflow --verbose`
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo test -p tokmd-core --all-features lang_workflow --verbose`
- `cargo clippy -p tokmd-core --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask proof-artifacts-check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json` (unknown_files: [])
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`