### PR TITLE
docs: checkpoint derived owner-module consolidation

### DIFF
--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -63,6 +63,7 @@ fixtures:
 | Analysis API surface | `crates/tokmd-analysis/src/api_surface/mod.rs` and `crates/tokmd-analysis/src/api_surface/` | `mod.rs` 13; report owner 227; symbol dispatcher 56; language scanners <=68; symbol tests 385 | Keep `mod.rs` as a thin coordinator, report aggregation in `report.rs`, source scanning in language owner modules under `symbols`, and leave large integration tests under `api_surface/tests` |
 | Context packing and handoff | `crates/tokmd/src/context_pack.rs`, `crates/tokmd/src/context_pack/`, `crates/tokmd/src/commands/context.rs`, and `crates/tokmd/src/commands/handoff.rs` | `context_pack.rs` 15; selection coordinator 338 + selection tests 1215; ranking/packing owner 165; output/log submodule 224; render submodule 204; manifest submodule 195; budget parser/tests 220; context command 218; handoff command 268; handoff capability owner 113; handoff intelligence coordinator 196 + complexity owner 434; handoff output owner/tests 242 | Budget parsing, file selection, selection proof tests, ranking/packing, bundle text rendering, single-output/log writing, context bundle manifest writing, handoff capability detection, handoff intelligence construction, lightweight source-complexity estimation, and handoff artifact output writing now live in owner modules; keep context/handoff proof scoped while future handoff splits depend on fresh evidence |
 | Analysis DTO contracts | `crates/tokmd-analysis-types/src/lib.rs` and owner DTO modules | `lib.rs` 113; baseline owner 37 + complexity-baseline submodule 256 + complexity-section submodule 37 + determinism submodule 22 + metrics submodule 45 + file-entry submodule 23; envelope owner 24; receipt owner 42; topics owner tests 42; entropy owner tests 58; license owner tests 42; churn owner tests 50; complexity owner tests 51 + file submodule 46 + risk submodule 43 + halstead submodule 30 + maintainability submodule 25 + histogram submodule 79 + technical-debt submodule 42; effort owner 25 + estimate submodule 70 + assumptions submodule 35 + cocomo submodule 48 + model submodule 37 + confidence submodule 45 + delta submodule 56 + driver submodule 43 + size submodule 65 + results submodule 45 | Keep root receipt glue and public re-exports stable while moving remaining DTO ownership into modules |
+| Derived analysis report | `crates/tokmd-analysis/src/derived/mod.rs` and `crates/tokmd-analysis/src/derived/` | `mod.rs` 547; distribution owner 80; integrity owner 124 | Keep `mod.rs` as the receipt assembly coordinator; distribution/histogram calculations and integrity hashing now live in owner modules, and future splits should target coherent subreport owners rather than one-helper modules |
 | Core facade and FFI | `crates/tokmd-core/src/lib.rs`, `crates/tokmd-core/src/tests.rs`, `crates/tokmd-core/src/mutation_tests.rs`, `crates/tokmd-core/src/receipts.rs`, `crates/tokmd-core/src/workflows/`, and `crates/tokmd-core/src/ffi/` | `lib.rs` 159; root facade test owner 137; mutation test owner 330; receipt helper owner 144; workflow coordinator 31; workflow support owner 99; language workflow owner 84; module workflow owner 94; export workflow owner 106; diff workflow owner 64; analysis workflow owner 169; analysis input owner 118; analysis request owner 178; cockpit workflow owner 90; FFI coordinator 98; FFI test owner 913; envelope owner 15; mode owner 149; input owner 187; parse owner 257; settings parser owner 150 | Language, module, export, diff, analysis, and cockpit workflow facades now live under `workflows/`; core receipt construction lives in `receipts.rs`; root facade tests and mutation-killing receipt/parser tests live in private test owners; shared workflow support helpers live in `workflows/support.rs`; analysis in-memory export preparation lives in `workflows/analyze/input.rs`; analysis request construction lives in `workflows/analyze/request.rs`; public `run_json` coordination, FFI tests, in-memory input decoding/path validation, strict JSON parsing, FFI settings construction, mode dispatch, and response-envelope conversion live under `ffi/`; remaining work is extracting any future FFI helpers without changing public APIs |
 | Analysis complexity | `crates/tokmd-analysis/src/complexity/mod.rs` + `complexity/functions.rs` + `complexity/functions/` + `complexity/details.rs` + `complexity/details/` + `complexity/summary.rs` + `complexity/risk.rs` + `complexity/debt.rs` + `complexity/histogram.rs` + `complexity/language.rs` + `complexity/math.rs` + `complexity/tests/unit.rs` | 156 + 223 + Rust function owner 126 + 122 + Rust span owner 37 + Python span owner 79 + JS/TS span owner 57 + Go span owner 47 + C-family span owner 52 + 138 + 78 + 69 + 33 + 35 + 5 + 346 | Keep shared complexity logic in `tokmd-analysis`, with Rust function counting plus Rust, Python, JavaScript/TypeScript, Go, and C-family function-span detection in owner modules; split remaining language/source/summary helpers and local unit tests only when fresh evidence shows a clear next seam |
 | CLI parser | `crates/tokmd/src/cli/parser.rs` and `crates/tokmd/src/cli/parser/` | `parser.rs` 209; command enum owner 103; global scan args owner 133; shared value-enum owner 235; analyze parser owner 178; context/handoff parser owner 166; cockpit/baseline parser owner 89; diff parser owner 67; gate parser owner 55; sensor parser owner 43; export parser owner 43; badge parser owner 45; module parser owner 36; lang parser owner 26; run parser owner 25; check-ignore parser owner 15; completions parser owner 21; init parser owner 36; tools parser owner 15 | Context, handoff, analyze, cockpit, baseline, diff, gate, sensor, export, badge, module, lang, run, check-ignore, completions, init, tools, command enum, global scan args, and shared value enums now live under parser owner modules; continue command-family splits only when clap snapshots prove behavior is unchanged |
@@ -174,6 +175,7 @@ crates/tokmd-analysis-types/src/
 crates/tokmd-analysis/src/
   complexity/
   content/complexity/
+  derived/
   maintainability/
   halstead/
 ```
@@ -184,12 +186,13 @@ Required proof:
 cargo test -p tokmd-analysis-types --verbose
 cargo test -p tokmd-analysis --all-features complexity --verbose
 cargo test -p tokmd-analysis --all-features content --verbose
+cargo test -p tokmd-analysis --all-features derived --verbose
 cargo test -p tokmd-types schema --verbose
 ```
 
 Relevant proof scopes: `analysis_receipt_types`, `analysis_types_*`,
-`analysis_complexity`, `analysis_content_assets`, `analysis_halstead`, and
-`analysis_maintainability`.
+`analysis_complexity`, `analysis_content_assets`, `analysis_derived`,
+`analysis_halstead`, and `analysis_maintainability`.
 
 ### Batch D: Core Facade and Binding Boundaries
 
@@ -347,7 +350,9 @@ Stop and split the work if a consolidation PR:
 ## First Suggested PRs
 
 1. Continue production owner-module splits under `tokmd-analysis` only where
-   production seams remain broad; avoid splitting tests solely for line count.
+   production seams remain broad; for derived analysis, prefer coherent
+   subreport owners over one-helper modules and avoid splitting tests solely
+   for line count.
 2. Continue context and handoff splits only when fresh evidence shows a broad
    owner seam; current context packing and handoff intelligence/output owners
    are already split enough for routine work.


### PR DESCRIPTION
## Summary
- checkpoint the derived analysis owner-module state after the distribution and integrity extractions
- add `derived/` and `analysis_derived` to the architecture consolidation Batch C guidance
- clarify that future derived splits should target coherent subreport owners rather than one-helper modules

## Validation
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json` -> `project_truth_docs`, no unknown files
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` -> required `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main...HEAD`