### PR TITLE
Refactor analysis orchestration into SRP modules

### DIFF
--- a/crates/tokmd-analysis/src/analysis.rs
+++ b/crates/tokmd-analysis/src/analysis.rs
@@ -2,49 +2,30 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-#[cfg(feature = "effort")]
-use crate::effort::{EffortRequest, build_effort_report};
 use anyhow::Result;
-use tokmd_analysis_types::AnalysisLimits;
 use tokmd_analysis_types::{
-    AnalysisArgsMeta, AnalysisReceipt, AnalysisSource, ApiSurfaceReport, Archetype, AssetReport,
-    ComplexityReport, CorporateFingerprint, DependencyReport, DuplicateReport, EntropyReport,
-    FunReport, GitReport, ImportReport, LicenseReport, NearDupScope, PredictiveChurnReport,
-    TopicClouds,
+    AnalysisArgsMeta, AnalysisLimits, AnalysisReceipt, AnalysisSource, NearDupScope,
 };
-use tokmd_types::{ExportData, ScanStatus, ToolInfo};
+use tokmd_types::ExportData;
 
-#[cfg(all(feature = "content", feature = "walk"))]
-use crate::api_surface::build_api_surface_report;
-#[cfg(feature = "archetype")]
-use crate::archetype::detect_archetype;
-#[cfg(feature = "walk")]
-use crate::assets::{build_assets_report, build_dependency_report};
 #[cfg(feature = "content")]
-use crate::content::{
-    ContentLimits, ImportGranularity as ContentImportGranularity, build_duplicate_report,
-    build_import_report, build_todo_report,
-};
-use crate::derived::{build_tree, derive_report};
-#[cfg(feature = "git")]
-use crate::fingerprint::build_corporate_fingerprint;
-#[cfg(feature = "fun")]
-use crate::fun::build_fun_report;
-#[cfg(feature = "git")]
-use crate::git::{build_git_report, build_predictive_churn_report};
+use crate::content::{ContentLimits, ImportGranularity as ContentImportGranularity};
+#[cfg(feature = "effort")]
+use crate::effort::EffortRequest;
 use crate::grid::{PresetKind, PresetPlan, preset_plan_for};
-#[cfg(feature = "content")]
-use crate::near_dup::{NearDupLimits, build_near_dup_report};
-#[cfg(feature = "topics")]
-use crate::topics::build_topic_clouds;
-use crate::util::now_ms;
-#[cfg(all(feature = "content", feature = "walk"))]
-use crate::{
-    complexity::build_complexity_report, entropy::build_entropy_report,
-    license::build_license_report,
-};
-#[cfg(all(feature = "halstead", feature = "content", feature = "walk"))]
-use crate::{halstead::build_halstead_report, maintainability::attach_halstead_metrics};
+
+mod content_reports;
+mod derived_stage;
+mod file_inventory;
+mod fun_effort_reports;
+mod git_reports;
+mod identity_reports;
+mod quality_reports;
+mod receipt;
+mod reports;
+mod walk_reports;
+
+use reports::AnalysisReports;
 
 /// Canonical preset enum for analysis orchestration.
 pub type AnalysisPreset = PresetKind;
@@ -127,483 +108,62 @@ fn push_warning_once(warnings: &mut Vec<String>, warning: &str) {
 }
 
 pub fn analyze(ctx: AnalysisContext, req: AnalysisRequest) -> Result<AnalysisReceipt> {
-    let mut warnings: Vec<String> = Vec::new();
-    #[cfg_attr(not(feature = "content"), allow(unused_mut))]
-    let mut derived = derive_report(&ctx.export, req.window_tokens);
-    if req.args.format.contains("tree") {
-        derived.tree = Some(build_tree(&ctx.export));
-    }
-
-    let mut source = ctx.source.clone();
-    if source.base_signature.is_none() {
-        source.base_signature = Some(derived.integrity.hash.clone());
-    }
+    let mut warnings = Vec::new();
+    let mut derived = derived_stage::build_derived_report(&ctx.export, &req);
+    let source = derived_stage::source_with_base_signature(&ctx.source, &derived);
 
     let plan = preset_plan(req.preset);
-    let include_git = match req.git {
-        Some(flag) => flag,
-        None => plan.git,
-    };
-    #[cfg(any(feature = "walk", feature = "content", feature = "git"))]
-    let has_host_root = has_host_root(&ctx.root);
+    let include_git = req.git.unwrap_or(plan.git);
+    let files =
+        file_inventory::collect_files_for_plan(&ctx.root, &req.limits, &plan, &mut warnings);
+    let file_slice = files.as_deref();
 
-    #[cfg(feature = "walk")]
-    let mut assets: Option<AssetReport> = None;
-    #[cfg(not(feature = "walk"))]
-    let assets: Option<AssetReport> = None;
-
-    #[cfg(feature = "walk")]
-    let mut deps: Option<DependencyReport> = None;
-    #[cfg(not(feature = "walk"))]
-    let deps: Option<DependencyReport> = None;
-
-    #[cfg(feature = "content")]
-    let mut imports: Option<ImportReport> = None;
-    #[cfg(not(feature = "content"))]
-    let imports: Option<ImportReport> = None;
-
-    #[cfg(feature = "content")]
-    let mut dup: Option<DuplicateReport> = None;
-    #[cfg(not(feature = "content"))]
-    let dup: Option<DuplicateReport> = None;
-
-    #[cfg(feature = "git")]
-    let mut git: Option<GitReport> = None;
-    #[cfg(not(feature = "git"))]
-    let git: Option<GitReport> = None;
-
-    #[cfg(feature = "git")]
-    let mut churn: Option<PredictiveChurnReport> = None;
-    #[cfg(not(feature = "git"))]
-    let churn: Option<PredictiveChurnReport> = None;
-
-    #[cfg(feature = "git")]
-    let mut fingerprint: Option<CorporateFingerprint> = None;
-    #[cfg(not(feature = "git"))]
-    let fingerprint: Option<CorporateFingerprint> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut entropy: Option<EntropyReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let entropy: Option<EntropyReport> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut license: Option<LicenseReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let license: Option<LicenseReport> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut complexity: Option<ComplexityReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let complexity: Option<ComplexityReport> = None;
-
-    #[cfg(all(feature = "content", feature = "walk"))]
-    let mut api_surface: Option<ApiSurfaceReport> = None;
-    #[cfg(not(all(feature = "content", feature = "walk")))]
-    let api_surface: Option<ApiSurfaceReport> = None;
-
-    #[cfg(feature = "archetype")]
-    let mut archetype: Option<Archetype> = None;
-    #[cfg(not(feature = "archetype"))]
-    let archetype: Option<Archetype> = None;
-    #[cfg(feature = "topics")]
-    let mut topics: Option<TopicClouds> = None;
-    #[cfg(not(feature = "topics"))]
-    let topics: Option<TopicClouds> = None;
-
-    let fun: Option<FunReport>;
-
-    #[cfg(any(feature = "walk", feature = "content"))]
-    #[cfg_attr(not(feature = "walk"), allow(unused_mut))]
-    let mut files: Option<Vec<PathBuf>> = None;
-    #[cfg(not(any(feature = "walk", feature = "content")))]
-    let _files: Option<Vec<PathBuf>> = None;
-
-    if plan.needs_files() {
-        #[cfg(feature = "walk")]
-        if has_host_root {
-            match tokmd_scan::walk::list_files(&ctx.root, req.limits.max_files) {
-                Ok(list) => files = Some(list),
-                Err(err) => warnings.push(format!("walk failed: {}", err)),
-            }
-        } else {
-            push_warning_once(&mut warnings, ROOTLESS_FILE_ANALYSIS_WARNING);
-        }
-        #[cfg(not(feature = "walk"))]
-        {
-            warnings.push(
-                crate::grid::DisabledFeature::FileInventory
-                    .warning()
-                    .to_string(),
-            );
-        }
-    }
-
-    if plan.assets {
-        #[cfg(feature = "walk")]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_assets_report(&ctx.root, list) {
-                    Ok(report) => assets = Some(report),
-                    Err(err) => warnings.push(format!("asset scan failed: {}", err)),
-                }
-            }
-        }
-    }
-
-    if plan.deps {
-        #[cfg(feature = "walk")]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_dependency_report(&ctx.root, list) {
-                    Ok(report) => deps = Some(report),
-                    Err(err) => warnings.push(format!("dependency scan failed: {}", err)),
-                }
-            }
-        }
-    }
-
-    if plan.todo {
-        #[cfg(feature = "content")]
-        {
-            if let Some(list) = files.as_deref() {
-                let limits = content_limits(&req.limits);
-                match build_todo_report(&ctx.root, list, &limits, derived.totals.code) {
-                    Ok(report) => derived.todo = Some(report),
-                    Err(err) => warnings.push(format!("todo scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(crate::grid::DisabledFeature::TodoScan.warning().to_string());
-    }
-
-    if plan.dup {
-        #[cfg(feature = "content")]
-        {
-            if let Some(list) = files.as_deref() {
-                let limits = content_limits(&req.limits);
-                match build_duplicate_report(&ctx.root, list, &ctx.export, &limits) {
-                    Ok(report) => dup = Some(report),
-                    Err(err) => warnings.push(format!("dup scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(
-            crate::grid::DisabledFeature::DuplicationScan
-                .warning()
-                .to_string(),
-        );
-    }
-
-    // Near-duplicate detection (opt-in via --near-dup)
-    if req.near_dup {
-        #[cfg(feature = "content")]
-        {
-            if has_host_root {
-                let near_dup_limits = NearDupLimits {
-                    max_bytes: req.limits.max_bytes,
-                    max_file_bytes: req.limits.max_file_bytes,
-                };
-                match build_near_dup_report(
-                    &ctx.root,
-                    &ctx.export,
-                    req.near_dup_scope,
-                    req.near_dup_threshold,
-                    req.near_dup_max_files,
-                    req.near_dup_max_pairs,
-                    &near_dup_limits,
-                    &req.near_dup_exclude,
-                ) {
-                    Ok(report) => {
-                        // Attach to existing dup report or create a minimal one
-                        if let Some(ref mut d) = dup {
-                            d.near = Some(report);
-                        } else {
-                            dup = Some(DuplicateReport {
-                                groups: Vec::new(),
-                                wasted_bytes: 0,
-                                strategy: "none".to_string(),
-                                density: None,
-                                near: Some(report),
-                            });
-                        }
-                    }
-                    Err(err) => warnings.push(format!("near-dup scan failed: {}", err)),
-                }
-            } else {
-                push_warning_once(&mut warnings, ROOTLESS_FILE_ANALYSIS_WARNING);
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(
-            crate::grid::DisabledFeature::NearDuplicateScan
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.imports {
-        #[cfg(feature = "content")]
-        {
-            if let Some(list) = files.as_deref() {
-                let limits = content_limits(&req.limits);
-                let granularity = content_import_granularity(req.import_granularity);
-                match build_import_report(&ctx.root, list, &ctx.export, granularity, &limits) {
-                    Ok(report) => imports = Some(report),
-                    Err(err) => warnings.push(format!("import scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(feature = "content"))]
-        warnings.push(
-            crate::grid::DisabledFeature::ImportScan
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if include_git {
-        #[cfg(feature = "git")]
-        {
-            if has_host_root {
-                let repo_root = match tokmd_git::repo_root(&ctx.root) {
-                    Some(root) => root,
-                    None => {
-                        warnings.push("git scan failed: not a git repo".to_string());
-                        PathBuf::new()
-                    }
-                };
-                if !repo_root.as_os_str().is_empty() {
-                    match tokmd_git::collect_history(
-                        &repo_root,
-                        req.limits.max_commits,
-                        req.limits.max_commit_files,
-                    ) {
-                        Ok(commits) => {
-                            if plan.git {
-                                match build_git_report(&repo_root, &ctx.export, &commits) {
-                                    Ok(report) => git = Some(report),
-                                    Err(err) => warnings.push(format!("git scan failed: {}", err)),
-                                }
-                            }
-                            if plan.churn {
-                                churn = Some(build_predictive_churn_report(
-                                    &ctx.export,
-                                    &commits,
-                                    &repo_root,
-                                ));
-                            }
-                            if plan.fingerprint {
-                                fingerprint = Some(build_corporate_fingerprint(&commits));
-                            }
-                        }
-                        Err(err) => warnings.push(format!("git scan failed: {}", err)),
-                    }
-                }
-            } else {
-                push_warning_once(&mut warnings, ROOTLESS_GIT_ANALYSIS_WARNING);
-            }
-        }
-        #[cfg(not(feature = "git"))]
-        warnings.push(
-            crate::grid::DisabledFeature::GitMetrics
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.archetype {
-        #[cfg(feature = "archetype")]
-        {
-            archetype = detect_archetype(&ctx.export);
-        }
-        #[cfg(not(feature = "archetype"))]
-        {
-            warnings.push(
-                crate::grid::DisabledFeature::Archetype
-                    .warning()
-                    .to_string(),
-            );
-        }
-    }
-
-    if plan.topics {
-        #[cfg(feature = "topics")]
-        {
-            topics = Some(build_topic_clouds(&ctx.export));
-        }
-        #[cfg(not(feature = "topics"))]
-        {
-            warnings.push(crate::grid::DisabledFeature::Topics.warning().to_string());
-        }
-    }
-
-    if plan.entropy {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_entropy_report(&ctx.root, list, &ctx.export, &req.limits) {
-                    Ok(report) => entropy = Some(report),
-                    Err(err) => warnings.push(format!("entropy scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::EntropyProfiling
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.license {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_license_report(&ctx.root, list, &req.limits) {
-                    Ok(report) => license = Some(report),
-                    Err(err) => warnings.push(format!("license scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::LicenseRadar
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.complexity {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_complexity_report(
-                    &ctx.root,
-                    list,
-                    &ctx.export,
-                    &req.limits,
-                    req.detail_functions,
-                ) {
-                    Ok(report) => complexity = Some(report),
-                    Err(err) => warnings.push(format!("complexity scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::ComplexityAnalysis
-                .warning()
-                .to_string(),
-        );
-    }
-
-    if plan.api_surface {
-        #[cfg(all(feature = "content", feature = "walk"))]
-        {
-            if let Some(list) = files.as_deref() {
-                match build_api_surface_report(&ctx.root, list, &ctx.export, &req.limits) {
-                    Ok(report) => api_surface = Some(report),
-                    Err(err) => warnings.push(format!("api surface scan failed: {}", err)),
-                }
-            }
-        }
-        #[cfg(not(all(feature = "content", feature = "walk")))]
-        warnings.push(
-            crate::grid::DisabledFeature::ApiSurfaceAnalysis
-                .warning()
-                .to_string(),
-        );
-    }
-
-    // Halstead metrics (feature-gated)
-    #[cfg(all(feature = "halstead", feature = "content", feature = "walk"))]
-    if plan.halstead
-        && let Some(list) = files.as_deref()
-    {
-        match build_halstead_report(&ctx.root, list, &ctx.export, &req.limits) {
-            Ok(halstead_report) => {
-                // Wire Halstead into complexity report if available
-                if let Some(ref mut cx) = complexity {
-                    attach_halstead_metrics(cx, halstead_report);
-                }
-            }
-            Err(err) => warnings.push(format!("halstead scan failed: {}", err)),
-        }
-    }
-
-    if plan.fun {
-        #[cfg(feature = "fun")]
-        {
-            fun = Some(build_fun_report(&derived));
-        }
-        #[cfg(not(feature = "fun"))]
-        {
-            warnings.push(crate::grid::DisabledFeature::Fun.warning().to_string());
-            fun = None;
-        }
-    } else {
-        fun = None;
-    }
+    let mut reports = AnalysisReports::default();
+    walk_reports::enrich_walk_reports(&ctx.root, file_slice, &plan, &mut reports, &mut warnings);
+    content_reports::enrich_content_reports(
+        content_reports::ContentEnrichmentContext {
+            root: &ctx.root,
+            export: &ctx.export,
+            files: file_slice,
+            plan: &plan,
+            req: &req,
+        },
+        &mut derived,
+        &mut reports,
+        &mut warnings,
+    );
+    git_reports::enrich_git_reports(
+        &ctx.root,
+        &ctx.export,
+        &req.limits,
+        include_git,
+        &plan,
+        &mut reports,
+        &mut warnings,
+    );
+    identity_reports::enrich_identity_reports(&ctx.export, &plan, &mut reports, &mut warnings);
+    quality_reports::enrich_quality_reports(
+        &ctx.root,
+        &ctx.export,
+        file_slice,
+        &plan,
+        &req,
+        &mut reports,
+        &mut warnings,
+    );
+    fun_effort_reports::enrich_fun_report(&plan, &derived, &mut reports, &mut warnings);
 
     #[cfg(feature = "effort")]
-    let effort = if let Some(effort_request) = &req.effort {
-        match build_effort_report(
-            &ctx.root,
-            &ctx.export,
-            &derived,
-            git.as_ref(),
-            complexity.as_ref(),
-            api_surface.as_ref(),
-            dup.as_ref(),
-            effort_request,
-        ) {
-            Ok(report) => Some(report),
-            Err(err) => {
-                warnings.push(format!("effort estimate failed: {}", err));
-                None
-            }
-        }
-    } else {
-        None
-    };
-    #[cfg(not(feature = "effort"))]
-    let effort: Option<tokmd_analysis_types::EffortEstimateReport> = None;
+    fun_effort_reports::enrich_effort_report(
+        &ctx.root,
+        &ctx.export,
+        &derived,
+        req.effort.as_ref(),
+        &mut reports,
+        &mut warnings,
+    );
 
-    let status = if warnings.is_empty() {
-        ScanStatus::Complete
-    } else {
-        ScanStatus::Partial
-    };
-
-    let receipt = AnalysisReceipt {
-        schema_version: tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION,
-        generated_at_ms: now_ms(),
-        tool: ToolInfo::current(),
-        mode: "analysis".to_string(),
-        status,
-        warnings,
-        source,
-        args: req.args,
-        archetype,
-        topics,
-        entropy,
-        predictive_churn: churn,
-        corporate_fingerprint: fingerprint,
-        license,
-        derived: Some(derived),
-        assets,
-        deps,
-        git,
-        imports,
-        dup,
-        complexity,
-        api_surface,
-        effort,
-        fun,
-    };
-
-    Ok(receipt)
+    Ok(receipt::build_receipt(
+        source, req.args, derived, reports, warnings,
+    ))
 }

--- a/crates/tokmd-analysis/src/analysis/content_reports.rs
+++ b/crates/tokmd-analysis/src/analysis/content_reports.rs
@@ -1,0 +1,178 @@
+use std::path::{Path, PathBuf};
+
+use tokmd_analysis_types::DerivedReport;
+use tokmd_types::ExportData;
+
+use crate::grid::PresetPlan;
+
+use super::AnalysisRequest;
+use super::reports::AnalysisReports;
+#[cfg(feature = "content")]
+use super::{ROOTLESS_FILE_ANALYSIS_WARNING, has_host_root, push_warning_once};
+
+pub(super) struct ContentEnrichmentContext<'a> {
+    pub(super) root: &'a Path,
+    pub(super) export: &'a ExportData,
+    pub(super) files: Option<&'a [PathBuf]>,
+    pub(super) plan: &'a PresetPlan,
+    pub(super) req: &'a AnalysisRequest,
+}
+
+pub(super) fn enrich_content_reports(
+    ctx: ContentEnrichmentContext<'_>,
+    derived: &mut DerivedReport,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    #[cfg(not(feature = "content"))]
+    let _ = (ctx.root, ctx.export, ctx.files);
+
+    enrich_todo(&ctx, derived, warnings);
+    enrich_duplicates(&ctx, reports, warnings);
+    enrich_near_duplicates(&ctx, reports, warnings);
+    enrich_imports(&ctx, reports, warnings);
+}
+
+fn enrich_todo(
+    ctx: &ContentEnrichmentContext<'_>,
+    derived: &mut DerivedReport,
+    warnings: &mut Vec<String>,
+) {
+    if !ctx.plan.todo {
+        return;
+    }
+
+    #[cfg(feature = "content")]
+    if let Some(list) = ctx.files {
+        let limits = super::content_limits(&ctx.req.limits);
+        match crate::content::build_todo_report(ctx.root, list, &limits, derived.totals.code) {
+            Ok(report) => derived.todo = Some(report),
+            Err(err) => warnings.push(format!("todo scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(feature = "content"))]
+    warnings.push(crate::grid::DisabledFeature::TodoScan.warning().to_string());
+
+    let _ = (ctx, derived, warnings);
+}
+
+fn enrich_duplicates(
+    ctx: &ContentEnrichmentContext<'_>,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !ctx.plan.dup {
+        return;
+    }
+
+    #[cfg(feature = "content")]
+    if let Some(list) = ctx.files {
+        let limits = super::content_limits(&ctx.req.limits);
+        match crate::content::build_duplicate_report(ctx.root, list, ctx.export, &limits) {
+            Ok(report) => reports.dup = Some(report),
+            Err(err) => warnings.push(format!("dup scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(feature = "content"))]
+    warnings.push(
+        crate::grid::DisabledFeature::DuplicationScan
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (ctx, reports, warnings);
+}
+
+fn enrich_near_duplicates(
+    ctx: &ContentEnrichmentContext<'_>,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !ctx.req.near_dup {
+        return;
+    }
+
+    #[cfg(feature = "content")]
+    {
+        if has_host_root(ctx.root) {
+            let near_dup_limits = crate::near_dup::NearDupLimits {
+                max_bytes: ctx.req.limits.max_bytes,
+                max_file_bytes: ctx.req.limits.max_file_bytes,
+            };
+            match crate::near_dup::build_near_dup_report(
+                ctx.root,
+                ctx.export,
+                ctx.req.near_dup_scope,
+                ctx.req.near_dup_threshold,
+                ctx.req.near_dup_max_files,
+                ctx.req.near_dup_max_pairs,
+                &near_dup_limits,
+                &ctx.req.near_dup_exclude,
+            ) {
+                Ok(report) => attach_near_duplicate_report(reports, report),
+                Err(err) => warnings.push(format!("near-dup scan failed: {}", err)),
+            }
+        } else {
+            push_warning_once(warnings, ROOTLESS_FILE_ANALYSIS_WARNING);
+        }
+    }
+
+    #[cfg(not(feature = "content"))]
+    warnings.push(
+        crate::grid::DisabledFeature::NearDuplicateScan
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (ctx, reports, warnings);
+}
+
+#[cfg(feature = "content")]
+fn attach_near_duplicate_report(
+    reports: &mut AnalysisReports,
+    report: tokmd_analysis_types::NearDuplicateReport,
+) {
+    if let Some(ref mut dup) = reports.dup {
+        dup.near = Some(report);
+    } else {
+        reports.dup = Some(tokmd_analysis_types::DuplicateReport {
+            groups: Vec::new(),
+            wasted_bytes: 0,
+            strategy: "none".to_string(),
+            density: None,
+            near: Some(report),
+        });
+    }
+}
+
+fn enrich_imports(
+    ctx: &ContentEnrichmentContext<'_>,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !ctx.plan.imports {
+        return;
+    }
+
+    #[cfg(feature = "content")]
+    if let Some(list) = ctx.files {
+        let limits = super::content_limits(&ctx.req.limits);
+        let granularity = super::content_import_granularity(ctx.req.import_granularity);
+        match crate::content::build_import_report(ctx.root, list, ctx.export, granularity, &limits)
+        {
+            Ok(report) => reports.imports = Some(report),
+            Err(err) => warnings.push(format!("import scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(feature = "content"))]
+    warnings.push(
+        crate::grid::DisabledFeature::ImportScan
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (ctx, reports, warnings);
+}

--- a/crates/tokmd-analysis/src/analysis/derived_stage.rs
+++ b/crates/tokmd-analysis/src/analysis/derived_stage.rs
@@ -1,0 +1,25 @@
+use tokmd_analysis_types::{AnalysisSource, DerivedReport};
+use tokmd_types::ExportData;
+
+use crate::derived::{build_tree, derive_report};
+
+use super::AnalysisRequest;
+
+pub(super) fn build_derived_report(export: &ExportData, req: &AnalysisRequest) -> DerivedReport {
+    let mut derived = derive_report(export, req.window_tokens);
+    if req.args.format.contains("tree") {
+        derived.tree = Some(build_tree(export));
+    }
+    derived
+}
+
+pub(super) fn source_with_base_signature(
+    source: &AnalysisSource,
+    derived: &DerivedReport,
+) -> AnalysisSource {
+    let mut source = source.clone();
+    if source.base_signature.is_none() {
+        source.base_signature = Some(derived.integrity.hash.clone());
+    }
+    source
+}

--- a/crates/tokmd-analysis/src/analysis/file_inventory.rs
+++ b/crates/tokmd-analysis/src/analysis/file_inventory.rs
@@ -1,0 +1,45 @@
+use std::path::{Path, PathBuf};
+
+use crate::grid::PresetPlan;
+use tokmd_analysis_types::AnalysisLimits;
+
+#[cfg(feature = "walk")]
+use super::{ROOTLESS_FILE_ANALYSIS_WARNING, has_host_root, push_warning_once};
+
+pub(super) fn collect_files_for_plan(
+    root: &Path,
+    limits: &AnalysisLimits,
+    plan: &PresetPlan,
+    warnings: &mut Vec<String>,
+) -> Option<Vec<PathBuf>> {
+    if !plan.needs_files() {
+        return None;
+    }
+
+    #[cfg(feature = "walk")]
+    {
+        if has_host_root(root) {
+            match tokmd_scan::walk::list_files(root, limits.max_files) {
+                Ok(list) => Some(list),
+                Err(err) => {
+                    warnings.push(format!("walk failed: {}", err));
+                    None
+                }
+            }
+        } else {
+            push_warning_once(warnings, ROOTLESS_FILE_ANALYSIS_WARNING);
+            None
+        }
+    }
+
+    #[cfg(not(feature = "walk"))]
+    {
+        let _ = (root, limits);
+        warnings.push(
+            crate::grid::DisabledFeature::FileInventory
+                .warning()
+                .to_string(),
+        );
+        None
+    }
+}

--- a/crates/tokmd-analysis/src/analysis/fun_effort_reports.rs
+++ b/crates/tokmd-analysis/src/analysis/fun_effort_reports.rs
@@ -1,0 +1,64 @@
+#[cfg(feature = "effort")]
+use std::path::Path;
+
+use tokmd_analysis_types::DerivedReport;
+#[cfg(feature = "effort")]
+use tokmd_types::ExportData;
+
+use crate::grid::PresetPlan;
+
+#[cfg(feature = "effort")]
+use crate::effort::{EffortRequest, build_effort_report};
+
+use super::reports::AnalysisReports;
+
+pub(super) fn enrich_fun_report(
+    plan: &PresetPlan,
+    derived: &DerivedReport,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if plan.fun {
+        #[cfg(feature = "fun")]
+        {
+            reports.fun = Some(crate::fun::build_fun_report(derived));
+        }
+        #[cfg(not(feature = "fun"))]
+        {
+            warnings.push(crate::grid::DisabledFeature::Fun.warning().to_string());
+            reports.fun = None;
+        }
+    } else {
+        reports.fun = None;
+    }
+
+    let _ = (plan, derived, reports, warnings);
+}
+
+#[cfg(feature = "effort")]
+pub(super) fn enrich_effort_report(
+    root: &Path,
+    export: &ExportData,
+    derived: &DerivedReport,
+    effort: Option<&EffortRequest>,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    let Some(effort_request) = effort else {
+        return;
+    };
+
+    match build_effort_report(
+        root,
+        export,
+        derived,
+        reports.git.as_ref(),
+        reports.complexity.as_ref(),
+        reports.api_surface.as_ref(),
+        reports.dup.as_ref(),
+        effort_request,
+    ) {
+        Ok(report) => reports.effort = Some(report),
+        Err(err) => warnings.push(format!("effort estimate failed: {}", err)),
+    }
+}

--- a/crates/tokmd-analysis/src/analysis/git_reports.rs
+++ b/crates/tokmd-analysis/src/analysis/git_reports.rs
@@ -1,0 +1,78 @@
+use std::path::Path;
+
+use tokmd_analysis_types::AnalysisLimits;
+use tokmd_types::ExportData;
+
+use crate::grid::PresetPlan;
+
+use super::reports::AnalysisReports;
+#[cfg(feature = "git")]
+use super::{ROOTLESS_GIT_ANALYSIS_WARNING, has_host_root, push_warning_once};
+
+pub(super) fn enrich_git_reports(
+    root: &Path,
+    export: &ExportData,
+    limits: &AnalysisLimits,
+    include_git: bool,
+    plan: &PresetPlan,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !include_git {
+        return;
+    }
+
+    #[cfg(feature = "git")]
+    {
+        if has_host_root(root) {
+            collect_git_reports(root, export, limits, plan, reports, warnings);
+        } else {
+            push_warning_once(warnings, ROOTLESS_GIT_ANALYSIS_WARNING);
+        }
+    }
+
+    #[cfg(not(feature = "git"))]
+    warnings.push(
+        crate::grid::DisabledFeature::GitMetrics
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (root, export, limits, plan, reports, warnings);
+}
+
+#[cfg(feature = "git")]
+fn collect_git_reports(
+    root: &Path,
+    export: &ExportData,
+    limits: &AnalysisLimits,
+    plan: &PresetPlan,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    let Some(repo_root) = tokmd_git::repo_root(root) else {
+        warnings.push("git scan failed: not a git repo".to_string());
+        return;
+    };
+
+    match tokmd_git::collect_history(&repo_root, limits.max_commits, limits.max_commit_files) {
+        Ok(commits) => {
+            if plan.git {
+                match crate::git::build_git_report(&repo_root, export, &commits) {
+                    Ok(report) => reports.git = Some(report),
+                    Err(err) => warnings.push(format!("git scan failed: {}", err)),
+                }
+            }
+            if plan.churn {
+                reports.predictive_churn = Some(crate::git::build_predictive_churn_report(
+                    export, &commits, &repo_root,
+                ));
+            }
+            if plan.fingerprint {
+                reports.corporate_fingerprint =
+                    Some(crate::fingerprint::build_corporate_fingerprint(&commits));
+            }
+        }
+        Err(err) => warnings.push(format!("git scan failed: {}", err)),
+    }
+}

--- a/crates/tokmd-analysis/src/analysis/identity_reports.rs
+++ b/crates/tokmd-analysis/src/analysis/identity_reports.rs
@@ -1,0 +1,40 @@
+use tokmd_types::ExportData;
+
+use crate::grid::PresetPlan;
+
+use super::reports::AnalysisReports;
+
+pub(super) fn enrich_identity_reports(
+    export: &ExportData,
+    plan: &PresetPlan,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if plan.archetype {
+        #[cfg(feature = "archetype")]
+        {
+            reports.archetype = crate::archetype::detect_archetype(export);
+        }
+        #[cfg(not(feature = "archetype"))]
+        {
+            warnings.push(
+                crate::grid::DisabledFeature::Archetype
+                    .warning()
+                    .to_string(),
+            );
+        }
+    }
+
+    if plan.topics {
+        #[cfg(feature = "topics")]
+        {
+            reports.topics = Some(crate::topics::build_topic_clouds(export));
+        }
+        #[cfg(not(feature = "topics"))]
+        {
+            warnings.push(crate::grid::DisabledFeature::Topics.warning().to_string());
+        }
+    }
+
+    let _ = (export, plan, reports, warnings);
+}

--- a/crates/tokmd-analysis/src/analysis/quality_reports.rs
+++ b/crates/tokmd-analysis/src/analysis/quality_reports.rs
@@ -1,0 +1,179 @@
+use std::path::{Path, PathBuf};
+
+use tokmd_types::ExportData;
+
+use crate::grid::PresetPlan;
+
+use super::AnalysisRequest;
+use super::reports::AnalysisReports;
+
+pub(super) fn enrich_quality_reports(
+    root: &Path,
+    export: &ExportData,
+    files: Option<&[PathBuf]>,
+    plan: &PresetPlan,
+    req: &AnalysisRequest,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    enrich_entropy(root, export, files, plan, req, reports, warnings);
+    enrich_license(root, files, plan, req, reports, warnings);
+    enrich_complexity(root, export, files, plan, req, reports, warnings);
+    enrich_api_surface(root, export, files, plan, req, reports, warnings);
+    enrich_halstead(root, export, files, plan, req, reports, warnings);
+}
+
+fn enrich_entropy(
+    root: &Path,
+    export: &ExportData,
+    files: Option<&[PathBuf]>,
+    plan: &PresetPlan,
+    req: &AnalysisRequest,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !plan.entropy {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match crate::entropy::build_entropy_report(root, list, export, &req.limits) {
+            Ok(report) => reports.entropy = Some(report),
+            Err(err) => warnings.push(format!("entropy scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    warnings.push(
+        crate::grid::DisabledFeature::EntropyProfiling
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (root, export, files, req, reports, warnings);
+}
+
+fn enrich_license(
+    root: &Path,
+    files: Option<&[PathBuf]>,
+    plan: &PresetPlan,
+    req: &AnalysisRequest,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !plan.license {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match crate::license::build_license_report(root, list, &req.limits) {
+            Ok(report) => reports.license = Some(report),
+            Err(err) => warnings.push(format!("license scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    warnings.push(
+        crate::grid::DisabledFeature::LicenseRadar
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (root, files, req, reports, warnings);
+}
+
+fn enrich_complexity(
+    root: &Path,
+    export: &ExportData,
+    files: Option<&[PathBuf]>,
+    plan: &PresetPlan,
+    req: &AnalysisRequest,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !plan.complexity {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match crate::complexity::build_complexity_report(
+            root,
+            list,
+            export,
+            &req.limits,
+            req.detail_functions,
+        ) {
+            Ok(report) => reports.complexity = Some(report),
+            Err(err) => warnings.push(format!("complexity scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    warnings.push(
+        crate::grid::DisabledFeature::ComplexityAnalysis
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (root, export, files, req, reports, warnings);
+}
+
+fn enrich_api_surface(
+    root: &Path,
+    export: &ExportData,
+    files: Option<&[PathBuf]>,
+    plan: &PresetPlan,
+    req: &AnalysisRequest,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if !plan.api_surface {
+        return;
+    }
+
+    #[cfg(all(feature = "content", feature = "walk"))]
+    if let Some(list) = files {
+        match crate::api_surface::build_api_surface_report(root, list, export, &req.limits) {
+            Ok(report) => reports.api_surface = Some(report),
+            Err(err) => warnings.push(format!("api surface scan failed: {}", err)),
+        }
+    }
+
+    #[cfg(not(all(feature = "content", feature = "walk")))]
+    warnings.push(
+        crate::grid::DisabledFeature::ApiSurfaceAnalysis
+            .warning()
+            .to_string(),
+    );
+
+    let _ = (root, export, files, req, reports, warnings);
+}
+
+fn enrich_halstead(
+    root: &Path,
+    export: &ExportData,
+    files: Option<&[PathBuf]>,
+    plan: &PresetPlan,
+    req: &AnalysisRequest,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    #[cfg(all(feature = "halstead", feature = "content", feature = "walk"))]
+    if plan.halstead
+        && let Some(list) = files
+    {
+        match crate::halstead::build_halstead_report(root, list, export, &req.limits) {
+            Ok(halstead_report) => {
+                if let Some(ref mut complexity) = reports.complexity {
+                    crate::maintainability::attach_halstead_metrics(complexity, halstead_report);
+                }
+            }
+            Err(err) => warnings.push(format!("halstead scan failed: {}", err)),
+        }
+    }
+
+    let _ = (root, export, files, plan, req, reports, warnings);
+}

--- a/crates/tokmd-analysis/src/analysis/receipt.rs
+++ b/crates/tokmd-analysis/src/analysis/receipt.rs
@@ -1,0 +1,47 @@
+use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisReceipt, AnalysisSource, DerivedReport};
+use tokmd_types::{ScanStatus, ToolInfo};
+
+use crate::util::now_ms;
+
+use super::reports::AnalysisReports;
+
+pub(super) fn build_receipt(
+    source: AnalysisSource,
+    args: AnalysisArgsMeta,
+    derived: DerivedReport,
+    reports: AnalysisReports,
+    warnings: Vec<String>,
+) -> AnalysisReceipt {
+    let status = if warnings.is_empty() {
+        ScanStatus::Complete
+    } else {
+        ScanStatus::Partial
+    };
+
+    AnalysisReceipt {
+        schema_version: tokmd_analysis_types::ANALYSIS_SCHEMA_VERSION,
+        generated_at_ms: now_ms(),
+        tool: ToolInfo::current(),
+        mode: "analysis".to_string(),
+        status,
+        warnings,
+        source,
+        args,
+        archetype: reports.archetype,
+        topics: reports.topics,
+        entropy: reports.entropy,
+        predictive_churn: reports.predictive_churn,
+        corporate_fingerprint: reports.corporate_fingerprint,
+        license: reports.license,
+        derived: Some(derived),
+        assets: reports.assets,
+        deps: reports.deps,
+        git: reports.git,
+        imports: reports.imports,
+        dup: reports.dup,
+        complexity: reports.complexity,
+        api_surface: reports.api_surface,
+        effort: reports.effort,
+        fun: reports.fun,
+    }
+}

--- a/crates/tokmd-analysis/src/analysis/reports.rs
+++ b/crates/tokmd-analysis/src/analysis/reports.rs
@@ -1,0 +1,24 @@
+use tokmd_analysis_types::{
+    ApiSurfaceReport, Archetype, AssetReport, ComplexityReport, CorporateFingerprint,
+    DependencyReport, DuplicateReport, EffortEstimateReport, EntropyReport, FunReport, GitReport,
+    ImportReport, LicenseReport, PredictiveChurnReport, TopicClouds,
+};
+
+#[derive(Debug, Default)]
+pub(super) struct AnalysisReports {
+    pub(super) archetype: Option<Archetype>,
+    pub(super) topics: Option<TopicClouds>,
+    pub(super) entropy: Option<EntropyReport>,
+    pub(super) predictive_churn: Option<PredictiveChurnReport>,
+    pub(super) corporate_fingerprint: Option<CorporateFingerprint>,
+    pub(super) license: Option<LicenseReport>,
+    pub(super) assets: Option<AssetReport>,
+    pub(super) deps: Option<DependencyReport>,
+    pub(super) git: Option<GitReport>,
+    pub(super) imports: Option<ImportReport>,
+    pub(super) dup: Option<DuplicateReport>,
+    pub(super) complexity: Option<ComplexityReport>,
+    pub(super) api_surface: Option<ApiSurfaceReport>,
+    pub(super) effort: Option<EffortEstimateReport>,
+    pub(super) fun: Option<FunReport>,
+}

--- a/crates/tokmd-analysis/src/analysis/walk_reports.rs
+++ b/crates/tokmd-analysis/src/analysis/walk_reports.rs
@@ -1,0 +1,35 @@
+use std::path::{Path, PathBuf};
+
+use crate::grid::PresetPlan;
+
+use super::reports::AnalysisReports;
+
+pub(super) fn enrich_walk_reports(
+    root: &Path,
+    files: Option<&[PathBuf]>,
+    plan: &PresetPlan,
+    reports: &mut AnalysisReports,
+    warnings: &mut Vec<String>,
+) {
+    if plan.assets {
+        #[cfg(feature = "walk")]
+        if let Some(list) = files {
+            match crate::assets::build_assets_report(root, list) {
+                Ok(report) => reports.assets = Some(report),
+                Err(err) => warnings.push(format!("asset scan failed: {}", err)),
+            }
+        }
+    }
+
+    if plan.deps {
+        #[cfg(feature = "walk")]
+        if let Some(list) = files {
+            match crate::assets::build_dependency_report(root, list) {
+                Ok(report) => reports.deps = Some(report),
+                Err(err) => warnings.push(format!("dependency scan failed: {}", err)),
+            }
+        }
+    }
+
+    let _ = (root, files, plan, reports, warnings);
+}


### PR DESCRIPTION
### Motivation
- The `analyze` implementation had grown into a large monolithic function mixing orchestration, feature-gated branching, and many side-effecting enrichers, making it hard to reason about and test incrementally.
- Break the orchestration into single-responsibility units so each phase (derived/source setup, file inventory, walk/content/git/identity/quality/fun/effort enrichers, aggregation, receipt assembly) is isolated and easier to maintain.

### Description
- Replace the long `analyze` body with a high-level orchestrator in `crates/tokmd-analysis/src/analysis.rs` that delegates work to small SRP modules while keeping the public API (`analyze`, `AnalysisRequest`, `AnalysisContext`) unchanged.
- Add new submodules under `crates/tokmd-analysis/src/analysis/`: `derived_stage.rs`, `file_inventory.rs`, `walk_reports.rs`, `content_reports.rs`, `git_reports.rs`, `identity_reports.rs`, `quality_reports.rs`, `fun_effort_reports.rs`, `reports.rs`, and `receipt.rs` to encapsulate respective responsibilities and report storage.
- Wire the new modules into the orchestration so feature-gated behavior and existing disabled-feature warnings are preserved, and near-dup/git/content/work flows reuse the original logic via focused helpers.
- Minor API helpers remain internal; the public `analyze` call now reads like a clear pipeline (derive -> collect files -> enrichers -> effort -> build receipt) and final receipt assembly is centralized in `receipt::build_receipt`.

### Testing
- Ran `cargo check -p tokmd-analysis --no-default-features` and it completed successfully.
- Ran `cargo check -p tokmd-analysis` and `cargo check -p tokmd-analysis --all-features` and both completed successfully.
- Ran linting with `cargo clippy -p tokmd-analysis --all-features -- -D warnings` and it passed with no warnings.
- Ran unit/integration tests with `cargo test -p tokmd-analysis` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02816fb6208333a02849bc20d5c493)