### PR TITLE
docs: define source of truth model

### DIFF
--- a/.jules/README.md
+++ b/.jules/README.md
@@ -56,6 +56,9 @@ The primary truth for any run is the **per-run packet** under:
 - friction items under `.jules/friction/open/`
 - persona-local notes under `.jules/personas/<persona>/notes/`
   *(Use this directory only for **reusable learnings** that later runs can benefit from. Do not write per-run summaries here; per-run packets belong under `.jules/runs/<run-id>/`.)*
+- machine-readable active state under `.jules/goals/active.toml` when the
+  prompt explicitly changes the active lane or asks for a durable control
+  surface update
 
 ### Agents must not write
 - shared append-only ledgers as primary truth
@@ -70,6 +73,7 @@ The primary truth for any run is the **per-run packet** under:
 - `personas/` — persona-local notes and README files
 - `runs/` — per-run packets
 - `index/` — optional generated summaries
+- `goals/` — small machine-readable active-lane state
 
 ## Persona instruction surface
 

--- a/.jules/goals/README.md
+++ b/.jules/goals/README.md
@@ -1,0 +1,27 @@
+# Jules Goals
+
+This directory stores machine-readable active-agent state for Jules and related
+automation.
+
+The primary file is:
+
+- `active.toml`
+
+It should stay small and point to durable human-readable docs. It is not a run
+log, not a chat transcript, and not a replacement for proposals, specs, ADRs,
+plans, or policy files.
+
+## Allowed Content
+
+- current program or lane name;
+- links to the active plan/spec/ADR;
+- current stop conditions;
+- checked policy references;
+- short notes that automation can parse.
+
+## Disallowed Content
+
+- raw terminal output;
+- daily narrative logs;
+- complete PR histories;
+- pasted model transcripts.

--- a/.jules/goals/active.toml
+++ b/.jules/goals/active.toml
@@ -1,0 +1,22 @@
+schema = "tokmd.jules.active_goal.v1"
+status = "active"
+program = "source_of_truth_docs"
+lane = "documentation_control_surface"
+
+[links]
+source_of_truth = "docs/source-of-truth.md"
+plan_readme = "docs/plans/README.md"
+proposal_readme = "docs/proposals/README.md"
+spec_readme = "docs/specs/README.md"
+adr_readme = "docs/adr/README.md"
+
+[rules]
+proof_promotion = "do_not_promote_without_maintainer_decision"
+codecov_default_upload = "do_not_enable_without_maintainer_decision"
+product_behavior = "docs_only_lane"
+
+[stop_conditions]
+open_pr_queue = "must_be_empty_before_starting_new_lane"
+docs_check = "cargo xtask docs --check"
+proof_policy = "cargo xtask proof-policy --check"
+affected_plan = "cargo xtask affected --base origin/main --head HEAD --json"

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1067,13 +1067,17 @@ paths = [
   "docs/install.md",
   "docs/adr/**",
   "docs/audits/**",
+  "docs/plans/**",
   "docs/progress-events.md",
+  "docs/proposals/**",
   "docs/requirements.md",
   "docs/sensor-report-v1.md",
+  "docs/source-of-truth.md",
+  "docs/specs/**",
   "docs/specification.md",
 ]
 proof = ["cargo xtask docs --check"]
-reason = "Top-level architecture, ADR, design, roadmap, requirements, and audit docs are project truth surfaces; edits should route to documentation checks instead of appearing as unknown files."
+reason = "Top-level architecture, ADR, design, roadmap, requirements, proposal/spec/plan, and audit docs are project truth surfaces; edits should route to documentation checks instead of appearing as unknown files."
 mutation = false
 coverage = false
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -29,9 +29,16 @@ hashes without promoting proof gates. Keep `tokmd cockpit` as the PR-review
 evidence surface before adding any separate `tokmd review` command.
 
 Architecture consolidation is paused unless fresh product or proof evidence
-shows a real owner-module problem. The active implementation lane is now
-measurement before optimization: add receipt-grade timing evidence before
-touching the open unbuffered-I/O, clone, or allocation performance issues.
+shows a real owner-module problem. The performance mini-lane has a measurement
+spine and several small fixes on main; future performance work should continue
+to cite `cargo xtask perf-smoke` receipts or explicitly say it is
+structure-only.
+
+The active documentation-control lane is the source-of-truth stack: proposals
+own exploratory rationale, specs own behavior contracts and proof
+requirements, ADRs own durable architecture decisions, plans own sequencing,
+`.jules/goals/active.toml` owns small machine-readable active-agent state, and
+checked policy TOMLs own machine-enforced rules.
 
 ## Next Work Packets
 
@@ -43,8 +50,10 @@ touching the open unbuffered-I/O, clone, or allocation performance issues.
    a separate review orchestrator has a real contract.
 4. Continue architecture consolidation in batches, preserving `ci/proof.toml`
    scope granularity as implementation microcrates collapse into SRP modules.
-5. Add bounded performance timing receipts before optimizing hot paths.
-6. Draft AST foundation work only after the review packet and consolidation
+5. Use bounded performance timing receipts before optimizing hot paths.
+6. Keep source-of-truth docs, active goal state, and proof-policy routing
+   aligned as new lanes start.
+7. Draft AST foundation work only after the review packet and consolidation
    direction are stable.
 
 ## Directional Rules

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,6 +5,9 @@ decisions for tokmd. ADRs explain why a durable decision exists; exact
 behavioral contracts belong in specs such as `docs/specification.md` or
 surface-specific schema documents.
 
+For the broader documentation routing model, see
+[`docs/source-of-truth.md`](../source-of-truth.md).
+
 ## Index
 
 | ADR | Status | Title |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,47 @@
+# Plans
+
+Plans own implementation sequencing. They turn accepted direction into small
+reviewable PR packets, validation commands, dependencies, and stop conditions.
+
+## Use This Directory For
+
+- milestone plans;
+- PR-by-PR work packets;
+- validation ladders;
+- migration order;
+- explicit stop or pivot conditions.
+
+## Do Not Use It For
+
+- final behavior contracts;
+- durable architecture decisions;
+- machine-checkable policy;
+- raw execution logs.
+
+## Suggested Shape
+
+```md
+# Plan: <title>
+
+- Status: active | paused | complete | superseded
+- Related proposal:
+- Related spec:
+- Related ADR:
+- Related issues:
+
+## Goal
+
+## Non-goals
+
+## Work Packets
+
+## Validation
+
+## Stop Conditions
+
+## Checkpoint History
+```
+
+Plans should be updated when sequencing changes. Once a plan is complete, leave
+a short checkpoint and link to the merged PRs rather than continuing to append
+daily status.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,47 @@
+# Proposals
+
+Proposals are exploratory design documents. They explain why a change might be
+worth doing, what alternatives were considered, and what questions remain before
+the work becomes a spec, ADR, or implementation plan.
+
+## Use This Directory For
+
+- product or architecture ideas that need comparison before commitment;
+- research summaries that should survive beyond a chat thread;
+- tradeoff analysis for future lanes;
+- proposed policy or proof-control changes before they become checked rules.
+
+## Do Not Use It For
+
+- accepted behavior contracts;
+- schema definitions;
+- PR-by-PR implementation sequencing;
+- raw run logs or terminal transcripts.
+
+## Suggested Shape
+
+```md
+# Proposal: <title>
+
+- Status: draft | proposed | accepted | superseded | withdrawn
+- Owner:
+- Related issues:
+- Related specs:
+- Related ADRs:
+
+## Problem
+
+## Goals
+
+## Non-goals
+
+## Options
+
+## Recommendation
+
+## Open Questions
+```
+
+When a proposal is accepted, move durable behavior into `docs/specs/`, durable
+architecture decisions into `docs/adr/`, and implementation sequencing into
+`docs/plans/`.

--- a/docs/source-of-truth.md
+++ b/docs/source-of-truth.md
@@ -1,0 +1,109 @@
+# Source of Truth Model
+
+Status: active documentation convention.
+
+This document defines where durable tokmd intent, behavior, decisions, plans,
+agent state, and machine-checkable policy belong. It is a routing guide for
+maintainers and agents, not a new product feature.
+
+## Goal
+
+Keep tokmd's repository knowledge reviewable and enforceable by putting each
+kind of truth in the artifact that can best carry it.
+
+The intended flow is:
+
+```text
+idea or problem
+  -> proposal
+  -> spec
+  -> ADR when a durable architecture decision is needed
+  -> implementation plan
+  -> policy/checks
+  -> receipts and PR evidence
+```
+
+Skipping a step is fine for small changes, but mixing these roles in one
+document makes later work harder to audit.
+
+## Artifact Roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| `docs/proposals/` | Exploratory rationale, alternatives, open questions, and the reason a change should exist before it becomes a contract. | Final behavior contracts, merge verdicts, or machine policy. |
+| `docs/specs/` | Testable behavior contracts, artifact shapes, compatibility rules, proof requirements, and accepted semantics. | Historical decision rationale or PR-by-PR sequencing. |
+| `docs/adr/` | Durable architecture, packaging, boundary, or governance decisions and their consequences. | Detailed behavior matrices that should be tested as specs. |
+| `docs/plans/` | PR sequencing, implementation packets, validation commands, dependencies, and stop conditions. | Product contracts or architecture decisions. |
+| `.jules/goals/active.toml` | Machine-readable active-agent state: current program, current lane, stop conditions, and where to find the human plan. | Raw terminal logs, complete run history, or policy. |
+| `.jules/runs/` | Per-run Jules packets, receipts, decisions, and PR bodies. | Shared active state or edited truth ledgers. |
+| `.jules/friction/` | Structured future-work and friction items found by agent runs. | Current implementation plans or accepted decisions. |
+| `ci/proof.toml` | Proof scope classification, affected-plan policy, executor defaults, allowlists, and dependency/fixture rules. | Narrative rationale or PR sequencing. |
+| `policy/*.toml` | Machine-checkable repo policies that are not proof-scope policy. | Human-only conventions. |
+| PR bodies and comments | Review-local summary, validation evidence, links to durable artifacts, and disposition rationale. | Primary long-term truth when a repo artifact should exist. |
+
+## Conflict Resolution
+
+When artifacts disagree:
+
+1. Machine-checked policy and schema files define what current tooling enforces.
+2. Specs define intended behavior contracts.
+3. ADRs explain why durable decisions exist.
+4. Plans define the next implementation order, but never override specs or ADRs.
+5. Proposals explain unaccepted or exploratory direction.
+6. `.jules/goals/active.toml` points at the active lane, but it does not replace
+   the linked plan, spec, ADR, or policy.
+
+If a PR changes behavior, update the spec or schema that owns that behavior. If
+it changes architecture boundaries, add or update an ADR. If it changes the
+work order, update a plan. If it changes a checker, update the policy file and
+its tests.
+
+## Lifecycle
+
+### Proposal
+
+Use a proposal when the team needs to compare approaches or preserve why a lane
+is worth doing. A proposal can be dropped without cleanup if no implementation
+depends on it.
+
+### Spec
+
+Use a spec when a behavior or artifact shape should be testable. Specs should
+name the proof commands or checks that keep the contract honest.
+
+### ADR
+
+Use an ADR when the repo needs a durable decision about architecture, public
+surface, release governance, proof promotion, or product boundaries. ADRs should
+link to specs rather than embedding every behavior detail.
+
+### Plan
+
+Use a plan when work needs sequencing. Plans should be concrete enough that a
+future agent can pick the next PR without reopening the whole design discussion.
+
+### Active agent state
+
+Use `.jules/goals/active.toml` to make the current program machine-readable. It
+should be small, current, and linked to durable human docs. It should not become
+a diary.
+
+### Policy
+
+Use `ci/proof.toml` and files under `policy/` for rules that tooling can check.
+Narrative docs may explain policy, but checked TOML is the source for automated
+behavior.
+
+## Review Expectations
+
+For non-trivial PRs, the PR body should link to the relevant durable artifact:
+
+- proposal for exploratory rationale;
+- spec for behavior or artifact changes;
+- ADR for durable architecture decisions;
+- plan for sequencing;
+- policy file for machine-checked rule changes;
+- receipt or verifier output for proof evidence.
+
+Docs-only PRs may update this routing model without changing product behavior,
+schemas, proof promotion, Codecov defaults, or publish surface.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,51 @@
+# Specs
+
+Specs own testable behavior contracts. A spec should say what an artifact,
+command, schema, workflow, or policy means and what proof keeps that meaning
+honest.
+
+Existing repository specs may still live as top-level documents such as
+`docs/specification.md`, `docs/review-packet.md`, and schema-specific reference
+files. This directory is the home for new focused specs that should not grow the
+top-level docs list.
+
+## Use This Directory For
+
+- command behavior contracts;
+- receipt and packet semantics;
+- compatibility and migration rules;
+- proof requirements for a behavior or artifact;
+- accepted product surfaces that need tests or verifiers.
+
+## Do Not Use It For
+
+- exploratory rationale before a direction is chosen;
+- ADR-style architecture decisions;
+- release notes;
+- per-PR task lists.
+
+## Suggested Shape
+
+```md
+# Spec: <title>
+
+- Status: draft | active | superseded | retired
+- Schema family, if any:
+- Related ADRs:
+- Related proof scopes:
+
+## Contract
+
+## Inputs
+
+## Outputs
+
+## Compatibility
+
+## Proof Requirements
+
+## Open Questions
+```
+
+Specs should cite concrete commands, tests, schema files, or verifiers whenever
+the contract is already enforced.


### PR DESCRIPTION
## Summary
- add `docs/source-of-truth.md` to define where proposals, specs, ADRs, plans, active agent state, policy, and PR evidence belong
- add README scaffolding for `docs/proposals`, `docs/specs`, `docs/plans`, and `.jules/goals`, plus `.jules/goals/active.toml`
- update `ci/proof.toml` so the new source-of-truth docs route through affected proof planning instead of appearing as unknown files
- keep this docs/control-surface only: no product behavior, schema, proof promotion, Codecov default, or publish-surface changes

## Validation
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --summary-md target/proof/proof-plan.md > target/proof/proof-plan.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo fmt-check`
- `git diff --check`

Publish surface was not run locally because this PR does not change package manifests, public exports, dependency surfaces, or crate ownership.