### PR TITLE
refactor(model): extract child language aggregation

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -663,6 +663,7 @@ name = "model_scan_path_normalization"
 kind = "rust"
 paths = [
   "crates/tokmd-model/src/aggregate.rs",
+  "crates/tokmd-model/src/children.rs",
   "crates/tokmd-model/src/lib.rs",
   "crates/tokmd-model/src/module_key/**",
   "crates/tokmd-model/src/rows.rs",
@@ -674,6 +675,7 @@ paths = [
 ]
 packages = ["tokmd-model", "tokmd-scan"]
 proof = [
+  "cargo test -p tokmd-model children --verbose",
   "cargo test -p tokmd-model normalize --verbose",
   "cargo test -p tokmd-scan normalize --verbose",
 ]

--- a/crates/tokmd-model/src/aggregate.rs
+++ b/crates/tokmd-model/src/aggregate.rs
@@ -9,6 +9,7 @@ use tokmd_types::{
     ModuleReport, ModuleRow, Totals,
 };
 
+use crate::children::aggregate_lang_rows;
 use crate::sorting::{sort_file_rows, sort_lang_rows, sort_module_rows};
 use crate::{avg, collect_file_rows, unique_parent_file_count_from_rows};
 
@@ -28,99 +29,7 @@ pub fn create_lang_report_from_rows(
     with_files: bool,
     children: ChildrenMode,
 ) -> LangReport {
-    #[derive(Default)]
-    struct LangAgg {
-        code: usize,
-        lines: usize,
-        bytes: usize,
-        tokens: usize,
-    }
-
-    let parent_lang_by_path: BTreeMap<&str, &str> = file_rows
-        .iter()
-        .filter(|row| row.kind == FileKind::Parent)
-        .map(|row| (row.path.as_str(), row.lang.as_str()))
-        .collect();
-    let mut child_totals_by_path: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
-    for row in file_rows.iter().filter(|row| row.kind == FileKind::Child) {
-        let entry = child_totals_by_path.entry(row.path.as_str()).or_default();
-        entry.0 += row.code;
-        entry.1 += row.lines;
-    }
-
-    let mut by_lang: BTreeMap<(&str, bool), (LangAgg, BTreeSet<&str>)> = BTreeMap::new();
-
-    for row in file_rows {
-        match (children, row.kind) {
-            (ChildrenMode::Collapse, FileKind::Parent) => {
-                let entry = by_lang
-                    .entry((row.lang.as_str(), false))
-                    .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
-                entry.0.code += row.code;
-                entry.0.lines += row.lines;
-                entry.0.bytes += row.bytes;
-                entry.0.tokens += row.tokens;
-                entry.1.insert(row.path.as_str());
-            }
-            (ChildrenMode::Collapse, FileKind::Child) => {
-                if !parent_lang_by_path.contains_key(row.path.as_str()) {
-                    let entry = by_lang
-                        .entry((row.lang.as_str(), false))
-                        .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
-                    entry.0.code += row.code;
-                    entry.0.lines += row.lines;
-                    entry.0.bytes += row.bytes;
-                    entry.0.tokens += row.tokens;
-                    entry.1.insert(row.path.as_str());
-                }
-            }
-            (ChildrenMode::Separate, FileKind::Parent) => {
-                let (child_code, child_lines) = child_totals_by_path
-                    .get(row.path.as_str())
-                    .copied()
-                    .unwrap_or((0, 0));
-
-                let entry = by_lang
-                    .entry((row.lang.as_str(), false))
-                    .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
-                entry.0.code += row.code.saturating_sub(child_code);
-                entry.0.lines += row.lines.saturating_sub(child_lines);
-                entry.0.bytes += row.bytes;
-                entry.0.tokens += row.tokens;
-                entry.1.insert(row.path.as_str());
-            }
-            (ChildrenMode::Separate, FileKind::Child) => {
-                let entry = by_lang
-                    .entry((row.lang.as_str(), true))
-                    .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
-                entry.0.code += row.code;
-                entry.0.lines += row.lines;
-                entry.1.insert(row.path.as_str());
-            }
-        }
-    }
-
-    let mut rows: Vec<LangRow> = Vec::with_capacity(by_lang.len());
-    for ((lang, is_embedded), (agg, files_set)) in by_lang {
-        if agg.code == 0 {
-            continue;
-        }
-        let files = files_set.len();
-        rows.push(LangRow {
-            lang: if is_embedded {
-                format!("{} (embedded)", lang)
-            } else {
-                lang.to_string()
-            },
-            code: agg.code,
-            lines: agg.lines,
-            files,
-            bytes: agg.bytes,
-            tokens: agg.tokens,
-            avg_lines: avg(agg.lines, files),
-        });
-    }
-
+    let mut rows = aggregate_lang_rows(file_rows, children);
     sort_lang_rows(&mut rows);
 
     let total_code: usize = rows.iter().map(|r| r.code).sum();

--- a/crates/tokmd-model/src/children.rs
+++ b/crates/tokmd-model/src/children.rs
@@ -1,0 +1,180 @@
+//! Child and embedded-language aggregation for model receipts.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use tokmd_types::{ChildrenMode, FileKind, FileRow, LangRow};
+
+use crate::avg;
+
+#[derive(Default)]
+struct LangAgg {
+    code: usize,
+    lines: usize,
+    bytes: usize,
+    tokens: usize,
+}
+
+pub(crate) fn aggregate_lang_rows(file_rows: &[FileRow], children: ChildrenMode) -> Vec<LangRow> {
+    let parent_lang_by_path: BTreeMap<&str, &str> = file_rows
+        .iter()
+        .filter(|row| row.kind == FileKind::Parent)
+        .map(|row| (row.path.as_str(), row.lang.as_str()))
+        .collect();
+    let mut child_totals_by_path: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+    for row in file_rows.iter().filter(|row| row.kind == FileKind::Child) {
+        let entry = child_totals_by_path.entry(row.path.as_str()).or_default();
+        entry.0 += row.code;
+        entry.1 += row.lines;
+    }
+
+    let mut by_lang: BTreeMap<(&str, bool), (LangAgg, BTreeSet<&str>)> = BTreeMap::new();
+
+    for row in file_rows {
+        match (children, row.kind) {
+            (ChildrenMode::Collapse, FileKind::Parent) => {
+                let entry = by_lang
+                    .entry((row.lang.as_str(), false))
+                    .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
+                entry.0.code += row.code;
+                entry.0.lines += row.lines;
+                entry.0.bytes += row.bytes;
+                entry.0.tokens += row.tokens;
+                entry.1.insert(row.path.as_str());
+            }
+            (ChildrenMode::Collapse, FileKind::Child) => {
+                if !parent_lang_by_path.contains_key(row.path.as_str()) {
+                    let entry = by_lang
+                        .entry((row.lang.as_str(), false))
+                        .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
+                    entry.0.code += row.code;
+                    entry.0.lines += row.lines;
+                    entry.0.bytes += row.bytes;
+                    entry.0.tokens += row.tokens;
+                    entry.1.insert(row.path.as_str());
+                }
+            }
+            (ChildrenMode::Separate, FileKind::Parent) => {
+                let (child_code, child_lines) = child_totals_by_path
+                    .get(row.path.as_str())
+                    .copied()
+                    .unwrap_or((0, 0));
+
+                let entry = by_lang
+                    .entry((row.lang.as_str(), false))
+                    .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
+                entry.0.code += row.code.saturating_sub(child_code);
+                entry.0.lines += row.lines.saturating_sub(child_lines);
+                entry.0.bytes += row.bytes;
+                entry.0.tokens += row.tokens;
+                entry.1.insert(row.path.as_str());
+            }
+            (ChildrenMode::Separate, FileKind::Child) => {
+                let entry = by_lang
+                    .entry((row.lang.as_str(), true))
+                    .or_insert_with(|| (LangAgg::default(), BTreeSet::new()));
+                entry.0.code += row.code;
+                entry.0.lines += row.lines;
+                entry.1.insert(row.path.as_str());
+            }
+        }
+    }
+
+    by_lang
+        .into_iter()
+        .filter_map(|((lang, is_embedded), (agg, files_set))| {
+            if agg.code == 0 {
+                return None;
+            }
+            let files = files_set.len();
+            Some(LangRow {
+                lang: if is_embedded {
+                    format!("{lang} (embedded)")
+                } else {
+                    lang.to_string()
+                },
+                code: agg.code,
+                lines: agg.lines,
+                files,
+                bytes: agg.bytes,
+                tokens: agg.tokens,
+                avg_lines: avg(agg.lines, files),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(path: &str, lang: &str, kind: FileKind, code: usize, lines: usize) -> FileRow {
+        FileRow {
+            path: path.to_string(),
+            module: "(root)".to_string(),
+            lang: lang.to_string(),
+            kind,
+            code,
+            comments: 0,
+            blanks: lines.saturating_sub(code),
+            lines,
+            bytes: if kind == FileKind::Parent { 120 } else { 0 },
+            tokens: if kind == FileKind::Parent { 30 } else { 0 },
+        }
+    }
+
+    #[test]
+    fn collapse_keeps_parent_row_and_skips_known_child_row() {
+        let rows = [
+            row("docs/mixed.md", "Markdown", FileKind::Parent, 10, 20),
+            row("docs/mixed.md", "Rust", FileKind::Child, 4, 5),
+        ];
+
+        let aggregated = aggregate_lang_rows(&rows, ChildrenMode::Collapse);
+
+        assert_eq!(aggregated.len(), 1);
+        assert_eq!(aggregated[0].lang, "Markdown");
+        assert_eq!(aggregated[0].code, 10);
+        assert_eq!(aggregated[0].lines, 20);
+        assert_eq!(aggregated[0].bytes, 120);
+        assert_eq!(aggregated[0].tokens, 30);
+    }
+
+    #[test]
+    fn separate_subtracts_child_lines_from_parent_and_labels_child() {
+        let rows = [
+            row("docs/mixed.md", "Markdown", FileKind::Parent, 10, 20),
+            row("docs/mixed.md", "Rust", FileKind::Child, 4, 5),
+        ];
+
+        let aggregated = aggregate_lang_rows(&rows, ChildrenMode::Separate);
+        let parent = aggregated
+            .iter()
+            .find(|row| row.lang == "Markdown")
+            .expect("separate aggregation should keep parent row");
+        let child = aggregated
+            .iter()
+            .find(|row| row.lang == "Rust (embedded)")
+            .expect("separate aggregation should label child row");
+
+        assert_eq!(parent.code, 6);
+        assert_eq!(parent.lines, 15);
+        assert_eq!(parent.bytes, 120);
+        assert_eq!(parent.tokens, 30);
+        assert_eq!(child.code, 4);
+        assert_eq!(child.lines, 5);
+        assert_eq!(child.bytes, 0);
+        assert_eq!(child.tokens, 0);
+    }
+
+    #[test]
+    fn collapse_preserves_orphan_child_without_parent() {
+        let rows = [row("orphan.template", "Rust", FileKind::Child, 4, 5)];
+
+        let aggregated = aggregate_lang_rows(&rows, ChildrenMode::Collapse);
+
+        assert_eq!(aggregated.len(), 1);
+        assert_eq!(aggregated[0].lang, "Rust");
+        assert_eq!(aggregated[0].code, 4);
+        assert_eq!(aggregated[0].lines, 5);
+    }
+}

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -20,6 +20,7 @@ use std::borrow::Cow;
 use std::path::Path;
 
 mod aggregate;
+mod children;
 pub mod module_key;
 mod rows;
 mod sorting;

--- a/crates/tokmd-model/tests/snapshots/snapshots__file_rows_parents_only.snap
+++ b/crates/tokmd-model/tests/snapshots/snapshots__file_rows_parents_only.snap
@@ -1,17 +1,8 @@
 ---
 source: crates/tokmd-model/tests/snapshots.rs
-assertion_line: 127
 expression: redacted
 ---
 [
-  {
-    "code_gt_zero": true,
-    "kind": "Parent",
-    "lang": "Rust",
-    "lines_eq_sum": true,
-    "module": "<root>",
-    "path": "crates/tokmd-model/src/aggregate.rs"
-  },
   {
     "code_gt_zero": true,
     "kind": "Parent",
@@ -26,7 +17,23 @@ expression: redacted
     "lang": "Rust",
     "lines_eq_sum": true,
     "module": "<root>",
+    "path": "crates/tokmd-model/src/aggregate.rs"
+  },
+  {
+    "code_gt_zero": true,
+    "kind": "Parent",
+    "lang": "Rust",
+    "lines_eq_sum": true,
+    "module": "<root>",
     "path": "crates/tokmd-model/src/lib.rs"
+  },
+  {
+    "code_gt_zero": true,
+    "kind": "Parent",
+    "lang": "Rust",
+    "lines_eq_sum": true,
+    "module": "<root>",
+    "path": "crates/tokmd-model/src/children.rs"
   },
   {
     "code_gt_zero": true,

--- a/crates/tokmd-model/tests/snapshots/snapshots__file_rows_separate.snap
+++ b/crates/tokmd-model/tests/snapshots/snapshots__file_rows_separate.snap
@@ -1,17 +1,8 @@
 ---
 source: crates/tokmd-model/tests/snapshots.rs
-assertion_line: 135
 expression: redacted
 ---
 [
-  {
-    "code_gt_zero": true,
-    "kind": "Parent",
-    "lang": "Rust",
-    "lines_eq_sum": true,
-    "module": "<root>",
-    "path": "crates/tokmd-model/src/aggregate.rs"
-  },
   {
     "code_gt_zero": true,
     "kind": "Parent",
@@ -26,7 +17,23 @@ expression: redacted
     "lang": "Rust",
     "lines_eq_sum": true,
     "module": "<root>",
+    "path": "crates/tokmd-model/src/aggregate.rs"
+  },
+  {
+    "code_gt_zero": true,
+    "kind": "Parent",
+    "lang": "Rust",
+    "lines_eq_sum": true,
+    "module": "<root>",
     "path": "crates/tokmd-model/src/lib.rs"
+  },
+  {
+    "code_gt_zero": true,
+    "kind": "Parent",
+    "lang": "Rust",
+    "lines_eq_sum": true,
+    "module": "<root>",
+    "path": "crates/tokmd-model/src/children.rs"
   },
   {
     "code_gt_zero": true,
@@ -51,6 +58,14 @@ expression: redacted
     "lines_eq_sum": true,
     "module": "<root>",
     "path": "crates/tokmd-model/src/aggregate.rs"
+  },
+  {
+    "code_gt_zero": false,
+    "kind": "Child",
+    "lang": "Markdown",
+    "lines_eq_sum": true,
+    "module": "<root>",
+    "path": "crates/tokmd-model/src/children.rs"
   },
   {
     "code_gt_zero": false,

--- a/docs/architecture-consolidation-plan.md
+++ b/docs/architecture-consolidation-plan.md
@@ -71,7 +71,7 @@ fixtures:
 | CLI config resolution | `crates/tokmd/src/config.rs` and `crates/tokmd/src/config/resolve.rs` | `config.rs` 313; resolver owner 456 | Keep config discovery, profile selection, `ConfigContext`, and `ResolvedConfig` in the root config module while lang/module/export CLI-to-receipt argument resolution lives in the resolver owner module. Preserve root re-exports. |
 | Gate command | `crates/tokmd/src/commands/gate.rs` and `crates/tokmd/src/commands/gate/` | `gate.rs` 135; policy owner/tests 215; receipt owner/tests 144; render owner 111 | Gate policy loading, ratchet loading, and config-rule conversion live in the policy owner; receipt loading and compute-then-gate preparation live in the receipt owner; text/JSON result rendering lives in the render owner; the command coordinator keeps flow, evaluation, and result combining. Keep `tokmd_gate` proof scoped to all gate command paths. |
 | Sensor command | `crates/tokmd/src/commands/sensor.rs` and `crates/tokmd/src/commands/sensor/` | `sensor.rs` 157; findings owner/tests 344; gate mapping owner/tests 189; output owner/tests 141 | Sensor finding emission, cockpit-evidence-to-envelope gate mapping, and 3-layer output topology now live in owner modules while the command keeps git resolution, cockpit execution, and envelope assembly. |
-| Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 267; aggregation owner/tests 427; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, in-memory row detection, and row sorting now live in owner modules; remaining work is child-language behavior only if future evidence shows the seam is still too broad |
+| Model aggregation | `crates/tokmd-model/src/lib.rs`, `crates/tokmd-model/src/aggregate.rs`, `crates/tokmd-model/src/children.rs`, `crates/tokmd-model/src/rows.rs`, and `crates/tokmd-model/src/sorting.rs` | `lib.rs` 255; aggregation owner/tests 344; child-language owner/tests 160; row collection owner/tests 411; sorting owner/tests 91 | Report builders, file-row collection, child/embedded language aggregation, in-memory row detection, and row sorting now live in owner modules; future model work should start from concrete product or proof evidence rather than splitting for line count |
 
 ## Batch Order
 
@@ -330,8 +330,8 @@ Target modules:
 crates/tokmd-model/src/
   lib.rs
   aggregate.rs
-  rows.rs
   children.rs
+  rows.rs
   sorting.rs
 
 crates/tokmd-scan/src/


### PR DESCRIPTION
## Summary
- Extract child/embedded-language aggregation from `tokmd-model` aggregation into `children.rs`.
- Keep report assembly, sorting, top folding, totals, public exports, and output semantics unchanged.
- Route the new owner module through the existing model proof scope and refresh self-scan snapshots for the new file layout.

## Validation
- `cargo test -p tokmd-model children --verbose`
- `cargo test -p tokmd-model --verbose` (after inspecting and accepting expected self-scan snapshot drift from the new `children.rs` file)
- `cargo test -p tokmd --test integration children --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo test -p tokmd-scan normalize --verbose`
- `cargo test -p tokmd-model normalize --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo fmt-check`
- `cargo clippy -p tokmd-model --all-targets -- -D warnings`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check origin/main..HEAD`