### PR TITLE
refactor(core): extract export workflow owner

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -175,6 +175,7 @@ packages = ["tokmd-core"]
 proof = [
   "cargo test -p tokmd-core lang_workflow --verbose",
   "cargo test -p tokmd-core module_workflow --verbose",
+  "cargo test -p tokmd-core export_workflow --verbose",
   "cargo test -p tokmd-core ffi",
   "cargo test -p tokmd-core --test ffi_parity_w53",
 ]

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -69,7 +69,8 @@ mod workflows;
 pub use tokmd_scan::InMemoryFile;
 pub use tokmd_types as types;
 pub use workflows::{
-    lang_workflow, lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
+    export_workflow, export_workflow_from_inputs, lang_workflow, lang_workflow_from_inputs,
+    module_workflow, module_workflow_from_inputs,
 };
 
 use settings::{DiffSettings, ExportSettings, LangSettings, ModuleSettings, ScanSettings};
@@ -98,101 +99,6 @@ fn now_ms() -> u128 {
 // =============================================================================
 // Settings-based workflows (new API for bindings)
 // =============================================================================
-
-/// Runs the export workflow with pure settings types.
-///
-/// # Arguments
-///
-/// * `scan` - Scan settings (paths, exclusions, etc.)
-/// * `export` - Export-specific settings (format, min_code, etc.)
-///
-/// # Returns
-///
-/// An `ExportReceipt` containing file-level data.
-///
-/// # Example
-///
-/// ```rust
-/// use tokmd_core::{export_workflow, settings::{ScanSettings, ExportSettings}};
-///
-/// let scan = ScanSettings::current_dir();
-/// let export = ExportSettings::default();
-///
-/// let receipt = export_workflow(&scan, &export).expect("Export scan failed");
-/// assert!(receipt.data.rows.len() > 0);
-/// ```
-pub fn export_workflow(scan: &ScanSettings, export: &ExportSettings) -> Result<ExportReceipt> {
-    let scan_opts = settings_to_scan_options(scan);
-    let paths = scan_paths_or_current_dir(scan);
-    let strip_prefix = export.strip_prefix.as_deref();
-
-    // Scan
-    let languages = tokmd_scan::scan(&paths, &scan_opts)?;
-
-    // Model
-    let data = tokmd_model::create_export_data(
-        &languages,
-        &export.module_roots,
-        export.module_depth,
-        export.children,
-        strip_prefix.map(std::path::Path::new),
-        export.min_code,
-        export.max_rows,
-    );
-
-    Ok(build_export_receipt(&paths, &scan_opts, export, data))
-}
-
-/// Runs the file export workflow for ordered in-memory inputs.
-///
-/// # Example
-///
-/// ```rust
-/// use tokmd_core::{
-///     InMemoryFile, export_workflow_from_inputs,
-///     settings::{ExportSettings, ScanOptions},
-/// };
-///
-/// let inputs = vec![InMemoryFile::new("src/main.rs", b"fn main() {}".to_vec())];
-/// let scan_opts = ScanOptions::default();
-/// let export = ExportSettings::default();
-///
-/// let receipt =
-///     export_workflow_from_inputs(&inputs, &scan_opts, &export).expect("Export scan failed");
-/// assert_eq!(receipt.data.rows.len(), 1);
-/// ```
-pub fn export_workflow_from_inputs(
-    inputs: &[InMemoryFile],
-    scan_opts: &ScanOptions,
-    export: &ExportSettings,
-) -> Result<ExportReceipt> {
-    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
-    let (paths, mut rows) = collect_pure_in_memory_rows(
-        inputs,
-        &scan_opts,
-        &export.module_roots,
-        export.module_depth,
-        export.children,
-    )?;
-    if let Some(strip_prefix) = export.strip_prefix.as_deref() {
-        rows = strip_virtual_export_prefix(
-            rows,
-            strip_prefix,
-            &export.module_roots,
-            export.module_depth,
-        );
-    }
-    let data = tokmd_model::create_export_data_from_rows(
-        rows,
-        &export.module_roots,
-        export.module_depth,
-        export.children,
-        export.min_code,
-        export.max_rows,
-    );
-
-    Ok(build_export_receipt(&paths, &scan_opts, export, data))
-}
 
 /// Runs the diff workflow comparing two receipts or paths.
 ///

--- a/crates/tokmd-core/src/workflows/export.rs
+++ b/crates/tokmd-core/src/workflows/export.rs
@@ -1,0 +1,106 @@
+//! File export workflow facade.
+
+use std::path::Path;
+
+use anyhow::Result;
+use tokmd_settings::ScanOptions;
+use tokmd_types::ExportReceipt;
+
+use crate::settings::{ExportSettings, ScanSettings};
+use crate::{
+    InMemoryFile, build_export_receipt, collect_pure_in_memory_rows,
+    deterministic_in_memory_scan_options, scan_paths_or_current_dir, settings_to_scan_options,
+    strip_virtual_export_prefix,
+};
+
+/// Runs the export workflow with pure settings types.
+///
+/// # Arguments
+///
+/// * `scan` - Scan settings (paths, exclusions, etc.)
+/// * `export` - Export-specific settings (format, min_code, etc.)
+///
+/// # Returns
+///
+/// An `ExportReceipt` containing file-level data.
+///
+/// # Example
+///
+/// ```rust
+/// use tokmd_core::{export_workflow, settings::{ScanSettings, ExportSettings}};
+///
+/// let scan = ScanSettings::current_dir();
+/// let export = ExportSettings::default();
+///
+/// let receipt = export_workflow(&scan, &export).expect("Export scan failed");
+/// assert!(receipt.data.rows.len() > 0);
+/// ```
+pub fn export_workflow(scan: &ScanSettings, export: &ExportSettings) -> Result<ExportReceipt> {
+    let scan_opts = settings_to_scan_options(scan);
+    let paths = scan_paths_or_current_dir(scan);
+    let strip_prefix = export.strip_prefix.as_deref();
+
+    let languages = tokmd_scan::scan(&paths, &scan_opts)?;
+    let data = tokmd_model::create_export_data(
+        &languages,
+        &export.module_roots,
+        export.module_depth,
+        export.children,
+        strip_prefix.map(Path::new),
+        export.min_code,
+        export.max_rows,
+    );
+
+    Ok(build_export_receipt(&paths, &scan_opts, export, data))
+}
+
+/// Runs the file export workflow for ordered in-memory inputs.
+///
+/// # Example
+///
+/// ```rust
+/// use tokmd_core::{
+///     InMemoryFile, export_workflow_from_inputs,
+///     settings::{ExportSettings, ScanOptions},
+/// };
+///
+/// let inputs = vec![InMemoryFile::new("src/main.rs", b"fn main() {}".to_vec())];
+/// let scan_opts = ScanOptions::default();
+/// let export = ExportSettings::default();
+///
+/// let receipt =
+///     export_workflow_from_inputs(&inputs, &scan_opts, &export).expect("Export scan failed");
+/// assert_eq!(receipt.data.rows.len(), 1);
+/// ```
+pub fn export_workflow_from_inputs(
+    inputs: &[InMemoryFile],
+    scan_opts: &ScanOptions,
+    export: &ExportSettings,
+) -> Result<ExportReceipt> {
+    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
+    let (paths, mut rows) = collect_pure_in_memory_rows(
+        inputs,
+        &scan_opts,
+        &export.module_roots,
+        export.module_depth,
+        export.children,
+    )?;
+    if let Some(strip_prefix) = export.strip_prefix.as_deref() {
+        rows = strip_virtual_export_prefix(
+            rows,
+            strip_prefix,
+            &export.module_roots,
+            export.module_depth,
+        );
+    }
+    let data = tokmd_model::create_export_data_from_rows(
+        rows,
+        &export.module_roots,
+        export.module_depth,
+        export.children,
+        export.min_code,
+        export.max_rows,
+    );
+
+    Ok(build_export_receipt(&paths, &scan_opts, export, data))
+}

--- a/crates/tokmd-core/src/workflows/mod.rs
+++ b/crates/tokmd-core/src/workflows/mod.rs
@@ -1,7 +1,9 @@
 //! Public workflow facade owner modules.
 
+mod export;
 mod lang;
 mod module;
 
+pub use export::{export_workflow, export_workflow_from_inputs};
 pub use lang::{lang_workflow, lang_workflow_from_inputs};
 pub use module::{module_workflow, module_workflow_from_inputs};

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1503; workflow coordinator 7; language workflow owner 84; module workflow owner 94; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language and module workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is export/diff/analysis/cockpit workflow facade without changing public APIs |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1267; workflow coordinator 7; language workflow owner 77; module workflow owner 87; export workflow owner 98; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, and export workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is diff/analysis/cockpit workflow facade without changing public APIs |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -203,6 +203,7 @@ crates/tokmd-core/src/
   workflows/
     lang.rs               # language workflow owner
     module.rs             # module workflow owner
+    export.rs             # file export workflow owner
   ffi.rs                  # public run_json coordinator during staged split
   ffi/
     inputs.rs             # in-memory input decoding and path validation
@@ -217,13 +218,15 @@ Current checkpoint: in-memory input decoding/path validation and strict JSON
 field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`, and
 mode-specific settings construction has moved into `ffi/settings_parse.rs`.
 Mode dispatch has moved into `ffi/modes.rs`, and response-envelope conversion
-has moved into `ffi/envelope.rs`. Language and module workflow construction
-have moved into `workflows/lang.rs` and `workflows/module.rs` while the root
+has moved into `ffi/envelope.rs`. Language, module, and export workflow
+construction have moved into `workflows/lang.rs`, `workflows/module.rs`, and
+`workflows/export.rs` while the root
 `tokmd_core::lang_workflow`, `tokmd_core::lang_workflow_from_inputs`,
-`tokmd_core::module_workflow`, and `tokmd_core::module_workflow_from_inputs`
+`tokmd_core::module_workflow`, `tokmd_core::module_workflow_from_inputs`,
+`tokmd_core::export_workflow`, and `tokmd_core::export_workflow_from_inputs`
 exports remain stable. `ffi.rs` still owns public `run_json` while that public
 binding boundary remains staged, and `lib.rs` still owns the remaining
-export/diff/analyze/cockpit workflow facade helpers.
+diff/analyze/cockpit workflow facade helpers.
 
 Required proof:
 


### PR DESCRIPTION
## Summary
- move `export_workflow` and `export_workflow_from_inputs` into `tokmd-core`'s `workflows/export.rs` owner module
- preserve the root `tokmd_core::{export_workflow, export_workflow_from_inputs}` re-exports and receipt behavior
- route core workflow changes through the explicit `export_workflow` proof command and update the architecture consolidation checkpoint

## Validation
- `cargo fmt-check`
- `cargo test -p tokmd-core export_workflow --verbose`
- `cargo test -p tokmd-core --all-features export_workflow --verbose`
- `cargo clippy -p tokmd-core --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask proof-artifacts-check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`