### PR TITLE
feat(cockpit): link review docs to doc evidence

### DIFF
--- a/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
+++ b/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
@@ -65,6 +65,8 @@ pub fn parse_doc_artifacts_evidence_input(
 
 pub(crate) fn source_of_truth_path(path: &str) -> bool {
     path == "docs/source-of-truth.md"
+        || path == "docs/review-packet.md"
+        || path == "docs/cockpit-proof-evidence.md"
         || path == "policy/doc-artifacts.toml"
         || path.starts_with("docs/proposals/")
         || path.starts_with("docs/specs/")
@@ -118,6 +120,8 @@ mod tests {
     #[test]
     fn recognizes_source_of_truth_paths() {
         assert!(source_of_truth_path("docs/source-of-truth.md"));
+        assert!(source_of_truth_path("docs/review-packet.md"));
+        assert!(source_of_truth_path("docs/cockpit-proof-evidence.md"));
         assert!(source_of_truth_path("docs/specs/doc-artifacts.md"));
         assert!(source_of_truth_path(".jules/goals/active.toml"));
         assert!(source_of_truth_path("policy/doc-artifacts.toml"));

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1095,13 +1095,22 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
 fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
     let dir = tempfile::tempdir().unwrap();
     let mut receipt = minimal_receipt();
-    receipt.review_plan = vec![ReviewItem {
-        path: "docs/specs/doc-artifacts.md".to_string(),
-        reason: "Documentation artifact contract changed".to_string(),
-        priority: 1,
-        complexity: None,
-        lines_changed: Some(24),
-    }];
+    receipt.review_plan = vec![
+        ReviewItem {
+            path: "docs/specs/doc-artifacts.md".to_string(),
+            reason: "Documentation artifact contract changed".to_string(),
+            priority: 1,
+            complexity: None,
+            lines_changed: Some(24),
+        },
+        ReviewItem {
+            path: "docs/review-packet.md".to_string(),
+            reason: "Review packet contract changed".to_string(),
+            priority: 1,
+            complexity: None,
+            lines_changed: Some(6),
+        },
+    ];
     let out = dir.path().join("review");
     let doc_artifacts = tokmd_cockpit::parse_doc_artifacts_evidence_input(
         r#"{
@@ -1186,6 +1195,14 @@ fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
         review_map["items"][0]["doc_artifacts_refs"][1],
         "docs/doc-artifacts-check.json"
     );
+    assert_eq!(
+        review_map["items"][1]["doc_artifacts_refs"][0], "evidence.json#/doc_artifacts",
+        "active review-packet contract docs should be treated as source-of-truth review items"
+    );
+    assert_eq!(
+        review_map["items"][1]["doc_artifacts_refs"][1],
+        "docs/doc-artifacts-check.json"
+    );
     assert!(
         review_map["items"][0]["reproduce"]
             .as_array()
@@ -1196,6 +1213,17 @@ fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
                     "cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json"
                 )),
         "source-of-truth review items should include the docs checker receipt command"
+    );
+    assert!(
+        review_map["items"][1]["reproduce"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|command| command.as_str()
+                == Some(
+                    "cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json"
+                )),
+        "active review-packet contract docs should include the docs checker receipt command"
     );
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();

--- a/xtask/src/tasks/doc_artifacts.rs
+++ b/xtask/src/tasks/doc_artifacts.rs
@@ -299,8 +299,13 @@ fn validate_active_goal(root: &Path, policy: &ActiveGoalPolicy, errors: &mut Vec
         }
     }
     for link in &policy.required_links {
-        let Some(link_value) = goal.links.get(link).and_then(toml::Value::as_str) else {
+        if !goal.links.contains_key(link) {
             errors.push(format!("{}: missing [links].{link}", policy.path));
+        }
+    }
+    for (link, value) in &goal.links {
+        let Some(link_value) = value.as_str() else {
+            errors.push(format!("{}: [links].{link} must be a string", policy.path));
             continue;
         };
         validate_active_goal_link(root, &policy.path, link, link_value, policy, errors);
@@ -563,6 +568,28 @@ mod tests {
                 .errors
                 .iter()
                 .any(|error| error.contains("points at missing path")),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn extra_active_goal_links_are_validated() {
+        let temp = tempfile::tempdir().unwrap();
+        write_valid_fixture(temp.path());
+        let goal = active_goal("docs/source-of-truth.md", "tokmd.jules.active_goal.v1").replace(
+            "adr_readme = \"docs/adr/README.md\"",
+            "adr_readme = \"docs/adr/README.md\"\nreview_packet_contract = \"missing.md\"",
+        );
+        fs::write(temp.path().join(".jules/goals/active.toml"), goal).unwrap();
+
+        let report = check(temp.path(), Path::new("policy/doc-artifacts.toml")).unwrap();
+
+        assert!(
+            report.errors.iter().any(|error| {
+                error.contains("[links].review_packet_contract")
+                    && error.contains("points at missing path")
+            }),
             "{:?}",
             report.errors
         );


### PR DESCRIPTION
## Summary
- treat active review-packet contract docs as source-of-truth review items for doc-artifacts evidence
- validate all active-goal links in the doc-artifacts checker, not only the required link subset
- extend review-packet BDD coverage so active review docs get doc-artifacts refs and reproduction commands

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit doc_artifacts --verbose`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json`
- `cargo run -p tokmd -- cockpit --base HEAD~1 --head HEAD --doc-artifacts-check target/docs/doc-artifacts-check.json --review-packet-dir target/review-smoke-active-links --output target/review-smoke-active-links/stdout.md`
- `cargo xtask review-packet-check --dir target/review-smoke-active-links --json target/review-smoke-active-links/review-packet-check.json`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `cargo test -p xtask --test deep_w71 --verbose`
- `cargo test -p xtask --test docs_schema_w72 --verbose`
- `cargo test -p xtask --test docs_w43 --verbose`
- `cargo test -p xtask --test xtask_contract_w65 --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask bump --verbose`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask jules_index --verbose`
- `cargo test -p xtask perf_smoke --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo xtask ci-lane-whitelist`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan`
- `git diff --check origin/main..HEAD`