### PR TITLE
refactor(analysis): extract derived distribution owner

### DIFF
--- a/crates/tokmd-analysis/src/derived/distribution.rs
+++ b/crates/tokmd-analysis/src/derived/distribution.rs
@@ -1,0 +1,87 @@
+use tokmd_analysis_types::{DistributionReport, HistogramBucket};
+use tokmd_scan::{gini_coefficient, percentile, round_f64};
+use tokmd_types::FileRow;
+
+pub(super) fn build_distribution_report(rows: &[&FileRow]) -> DistributionReport {
+    let mut sizes: Vec<usize> = rows.iter().map(|r| r.lines).collect();
+    sizes.sort();
+
+    if sizes.is_empty() {
+        return DistributionReport {
+            count: 0,
+            min: 0,
+            max: 0,
+            mean: 0.0,
+            median: 0.0,
+            p90: 0.0,
+            p99: 0.0,
+            gini: 0.0,
+        };
+    }
+
+    let count = sizes.len();
+    let sum: usize = sizes.iter().sum();
+    let mean = sum as f64 / count as f64;
+    let median = if count % 2 == 1 {
+        sizes[count / 2] as f64
+    } else {
+        (sizes[count / 2 - 1] as f64 + sizes[count / 2] as f64) / 2.0
+    };
+    let p90 = percentile(&sizes, 0.90);
+    let p99 = percentile(&sizes, 0.99);
+    let gini = gini_coefficient(&sizes);
+
+    DistributionReport {
+        count,
+        min: *sizes.first().unwrap_or(&0),
+        max: *sizes.last().unwrap_or(&0),
+        mean: round_f64(mean, 2),
+        median: round_f64(median, 2),
+        p90: round_f64(p90, 2),
+        p99: round_f64(p99, 2),
+        gini: round_f64(gini, 4),
+    }
+}
+
+pub(super) fn build_histogram(rows: &[&FileRow]) -> Vec<HistogramBucket> {
+    let total = rows.len();
+    let buckets = vec![
+        ("Tiny", 0, Some(50)),
+        ("Small", 51, Some(200)),
+        ("Medium", 201, Some(500)),
+        ("Large", 501, Some(1000)),
+        ("Huge", 1001, None),
+    ];
+
+    let mut counts = vec![0usize; buckets.len()];
+    for row in rows {
+        let size = row.lines;
+        for (idx, (_label, min, max)) in buckets.iter().enumerate() {
+            let in_range = if let Some(max) = max {
+                size >= *min && size <= *max
+            } else {
+                size >= *min
+            };
+            if in_range {
+                counts[idx] += 1;
+                break;
+            }
+        }
+    }
+
+    buckets
+        .into_iter()
+        .zip(counts)
+        .map(|((label, min, max), files)| HistogramBucket {
+            label: label.to_string(),
+            min,
+            max,
+            files,
+            pct: if total == 0 {
+                0.0
+            } else {
+                round_f64(files as f64 / total as f64, 4)
+            },
+        })
+        .collect()
+}

--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -2,18 +2,20 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use tokmd_analysis_types::{
     BoilerplateReport, CocomoReport, ContextWindowReport, DerivedReport, DerivedTotals,
-    DistributionReport, FileStatRow, HistogramBucket, LangPurityReport, LangPurityRow,
-    MaxFileReport, MaxFileRow, NestingReport, NestingRow, PolyglotReport, RateReport, RateRow,
-    RatioReport, RatioRow, ReadingTimeReport, TestDensityReport, TopOffenders,
+    FileStatRow, LangPurityReport, LangPurityRow, MaxFileReport, MaxFileRow, NestingReport,
+    NestingRow, PolyglotReport, RateReport, RateRow, RatioReport, RatioRow, ReadingTimeReport,
+    TestDensityReport, TopOffenders,
 };
 use tokmd_analysis_types::{empty_file_row, is_infra_lang, is_test_path, path_depth};
 use tokmd_format::render_analysis_tree;
-use tokmd_scan::{gini_coefficient, percentile, round_f64, safe_ratio};
+use tokmd_scan::{round_f64, safe_ratio};
 use tokmd_types::{ExportData, FileKind, FileRow};
 
 use crate::cocomo81_core::{COCOMO81_COEFFICIENTS, cocomo81_effort_pm};
 
+mod distribution;
 mod integrity;
+use distribution::{build_distribution_report, build_histogram};
 use integrity::build_integrity_report;
 
 const LINES_PER_MINUTE: usize = 20;
@@ -567,90 +569,6 @@ fn build_polyglot_report(rows: &[&FileRow]) -> PolyglotReport {
         dominant_lines,
         dominant_pct,
     }
-}
-
-fn build_distribution_report(rows: &[&FileRow]) -> DistributionReport {
-    let mut sizes: Vec<usize> = rows.iter().map(|r| r.lines).collect();
-    sizes.sort();
-
-    if sizes.is_empty() {
-        return DistributionReport {
-            count: 0,
-            min: 0,
-            max: 0,
-            mean: 0.0,
-            median: 0.0,
-            p90: 0.0,
-            p99: 0.0,
-            gini: 0.0,
-        };
-    }
-
-    let count = sizes.len();
-    let sum: usize = sizes.iter().sum();
-    let mean = sum as f64 / count as f64;
-    let median = if count % 2 == 1 {
-        sizes[count / 2] as f64
-    } else {
-        (sizes[count / 2 - 1] as f64 + sizes[count / 2] as f64) / 2.0
-    };
-    let p90 = percentile(&sizes, 0.90);
-    let p99 = percentile(&sizes, 0.99);
-    let gini = gini_coefficient(&sizes);
-
-    DistributionReport {
-        count,
-        min: *sizes.first().unwrap_or(&0),
-        max: *sizes.last().unwrap_or(&0),
-        mean: round_f64(mean, 2),
-        median: round_f64(median, 2),
-        p90: round_f64(p90, 2),
-        p99: round_f64(p99, 2),
-        gini: round_f64(gini, 4),
-    }
-}
-
-fn build_histogram(rows: &[&FileRow]) -> Vec<HistogramBucket> {
-    let total = rows.len();
-    let buckets = vec![
-        ("Tiny", 0, Some(50)),
-        ("Small", 51, Some(200)),
-        ("Medium", 201, Some(500)),
-        ("Large", 501, Some(1000)),
-        ("Huge", 1001, None),
-    ];
-
-    let mut counts = vec![0usize; buckets.len()];
-    for row in rows {
-        let size = row.lines;
-        for (idx, (_label, min, max)) in buckets.iter().enumerate() {
-            let in_range = if let Some(max) = max {
-                size >= *min && size <= *max
-            } else {
-                size >= *min
-            };
-            if in_range {
-                counts[idx] += 1;
-                break;
-            }
-        }
-    }
-
-    buckets
-        .into_iter()
-        .zip(counts)
-        .map(|((label, min, max), files)| HistogramBucket {
-            label: label.to_string(),
-            min,
-            max,
-            files,
-            pct: if total == 0 {
-                0.0
-            } else {
-                round_f64(files as f64 / total as f64, 4)
-            },
-        })
-        .collect()
 }
 
 pub fn build_tree(export: &ExportData) -> String {


### PR DESCRIPTION
## Summary
- Extract derived distribution and histogram subreport builders into `derived::distribution`
- Keep `derived::mod` focused on report assembly and remaining subreport coordinators
- Preserve derived receipt/schema/CLI behavior

## Affected proof
`cargo xtask affected --base origin/main --head HEAD --json` maps this change to `analysis_derived` with no unknown files.

`cargo xtask proof --profile affected --base origin/main --head HEAD --plan` selects:
- required: `cargo test -p tokmd-analysis --all-features derived --verbose`
- required: `cargo test -p tokmd-analysis --all-features mutant --verbose`
- advisory coverage/mutation commands for the changed derived files

## Validation
- `cargo test -p tokmd-analysis --all-features derived`
- `cargo test -p tokmd-analysis --all-features mutant`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask publish-surface --json --verify-publish`

## Notes
- No proof gate promotion, Codecov change, schema change, or public API change.