### PR TITLE
perf: inline hot helper functions

### DIFF
--- a/crates/tokmd-analysis/src/near_dup/fingerprint.rs
+++ b/crates/tokmd-analysis/src/near_dup/fingerprint.rs
@@ -25,6 +25,7 @@ pub(super) fn read_and_fingerprint(path: &Path) -> Result<Vec<u64>> {
 }
 
 /// Tokenize text by splitting on non-alphanumeric/underscore boundaries.
+#[inline]
 pub(super) fn tokenize(text: &str) -> Vec<&str> {
     let mut tokens = Vec::new();
     let bytes = text.as_bytes();
@@ -48,6 +49,7 @@ pub(super) fn tokenize(text: &str) -> Vec<&str> {
 }
 
 /// Hash a k-gram (slice of tokens) using FxHash.
+#[inline]
 fn hash_kgram(tokens: &[&str]) -> u64 {
     let mut hasher = FxHasher::default();
     for t in tokens {
@@ -57,6 +59,7 @@ fn hash_kgram(tokens: &[&str]) -> u64 {
 }
 
 /// Apply the Winnowing algorithm to extract fingerprints from text.
+#[inline]
 pub(super) fn winnow(text: &str) -> Vec<u64> {
     let tokens = tokenize(text);
     if tokens.len() < K {

--- a/crates/tokmd-core/src/receipts.rs
+++ b/crates/tokmd-core/src/receipts.rs
@@ -14,12 +14,14 @@ use tokmd_types::{
 use crate::settings::{ExportSettings, LangSettings, ModuleSettings};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[inline]
 fn now_ms() -> u128 {
     // Keep wasm receipts from reusing zero as a fake wall-clock sentinel.
     js_sys::Date::now().max(1.0) as u128
 }
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[inline]
 fn now_ms() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/tokmd-core/src/workflows/support.rs
+++ b/crates/tokmd-core/src/workflows/support.rs
@@ -10,6 +10,7 @@ use crate::InMemoryFile;
 use crate::settings::ScanSettings;
 
 /// Convert `ScanSettings` to lower-tier scan options.
+#[inline]
 pub(crate) fn settings_to_scan_options(scan: &ScanSettings) -> ScanOptions {
     scan.options.clone()
 }

--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -49,6 +49,7 @@ pub use rows::{
 /// // Rounds to nearest: 7 / 2 = 3.5 → 4
 /// assert_eq!(avg(7, 2), 4);
 /// ```
+#[inline]
 pub fn avg(lines: usize, files: usize) -> usize {
     if files == 0 {
         return 0;
@@ -78,6 +79,7 @@ pub fn avg(lines: usize, files: usize) -> usize {
 /// let prefix = Path::new("project");
 /// assert_eq!(normalize_path(&p, Some(&prefix)), "src/lib.rs");
 /// ```
+#[inline]
 pub fn normalize_path(path: &Path, strip_prefix: Option<&Path>) -> String {
     let s_cow = path.to_string_lossy();
     let s: Cow<str> = if s_cow.contains('\\') {

--- a/crates/tokmd-model/src/rows.rs
+++ b/crates/tokmd-model/src/rows.rs
@@ -191,6 +191,7 @@ fn detect_in_memory_language(
         .or_else(|| language_from_in_memory_shebang(bytes))
 }
 
+#[inline]
 fn insert_row<'a>(
     map: &mut BTreeMap<Key<'a>, (String, Agg)>,
     key: Key<'a>,


### PR DESCRIPTION
## Summary
- add conservative `#[inline]` hints to hot helper functions called out in #990
- cover model row insertion/path normalization, near-duplicate token/winnow helpers, and core receipt/workflow helpers
- keep receipt schemas, CLI behavior, proof policy, and public API behavior unchanged

Fixes #990.

## Validation
- `cargo test -p tokmd-model --verbose`
- `cargo test -p tokmd-analysis --all-features near_dup --verbose`
- `cargo test -p tokmd-core --verbose`
- `cargo clippy -p tokmd-model -p tokmd-analysis -p tokmd-core --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --summary-md target/proof/proof-plan.md > target/proof/proof-plan.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask docs --check`
- `cargo xtask publish-surface --json --verify-publish`