### PR TITLE
refactor(core): extract cockpit workflow owner

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -862,6 +862,7 @@ kind = "rust"
 paths = [
   ".github/workflows/cockpit.yml",
   "crates/tokmd-cockpit/**",
+  "crates/tokmd-core/src/workflows/cockpit.rs",
   "crates/tokmd-core/tests/cockpit_workflow.rs",
   "crates/tokmd-types/src/cockpit.rs",
   "crates/tokmd-types/tests/cockpit_tests.rs",

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -66,6 +66,10 @@ pub mod settings;
 mod workflows;
 pub use tokmd_scan::InMemoryFile;
 pub use tokmd_types as types;
+#[cfg(feature = "cockpit")]
+pub use workflows::cockpit_workflow;
+#[cfg(all(test, feature = "cockpit"))]
+use workflows::parse_cockpit_range_mode;
 #[cfg(feature = "analysis")]
 pub use workflows::{
     analyze_workflow, analyze_workflow_from_inputs, supports_rootless_in_memory_analyze_preset,
@@ -103,99 +107,6 @@ fn now_ms() -> u128 {
 // =============================================================================
 // Settings-based workflows (new API for bindings)
 // =============================================================================
-
-// =============================================================================
-// Cockpit workflow (requires `cockpit` feature)
-// =============================================================================
-
-/// Cockpit workflow: compute PR metrics and evidence gates.
-///
-/// Runs the cockpit analysis pipeline using pure settings types.
-///
-/// # Arguments
-///
-/// * `settings` - Cockpit settings (base/head refs, range mode, baseline)
-///
-/// # Returns
-///
-/// A `CockpitReceipt` containing PR metrics, evidence gates, and review plan.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// use tokmd_core::{cockpit_workflow, settings::CockpitSettings};
-///
-/// let settings = CockpitSettings {
-///     base: "HEAD~1".to_string(),
-///     head: "HEAD".to_string(),
-///     range_mode: "2dot".to_string(),
-///     ..Default::default()
-/// };
-///
-/// let receipt = cockpit_workflow(&settings).expect("Cockpit scan failed");
-/// assert!(!receipt.review_plan.is_empty());
-/// ```
-#[cfg(feature = "cockpit")]
-pub fn cockpit_workflow(
-    settings: &settings::CockpitSettings,
-) -> Result<tokmd_types::cockpit::CockpitReceipt> {
-    use tokmd_types::cockpit::CockpitReceipt;
-
-    if !tokmd_git::git_available() {
-        anyhow::bail!("git is not available on PATH");
-    }
-
-    let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
-    let repo_root =
-        tokmd_git::repo_root(&cwd).ok_or_else(|| anyhow::anyhow!("not inside a git repository"))?;
-
-    let range_mode = parse_cockpit_range_mode(&settings.range_mode)?;
-
-    let resolved_base =
-        tokmd_git::resolve_base_ref(&repo_root, &settings.base).ok_or_else(|| {
-            anyhow::anyhow!(
-                "base ref '{}' not found and no fallback resolved",
-                settings.base
-            )
-        })?;
-
-    let baseline_path = settings.baseline.as_deref();
-
-    let mut receipt: CockpitReceipt = tokmd_cockpit::compute_cockpit(
-        &repo_root,
-        &resolved_base,
-        &settings.head,
-        range_mode,
-        baseline_path.map(std::path::Path::new),
-    )?;
-
-    // Load baseline and compute trend if provided
-    if let Some(baseline_path) = baseline_path {
-        receipt.trend = Some(tokmd_cockpit::load_and_compute_trend(
-            std::path::Path::new(baseline_path),
-            &receipt,
-        )?);
-    }
-
-    Ok(receipt)
-}
-
-#[cfg(feature = "cockpit")]
-fn parse_cockpit_range_mode(value: &str) -> Result<tokmd_git::GitRangeMode> {
-    let normalized = value.trim().to_ascii_lowercase();
-    match normalized.as_str() {
-        "two-dot" | "2dot" => Ok(tokmd_git::GitRangeMode::TwoDot),
-        "three-dot" | "3dot" => Ok(tokmd_git::GitRangeMode::ThreeDot),
-        _ => Err(error::TokmdError::invalid_field(
-            "range_mode",
-            "'two-dot', '2dot', 'three-dot', or '3dot'",
-        )
-        .into()),
-    }
-}
-
-#[cfg(feature = "cockpit")]
-use anyhow::Context as _;
 
 // =============================================================================
 // Analysis formatting facade (requires `analysis` feature)

--- a/crates/tokmd-core/src/workflows/cockpit.rs
+++ b/crates/tokmd-core/src/workflows/cockpit.rs
@@ -1,0 +1,90 @@
+//! Cockpit workflow facade.
+
+use anyhow::{Context as _, Result};
+
+use crate::error;
+use crate::settings::CockpitSettings;
+
+/// Cockpit workflow: compute PR metrics and evidence gates.
+///
+/// Runs the cockpit analysis pipeline using pure settings types.
+///
+/// # Arguments
+///
+/// * `settings` - Cockpit settings (base/head refs, range mode, baseline)
+///
+/// # Returns
+///
+/// A `CockpitReceipt` containing PR metrics, evidence gates, and review plan.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tokmd_core::{cockpit_workflow, settings::CockpitSettings};
+///
+/// let settings = CockpitSettings {
+///     base: "HEAD~1".to_string(),
+///     head: "HEAD".to_string(),
+///     range_mode: "2dot".to_string(),
+///     ..Default::default()
+/// };
+///
+/// let receipt = cockpit_workflow(&settings).expect("Cockpit scan failed");
+/// assert!(!receipt.review_plan.is_empty());
+/// ```
+pub fn cockpit_workflow(
+    settings: &CockpitSettings,
+) -> Result<tokmd_types::cockpit::CockpitReceipt> {
+    use tokmd_types::cockpit::CockpitReceipt;
+
+    if !tokmd_git::git_available() {
+        anyhow::bail!("git is not available on PATH");
+    }
+
+    let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
+    let repo_root =
+        tokmd_git::repo_root(&cwd).ok_or_else(|| anyhow::anyhow!("not inside a git repository"))?;
+
+    let range_mode = parse_cockpit_range_mode(&settings.range_mode)?;
+
+    let resolved_base =
+        tokmd_git::resolve_base_ref(&repo_root, &settings.base).ok_or_else(|| {
+            anyhow::anyhow!(
+                "base ref '{}' not found and no fallback resolved",
+                settings.base
+            )
+        })?;
+
+    let baseline_path = settings.baseline.as_deref();
+
+    let mut receipt: CockpitReceipt = tokmd_cockpit::compute_cockpit(
+        &repo_root,
+        &resolved_base,
+        &settings.head,
+        range_mode,
+        baseline_path.map(std::path::Path::new),
+    )?;
+
+    // Load baseline and compute trend if provided.
+    if let Some(baseline_path) = baseline_path {
+        receipt.trend = Some(tokmd_cockpit::load_and_compute_trend(
+            std::path::Path::new(baseline_path),
+            &receipt,
+        )?);
+    }
+
+    Ok(receipt)
+}
+
+pub(crate) fn parse_cockpit_range_mode(value: &str) -> Result<tokmd_git::GitRangeMode> {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "two-dot" | "2dot" => Ok(tokmd_git::GitRangeMode::TwoDot),
+        "three-dot" | "3dot" => Ok(tokmd_git::GitRangeMode::ThreeDot),
+        _ => Err(error::TokmdError::invalid_field(
+            "range_mode",
+            "'two-dot', '2dot', 'three-dot', or '3dot'",
+        )
+        .into()),
+    }
+}

--- a/crates/tokmd-core/src/workflows/mod.rs
+++ b/crates/tokmd-core/src/workflows/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "analysis")]
 mod analyze;
+#[cfg(feature = "cockpit")]
+mod cockpit;
 mod diff;
 mod export;
 mod lang;
@@ -13,6 +15,10 @@ pub use analyze::{
 };
 #[cfg(all(test, feature = "analysis"))]
 pub(crate) use analyze::{parse_analysis_preset, parse_effort_request};
+#[cfg(feature = "cockpit")]
+pub use cockpit::cockpit_workflow;
+#[cfg(all(test, feature = "cockpit"))]
+pub(crate) use cockpit::parse_cockpit_range_mode;
 pub use diff::diff_workflow;
 pub use export::{export_workflow, export_workflow_from_inputs};
 pub use lang::{lang_workflow, lang_workflow_from_inputs};

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,7 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, and `crates/tokmd/src/commands/context.rs` | `context_pack.rs` 15; selection submodule/tests 1896; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218 | Budget parsing, file selection, bundle text rendering, single-output/log writing, and context bundle manifest writing now live in owner modules; keep context/handoff proof scoped while CLI parser splits continue |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
-| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 968; workflow coordinator 19; language workflow owner 77; module workflow owner 87; export workflow owner 98; diff workflow owner 41; analysis workflow owner 400; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, export, diff, and analysis workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is cockpit workflow facade without changing public APIs |
+| Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/workflows/`, `crates/tokmd-core/src/ffi.rs`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 879; workflow coordinator 25; language workflow owner 77; module workflow owner 87; export workflow owner 98; diff workflow owner 41; analysis workflow owner 400; cockpit workflow owner 90; `ffi.rs` 1016; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, export, diff, analysis, and cockpit workflow facades now live under `workflows/`; in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is public FFI coordinator cleanup without changing public APIs |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/details.rs` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 301 + 343 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, split language/source/summary helpers and local unit tests |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 1022; analyze parser owner 217; context/handoff parser owner 208; cockpit/baseline parser owner 109 | Context, handoff, analyze, cockpit, and baseline argument families now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
 | Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
@@ -206,6 +206,7 @@ crates/tokmd-core/src/
     export.rs             # file export workflow owner
     diff.rs               # diff workflow owner
     analyze.rs            # analysis workflow owner
+    cockpit.rs            # cockpit workflow owner
   ffi.rs                  # public run_json coordinator during staged split
   ffi/
     inputs.rs             # in-memory input decoding and path validation
@@ -220,16 +221,18 @@ Current checkpoint: in-memory input decoding/path validation and strict JSON
 field parsing have moved into `ffi/inputs.rs` and `ffi/parse.rs`, and
 mode-specific settings construction has moved into `ffi/settings_parse.rs`.
 Mode dispatch has moved into `ffi/modes.rs`, and response-envelope conversion
-has moved into `ffi/envelope.rs`. Language, module, export, diff, and analysis
-workflow construction have moved into `workflows/lang.rs`, `workflows/module.rs`,
-`workflows/export.rs`, `workflows/diff.rs`, and `workflows/analyze.rs` while the root
+has moved into `ffi/envelope.rs`. Language, module, export, diff, analysis, and
+cockpit workflow construction have moved into `workflows/lang.rs`,
+`workflows/module.rs`, `workflows/export.rs`, `workflows/diff.rs`,
+`workflows/analyze.rs`, and `workflows/cockpit.rs` while the root
 `tokmd_core::lang_workflow`, `tokmd_core::lang_workflow_from_inputs`,
 `tokmd_core::module_workflow`, `tokmd_core::module_workflow_from_inputs`,
 `tokmd_core::export_workflow`, `tokmd_core::export_workflow_from_inputs`, and
 `tokmd_core::diff_workflow`, `tokmd_core::analyze_workflow`, and
-`tokmd_core::analyze_workflow_from_inputs` exports remain stable. `ffi.rs` still
-owns public `run_json` while that public binding boundary remains staged, and
-`lib.rs` still owns the remaining cockpit workflow facade helper.
+`tokmd_core::analyze_workflow_from_inputs`, and `tokmd_core::cockpit_workflow`
+exports remain stable. `ffi.rs` still owns public `run_json` while that public
+binding boundary remains staged, and `lib.rs` remains the root facade and shared
+receipt helper owner.
 
 Required proof:
 


### PR DESCRIPTION
## Summary
- move the cockpit workflow facade and range-mode parser from `tokmd-core/src/lib.rs` into `tokmd-core/src/workflows/cockpit.rs`
- preserve the root `tokmd_core::cockpit_workflow` export, feature gating, schema behavior, and receipt semantics
- map the new owner file into the `tokmd_cockpit` proof scope and update the architecture consolidation checkpoint

## Validation
- `cargo test -p tokmd-core --features cockpit cockpit_workflow --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-core --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask proof-artifacts-check`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p tokmd-core ffi --verbose`
- `cargo test -p tokmd-core --test ffi_parity_w53 --verbose`
- `cargo test -p tokmd-core diff_workflow --verbose`
- `cargo test -p tokmd-core --all-features analyze_workflow --verbose`
- `git diff --check origin/main..HEAD`