### PR TITLE
Refactor analysis orchestration into SRP submodules

### DIFF
--- a/crates/tokmd-analysis/src/analysis.rs
+++ b/crates/tokmd-analysis/src/analysis.rs
@@ -1,50 +1,23 @@
-#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
-use std::path::Path;
 use std::path::PathBuf;
 
 #[cfg(feature = "effort")]
-use crate::effort::{EffortRequest, build_effort_report};
+use crate::effort::EffortRequest;
 use anyhow::Result;
-use tokmd_analysis_types::AnalysisLimits;
-use tokmd_analysis_types::{
-    AnalysisArgsMeta, AnalysisReceipt, AnalysisSource, ApiSurfaceReport, Archetype, AssetReport,
-    ComplexityReport, CorporateFingerprint, DependencyReport, DuplicateReport, EntropyReport,
-    FunReport, GitReport, ImportReport, LicenseReport, NearDupScope, PredictiveChurnReport,
-    TopicClouds,
-};
-use tokmd_types::{ExportData, ScanStatus, ToolInfo};
+use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisReceipt, AnalysisSource, NearDupScope};
+use tokmd_types::ExportData;
 
-#[cfg(all(feature = "content", feature = "walk"))]
-use crate::api_surface::build_api_surface_report;
-#[cfg(feature = "archetype")]
-use crate::archetype::detect_archetype;
-#[cfg(feature = "walk")]
-use crate::assets::{build_assets_report, build_dependency_report};
-#[cfg(feature = "content")]
-use crate::content::{
-    ContentLimits, ImportGranularity as ContentImportGranularity, build_duplicate_report,
-    build_import_report, build_todo_report,
-};
-use crate::derived::{build_tree, derive_report};
-#[cfg(feature = "git")]
-use crate::fingerprint::build_corporate_fingerprint;
-#[cfg(feature = "fun")]
-use crate::fun::build_fun_report;
-#[cfg(feature = "git")]
-use crate::git::{build_git_report, build_predictive_churn_report};
 use crate::grid::{PresetKind, PresetPlan, preset_plan_for};
-#[cfg(feature = "content")]
-use crate::near_dup::{NearDupLimits, build_near_dup_report};
-#[cfg(feature = "topics")]
-use crate::topics::build_topic_clouds;
-use crate::util::now_ms;
-#[cfg(all(feature = "content", feature = "walk"))]
-use crate::{
-    complexity::build_complexity_report, entropy::build_entropy_report,
-    license::build_license_report,
-};
-#[cfg(all(feature = "halstead", feature = "content", feature = "walk"))]
-use crate::{halstead::build_halstead_report, maintainability::attach_halstead_metrics};
+
+#[path = "analysis/enrichers.rs"]
+mod enrichers;
+#[path = "analysis/file_inventory.rs"]
+mod file_inventory;
+#[path = "analysis/receipt.rs"]
+mod receipt;
+#[path = "analysis/report_set.rs"]
+mod report_set;
+#[path = "analysis/warnings.rs"]
+mod warnings;
 
 /// Canonical preset enum for analysis orchestration.
 pub type AnalysisPreset = PresetKind;
@@ -53,22 +26,6 @@ pub type AnalysisPreset = PresetKind;
 pub enum ImportGranularity {
     Module,
     File,
-}
-
-#[cfg(feature = "content")]
-fn content_limits(limits: &AnalysisLimits) -> ContentLimits {
-    ContentLimits {
-        max_bytes: limits.max_bytes,
-        max_file_bytes: limits.max_file_bytes,
-    }
-}
-
-#[cfg(feature = "content")]
-fn content_import_granularity(granularity: ImportGranularity) -> ContentImportGranularity {
-    match granularity {
-        ImportGranularity::Module => ContentImportGranularity::Module,
-        ImportGranularity::File => ContentImportGranularity::File,
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -82,7 +39,7 @@ pub struct AnalysisContext {
 pub struct AnalysisRequest {
     pub preset: AnalysisPreset,
     pub args: AnalysisArgsMeta,
-    pub limits: AnalysisLimits,
+    pub limits: tokmd_analysis_types::AnalysisLimits,
     #[cfg(feature = "effort")]
     pub effort: Option<EffortRequest>,
     pub window_tokens: Option<usize>,
@@ -107,503 +64,29 @@ fn preset_plan(preset: AnalysisPreset) -> PresetPlan {
     preset_plan_for(preset)
 }
 
-#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
-const ROOTLESS_FILE_ANALYSIS_WARNING: &str =
-    "in-memory analysis has no host root; skipping file-backed enrichers";
-#[cfg(feature = "git")]
-const ROOTLESS_GIT_ANALYSIS_WARNING: &str =
-    "in-memory analysis has no host root; skipping git-backed enrichers";
-
-#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
-fn has_host_root(root: &Path) -> bool {
-    !root.as_os_str().is_empty()
-}
-
-#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
-fn push_warning_once(warnings: &mut Vec<String>, warning: &str) {
-    if warnings.iter().all(|existing| existing != warning) {
-        warnings.push(warning.to_string());
-    }
-}
-
 pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisReceipt> {
-    let mut warnings: Vec<String> = Vec::new();
-    #[cfg_attr(not(feature = "content"), allow(unused_mut))]
-    let mut derived = derive_report(&ctx.export, req.window_tokens);
-    if req.args.format.contains("tree") {
-        derived.tree = Some(build_tree(&ctx.export));
-    }
-
-    let mut source = ctx.source.clone();
-    if source.base_signature.is_none() {
-        source.base_signature = Some(derived.integrity.hash.clone());
-    }
-
+    let mut warnings = Vec::new();
+    let mut derived = receipt::prepare_derived(&ctx.export, &req.args, req.window_tokens);
+    let source = receipt::source_with_base_signature(&ctx.source, &derived);
     let plan = preset_plan(req.preset);
-    let include_git = match req.git {
-        Some(flag) => flag,
-        None => plan.git,
-    };
-    #[cfg(any(feature = "walk", feature = "content", feature = "git"))]
-    let has_host_root = has_host_root(&ctx.root);
+    let include_git = req.git.unwrap_or(plan.git);
+    let mut reports = report_set::AnalysisReports::default();
 
-    #[cfg(feature = "walk")]
-    let mut assets: Option<AssetReport> = None;
-    #[cfg(not(feature = "walk"))]
-    let assets: Option<AssetReport> = None;
+    let files = file_inventory::collect_analysis_files(&ctx, &req, &plan, &mut warnings);
+    enrichers::run_file_enrichers(
+        &ctx,
+        &req,
+        &plan,
+        files.as_deref(),
+        &mut derived,
+        &mut reports,
+        &mut warnings,
+    );
+    enrichers::run_git_enrichers(&ctx, &req, &plan, include_git, &mut reports, &mut warnings);
+    enrichers::run_model_enrichers(&ctx, &plan, &derived, &mut reports, &mut warnings);
+    enrichers::run_effort_enricher(&ctx, &req, &derived, &mut reports, &mut warnings);
 
-    #[cfg(feature = "walk")]
-    let mut deps: Option<DependencyReport> = None;
-    #[cfg(not(feature = "walk"))]
-    let deps: Option<DependencyReport> = None;
-
-    #[cfg(feature = "content")]
-    let mut imports: Option<ImportReport> = None;
-    #[cfg(not(feature = "content"))]
-    let imports: Option<ImportReport> = None;
-
-    #[cfg(feature = "content")]
-    let mut dup: Option<DuplicateReport> = None;
-    #[cfg(not(feature = "content"))]
-    let dup: Option<DuplicateReport> = None;
-
-    #[cfg(feature = "git")]
-    let mut git: Option<GitReport> = None;
-    #[cfg(not(feature = "git"))]
-    let git: Option<GitReport> = None;
-
-    #[cfg(feature = "git")]
-    let mut churn: Option<PredictiveChurnReport> = None;
-    #[cfg(not(feature = "git"))]
-    let churn: Option<PredictiveChurnReport> = None;
-
-    #[cfg(feature = "git")]
-    let mut fingerprint: Option<CorporateFingerprint> = None;
-    #[cfg(not(feature = "git"))]
-    let fingerprint: Option<CorporateFingerprint> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut entropy: Option<EntropyReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let entropy: Option<EntropyReport> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut license: Option<LicenseReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let license: Option<LicenseReport> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut complexity: Option<ComplexityReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let complexity: Option<ComplexityReport> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut api_surface: Option<ApiSurfaceReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let api_surface: Option<ApiSurfaceReport> = None;
-
-    #[cfg(feature = "archetype")]
-    let mut archetype: Option<Archetype> = None;
-    #[cfg(not(feature = "archetype"))]
-    let archetype: Option<Archetype> = None;
-    #[cfg(feature = "topics")]
-    let mut topics: Option<TopicClouds> = None;
-    #[cfg(not(feature = "topics"))]
-    let topics: Option<TopicClouds> = None;
-
-    let fun: Option<FunReport>;
-
-    #[cfg(any(feature = "walk", feature = "content"))]
-    #[cfg_attr(not(feature = "walk"), allow(unused_mut))]
-    let mut files: Option<Vec<PathBuf>> = None;
-    #[cfg(not(any(feature = "walk", feature = "content")))]
-    let _files: Option<Vec<PathBuf>> = None;
-
-    if plan.needs_files() {
-        #[cfg(feature = "walk")]
-        if has_host_root {
-            match tokmd_scan::walk::list_files(&ctx.root, req.limits.max_files) {
-                Ok(list) => files = Some(list),
-                Err(err) => warnings.push(format!("walk failed: {}", err)),
-            }
-        } else {
-            push_warning_once(&mut warnings, ROOTLESS_FILE_ANALYSIS_WARNING);
-        }
-        #[cfg(not(feature = "walk"))]
-        {
-            warnings.push(
-                crate::grid::DisabledFeature::FileInventory
-                    .warning()
-                    .to_string(),
-            );
-        }
-    }
-
-    if plan.assets {
-        #[cfg(feature = "walk")]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_assets_report(&ctx.root, list) {
-                    Ok(report) => assets = Some(report),
-                    Err(err) => warnings.push(format!("asset scan failed: {}", err)),
-                }
-            }
-        }
-    }
-
-    if plan.deps {
-        #[cfg(feature = "walk")]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_dependency_report(&ctx.root, list) {
-                    Ok(report) => deps = Some(report),
-                    Err(err) => warnings.push(format!("dependency scan failed: {}", err)),
-                }
-            }
-        }
-    }
-
-    if plan.todo {
-        #[cfg(feature = "content")]
-        {
-            if let Some(list) = files.as_deref() {
-                let limits = content_limits(&req.limits);
-                match build_todo_report(&ctx.root, list, &limits, derived.totals.code) {
-                    Ok(report) => derived.todo = Some(report),
-                    Err(err) => warnings.push(format!("todo scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(crate::grid::DisabledFeature::TodoScan.warning().to_string());
-    }
-
-    if plan.dup {
-        #[cfg(feature = "content")]
-        {
-            if let Some(list) = files.as_deref() {
-                let limits = content_limits(&req.limits);
-                match build_duplicate_report(&ctx.root, list, &ctx.export, &limits) {
-                    Ok(report) => dup = Some(report),
-                    Err(err) => warnings.push(format!("dup scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(
-            crate::grid::DisabledFeature::DuplicationScan
-                .warning()
-                .to_string(),
-        );
-    }
-
-    // Near-duplicate detection (opt-in via --near-dup)
-    if req.near_dup {
-        #[cfg(feature = "content")]
-        {
-            if has_host_root {
-                let near_dup_limits = NearDupLimits {
-                    max_bytes: req.limits.max_bytes,
-                    max_file_bytes: req.limits.max_file_bytes,
-                };
-                match build_near_dup_report(
-                    &ctx.root,
-                    &ctx.export,
-                    req.near_dup_scope,
-                    req.near_dup_threshold,
-                    req.near_dup_max_files,
-                    req.near_dup_max_pairs,
-                    &near_dup_limits,
-                    &req.near_dup_exclude,
-                ) {
-                    Ok(report) => {
-                        // Attach to existing dup report or create a minimal one
-                        if let Some(ref mut d) = dup {
-                            d.near = Some(report);
-                        } else {
-                            dup = Some(DuplicateReport {
-                                groups: Vec::new(),
-                                wasted_bytes: 0,
-                                strategy: "none".to_string(),
-                                density: None,
-                                near: Some(report),
-                            });
-                        }
-                    }
-                    Err(err) => warnings.push(format!("near-dup scan failed: {}", err)),
-                }
-            } else {
-                push_warning_once(&mut warnings, ROOTLESS_FILE_ANALYSIS_WARNING);
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(
-            crate::grid::DisabledFeature::NearDuplicateScan
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.imports {
-        #[cfg(feature = "content")]
-        {
-            if let Some(list) = files.as_deref() {
-                let limits = content_limits(&req.limits);
-                let granularity = content_import_granularity(req.import_granularity);
-                match build_import_report(&ctx.root, list, &ctx.export, granularity, &limits) {
-                    Ok(report) => imports = Some(report),
-                    Err(err) => warnings.push(format!("import scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(
-            crate::grid::DisabledFeature::ImportScan
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if include_git {
-        #[cfg(feature = "git")]
-        {
-            if has_host_root {
-                let repo_root = match tokmd_git::repo_root(&ctx.root) {
-                    Some(root) => root,
-                    None => {
-                        warnings.push("git scan failed: not a git repo".to_string());
-                        PathBuf::new()
-                    }
-                };
-                if !repo_root.as_os_str().is_empty() {
-                    match tokmd_git::collect_history(
-                        &repo_root,
-                        req.limits.max_commits,
-                        req.limits.max_commit_files,
-                    ) {
-                        Ok(commits) => {
-                            if plan.git {
-                                match build_git_report(&repo_root, &ctx.export, &commits) {
-                                    Ok(report) => git = Some(report),
-                                    Err(err) => warnings.push(format!("git scan failed: {}", err)),
-                                }
-                            }
-                            if plan.churn {
-                                churn = Some(build_predictive_churn_report(
-                                    &ctx.export,
-                                    &commits,
-                                    &repo_root,
-                                ));
-                            }
-                            if plan.fingerprint {
-                                fingerprint = Some(build_corporate_fingerprint(&commits));
-                            }
-                        }
-                        Err(err) => warnings.push(format!("git scan failed: {}", err)),
-                    }
-                }
-            } else {
-                push_warning_once(&mut warnings, ROOTLESS_GIT_ANALYSIS_WARNING);
-            }
-        }
-        #[cfg(not(feature = "git"))]
-        warnings.push(
-            crate::grid::DisabledFeature::GitMetrics
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.archetype {
-        #[cfg(feature = "archetype")]
-        {
-            archetype = detect_archetype(&ctx.export);
-        }
-        #[cfg(not(feature = "archetype"))]
-        {
-            warnings.push(
-                crate::grid::DisabledFeature::Archetype
-                    .warning()
-                    .to_string(),
-            );
-        }
-    }
-
-    if plan.topics {
-        #[cfg(feature = "topics")]
-        {
-            topics = Some(build_topic_clouds(&ctx.export));
-        }
-        #[cfg(not(feature = "topics"))]
-        {
-            warnings.push(crate::grid::DisabledFeature::Topics.warning().to_string());
-        }
-    }
-
-    if plan.entropy {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_entropy_report(&ctx.root, list, &ctx.export, &req.limits) {
-                    Ok(report) => entropy = Some(report),
-                    Err(err) => warnings.push(format!("entropy scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::EntropyProfiling
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.license {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_license_report(&ctx.root, list, &req.limits) {
-                    Ok(report) => license = Some(report),
-                    Err(err) => warnings.push(format!("license scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::LicenseRadar
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.complexity {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_complexity_report(
-                    &ctx.root,
-                    list,
-                    &ctx.export,
-                    &req.limits,
-                    req.detail_functions,
-                ) {
-                    Ok(report) => complexity = Some(report),
-                    Err(err) => warnings.push(format!("complexity scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::ComplexityAnalysis
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.api_surface {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_api_surface_report(&ctx.root, list, &ctx.export, &req.limits) {
-                    Ok(report) => api_surface = Some(report),
-                    Err(err) => warnings.push(format!("api surface scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::ApiSurfaceAnalysis
-                .warning()
-                .to_string(),
-        );
-    }
-
-    // Halstead metrics (feature-gated)
-    #[cfg(all(feature = "halstead", feature = "content", feature = "walk"))]
-    if plan.halstead
-        && let Some(list) = files.as_deref()
-    {
-        match build_halstead_report(&ctx.root, list, &ctx.export, &req.limits) {
-            Ok(halstead_report) => {
-                // Wire Halstead into complexity report if available
-                if let Some(ref mut cx) = complexity {
-                    attach_halstead_metrics(cx, halstead_report);
-                }
-            }
-            Err(err) => warnings.push(format!("halstead scan failed: {}", err)),
-        }
-    }
-
-    if plan.fun {
-        #[cfg(feature = "fun")]
-        {
-            fun = Some(build_fun_report(&derived));
-        }
-        #[cfg(not(feature = "fun"))]
-        {
-            warnings.push(crate::grid::DisabledFeature::Fun.warning().to_string());
-            fun = None;
-        }
-    } else {
-        fun = None;
-    }
-
-    #[cfg(feature = "effort")]
-    let effort = if let Some(effort_request) = &req.effort {
-        match build_effort_report(
-            &ctx.root,
-            &ctx.export,
-            &derived,
-            git.as_ref(),
-            complexity.as_ref(),
-            api_surface.as_ref(),
-            dup.as_ref(),
-            effort_request,
-        ) {
-            Ok(report) => Some(report),
-            Err(err) => {
-                warnings.push(format!("effort estimate failed: {}", err));
-                None
-            }
-        }
-    } else {
-        None
-    };
-    #[cfg(not(feature = "effort"))]
-    let effort: Option<tokmd_analysis_types::EffortEstimateReport> = None;
-
-    let status = if warnings.is_empty() {
-        ScanStatus::Complete
-    } else {
-        ScanStatus::Partial
-    };
-
-    let receipt = AnalysisReceipt {
-        schema_version: tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION,
-        generated_at_ms: now_ms(),
-        tool: ToolInfo::current(),
-        mode: "analysis".to_string(),
-        status,
-        warnings,
-        source,
-        args: req.args,
-        archetype,
-        topics,
-        entropy,
-        predictive_churn: churn,
-        corporate_fingerprint: fingerprint,
-        license,
-        derived: Some(derived),
-        assets,
-        deps,
-        git,
-        imports,
-        dup,
-        complexity,
-        api_surface,
-        effort,
-        fun,
-    };
-
-    Ok(receipt)
+    Ok(receipt::build_receipt(
+        source, req.args, derived, reports, warnings,
+    ))
 }

--- a/crates/tokmd-analysis/src/analysis/enrichers.rs
+++ b/crates/tokmd-analysis/src/analysis/enrichers.rs
@@ -1,0 +1,616 @@
+use tokmd_analysis_types::DerivedReport;
+#[cfg(feature = "content")]
+use tokmd_analysis_types::DuplicateReport;
+
+#[cfg(feature = "archetype")]
+use crate::archetype::detect_archetype;
+#[cfg(feature = "walk")]
+use crate::assets::{build_assets_report, build_dependency_report};
+#[cfg(feature = "content")]
+use crate::content::{
+    ContentLimits, ImportGranularity as ContentImportGranularity, build_duplicate_report,
+    build_import_report, build_todo_report,
+};
+#[cfg(feature = "effort")]
+use crate::effort::build_effort_report;
+#[cfg(feature = "git")]
+use crate::fingerprint::build_corporate_fingerprint;
+#[cfg(feature = "fun")]
+use crate::fun::build_fun_report;
+#[cfg(feature = "git")]
+use crate::git::{build_git_report, build_predictive_churn_report};
+use crate::grid::PresetPlan;
+#[cfg(feature = "content")]
+use crate::near_dup::{NearDupLimits, build_near_dup_report};
+#[cfg(feature = "topics")]
+use crate::topics::build_topic_clouds;
+#[cfg(all(feature = "content", feature = "walk"))]
+use crate::{
+    api_surface::build_api_surface_report, complexity::build_complexity_report,
+    entropy::build_entropy_report, license::build_license_report,
+};
+#[cfg(all(feature = "halstead", feature = "content", feature = "walk"))]
+use crate::{halstead::build_halstead_report, maintainability::attach_halstead_metrics};
+
+#[cfg(feature = "content")]
+use super::ImportGranularity;
+use super::report_set::AnalysisReports;
+#[cfg(any(feature = "content", feature = "git"))]
+use super::warnings;
+use super::{AnalysisContext, AnalysisRequest};
+
+#[cfg(feature = "content")]
+fn content_limits(limits: &tokmd_analysis_types::AnalysisLimits) -> ContentLimits {
+    ContentLimits {
+        max_bytes: limits.max_bytes,
+        max_file_bytes: limits.max_file_bytes,
+    }
+}
+
+#[cfg(feature = "content")]
+fn content_import_granularity(granularity: ImportGranularity) -> ContentImportGranularity {
+    match granularity {
+        ImportGranularity::Module => ContentImportGranularity::Module,
+        ImportGranularity::File => ContentImportGranularity::File,
+    }
+}
+
+pub(super) fn run_file_enrichers(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    derived: &mut DerivedReport,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    run_asset_enrichers(ctx, plan, files, reports, warnings_out);
+    run_content_enrichers(ctx, req, plan, files, derived, reports, warnings_out);
+    run_content_walk_enrichers(ctx, req, plan, files, reports, warnings_out);
+}
+
+fn run_asset_enrichers(
+    ctx: &AnalysisContext,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if plan.assets {
+        #[cfg(feature = "walk")]
+        if let Some(list) = files {
+            match build_assets_report(&ctx.root, list) {
+                Ok(report) => reports.assets = Some(report),
+                Err(err) => warnings_out.push(format!("asset scan failed: {}", err)),
+            }
+        }
+    }
+
+    if plan.deps {
+        #[cfg(feature = "walk")]
+        if let Some(list) = files {
+            match build_dependency_report(&ctx.root, list) {
+                Ok(report) => reports.deps = Some(report),
+                Err(err) => warnings_out.push(format!("dependency scan failed: {}", err)),
+            }
+        }
+    }
+
+    #[cfg(not(feature = "walk"))]
+    let _ = (ctx, files, reports, warnings_out);
+}
+
+fn run_content_enrichers(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    derived: &mut DerivedReport,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    run_todo_enricher(ctx, req, plan, files, derived, warnings_out);
+    run_duplicate_enrichers(ctx, req, plan, files, reports, warnings_out);
+    run_import_enricher(ctx, req, plan, files, reports, warnings_out);
+}
+
+fn run_todo_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    derived: &mut DerivedReport,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.todo {
+        return;
+    }
+
+    #[cfg(feature = "content")]
+    if let Some(list) = files {
+        let limits = content_limits(&req.limits);
+        match build_todo_report(&ctx.root, list, &limits, derived.totals.code) {
+            Ok(report) => derived.todo = Some(report),
+            Err(err) => warnings_out.push(format!("todo scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(feature = "content"))]
+    {
+        let _ = (ctx, req, files, derived);
+        warnings_out.push(crate::grid::DisabledFeature::TodoScan.warning().to_string());
+    }
+}
+
+fn run_duplicate_enrichers(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    #[cfg(not(feature = "content"))]
+    let _ = (ctx, files, reports);
+
+    if plan.dup {
+        #[cfg(feature = "content")]
+        if let Some(list) = files {
+            let limits = content_limits(&req.limits);
+            match build_duplicate_report(&ctx.root, list, &ctx.export, &limits) {
+                Ok(report) => reports.dup = Some(report),
+                Err(err) => warnings_out.push(format!("dup scan failed: {}", err)),
+            }
+        }
+
+        #[cfg(not(feature = "content"))]
+        warnings_out.push(
+            crate::grid::DisabledFeature::DuplicationScan
+                .warning()
+                .to_string(),
+        );
+    }
+
+    if req.near_dup {
+        #[cfg(feature = "content")]
+        {
+            if warnings::has_host_root(&ctx.root) {
+                let limits = NearDupLimits {
+                    max_bytes: req.limits.max_bytes,
+                    max_file_bytes: req.limits.max_file_bytes,
+                };
+                match build_near_dup_report(
+                    &ctx.root,
+                    &ctx.export,
+                    req.near_dup_scope,
+                    req.near_dup_threshold,
+                    req.near_dup_max_files,
+                    req.near_dup_max_pairs,
+                    &limits,
+                    &req.near_dup_exclude,
+                ) {
+                    Ok(report) => attach_near_duplicate_report(reports, report),
+                    Err(err) => warnings_out.push(format!("near-dup scan failed: {}", err)),
+                }
+            } else {
+                warnings::push_warning_once(warnings_out, warnings::ROOTLESS_FILE_ANALYSIS_WARNING);
+            }
+        }
+
+        #[cfg(not(feature = "content"))]
+        warnings_out.push(
+            crate::grid::DisabledFeature::NearDuplicateScan
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+#[cfg(feature = "content")]
+fn attach_near_duplicate_report(
+    reports: &mut AnalysisReports,
+    report: tokmd_analysis_types::NearDuplicateReport,
+) {
+    if let Some(ref mut dup) = reports.dup {
+        dup.near = Some(report);
+    } else {
+        reports.dup = Some(DuplicateReport {
+            groups: Vec::new(),
+            wasted_bytes: 0,
+            strategy: "none".to_string(),
+            density: None,
+            near: Some(report),
+        });
+    }
+}
+
+fn run_import_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.imports {
+        return;
+    }
+
+    #[cfg(feature = "content")]
+    if let Some(list) = files {
+        let limits = content_limits(&req.limits);
+        let granularity = content_import_granularity(req.import_granularity);
+        match build_import_report(&ctx.root, list, &ctx.export, granularity, &limits) {
+            Ok(report) => reports.imports = Some(report),
+            Err(err) => warnings_out.push(format!("import scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(feature = "content"))]
+    {
+        let _ = (ctx, req, files, reports);
+        warnings_out.push(
+            crate::grid::DisabledFeature::ImportScan
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+fn run_content_walk_enrichers(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    run_entropy_enricher(ctx, req, plan, files, reports, warnings_out);
+    run_license_enricher(ctx, req, plan, files, reports, warnings_out);
+    run_complexity_enricher(ctx, req, plan, files, reports, warnings_out);
+    run_api_surface_enricher(ctx, req, plan, files, reports, warnings_out);
+    run_halstead_enricher(ctx, req, plan, files, reports, warnings_out);
+}
+
+fn run_entropy_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.entropy {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match build_entropy_report(&ctx.root, list, &ctx.export, &req.limits) {
+            Ok(report) => reports.entropy = Some(report),
+            Err(err) => warnings_out.push(format!("entropy scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    {
+        let _ = (ctx, req, files, reports);
+        warnings_out.push(
+            crate::grid::DisabledFeature::EntropyProfiling
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+fn run_license_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.license {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match build_license_report(&ctx.root, list, &req.limits) {
+            Ok(report) => reports.license = Some(report),
+            Err(err) => warnings_out.push(format!("license scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    {
+        let _ = (ctx, req, files, reports);
+        warnings_out.push(
+            crate::grid::DisabledFeature::LicenseRadar
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+fn run_complexity_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.complexity {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match build_complexity_report(
+            &ctx.root,
+            list,
+            &ctx.export,
+            &req.limits,
+            req.detail_functions,
+        ) {
+            Ok(report) => reports.complexity = Some(report),
+            Err(err) => warnings_out.push(format!("complexity scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    {
+        let _ = (ctx, req, files, reports);
+        warnings_out.push(
+            crate::grid::DisabledFeature::ComplexityAnalysis
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+fn run_api_surface_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.api_surface {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match build_api_surface_report(&ctx.root, list, &ctx.export, &req.limits) {
+            Ok(report) => reports.api_surface = Some(report),
+            Err(err) => warnings_out.push(format!("api surface scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    {
+        let _ = (ctx, req, files, reports);
+        warnings_out.push(
+            crate::grid::DisabledFeature::ApiSurfaceAnalysis
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+fn run_halstead_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    files: Option<&[std::path::PathBuf]>,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    #[cfg(all(feature = "halstead", feature = "content", feature = "walk"))]
+    if plan.halstead
+        && let Some(list) = files
+    {
+        match build_halstead_report(&ctx.root, list, &ctx.export, &req.limits) {
+            Ok(halstead_report) => {
+                if let Some(ref mut complexity) = reports.complexity {
+                    attach_halstead_metrics(complexity, halstead_report);
+                }
+            }
+            Err(err) => warnings_out.push(format!("halstead scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "halstead", feature = "content", feature = "walk")))]
+    let _ = (ctx, req, plan, files, reports, warnings_out);
+}
+
+pub(super) fn run_git_enrichers(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    include_git: bool,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !include_git {
+        return;
+    }
+
+    #[cfg(feature = "git")]
+    {
+        if warnings::has_host_root(&ctx.root) {
+            collect_git_reports(ctx, req, plan, reports, warnings_out);
+        } else {
+            warnings::push_warning_once(warnings_out, warnings::ROOTLESS_GIT_ANALYSIS_WARNING);
+        }
+    }
+
+    #[cfg(not(feature = "git"))]
+    {
+        let _ = (ctx, req, plan, reports);
+        warnings_out.push(
+            crate::grid::DisabledFeature::GitMetrics
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+#[cfg(feature = "git")]
+fn collect_git_reports(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    let Some(repo_root) = tokmd_git::repo_root(&ctx.root) else {
+        warnings_out.push("git scan failed: not a git repo".to_string());
+        return;
+    };
+
+    match tokmd_git::collect_history(
+        &repo_root,
+        req.limits.max_commits,
+        req.limits.max_commit_files,
+    ) {
+        Ok(commits) => {
+            if plan.git {
+                match build_git_report(&repo_root, &ctx.export, &commits) {
+                    Ok(report) => reports.git = Some(report),
+                    Err(err) => warnings_out.push(format!("git scan failed: {}", err)),
+                }
+            }
+            if plan.churn {
+                reports.predictive_churn = Some(build_predictive_churn_report(
+                    &ctx.export,
+                    &commits,
+                    &repo_root,
+                ));
+            }
+            if plan.fingerprint {
+                reports.corporate_fingerprint = Some(build_corporate_fingerprint(&commits));
+            }
+        }
+        Err(err) => warnings_out.push(format!("git scan failed: {}", err)),
+    }
+}
+
+pub(super) fn run_model_enrichers(
+    ctx: &AnalysisContext,
+    plan: &PresetPlan,
+    derived: &DerivedReport,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    run_archetype_enricher(ctx, plan, reports, warnings_out);
+    run_topics_enricher(ctx, plan, reports, warnings_out);
+    run_fun_enricher(plan, derived, reports, warnings_out);
+}
+
+fn run_archetype_enricher(
+    ctx: &AnalysisContext,
+    plan: &PresetPlan,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.archetype {
+        return;
+    }
+
+    #[cfg(feature = "archetype")]
+    {
+        let _ = warnings_out;
+        reports.archetype = detect_archetype(&ctx.export);
+    }
+
+    #[cfg(not(feature = "archetype"))]
+    {
+        let _ = (ctx, reports);
+        warnings_out.push(
+            crate::grid::DisabledFeature::Archetype
+                .warning()
+                .to_string(),
+        );
+    }
+}
+
+fn run_topics_enricher(
+    ctx: &AnalysisContext,
+    plan: &PresetPlan,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.topics {
+        return;
+    }
+
+    #[cfg(feature = "topics")]
+    {
+        let _ = warnings_out;
+        reports.topics = Some(build_topic_clouds(&ctx.export));
+    }
+
+    #[cfg(not(feature = "topics"))]
+    {
+        let _ = (ctx, reports);
+        warnings_out.push(crate::grid::DisabledFeature::Topics.warning().to_string());
+    }
+}
+
+fn run_fun_enricher(
+    plan: &PresetPlan,
+    derived: &DerivedReport,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    if !plan.fun {
+        reports.fun = None;
+        return;
+    }
+
+    #[cfg(feature = "fun")]
+    {
+        let _ = warnings_out;
+        reports.fun = Some(build_fun_report(derived));
+    }
+
+    #[cfg(not(feature = "fun"))]
+    {
+        let _ = derived;
+        warnings_out.push(crate::grid::DisabledFeature::Fun.warning().to_string());
+        reports.fun = None;
+    }
+}
+
+pub(super) fn run_effort_enricher(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    derived: &DerivedReport,
+    reports: &mut AnalysisReports,
+    warnings_out: &mut Vec<String>,
+) {
+    #[cfg(feature = "effort")]
+    if let Some(effort_request) = &req.effort {
+        match build_effort_report(
+            &ctx.root,
+            &ctx.export,
+            derived,
+            reports.git.as_ref(),
+            reports.complexity.as_ref(),
+            reports.api_surface.as_ref(),
+            reports.dup.as_ref(),
+            effort_request,
+        ) {
+            Ok(report) => reports.effort = Some(report),
+            Err(err) => warnings_out.push(format!("effort estimate failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(feature = "effort"))]
+    let _ = (ctx, req, derived, reports, warnings_out);
+}

--- a/crates/tokmd-analysis/src/analysis/file_inventory.rs
+++ b/crates/tokmd-analysis/src/analysis/file_inventory.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use crate::grid::PresetPlan;
+
+#[cfg(feature = "walk")]
+use super::warnings;
+use super::{AnalysisContext, AnalysisRequest};
+
+pub(super) fn collect_analysis_files(
+    ctx: &AnalysisContext,
+    req: &AnalysisRequest,
+    plan: &PresetPlan,
+    warnings_out: &mut Vec<String>,
+) -> Option<Vec<PathBuf>> {
+    if !plan.needs_files() {
+        return None;
+    }
+
+    #[cfg(feature = "walk")]
+    {
+        if warnings::has_host_root(&ctx.root) {
+            match tokmd_scan::walk::list_files(&ctx.root, req.limits.max_files) {
+                Ok(list) => Some(list),
+                Err(err) => {
+                    warnings_out.push(format!("walk failed: {}", err));
+                    None
+                }
+            }
+        } else {
+            warnings::push_warning_once(warnings_out, warnings::ROOTLESS_FILE_ANALYSIS_WARNING);
+            None
+        }
+    }
+
+    #[cfg(not(feature = "walk"))]
+    {
+        let _ = (ctx, req);
+        warnings_out.push(
+            crate::grid::DisabledFeature::FileInventory
+                .warning()
+                .to_string(),
+        );
+        None
+    }
+}

--- a/crates/tokmd-analysis/src/analysis/receipt.rs
+++ b/crates/tokmd-analysis/src/analysis/receipt.rs
@@ -1,0 +1,71 @@
+use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisReceipt, AnalysisSource, DerivedReport};
+use tokmd_types::{ExportData, ScanStatus, ToolInfo};
+
+use crate::derived::{build_tree, derive_report};
+use crate::util::now_ms;
+
+use super::report_set::AnalysisReports;
+
+pub(super) fn prepare_derived(
+    export: &ExportData,
+    args: &AnalysisArgsMeta,
+    window_tokens: Option<usize>,
+) -> DerivedReport {
+    let mut derived = derive_report(export, window_tokens);
+    if args.format.contains("tree") {
+        derived.tree = Some(build_tree(export));
+    }
+    derived
+}
+
+pub(super) fn source_with_base_signature(
+    source: &AnalysisSource,
+    derived: &DerivedReport,
+) -> AnalysisSource {
+    let mut source = source.clone();
+    if source.base_signature.is_none() {
+        source.base_signature = Some(derived.integrity.hash.clone());
+    }
+    source
+}
+
+pub(super) fn build_receipt(
+    source: AnalysisSource,
+    args: AnalysisArgsMeta,
+    derived: DerivedReport,
+    reports: AnalysisReports,
+    warnings: Vec<String>,
+) -> AnalysisReceipt {
+    let status = if warnings.is_empty() {
+        ScanStatus::Complete
+    } else {
+        ScanStatus::Partial
+    };
+
+    AnalysisReceipt {
+        schema_version: tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: now_ms(),
+        tool: ToolInfo::current(),
+        mode: "analysis".to_string(),
+        status,
+        warnings,
+        source,
+        args,
+        archetype: reports.archetype,
+        topics: reports.topics,
+        entropy: reports.entropy,
+        predictive_churn: reports.predictive_churn,
+        corporate_fingerprint: reports.corporate_fingerprint,
+        license: reports.license,
+        derived: Some(derived),
+        assets: reports.assets,
+        deps: reports.deps,
+        git: reports.git,
+        imports: reports.imports,
+        dup: reports.dup,
+        complexity: reports.complexity,
+        api_surface: reports.api_surface,
+        effort: reports.effort,
+        fun: reports.fun,
+    }
+}

--- a/crates/tokmd-analysis/src/analysis/report_set.rs
+++ b/crates/tokmd-analysis/src/analysis/report_set.rs
@@ -1,0 +1,24 @@
+use tokmd_analysis_types::{
+    ApiSurfaceReport, Archetype, AssetReport, ComplexityReport, CorporateFingerprint,
+    DependencyReport, DuplicateReport, EffortEstimateReport, EntropyReport, FunReport, GitReport,
+    ImportReport, LicenseReport, PredictiveChurnReport, TopicClouds,
+};
+
+#[derive(Debug, Default)]
+pub(super) struct AnalysisReports {
+    pub(super) archetype: Option<Archetype>,
+    pub(super) topics: Option<TopicClouds>,
+    pub(super) entropy: Option<EntropyReport>,
+    pub(super) predictive_churn: Option<PredictiveChurnReport>,
+    pub(super) corporate_fingerprint: Option<CorporateFingerprint>,
+    pub(super) license: Option<LicenseReport>,
+    pub(super) assets: Option<AssetReport>,
+    pub(super) deps: Option<DependencyReport>,
+    pub(super) git: Option<GitReport>,
+    pub(super) imports: Option<ImportReport>,
+    pub(super) dup: Option<DuplicateReport>,
+    pub(super) complexity: Option<ComplexityReport>,
+    pub(super) api_surface: Option<ApiSurfaceReport>,
+    pub(super) effort: Option<EffortEstimateReport>,
+    pub(super) fun: Option<FunReport>,
+}

--- a/crates/tokmd-analysis/src/analysis/warnings.rs
+++ b/crates/tokmd-analysis/src/analysis/warnings.rs
@@ -1,0 +1,21 @@
+#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
+use std::path::Path;
+
+#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
+pub(super) const ROOTLESS_FILE_ANALYSIS_WARNING: &str =
+    "in-memory analysis has no host root; skipping file-backed enrichers";
+#[cfg(feature = "git")]
+pub(super) const ROOTLESS_GIT_ANALYSIS_WARNING: &str =
+    "in-memory analysis has no host root; skipping git-backed enrichers";
+
+#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
+pub(super) fn has_host_root(root: &Path) -> bool {
+    !root.as_os_str().is_empty()
+}
+
+#[cfg(any(feature = "walk", feature = "content", feature = "git"))]
+pub(super) fn push_warning_once(warnings: &mut Vec<String>, warning: &str) {
+    if warnings.iter().all(|existing| existing != warning) {
+        warnings.push(warning.to_string());
+    }
+}


### PR DESCRIPTION
### Motivation
- The original `analyze` implementation was large and handled many responsibilities (file collection, enrichment orchestration, report aggregation, receipt construction and warnings) in one place, making it hard to read and maintain. 
- Break the monolithic function into single-responsibility modules to improve clarity, reduce local state surface area, and make feature-gated logic easier to reason about. 
- Preserve the public API and existing feature-gated behavior while making the orchestration code a concise coordinator. 

### Description
- Split analysis orchestration into focused submodules and added the following files: `analysis/enrichers.rs` (enricher runners and helpers), `analysis/file_inventory.rs` (host-root-aware file listing), `analysis/receipt.rs` (derived prep and receipt builder), `analysis/report_set.rs` (typed container for optional reports), and `analysis/warnings.rs` (shared warning constants and helper). 
- Kept the public `analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisReceipt>` surface intact and replaced the previous monolith with a concise coordinator that delegates to `receipt::prepare_derived`, `file_inventory::collect_analysis_files`, `enrichers::run_*` helpers, and `receipt::build_receipt`. 
- Centralized optional report storage behind `AnalysisReports` and moved de-duplicated warning logic into `warnings`, preserving all original feature-gated behavior (assets, content, walk, git, halstead, etc.). 
- Adjusted imports and small callsites to use the new submodules and helpers while keeping output semantics unchanged. 

### Testing
- Ran formatting and linting checks with `cargo fmt-check` and `cargo clippy -p tokmd-analysis -- -D warnings`, both succeeded. 
- Performed compile checks with `cargo check -p tokmd-analysis` and `cargo check -p tokmd-analysis --all-features`, both succeeded. 
- Executed the crate test-suite with `cargo test -p tokmd-analysis`, and the analysis tests completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02816fb6208333a02849bc20d5c493)