### PR TITLE
feat(cockpit): reproduce doc artifact evidence

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -57,6 +57,7 @@ fn review_map_item(
     let evidence = review_map_item_evidence(item, receipt);
     let proof = review_map_item_proof(item, proof_refs);
     let doc_artifacts_refs = review_map_item_doc_artifacts_refs(item, doc_artifacts);
+    let reproduce = review_map_item_reproduce(item, receipt);
 
     json!({
         "rank": idx + 1,
@@ -82,17 +83,30 @@ fn review_map_item(
             "unavailable": evidence.unavailable,
             "refs": ["evidence.json#/gates"],
         },
-        "reproduce": [
-            format!(
-                "tokmd cockpit --base {} --head {} --format json",
-                receipt.base_ref, receipt.head_ref
-            ),
-            format!(
-                "tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review",
-                receipt.base_ref, receipt.head_ref
-            ),
-        ],
+        "reproduce": reproduce,
     })
+}
+
+fn review_map_item_reproduce(item: &ReviewItem, receipt: &CockpitReceipt) -> Vec<String> {
+    let mut commands = vec![
+        format!(
+            "tokmd cockpit --base {} --head {} --format json",
+            receipt.base_ref, receipt.head_ref
+        ),
+        format!(
+            "tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review",
+            receipt.base_ref, receipt.head_ref
+        ),
+    ];
+
+    if review_item_is_source_of_truth(item) {
+        commands.push(
+            "cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json"
+                .to_string(),
+        );
+    }
+
+    commands
 }
 
 fn review_map_evidence_refs(
@@ -271,6 +285,12 @@ pub(super) fn render_review_map_md(
             "   - `tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review`",
             receipt.base_ref, receipt.head_ref
         );
+        if review_item_is_source_of_truth(item) {
+            let _ = writeln!(
+                s,
+                "   - `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json`"
+            );
+        }
         let _ = writeln!(s);
     }
 

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1186,11 +1186,27 @@ fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
         review_map["items"][0]["doc_artifacts_refs"][1],
         "docs/doc-artifacts-check.json"
     );
+    assert!(
+        review_map["items"][0]["reproduce"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|command| command.as_str()
+                == Some(
+                    "cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json"
+                )),
+        "source-of-truth review items should include the docs checker receipt command"
+    );
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("Doc artifacts: verified"));
     assert!(review_map_md.contains("evidence.json#/doc_artifacts"));
     assert!(review_map_md.contains("docs/doc-artifacts-check.json"));
+    assert!(
+        review_map_md.contains(
+            "cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json"
+        )
+    );
 
     let comment_md = std::fs::read_to_string(out.join("comment.md")).unwrap();
     assert!(comment_md.contains("Doc artifacts"));
@@ -1225,6 +1241,11 @@ fn scenario_write_review_packet_marks_missing_doc_artifacts_for_source_of_truth_
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("Doc artifacts: missing for source-of-truth changes."));
     assert!(review_map_md.contains("   Doc artifacts: missing"));
+    assert!(
+        review_map_md.contains(
+            "cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json"
+        )
+    );
 
     let comment_md = std::fs::read_to_string(out.join("comment.md")).unwrap();
     assert!(comment_md.contains("Doc artifacts"));

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -170,6 +170,9 @@ Packet treatment:
   missing, stale, or degraded for source-of-truth changes.
 - `comment.md` may include a compact line such as `Doc artifacts: verified` or
   `Doc artifacts: missing for source-of-truth changes`.
+- Source-of-truth review-map items include the `cargo xtask doc-artifacts
+  --check --json target/docs/doc-artifacts-check.json` command in their
+  reproduction commands, so reviewers can regenerate the imported receipt.
 
 Absent doc-artifacts evidence is `missing` only when source-of-truth paths are
 changed and the packet has enough context to know the receipt was expected.


### PR DESCRIPTION
## Summary
- add the doc-artifacts checker receipt command to source-of-truth review-map item reproduction commands
- render the same command in review-map.md when source-of-truth files need doc-artifact evidence
- document the review-packet contract for regenerating doc-artifacts evidence

## Validation
- `cargo test -p tokmd-cockpit doc_artifacts --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`