### PR TITLE
perf(analysis): borrow git aggregation keys

### DIFF
--- a/crates/tokmd-analysis/src/git/churn.rs
+++ b/crates/tokmd-analysis/src/git/churn.rs
@@ -19,14 +19,14 @@ pub(crate) fn build_predictive_churn_report(
         row_map.insert(normalize_path(&row.path, repo_root), row);
     }
 
-    let mut series: BTreeMap<String, BTreeMap<i64, i64>> = BTreeMap::new();
+    let mut series: BTreeMap<&str, BTreeMap<i64, i64>> = BTreeMap::new();
     for commit in commits {
         let week = commit.timestamp / SECONDS_PER_WEEK;
-        let mut seen: BTreeSet<String> = BTreeSet::new();
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
         for file in &commit.files {
             let key = normalize_git_path(file);
             if let Some(row) = row_map.get(&key) {
-                seen.insert(row.module.clone());
+                seen.insert(row.module.as_str());
             }
         }
         for module in seen {
@@ -41,7 +41,7 @@ pub(crate) fn build_predictive_churn_report(
         let recent_change = recent_delta(&points);
         let classification = classify_trend(slope);
         per_module.insert(
-            module,
+            module.to_string(),
             ChurnTrend {
                 slope,
                 r2,

--- a/crates/tokmd-analysis/src/git/freshness.rs
+++ b/crates/tokmd-analysis/src/git/freshness.rs
@@ -16,17 +16,17 @@ const REFRESH_TREND_EPSILON: f64 = 0.10;
 
 pub(super) fn build_freshness_report(
     last_change: &BTreeMap<String, i64>,
-    row_map: &BTreeMap<String, (&FileRow, String)>,
+    row_map: &BTreeMap<String, (&FileRow, &str)>,
     reference_ts: i64,
 ) -> FreshnessReport {
     let threshold_days = 365usize;
     let mut stale_files = 0usize;
     let mut total_files = 0usize;
-    let mut by_module: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    let mut by_module: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
 
     for (path, ts) in last_change {
-        let (_, module) = match row_map.get(path) {
-            Some(v) => v,
+        let module = match row_map.get(path) {
+            Some((_, module)) => *module,
             None => continue,
         };
         let days = if reference_ts > *ts {
@@ -38,11 +38,7 @@ pub(super) fn build_freshness_report(
         if days > threshold_days {
             stale_files += 1;
         }
-        if let Some(list) = by_module.get_mut(module) {
-            list.push(days);
-        } else {
-            by_module.insert(module.clone(), vec![days]);
-        }
+        by_module.entry(module).or_default().push(days);
     }
 
     let stale_pct = if total_files == 0 {
@@ -71,7 +67,7 @@ pub(super) fn build_freshness_report(
             round_f64(stale as f64 / days.len() as f64, 4)
         };
         module_rows.push(ModuleFreshnessRow {
-            module,
+            module: module.to_string(),
             avg_days: avg,
             p90_days: p90,
             stale_pct: pct,

--- a/crates/tokmd-analysis/src/git/mod.rs
+++ b/crates/tokmd-analysis/src/git/mod.rs
@@ -22,14 +22,14 @@ pub(crate) fn build_git_report(
     export: &ExportData,
     commits: &[tokmd_git::GitCommit],
 ) -> Result<GitReport> {
-    let mut row_map: BTreeMap<String, (&FileRow, String)> = BTreeMap::new();
+    let mut row_map: BTreeMap<String, (&FileRow, &str)> = BTreeMap::new();
     for row in export.rows.iter().filter(|r| r.kind == FileKind::Parent) {
         let key = normalize_path(&row.path, repo_root);
-        row_map.insert(key, (row, row.module.clone()));
+        row_map.insert(key, (row, row.module.as_str()));
     }
 
     let mut commit_counts: BTreeMap<String, usize> = BTreeMap::new();
-    let mut authors_by_module: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut authors_by_module: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
     let mut last_change: BTreeMap<String, i64> = BTreeMap::new();
     let mut max_ts = 0i64;
 
@@ -37,23 +37,13 @@ pub(crate) fn build_git_report(
         max_ts = max_ts.max(commit.timestamp);
         for file in &commit.files {
             let key = normalize_git_path(file);
-            if let Some((row, module)) = row_map.get(&key) {
-                if let Some(val) = commit_counts.get_mut(&key) {
-                    *val += 1;
-                } else {
-                    commit_counts.insert(key.clone(), 1);
-                }
-                if let Some(val) = authors_by_module.get_mut(module) {
-                    val.insert(commit.author.clone());
-                } else {
-                    let mut set = BTreeSet::new();
-                    set.insert(commit.author.clone());
-                    authors_by_module.insert(module.clone(), set);
-                }
-                if !last_change.contains_key(&key) {
-                    last_change.insert(key.clone(), commit.timestamp);
-                }
-                let _ = row;
+            if let Some(&(_row, module)) = row_map.get(&key) {
+                *commit_counts.entry(key.clone()).or_insert(0) += 1;
+                authors_by_module
+                    .entry(module)
+                    .or_default()
+                    .insert(commit.author.as_str());
+                last_change.entry(key).or_insert(commit.timestamp);
             }
         }
     }
@@ -61,7 +51,7 @@ pub(crate) fn build_git_report(
     let mut hotspots: Vec<HotspotRow> = commit_counts
         .iter()
         .filter_map(|(path, commits)| {
-            let (row, _) = row_map.get(path)?;
+            let &(row, _) = row_map.get(path)?;
             Some(HotspotRow {
                 path: path.clone(),
                 commits: *commits,
@@ -75,7 +65,7 @@ pub(crate) fn build_git_report(
     let mut bus_factor: Vec<BusFactorRow> = authors_by_module
         .into_iter()
         .map(|(module, authors)| BusFactorRow {
-            module,
+            module: module.to_string(),
             authors: authors.len(),
         })
         .collect();
@@ -105,7 +95,7 @@ pub(crate) fn build_git_report(
 
 fn build_coupling(
     commits: &[tokmd_git::GitCommit],
-    row_map: &BTreeMap<String, (&FileRow, String)>,
+    row_map: &BTreeMap<String, (&FileRow, &str)>,
 ) -> Vec<CouplingRow> {
     let mut pairs: BTreeMap<(&str, &str), usize> = BTreeMap::new();
     let mut touches: BTreeMap<&str, usize> = BTreeMap::new();
@@ -115,8 +105,8 @@ fn build_coupling(
         let mut modules: BTreeSet<&str> = BTreeSet::new();
         for file in &commit.files {
             let key = normalize_git_path(file);
-            if let Some((_row, module)) = row_map.get(&key) {
-                modules.insert(module.as_str());
+            if let Some(&(_row, module)) = row_map.get(&key) {
+                modules.insert(module);
             }
         }
         // Only count commits where at least one file maps to a module
@@ -179,10 +169,10 @@ fn build_coupling(
 
 fn build_intent_report(
     commits: &[tokmd_git::GitCommit],
-    row_map: &BTreeMap<String, (&FileRow, String)>,
+    row_map: &BTreeMap<String, (&FileRow, &str)>,
 ) -> CommitIntentReport {
     let mut overall = CommitIntentCounts::default();
-    let mut by_module_counts: BTreeMap<String, CommitIntentCounts> = BTreeMap::new();
+    let mut by_module_counts: BTreeMap<&str, CommitIntentCounts> = BTreeMap::new();
 
     for commit in commits {
         let kind = tokmd_git::classify_intent(&commit.subject);
@@ -192,15 +182,12 @@ fn build_intent_report(
         let mut modules: BTreeSet<&str> = BTreeSet::new();
         for file in &commit.files {
             let key = normalize_git_path(file);
-            if let Some((_row, module)) = row_map.get(&key) {
-                modules.insert(module.as_str());
+            if let Some(&(_row, module)) = row_map.get(&key) {
+                modules.insert(module);
             }
         }
         for module in modules {
-            by_module_counts
-                .entry(module.to_string())
-                .or_default()
-                .increment(kind);
+            by_module_counts.entry(module).or_default().increment(kind);
         }
     }
 
@@ -221,7 +208,10 @@ fn build_intent_report(
 
     let mut by_module: Vec<ModuleIntentRow> = by_module_counts
         .into_iter()
-        .map(|(module, counts)| ModuleIntentRow { module, counts })
+        .map(|(module, counts)| ModuleIntentRow {
+            module: module.to_string(),
+            counts,
+        })
         .collect();
     by_module.sort_by(|a, b| a.module.cmp(&b.module));
 


### PR DESCRIPTION
## Summary
- borrow module names in git row maps instead of cloning them before aggregation
- borrow author names for bus-factor sets and module names for freshness, intent, coupling, and churn aggregation
- keep owned `String` allocation at receipt DTO materialization boundaries so schemas and output stay unchanged

Refs #985.

## Validation
- `cargo test -p tokmd-analysis --all-features git --verbose`
- `cargo clippy -p tokmd-analysis --all-targets --all-features -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --summary-md target/proof/proof-plan.md > target/proof/proof-plan.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask docs --check`
- `cargo xtask publish-surface --json --verify-publish`