### PR TITLE
docs: add cockpit review packet quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,49 @@ tokmd context --budget 128k --mode bundle --output context.txt
 | summarize a repo | `tokmd`, `module`, `export` | Markdown summary, file receipt |
 | compare states | `diff`, `run` | deterministic diff and receipts |
 | analyze code health | `analyze` | risk, effort, complexity reports |
-| review a PR | `cockpit`, GitHub Action | review report |
+| review a PR | `cockpit --review-packet-dir`, GitHub Action `review-packet` | review map, evidence, comment, packet manifest |
 | gate policy in CI | `gate`, `baseline`, `sensor` | verdicts, ratchets, sensor envelope |
 | pack LLM context | `context`, `handoff` | bounded bundle, handoff directory |
+
+## Review a PR
+
+For local PR review, generate a cockpit review packet instead of reading CI logs
+or raw JSON first:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+```
+
+Start with `.tokmd/review/comment.md`, then use
+`.tokmd/review/review-map.md` for the review order and reproduction commands.
+`.tokmd/review/evidence.json` and `.tokmd/review/manifest.json` carry the
+machine-readable evidence state and hash-indexed packet inventory.
+
+In a tokmd contributor checkout, verify the packet before using it as review
+evidence:
+
+```bash
+cargo xtask review-packet-check --dir .tokmd/review
+```
+
+If a PR changes source-of-truth docs, plans, ADRs, templates, `.jules/goals/**`,
+or doc-artifact policy, generate the docs receipt first and import it:
+
+```bash
+cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
+
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --doc-artifacts-check target/docs/doc-artifacts-check.json \
+  --review-packet-dir .tokmd/review
+```
+
+This makes documentation-control evidence visible in the review packet; it does
+not turn cockpit into a merge verdict or promote advisory proof.
 
 ## GitHub Action
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1041,6 +1041,19 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "user_guides"
+kind = "non_rust"
+paths = [
+  "docs/recipes.md",
+  "docs/tutorial.md",
+  "docs/troubleshooting.md",
+]
+proof = ["cargo xtask docs --check"]
+reason = "User-facing tutorial, recipe, and troubleshooting docs should route to documentation checks instead of appearing as unknown files."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "crate_guidance_docs"
 kind = "non_rust"
 paths = [

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -401,42 +401,65 @@ tokmd tools --format jsonschema --pretty > schema.json
 
 **Use case**: Feed the schema to an AI agent so it can analyze repositories autonomously.
 
-## 15b. PR Cockpit Metrics
+## 15b. PR Review Packet
 
-Generate comprehensive PR metrics for code review automation with evidence gates.
+Generate a cockpit review packet for a pull request.
 
-**Goal**: Automate PR review with structured metrics and quality gates.
+**Goal**: Start review from a deterministic packet that says what changed, what
+to inspect first, what evidence exists, what evidence is missing, and which
+commands reproduce evidence claims.
 
 ```bash
-# Generate JSON metrics for CI parsing
-tokmd cockpit
+# Generate the packet for the current branch
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
 
-# Markdown summary for PR description
-tokmd cockpit --format md
-
-# Compact Markdown body for PR comments
-tokmd cockpit --format comment
-
-# Compare specific refs
-tokmd cockpit --base origin/main --head feature-branch --format md
-
-# Generate sections for PR template filling
-tokmd cockpit --format sections --output pr-metrics.txt
+# Verify packet-local paths, schemas, and BLAKE3 hashes
+cargo xtask review-packet-check --dir .tokmd/review
 ```
 
 **What you get**:
-- **Change surface**: Files added/modified/deleted, lines added/removed
-- **Composition**: Production vs test vs config breakdown
-- **Code health**: Complexity, doc coverage, test coverage
-- **Risk assessment**: Hotspots, coupling, freshness
-- **Evidence gates**: Mutation testing, diff coverage, contracts, supply chain
-- **Review plan**: Prioritized list of files to review
+- `.tokmd/review/comment.md`: compact PR-comment-ready summary
+- `.tokmd/review/review-map.md`: what to review first and how to reproduce
+  evidence claims
+- `.tokmd/review/evidence.json`: machine-readable evidence availability,
+  missing evidence, and any imported proof or doc-artifacts evidence
+- `.tokmd/review/manifest.json`: packet artifact inventory with hashes
+- optional `target/tokmd/review-packet-check.json`: verifier receipt when
+  `--json` is passed to `review-packet-check`
+
+If the PR changes source-of-truth docs, plans, ADRs, templates,
+`.jules/goals/**`, or doc-artifact policy, include the doc-artifacts receipt:
+
+```bash
+cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
+
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --doc-artifacts-check target/docs/doc-artifacts-check.json \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+This makes documentation-control evidence visible in the review packet. It is
+not a merge verdict and does not promote advisory proof, coverage, or Codecov
+upload into a required gate.
 
 **GitHub Actions integration**:
 ```yaml
 name: PR Cockpit
 on:
   pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   cockpit:
@@ -446,25 +469,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install tokmd
-        run: cargo install tokmd --locked
-
-      - name: Generate cockpit metrics
-        run: |
-          tokmd cockpit --base origin/${{ github.base_ref }} --head HEAD --format comment > cockpit.md
-
-      - name: Post PR comment
-        uses: actions/github-script@v7
+      - uses: EffortlessMetrics/tokmd@v1
         with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('cockpit.md', 'utf8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
+          version: '1.11.0'
+          mode: cockpit
+          base: origin/${{ github.base_ref }}
+          head: HEAD
+          review-packet: 'true'
+          artifact: 'true'
+          comment: 'true'
 ```
 
 ## 15c. One-command PR Artifact Bundle

--- a/docs/tokmd-in-cockpit.md
+++ b/docs/tokmd-in-cockpit.md
@@ -22,6 +22,55 @@ additive PR review artifact shape, not a replacement for the shipped
 `--artifacts-dir` contract. The packet includes `review-map.json` and
 `review-map.md` derived from the cockpit review plan.
 
+## Local Review Packet Quickstart
+
+Use this flow when reviewing a branch locally:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+Open the packet in this order:
+
+1. `.tokmd/review/comment.md` for the short review summary.
+2. `.tokmd/review/review-map.md` for what to inspect first and how to
+   reproduce evidence claims.
+3. `.tokmd/review/evidence.json` for the exact available, missing, stale,
+   degraded, skipped, or unavailable evidence state.
+4. `.tokmd/review/manifest.json` for packet-local artifact paths and hashes.
+5. `target/tokmd/review-packet-check.json` for the verifier receipt.
+
+When the PR changes source-of-truth docs, plans, ADRs, templates,
+`.jules/goals/**`, or doc-artifact policy, generate the documentation-control
+receipt first and import it:
+
+```bash
+cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
+
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --doc-artifacts-check target/docs/doc-artifacts-check.json \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+The imported doc-artifacts receipt is review evidence only. It shows whether
+the source-of-truth artifact shape, links, active goal state, and policy routing
+checked by `cargo xtask doc-artifacts --check` were valid. It does not prove
+the prose is correct, decide whether to merge, promote proof gates, or enable
+Codecov uploads.
+
 ## Default Policy
 
 tokmd is **informational by default**. A repo may choose to gate on tokmd output,


### PR DESCRIPTION
## Summary
- add a README-level local PR review packet path with packet verification and optional doc-artifacts import
- expand the cockpit integration doc with the artifact-open order and verifier receipt workflow
- replace the old PR metrics recipe with the review-packet flow and route user guide docs through affected proof

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask affected --verbose
- cargo test -p xtask proof_policy --verbose
- cargo xtask ci-lane-whitelist
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo fmt-check
- git diff --check origin/main..HEAD

## Notes
- No product behavior, receipt schema, proof promotion, Codecov default, merge verdict, or new review command change.