### PR TITLE
refactor(analysis): extract derived integrity owner

### DIFF
--- a/crates/tokmd-analysis/src/derived/integrity.rs
+++ b/crates/tokmd-analysis/src/derived/integrity.rs
@@ -1,0 +1,143 @@
+use tokmd_analysis_types::IntegrityReport;
+use tokmd_types::FileRow;
+
+pub(super) fn build_integrity_report(rows: &[&FileRow]) -> IntegrityReport {
+    let mut sorted_rows = rows.to_vec();
+    sorted_rows.sort_unstable_by(|&a, &b| compare_integrity_rows(a, b));
+
+    let mut hasher = blake3::Hasher::new();
+    let mut first = true;
+    for row in sorted_rows {
+        if !first {
+            hasher.update(b"\n");
+        }
+        first = false;
+        hasher.update(row.path.as_bytes());
+        hasher.update(b":");
+        hasher.update(row.bytes.to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(row.lines.to_string().as_bytes());
+    }
+
+    IntegrityReport {
+        algo: "blake3".to_string(),
+        hash: hasher.finalize().to_hex().to_string(),
+        entries: rows.len(),
+    }
+}
+
+fn compare_integrity_rows(a: &FileRow, b: &FileRow) -> std::cmp::Ordering {
+    let a_bytes = a.path.as_bytes();
+    let b_bytes = b.path.as_bytes();
+    let min_len = a_bytes.len().min(b_bytes.len());
+
+    let ord = a_bytes[..min_len].cmp(&b_bytes[..min_len]);
+    if ord != std::cmp::Ordering::Equal {
+        return ord;
+    }
+
+    if a_bytes.len() == b_bytes.len() {
+        return compare_usize_pair_ascii(a.bytes, a.lines, b.bytes, b.lines);
+    }
+
+    if a_bytes.len() < b_bytes.len() {
+        b':'.cmp(&b_bytes[min_len])
+    } else {
+        a_bytes[min_len].cmp(&b':')
+    }
+}
+
+fn compare_usize_pair_ascii(
+    a_bytes: usize,
+    a_lines: usize,
+    b_bytes: usize,
+    b_lines: usize,
+) -> std::cmp::Ordering {
+    let mut a_buf = [0_u8; 64];
+    let mut b_buf = [0_u8; 64];
+    let a_len = write_usize_pair_ascii(&mut a_buf, a_bytes, a_lines);
+    let b_len = write_usize_pair_ascii(&mut b_buf, b_bytes, b_lines);
+    a_buf[..a_len].cmp(&b_buf[..b_len])
+}
+
+fn write_usize_pair_ascii(buf: &mut [u8; 64], bytes: usize, lines: usize) -> usize {
+    let mut len = write_usize_ascii(&mut buf[..], bytes);
+    buf[len] = b':';
+    len += 1;
+    len + write_usize_ascii(&mut buf[len..], lines)
+}
+
+fn write_usize_ascii(buf: &mut [u8], value: usize) -> usize {
+    if value == 0 {
+        buf[0] = b'0';
+        return 1;
+    }
+
+    let mut digits = 0;
+    let mut n = value;
+    while n > 0 {
+        digits += 1;
+        n /= 10;
+    }
+
+    debug_assert!(digits <= buf.len());
+
+    let mut n = value;
+    for idx in (0..digits).rev() {
+        buf[idx] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+    digits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokmd_types::FileKind;
+
+    fn make_row(path: &str, bytes: usize, lines: usize) -> FileRow {
+        FileRow {
+            path: path.to_string(),
+            module: "mod".to_string(),
+            lang: "rust".to_string(),
+            kind: FileKind::Parent,
+            code: 0,
+            comments: 0,
+            blanks: 0,
+            lines,
+            bytes,
+            tokens: 0,
+        }
+    }
+
+    #[test]
+    fn compare_integrity_rows_matches_string_sort() {
+        let cases = vec![
+            ("a", 10, 10, "b", 10, 10),
+            ("a", 10, 10, "a", 10, 10),
+            ("a", 10, 10, "a", 20, 10),
+            ("a", 100, 10, "a", 20, 10),
+            ("a", 10, 10, "a.b", 10, 10),
+            ("a.b", 10, 10, "a", 10, 10),
+            ("foo", 10, 10, "foo.bar", 10, 10),
+            ("foo.bar", 10, 10, "foo", 10, 10),
+            ("foo", 10, 10, "foo_bar", 10, 10),
+            ("a", usize::MAX, 0, "a", 9, usize::MAX),
+            ("a", 0, usize::MAX, "a", 0, 9),
+            ("a", 999, 0, "a", 1000, 0),
+            ("a", 10, 2, "a", 10, 10),
+        ];
+
+        for (p1, b1, l1, p2, b2, l2) in cases {
+            let r1 = make_row(p1, b1, l1);
+            let r2 = make_row(p2, b2, l2);
+
+            let s1 = format!("{p1}:{b1}:{l1}");
+            let s2 = format!("{p2}:{b2}:{l2}");
+            let expected = s1.cmp(&s2);
+            let actual = compare_integrity_rows(&r1, &r2);
+
+            assert_eq!(actual, expected, "Failed for {s1} vs {s2}");
+        }
+    }
+}

--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -2,9 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use tokmd_analysis_types::{
     BoilerplateReport, CocomoReport, ContextWindowReport, DerivedReport, DerivedTotals,
-    DistributionReport, FileStatRow, HistogramBucket, IntegrityReport, LangPurityReport,
-    LangPurityRow, MaxFileReport, MaxFileRow, NestingReport, NestingRow, PolyglotReport,
-    RateReport, RateRow, RatioReport, RatioRow, ReadingTimeReport, TestDensityReport, TopOffenders,
+    DistributionReport, FileStatRow, HistogramBucket, LangPurityReport, LangPurityRow,
+    MaxFileReport, MaxFileRow, NestingReport, NestingRow, PolyglotReport, RateReport, RateRow,
+    RatioReport, RatioRow, ReadingTimeReport, TestDensityReport, TopOffenders,
 };
 use tokmd_analysis_types::{empty_file_row, is_infra_lang, is_test_path, path_depth};
 use tokmd_format::render_analysis_tree;
@@ -12,6 +12,9 @@ use tokmd_scan::{gini_coefficient, percentile, round_f64, safe_ratio};
 use tokmd_types::{ExportData, FileKind, FileRow};
 
 use crate::cocomo81_core::{COCOMO81_COEFFICIENTS, cocomo81_effort_pm};
+
+mod integrity;
+use integrity::build_integrity_report;
 
 const LINES_PER_MINUTE: usize = 20;
 const TOP_N: usize = 10;
@@ -692,161 +695,6 @@ fn build_top_offenders(rows: &[FileStatRow]) -> TopOffenders {
         largest_bytes: by_bytes.into_iter().take(TOP_N).cloned().collect(),
         least_documented: least_doc.into_iter().take(TOP_N).cloned().collect(),
         most_dense: dense.into_iter().take(TOP_N).cloned().collect(),
-    }
-}
-
-fn build_integrity_report(rows: &[&FileRow]) -> IntegrityReport {
-    let mut sorted_rows = rows.to_vec();
-    sorted_rows.sort_unstable_by(|&a, &b| compare_integrity_rows(a, b));
-
-    let mut hasher = blake3::Hasher::new();
-    let mut first = true;
-    for row in sorted_rows {
-        if !first {
-            hasher.update(b"\n");
-        }
-        first = false;
-        hasher.update(row.path.as_bytes());
-        hasher.update(b":");
-        hasher.update(row.bytes.to_string().as_bytes());
-        hasher.update(b":");
-        hasher.update(row.lines.to_string().as_bytes());
-    }
-
-    IntegrityReport {
-        algo: "blake3".to_string(),
-        hash: hasher.finalize().to_hex().to_string(),
-        entries: rows.len(),
-    }
-}
-
-fn compare_integrity_rows(a: &FileRow, b: &FileRow) -> std::cmp::Ordering {
-    let a_bytes = a.path.as_bytes();
-    let b_bytes = b.path.as_bytes();
-    let min_len = a_bytes.len().min(b_bytes.len());
-
-    // Fast slice compare for common prefix
-    let ord = a_bytes[..min_len].cmp(&b_bytes[..min_len]);
-    if ord != std::cmp::Ordering::Equal {
-        return ord;
-    }
-
-    // Paths are identical or one is prefix of other
-    if a_bytes.len() == b_bytes.len() {
-        // Identical paths. Compare numbers.
-        // We must emulate string sort of "bytes:lines".
-        return compare_usize_pair_ascii(a.bytes, a.lines, b.bytes, b.lines);
-    }
-
-    // One is shorter.
-    // The separator is ':'.
-    if a_bytes.len() < b_bytes.len() {
-        // a is prefix of b.
-        // Effective string a: "path:..."
-        // Effective string b: "path..."
-        // Compare ':' vs b[min_len]
-        b':'.cmp(&b_bytes[min_len])
-    } else {
-        // b is prefix of a.
-        // Effective string a: "path..."
-        // Effective string b: "path:..."
-        // Compare a[min_len] vs ':'
-        a_bytes[min_len].cmp(&b':')
-    }
-}
-
-fn compare_usize_pair_ascii(
-    a_bytes: usize,
-    a_lines: usize,
-    b_bytes: usize,
-    b_lines: usize,
-) -> std::cmp::Ordering {
-    let mut a_buf = [0_u8; 64];
-    let mut b_buf = [0_u8; 64];
-    let a_len = write_usize_pair_ascii(&mut a_buf, a_bytes, a_lines);
-    let b_len = write_usize_pair_ascii(&mut b_buf, b_bytes, b_lines);
-    a_buf[..a_len].cmp(&b_buf[..b_len])
-}
-
-fn write_usize_pair_ascii(buf: &mut [u8; 64], bytes: usize, lines: usize) -> usize {
-    let mut len = write_usize_ascii(&mut buf[..], bytes);
-    buf[len] = b':';
-    len += 1;
-    len + write_usize_ascii(&mut buf[len..], lines)
-}
-
-fn write_usize_ascii(buf: &mut [u8], value: usize) -> usize {
-    if value == 0 {
-        buf[0] = b'0';
-        return 1;
-    }
-
-    let mut digits = 0;
-    let mut n = value;
-    while n > 0 {
-        digits += 1;
-        n /= 10;
-    }
-
-    debug_assert!(digits <= buf.len());
-
-    let mut n = value;
-    for idx in (0..digits).rev() {
-        buf[idx] = b'0' + (n % 10) as u8;
-        n /= 10;
-    }
-    digits
-}
-
-#[cfg(test)]
-mod unit_tests {
-    use super::*;
-    use tokmd_types::{FileKind, FileRow};
-
-    fn make_row(path: &str, bytes: usize, lines: usize) -> FileRow {
-        FileRow {
-            path: path.to_string(),
-            module: "mod".to_string(),
-            lang: "rust".to_string(),
-            kind: FileKind::Parent,
-            code: 0,
-            comments: 0,
-            blanks: 0,
-            lines,
-            bytes,
-            tokens: 0,
-        }
-    }
-
-    #[test]
-    fn test_compare_integrity_rows_matches_string_sort() {
-        let cases = vec![
-            ("a", 10, 10, "b", 10, 10),
-            ("a", 10, 10, "a", 10, 10),
-            ("a", 10, 10, "a", 20, 10),
-            ("a", 100, 10, "a", 20, 10), // "100" < "20" as string? No, '1' < '2'. So "100" < "20".
-            ("a", 10, 10, "a.b", 10, 10),
-            ("a.b", 10, 10, "a", 10, 10),
-            ("foo", 10, 10, "foo.bar", 10, 10),
-            ("foo.bar", 10, 10, "foo", 10, 10),
-            ("foo", 10, 10, "foo_bar", 10, 10),
-            ("a", usize::MAX, 0, "a", 9, usize::MAX),
-            ("a", 0, usize::MAX, "a", 0, 9),
-            ("a", 999, 0, "a", 1000, 0),
-            ("a", 10, 2, "a", 10, 10),
-        ];
-
-        for (p1, b1, l1, p2, b2, l2) in cases {
-            let r1 = make_row(p1, b1, l1);
-            let r2 = make_row(p2, b2, l2);
-
-            let s1 = format!("{}:{}:{}", p1, b1, l1);
-            let s2 = format!("{}:{}:{}", p2, b2, l2);
-            let expected = s1.cmp(&s2);
-            let actual = compare_integrity_rows(&r1, &r2);
-
-            assert_eq!(actual, expected, "Failed for {} vs {}", s1, s2);
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Extract derived-report integrity hashing and deterministic row ordering into `derived::integrity`
- Keep `derived::mod` focused on report assembly and other derived subreport builders
- Move the existing integrity row-ordering unit test with the owner module

## Affected proof
`cargo xtask affected --base origin/main --head HEAD --json` maps this change to `analysis_derived` with no unknown files.

`cargo xtask proof --profile affected --base origin/main --head HEAD --plan` selects:
- required: `cargo test -p tokmd-analysis --all-features derived --verbose`
- required: `cargo test -p tokmd-analysis --all-features mutant --verbose`
- advisory coverage/mutation commands for the changed derived files

## Validation
- `cargo test -p tokmd-analysis --all-features derived`
- `cargo test -p tokmd-analysis --all-features mutant`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask publish-surface --json --verify-publish`

## Notes
- No receipt/schema/CLI behavior changes intended.
- `cargo test -p tokmd-analysis --all-features derived --verbose` was attempted first but the local tool wrapper timed out and closed the pipe while listing a large filtered test set; the same proof completed cleanly without `--verbose`.