### PR TITLE
refactor(analysis): extract derived language owner

### DIFF
--- a/crates/tokmd-analysis/src/derived/languages.rs
+++ b/crates/tokmd-analysis/src/derived/languages.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use tokmd_analysis_types::{LangPurityReport, LangPurityRow, PolyglotReport};
+use tokmd_scan::{round_f64, safe_ratio};
+use tokmd_types::FileRow;
+
+pub(super) fn build_lang_purity_report(rows: &[&FileRow]) -> LangPurityReport {
+    let mut by_module: BTreeMap<&str, BTreeMap<&str, usize>> = BTreeMap::new();
+
+    for row in rows {
+        let entry = if let Some(existing) = by_module.get_mut(row.module.as_str()) {
+            existing
+        } else {
+            by_module.insert(row.module.as_str(), BTreeMap::new());
+            by_module.get_mut(row.module.as_str()).unwrap()
+        };
+
+        if let Some(val) = entry.get_mut(row.lang.as_str()) {
+            *val += row.lines;
+        } else {
+            entry.insert(row.lang.as_str(), row.lines);
+        }
+    }
+
+    let mut out = Vec::new();
+    for (module, langs) in by_module {
+        let mut total = 0usize;
+        let mut dominant_lang: Option<&str> = None;
+        let mut dominant_lines = 0usize;
+        for (&lang, lines) in &langs {
+            total += *lines;
+            if *lines > dominant_lines
+                || (*lines == dominant_lines && dominant_lang.is_some_and(|d| lang < d))
+            {
+                dominant_lines = *lines;
+                dominant_lang = Some(lang);
+            }
+        }
+        let pct = if total == 0 {
+            0.0
+        } else {
+            safe_ratio(dominant_lines, total)
+        };
+        out.push(LangPurityRow {
+            module: module.to_string(),
+            lang_count: langs.len(),
+            dominant_lang: dominant_lang.unwrap_or_default().to_string(),
+            dominant_lines,
+            dominant_pct: pct,
+        });
+    }
+
+    out.sort_by(|a, b| a.module.cmp(&b.module));
+    LangPurityReport { rows: out }
+}
+
+pub(super) fn build_polyglot_report(rows: &[&FileRow]) -> PolyglotReport {
+    let mut by_lang: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut total = 0usize;
+
+    for row in rows {
+        if let Some(val) = by_lang.get_mut(row.lang.as_str()) {
+            *val += row.code;
+        } else {
+            by_lang.insert(row.lang.as_str(), row.code);
+        }
+        total += row.code;
+    }
+
+    let mut entropy = 0.0;
+    let mut dominant_lang: Option<&str> = None;
+    let mut dominant_lines = 0usize;
+
+    for (&lang, lines) in &by_lang {
+        if *lines > dominant_lines
+            || (*lines == dominant_lines && dominant_lang.is_some_and(|d| lang < d))
+        {
+            dominant_lines = *lines;
+            dominant_lang = Some(lang);
+        }
+        if total > 0 && *lines > 0 {
+            let p = *lines as f64 / total as f64;
+            entropy -= p * p.log2();
+        }
+    }
+
+    let dominant_pct = if total == 0 {
+        0.0
+    } else {
+        safe_ratio(dominant_lines, total)
+    };
+
+    PolyglotReport {
+        lang_count: by_lang.len(),
+        entropy: round_f64(entropy, 4),
+        dominant_lang: dominant_lang.unwrap_or_default().to_string(),
+        dominant_lines,
+        dominant_pct,
+    }
+}

--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -2,8 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use tokmd_analysis_types::{
     BoilerplateReport, CocomoReport, ContextWindowReport, DerivedReport, DerivedTotals,
-    FileStatRow, LangPurityReport, LangPurityRow, NestingReport, NestingRow, PolyglotReport,
-    ReadingTimeReport, TestDensityReport,
+    FileStatRow, NestingReport, NestingRow, ReadingTimeReport, TestDensityReport,
 };
 use tokmd_analysis_types::{is_infra_lang, is_test_path};
 use tokmd_format::render_analysis_tree;
@@ -15,10 +14,12 @@ use crate::cocomo81_core::{COCOMO81_COEFFICIENTS, cocomo81_effort_pm};
 mod distribution;
 mod files;
 mod integrity;
+mod languages;
 mod ratios;
 use distribution::{build_distribution_report, build_histogram};
 use files::{build_file_stats, build_max_file_report, build_top_offenders};
 use integrity::build_integrity_report;
+use languages::{build_lang_purity_report, build_polyglot_report};
 use ratios::{build_doc_density_report, build_verbosity_report, build_whitespace_report};
 
 const LINES_PER_MINUTE: usize = 20;
@@ -141,56 +142,6 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
     }
 }
 
-fn build_lang_purity_report(rows: &[&FileRow]) -> LangPurityReport {
-    let mut by_module: BTreeMap<&str, BTreeMap<&str, usize>> = BTreeMap::new();
-
-    for row in rows {
-        let entry = if let Some(existing) = by_module.get_mut(row.module.as_str()) {
-            existing
-        } else {
-            by_module.insert(row.module.as_str(), BTreeMap::new());
-            by_module.get_mut(row.module.as_str()).unwrap()
-        };
-
-        if let Some(val) = entry.get_mut(row.lang.as_str()) {
-            *val += row.lines;
-        } else {
-            entry.insert(row.lang.as_str(), row.lines);
-        }
-    }
-
-    let mut out = Vec::new();
-    for (module, langs) in by_module {
-        let mut total = 0usize;
-        let mut dominant_lang: Option<&str> = None;
-        let mut dominant_lines = 0usize;
-        for (&lang, lines) in &langs {
-            total += *lines;
-            if *lines > dominant_lines
-                || (*lines == dominant_lines && dominant_lang.is_some_and(|d| lang < d))
-            {
-                dominant_lines = *lines;
-                dominant_lang = Some(lang);
-            }
-        }
-        let pct = if total == 0 {
-            0.0
-        } else {
-            safe_ratio(dominant_lines, total)
-        };
-        out.push(LangPurityRow {
-            module: module.to_string(),
-            lang_count: langs.len(),
-            dominant_lang: dominant_lang.unwrap_or_default().to_string(),
-            dominant_lines,
-            dominant_pct: pct,
-        });
-    }
-
-    out.sort_by(|a, b| a.module.cmp(&b.module));
-    LangPurityReport { rows: out }
-}
-
 fn build_nesting_report(rows: &[FileStatRow]) -> NestingReport {
     if rows.is_empty() {
         return NestingReport {
@@ -299,51 +250,6 @@ fn build_boilerplate_report(rows: &[&FileRow]) -> BoilerplateReport {
         logic_lines,
         ratio,
         infra_langs: infra_langs.into_iter().map(String::from).collect(),
-    }
-}
-
-fn build_polyglot_report(rows: &[&FileRow]) -> PolyglotReport {
-    let mut by_lang: BTreeMap<&str, usize> = BTreeMap::new();
-    let mut total = 0usize;
-
-    for row in rows {
-        if let Some(val) = by_lang.get_mut(row.lang.as_str()) {
-            *val += row.code;
-        } else {
-            by_lang.insert(row.lang.as_str(), row.code);
-        }
-        total += row.code;
-    }
-
-    let mut entropy = 0.0;
-    let mut dominant_lang: Option<&str> = None;
-    let mut dominant_lines = 0usize;
-
-    for (&lang, lines) in &by_lang {
-        if *lines > dominant_lines
-            || (*lines == dominant_lines && dominant_lang.is_some_and(|d| lang < d))
-        {
-            dominant_lines = *lines;
-            dominant_lang = Some(lang);
-        }
-        if total > 0 && *lines > 0 {
-            let p = *lines as f64 / total as f64;
-            entropy -= p * p.log2();
-        }
-    }
-
-    let dominant_pct = if total == 0 {
-        0.0
-    } else {
-        safe_ratio(dominant_lines, total)
-    };
-
-    PolyglotReport {
-        lang_count: by_lang.len(),
-        entropy: round_f64(entropy, 4),
-        dominant_lang: dominant_lang.unwrap_or_default().to_string(),
-        dominant_lines,
-        dominant_pct,
     }
 }
 


### PR DESCRIPTION
## Summary
- extract derived language composition builders into `derived::languages`
- keep `derive_report` as the receipt assembly coordinator
- preserve `analysis_derived` proof routing and receipt/schema behavior

## Validation
- `cargo test -p tokmd-analysis --all-features derived --verbose`
- `cargo test -p tokmd-analysis --all-features mutant --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `git diff --check origin/main...HEAD`