### PR TITLE
refactor(core): extract diff workflow owner

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -176,6 +176,7 @@ proof = [
   "cargo test -p tokmd-core lang_workflow --verbose",
   "cargo test -p tokmd-core module_workflow --verbose",
   "cargo test -p tokmd-core export_workflow --verbose",
+  "cargo test -p tokmd-core diff_workflow --verbose",
   "cargo test -p tokmd-core ffi",
   "cargo test -p tokmd-core --test ffi_parity_w53",
 ]

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -69,16 +69,16 @@ mod workflows;
 pub use tokmd_scan::InMemoryFile;
 pub use tokmd_types as types;
 pub use workflows::{
-    export_workflow, export_workflow_from_inputs, lang_workflow, lang_workflow_from_inputs,
-    module_workflow, module_workflow_from_inputs,
+    diff_workflow, export_workflow, export_workflow_from_inputs, lang_workflow,
+    lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
 };
 
-use settings::{DiffSettings, ExportSettings, LangSettings, ModuleSettings, ScanSettings};
+use settings::{ExportSettings, LangSettings, ModuleSettings, ScanSettings};
 use tokmd_format::scan_args;
 use tokmd_settings::ScanOptions;
 use tokmd_types::{
-    ChildIncludeMode, DiffReceipt, ExportArgsMeta, ExportData, ExportReceipt, FileRow,
-    LangArgsMeta, LangReceipt, LangReport, ModuleArgsMeta, ModuleReceipt, ModuleReport, RedactMode,
+    ChildIncludeMode, ExportArgsMeta, ExportData, ExportReceipt, FileRow, LangArgsMeta,
+    LangReceipt, LangReport, ModuleArgsMeta, ModuleReceipt, ModuleReport, RedactMode,
     SCHEMA_VERSION, ScanStatus, ToolInfo,
 };
 
@@ -99,49 +99,6 @@ fn now_ms() -> u128 {
 // =============================================================================
 // Settings-based workflows (new API for bindings)
 // =============================================================================
-
-/// Runs the diff workflow comparing two receipts or paths.
-///
-/// # Arguments
-///
-/// * `settings` - Diff settings (from, to references)
-///
-/// # Returns
-///
-/// A `DiffReceipt` showing changes between the two states.
-///
-/// # Example
-///
-/// ```rust
-/// use tokmd_core::{diff_workflow, settings::DiffSettings};
-///
-/// let settings = DiffSettings {
-///     from: ".".to_string(), // compare current dir to itself as a quick test
-///     to: ".".to_string(),
-///     ..Default::default()
-/// };
-///
-/// let receipt = diff_workflow(&settings).expect("Diff failed");
-/// assert!(receipt.totals.delta_code == 0); // delta is zero
-/// ```
-pub fn diff_workflow(settings: &DiffSettings) -> Result<DiffReceipt> {
-    // Load or scan the "from" state
-    let from_report = load_lang_report(&settings.from)?;
-
-    // Load or scan the "to" state
-    let to_report = load_lang_report(&settings.to)?;
-
-    // Compute diff
-    let rows = tokmd_format::compute_diff_rows(&from_report, &to_report);
-    let totals = tokmd_format::compute_diff_totals(&rows);
-
-    Ok(tokmd_format::create_diff_receipt(
-        &settings.from,
-        &settings.to,
-        rows,
-        totals,
-    ))
-}
 
 /// Analyze workflow (requires `analysis` feature).
 ///

--- a/crates/tokmd-core/src/workflows/diff.rs
+++ b/crates/tokmd-core/src/workflows/diff.rs
@@ -1,0 +1,46 @@
+//! Diff workflow facade.
+
+use anyhow::Result;
+use tokmd_types::DiffReceipt;
+
+use crate::load_lang_report;
+use crate::settings::DiffSettings;
+
+/// Runs the diff workflow comparing two receipts or paths.
+///
+/// # Arguments
+///
+/// * `settings` - Diff settings (from, to references)
+///
+/// # Returns
+///
+/// A `DiffReceipt` showing changes between the two states.
+///
+/// # Example
+///
+/// ```rust
+/// use tokmd_core::{diff_workflow, settings::DiffSettings};
+///
+/// let settings = DiffSettings {
+///     from: ".".to_string(), // compare current dir to itself as a quick test
+///     to: ".".to_string(),
+///     ..Default::default()
+/// };
+///
+/// let receipt = diff_workflow(&settings).expect("Diff failed");
+/// assert!(receipt.totals.delta_code == 0); // delta is zero
+/// ```
+pub fn diff_workflow(settings: &DiffSettings) -> Result<DiffReceipt> {
+    let from_report = load_lang_report(&settings.from)?;
+    let to_report = load_lang_report(&settings.to)?;
+
+    let rows = tokmd_format::compute_diff_rows(&from_report, &to_report);
+    let totals = tokmd_format::compute_diff_totals(&rows);
+
+    Ok(tokmd_format::create_diff_receipt(
+        &settings.from,
+        &settings.to,
+        rows,
+        totals,
+    ))
+}

--- a/crates/tokmd-core/src/workflows/mod.rs
+++ b/crates/tokmd-core/src/workflows/mod.rs
@@ -1,9 +1,11 @@
 //! Public workflow facade owner modules.
 
+mod diff;
 mod export;
 mod lang;
 mod module;
 
+pub use diff::diff_workflow;
 pub use export::{export_workflow, export_workflow_from_inputs};
 pub use lang::{lang_workflow, lang_workflow_from_inputs};
 pub use module::{module_workflow, module_workflow_from_inputs};

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1267; workflow coordinator 7; language workflow owner 77; module workflow owner 87; export workflow owner 98; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, and export workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is diff/analysis/cockpit workflow facade without changing public APIs |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1228; workflow coordinator 9; language workflow owner 77; module workflow owner 87; export workflow owner 98; diff workflow owner 41; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, export, and diff workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is analysis/cockpit workflow facade without changing public APIs |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -204,6 +204,7 @@ crates/tokmd-core/src/
     lang.rs               # language workflow owner
     module.rs             # module workflow owner
     export.rs             # file export workflow owner
+    diff.rs               # diff workflow owner
   ffi.rs                  # public run_json coordinator during staged split
   ffi/
     inputs.rs             # in-memory input decoding and path validation
@@ -218,15 +219,15 @@ Current checkpoint: in-memory input decoding/path validation and strict JSON
 field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`, and
 mode-specific settings construction has moved into `ffi/settings_parse.rs`.
 Mode dispatch has moved into `ffi/modes.rs`, and response-envelope conversion
-has moved into `ffi/envelope.rs`. Language, module, and export workflow
-construction have moved into `workflows/lang.rs`, `workflows/module.rs`, and
-`workflows/export.rs` while the root
+has moved into `ffi/envelope.rs`. Language, module, export, and diff workflow
+construction have moved into `workflows/lang.rs`, `workflows/module.rs`,
+`workflows/export.rs`, and `workflows/diff.rs` while the root
 `tokmd_core::lang_workflow`, `tokmd_core::lang_workflow_from_inputs`,
 `tokmd_core::module_workflow`, `tokmd_core::module_workflow_from_inputs`,
-`tokmd_core::export_workflow`, and `tokmd_core::export_workflow_from_inputs`
-exports remain stable. `ffi.rs` still owns public `run_json` while that public
-binding boundary remains staged, and `lib.rs` still owns the remaining
-diff/analyze/cockpit workflow facade helpers.
+`tokmd_core::export_workflow`, `tokmd_core::export_workflow_from_inputs`, and
+`tokmd_core::diff_workflow` exports remain stable. `ffi.rs` still owns public
+`run_json` while that public binding boundary remains staged, and `lib.rs`
+still owns the remaining analyze/cockpit workflow facade helpers.
 
 Required proof:
 


### PR DESCRIPTION
## Summary

- move `tokmd_core::diff_workflow` into `crates/tokmd-core/src/workflows/diff.rs`
- preserve the root `tokmd_core::diff_workflow` re-export and existing diff receipt semantics
- add the diff workflow proof command to `tokmd_core_ffi` scope and update the architecture checkpoint

## Validation

- `cargo fmt-check`
- `cargo test -p tokmd-core --all-features diff_workflow --verbose`
- `cargo clippy -p tokmd-core --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask proof-artifacts-check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`

## Affected Plan

Scopes: `project_truth_docs`, `proof_control_plane`, `tokmd_core_ffi`.

Unknown files: none.