### PR TITLE
docs: add source-of-truth workflow templates

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1078,9 +1078,10 @@ paths = [
   "docs/source-of-truth.md",
   "docs/specs/**",
   "docs/specification.md",
+  "docs/templates/**",
 ]
 proof = ["cargo xtask docs --check"]
-reason = "Top-level architecture, ADR, design, roadmap, requirements, proposal/spec/plan, and audit docs are project truth surfaces; edits should route to documentation checks instead of appearing as unknown files."
+reason = "Top-level architecture, ADR, design, roadmap, requirements, proposal/spec/plan/template, and audit docs are project truth surfaces; edits should route to documentation checks instead of appearing as unknown files."
 mutation = false
 coverage = false
 

--- a/docs/source-of-truth.md
+++ b/docs/source-of-truth.md
@@ -26,6 +26,43 @@ idea or problem
 Skipping a step is fine for small changes, but mixing these roles in one
 document makes later work harder to audit.
 
+## How to Use This Model
+
+Start with the smallest artifact that can carry the truth without hiding it.
+For routine code changes, a PR body with validation evidence may be enough. For
+lanes that change behavior, architecture, sequencing, or checked policy, update
+the owning artifact before relying on chat history.
+
+When planning a lane:
+
+1. Read `docs/NEXT.md` for the current operating mode.
+2. Read `.jules/goals/active.toml` for the active machine-readable lane and its
+   linked plan/spec/ADR/policy files.
+3. Create or update a proposal only when the why, alternatives, or open
+   questions need durable review.
+4. Create or update a spec when behavior, artifact shape, compatibility, or
+   proof requirements change.
+5. Create or update an ADR when a durable architecture, governance, packaging,
+   or product-boundary decision changes.
+6. Create or update a plan when PR sequencing, validation commands, dependencies,
+   or stop conditions change.
+7. Update checked TOML policy when a rule becomes machine-checkable.
+
+When executing a lane:
+
+- keep `.jules/goals/active.toml` small and current;
+- follow the linked plan rather than inventing a parallel queue;
+- update specs before relying on new behavior contracts;
+- update ADRs before relying on new durable architecture decisions;
+- put raw run logs in run artifacts only when they are summarized into a durable
+  finding, plan, or PR body;
+- run `cargo xtask doc-artifacts --check` after changing source-of-truth
+  artifacts.
+
+Templates under `docs/templates/` are starting points for new artifacts. They
+are not source-of-truth documents until copied into the owning directory and
+filled with repo-specific content.
+
 ## Artifact Roles
 
 | Artifact | Owns | Does not own |

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,17 @@
+# Source-of-Truth Templates
+
+These templates are starter shapes for new source-of-truth artifacts. They are
+not source-of-truth documents by themselves; copy one into the owning directory
+and fill in repo-specific content before linking to it from a plan, spec, ADR,
+or `.jules/goals/active.toml`.
+
+Use:
+
+- `proposal.md` for exploratory rationale and alternatives;
+- `spec.md` for testable behavior contracts and proof requirements;
+- `adr.md` for durable architecture decisions;
+- `plan.md` for PR sequencing and validation commands;
+- `active-goal.toml` for the small machine-readable active lane.
+
+Run `cargo xtask doc-artifacts --check` after creating or changing active
+source-of-truth artifacts.

--- a/docs/templates/active-goal.toml
+++ b/docs/templates/active-goal.toml
@@ -1,0 +1,24 @@
+schema = "tokmd.jules.active_goal.v1"
+status = "active"
+program = ""
+lane = ""
+
+[links]
+source_of_truth = "docs/source-of-truth.md"
+doc_artifacts_spec = "docs/specs/doc-artifacts.md"
+doc_artifacts_plan = "docs/plans/doc-artifacts-check.md"
+plan_readme = "docs/plans/README.md"
+proposal_readme = "docs/proposals/README.md"
+spec_readme = "docs/specs/README.md"
+adr_readme = "docs/adr/README.md"
+
+[rules]
+proof_promotion = "do_not_promote_without_maintainer_decision"
+codecov_default_upload = "do_not_enable_without_maintainer_decision"
+product_behavior = "docs_only_lane"
+
+[stop_conditions]
+open_pr_queue = "must_be_empty_before_starting_new_lane"
+docs_check = "cargo xtask docs --check"
+proof_policy = "cargo xtask proof-policy --check"
+affected_plan = "cargo xtask affected --base origin/main --head HEAD --json"

--- a/docs/templates/adr.md
+++ b/docs/templates/adr.md
@@ -1,0 +1,30 @@
+# ADR-XXXX: <title>
+
+- Status: proposed
+- Date:
+- Related specs:
+- Related plans:
+
+## Context
+
+Describe the durable architecture, governance, packaging, release, or product
+boundary question.
+
+## Decision
+
+State the decision and the boundary it creates.
+
+## Consequences
+
+- Positive consequence:
+- Tradeoff or cost:
+- Follow-up work:
+
+## Alternatives
+
+- Alternative considered:
+
+## Enforcement
+
+Describe the policy, proof scope, test, or review expectation that keeps this
+decision from drifting.

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -1,0 +1,45 @@
+# Plan: <title>
+
+- Status: active
+- Related proposal:
+- Related spec:
+- Related ADR:
+- Related issues:
+
+## Goal
+
+State the concrete end state for this implementation sequence.
+
+## Non-goals
+
+- List work that must stay out of this plan.
+
+## Work Packets
+
+1. First narrow PR:
+2. Second narrow PR:
+3. Follow-up or checkpoint:
+
+## Validation
+
+Each implementation PR should run the relevant subset of:
+
+```bash
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan
+cargo fmt-check
+git diff --check
+```
+
+## Stop Conditions
+
+- Stop if the plan requires a behavior contract that no spec owns.
+- Stop if the plan requires a durable architecture decision that no ADR owns.
+- Stop if validation becomes noisy or broader than the lane justifies.
+
+## Checkpoint History
+
+- YYYY-MM-DD:

--- a/docs/templates/proposal.md
+++ b/docs/templates/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: <title>
+
+- Status: draft
+- Owner:
+- Related issues:
+- Related specs:
+- Related ADRs:
+
+## Problem
+
+Describe the problem, opportunity, or friction that makes this proposal worth
+reviewing.
+
+## Goals
+
+- State the outcomes this proposal is trying to achieve.
+
+## Non-goals
+
+- State adjacent work this proposal intentionally leaves out.
+
+## Options
+
+- Option A:
+- Option B:
+
+## Recommendation
+
+Name the recommended option and the reason it best fits tokmd's current
+constraints.
+
+## Open Questions
+
+- List decisions that must be answered before this can become a spec, ADR, or
+  plan.

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -1,0 +1,33 @@
+# Spec: <title>
+
+- Status: draft
+- Schema family, if any:
+- Related ADRs:
+- Related proof scopes:
+
+## Contract
+
+Define the behavior, artifact shape, compatibility rule, or policy semantics
+that consumers can rely on.
+
+## Inputs
+
+- List accepted inputs, flags, files, schemas, or preconditions.
+
+## Outputs
+
+- List generated outputs, receipt fields, files, errors, or status values.
+
+## Compatibility
+
+Describe backwards-compatibility requirements, migration behavior, and allowed
+degraded states.
+
+## Proof Requirements
+
+- List commands, tests, schemas, verifiers, or fixtures that keep the contract
+  honest.
+
+## Open Questions
+
+- List unresolved behavior or proof questions.


### PR DESCRIPTION
## Summary
- add a practical human/agent workflow section to `docs/source-of-truth.md`
- add reusable source-of-truth starter templates for proposals, specs, ADRs, implementation plans, and active Jules goals
- route `docs/templates/**` through the existing `project_truth_docs` proof scope so affected planning stays clean

## Notes
- No product behavior, receipt schema, proof-promotion, Codecov default, or publish-surface changes.
- `docs/templates/*` are starter shapes only; they are not source-of-truth artifacts until copied into an owning directory and filled in.

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json` (`unknown_files: []`)
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo fmt-check`
- `git diff --check origin/main...HEAD`