### PR TITLE
perf(analysis): buffer near-duplicate file reads

### DIFF
--- a/crates/tokmd-analysis/src/near_dup/fingerprint.rs
+++ b/crates/tokmd-analysis/src/near_dup/fingerprint.rs
@@ -1,7 +1,7 @@
 //! Winnowing fingerprint construction for near-duplicate detection.
 
 use std::hash::{Hash, Hasher};
-use std::io::Read;
+use std::io::{BufReader, Read};
 use std::path::Path;
 
 use anyhow::Result;
@@ -17,8 +17,9 @@ pub(super) const MAX_POSTINGS: usize = 50;
 /// Read a file and compute its Winnowing fingerprints.
 pub(super) fn read_and_fingerprint(path: &Path) -> Result<Vec<u64>> {
     let mut content = String::new();
-    let mut file = std::fs::File::open(path)?;
-    file.read_to_string(&mut content)?;
+    let file = std::fs::File::open(path)?;
+    let mut reader = BufReader::with_capacity(64 * 1024, file);
+    reader.read_to_string(&mut content)?;
 
     Ok(winnow(&content))
 }


### PR DESCRIPTION
## Summary

- buffer near-duplicate fingerprint file reads with a 64 KiB `BufReader`
- preserve Winnowing/tokenization behavior and receipt output

Fixes #989.

## Validation

- `cargo fmt-fix`
- `cargo test -p tokmd-analysis near_dup --verbose`
- `cargo test -p tokmd-analysis --all-features near_dup:: --verbose`
- `cargo test -p tokmd-analysis --all-features near_dup --verbose`
- `cargo clippy -p tokmd-analysis --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --summary-md target/proof/proof-plan.md`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary.json`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask docs --check`