### PR TITLE
fix(bindings): expose export meta settings

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -226,6 +226,19 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "tokmd_node_binding"
+kind = "rust"
+paths = [
+  "crates/tokmd-node/src/**",
+  "crates/tokmd-node/index.d.ts",
+  "crates/tokmd-node/npm/index.d.ts",
+]
+packages = ["tokmd-node"]
+proof = ["cargo check -p tokmd-node --all-targets"]
+mutation = false
+coverage = false
+
+[[scope]]
 name = "lint_policy"
 kind = "rust"
 paths = [

--- a/crates/tokmd-node/index.d.ts
+++ b/crates/tokmd-node/index.d.ts
@@ -64,6 +64,10 @@ export interface ExportOptions {
   min_code?: number;
   /** Maximum rows to return (0 = unlimited) */
   max_rows?: number;
+  /** Include a meta record in JSON/JSONL output (default: true) */
+  meta?: boolean;
+  /** Strip this prefix from output paths */
+  strip_prefix?: string;
   /** How to handle embedded languages ("collapse" or "separate") */
   children?: "collapse" | "separate";
   /** Redaction mode ("none", "paths", "all") */

--- a/crates/tokmd-node/npm/index.d.ts
+++ b/crates/tokmd-node/npm/index.d.ts
@@ -26,6 +26,8 @@ export interface ExportOptions {
   format?: 'jsonl' | 'json' | 'csv' | 'cyclonedx'
   min_code?: number
   max_rows?: number
+  meta?: boolean
+  strip_prefix?: string
   module_roots?: string[]
   module_depth?: number
   children?: 'separate' | 'parents-only'

--- a/crates/tokmd-node/src/lib.rs
+++ b/crates/tokmd-node/src/lib.rs
@@ -177,6 +177,8 @@ pub async fn module_fn(options: Option<serde_json::Value>) -> Result<serde_json:
 /// @param options.format - Output format ("jsonl", "json", "csv", "cyclonedx")
 /// @param options.min_code - Minimum lines of code to include (default: 0)
 /// @param options.max_rows - Maximum rows to return (0 = unlimited)
+/// @param options.meta - Include a meta record in JSON/JSONL output (default: true)
+/// @param options.strip_prefix - Strip this prefix from output paths (optional)
 /// @returns Promise resolving to export receipt
 ///
 /// @example
@@ -370,6 +372,25 @@ mod tests {
                 .as_array()
                 .map(|r| !r.is_empty())
                 .unwrap_or(false)
+        );
+    }
+
+    #[test]
+    fn export_accepts_meta_and_strip_prefix_options() {
+        let repo = make_repo("fn main() { println!(\"hi\"); }\n");
+        let path = repo.path().to_string_lossy().to_string();
+
+        let export_result = block_on(export_fn(Some(json!({
+            "paths": [path.clone()],
+            "format": "json",
+            "meta": false,
+            "strip_prefix": path.clone(),
+        }))))
+        .expect("export should succeed");
+
+        assert_eq!(
+            export_result["args"]["strip_prefix"].as_str().unwrap_or(""),
+            path
         );
     }
 

--- a/crates/tokmd-python/src/lib.rs
+++ b/crates/tokmd-python/src/lib.rs
@@ -188,6 +188,8 @@ fn module(
 ///     redact: Redaction mode (default: "none")
 ///     excluded: List of glob patterns to exclude (default: [])
 ///     hidden: Include hidden files (default: False)
+///     meta: Include a meta record in JSON/JSONL output (default: True)
+///     strip_prefix: Strip this prefix from output paths (default: None)
 ///
 /// Returns:
 ///     dict: Export receipt with file rows and metadata
@@ -199,7 +201,7 @@ fn module(
 #[cfg_attr(not(test), pyfunction)]
 #[cfg_attr(
     not(test),
-    pyo3(signature = (paths=None, format=None, min_code=0, max_rows=0, module_roots=None, module_depth=2, children=None, redact=None, excluded=None, hidden=false))
+    pyo3(signature = (paths=None, format=None, min_code=0, max_rows=0, module_roots=None, module_depth=2, children=None, redact=None, excluded=None, hidden=false, meta=true, strip_prefix=None))
 )]
 #[allow(clippy::too_many_arguments)]
 fn export(
@@ -214,6 +216,8 @@ fn export(
     redact: Option<&str>,
     excluded: Option<Vec<String>>,
     hidden: bool,
+    meta: bool,
+    strip_prefix: Option<&str>,
 ) -> PyResult<Py<PyAny>> {
     let args = build_args(py, paths, 0, excluded, hidden)?;
     args.set_item("min_code", min_code)?;
@@ -230,6 +234,10 @@ fn export(
     }
     if let Some(r) = redact {
         args.set_item("redact", r)?;
+    }
+    args.set_item("meta", meta)?;
+    if let Some(prefix) = strip_prefix {
+        args.set_item("strip_prefix", prefix)?;
     }
     run(py, "export", &args)
 }

--- a/crates/tokmd-python/src/tests.rs
+++ b/crates/tokmd-python/src/tests.rs
@@ -289,6 +289,8 @@ fn wrappers_scan_small_repo() {
             Some("none"),
             None,
             false,
+            true,
+            None,
         )
         .expect("export should succeed");
         let export_dict = export_result.cast_bound::<PyDict>(py).expect("export dict");
@@ -367,6 +369,8 @@ fn wrappers_scan_small_repo_defaults() {
             None,
             None,
             false,
+            true,
+            None,
         )
         .expect("export should succeed");
         let export_dict = export_result.cast_bound::<PyDict>(py).expect("export dict");
@@ -411,6 +415,40 @@ fn wrappers_scan_small_repo_defaults() {
                 .extract::<String>()
                 .unwrap(),
             "analysis"
+        );
+    });
+}
+
+#[test]
+fn export_forwards_strip_prefix_option() {
+    with_py(|py| {
+        let repo = make_repo("fn main() { println!(\"hi\"); }\n");
+        let path = repo.path().to_string_lossy().to_string();
+
+        let export_result = export(
+            py,
+            Some(vec![path.clone()]),
+            Some("json"),
+            0,
+            0,
+            None,
+            2,
+            Some("separate"),
+            Some("none"),
+            None,
+            false,
+            false,
+            Some(&path),
+        )
+        .expect("export should succeed");
+        let export_dict = export_result.cast_bound::<PyDict>(py).expect("export dict");
+        let args = export_dict.get_item("args").unwrap().unwrap();
+        assert_eq!(
+            args.get_item("strip_prefix")
+                .unwrap()
+                .extract::<String>()
+                .unwrap(),
+            path
         );
     });
 }
@@ -785,6 +823,8 @@ fn red_test_python_ffi_all_wrappers_return_pyresult() {
             None,
             None,
             false,
+            true,
+            None,
         );
 
         // analyze() - should return PyResult

--- a/crates/tokmd-python/tests/test_basic.py
+++ b/crates/tokmd-python/tests/test_basic.py
@@ -196,3 +196,9 @@ class TestExportOptions:
 
         result = tokmd.export(paths=["src"], max_rows=10)
         assert result["args"]["max_rows"] == 10
+
+    def test_meta_and_strip_prefix_are_accepted(self):
+        import tokmd
+
+        result = tokmd.export(paths=["src"], meta=False, strip_prefix="src")
+        assert result["args"]["strip_prefix"] == "src"


### PR DESCRIPTION
## Summary
- Expose `meta` and `strip_prefix` through the high-level Python `export()` binding.
- Add Node export option docs and checked-in TypeScript declarations for the same settings.
- Add focused binding regressions and a `tokmd_node_binding` proof scope so affected planning routes Node binding changes.

## Notes
- Synthesized from draft #2136 while dropping `.orig` backup files, browser lockfile noise, and generated run artifacts.
- Node already forwards arbitrary JSON options at runtime; this fixes the declared/API docs surface and adds a regression for the existing pass-through behavior.
- No receipt schema, CLI, proof gate promotion, or Codecov behavior changes.

## Validation
- `cargo test -p tokmd-python export --no-default-features --verbose`
- `cargo test -p tokmd-node export --verbose`
- `cargo check -p tokmd-python --all-targets`
- `cargo check -p tokmd-node --all-targets`
- `cargo clippy -p tokmd-python --all-targets --no-default-features -- -D warnings`
- `cargo clippy -p tokmd-node --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask proof-artifacts-check`
- `git diff --check`