### PR TITLE
docs: close out source-of-truth control lane

### DIFF
--- a/.jules/goals/archive/2026-05-13-doc-artifacts-check.toml
+++ b/.jules/goals/archive/2026-05-13-doc-artifacts-check.toml
@@ -1,7 +1,25 @@
 schema = "tokmd.jules.active_goal.v1"
-status = "active"
-program = "review_packet_product"
-lane = "cockpit_review_usefulness"
+status = "complete"
+program = "source_of_truth_docs"
+lane = "documentation_control_surface"
+completed = "2026-05-13"
+closeout_plan = "docs/plans/doc-artifacts-check.md"
+
+completed_prs = [
+  2174,
+  2175,
+  2176,
+  2177,
+  2178,
+  2185,
+  2187,
+  2188,
+  2189,
+  2190,
+  2191,
+  2192,
+  2199,
+]
 
 [links]
 source_of_truth = "docs/source-of-truth.md"
@@ -11,18 +29,14 @@ plan_readme = "docs/plans/README.md"
 proposal_readme = "docs/proposals/README.md"
 spec_readme = "docs/specs/README.md"
 adr_readme = "docs/adr/README.md"
-review_packet_contract = "docs/review-packet.md"
-cockpit_proof_evidence = "docs/cockpit-proof-evidence.md"
 
 [rules]
 proof_promotion = "do_not_promote_without_maintainer_decision"
 codecov_default_upload = "do_not_enable_without_maintainer_decision"
-product_behavior = "preserve_receipt_semantics"
-review_surface = "cockpit_remains_review_evidence_surface"
+product_behavior = "docs_only_lane"
 
 [stop_conditions]
 open_pr_queue = "must_be_empty_before_starting_new_lane"
 docs_check = "cargo xtask docs --check"
 proof_policy = "cargo xtask proof-policy --check"
 affected_plan = "cargo xtask affected --base origin/main --head HEAD --json"
-review_packet_check = "cargo xtask review-packet-check --dir .tokmd/review"

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -34,11 +34,13 @@ spine and several small fixes on main; future performance work should continue
 to cite `cargo xtask perf-smoke` receipts or explicitly say it is
 structure-only.
 
-The active documentation-control lane is the source-of-truth stack: proposals
+The source-of-truth stack is installed and in routine maintenance: proposals
 own exploratory rationale, specs own behavior contracts and proof
 requirements, ADRs own durable architecture decisions, plans own sequencing,
 `.jules/goals/active.toml` owns small machine-readable active-agent state, and
-checked policy TOMLs own machine-enforced rules.
+checked policy TOMLs own machine-enforced rules. The completed doc-artifacts
+checker plan is closed out; the current active goal now points at cockpit
+review usefulness.
 
 ## Next Work Packets
 
@@ -52,7 +54,8 @@ checked policy TOMLs own machine-enforced rules.
    scope granularity as implementation microcrates collapse into SRP modules.
 5. Use bounded performance timing receipts before optimizing hot paths.
 6. Keep source-of-truth docs, active goal state, and proof-policy routing
-   aligned as new lanes start.
+   aligned as new lanes start; do not reopen the doc-artifacts checker lane
+   unless the spec changes.
 7. Draft AST foundation work only after the review packet and consolidation
    direction are stable.
 
@@ -178,6 +181,10 @@ checked policy TOMLs own machine-enforced rules.
 - `docs/agent-workflows/source-of-truth.md` now gives maintainers and coding agents an operational checklist for reading `docs/NEXT.md`, `.jules/goals/active.toml`, linked plans/specs/ADRs, policy files, and proof output before changing a lane.
 - `.jules/goals/archive/README.md` now defines how completed, paused, or superseded active goals can be archived as historical snapshots without turning archives into a second active queue.
 - `tokmd cockpit --doc-artifacts-check <path> --review-packet-dir <dir>` now imports the visibility-only `tokmd.doc_artifacts_check.v1` receipt into review packets, copies it to `docs/doc-artifacts-check.json`, records it in `manifest.json` and `evidence.json`, and summarizes it in `review-map.md` / `comment.md` without changing merge behavior, proof promotion, or Codecov defaults.
+- The documentation source-of-truth lane is closed through first enforcement:
+  `docs/plans/doc-artifacts-check.md` is complete, the completed goal is
+  archived in `.jules/goals/archive/2026-05-13-doc-artifacts-check.toml`, and
+  `.jules/goals/active.toml` now points at cockpit review usefulness.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
 - The composite Action now adds hosted packet metadata to review-packet PR comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.

--- a/docs/plans/doc-artifacts-check.md
+++ b/docs/plans/doc-artifacts-check.md
@@ -1,6 +1,6 @@
 # Plan: Documentation Artifact Checker
 
-- Status: active
+- Status: complete
 - Related proposal: none
 - Related spec: `docs/specs/doc-artifacts.md`
 - Related ADR: `docs/adr/0000-adr-process.md`
@@ -10,13 +10,13 @@
 
 Make tokmd's source-of-truth stack checkable without changing product behavior.
 
-The first implementation target is:
+The implemented checker is:
 
 ```bash
 cargo xtask doc-artifacts --check
 ```
 
-That command should verify the shape, links, and routing of source-of-truth
+That command verifies the shape, links, and routing of source-of-truth
 documentation artifacts defined by `docs/source-of-truth.md` and
 `docs/specs/doc-artifacts.md`.
 
@@ -30,6 +30,10 @@ documentation artifacts defined by `docs/source-of-truth.md` and
 - Do not add a new product command; keep this in `xtask`.
 
 ## Work Packets
+
+All work packets in this plan are complete as of 2026-05-13. Future changes that
+extend the contract beyond these packets should open a new plan or update the
+spec before changing behavior.
 
 1. Add the doc-artifact contract.
 
@@ -83,6 +87,21 @@ documentation artifacts defined by `docs/source-of-truth.md` and
    `target/docs/doc-artifacts-check.json` as documentation-control evidence for
    source-of-truth changes. Keep the import explicit and visibility-only: no
    merge verdict, proof promotion, or Codecov behavior changes.
+
+## Closeout
+
+The source-of-truth control surface is now installed through first enforcement:
+the docs model exists, policy owns the machine-checkable shape, `xtask` checks
+that shape, docs CI uploads a visibility-only receipt, affected proof routes
+source-of-truth changes to the checker, and cockpit can explicitly import the
+receipt into review packets.
+
+Deferred follow-up work belongs in new lanes:
+
+- Cockpit may use the doc-artifacts receipt to improve review usefulness.
+- Evidencebus integration may wrap the receipt as part of a broader packet.
+- Future source-of-truth policy changes should update
+  `docs/specs/doc-artifacts.md` before changing checker behavior.
 
 ## Validation
 
@@ -144,3 +163,7 @@ package, export, public API, or publish-surface files.
   receipts as documentation-control evidence, copies them into the packet,
   records them in the manifest and evidence files, and summarizes them in the
   review map and comment without changing merge behavior.
+- 2026-05-13: The plan is complete. The former active goal was archived under
+  `.jules/goals/archive/2026-05-13-doc-artifacts-check.toml`, and
+  `.jules/goals/active.toml` now points at the next cockpit review-usefulness
+  lane.


### PR DESCRIPTION
## Summary
- mark `docs/plans/doc-artifacts-check.md` complete now that policy, checker, JSON receipt, CI upload, proof routing, and cockpit import are landed
- archive the completed source-of-truth active goal under `.jules/goals/archive/2026-05-13-doc-artifacts-check.toml`
- retarget `.jules/goals/active.toml` and `docs/NEXT.md` toward the next cockpit review-usefulness lane

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`