### PR TITLE
test(format): avoid panicking badge width helper

### DIFF
--- a/crates/tokmd-format/src/badge/mod.rs
+++ b/crates/tokmd-format/src/badge/mod.rs
@@ -78,10 +78,11 @@ mod tests {
     }
 
     #[test]
-    fn badge_svg_width_scales_with_text() {
+    fn badge_svg_width_scales_with_text() -> Result<(), String> {
         let short_svg = badge_svg("a", "1");
         let long_svg = badge_svg("averylonglabel", "averylongvalue");
-        assert!(extract_svg_width(&long_svg) > extract_svg_width(&short_svg));
+        assert!(extract_svg_width(&long_svg)? > extract_svg_width(&short_svg)?);
+        Ok(())
     }
 
     #[test]
@@ -95,9 +96,23 @@ mod tests {
         assert!(!svg.contains(value));
     }
 
-    fn extract_svg_width(svg: &str) -> i32 {
-        let start = svg.find("width=\"").expect("width attr") + 7;
-        let end = svg[start..].find('"').expect("width close") + start;
-        svg[start..end].parse().expect("numeric width")
+    #[test]
+    fn extract_svg_width_reports_malformed_svg() {
+        assert!(extract_svg_width("<svg></svg>").is_err());
+        assert!(extract_svg_width("<svg width=\"abc\"></svg>").is_err());
+    }
+
+    fn extract_svg_width(svg: &str) -> Result<i32, String> {
+        let start = svg
+            .find("width=\"")
+            .ok_or_else(|| "missing SVG width attribute".to_string())?
+            + 7;
+        let end = svg[start..]
+            .find('"')
+            .map(|offset| offset + start)
+            .ok_or_else(|| "unterminated SVG width attribute".to_string())?;
+        svg[start..end]
+            .parse()
+            .map_err(|error| format!("invalid SVG width `{}`: {error}", &svg[start..end]))
     }
 }


### PR DESCRIPTION
## Summary
- make the badge SVG width test helper return a `Result` instead of panicking on malformed SVG input
- add regression coverage for malformed width extraction

Fixes #983.

## Validation
- `cargo test -p tokmd-format badge --verbose`
- `cargo test -p tokmd --test badge_integration --verbose`
- `cargo test -p tokmd --test cli_badge_e2e --verbose`
- `cargo clippy -p tokmd-format --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json --summary-md target/proof/proof-plan.md > target/proof/proof-plan.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `git diff --check origin/main...HEAD`