### PR TITLE
archivist: fix Jules index drift 🗃️

### DIFF
--- a/.jules/index/generated/FRICTION_ROLLUP.md
+++ b/.jules/index/generated/FRICTION_ROLLUP.md
@@ -6,6 +6,7 @@ It rolls up active friction metadata from `.jules/friction/open/`.
 | ID | Persona | Style | Shard | Status | Summary |
 |---|---|---|---|---|---|
 | `compat-wasm-pack-args` | compat | builder | bindings-targets | open | `wasm-pack test` argument placement is easy to get wrong when future runs need to pass Cargo feature flags or profile flags through to wasm test builds. |
+| `config_resolver_doctests` | Unknown | Unknown | Unknown | open | While investigating the `crates/tokmd/src/config/resolve/` interfaces (such as `resolve_lang`, `resolve_export`, and `resolve_module`), I discovered that comprehensive and passing executable `rust` doctests are already in place for all `resolve_*` and `resolve_*_with_config` functions. |
 | `fuzz_toolchain_blocker` | fuzzer | prover | interfaces | open | `cargo fuzz` is not a reliable local gate in the current agent environments. Repeated runs hit either missing nightly-toolchain support in sandboxed Linux environments or sanitizer/LLVM link failures on Windows/MSVC before the target starts. |
 | `librarian_doctest_git_dependency` | librarian | prover | core-pipeline | open | The `cockpit_workflow` public API doctest is marked as `no_run` and skipping validation because it implicitly requires an active Git repository to execute (it fails with `not inside a git repository` when executed normally). |
 | `mutant_high_value` | Mutant | Prover | core-pipeline | open | During the assignment `mutant_high_value`, I was prompted to target a high-value core surface and provide mutation-style proof improvements. |

--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -10,16 +10,13 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `36cec87d-2836-42ed-9ae1-33dbf2702319` | Librarian | Explorer | docs | completed | 3 | live |
 | `37581ca1` | Sentinel | Stabilizer | core-pipeline | in-progress | 0 | live |
 | `archivist_jules` | Archivist | Builder | workspace-wide | in-progress | 1 | live |
-| `auditor_bindings_manifests` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `bolt-run-001` | Bolt | Refactorer | core-pipeline | in-progress | 0 | live |
-| `bolt_analysis_stack_builder` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `cartographer_roadmap_design` | Cartographer | Builder | tooling-governance | in-progress | 0 | live |
 | `cartographer_roadmap_design_1` | cartographer | builder | tooling-governance | in-progress | 0 | live |
-| `compat_interfaces_matrix_01` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `d657338a-caa9-4ccf-93a1-4733ada7154c` | Gatekeeper | Unknown | quality | completed | 0 | live |
 | `fuzzer_input_hardening_1` | Fuzzer 🌪️ | Prover | interfaces | in-progress | 1 | live |
 | `gatekeeper_contracts` | Gatekeeper | Builder | tooling-governance | in-progress | 6 | live |
-| `invariant_model_analysis` | invariant | prover | analysis-stack | success | 0 | live |
+| `invariant_model_analysis` | invariant | prover | analysis-stack | in-progress | 0 | live |
 | `librarian_api_doctests` | Librarian | Prover | interfaces | success | 0 | live |
 | `librarian_docs_examples` | Librarian | Builder | tooling-governance | success | 0 | live |
 | `mutant_high_value` | Mutant | Prover | core-pipeline | in-progress | 0 | live |

--- a/.jules/runs/archivist_jules/decision.md
+++ b/.jules/runs/archivist_jules/decision.md
@@ -1,27 +1,23 @@
-# Decision
+# Investigation and Decision
 
 ## Context
-The Archivist persona focuses on improving Jules itself by consolidating learnings and sharing scaffolding. Target ranking #2 is "summarize per-run packets into generated indexes/rollups", and target #1 is "consolidate recurring friction themes into better templates/policy/docs".
+The mission is to improve Jules itself by consolidating run packets, friction, learnings, and shared scaffolding. The target ranking is:
+1) consolidate recurring friction themes into better templates/policy/docs
+2) summarize per-run packets into generated indexes/rollups
+3) clean up prompt/runtime documentation so future runs improve
+4) move duplicated persona-local conventions into neutral shared guidance
 
-Looking at the generated indexes (`.jules/index/generated/RUNS_ROLLUP.md` and `FRICTION_ROLLUP.md`), they are currently out-of-date and missing some metadata, which is exposed by running `cargo xtask jules-index`. Also, the `FRICTION_ROLLUP.md` shows missing or "Unknown" metadata for friction items like `librarian_doctest_git_dependency.md` and `steward-release-clean-state.md` because they don't conform precisely to the metadata schema in `.jules/runbooks/FRICTION_ITEM.md`.
+Running `cargo xtask jules-index --check` reveals that the generated indexes in `.jules/index/generated/` are out of date compared to the actual `.jules/runs/` and `.jules/friction/` contents.
 
-## Options considered
+## Option A
+Regenerate the out-of-sync `.jules/index/generated/` indexes by running `cargo xtask jules-index`.
+- Fits the repository nicely, directly matching the #2 target ranking "summarize per-run packets into generated indexes/rollups".
+- Trade-offs: Structure/Governance - High confidence change, automatically generated.
 
-### Option A: Clean up friction items metadata and regenerate the indexes (Recommended)
-1. Fix the metadata frontmatter in the `librarian_doctest_git_dependency.md` and `steward-release-clean-state.md` friction items so they match the expected schema from the runbook.
-2. Run `cargo xtask jules-index` to update the generated `RUNS_ROLLUP.md` and `FRICTION_ROLLUP.md` files.
-3. Commit these changes.
-
-- **Structure**: High. Brings disparate friction items into compliance with the official runbook.
-- **Velocity**: Low impact on product code velocity, but improves Jules system health.
-- **Governance**: High. The generated indexes will now correctly track all friction items and run statuses.
-
-### Option B: Only regenerate the indexes without fixing the friction metadata
-1. Just run `cargo xtask jules-index`.
-
-- **Structure**: Low. The indexes will still show "Unknown" values for important metadata.
-- **Velocity**: Low.
-- **Governance**: Low. We leave broken metadata in the repo.
+## Option B
+Find an issue in `.jules/friction/` and fix it.
+- Slower, requires researching different aspects, which are beyond the specific tool execution.
+- Trade-offs: May affect other components, more risky than generating indexes.
 
 ## Decision
-**Option A**. By fixing the friction item metadata frontmatter to align with `.jules/runbooks/FRICTION_ITEM.md` and then regenerating the indexes, we accomplish both target #1 (consolidate friction themes/docs) and target #2 (summarize into generated indexes/rollups).
+I have chosen **Option A**. Regenerating the out-of-sync Jules indexes is the most straightforward and high-confidence fix that fulfills the "Archivist" persona's mission.

--- a/.jules/runs/archivist_jules/pr_body.md
+++ b/.jules/runs/archivist_jules/pr_body.md
@@ -1,46 +1,54 @@
 ## 💡 Summary
-Fixed malformed metadata frontmatter in two existing friction items and regenerated the Jules indexes. This ensures the `.jules/index/generated/FRICTION_ROLLUP.md` accurately tracks personas, styles, and shards for open friction rather than listing them as "Unknown", and updates the `RUNS_ROLLUP.md` with missing runs.
+Regenerated `.jules/index/generated/` rollups to fix out-of-sync drift.
 
 ## 🎯 Why
-The Archivist persona is responsible for consolidating recurring friction themes into better templates and summarizing run packets into generated indexes. Because `librarian_doctest_git_dependency.md` and `steward-release-clean-state.md` lacked standard `id/persona/style/shard/status` frontmatter, the `cargo xtask jules-index` aggregator could not properly identify them.
+The generated Jules rollups were out of sync with the actual contents of `.jules/runs/` and `.jules/friction/open/`. This violates the expectation that generated indexes represent reality and caused `cargo xtask jules-index --check` to fail.
 
 ## 🔎 Evidence
-- files: `.jules/index/generated/FRICTION_ROLLUP.md`
-- observed behavior before: `librarian_doctest_git_dependency` showed `Unknown` persona and style.
-- command receipt: `cargo xtask jules-index` successfully regenerates with corrected metadata.
+Minimal proof:
+- file paths: `.jules/index/generated/FRICTION_ROLLUP.md`, `.jules/index/generated/RUNS_ROLLUP.md`
+- observed behavior: `cargo xtask jules-index --check` failed.
+- command receipt:
+```text
+Error: Jules index drift detected in /app/.jules/index/generated/RUNS_ROLLUP.md. Run `cargo xtask jules-index` to update.
+```
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- what it is: Fix the metadata frontmatter in the friction items and run `cargo xtask jules-index`.
-- why it fits this repo and shard: It directly satisfies Archivist targets #1 and #2 (consolidating friction templates and generating indexes) in the `workspace-wide` shard.
-- trade-offs: Structure: High. Governance: High. Velocity: Neutral.
+- Regenerate the out-of-sync `.jules/index/generated/` indexes by running `cargo xtask jules-index`.
+- Why it fits this repo and this shard: Fits the ranking of summarizing run packets into generated indexes/rollups.
+- Trade-offs: Structure / Velocity / Governance: High confidence change, automatically generated.
 
 ### Option B
-- what it is: Only regenerate the indexes without fixing metadata.
-- when to choose it instead: If the metadata formats were intentionally non-standard (they weren't).
-- trade-offs: We would leave broken metadata rendering as "Unknown" in the generated docs.
+- Find an issue in `.jules/friction/` and fix it.
+- When to choose it instead: If indexes are already up to date.
+- Trade-offs: Slower, requires researching different aspects, more risky.
 
 ## ✅ Decision
-Option A. It's an honest patch that directly improves the Jules scaffolding and indexing health by fixing the root cause of the "Unknown" rows.
+I chose Option A because it is a fast, high-confidence patch that directly matches the Archivist persona's mission to summarize per-run packets and resolve factual drift.
 
 ## 🧱 Changes made (SRP)
-- Re-formatted `.jules/friction/open/librarian_doctest_git_dependency.md` to include valid frontmatter.
-- Re-formatted `.jules/friction/open/steward-release-clean-state.md` to include valid frontmatter.
-- Ran `cargo xtask jules-index` to update `.jules/index/generated/RUNS_ROLLUP.md` and `.jules/index/generated/FRICTION_ROLLUP.md`.
+- `.jules/index/generated/FRICTION_ROLLUP.md`
+- `.jules/index/generated/RUNS_ROLLUP.md`
 
 ## 🧪 Verification receipts
 ```text
-{"ts_utc": "2024-05-08T20:55:00Z", "phase": "investigation", "cwd": "/app", "cmd": "cat .jules/index/generated/FRICTION_ROLLUP.md", "status": 0, "summary": "Found that friction items librarian_doctest_git_dependency and steward-release-clean-state had Unknown metadata in the rollup."}
-{"ts_utc": "2024-05-08T20:56:00Z", "phase": "implementation", "cwd": "/app", "cmd": "cat << 'EOF' > .jules/friction/open/librarian_doctest_git_dependency.md ...", "status": 0, "summary": "Fixed frontmatter for librarian_doctest_git_dependency.md and steward-release-clean-state.md to match schema."}
-{"ts_utc": "2024-05-08T20:57:00Z", "phase": "implementation", "cwd": "/app", "cmd": "cargo xtask jules-index", "status": 0, "summary": "Regenerated the indexes, which correctly updated FRICTION_ROLLUP.md and RUNS_ROLLUP.md"}
+$ cargo xtask jules-index --check
+Error: Jules index drift detected in /app/.jules/index/generated/RUNS_ROLLUP.md. Run `cargo xtask jules-index` to update.
+
+$ cargo xtask jules-index
+Jules indexes written under /app/.jules/index/generated
+
+$ cargo xtask jules-index --check
+Jules indexes are up to date.
 ```
 
 ## 🧭 Telemetry
-- Change shape: Documentation and metadata indexing
-- Blast radius: Jules documentation / scaffolding
-- Risk class: Low
-- Rollback: `git restore .jules/friction/open/ .jules/index/generated/`
-- Gates run: `cargo xtask jules-index`
+- Change shape: Index generation.
+- Blast radius: Internal `.jules` reporting only.
+- Risk class + why: Low risk, automatically generated by tooling.
+- Rollback: `git restore .jules/index/generated/`
+- Gates run: `cargo xtask jules-index --check`
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/archivist_jules/envelope.json`

--- a/.jules/runs/archivist_jules/receipts.jsonl
+++ b/.jules/runs/archivist_jules/receipts.jsonl
@@ -1,3 +1,5 @@
 {"ts_utc": "2024-05-08T20:55:00Z", "phase": "investigation", "cwd": "/app", "cmd": "cat .jules/index/generated/FRICTION_ROLLUP.md", "status": 0, "summary": "Found that friction items librarian_doctest_git_dependency and steward-release-clean-state had Unknown metadata in the rollup."}
 {"ts_utc": "2024-05-08T20:56:00Z", "phase": "implementation", "cwd": "/app", "cmd": "cat << 'EOF' > .jules/friction/open/librarian_doctest_git_dependency.md ...", "status": 0, "summary": "Fixed frontmatter for librarian_doctest_git_dependency.md and steward-release-clean-state.md to match schema."}
 {"ts_utc": "2024-05-08T20:57:00Z", "phase": "implementation", "cwd": "/app", "cmd": "cargo xtask jules-index", "status": 0, "summary": "Regenerated the indexes, which correctly updated FRICTION_ROLLUP.md and RUNS_ROLLUP.md"}
+{"timestamp": "2026-05-13T00:00:00Z", "command": "cargo xtask jules-index --check", "output": "Error: Jules index drift detected in /app/.jules/index/generated/RUNS_ROLLUP.md. Run `cargo xtask jules-index` to update."}
+{"timestamp": "2026-05-13T00:00:10Z", "command": "cargo xtask jules-index", "output": "Jules indexes written under /app/.jules/index/generated"}

--- a/.jules/runs/archivist_jules/result.json
+++ b/.jules/runs/archivist_jules/result.json
@@ -1,17 +1,15 @@
 {
-  "outcome_type": "patch",
-  "title": "archivist: fix friction metadata and regenerate indexes 🗃️",
-  "summary": "Fixed schema non-compliance in two friction items and ran `cargo xtask jules-index` to successfully update the generated run and friction rollups.",
+  "outcome": "patch",
+  "title": "archivist: fix Jules index drift 🗃️",
+  "summary": "Updated out-of-sync generated Jules indexes by running `cargo xtask jules-index`.",
   "target_paths": [
-    ".jules/friction/open/librarian_doctest_git_dependency.md",
-    ".jules/friction/open/steward-release-clean-state.md",
-    ".jules/index/generated/RUNS_ROLLUP.md",
-    ".jules/index/generated/FRICTION_ROLLUP.md"
+    ".jules/index/generated/FRICTION_ROLLUP.md",
+    ".jules/index/generated/RUNS_ROLLUP.md"
   ],
-  "proof_summary": "The FRICTION_ROLLUP.md no longer shows 'Unknown' metadata for librarian and steward friction items.",
-  "gates_run": ["cargo xtask jules-index"],
+  "proof_summary": "Running `cargo xtask jules-index --check` originally failed with an index drift error. After running `cargo xtask jules-index`, the check passes cleanly.",
+  "gates_run": ["cargo xtask jules-index --check"],
   "friction_items_created": [],
   "persona_notes_created": [],
-  "rollback": "git restore .jules/friction/open/ .jules/index/generated/",
+  "rollback": "git restore .jules/index/generated/",
   "follow_ups": []
 }


### PR DESCRIPTION
Regenerated `.jules/index/generated/` rollups to fix out-of-sync drift.

---
*PR created automatically by Jules for task [15280551477635749336](https://jules.google.com/task/15280551477635749336) started by @EffortlessSteven*