### PR TITLE
chore(proof): classify remaining workflow surfaces

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -100,6 +100,9 @@ kind = "rust"
 paths = [
   ".github/workflows/ci-policy.yml",
   ".github/workflows/ci.yml",
+  ".github/workflows/mutants.yml",
+  ".github/workflows/nix-full.yml",
+  ".github/workflows/nix-macos.yml",
   ".github/workflows/no-panic-policy.yml",
   ".github/workflows/pr-plan.yml",
   ".github/workflows/proof-observation-collection.yml",
@@ -148,6 +151,7 @@ paths = [
 packages = ["xtask"]
 proof = [
   "cargo xtask proof-policy --check",
+  "cargo xtask ci-lane-whitelist",
   "cargo test -p xtask proof_policy --verbose",
   "cargo test -p xtask affected --verbose",
   "cargo test -p xtask ci_actuals --verbose",
@@ -1009,6 +1013,7 @@ name = "ci_economics_docs"
 kind = "non_rust"
 paths = [
   ".github/pull_request_template.md",
+  ".github/workflows/sync-labels.yml",
   "docs/POLICY_ALLOWLISTS.md",
   "docs/RIPR_EVIDENCE_POLICY.md",
   "docs/ci/**",
@@ -1085,13 +1090,15 @@ coverage = false
 name = "release_metadata"
 kind = "non_rust"
 paths = [
+  ".github/workflows/release.yml",
   "CHANGELOG.md",
 ]
 proof = [
   "cargo xtask version-consistency",
+  "cargo xtask publish-surface --json --verify-publish",
   "cargo xtask docs --check",
 ]
-reason = "CHANGELOG is a release artifact updated with every version bump; proof routes to version-consistency and docs checks."
+reason = "CHANGELOG and release workflow changes are release artifacts; proof routes to version consistency, publish-surface verification, and docs checks."
 mutation = false
 coverage = false
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -61,6 +61,7 @@ granularity; avoid carving already-stable modules just because files exist.
 - `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` now prints a stable proof plan without running commands; `fast`, `release`, and `deep` profiles are plan-only placeholders for the next CI integration slices.
 - CI now validates `cargo xtask proof-policy --check` as part of the required aggregate and uploads PR-only affected proof artifacts while keeping existing jobs authoritative.
 - The proof scope registry now covers first-class product/control-plane surfaces for CLI, gate, cockpit, WASM, browser runner, the composite GitHub Action, schema contracts, and the proof control plane.
+- Release, mutation, Nix validation, and label-sync workflows now have explicit proof-scope routing so Dependabot or workflow-only action updates do not fail affected planning as unknown files before they reach their relevant release, policy, or documentation proof.
 - Clippy policy now has a governed ledger and `cargo xtask check-lint-policy` check while keeping the repository MSRV at 1.92 and leaving crate-wide lint inheritance as a later cleanup stack.
 - Analysis and formatting module scopes now route `tokmd-analysis`, `tokmd-analysis-types`, and `tokmd-format` changes to targeted package, snapshot, renderer, and module proof commands.
 - Affected proof plans now include advisory scoped coverage and mutation commands derived from matched scope metadata while leaving existing proof commands required and CI behavior unchanged.

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -136,6 +136,28 @@ fn proof_policy_includes_current_product_scopes() {
     assert!(no_panic_proof.contains("cargo xtask check-no-panic-family"));
     assert!(no_panic_proof.contains("cargo test -p xtask no_panic --verbose"));
 
+    let proof_control_plane = scopes
+        .iter()
+        .find(|scope| scope["name"].as_str() == Some("proof_control_plane"))
+        .expect("proof_control_plane scope should exist");
+    let proof_control_paths = proof_control_plane["paths"]
+        .as_array()
+        .expect("proof_control_plane should expose path globs")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+    let proof_control_proof = proof_control_plane["proof"]
+        .as_array()
+        .expect("proof_control_plane should expose proof commands")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+
+    assert!(proof_control_paths.contains(".github/workflows/mutants.yml"));
+    assert!(proof_control_paths.contains(".github/workflows/nix-full.yml"));
+    assert!(proof_control_paths.contains(".github/workflows/nix-macos.yml"));
+    assert!(proof_control_proof.contains("cargo xtask ci-lane-whitelist"));
+
     let dependency_graph = scopes
         .iter()
         .find(|scope| scope["name"].as_str() == Some("workspace_dependency_graph"))
@@ -196,6 +218,39 @@ fn proof_policy_includes_current_product_scopes() {
 
     assert!(tokmd_cli_paths.contains("crates/tokmd/tests/cli_*.rs"));
     assert!(tokmd_cli_paths.contains("crates/tokmd/tests/error_handling_w70.rs"));
+
+    let ci_economics_docs = scopes
+        .iter()
+        .find(|scope| scope["name"].as_str() == Some("ci_economics_docs"))
+        .expect("ci_economics_docs scope should exist");
+    let ci_economics_paths = ci_economics_docs["paths"]
+        .as_array()
+        .expect("ci_economics_docs should expose path globs")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+
+    assert!(ci_economics_paths.contains(".github/workflows/sync-labels.yml"));
+
+    let release_metadata = scopes
+        .iter()
+        .find(|scope| scope["name"].as_str() == Some("release_metadata"))
+        .expect("release_metadata scope should exist");
+    let release_paths = release_metadata["paths"]
+        .as_array()
+        .expect("release_metadata should expose path globs")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+    let release_proof = release_metadata["proof"]
+        .as_array()
+        .expect("release_metadata should expose proof commands")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+
+    assert!(release_paths.contains(".github/workflows/release.yml"));
+    assert!(release_proof.contains("cargo xtask publish-surface --json --verify-publish"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- route mutation, Nix, release, and label-sync workflow files through existing proof-policy scopes
- add ci-lane whitelist proof to the proof-control-plane scope
- lock the new routing in the proof-policy test and record the checkpoint in docs/NEXT.md

## Evidence
- cargo xtask proof-policy --check
- cargo test -p xtask proof_policy --verbose
- cargo xtask ci-lane-whitelist
- cargo xtask affected --base origin/main --head origin/pr/2088 --json
- cargo xtask proof --profile affected --base origin/main --head origin/pr/2088 --plan
- cargo xtask docs --check
- cargo fmt-check
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo xtask proof-artifacts-check
- cargo xtask publish-surface --json --verify-publish
- git diff --check origin/main..HEAD

## Notes
This addresses the fresh failure observed on the closed Dependabot #2088 branch: the same workflow-only update probe now reports zero unknown files and produces a proof plan instead of failing affected discovery.