### PR TITLE
feat(xtask): add perf smoke timing receipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
+ "tokmd-core",
  "toml 1.1.2+spec-1.1.0",
  "walkdir",
 ]

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -137,6 +137,7 @@ paths = [
   "xtask/src/tasks/file_policy.rs",
   "xtask/src/tasks/fixture_blobs_check.rs",
   "xtask/src/tasks/jules_index.rs",
+  "xtask/src/tasks/perf_smoke.rs",
   "xtask/src/tasks/proof_artifacts_check.rs",
   "xtask/src/tasks/proof_policy.rs",
   "xtask/src/tasks/proof_plan.rs",
@@ -165,6 +166,7 @@ proof = [
   "cargo test -p xtask --test docs_w43 --verbose",
   "cargo test -p xtask fixture_blob --verbose",
   "cargo test -p xtask jules_index --verbose",
+  "cargo test -p xtask perf_smoke --verbose",
   "cargo test -p xtask proof_artifacts --verbose",
   "cargo test -p xtask proof_plan --verbose",
 ]

--- a/crates/tokmd-core/src/lib.rs
+++ b/crates/tokmd-core/src/lib.rs
@@ -66,13 +66,14 @@ pub use tokmd_types as types;
 pub use workflows::cockpit_workflow;
 #[cfg(all(test, feature = "cockpit"))]
 use workflows::parse_cockpit_range_mode;
+pub use workflows::{
+    TimedWorkflow, WorkflowTiming, diff_workflow, export_workflow, export_workflow_from_inputs,
+    lang_workflow, lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
+    timed_export_workflow, timed_lang_workflow, timed_module_workflow,
+};
 #[cfg(feature = "analysis")]
 pub use workflows::{
     analyze_workflow, analyze_workflow_from_inputs, supports_rootless_in_memory_analyze_preset,
-};
-pub use workflows::{
-    diff_workflow, export_workflow, export_workflow_from_inputs, lang_workflow,
-    lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
 };
 #[cfg(all(test, feature = "analysis"))]
 use workflows::{parse_analysis_preset, parse_effort_request};

--- a/crates/tokmd-core/src/workflows/mod.rs
+++ b/crates/tokmd-core/src/workflows/mod.rs
@@ -9,6 +9,7 @@ mod export;
 mod lang;
 mod module;
 mod support;
+mod timing;
 
 #[cfg(feature = "analysis")]
 pub use analyze::{
@@ -24,6 +25,10 @@ pub use diff::diff_workflow;
 pub use export::{export_workflow, export_workflow_from_inputs};
 pub use lang::{lang_workflow, lang_workflow_from_inputs};
 pub use module::{module_workflow, module_workflow_from_inputs};
+pub use timing::{
+    TimedWorkflow, WorkflowTiming, timed_export_workflow, timed_lang_workflow,
+    timed_module_workflow,
+};
 
 pub(crate) use support::{
     collect_pure_in_memory_rows, deterministic_in_memory_scan_options, scan_paths_or_current_dir,

--- a/crates/tokmd-core/src/workflows/timing.rs
+++ b/crates/tokmd-core/src/workflows/timing.rs
@@ -1,0 +1,261 @@
+//! Phase timing helpers for core inventory workflows.
+//!
+//! These helpers are opt-in measurement surfaces. They use the same scan,
+//! model, and receipt builders as the normal workflows and return the same
+//! receipts plus phase timings, without changing default receipt schemas or CLI
+//! output.
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokmd_types::{ExportReceipt, LangReceipt, ModuleReceipt};
+
+use crate::settings::{ExportSettings, LangSettings, ModuleSettings, ScanSettings};
+use crate::{build_export_receipt, build_lang_receipt, build_module_receipt};
+
+use super::{scan_paths_or_current_dir, settings_to_scan_options};
+
+/// Timing evidence for one core workflow run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowTiming {
+    /// Schema identifier for downstream tools.
+    pub schema: String,
+    /// Schema version for this timing record.
+    pub schema_version: u32,
+    /// `lang`, `module`, or `export`.
+    pub workflow: String,
+    /// Number of caller-provided scan roots. Paths are deliberately omitted.
+    pub path_count: usize,
+    /// Number of language entries returned by `tokei`.
+    pub language_count: usize,
+    /// Number of rows in the workflow's final report/data section.
+    pub row_count: usize,
+    /// Time spent in `tokmd-scan`.
+    pub scan_ms: u128,
+    /// Time spent in `tokmd-model` aggregation/selection.
+    pub model_ms: u128,
+    /// Time spent constructing the final receipt object.
+    pub receipt_ms: u128,
+    /// End-to-end time measured around the workflow body.
+    pub total_ms: u128,
+}
+
+/// A normal workflow receipt plus opt-in timing evidence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimedWorkflow<T> {
+    pub receipt: T,
+    pub timing: WorkflowTiming,
+}
+
+/// Runs the language workflow and records scan/model/receipt phase timings.
+///
+/// # Errors
+/// Returns any error produced by the underlying scan or model workflow.
+pub fn timed_lang_workflow(
+    scan: &ScanSettings,
+    lang: &LangSettings,
+) -> Result<TimedWorkflow<LangReceipt>> {
+    let total_start = Instant::now();
+    let scan_opts = settings_to_scan_options(scan);
+    let paths = scan_paths_or_current_dir(scan);
+
+    let scan_start = Instant::now();
+    let languages = tokmd_scan::scan(&paths, &scan_opts)?;
+    let scan_ms = elapsed_ms(scan_start);
+    let language_count = languages.len();
+
+    let model_start = Instant::now();
+    let report = tokmd_model::create_lang_report(&languages, lang.top, lang.files, lang.children);
+    let row_count = report.rows.len();
+    let model_ms = elapsed_ms(model_start);
+
+    let receipt_start = Instant::now();
+    let receipt = build_lang_receipt(&paths, &scan_opts, lang, report);
+    let receipt_ms = elapsed_ms(receipt_start);
+
+    Ok(TimedWorkflow {
+        receipt,
+        timing: timing_record(TimingRecordInput {
+            workflow: "lang",
+            path_count: paths.len(),
+            language_count,
+            row_count,
+            scan_ms,
+            model_ms,
+            receipt_ms,
+            total_ms: elapsed_ms(total_start),
+        }),
+    })
+}
+
+/// Runs the module workflow and records scan/model/receipt phase timings.
+///
+/// # Errors
+/// Returns any error produced by the underlying scan or model workflow.
+pub fn timed_module_workflow(
+    scan: &ScanSettings,
+    module: &ModuleSettings,
+) -> Result<TimedWorkflow<ModuleReceipt>> {
+    let total_start = Instant::now();
+    let scan_opts = settings_to_scan_options(scan);
+    let paths = scan_paths_or_current_dir(scan);
+
+    let scan_start = Instant::now();
+    let languages = tokmd_scan::scan(&paths, &scan_opts)?;
+    let scan_ms = elapsed_ms(scan_start);
+    let language_count = languages.len();
+
+    let model_start = Instant::now();
+    let report = tokmd_model::create_module_report(
+        &languages,
+        &module.module_roots,
+        module.module_depth,
+        module.children,
+        module.top,
+    );
+    let row_count = report.rows.len();
+    let model_ms = elapsed_ms(model_start);
+
+    let receipt_start = Instant::now();
+    let receipt = build_module_receipt(&paths, &scan_opts, module, report);
+    let receipt_ms = elapsed_ms(receipt_start);
+
+    Ok(TimedWorkflow {
+        receipt,
+        timing: timing_record(TimingRecordInput {
+            workflow: "module",
+            path_count: paths.len(),
+            language_count,
+            row_count,
+            scan_ms,
+            model_ms,
+            receipt_ms,
+            total_ms: elapsed_ms(total_start),
+        }),
+    })
+}
+
+/// Runs the export workflow and records scan/model/receipt phase timings.
+///
+/// # Errors
+/// Returns any error produced by the underlying scan or model workflow.
+pub fn timed_export_workflow(
+    scan: &ScanSettings,
+    export: &ExportSettings,
+) -> Result<TimedWorkflow<ExportReceipt>> {
+    let total_start = Instant::now();
+    let scan_opts = settings_to_scan_options(scan);
+    let paths = scan_paths_or_current_dir(scan);
+    let strip_prefix = export.strip_prefix.as_deref();
+
+    let scan_start = Instant::now();
+    let languages = tokmd_scan::scan(&paths, &scan_opts)?;
+    let scan_ms = elapsed_ms(scan_start);
+    let language_count = languages.len();
+
+    let model_start = Instant::now();
+    let data = tokmd_model::create_export_data(
+        &languages,
+        &export.module_roots,
+        export.module_depth,
+        export.children,
+        strip_prefix.map(Path::new),
+        export.min_code,
+        export.max_rows,
+    );
+    let row_count = data.rows.len();
+    let model_ms = elapsed_ms(model_start);
+
+    let receipt_start = Instant::now();
+    let receipt = build_export_receipt(&paths, &scan_opts, export, data);
+    let receipt_ms = elapsed_ms(receipt_start);
+
+    Ok(TimedWorkflow {
+        receipt,
+        timing: timing_record(TimingRecordInput {
+            workflow: "export",
+            path_count: paths.len(),
+            language_count,
+            row_count,
+            scan_ms,
+            model_ms,
+            receipt_ms,
+            total_ms: elapsed_ms(total_start),
+        }),
+    })
+}
+
+struct TimingRecordInput {
+    workflow: &'static str,
+    path_count: usize,
+    language_count: usize,
+    row_count: usize,
+    scan_ms: u128,
+    model_ms: u128,
+    receipt_ms: u128,
+    total_ms: u128,
+}
+
+fn timing_record(input: TimingRecordInput) -> WorkflowTiming {
+    WorkflowTiming {
+        schema: "tokmd.workflow_timing.v1".to_string(),
+        schema_version: 1,
+        workflow: input.workflow.to_string(),
+        path_count: input.path_count,
+        language_count: input.language_count,
+        row_count: input.row_count,
+        scan_ms: input.scan_ms,
+        model_ms: input.model_ms,
+        receipt_ms: input.receipt_ms,
+        total_ms: input.total_ms,
+    }
+}
+
+fn elapsed_ms(start: Instant) -> u128 {
+    start.elapsed().as_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use anyhow::Result;
+
+    use super::*;
+
+    #[test]
+    fn timed_lang_workflow_preserves_receipt_and_records_phases() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(temp.path().join("main.rs"), "fn main() {}\n")?;
+        let scan = ScanSettings::for_paths(vec![temp.path().to_string_lossy().into_owned()]);
+        let result = timed_lang_workflow(&scan, &LangSettings::default())?;
+
+        assert_eq!(result.receipt.mode, "lang");
+        assert_eq!(result.timing.workflow, "lang");
+        assert_eq!(result.timing.path_count, 1);
+        assert_eq!(result.timing.language_count, 1);
+        assert_eq!(result.timing.row_count, result.receipt.report.rows.len());
+        assert_eq!(result.timing.schema, "tokmd.workflow_timing.v1");
+        Ok(())
+    }
+
+    #[test]
+    fn timed_module_and_export_workflows_record_rows_without_paths() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::create_dir_all(temp.path().join("src"))?;
+        fs::write(temp.path().join("src").join("lib.rs"), "pub fn lib() {}\n")?;
+        let scan = ScanSettings::for_paths(vec![temp.path().to_string_lossy().into_owned()]);
+
+        let module = timed_module_workflow(&scan, &ModuleSettings::default())?;
+        let export = timed_export_workflow(&scan, &ExportSettings::default())?;
+
+        assert_eq!(module.timing.workflow, "module");
+        assert_eq!(module.timing.row_count, module.receipt.report.rows.len());
+        assert_eq!(export.timing.workflow, "export");
+        assert_eq!(export.timing.row_count, export.receipt.data.rows.len());
+        assert_eq!(export.timing.path_count, 1);
+        Ok(())
+    }
+}

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -28,9 +28,10 @@ packets can preserve imported proof artifacts, surface proof evidence in
 hashes without promoting proof gates. Keep `tokmd cockpit` as the PR-review
 evidence surface before adding any separate `tokmd review` command.
 
-The active implementation lane is architecture consolidation. Continue
-owner-module batches only where they preserve product behavior and proof-scope
-granularity; avoid carving already-stable modules just because files exist.
+Architecture consolidation is paused unless fresh product or proof evidence
+shows a real owner-module problem. The active implementation lane is now
+measurement before optimization: add receipt-grade timing evidence before
+touching the open unbuffered-I/O, clone, or allocation performance issues.
 
 ## Next Work Packets
 
@@ -42,7 +43,8 @@ granularity; avoid carving already-stable modules just because files exist.
    a separate review orchestrator has a real contract.
 4. Continue architecture consolidation in batches, preserving `ci/proof.toml`
    scope granularity as implementation microcrates collapse into SRP modules.
-5. Draft AST foundation work only after the review packet and consolidation
+5. Add bounded performance timing receipts before optimizing hot paths.
+6. Draft AST foundation work only after the review packet and consolidation
    direction are stable.
 
 ## Directional Rules
@@ -157,6 +159,7 @@ granularity; avoid carving already-stable modules just because files exist.
 - Manual proof-observation collector run `25515026895` on `main` passed on 2026-05-07 after #1748 merged. The workflow resolved `run_limit = 100`, `min_observations = 1`, `min_executed = 4`, `min_scopes = 4`, `min_artifacts = 4`, and `min_passing_collector_runs = 1` from `ci/proof.toml`; the collection recorded 80 observations, 16 selected/executed/passed coverage commands, 16 artifacts, and 7 distinct scopes: `analysis_complexity`, `analysis_content_assets`, `format_redaction_scan_args`, `tokmd_cli`, `tokmd_cockpit`, `tokmd_core_ffi`, and `tokmd_gate`. The `proof-executor-promotion-readiness.json` receipt reported schema `tokmd.proof_executor_promotion_readiness.v1`, `ok = true`, and 1 recent passing collector run from `25512575044`.
 - Manual proof-observation collector run `25516861742` on `main` passed on 2026-05-07 after #1750 merged. The collection recorded 82 observations, 16 selected/executed/passed coverage commands, 16 artifacts, and 7 distinct scopes: `analysis_complexity`, `analysis_content_assets`, `format_redaction_scan_args`, `tokmd_cli`, `tokmd_cockpit`, `tokmd_core_ffi`, and `tokmd_gate`. The new source-run window accounting reported `expected_runs = 99`, `observed_runs = 82`, `missing_runs = 17`, and `unmatched_observations = 0`, proving the collector can distinguish successful executor runs that lacked downloadable observation artifacts from observations outside the saved run window.
 - Proof-control-plane status: routine PR observations continue under the two-command default. There is no active promotion slice for a required gate, default Codecov upload, or larger command-limit default.
+- `cargo xtask perf-smoke --target-repo <path> --output target/perf/perf-smoke.json` now emits `tokmd.perf_smoke.v1`, an opt-in measurement receipt for core `lang`, `module`, and `export` workflows. The receipt records scan/model/receipt/total phase timings plus row and language counts while redacting raw target paths, giving performance issues a measurement baseline before optimization work.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
 - The composite Action now adds hosted packet metadata to review-packet PR comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -24,6 +24,7 @@ syn = { version = "2.0.117", features = ["full", "extra-traits", "visit"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 walkdir = "2"
+tokmd-core.workspace = true
 
 [dev-dependencies]
 serde_json = "1"

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -76,6 +76,8 @@ pub enum Commands {
     Sccache(SccacheArgs),
     /// Reclaim target/debug space by trimming Windows PDBs and incremental state
     TrimTarget(TrimTargetArgs),
+    /// Emit a small phase-timing receipt for core inventory workflows
+    PerfSmoke(PerfSmokeArgs),
 }
 
 #[derive(Args, Debug, Clone, Default)]
@@ -192,6 +194,37 @@ impl Default for CiActualsArgs {
             output: std::path::PathBuf::from("target/ci/ci-actuals.json"),
             repo: "tokmd".to_string(),
             workflow: "CI".to_string(),
+            sha: None,
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct PerfSmokeArgs {
+    /// Repository or directory to measure. The emitted receipt records counts,
+    /// not the raw path.
+    #[arg(long, default_value = ".")]
+    pub target_repo: std::path::PathBuf,
+
+    /// Output path for the performance smoke receipt.
+    #[arg(long, default_value = "target/perf/perf-smoke.json")]
+    pub output: std::path::PathBuf,
+
+    /// Repository identifier recorded in the receipt.
+    #[arg(long, default_value = "tokmd")]
+    pub repo: String,
+
+    /// Commit SHA recorded in the receipt; defaults to GITHUB_SHA or HEAD.
+    #[arg(long)]
+    pub sha: Option<String>,
+}
+
+impl Default for PerfSmokeArgs {
+    fn default() -> Self {
+        Self {
+            target_repo: std::path::PathBuf::from("."),
+            output: std::path::PathBuf::from("target/perf/perf-smoke.json"),
+            repo: "tokmd".to_string(),
             sha: None,
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -56,6 +56,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::LintFix(args)) => tasks::lint_fix::run(args),
         Some(cli::Commands::Sccache(args)) => tasks::sccache::run(args),
         Some(cli::Commands::TrimTarget(args)) => tasks::trim_target::run(args),
+        Some(cli::Commands::PerfSmoke(args)) => tasks::perf_smoke::run(args),
         None => tasks::publish::run(PublishArgs::default()),
     }
 }

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -16,6 +16,7 @@ pub mod jules_index;
 pub mod lint_fix;
 pub mod lint_policy;
 pub mod no_panic;
+pub mod perf_smoke;
 pub mod proof_artifacts_check;
 pub mod proof_plan;
 pub mod proof_policy;

--- a/xtask/src/tasks/perf_smoke.rs
+++ b/xtask/src/tasks/perf_smoke.rs
@@ -1,0 +1,169 @@
+use crate::cli::PerfSmokeArgs;
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokmd_core::settings::{ExportSettings, LangSettings, ModuleSettings, ScanSettings};
+use tokmd_core::{
+    WorkflowTiming, timed_export_workflow, timed_lang_workflow, timed_module_workflow,
+};
+
+const PERF_SMOKE_SCHEMA: &str = "tokmd.perf_smoke.v1";
+
+#[derive(Debug, Serialize)]
+struct PerfSmokeReceipt {
+    schema: String,
+    schema_version: u32,
+    generated_at_ms: u128,
+    repo: String,
+    sha: String,
+    target: PerfSmokeTarget,
+    workflows: Vec<WorkflowTiming>,
+    status: PerfSmokeStatus,
+}
+
+#[derive(Debug, Serialize)]
+struct PerfSmokeTarget {
+    path_count: usize,
+    paths_redacted: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct PerfSmokeStatus {
+    ok: bool,
+    workflow_count: usize,
+}
+
+pub fn run(args: PerfSmokeArgs) -> Result<()> {
+    let receipt = perf_smoke_receipt(&args)?;
+
+    if let Some(parent) = args.output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(&receipt).context("serialize perf smoke receipt")?;
+    fs::write(&args.output, format!("{json}\n"))
+        .with_context(|| format!("write {}", args.output.display()))?;
+
+    println!(
+        "perf smoke receipt written to {} ({} workflow(s))",
+        args.output.display(),
+        receipt.workflows.len()
+    );
+    Ok(())
+}
+
+fn perf_smoke_receipt(args: &PerfSmokeArgs) -> Result<PerfSmokeReceipt> {
+    let scan = ScanSettings::for_paths(vec![path_arg(&args.target_repo)]);
+    let lang = timed_lang_workflow(&scan, &LangSettings::default())
+        .with_context(|| format!("run lang timing for {}", args.target_repo.display()))?;
+    let module = timed_module_workflow(&scan, &ModuleSettings::default())
+        .with_context(|| format!("run module timing for {}", args.target_repo.display()))?;
+    let export = timed_export_workflow(&scan, &ExportSettings::default())
+        .with_context(|| format!("run export timing for {}", args.target_repo.display()))?;
+
+    let workflows = vec![lang.timing, module.timing, export.timing];
+
+    Ok(PerfSmokeReceipt {
+        schema: PERF_SMOKE_SCHEMA.to_string(),
+        schema_version: 1,
+        generated_at_ms: now_ms(),
+        repo: args.repo.clone(),
+        sha: receipt_sha(args),
+        target: PerfSmokeTarget {
+            path_count: 1,
+            paths_redacted: true,
+        },
+        status: PerfSmokeStatus {
+            ok: true,
+            workflow_count: workflows.len(),
+        },
+        workflows,
+    })
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn receipt_sha(args: &PerfSmokeArgs) -> String {
+    args.sha
+        .clone()
+        .or_else(|| env_non_empty("GITHUB_SHA"))
+        .unwrap_or_else(|| "HEAD".to_string())
+}
+
+fn env_non_empty(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn now_ms() -> u128 {
+    1
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use anyhow::Result;
+
+    use super::*;
+
+    #[test]
+    fn receipt_records_phase_timings_without_raw_paths() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(temp.path().join("main.rs"), "fn main() {}\n")?;
+        let args = PerfSmokeArgs {
+            target_repo: temp.path().to_path_buf(),
+            output: temp.path().join("perf.json"),
+            sha: Some("abc123".to_string()),
+            ..PerfSmokeArgs::default()
+        };
+
+        let receipt = perf_smoke_receipt(&args)?;
+
+        assert_eq!(receipt.schema, PERF_SMOKE_SCHEMA);
+        assert_eq!(receipt.schema_version, 1);
+        assert_eq!(receipt.sha, "abc123");
+        assert_eq!(receipt.target.path_count, 1);
+        assert!(receipt.target.paths_redacted);
+        assert!(receipt.status.ok);
+        assert_eq!(receipt.status.workflow_count, 3);
+        assert_eq!(receipt.workflows.len(), 3);
+        assert_eq!(receipt.workflows[0].workflow, "lang");
+        assert_eq!(receipt.workflows[1].workflow, "module");
+        assert_eq!(receipt.workflows[2].workflow, "export");
+        assert!(!serde_json::to_string(&receipt)?.contains(temp.path().to_string_lossy().as_ref()));
+        Ok(())
+    }
+
+    #[test]
+    fn run_writes_pretty_json_receipt() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(temp.path().join("lib.rs"), "pub fn lib() {}\n")?;
+        let output = temp.path().join("out").join("perf-smoke.json");
+        let args = PerfSmokeArgs {
+            target_repo: temp.path().to_path_buf(),
+            output: output.clone(),
+            ..PerfSmokeArgs::default()
+        };
+
+        run(args)?;
+
+        let value: serde_json::Value = serde_json::from_str(&fs::read_to_string(output)?)?;
+        assert_eq!(value["schema"], PERF_SMOKE_SCHEMA);
+        assert_eq!(value["status"]["workflow_count"], 3);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add opt-in `tokmd_core` phase timing helpers for lang/module/export workflows
- add `cargo xtask perf-smoke` to emit a path-redacted `tokmd.perf_smoke.v1` timing receipt
- route the new xtask surface through proof policy and record measurement-before-optimization in `docs/NEXT.md`

Closes #988.

## Notes
- normal `tokmd` CLI output and receipt schemas are unchanged
- proof gates, Codecov behavior, and default workflow behavior are unchanged
- perf-smoke receipts redact target paths while retaining counts and phase timing buckets

## Validation
- `cargo test -p tokmd-core timed_ --verbose`
- `cargo test -p xtask perf_smoke --verbose`
- `cargo xtask perf-smoke --target-repo crates/tokmd-core --output target/perf/perf-smoke.json`
- `cargo test -p tokmd-core lang_workflow --verbose`
- `cargo test -p tokmd-core module_workflow --verbose`
- `cargo test -p tokmd-core export_workflow --verbose`
- `cargo clippy -p tokmd-core --all-targets -- -D warnings`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask docs --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan ... > target/proof/proof-plan.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask check-lint-policy`
- `cargo xtask check-clippy-exceptions`
- `cargo xtask check-no-panic-family`
- `cargo xtask boundaries-check`
- `cargo test -p tokmd-types manifest_stays_clap_free --verbose`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`