### PR TITLE
jules: record librarian learning on config resolvers 📚

### DIFF
--- a/.jules/friction/open/config_resolver_doctests.md
+++ b/.jules/friction/open/config_resolver_doctests.md
@@ -1,0 +1,6 @@
+# Config Resolver Doctest Coverage
+While investigating the `crates/tokmd/src/config/resolve/` interfaces (such as `resolve_lang`, `resolve_export`, and `resolve_module`), I discovered that comprehensive and passing executable `rust` doctests are already in place for all `resolve_*` and `resolve_*_with_config` functions.
+
+Because `Librarian` rules require factual drift, missing executable coverage, or a clearly misleading omission to justify a patch, and because there was no drift or missing coverage on this targeted public interface, a code change here would have forced a fake fix.
+
+Instead of forcing a patch, this run was pivoted into a learning PR to document that the public CLI config resolving interfaces are already well-covered and protected against silent drift.

--- a/.jules/runs/librarian_api_doctests/decision.md
+++ b/.jules/runs/librarian_api_doctests/decision.md
@@ -1,14 +1,10 @@
-## Options considered
+# Decision
 
-### Option A (recommended)
-- **What it is**: Update the existing `no_run` doctest in `cockpit_workflow` to use a temporary git repository via `tempfile` and `std::process::Command`, ensuring deterministic, executable coverage for this critical API. Add a test demonstrating `try_parse_from` to `crates/tokmd/src/cli/parser.rs`.
-- **Why it fits this repo and shard**: Aligns perfectly with the `docs-executable` gate profile requiring doctests to execute, avoiding silent drift in the `interfaces` shard.
-- **Trade-offs**: Slightly increased doctest execution time since it invokes `git init/commit` in a temporary directory, but provides real proof that the API works.
+## Option A: Add doctests to config resolvers
+Add concrete executable doctests to `tokmd`'s CLI config resolvers (`resolve_lang`, `resolve_export`, etc.) in `crates/tokmd/src/config/resolve/`. These are the public bridge between CLI arguments and core functionality, and missing coverage means config behaviour could silently drift.
 
-### Option B
-- **What it is**: Mock `tokmd-git` to simulate git behavior instead of actually running `git` inside the doctest.
-- **When to choose it instead**: If the CI environment does not have `git` available or if running `git` becomes prohibitively slow across many tests.
-- **Trade-offs**: Requires more complex setup, potentially modifying the `tokmd-git` API to be easily injectable or mockable just for doctests, increasing surface area.
+## Option B: Add doctests to `tokmd_core::workflows`
+Add doctests to workflow execution modules. This might duplicate the existing integration tests and focus less on public APIs than the configuration layer.
 
-## Decision
-Chose Option A to create deterministic execution proofs while preserving the exact user-facing behavior in the doctest, fulfilling the Prover objective directly.
+### Decision
+Option A. The `resolve_*` and `resolve_*_with_config` functions are directly responsible for mapping complex user-facing configurations (CLI args + profile + toml) and currently lack execution coverage in `resolve_export.rs` and `resolve_module.rs`. I will add doctests to these resolver methods.

--- a/.jules/runs/librarian_api_doctests/decision.md
+++ b/.jules/runs/librarian_api_doctests/decision.md
@@ -7,4 +7,4 @@ Add concrete executable doctests to `tokmd`'s CLI config resolvers (`resolve_lan
 Add doctests to workflow execution modules. This might duplicate the existing integration tests and focus less on public APIs than the configuration layer.
 
 ### Decision
-Option A. The `resolve_*` and `resolve_*_with_config` functions are directly responsible for mapping complex user-facing configurations (CLI args + profile + toml) and currently lack execution coverage in `resolve_export.rs` and `resolve_module.rs`. I will add doctests to these resolver methods.
+Option A was investigated because the `resolve_*` and `resolve_*_with_config` functions directly map complex user-facing configuration (CLI args + profile + toml) into command settings. The current `resolve_export.rs` and `resolve_module.rs` interfaces already have executable doctest coverage, so no code changes or new doctests are required for this shard.

--- a/.jules/runs/librarian_api_doctests/envelope.json
+++ b/.jules/runs/librarian_api_doctests/envelope.json
@@ -1,1 +1,16 @@
-{"prompt_id": "librarian_api_doctests", "persona": "Librarian", "style": "Prover", "primary_shard": "interfaces", "allowed_paths": ["crates/tokmd-config/**", "crates/tokmd-core/**", "crates/tokmd/**", "docs/reference-cli.md", "docs/tutorial.md", "crates/tokmd/tests/**"], "gate_profile": "docs-executable", "allowed_outcomes": ["proof-improvement", "learning"]}
+{
+  "prompt_id": "librarian_api_doctests",
+  "persona": "Librarian",
+  "style": "Prover",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": ["proof-improvement", "learning"]
+}

--- a/.jules/runs/librarian_api_doctests/pr_body.md
+++ b/.jules/runs/librarian_api_doctests/pr_body.md
@@ -1,50 +1,43 @@
 ## 💡 Summary
-Converted `no_run` doctests in core workflows to executable tests and added missing CLI parsing examples. This improves executable test coverage across public APIs to prevent silent drift.
+This is a learning PR. I investigated adding executable doctests to the config resolver interfaces (`crates/tokmd/src/config/resolve/`) but found they already have comprehensive, passing doctest coverage.
 
 ## 🎯 Why
-The `interfaces` shard has a `docs-executable` gate profile requiring that examples actually compile and run where possible. The `cockpit_workflow` had a `no_run` example that wasn't verifying the API contract, and the main `Cli` parser lacked an example demonstrating safe parsing (via `try_parse_from`).
+The goal was to improve factual docs quality and executable examples for public interfaces to prevent silent drift.
 
 ## 🔎 Evidence
-- `crates/tokmd-core/src/workflows/cockpit.rs` contained `/// ```rust,no_run`.
-- `crates/tokmd/src/cli/parser.rs` lacked a struct-level doctest.
-- `cargo test -p tokmd --doc` and `cargo test -p tokmd-core --doc` successfully executed the new doctests.
+- `crates/tokmd/src/config/resolve/export.rs`
+- `crates/tokmd/src/config/resolve/module.rs`
+- `crates/tokmd/src/config/resolve/lang.rs`
+- The `resolve_*` and `resolve_*_with_config` functions all have `/// # Examples` sections containing executable ````rust` doctests.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- what it is: Update the existing `no_run` doctest in `cockpit_workflow` to use a temporary git repository via `tempfile` and `std::process::Command`, and add a `try_parse_from` test to `Cli`.
-- why it fits this repo and shard: Directly satisfies the `docs-executable` gate profile.
-- trade-offs: Structure is preserved. Velocity is slightly impacted by `git init` during doctest execution. Governance is improved through deterministic proof.
+- Add doctests to config resolvers (`resolve_lang`, `resolve_export`, etc.).
+- This fits the shard by directly targeting the core CLI configuration interfaces.
+- Trade-offs: Structure is improved by ensuring public APIs have executable examples. Velocity is unaffected. Governance is improved by preventing silent drift.
 
 ### Option B
-- what it is: Mock `tokmd-git` behavior for testing.
-- when to choose it instead: If git isn't available or takes too long.
-- trade-offs: Increases mocking surface area and reduces realism.
+- Add doctests to `tokmd_core::workflows`.
+- Choose this if the config layer is already fully covered.
+- Trade-offs: Might duplicate existing integration tests, focusing less on public APIs than the configuration layer.
 
 ## ✅ Decision
-Option A. Leveraging a real temporary git repository provides concrete proof of the workflow's correctness without mocking.
+Option A was chosen to investigate the config resolvers. Upon investigation, the config resolvers already have comprehensive doctest coverage. Therefore, this is submitted as a learning PR instead of forcing a fake fix.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd-core/src/workflows/cockpit.rs`: Replaced `no_run` doctest with an executable git-based setup.
-- `crates/tokmd/src/cli/parser.rs`: Added an executable doctest to `Cli` demonstrating `try_parse_from`.
+- None. This is a learning PR.
 
 ## 🧪 Verification receipts
 ```text
-cargo test -p tokmd --doc
-test result: ok. 12 passed; 0 failed
-
-cargo test -p tokmd-core --doc --all-features
-test result: ok. 14 passed; 0 failed
-
-cargo fmt -- --check && cargo clippy -- -D warnings
-Finished `dev` profile
+cargo test --doc
 ```
 
 ## 🧭 Telemetry
-- Change shape: Test/docs improvement.
-- Blast radius: Docs / tests only.
-- Risk class: Low.
-- Rollback: Revert PR.
-- Gates run: `cargo test --doc`, `cargo fmt`, `cargo clippy`.
+- Change shape: learning PR
+- Blast radius: none
+- Risk class: none (learning PR)
+- Rollback: none
+- Gates run: docs-executable (cargo xtask docs --check, cargo test --doc)
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/librarian_api_doctests/envelope.json`
@@ -52,6 +45,7 @@ Finished `dev` profile
 - `.jules/runs/librarian_api_doctests/receipts.jsonl`
 - `.jules/runs/librarian_api_doctests/result.json`
 - `.jules/runs/librarian_api_doctests/pr_body.md`
+- `.jules/friction/open/config_resolver_doctests.md`
 
 ## 🔜 Follow-ups
 None.

--- a/.jules/runs/librarian_api_doctests/pr_body.md
+++ b/.jules/runs/librarian_api_doctests/pr_body.md
@@ -29,6 +29,7 @@ Option A was chosen to investigate the config resolvers. Upon investigation, the
 
 ## 🧪 Verification receipts
 ```text
+cargo xtask docs --check
 cargo test --doc
 ```
 

--- a/.jules/runs/librarian_api_doctests/receipts.jsonl
+++ b/.jules/runs/librarian_api_doctests/receipts.jsonl
@@ -1,3 +1,4 @@
-{"timestamp": "2024-05-18T10:00:00Z", "command": "cargo test -p tokmd --doc", "output": "test result: ok. 12 passed; 0 failed"}
-{"timestamp": "2024-05-18T10:00:10Z", "command": "cargo test -p tokmd-core --doc", "output": "test result: ok. 10 passed; 0 failed"}
-{"timestamp": "2024-05-18T10:00:20Z", "command": "cargo fmt -- --check && cargo clippy -- -D warnings", "output": "Finished `dev` profile"}
+{"timestamp": "2026-05-12T21:14:00Z", "command": "cargo xtask docs --check", "output": "Documentation is up to date.\n"}
+{"timestamp": "2026-05-12T21:14:00Z", "command": "cargo test --doc", "output": "test crates/tokmd/src/config/resolve/export.rs - config::resolve::export::resolve_export_with_config (line 92) ... ok\ntest crates/tokmd/src/config/resolve/module.rs - config::resolve::module::resolve_module_with_config (line 76) ... ok\ntest result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n"}
+{"timestamp": "2026-05-12T21:18:00Z", "command": "cargo test --doc", "output": "test crates/tokmd/src/config/resolve/export.rs - config::resolve::export::resolve_export_with_config (line 92) ... ok\ntest crates/tokmd/src/config/resolve/module.rs - config::resolve::module::resolve_module_with_config (line 76) ... ok\ntest result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s\n"}
+{"timestamp": "2026-05-12T21:18:00Z", "command": "cargo xtask docs --check", "output": "Documentation is up to date.\n"}

--- a/.jules/runs/librarian_api_doctests/result.json
+++ b/.jules/runs/librarian_api_doctests/result.json
@@ -1,5 +1,1 @@
-{
-  "status": "success",
-  "outcome": "proof-improvement",
-  "summary": "Converted the 'no_run' doctest in 'cockpit_workflow' to an executable test using a temporary git repository, and added an executable doctest to the CLI parser struct demonstrating 'try_parse_from'."
-}
+{"status": "success", "outcome": "learning"}


### PR DESCRIPTION
## 💡 Summary
This is a learning PR. I investigated adding executable doctests to the config resolver interfaces (`crates/tokmd/src/config/resolve/`) but found they already have comprehensive, passing doctest coverage.

## 🎯 Why
The goal was to improve factual docs quality and executable examples for public interfaces to prevent silent drift.

## 🔎 Evidence
- `crates/tokmd/src/config/resolve/export.rs`
- `crates/tokmd/src/config/resolve/module.rs`
- `crates/tokmd/src/config/resolve/lang.rs`
- The `resolve_*` and `resolve_*_with_config` functions all have `/// # Examples` sections containing executable ````rust` doctests.

## 🧭 Options considered
### Option A (recommended)
- Add doctests to config resolvers (`resolve_lang`, `resolve_export`, etc.).
- This fits the shard by directly targeting the core CLI configuration interfaces.
- Trade-offs: Structure is improved by ensuring public APIs have executable examples. Velocity is unaffected. Governance is improved by preventing silent drift.

### Option B
- Add doctests to `tokmd_core::workflows`.
- Choose this if the config layer is already fully covered.
- Trade-offs: Might duplicate existing integration tests, focusing less on public APIs than the configuration layer.

## ✅ Decision
Option A was chosen to investigate the config resolvers. Upon investigation, the config resolvers already have comprehensive doctest coverage. Therefore, this is submitted as a learning PR instead of forcing a fake fix.

## 🧱 Changes made (SRP)
- None. This is a learning PR.

## 🧪 Verification receipts
```text
cargo xtask docs --check
cargo test --doc
```

## 🧭 Telemetry
- Change shape: learning PR
- Blast radius: none
- Risk class: none (learning PR)
- Rollback: none
- Gates run: docs-executable (cargo xtask docs --check, cargo test --doc)

## 🗂️ .jules artifacts
- `.jules/runs/librarian_api_doctests/envelope.json`
- `.jules/runs/librarian_api_doctests/decision.md`
- `.jules/runs/librarian_api_doctests/receipts.jsonl`
- `.jules/runs/librarian_api_doctests/result.json`
- `.jules/runs/librarian_api_doctests/pr_body.md`
- `.jules/friction/open/config_resolver_doctests.md`

## 🔜 Follow-ups
None.
