### PR TITLE
chore(proof): map deep analysis integration tests

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -301,7 +301,9 @@ paths = [
   "crates/tokmd-analysis/src/analysis/**",
   "crates/tokmd-analysis/src/grid/**",
   "crates/tokmd-analysis/src/lib.rs",
+  "crates/tokmd-analysis/tests/analysis_*.rs",
   "crates/tokmd-analysis/tests/capability_reporting_w53.rs",
+  "crates/tokmd-analysis/tests/deep*.rs",
   "crates/tokmd-analysis/tests/enricher_pipeline.rs",
   "crates/tokmd-analysis/tests/feature_*.rs",
   "crates/tokmd-analysis/tests/orchestration*.rs",
@@ -313,6 +315,7 @@ paths = [
 packages = ["tokmd-analysis", "tokmd"]
 proof = [
   "cargo test -p tokmd-analysis --all-features --test orchestrator --test orchestration_w54 --test orchestration_w68 --test orchestration_w73 --verbose",
+  "cargo test -p tokmd-analysis --all-features --test analysis_deep_w64 --test analysis_depth_w62 --test deep --test deep_analysis_w48 --verbose",
   "cargo test -p tokmd-analysis --all-features --test orchestration receipt --verbose",
   "cargo test -p tokmd-analysis --all-features feature --verbose",
   "cargo test -p tokmd --test analyze_integration --verbose",


### PR DESCRIPTION
## Summary
- Map existing deep analysis integration test files into the `analysis_orchestration` proof scope.
- Add the matching all-features test command so changes to those files route to targeted analysis proof.
- Close the unknown-file gap exposed by draft #2160 without landing its weak generated tests.

## Validation
- `cargo xtask proof-policy --check`
- `cargo test -p tokmd-analysis --all-features --test analysis_deep_w64 --test analysis_depth_w62 --test deep --test deep_analysis_w48 --verbose`
- `cargo xtask affected --base <2160-merge-base> --head origin/pr/2160 --policy ci/proof.toml --json` showed `unknown_files: []`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `target/debug/xtask-proof-runner.exe proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary.json`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask publish-surface --json --verify-publish`

Note: the required proof runner was invoked via a copied xtask executable on Windows so nested `cargo test -p xtask` commands could rebuild the canonical `target/debug/xtask.exe` without file-lock failures.