### PR TITLE
perf(model): avoid normalize_path prefix allocations

### DIFF
--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -95,39 +95,16 @@ pub fn normalize_path(path: &Path, strip_prefix: Option<&Path>) -> String {
     if let Some(prefix) = strip_prefix {
         let p_cow = prefix.to_string_lossy();
         // Strip leading ./ from prefix so it can match normalized paths
-        let p_cow_stripped: Cow<str> = if let Some(stripped) = p_cow.strip_prefix("./") {
-            Cow::Borrowed(stripped)
-        } else {
-            p_cow
-        };
+        let p_source = p_cow.as_ref();
+        let mut p_slice = p_source.strip_prefix("./").unwrap_or(p_source);
+        let normalized_prefix;
+        if p_slice.contains('\\') {
+            normalized_prefix = p_slice.replace('\\', "/");
+            p_slice = &normalized_prefix;
+        }
 
-        let needs_replace = p_cow_stripped.contains('\\');
-        let needs_slash = !p_cow_stripped.ends_with('/');
-
-        if !needs_replace && !needs_slash {
-            // Fast path: prefix is already clean and ends with slash
-            if slice.starts_with(p_cow_stripped.as_ref()) {
-                slice = &slice[p_cow_stripped.len()..];
-            }
-        } else {
-            // Slow path: avoid string allocation if not replacing
-            let pfx: Cow<str> = if needs_replace {
-                let mut pfx = p_cow_stripped.replace('\\', "/");
-                if needs_slash {
-                    pfx.push('/');
-                }
-                Cow::Owned(pfx)
-            } else if needs_slash {
-                let mut pfx = p_cow_stripped.into_owned();
-                pfx.push('/');
-                Cow::Owned(pfx)
-            } else {
-                p_cow_stripped.clone()
-            };
-
-            if slice.starts_with(pfx.as_ref()) {
-                slice = &slice[pfx.len()..];
-            }
+        if let Some(stripped) = strip_path_prefix(slice, p_slice) {
+            slice = stripped;
         }
     }
 
@@ -143,6 +120,15 @@ pub fn normalize_path(path: &Path, strip_prefix: Option<&Path>) -> String {
         s.into_owned()
     } else {
         slice.to_string()
+    }
+}
+
+fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
+    if prefix.ends_with('/') {
+        path.strip_prefix(prefix)
+    } else {
+        path.strip_prefix(prefix)
+            .and_then(|stripped| stripped.strip_prefix('/'))
     }
 }
 

--- a/crates/tokmd-model/tests/bdd_normalize_path.rs
+++ b/crates/tokmd-model/tests/bdd_normalize_path.rs
@@ -14,6 +14,22 @@ fn normalize_path_prefix_partial_match() {
 }
 
 #[test]
+fn normalize_path_prefix_exact_match_keeps_path() {
+    let path = PathBuf::from("project");
+    let prefix = PathBuf::from("project");
+
+    assert_eq!(normalize_path(&path, Some(&prefix)), "project");
+}
+
+#[test]
+fn normalize_path_prefix_without_separator_strips_child() {
+    let path = PathBuf::from("project/src/lib.rs");
+    let prefix = PathBuf::from("project");
+
+    assert_eq!(normalize_path(&path, Some(&prefix)), "src/lib.rs");
+}
+
+#[test]
 fn normalize_path_prefix_mixed_slashes() {
     let path = PathBuf::from("my/prefix/dir/file.rs");
     let prefix = PathBuf::from("my\\prefix/");


### PR DESCRIPTION
## Summary

- avoid building a temporary `prefix/` string in `tokmd_model::normalize_path` when the prefix is already clean
- preserve directory-boundary stripping semantics, including the exact-prefix case
- add focused BDD coverage for exact-prefix and child-prefix behavior

Supersedes draft #2050 with a current-main keeper that drops the accidental root `commit_message.txt` artifact and preserves the existing exact-prefix boundary behavior.

## Validation

- `cargo test -p tokmd-model normalize_path --verbose`
- `cargo test -p tokmd-model --test bdd_normalize_path --verbose`
- `cargo test -p tokmd-model --test model_tests normalize_path --verbose`
- `cargo test -p tokmd-scan normalize --verbose`
- `cargo clippy -p tokmd-model --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-artifacts-check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask publish-surface --json --verify-publish`