### PR TITLE
invariant: tighten property tests for derived distributions 🔬

### DIFF
--- a/.jules/runs/invariant_model_analysis/decision.md
+++ b/.jules/runs/invariant_model_analysis/decision.md
@@ -1,17 +1,15 @@
-## Target Selection
-Target: `tokmd-analysis` derived property testing.
-Invariant: The `test_density` and `boilerplate` ratio metrics must always be bounded mathematically to the unit range `[0.0, 1.0]`.
+# Decision
 
-### Option A (recommended)
-Add property tests asserting the unit-range boundary invariants of `test_density` and `boilerplate` against the arbitrary `FileRow` generation corpus.
-- Fits this repo and shard as it strictly reinforces model guarantees.
-- Structure: high, guarantees expected output schema constraints.
-- Velocity: medium, low runtime impact, high stability.
-- Governance: matches the 'property' gate expectations for invariant testing.
+## Option A
+Add property tests for the `distribution_median`, `distribution_percentiles`, and `histogram_bucket_bounds` invariants in `crates/tokmd-analysis/src/derived/tests/properties.rs`.
 
-### Option B
-Manually exhaust all possible `lines`, `code`, `infra` and `test` combinations with targeted edge case unit tests.
-- High manual toil, does not fully lock the invariant against combinations proptest might surface later.
+These invariants reflect important facts about the analysis:
+1. `distribution_median_is_correct` - median should accurately reflect the 50th percentile.
+2. `distribution_percentiles_are_correct` - p90 and p99 should accurately reflect the underlying `tokmd_scan::percentile` calculations over sizes.
+3. `histogram_bucket_bounds_are_ordered_and_non_overlapping` - bucket sizes should remain contiguous with `prev.max.unwrap() + 1 == curr.min` allowing no gaps or overlap.
+
+## Option B
+Find an alternative location to add property tests. But the existing `derived::tests::properties` clearly contains a gap because only `distribution_count`, `min_le_max`, `mean_between_min_max` and `gini` were verified, ignoring other critical metrics returned by `build_distribution_report` and `build_histogram`.
 
 ## Decision
-Chosen Option A. Generating arbitrary file rows and evaluating `derive_report` is the highest-signal proof that the derived model does not break fundamental unit range mathematical constraints.
+Choose Option A. I have implemented and verified all three new invariants which reduce uncertainty over these analytical outputs using proptest properties in the analysis crate tests.

--- a/.jules/runs/invariant_model_analysis/envelope.json
+++ b/.jules/runs/invariant_model_analysis/envelope.json
@@ -12,8 +12,5 @@
     "docs/**"
   ],
   "gate_profile": "property",
-  "allowed_outcomes": [
-    "proof-improvement patch",
-    "learning PR"
-  ]
+  "allowed_outcomes": ["proof-improvement patch", "learning PR"]
 }

--- a/.jules/runs/invariant_model_analysis/pr_body.md
+++ b/.jules/runs/invariant_model_analysis/pr_body.md
@@ -1,45 +1,48 @@
 ## 💡 Summary
-Added two new property-based tests in `tokmd-analysis` to explicitly lock in the unit range invariant `[0.0, 1.0]` for `test_density.ratio` and `boilerplate.ratio`.
+Tightened property invariants around derived analysis distributions and histograms. These new proptests verify the correctness of the median, percentiles (p90, p99), and ensure that histogram buckets remain contiguous without overlaps or gaps.
 
 ## 🎯 Why
-The codebase has `TestDensityReport` and `BoilerplateReport` outputs within the `AnalysisReceipt`. These reports calculate ratios based on code logic and infrastructure lines. By mathematically defining boundaries around these metric values, we strengthen the reliability of our reports across any potential combination of inputs. Missing property tests for these left edge behavior unverified against extreme values surfaced by proptest.
+Previously, the derived properties only verified the extremes (min, max, mean, gini) of the distribution, ignoring the core statistical quantiles and assuming bucket boundaries without checking their coherence across sizes. Locking these down prevents regressions in report derivations.
 
 ## 🔎 Evidence
-- File path: `crates/tokmd-analysis/src/derived/tests/properties.rs`
-- Finding: `test_density` and `boilerplate` metrics lacked property-based test invariants verifying that the final generated output `.ratio` fields are securely bounded between `0.0` and `1.0`.
+- `crates/tokmd-analysis/src/derived/tests/properties.rs`
+- Observed missing tests for `median`, `p90`, `p99`, and bucket boundary contiguity.
+- Proptest coverage now properly models these bounds and constraints.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-Add property tests asserting the unit-range boundary invariants of `test_density` and `boilerplate` against the arbitrary `FileRow` generation corpus.
-- Fits this repo and shard as it strictly reinforces model guarantees.
-- Structure: high, guarantees expected output schema constraints.
-- Velocity: medium, low runtime impact, high stability.
-- Governance: matches the 'property' gate expectations for invariant testing.
+- Add strict checks for median calculations and gapless bounds between `min`/`max` fields on histogram buckets.
+- Fits the analysis-stack by increasing deterministic guarantees in data generation.
+- **Trade-offs:** Increases test compilation and execution time slightly but greatly enhances proof surface for `distribution_report` structure.
 
 ### Option B
-Manually exhaust all possible `lines`, `code`, `infra` and `test` combinations with targeted edge case unit tests.
-- High manual toil, does not fully lock the invariant against combinations proptest might surface later.
+- Add deterministic hard-coded unit test values.
+- **When to choose:** Only when randomized testing fails to hit specific complex mathematical edge cases or requires deterministic manual coverage.
+- **Trade-offs:** Weaker invariants and more maintenance overhead over time.
 
 ## ✅ Decision
-Chosen Option A. Generating arbitrary file rows and evaluating `derive_report` is the highest-signal proof that the derived model does not break fundamental unit range mathematical constraints.
+Chose Option A to enforce invariants across arbitrary file arrays properly.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd-analysis/src/derived/tests/properties.rs`
-  - Added `test_density_ratio_in_unit_range`
-  - Added `boilerplate_ratio_in_unit_range`
+- `crates/tokmd-analysis/src/derived/tests/properties.rs` - added `distribution_median_is_correct`, `distribution_percentiles_are_correct`, and `histogram_bucket_bounds_are_ordered_and_non_overlapping`.
 
 ## 🧪 Verification receipts
 ```text
-cargo test -p tokmd-analysis test_density_ratio_in_unit_range
-cargo test -p tokmd-analysis boilerplate_ratio_in_unit_range
+cargo test -p tokmd-analysis --lib derived::tests::properties
+...
+test derived::tests::properties::distribution_median_is_correct ... ok
+test derived::tests::properties::distribution_percentiles_are_correct ... ok
+test derived::tests::properties::histogram_bucket_bounds_are_ordered_and_non_overlapping ... ok
+...
+test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 1515 filtered out; finished in 4.40s
 ```
 
 ## 🧭 Telemetry
-- Change shape: Internal tests only
-- Blast radius: `tokmd-analysis` tests
+- Change shape: Test/Proof improvement
+- Blast radius: Internal test surface only
 - Risk class: Low
 - Rollback: Revert the PR
-- Gates run: `cargo test -p tokmd-analysis`
+- Gates run: `cargo test -p tokmd-analysis --lib derived::tests::properties`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/invariant_model_analysis/envelope.json`
@@ -49,4 +52,4 @@ cargo test -p tokmd-analysis boilerplate_ratio_in_unit_range
 - `.jules/runs/invariant_model_analysis/pr_body.md`
 
 ## 🔜 Follow-ups
-None
+None.

--- a/.jules/runs/invariant_model_analysis/receipts.jsonl
+++ b/.jules/runs/invariant_model_analysis/receipts.jsonl
@@ -2,3 +2,4 @@
 {"timestamp": "2026-05-07T20:24:59Z", "command": "wrote decision.md"}
 {"timestamp": "2026-05-07T20:30:39Z", "command": "cargo test -p tokmd-analysis test_density_ratio_in_unit_range"}
 {"timestamp": "2026-05-07T20:30:39Z", "command": "cargo test -p tokmd-analysis boilerplate_ratio_in_unit_range"}
+{"timestamp": "2026-05-12T14:24:44Z", "command": "cargo test -p tokmd-analysis --lib derived::tests::properties", "output": "test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 1515 filtered out; finished in 4.40s"}

--- a/.jules/runs/invariant_model_analysis/result.json
+++ b/.jules/runs/invariant_model_analysis/result.json
@@ -1,5 +1,11 @@
 {
-  "status": "success",
-  "patch_type": "proof-improvement",
-  "message": "Added property tests asserting unit-range bounds for test_density and boilerplate metrics."
+  "outcome": "proof-improvement patch",
+  "files_touched": [
+    "crates/tokmd-analysis/src/derived/tests/properties.rs"
+  ],
+  "invariants_added": [
+    "distribution_median_is_correct",
+    "distribution_percentiles_are_correct",
+    "histogram_bucket_bounds_are_ordered_and_non_overlapping"
+  ]
 }

--- a/crates/tokmd-analysis/src/derived/tests/properties.rs
+++ b/crates/tokmd-analysis/src/derived/tests/properties.rs
@@ -146,6 +146,24 @@ proptest! {
     }
 
     #[test]
+    fn distribution_median_is_correct(rows in arb_file_rows()) {
+        let mut sizes: Vec<usize> = rows.iter().map(|r| r.lines).collect();
+        sizes.sort();
+
+        let expected_median = if sizes.is_empty() {
+            0.0
+        } else if sizes.len() % 2 == 1 {
+            sizes[sizes.len() / 2] as f64
+        } else {
+            (sizes[sizes.len() / 2 - 1] as f64 + sizes[sizes.len() / 2] as f64) / 2.0
+        };
+
+        let report = derive_report(&export(rows), None);
+        let d = &report.distribution;
+        prop_assert_eq!(d.median, round_f64(expected_median, 2));
+    }
+
+    #[test]
     fn distribution_mean_between_min_and_max(rows in arb_file_rows()) {
         let report = derive_report(&export(rows), None);
         let d = &report.distribution;
@@ -154,6 +172,16 @@ proptest! {
             "mean ({}) should be in [{}, {}]",
             d.mean, d.min, d.max
         );
+    }
+
+    #[test]
+    fn distribution_percentiles_are_correct(rows in arb_file_rows()) {
+        let mut sizes: Vec<usize> = rows.iter().map(|r| r.lines).collect();
+        sizes.sort();
+
+        let report = derive_report(&export(rows), None);
+        prop_assert_eq!(report.distribution.p90, round_f64(tokmd_scan::percentile(&sizes, 0.90), 2));
+        prop_assert_eq!(report.distribution.p99, round_f64(tokmd_scan::percentile(&sizes, 0.99), 2));
     }
 
     #[test]
@@ -182,6 +210,18 @@ proptest! {
             "histogram pcts should sum to ~1.0, got {}",
             total_pct
         );
+    }
+
+    #[test]
+    fn histogram_bucket_bounds_are_ordered_and_non_overlapping(rows in arb_file_rows()) {
+        let report = derive_report(&export(rows), None);
+        for window in report.histogram.windows(2) {
+            let prev = &window[0];
+            let curr = &window[1];
+            prop_assert!(prev.max.is_some(), "Only the last bucket can have an unbounded max");
+            prop_assert_eq!(prev.max.unwrap() + 1, curr.min, "Buckets must be strictly adjacent");
+            prop_assert!(curr.max.is_none() || curr.max.unwrap() >= curr.min, "Bucket max must be >= min");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 💡 Summary 
Tightened property invariants around derived analysis distributions and histograms. These new proptests verify the correctness of the median, percentiles (p90, p99), and ensure that histogram buckets remain contiguous without overlaps or gaps.

## 🎯 Why 
Previously, the derived properties only verified the extremes (min, max, mean, gini) of the distribution, ignoring the core statistical quantiles and assuming bucket boundaries without checking their coherence across sizes. Locking these down prevents regressions in report derivations.

## 🔎 Evidence 
- `crates/tokmd-analysis/src/derived/tests/properties.rs`
- Observed missing tests for `median`, `p90`, `p99`, and bucket boundary contiguity.
- Proptest coverage now properly models these bounds and constraints.

## 🧭 Options considered 
### Option A (recommended) 
- Add strict checks for median calculations and gapless bounds between `min`/`max` fields on histogram buckets.
- Fits the analysis-stack by increasing deterministic guarantees in data generation.
- **Trade-offs:** Increases test compilation and execution time slightly but greatly enhances proof surface for `distribution_report` structure.

### Option B 
- Add deterministic hard-coded unit test values.
- **When to choose:** Only when randomized testing fails to hit specific complex mathematical edge cases or requires deterministic manual coverage.
- **Trade-offs:** Weaker invariants and more maintenance overhead over time.

## ✅ Decision 
Chose Option A to enforce invariants across arbitrary file arrays properly.

## 🧱 Changes made (SRP) 
- `crates/tokmd-analysis/src/derived/tests/properties.rs` - added `distribution_median_is_correct`, `distribution_percentiles_are_correct`, and `histogram_bucket_bounds_are_ordered_and_non_overlapping`.

## 🧪 Verification receipts 
```text
cargo test -p tokmd-analysis --lib derived::tests::properties
...
test derived::tests::properties::distribution_median_is_correct ... ok
test derived::tests::properties::distribution_percentiles_are_correct ... ok
test derived::tests::properties::histogram_bucket_bounds_are_ordered_and_non_overlapping ... ok
...
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 1515 filtered out; finished in 4.40s
```

## 🧭 Telemetry 
- Change shape: Test/Proof improvement
- Blast radius: Internal test surface only
- Risk class: Low
- Rollback: Revert the PR
- Gates run: `cargo test -p tokmd-analysis --lib derived::tests::properties`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`

## 🗂️ .jules artifacts 
- `.jules/runs/invariant_model_analysis/envelope.json`
- `.jules/runs/invariant_model_analysis/decision.md`
- `.jules/runs/invariant_model_analysis/receipts.jsonl`
- `.jules/runs/invariant_model_analysis/result.json`
- `.jules/runs/invariant_model_analysis/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [15642043138354815638](https://jules.google.com/task/15642043138354815638) started by @EffortlessSteven*