### PR TITLE
feat(cockpit): summarize proof evidence in review map

### DIFF
--- a/crates/tokmd-cockpit/src/render.rs
+++ b/crates/tokmd-cockpit/src/render.rs
@@ -11,6 +11,7 @@ mod comment;
 mod evidence;
 mod manifest;
 mod markdown;
+mod proof_summary;
 mod review_map;
 mod review_map_proof;
 mod review_packet;

--- a/crates/tokmd-cockpit/src/render/comment.rs
+++ b/crates/tokmd-cockpit/src/render/comment.rs
@@ -1,12 +1,10 @@
 //! PR comment rendering for cockpit receipts and review packets.
 
-use crate::proof_evidence::{
-    ProofEvidenceAvailability, ProofEvidenceInput, ProofExecutionStatus,
-    normalize_proof_evidence_inputs,
-};
-use crate::{CockpitReceipt, CommitMatch, GateStatus, RiskLevel};
+use crate::proof_evidence::ProofEvidenceInput;
+use crate::{CockpitReceipt, GateStatus, RiskLevel};
 
 use super::evidence::evidence_counts;
+use super::proof_summary::proof_evidence_summary;
 
 /// Render comment.md for PR comments.
 pub fn render_comment_md(receipt: &CockpitReceipt) -> String {
@@ -176,24 +174,6 @@ pub(super) fn render_review_packet_comment_md(
     s
 }
 
-#[derive(Default)]
-struct ProofCommentCounts {
-    total: usize,
-    required_passed: usize,
-    required_failed: usize,
-    required_missing: usize,
-    advisory_available: usize,
-    advisory_missing: usize,
-    exact: usize,
-    partial: usize,
-    stale: usize,
-    unknown: usize,
-    not_run: usize,
-    degraded: usize,
-    skipped: usize,
-    unavailable: usize,
-}
-
 fn write_proof_evidence_summary(
     s: &mut String,
     receipt: &CockpitReceipt,
@@ -201,7 +181,7 @@ fn write_proof_evidence_summary(
 ) {
     use std::fmt::Write;
 
-    let counts = proof_comment_counts(receipt, proof_inputs);
+    let counts = proof_evidence_summary(receipt, proof_inputs);
     if counts.total == 0 {
         return;
     }
@@ -233,68 +213,4 @@ fn write_proof_evidence_summary(
         );
     }
     let _ = writeln!(s);
-}
-
-fn proof_comment_counts(
-    receipt: &CockpitReceipt,
-    proof_inputs: &[ProofEvidenceInput],
-) -> ProofCommentCounts {
-    let mut counts = ProofCommentCounts::default();
-
-    for item in normalize_proof_evidence_inputs(
-        proof_inputs,
-        Some(&receipt.base_ref),
-        Some(&receipt.head_ref),
-    ) {
-        counts.total += 1;
-
-        match item.commit_match {
-            CommitMatch::Exact => counts.exact += 1,
-            CommitMatch::Partial => counts.partial += 1,
-            CommitMatch::Stale => counts.stale += 1,
-            CommitMatch::Unknown => counts.unknown += 1,
-        }
-
-        match item.availability {
-            ProofEvidenceAvailability::Degraded => counts.degraded += 1,
-            ProofEvidenceAvailability::Skipped => counts.skipped += 1,
-            ProofEvidenceAvailability::Unavailable => counts.unavailable += 1,
-            _ => {}
-        }
-
-        if matches!(
-            item.execution_status,
-            ProofExecutionStatus::Planned | ProofExecutionStatus::NotExecuted
-        ) {
-            counts.not_run += 1;
-        }
-
-        if item.required {
-            if item.execution_status == ProofExecutionStatus::ExecutedPassed
-                && item.availability == ProofEvidenceAvailability::Available
-            {
-                counts.required_passed += 1;
-            } else if item.execution_status == ProofExecutionStatus::ExecutedFailed {
-                counts.required_failed += 1;
-            } else if matches!(
-                item.availability,
-                ProofEvidenceAvailability::Missing | ProofEvidenceAvailability::Unavailable
-            ) {
-                counts.required_missing += 1;
-            }
-        }
-
-        if item.advisory {
-            if item.availability == ProofEvidenceAvailability::Available {
-                counts.advisory_available += 1;
-            } else if matches!(
-                item.availability,
-                ProofEvidenceAvailability::Missing | ProofEvidenceAvailability::Unavailable
-            ) {
-                counts.advisory_missing += 1;
-            }
-        }
-    }
-
-    counts
 }

--- a/crates/tokmd-cockpit/src/render/proof_summary.rs
+++ b/crates/tokmd-cockpit/src/render/proof_summary.rs
@@ -1,0 +1,89 @@
+//! Compact proof evidence counts shared by packet renderers.
+
+use crate::proof_evidence::{
+    ProofEvidenceAvailability, ProofEvidenceInput, ProofExecutionStatus,
+    normalize_proof_evidence_inputs,
+};
+use crate::{CockpitReceipt, CommitMatch};
+
+#[derive(Default)]
+pub(super) struct ProofEvidenceSummary {
+    pub(super) total: usize,
+    pub(super) required_passed: usize,
+    pub(super) required_failed: usize,
+    pub(super) required_missing: usize,
+    pub(super) advisory_available: usize,
+    pub(super) advisory_missing: usize,
+    pub(super) exact: usize,
+    pub(super) partial: usize,
+    pub(super) stale: usize,
+    pub(super) unknown: usize,
+    pub(super) not_run: usize,
+    pub(super) degraded: usize,
+    pub(super) skipped: usize,
+    pub(super) unavailable: usize,
+}
+
+pub(super) fn proof_evidence_summary(
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) -> ProofEvidenceSummary {
+    let mut counts = ProofEvidenceSummary::default();
+
+    for item in normalize_proof_evidence_inputs(
+        proof_inputs,
+        Some(&receipt.base_ref),
+        Some(&receipt.head_ref),
+    ) {
+        counts.total += 1;
+
+        match item.commit_match {
+            CommitMatch::Exact => counts.exact += 1,
+            CommitMatch::Partial => counts.partial += 1,
+            CommitMatch::Stale => counts.stale += 1,
+            CommitMatch::Unknown => counts.unknown += 1,
+        }
+
+        match item.availability {
+            ProofEvidenceAvailability::Degraded => counts.degraded += 1,
+            ProofEvidenceAvailability::Skipped => counts.skipped += 1,
+            ProofEvidenceAvailability::Unavailable => counts.unavailable += 1,
+            _ => {}
+        }
+
+        if matches!(
+            item.execution_status,
+            ProofExecutionStatus::Planned | ProofExecutionStatus::NotExecuted
+        ) {
+            counts.not_run += 1;
+        }
+
+        if item.required {
+            if item.execution_status == ProofExecutionStatus::ExecutedPassed
+                && item.availability == ProofEvidenceAvailability::Available
+            {
+                counts.required_passed += 1;
+            } else if item.execution_status == ProofExecutionStatus::ExecutedFailed {
+                counts.required_failed += 1;
+            } else if matches!(
+                item.availability,
+                ProofEvidenceAvailability::Missing | ProofEvidenceAvailability::Unavailable
+            ) {
+                counts.required_missing += 1;
+            }
+        }
+
+        if item.advisory {
+            if item.availability == ProofEvidenceAvailability::Available {
+                counts.advisory_available += 1;
+            } else if matches!(
+                item.availability,
+                ProofEvidenceAvailability::Missing | ProofEvidenceAvailability::Unavailable
+            ) {
+                counts.advisory_missing += 1;
+            }
+        }
+    }
+
+    counts
+}

--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -9,6 +9,7 @@ use super::evidence::{
     evidence_availability_optional, evidence_counts, review_packet_evidence_capabilities,
     review_packet_evidence_gate_specs, review_packet_evidence_summary,
 };
+use super::proof_summary::proof_evidence_summary;
 use super::review_map_proof::{
     ReviewMapProofRef, review_map_item_proof, review_map_proof_refs, write_proof_block,
 };
@@ -189,6 +190,7 @@ pub(super) fn render_review_map_md(
         evidence.missing,
     );
     let _ = writeln!(s);
+    write_proof_overview(&mut s, receipt, proof_inputs);
 
     if receipt.review_plan.is_empty() {
         let _ = writeln!(s, "No prioritized files were identified.");
@@ -245,6 +247,47 @@ pub(super) fn render_review_map_md(
     }
 
     s
+}
+
+fn write_proof_overview(
+    s: &mut String,
+    receipt: &CockpitReceipt,
+    proof_inputs: &[ProofEvidenceInput],
+) {
+    use std::fmt::Write;
+
+    let counts = proof_evidence_summary(receipt, proof_inputs);
+    if counts.total == 0 {
+        return;
+    }
+
+    let _ = writeln!(s, "Proof evidence overview:");
+    let _ = writeln!(
+        s,
+        "- Required proof: {} passed, {} failed, {} missing",
+        counts.required_passed, counts.required_failed, counts.required_missing,
+    );
+    let _ = writeln!(
+        s,
+        "- Advisory proof: {} available, {} missing",
+        counts.advisory_available, counts.advisory_missing,
+    );
+    let _ = writeln!(
+        s,
+        "- Freshness: {} exact, {} partial, {} stale, {} unknown",
+        counts.exact, counts.partial, counts.stale, counts.unknown,
+    );
+    if counts.not_run > 0 {
+        let _ = writeln!(s, "- Not run: {}", counts.not_run);
+    }
+    if counts.degraded > 0 || counts.skipped > 0 || counts.unavailable > 0 {
+        let _ = writeln!(
+            s,
+            "- Other proof state: {} degraded, {} skipped, {} unavailable",
+            counts.degraded, counts.skipped, counts.unavailable,
+        );
+    }
+    let _ = writeln!(s);
 }
 
 fn write_evidence_list(s: &mut String, label: &str, gates: &[&str]) {

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -898,6 +898,7 @@ fn scenario_write_review_packet_creates_contract_files() {
     );
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    assert!(!review_map_md.contains("Proof evidence overview"));
     assert!(review_map_md.contains("# Review Map"));
     assert!(review_map_md.contains("Evidence overview: 1 available"));
     assert!(review_map_md.contains("## Review First"));
@@ -1067,6 +1068,10 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
     );
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    assert!(review_map_md.contains("Proof evidence overview:"));
+    assert!(review_map_md.contains("- Required proof: 1 passed, 0 failed, 0 missing"));
+    assert!(review_map_md.contains("- Advisory proof: 0 available, 0 missing"));
+    assert!(review_map_md.contains("- Freshness: 1 exact, 0 partial, 0 stale, 0 unknown"));
     assert_eq!(
         review_map_md.matches("   Proof:").count(),
         1,
@@ -1084,6 +1089,69 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
     assert!(comment_md.contains("Required proof: 1 passed, 0 failed, 0 missing"));
     assert!(comment_md.contains("Advisory proof: 0 available, 0 missing"));
     assert!(comment_md.contains("Proof freshness: 1 exact, 0 partial, 0 stale, 0 unknown"));
+}
+
+#[test]
+fn scenario_review_map_md_includes_packet_level_proof_overview() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut receipt = minimal_receipt();
+    receipt.review_plan = vec![ReviewItem {
+        path: "crates/tokmd-cockpit/src/render/review_map.rs".to_string(),
+        reason: "Review map rendering changed".to_string(),
+        priority: 1,
+        complexity: Some(2),
+        lines_changed: Some(8),
+    }];
+    let out = dir.path().join("review");
+    let proof = tokmd_cockpit::parse_proof_evidence_input(
+        r#"{
+  "schema": "tokmd.coverage_receipt.v1",
+  "schema_version": 1,
+  "repo": "EffortlessMetrics/tokmd",
+  "lane": "scoped",
+  "flag": "tokmd_cockpit",
+  "workflow": "Coverage",
+  "sha": "feature",
+  "github": {
+    "run_id": "12345",
+    "run_attempt": "1",
+    "event_name": "pull_request",
+    "ref_name": "feature"
+  },
+  "artifacts": [
+    {
+      "path": "target/proof/coverage/tokmd-cockpit.lcov",
+      "kind": "lcov",
+      "bytes": 42,
+      "non_empty": true
+    }
+  ],
+  "status": {
+    "ok": true,
+    "missing": [],
+    "empty": []
+  }
+}"#,
+        "coverage-receipt.json",
+    )
+    .unwrap();
+
+    tokmd_cockpit::render::write_review_packet_with_proof_evidence(&out, &receipt, &[proof])
+        .unwrap();
+
+    let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    assert!(review_map_md.contains("Proof evidence overview:"));
+    assert!(review_map_md.contains("- Required proof: 0 passed, 0 failed, 0 missing"));
+    assert!(review_map_md.contains("- Advisory proof: 1 available, 0 missing"));
+    assert!(review_map_md.contains("- Freshness: 1 exact, 0 partial, 0 stale, 0 unknown"));
+    assert!(
+        !review_map_md.contains("   Proof:"),
+        "coverage receipts without direct changed-file matches should stay packet-level"
+    );
+    assert!(
+        review_map_md.contains("Evidence references:"),
+        "review map should still point reviewers to packet evidence refs"
+    );
 }
 
 // ===========================================================================

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -1,10 +1,11 @@
 # Cockpit Proof Evidence Import Contract
 
-Status: partially implemented. `tokmd cockpit` can validate explicitly supplied
-proof artifacts, copy them into the review packet under `proof/`, and attach
-normalized imported proof items to `evidence.json` when `--review-packet-dir`
-is used. `review-map.json` can link matching review items to packet-local
-proof refs, and `review-map.md` renders matching item-level proof lines.
+Status: implemented for explicit proof imports. `tokmd cockpit` can validate
+explicitly supplied proof artifacts, copy them into the review packet under
+`proof/`, and attach normalized imported proof items to `evidence.json` when
+`--review-packet-dir` is used. `review-map.json` can link direct changed-file
+matches to packet-local proof refs, and `review-map.md` now renders both a
+packet-level proof evidence overview and matching item-level proof lines.
 `comment.md` includes compact proof evidence totals for required/advisory proof
 and freshness.
 
@@ -210,6 +211,7 @@ The information should be visible in:
 
 - `evidence.json` gate entries and imported proof entries;
 - `review-map.json` item evidence status and `proof_refs`;
+- `review-map.md` packet-level proof overview;
 - `review-map.md` item proof lines for review-first direct changed-file matches;
 - `comment.md` compact evidence availability and proof evidence totals.
 
@@ -263,7 +265,7 @@ evidence.
 - Attach imported proof entries to `evidence.json`. (done)
 - Copy supplied proof artifacts into packet-local `proof/*.json` files. (done)
 - Attach proof refs to review-map items without duplicating large artifacts. (done for direct changed-file matches)
-- Render matching proof evidence in `review-map.md` without changing JSON schemas. (done for direct changed-file matches)
+- Render packet-level and matching proof evidence in `review-map.md` without changing JSON schemas. (done; item-level links currently use direct changed-file matches)
 - Render compact proof evidence totals in `comment.md` without listing raw commands. (done)
 - Keep review packet schemas versioned if output shape changes.
 - Keep proof-control-plane promotion decisions outside cockpit.


### PR DESCRIPTION
## Summary
- add a shared cockpit proof evidence summary helper reused by packet comments and review-map rendering
- render a packet-level proof evidence overview in `review-map.md` for imported proof artifacts, including required/advisory counts and freshness counts
- keep item-level proof lines limited to direct changed-file matches, with no schema, CLI, proof-gate, or Codecov behavior changes
- update the cockpit proof-evidence doc to describe the implemented review-map behavior

## Validation
- `cargo test -p tokmd-cockpit scenario_review_map_md_includes_packet_level_proof_overview --verbose`
- `cargo test -p tokmd-cockpit --test bdd --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main...HEAD`
