### PR TITLE
perf(analysis): buffer content hash reads

### DIFF
--- a/crates/tokmd-analysis/src/content/mod.rs
+++ b/crates/tokmd-analysis/src/content/mod.rs
@@ -313,12 +313,13 @@ pub(crate) fn build_import_report(
 }
 
 fn hash_file_full(path: &Path) -> Result<String> {
-    use std::io::Read;
-    let mut file = std::fs::File::open(path)?;
+    use std::io::{BufReader, Read};
+    let file = std::fs::File::open(path)?;
+    let mut reader = BufReader::with_capacity(64 * 1024, file);
     let mut hasher = blake3::Hasher::new();
     let mut buf = [0u8; 8192];
     loop {
-        let read = file.read(&mut buf)?;
+        let read = reader.read(&mut buf)?;
         if read == 0 {
             break;
         }


### PR DESCRIPTION
## Summary

- buffer full-content hashing reads with a 64 KiB `BufReader`
- preserve BLAKE3 hashing, content analysis reports, receipt shape, and CLI behavior

Fixes #987.

## Validation

- `cargo fmt-fix`
- `cargo test -p tokmd-analysis --all-features content --verbose`
- `cargo clippy -p tokmd-analysis --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --summary-md target/proof/proof-plan.md`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask docs --check`