### PR TITLE
refactor(analysis): extract derived ratio owner

### DIFF
--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -3,8 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use tokmd_analysis_types::{
     BoilerplateReport, CocomoReport, ContextWindowReport, DerivedReport, DerivedTotals,
     FileStatRow, LangPurityReport, LangPurityRow, MaxFileReport, MaxFileRow, NestingReport,
-    NestingRow, PolyglotReport, RateReport, RateRow, RatioReport, RatioRow, ReadingTimeReport,
-    TestDensityReport, TopOffenders,
+    NestingRow, PolyglotReport, ReadingTimeReport, TestDensityReport, TopOffenders,
 };
 use tokmd_analysis_types::{empty_file_row, is_infra_lang, is_test_path, path_depth};
 use tokmd_format::render_analysis_tree;
@@ -15,8 +14,10 @@ use crate::cocomo81_core::{COCOMO81_COEFFICIENTS, cocomo81_effort_pm};
 
 mod distribution;
 mod integrity;
+mod ratios;
 use distribution::{build_distribution_report, build_histogram};
 use integrity::build_integrity_report;
+use ratios::{build_doc_density_report, build_verbosity_report, build_whitespace_report};
 
 const LINES_PER_MINUTE: usize = 20;
 const TOP_N: usize = 10;
@@ -49,37 +50,13 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         totals.tokens += row.tokens;
     }
 
-    let doc_density = build_ratio_report(
-        "total",
-        totals.comments,
-        totals.code + totals.comments,
-        group_ratio(&parents, |r| r.lang.as_str(), |r| (r.comments, r.code)),
-        group_ratio(&parents, |r| r.module.as_str(), |r| (r.comments, r.code)),
-    );
+    let doc_density =
+        build_doc_density_report(&parents, totals.comments, totals.code + totals.comments);
 
-    let whitespace = build_ratio_report(
-        "total",
-        totals.blanks,
-        totals.code + totals.comments,
-        group_ratio(
-            &parents,
-            |r| r.lang.as_str(),
-            |r| (r.blanks, r.code + r.comments),
-        ),
-        group_ratio(
-            &parents,
-            |r| r.module.as_str(),
-            |r| (r.blanks, r.code + r.comments),
-        ),
-    );
+    let whitespace =
+        build_whitespace_report(&parents, totals.blanks, totals.code + totals.comments);
 
-    let verbosity = build_rate_report(
-        "total",
-        totals.bytes,
-        totals.lines,
-        group_rate(&parents, |r| r.lang.as_str(), |r| (r.bytes, r.lines)),
-        group_rate(&parents, |r| r.module.as_str(), |r| (r.bytes, r.lines)),
-    );
+    let verbosity = build_verbosity_report(&parents, totals.bytes, totals.lines);
 
     let file_stats = build_file_stats(&parents);
 
@@ -163,124 +140,6 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
         todo: None,
         integrity,
     }
-}
-
-fn build_ratio_report(
-    total_key: &str,
-    total_numer: usize,
-    total_denom: usize,
-    by_lang: BTreeMap<String, (usize, usize)>,
-    by_module: BTreeMap<String, (usize, usize)>,
-) -> RatioReport {
-    RatioReport {
-        total: RatioRow {
-            key: total_key.to_string(),
-            numerator: total_numer,
-            denominator: total_denom,
-            ratio: safe_ratio(total_numer, total_denom),
-        },
-        by_lang: build_ratio_rows(by_lang),
-        by_module: build_ratio_rows(by_module),
-    }
-}
-
-fn build_rate_report(
-    total_key: &str,
-    total_numer: usize,
-    total_denom: usize,
-    by_lang: BTreeMap<String, (usize, usize)>,
-    by_module: BTreeMap<String, (usize, usize)>,
-) -> RateReport {
-    RateReport {
-        total: RateRow {
-            key: total_key.to_string(),
-            numerator: total_numer,
-            denominator: total_denom,
-            rate: safe_ratio(total_numer, total_denom),
-        },
-        by_lang: build_rate_rows(by_lang),
-        by_module: build_rate_rows(by_module),
-    }
-}
-
-fn build_ratio_rows(map: BTreeMap<String, (usize, usize)>) -> Vec<RatioRow> {
-    let mut rows: Vec<RatioRow> = map
-        .into_iter()
-        .map(|(key, (numer, denom))| RatioRow {
-            key,
-            numerator: numer,
-            denominator: denom,
-            ratio: safe_ratio(numer, denom),
-        })
-        .collect();
-
-    rows.sort_by(|a, b| {
-        b.ratio
-            .partial_cmp(&a.ratio)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.key.cmp(&b.key))
-    });
-    rows
-}
-
-fn build_rate_rows(map: BTreeMap<String, (usize, usize)>) -> Vec<RateRow> {
-    let mut rows: Vec<RateRow> = map
-        .into_iter()
-        .map(|(key, (numer, denom))| RateRow {
-            key,
-            numerator: numer,
-            denominator: denom,
-            rate: safe_ratio(numer, denom),
-        })
-        .collect();
-
-    rows.sort_by(|a, b| {
-        b.rate
-            .partial_cmp(&a.rate)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.key.cmp(&b.key))
-    });
-    rows
-}
-
-fn group_ratio<'a, FKey, FVals>(
-    rows: &'a [&'a FileRow],
-    key_fn: FKey,
-    vals_fn: FVals,
-) -> BTreeMap<String, (usize, usize)>
-where
-    FKey: Fn(&'a FileRow) -> &'a str,
-    FVals: Fn(&'a FileRow) -> (usize, usize),
-{
-    let mut map: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
-    for row in rows {
-        let key = key_fn(row);
-        let (numer, denom_part) = vals_fn(row);
-        let entry = map.entry(key).or_insert((0, 0));
-        entry.0 += numer;
-        entry.1 += denom_part;
-    }
-    map.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
-}
-
-fn group_rate<'a, FKey, FVals>(
-    rows: &'a [&'a FileRow],
-    key_fn: FKey,
-    vals_fn: FVals,
-) -> BTreeMap<String, (usize, usize)>
-where
-    FKey: Fn(&'a FileRow) -> &'a str,
-    FVals: Fn(&'a FileRow) -> (usize, usize),
-{
-    let mut map: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
-    for row in rows {
-        let key = key_fn(row);
-        let (numer, denom) = vals_fn(row);
-        let entry = map.entry(key).or_insert((0, 0));
-        entry.0 += numer;
-        entry.1 += denom;
-    }
-    map.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
 }
 
 fn build_file_stats(rows: &[&FileRow]) -> Vec<FileStatRow> {

--- a/crates/tokmd-analysis/src/derived/ratios.rs
+++ b/crates/tokmd-analysis/src/derived/ratios.rs
@@ -1,0 +1,169 @@
+use std::collections::BTreeMap;
+
+use tokmd_analysis_types::{RateReport, RateRow, RatioReport, RatioRow};
+use tokmd_scan::safe_ratio;
+use tokmd_types::FileRow;
+
+pub(super) fn build_doc_density_report(
+    rows: &[&FileRow],
+    comments: usize,
+    code_and_comments: usize,
+) -> RatioReport {
+    build_ratio_report(
+        "total",
+        comments,
+        code_and_comments,
+        group_ratio(rows, |r| r.lang.as_str(), |r| (r.comments, r.code)),
+        group_ratio(rows, |r| r.module.as_str(), |r| (r.comments, r.code)),
+    )
+}
+
+pub(super) fn build_whitespace_report(
+    rows: &[&FileRow],
+    blanks: usize,
+    code_and_comments: usize,
+) -> RatioReport {
+    build_ratio_report(
+        "total",
+        blanks,
+        code_and_comments,
+        group_ratio(
+            rows,
+            |r| r.lang.as_str(),
+            |r| (r.blanks, r.code + r.comments),
+        ),
+        group_ratio(
+            rows,
+            |r| r.module.as_str(),
+            |r| (r.blanks, r.code + r.comments),
+        ),
+    )
+}
+
+pub(super) fn build_verbosity_report(rows: &[&FileRow], bytes: usize, lines: usize) -> RateReport {
+    build_rate_report(
+        "total",
+        bytes,
+        lines,
+        group_rate(rows, |r| r.lang.as_str(), |r| (r.bytes, r.lines)),
+        group_rate(rows, |r| r.module.as_str(), |r| (r.bytes, r.lines)),
+    )
+}
+
+fn build_ratio_report(
+    total_key: &str,
+    total_numer: usize,
+    total_denom: usize,
+    by_lang: BTreeMap<String, (usize, usize)>,
+    by_module: BTreeMap<String, (usize, usize)>,
+) -> RatioReport {
+    RatioReport {
+        total: RatioRow {
+            key: total_key.to_string(),
+            numerator: total_numer,
+            denominator: total_denom,
+            ratio: safe_ratio(total_numer, total_denom),
+        },
+        by_lang: build_ratio_rows(by_lang),
+        by_module: build_ratio_rows(by_module),
+    }
+}
+
+fn build_rate_report(
+    total_key: &str,
+    total_numer: usize,
+    total_denom: usize,
+    by_lang: BTreeMap<String, (usize, usize)>,
+    by_module: BTreeMap<String, (usize, usize)>,
+) -> RateReport {
+    RateReport {
+        total: RateRow {
+            key: total_key.to_string(),
+            numerator: total_numer,
+            denominator: total_denom,
+            rate: safe_ratio(total_numer, total_denom),
+        },
+        by_lang: build_rate_rows(by_lang),
+        by_module: build_rate_rows(by_module),
+    }
+}
+
+fn build_ratio_rows(map: BTreeMap<String, (usize, usize)>) -> Vec<RatioRow> {
+    let mut rows: Vec<RatioRow> = map
+        .into_iter()
+        .map(|(key, (numer, denom))| RatioRow {
+            key,
+            numerator: numer,
+            denominator: denom,
+            ratio: safe_ratio(numer, denom),
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        b.ratio
+            .partial_cmp(&a.ratio)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.key.cmp(&b.key))
+    });
+    rows
+}
+
+fn build_rate_rows(map: BTreeMap<String, (usize, usize)>) -> Vec<RateRow> {
+    let mut rows: Vec<RateRow> = map
+        .into_iter()
+        .map(|(key, (numer, denom))| RateRow {
+            key,
+            numerator: numer,
+            denominator: denom,
+            rate: safe_ratio(numer, denom),
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        b.rate
+            .partial_cmp(&a.rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.key.cmp(&b.key))
+    });
+    rows
+}
+
+fn group_ratio<'a, FKey, FVals>(
+    rows: &'a [&'a FileRow],
+    key_fn: FKey,
+    vals_fn: FVals,
+) -> BTreeMap<String, (usize, usize)>
+where
+    FKey: Fn(&'a FileRow) -> &'a str,
+    FVals: Fn(&'a FileRow) -> (usize, usize),
+{
+    let mut map: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+    for row in rows {
+        let key = key_fn(row);
+        let (numer, denom_part) = vals_fn(row);
+        let entry = map.entry(key).or_insert((0, 0));
+        entry.0 += numer;
+        entry.1 += denom_part;
+    }
+    map.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
+fn group_rate<'a, FKey, FVals>(
+    rows: &'a [&'a FileRow],
+    key_fn: FKey,
+    vals_fn: FVals,
+) -> BTreeMap<String, (usize, usize)>
+where
+    FKey: Fn(&'a FileRow) -> &'a str,
+    FVals: Fn(&'a FileRow) -> (usize, usize),
+{
+    let mut map: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+    for row in rows {
+        let key = key_fn(row);
+        let (numer, denom) = vals_fn(row);
+        let entry = map.entry(key).or_insert((0, 0));
+        entry.0 += numer;
+        entry.1 += denom;
+    }
+    map.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}


### PR DESCRIPTION
## Summary
- extract derived doc-density, whitespace, and verbosity ratio/rate builders into `derived::ratios`
- keep `derive_report` as the receipt assembly coordinator with unchanged field order and receipt semantics
- preserve existing `analysis_derived` proof routing for the moved owner module

## Validation
- `cargo test -p tokmd-analysis --all-features derived --verbose`
- `cargo test -p tokmd-analysis --all-features mutant --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json` -> `analysis_derived`, no unknown files
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` -> required derived + mutant proof, advisory coverage/mutation
- `cargo fmt-check`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main...HEAD`