### PR TITLE
refactor(core): extract analysis workflow owner

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -177,6 +177,7 @@ proof = [
   "cargo test -p tokmd-core module_workflow --verbose",
   "cargo test -p tokmd-core export_workflow --verbose",
   "cargo test -p tokmd-core diff_workflow --verbose",
+  "cargo test -p tokmd-core --all-features analyze_workflow --verbose",
   "cargo test -p tokmd-core ffi",
   "cargo test -p tokmd-core --test ffi_parity_w53",
 ]

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -54,10 +54,8 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-#[cfg(feature = "analysis")]
+#[cfg(all(test, feature = "analysis"))]
 use tokmd_analysis as analysis;
-#[cfg(feature = "analysis")]
-use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisSource};
 
 // Public modules
 pub mod context_git;
@@ -68,10 +66,16 @@ pub mod settings;
 mod workflows;
 pub use tokmd_scan::InMemoryFile;
 pub use tokmd_types as types;
+#[cfg(feature = "analysis")]
+pub use workflows::{
+    analyze_workflow, analyze_workflow_from_inputs, supports_rootless_in_memory_analyze_preset,
+};
 pub use workflows::{
     diff_workflow, export_workflow, export_workflow_from_inputs, lang_workflow,
     lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
 };
+#[cfg(all(test, feature = "analysis"))]
+use workflows::{parse_analysis_preset, parse_effort_request};
 
 use settings::{ExportSettings, LangSettings, ModuleSettings, ScanSettings};
 use tokmd_format::scan_args;
@@ -99,198 +103,6 @@ fn now_ms() -> u128 {
 // =============================================================================
 // Settings-based workflows (new API for bindings)
 // =============================================================================
-
-/// Analyze workflow (requires `analysis` feature).
-///
-/// Runs export + analysis workflows and returns an `AnalysisReceipt`.
-///
-/// # Example
-///
-/// ```rust
-/// use tokmd_core::{analyze_workflow, settings::{ScanSettings, AnalyzeSettings}};
-///
-/// let scan = ScanSettings::current_dir();
-/// let analyze = AnalyzeSettings {
-///     preset: "receipt".to_string(),
-///     ..Default::default()
-/// };
-///
-/// let receipt = analyze_workflow(&scan, &analyze).expect("Analyze scan failed");
-/// assert!(receipt.derived.is_some());
-/// ```
-#[cfg(feature = "analysis")]
-pub fn analyze_workflow(
-    scan: &ScanSettings,
-    analyze: &settings::AnalyzeSettings,
-) -> Result<tokmd_analysis_types::AnalysisReceipt> {
-    let export_receipt = export_workflow(scan, &ExportSettings::default())?;
-    let root = derive_analysis_root(scan)
-        .or_else(|| std::env::current_dir().ok())
-        .unwrap_or_else(|| PathBuf::from("."));
-
-    analyze_with_export_receipt(export_receipt, scan.paths.clone(), root, analyze)
-}
-
-/// Analyze workflow for ordered in-memory inputs (requires `analysis` feature).
-///
-/// Runs the in-memory export + analysis pipeline and returns an `AnalysisReceipt`.
-///
-/// `preset = "receipt"` and `preset = "estimate"` stay on the pure row path
-/// and do not borrow the host repository as a fake root. Richer presets still
-/// materialize a temporary scan root until the remaining analysis seams are
-/// moved off the filesystem.
-///
-/// # Example
-///
-/// ```rust
-/// use tokmd_core::{analyze_workflow_from_inputs, settings::{AnalyzeSettings, ScanOptions}, InMemoryFile};
-///
-/// let inputs = vec![
-///     InMemoryFile {
-///         path: "src/main.rs".into(),
-///         bytes: b"fn main() { println!(\"hello world\"); }".to_vec(),
-///     }
-/// ];
-///
-/// let scan_opts = ScanOptions::default();
-/// let analyze_opts = AnalyzeSettings {
-///     preset: "receipt".to_string(),
-///     ..Default::default()
-/// };
-///
-/// let receipt = analyze_workflow_from_inputs(&inputs, &scan_opts, &analyze_opts)
-///     .expect("analyze_workflow_from_inputs failed");
-/// assert!(receipt.derived.is_some());
-/// ```
-#[cfg(feature = "analysis")]
-pub fn analyze_workflow_from_inputs(
-    inputs: &[InMemoryFile],
-    scan_opts: &ScanOptions,
-    analyze: &settings::AnalyzeSettings,
-) -> Result<tokmd_analysis_types::AnalysisReceipt> {
-    let export = ExportSettings::default();
-    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
-    if supports_rootless_in_memory_analyze_preset(&analyze.preset) {
-        let (paths, rows) = collect_pure_in_memory_rows(
-            inputs,
-            &scan_opts,
-            &export.module_roots,
-            export.module_depth,
-            export.children,
-        )?;
-        let data = tokmd_model::create_export_data_from_rows(
-            rows,
-            &export.module_roots,
-            export.module_depth,
-            export.children,
-            export.min_code,
-            export.max_rows,
-        );
-        let logical_inputs: Vec<String> = paths
-            .iter()
-            .map(|path| tokmd_model::normalize_path(path, None))
-            .collect();
-        let export_receipt = build_export_receipt(&paths, &scan_opts, &export, data);
-
-        return analyze_with_export_receipt(
-            export_receipt,
-            logical_inputs,
-            PathBuf::new(),
-            analyze,
-        );
-    }
-
-    let scan = tokmd_scan::scan_in_memory(inputs, &scan_opts)?;
-    let data = collect_materialized_export_data(&scan, &export);
-    let logical_inputs: Vec<String> = scan
-        .logical_paths()
-        .iter()
-        .map(|path| tokmd_model::normalize_path(path, None))
-        .collect();
-    let root = scan.strip_prefix().to_path_buf();
-    let export_receipt = build_export_receipt(scan.logical_paths(), &scan_opts, &export, data);
-
-    analyze_with_export_receipt(export_receipt, logical_inputs, root, analyze)
-}
-
-#[cfg(feature = "analysis")]
-#[doc(hidden)]
-pub fn supports_rootless_in_memory_analyze_preset(preset: &str) -> bool {
-    let preset = preset.trim();
-    preset.eq_ignore_ascii_case("receipt") || preset.eq_ignore_ascii_case("estimate")
-}
-
-#[cfg(feature = "analysis")]
-fn analyze_with_export_receipt(
-    export_receipt: ExportReceipt,
-    inputs: Vec<String>,
-    root: PathBuf,
-    analyze: &settings::AnalyzeSettings,
-) -> Result<tokmd_analysis_types::AnalysisReceipt> {
-    let request = build_analysis_request(analyze)?;
-    let source = AnalysisSource {
-        inputs,
-        export_path: None,
-        base_receipt_path: None,
-        export_schema_version: Some(export_receipt.schema_version),
-        export_generated_at_ms: Some(export_receipt.generated_at_ms),
-        base_signature: None,
-        module_roots: export_receipt.data.module_roots.clone(),
-        module_depth: export_receipt.data.module_depth,
-        children: child_include_mode_to_string(export_receipt.data.children),
-    };
-
-    let ctx = analysis::AnalysisContext {
-        export: export_receipt.data,
-        root,
-        source,
-    };
-
-    analysis::analyze(ctx, request)
-}
-
-#[cfg(feature = "analysis")]
-fn build_analysis_request(
-    analyze: &settings::AnalyzeSettings,
-) -> Result<analysis::AnalysisRequest> {
-    let (preset, preset_meta) = parse_analysis_preset(&analyze.preset)?;
-    let (granularity, granularity_meta) = parse_import_granularity(&analyze.granularity)?;
-    let effort = parse_effort_request(analyze, &preset_meta)?;
-
-    Ok(analysis::AnalysisRequest {
-        preset,
-        args: AnalysisArgsMeta {
-            preset: preset_meta,
-            format: "json".to_string(),
-            window_tokens: analyze.window,
-            git: analyze.git,
-            max_files: analyze.max_files,
-            max_bytes: analyze.max_bytes,
-            max_file_bytes: analyze.max_file_bytes,
-            max_commits: analyze.max_commits,
-            max_commit_files: analyze.max_commit_files,
-            import_granularity: granularity_meta,
-        },
-        limits: analysis::AnalysisLimits {
-            max_files: analyze.max_files,
-            max_bytes: analyze.max_bytes,
-            max_file_bytes: analyze.max_file_bytes,
-            max_commits: analyze.max_commits,
-            max_commit_files: analyze.max_commit_files,
-        },
-        window_tokens: analyze.window,
-        git: analyze.git,
-        import_granularity: granularity,
-        detail_functions: false,
-        near_dup: false,
-        near_dup_threshold: 0.80,
-        near_dup_max_files: 2000,
-        near_dup_scope: analysis::NearDupScope::Module,
-        near_dup_max_pairs: None,
-        near_dup_exclude: Vec::new(),
-        effort,
-    })
-}
 
 // =============================================================================
 // Cockpit workflow (requires `cockpit` feature)
@@ -486,22 +298,6 @@ fn collect_pure_in_memory_rows(
     Ok((paths, rows))
 }
 
-#[cfg(feature = "analysis")]
-fn collect_materialized_rows(
-    scan: &tokmd_scan::MaterializedScan,
-    module_roots: &[String],
-    module_depth: usize,
-    children: ChildIncludeMode,
-) -> Vec<FileRow> {
-    tokmd_model::collect_file_rows(
-        scan.languages(),
-        module_roots,
-        module_depth,
-        children,
-        Some(scan.strip_prefix()),
-    )
-}
-
 fn strip_virtual_export_prefix(
     rows: Vec<FileRow>,
     strip_prefix: &str,
@@ -517,37 +313,6 @@ fn strip_virtual_export_prefix(
             row
         })
         .collect()
-}
-
-#[cfg(feature = "analysis")]
-fn collect_materialized_export_data(
-    scan: &tokmd_scan::MaterializedScan,
-    export: &ExportSettings,
-) -> ExportData {
-    let mut rows = collect_materialized_rows(
-        scan,
-        &export.module_roots,
-        export.module_depth,
-        export.children,
-    );
-
-    if let Some(strip_prefix) = export.strip_prefix.as_deref() {
-        rows = strip_virtual_export_prefix(
-            rows,
-            strip_prefix,
-            &export.module_roots,
-            export.module_depth,
-        );
-    }
-
-    tokmd_model::create_export_data_from_rows(
-        rows,
-        &export.module_roots,
-        export.module_depth,
-        export.children,
-        export.min_code,
-        export.max_rows,
-    )
 }
 
 fn build_lang_receipt(
@@ -635,169 +400,6 @@ fn build_export_receipt(
             strip_prefix_redacted,
         },
         data: redact_export_data(data, export.redact),
-    }
-}
-
-#[cfg(feature = "analysis")]
-fn parse_analysis_preset(value: &str) -> Result<(analysis::AnalysisPreset, String)> {
-    let normalized = value.trim().to_ascii_lowercase();
-    let preset = match normalized.as_str() {
-        "receipt" => analysis::AnalysisPreset::Receipt,
-        "estimate" => analysis::AnalysisPreset::Estimate,
-        "health" => analysis::AnalysisPreset::Health,
-        "risk" => analysis::AnalysisPreset::Risk,
-        "supply" => analysis::AnalysisPreset::Supply,
-        "architecture" => analysis::AnalysisPreset::Architecture,
-        "topics" => analysis::AnalysisPreset::Topics,
-        "security" => analysis::AnalysisPreset::Security,
-        "identity" => analysis::AnalysisPreset::Identity,
-        "git" => analysis::AnalysisPreset::Git,
-        "deep" => analysis::AnalysisPreset::Deep,
-        "fun" => analysis::AnalysisPreset::Fun,
-        _ => {
-            return Err(error::TokmdError::invalid_field(
-                "preset",
-                "'receipt', 'estimate', 'health', 'risk', 'supply', 'architecture', 'topics', 'security', 'identity', 'git', 'deep', or 'fun'",
-            )
-            .into());
-        }
-    };
-    Ok((preset, normalized))
-}
-
-#[cfg(feature = "analysis")]
-fn parse_import_granularity(value: &str) -> Result<(analysis::ImportGranularity, String)> {
-    let normalized = value.trim().to_ascii_lowercase();
-    let granularity = match normalized.as_str() {
-        "module" => analysis::ImportGranularity::Module,
-        "file" => analysis::ImportGranularity::File,
-        _ => {
-            return Err(
-                error::TokmdError::invalid_field("granularity", "'module' or 'file'").into(),
-            );
-        }
-    };
-    Ok((granularity, normalized))
-}
-
-#[cfg(feature = "analysis")]
-fn parse_effort_request(
-    analyze: &settings::AnalyzeSettings,
-    preset: &str,
-) -> Result<Option<analysis::EffortRequest>> {
-    let request = analysis::EffortRequest::default();
-    let requested = preset == "estimate"
-        || analyze.effort_model.is_some()
-        || analyze.effort_layer.is_some()
-        || analyze.effort_base_ref.is_some()
-        || analyze.effort_head_ref.is_some()
-        || analyze.effort_monte_carlo.unwrap_or(false)
-        || analyze.effort_mc_iterations.is_some()
-        || analyze.effort_mc_seed.is_some();
-
-    if !requested {
-        return Ok(None);
-    }
-
-    if (analyze.effort_base_ref.is_some() && analyze.effort_head_ref.is_none())
-        || (analyze.effort_base_ref.is_none() && analyze.effort_head_ref.is_some())
-    {
-        return Err(error::TokmdError::invalid_field(
-            "effort_base_ref/effort_head_ref",
-            "both effort_base_ref and effort_head_ref must be provided together",
-        )
-        .into());
-    }
-
-    let model = analyze
-        .effort_model
-        .as_deref()
-        .map(parse_effort_model)
-        .transpose()?
-        .unwrap_or(request.model);
-    let layer = analyze
-        .effort_layer
-        .as_deref()
-        .map(parse_effort_layer)
-        .transpose()?
-        .unwrap_or(request.layer);
-
-    let monte_carlo = analyze.effort_monte_carlo.unwrap_or(false);
-
-    let mc_iterations = analyze
-        .effort_mc_iterations
-        .unwrap_or(request.mc_iterations);
-
-    if mc_iterations == 0 {
-        return Err(error::TokmdError::invalid_field(
-            "effort_mc_iterations",
-            "must be greater than 0",
-        )
-        .into());
-    }
-
-    Ok(Some(analysis::EffortRequest {
-        model,
-        layer,
-        base_ref: analyze.effort_base_ref.clone(),
-        head_ref: analyze.effort_head_ref.clone(),
-        monte_carlo,
-        mc_iterations,
-        mc_seed: analyze.effort_mc_seed,
-    }))
-}
-
-#[cfg(feature = "analysis")]
-fn parse_effort_model(value: &str) -> Result<analysis::EffortModelKind> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "cocomo81-basic" => Ok(analysis::EffortModelKind::Cocomo81Basic),
-        "cocomo2-early" | "ensemble" => Err(error::TokmdError::invalid_field(
-            "effort_model",
-            "only 'cocomo81-basic' is currently supported",
-        )
-        .into()),
-        _ => Err(error::TokmdError::invalid_field("effort_model", "'cocomo81-basic'").into()),
-    }
-}
-
-#[cfg(feature = "analysis")]
-fn parse_effort_layer(value: &str) -> Result<analysis::EffortLayer> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "headline" => Ok(analysis::EffortLayer::Headline),
-        "why" => Ok(analysis::EffortLayer::Why),
-        "full" => Ok(analysis::EffortLayer::Full),
-        _ => Err(
-            error::TokmdError::invalid_field("effort_layer", "'headline', 'why', or 'full'").into(),
-        ),
-    }
-}
-
-#[cfg(feature = "analysis")]
-fn child_include_mode_to_string(mode: tokmd_types::ChildIncludeMode) -> String {
-    match mode {
-        tokmd_types::ChildIncludeMode::Separate => "separate".to_string(),
-        tokmd_types::ChildIncludeMode::ParentsOnly => "parents-only".to_string(),
-    }
-}
-
-#[cfg(feature = "analysis")]
-fn derive_analysis_root(scan: &ScanSettings) -> Option<PathBuf> {
-    let first = scan.paths.first()?;
-    if first.trim().is_empty() {
-        return None;
-    }
-
-    let candidate = PathBuf::from(first);
-    let absolute = if candidate.is_absolute() {
-        candidate
-    } else {
-        std::env::current_dir().ok()?.join(candidate)
-    };
-
-    if absolute.is_dir() {
-        Some(absolute)
-    } else {
-        absolute.parent().map(|p| p.to_path_buf())
     }
 }
 

--- a/crates/tokmd-core/src/workflows/analyze.rs
+++ b/crates/tokmd-core/src/workflows/analyze.rs
@@ -1,0 +1,400 @@
+//! Analysis workflow facade.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use tokmd_analysis as analysis;
+use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisReceipt, AnalysisSource};
+use tokmd_settings::ScanOptions;
+use tokmd_types::{ChildIncludeMode, ExportData, ExportReceipt, FileRow};
+
+use crate::settings::{AnalyzeSettings, ExportSettings, ScanSettings};
+use crate::{
+    InMemoryFile, build_export_receipt, collect_pure_in_memory_rows,
+    deterministic_in_memory_scan_options, error, strip_virtual_export_prefix,
+};
+
+use super::export_workflow;
+
+/// Analyze workflow (requires `analysis` feature).
+///
+/// Runs export + analysis workflows and returns an `AnalysisReceipt`.
+///
+/// # Example
+///
+/// ```rust
+/// use tokmd_core::{analyze_workflow, settings::{ScanSettings, AnalyzeSettings}};
+///
+/// let scan = ScanSettings::current_dir();
+/// let analyze = AnalyzeSettings {
+///     preset: "receipt".to_string(),
+///     ..Default::default()
+/// };
+///
+/// let receipt = analyze_workflow(&scan, &analyze).expect("Analyze scan failed");
+/// assert!(receipt.derived.is_some());
+/// ```
+pub fn analyze_workflow(scan: &ScanSettings, analyze: &AnalyzeSettings) -> Result<AnalysisReceipt> {
+    let export_receipt = export_workflow(scan, &ExportSettings::default())?;
+    let root = derive_analysis_root(scan)
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    analyze_with_export_receipt(export_receipt, scan.paths.clone(), root, analyze)
+}
+
+/// Analyze workflow for ordered in-memory inputs (requires `analysis` feature).
+///
+/// Runs the in-memory export + analysis pipeline and returns an `AnalysisReceipt`.
+///
+/// `preset = "receipt"` and `preset = "estimate"` stay on the pure row path
+/// and do not borrow the host repository as a fake root. Richer presets still
+/// materialize a temporary scan root until the remaining analysis seams are
+/// moved off the filesystem.
+///
+/// # Example
+///
+/// ```rust
+/// use tokmd_core::{analyze_workflow_from_inputs, settings::{AnalyzeSettings, ScanOptions}, InMemoryFile};
+///
+/// let inputs = vec![
+///     InMemoryFile {
+///         path: "src/main.rs".into(),
+///         bytes: b"fn main() { println!(\"hello world\"); }".to_vec(),
+///     }
+/// ];
+///
+/// let scan_opts = ScanOptions::default();
+/// let analyze_opts = AnalyzeSettings {
+///     preset: "receipt".to_string(),
+///     ..Default::default()
+/// };
+///
+/// let receipt = analyze_workflow_from_inputs(&inputs, &scan_opts, &analyze_opts)
+///     .expect("analyze_workflow_from_inputs failed");
+/// assert!(receipt.derived.is_some());
+/// ```
+pub fn analyze_workflow_from_inputs(
+    inputs: &[InMemoryFile],
+    scan_opts: &ScanOptions,
+    analyze: &AnalyzeSettings,
+) -> Result<AnalysisReceipt> {
+    let export = ExportSettings::default();
+    let scan_opts = deterministic_in_memory_scan_options(scan_opts);
+    if supports_rootless_in_memory_analyze_preset(&analyze.preset) {
+        let (paths, rows) = collect_pure_in_memory_rows(
+            inputs,
+            &scan_opts,
+            &export.module_roots,
+            export.module_depth,
+            export.children,
+        )?;
+        let data = tokmd_model::create_export_data_from_rows(
+            rows,
+            &export.module_roots,
+            export.module_depth,
+            export.children,
+            export.min_code,
+            export.max_rows,
+        );
+        let logical_inputs: Vec<String> = paths
+            .iter()
+            .map(|path| tokmd_model::normalize_path(path, None))
+            .collect();
+        let export_receipt = build_export_receipt(&paths, &scan_opts, &export, data);
+
+        return analyze_with_export_receipt(
+            export_receipt,
+            logical_inputs,
+            PathBuf::new(),
+            analyze,
+        );
+    }
+
+    let scan = tokmd_scan::scan_in_memory(inputs, &scan_opts)?;
+    let data = collect_materialized_export_data(&scan, &export);
+    let logical_inputs: Vec<String> = scan
+        .logical_paths()
+        .iter()
+        .map(|path| tokmd_model::normalize_path(path, None))
+        .collect();
+    let root = scan.strip_prefix().to_path_buf();
+    let export_receipt = build_export_receipt(scan.logical_paths(), &scan_opts, &export, data);
+
+    analyze_with_export_receipt(export_receipt, logical_inputs, root, analyze)
+}
+
+#[doc(hidden)]
+pub fn supports_rootless_in_memory_analyze_preset(preset: &str) -> bool {
+    let preset = preset.trim();
+    preset.eq_ignore_ascii_case("receipt") || preset.eq_ignore_ascii_case("estimate")
+}
+
+fn analyze_with_export_receipt(
+    export_receipt: ExportReceipt,
+    inputs: Vec<String>,
+    root: PathBuf,
+    analyze: &AnalyzeSettings,
+) -> Result<AnalysisReceipt> {
+    let request = build_analysis_request(analyze)?;
+    let source = AnalysisSource {
+        inputs,
+        export_path: None,
+        base_receipt_path: None,
+        export_schema_version: Some(export_receipt.schema_version),
+        export_generated_at_ms: Some(export_receipt.generated_at_ms),
+        base_signature: None,
+        module_roots: export_receipt.data.module_roots.clone(),
+        module_depth: export_receipt.data.module_depth,
+        children: child_include_mode_to_string(export_receipt.data.children),
+    };
+
+    let ctx = analysis::AnalysisContext {
+        export: export_receipt.data,
+        root,
+        source,
+    };
+
+    analysis::analyze(ctx, request)
+}
+
+fn build_analysis_request(analyze: &AnalyzeSettings) -> Result<analysis::AnalysisRequest> {
+    let (preset, preset_meta) = parse_analysis_preset(&analyze.preset)?;
+    let (granularity, granularity_meta) = parse_import_granularity(&analyze.granularity)?;
+    let effort = parse_effort_request(analyze, &preset_meta)?;
+
+    Ok(analysis::AnalysisRequest {
+        preset,
+        args: AnalysisArgsMeta {
+            preset: preset_meta,
+            format: "json".to_string(),
+            window_tokens: analyze.window,
+            git: analyze.git,
+            max_files: analyze.max_files,
+            max_bytes: analyze.max_bytes,
+            max_file_bytes: analyze.max_file_bytes,
+            max_commits: analyze.max_commits,
+            max_commit_files: analyze.max_commit_files,
+            import_granularity: granularity_meta,
+        },
+        limits: analysis::AnalysisLimits {
+            max_files: analyze.max_files,
+            max_bytes: analyze.max_bytes,
+            max_file_bytes: analyze.max_file_bytes,
+            max_commits: analyze.max_commits,
+            max_commit_files: analyze.max_commit_files,
+        },
+        window_tokens: analyze.window,
+        git: analyze.git,
+        import_granularity: granularity,
+        detail_functions: false,
+        near_dup: false,
+        near_dup_threshold: 0.80,
+        near_dup_max_files: 2000,
+        near_dup_scope: analysis::NearDupScope::Module,
+        near_dup_max_pairs: None,
+        near_dup_exclude: Vec::new(),
+        effort,
+    })
+}
+
+fn collect_materialized_rows(
+    scan: &tokmd_scan::MaterializedScan,
+    module_roots: &[String],
+    module_depth: usize,
+    children: ChildIncludeMode,
+) -> Vec<FileRow> {
+    tokmd_model::collect_file_rows(
+        scan.languages(),
+        module_roots,
+        module_depth,
+        children,
+        Some(scan.strip_prefix()),
+    )
+}
+
+fn collect_materialized_export_data(
+    scan: &tokmd_scan::MaterializedScan,
+    export: &ExportSettings,
+) -> ExportData {
+    let mut rows = collect_materialized_rows(
+        scan,
+        &export.module_roots,
+        export.module_depth,
+        export.children,
+    );
+
+    if let Some(strip_prefix) = export.strip_prefix.as_deref() {
+        rows = strip_virtual_export_prefix(
+            rows,
+            strip_prefix,
+            &export.module_roots,
+            export.module_depth,
+        );
+    }
+
+    tokmd_model::create_export_data_from_rows(
+        rows,
+        &export.module_roots,
+        export.module_depth,
+        export.children,
+        export.min_code,
+        export.max_rows,
+    )
+}
+
+pub(crate) fn parse_analysis_preset(value: &str) -> Result<(analysis::AnalysisPreset, String)> {
+    let normalized = value.trim().to_ascii_lowercase();
+    let preset = match normalized.as_str() {
+        "receipt" => analysis::AnalysisPreset::Receipt,
+        "estimate" => analysis::AnalysisPreset::Estimate,
+        "health" => analysis::AnalysisPreset::Health,
+        "risk" => analysis::AnalysisPreset::Risk,
+        "supply" => analysis::AnalysisPreset::Supply,
+        "architecture" => analysis::AnalysisPreset::Architecture,
+        "topics" => analysis::AnalysisPreset::Topics,
+        "security" => analysis::AnalysisPreset::Security,
+        "identity" => analysis::AnalysisPreset::Identity,
+        "git" => analysis::AnalysisPreset::Git,
+        "deep" => analysis::AnalysisPreset::Deep,
+        "fun" => analysis::AnalysisPreset::Fun,
+        _ => {
+            return Err(error::TokmdError::invalid_field(
+                "preset",
+                "'receipt', 'estimate', 'health', 'risk', 'supply', 'architecture', 'topics', 'security', 'identity', 'git', 'deep', or 'fun'",
+            )
+            .into());
+        }
+    };
+    Ok((preset, normalized))
+}
+
+fn parse_import_granularity(value: &str) -> Result<(analysis::ImportGranularity, String)> {
+    let normalized = value.trim().to_ascii_lowercase();
+    let granularity = match normalized.as_str() {
+        "module" => analysis::ImportGranularity::Module,
+        "file" => analysis::ImportGranularity::File,
+        _ => {
+            return Err(
+                error::TokmdError::invalid_field("granularity", "'module' or 'file'").into(),
+            );
+        }
+    };
+    Ok((granularity, normalized))
+}
+
+pub(crate) fn parse_effort_request(
+    analyze: &AnalyzeSettings,
+    preset: &str,
+) -> Result<Option<analysis::EffortRequest>> {
+    let request = analysis::EffortRequest::default();
+    let requested = preset == "estimate"
+        || analyze.effort_model.is_some()
+        || analyze.effort_layer.is_some()
+        || analyze.effort_base_ref.is_some()
+        || analyze.effort_head_ref.is_some()
+        || analyze.effort_monte_carlo.unwrap_or(false)
+        || analyze.effort_mc_iterations.is_some()
+        || analyze.effort_mc_seed.is_some();
+
+    if !requested {
+        return Ok(None);
+    }
+
+    if (analyze.effort_base_ref.is_some() && analyze.effort_head_ref.is_none())
+        || (analyze.effort_base_ref.is_none() && analyze.effort_head_ref.is_some())
+    {
+        return Err(error::TokmdError::invalid_field(
+            "effort_base_ref/effort_head_ref",
+            "both effort_base_ref and effort_head_ref must be provided together",
+        )
+        .into());
+    }
+
+    let model = analyze
+        .effort_model
+        .as_deref()
+        .map(parse_effort_model)
+        .transpose()?
+        .unwrap_or(request.model);
+    let layer = analyze
+        .effort_layer
+        .as_deref()
+        .map(parse_effort_layer)
+        .transpose()?
+        .unwrap_or(request.layer);
+
+    let monte_carlo = analyze.effort_monte_carlo.unwrap_or(false);
+
+    let mc_iterations = analyze
+        .effort_mc_iterations
+        .unwrap_or(request.mc_iterations);
+
+    if mc_iterations == 0 {
+        return Err(error::TokmdError::invalid_field(
+            "effort_mc_iterations",
+            "must be greater than 0",
+        )
+        .into());
+    }
+
+    Ok(Some(analysis::EffortRequest {
+        model,
+        layer,
+        base_ref: analyze.effort_base_ref.clone(),
+        head_ref: analyze.effort_head_ref.clone(),
+        monte_carlo,
+        mc_iterations,
+        mc_seed: analyze.effort_mc_seed,
+    }))
+}
+
+fn parse_effort_model(value: &str) -> Result<analysis::EffortModelKind> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "cocomo81-basic" => Ok(analysis::EffortModelKind::Cocomo81Basic),
+        "cocomo2-early" | "ensemble" => Err(error::TokmdError::invalid_field(
+            "effort_model",
+            "only 'cocomo81-basic' is currently supported",
+        )
+        .into()),
+        _ => Err(error::TokmdError::invalid_field("effort_model", "'cocomo81-basic'").into()),
+    }
+}
+
+fn parse_effort_layer(value: &str) -> Result<analysis::EffortLayer> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "headline" => Ok(analysis::EffortLayer::Headline),
+        "why" => Ok(analysis::EffortLayer::Why),
+        "full" => Ok(analysis::EffortLayer::Full),
+        _ => Err(
+            error::TokmdError::invalid_field("effort_layer", "'headline', 'why', or 'full'").into(),
+        ),
+    }
+}
+
+fn child_include_mode_to_string(mode: ChildIncludeMode) -> String {
+    match mode {
+        ChildIncludeMode::Separate => "separate".to_string(),
+        ChildIncludeMode::ParentsOnly => "parents-only".to_string(),
+    }
+}
+
+fn derive_analysis_root(scan: &ScanSettings) -> Option<PathBuf> {
+    let first = scan.paths.first()?;
+    if first.trim().is_empty() {
+        return None;
+    }
+
+    let candidate = PathBuf::from(first);
+    let absolute = if candidate.is_absolute() {
+        candidate
+    } else {
+        std::env::current_dir().ok()?.join(candidate)
+    };
+
+    if absolute.is_dir() {
+        Some(absolute)
+    } else {
+        absolute.parent().map(|p| p.to_path_buf())
+    }
+}

--- a/crates/tokmd-core/src/workflows/mod.rs
+++ b/crates/tokmd-core/src/workflows/mod.rs
@@ -1,10 +1,18 @@
 //! Public workflow facade owner modules.
 
+#[cfg(feature = "analysis")]
+mod analyze;
 mod diff;
 mod export;
 mod lang;
 mod module;
 
+#[cfg(feature = "analysis")]
+pub use analyze::{
+    analyze_workflow, analyze_workflow_from_inputs, supports_rootless_in_memory_analyze_preset,
+};
+#[cfg(all(test, feature = "analysis"))]
+pub(crate) use analyze::{parse_analysis_preset, parse_effort_request};
 pub use diff::diff_workflow;
 pub use export::{export_workflow, export_workflow_from_inputs};
 pub use lang::{lang_workflow, lang_workflow_from_inputs};

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 1228; workflow coordinator 9; language workflow owner 77; module workflow owner 87; export workflow owner 98; diff workflow owner 41; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, export, and diff workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is analysis/cockpit workflow facade without changing public APIs |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 968; workflow coordinator 19; language workflow owner 77; module workflow owner 87; export workflow owner 98; diff workflow owner 41; analysis workflow owner 400; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, export, diff, and analysis workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is cockpit workflow facade without changing public APIs |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -205,6 +205,7 @@ crates/tokmd-core/src/
     module.rs             # module workflow owner
     export.rs             # file export workflow owner
     diff.rs               # diff workflow owner
+    analyze.rs            # analysis workflow owner
   ffi.rs                  # public run_json coordinator during staged split
   ffi/
     inputs.rs             # in-memory input decoding and path validation
@@ -219,15 +220,16 @@ Current checkpoint: in-memory input decoding/path validation and strict JSON
 field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`, and
 mode-specific settings construction has moved into `ffi/settings_parse.rs`.
 Mode dispatch has moved into `ffi/modes.rs`, and response-envelope conversion
-has moved into `ffi/envelope.rs`. Language, module, export, and diff workflow
-construction have moved into `workflows/lang.rs`, `workflows/module.rs`,
-`workflows/export.rs`, and `workflows/diff.rs` while the root
+has moved into `ffi/envelope.rs`. Language, module, export, diff, and analysis
+workflow construction have moved into `workflows/lang.rs`, `workflows/module.rs`,
+`workflows/export.rs`, `workflows/diff.rs`, and `workflows/analyze.rs` while the root
 `tokmd_core::lang_workflow`, `tokmd_core::lang_workflow_from_inputs`,
 `tokmd_core::module_workflow`, `tokmd_core::module_workflow_from_inputs`,
 `tokmd_core::export_workflow`, `tokmd_core::export_workflow_from_inputs`, and
-`tokmd_core::diff_workflow` exports remain stable. `ffi.rs` still owns public
-`run_json` while that public binding boundary remains staged, and `lib.rs`
-still owns the remaining analyze/cockpit workflow facade helpers.
+`tokmd_core::diff_workflow`, `tokmd_core::analyze_workflow`, and
+`tokmd_core::analyze_workflow_from_inputs` exports remain stable. `ffi.rs` still
+owns public `run_json` while that public binding boundary remains staged, and
+`lib.rs` still owns the remaining cockpit workflow facade helper.
 
 Required proof:
 


### PR DESCRIPTION
## Summary
- Move the `tokmd-core` analysis workflow facade and analysis request helpers into `crates/tokmd-core/src/workflows/analyze.rs`.
- Preserve the root `tokmd_core::analyze_workflow`, `tokmd_core::analyze_workflow_from_inputs`, and rootless in-memory preset helper exports.
- Add the focused analyze workflow proof command to `ci/proof.toml` and update the architecture consolidation checkpoint.

## Behavior
- No schema, receipt, CLI, FFI, or publish-surface behavior changes intended.
- `lib.rs` remains the public facade and now delegates analysis workflow ownership through `workflows`.

## Validation
- `cargo test -p tokmd-core --all-features analyze_workflow --verbose`
- `cargo test -p tokmd-core --all-features parse_analysis_preset --verbose`
- `cargo test -p tokmd-core --all-features effort --verbose`
- `cargo clippy -p tokmd-core --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask proof-artifacts-check`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`

Affected proof plan scopes: `project_truth_docs`, `proof_control_plane`, `tokmd_core_ffi`; unknown files: none.