### PR TITLE
feat(cockpit): rank review plan contract changes

### DIFF
--- a/crates/tokmd-cockpit/src/review_plan.rs
+++ b/crates/tokmd-cockpit/src/review_plan.rs
@@ -1,20 +1,17 @@
 use tokmd_types::cockpit::{Contracts, ReviewItem};
 
 use crate::FileStat;
+use crate::doc_artifacts_evidence::source_of_truth_path;
 
 /// Generate review plan.
-pub fn generate_review_plan(file_stats: &[FileStat], _contracts: &Contracts) -> Vec<ReviewItem> {
+pub fn generate_review_plan(file_stats: &[FileStat], contracts: &Contracts) -> Vec<ReviewItem> {
     let mut items = Vec::new();
 
     for stat in file_stats {
         let lines = stat.insertions + stat.deletions;
-        let priority = if lines > 200 {
-            1
-        } else if lines > 50 {
-            2
-        } else {
-            3
-        };
+        let base_priority = review_priority_for_lines(lines);
+        let signal = ReviewSignal::for_path(&stat.path, contracts);
+        let priority = base_priority.min(signal.priority());
         let complexity = if lines > 300 {
             5
         } else if lines > 100 {
@@ -25,7 +22,7 @@ pub fn generate_review_plan(file_stats: &[FileStat], _contracts: &Contracts) -> 
 
         items.push(ReviewItem {
             path: stat.path.clone(),
-            reason: format!("{} lines changed", lines),
+            reason: signal.reason(lines),
             priority,
             complexity: Some(complexity),
             lines_changed: Some(lines),
@@ -35,9 +32,120 @@ pub fn generate_review_plan(file_stats: &[FileStat], _contracts: &Contracts) -> 
     items.sort_by(|a, b| {
         a.priority
             .cmp(&b.priority)
+            .then_with(|| review_signal_rank(&a.path).cmp(&review_signal_rank(&b.path)))
             .then_with(|| a.path.cmp(&b.path))
     });
     items
+}
+
+fn review_priority_for_lines(lines: usize) -> u32 {
+    if lines > 200 {
+        1
+    } else if lines > 50 {
+        2
+    } else {
+        3
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum ReviewSignal {
+    SourceOfTruth,
+    SchemaContract,
+    ProofPolicy,
+    CliContract,
+    ApiSurface,
+    Ordinary,
+}
+
+impl ReviewSignal {
+    fn for_path(path: &str, contracts: &Contracts) -> Self {
+        if source_of_truth_path(path) {
+            Self::SourceOfTruth
+        } else if schema_contract_path(path, contracts) {
+            Self::SchemaContract
+        } else if proof_policy_path(path) {
+            Self::ProofPolicy
+        } else if cli_contract_path(path, contracts) {
+            Self::CliContract
+        } else if api_surface_path(path, contracts) {
+            Self::ApiSurface
+        } else {
+            Self::Ordinary
+        }
+    }
+
+    fn priority(self) -> u32 {
+        match self {
+            Self::SourceOfTruth | Self::SchemaContract | Self::ProofPolicy | Self::CliContract => 1,
+            Self::ApiSurface => 2,
+            Self::Ordinary => 3,
+        }
+    }
+
+    fn reason(self, lines: usize) -> String {
+        let prefix = match self {
+            Self::SourceOfTruth => "source-of-truth contract changed",
+            Self::SchemaContract => "schema contract changed",
+            Self::ProofPolicy => "proof or policy routing changed",
+            Self::CliContract => "CLI contract changed",
+            Self::ApiSurface => "API surface changed",
+            Self::Ordinary => return format!("{lines} lines changed"),
+        };
+        format!("{prefix}; {lines} lines changed")
+    }
+}
+
+fn review_signal_rank(path: &str) -> ReviewSignal {
+    if source_of_truth_path(path) {
+        ReviewSignal::SourceOfTruth
+    } else if schema_contract_path_without_contracts(path) {
+        ReviewSignal::SchemaContract
+    } else if proof_policy_path(path) {
+        ReviewSignal::ProofPolicy
+    } else if cli_contract_path_without_contracts(path) {
+        ReviewSignal::CliContract
+    } else if api_surface_path_without_contracts(path) {
+        ReviewSignal::ApiSurface
+    } else {
+        ReviewSignal::Ordinary
+    }
+}
+
+fn schema_contract_path(path: &str, contracts: &Contracts) -> bool {
+    contracts.schema_changed && schema_contract_path_without_contracts(path)
+}
+
+fn schema_contract_path_without_contracts(path: &str) -> bool {
+    path == "docs/schema.json"
+        || path == "docs/SCHEMA.md"
+        || path.starts_with("docs/") && path.ends_with(".schema.json")
+        || path.starts_with("crates/tokmd/schemas/")
+}
+
+fn proof_policy_path(path: &str) -> bool {
+    path == "ci/proof.toml"
+        || path == "codecov.yml"
+        || path.starts_with("policy/")
+        || path.starts_with(".github/workflows/")
+}
+
+fn cli_contract_path(path: &str, contracts: &Contracts) -> bool {
+    contracts.cli_changed && cli_contract_path_without_contracts(path)
+}
+
+fn cli_contract_path_without_contracts(path: &str) -> bool {
+    path.starts_with("crates/tokmd/src/commands/")
+        || path.starts_with("crates/tokmd/src/cli/")
+        || path == "crates/tokmd/src/config.rs"
+}
+
+fn api_surface_path(path: &str, contracts: &Contracts) -> bool {
+    contracts.api_changed && api_surface_path_without_contracts(path)
+}
+
+fn api_surface_path_without_contracts(path: &str) -> bool {
+    path.ends_with("lib.rs") || path.ends_with("mod.rs")
 }
 
 #[cfg(test)]
@@ -89,6 +197,59 @@ mod tests {
         assert_eq!(plan[0].path, "alpha.rs");
         assert_eq!(plan[1].path, "middle.rs");
         assert_eq!(plan[2].path, "zeta.rs");
+    }
+
+    #[test]
+    fn test_review_plan_boosts_source_of_truth_contracts() {
+        let stats = vec![
+            make_stat("src/large.rs", 150, 100),
+            make_stat("docs/review-packet.md", 3, 2),
+            make_stat("docs/tutorial.md", 3, 2),
+        ];
+        let contracts = Contracts {
+            api_changed: false,
+            cli_changed: false,
+            schema_changed: false,
+            breaking_indicators: 0,
+        };
+        let plan = generate_review_plan(&stats, &contracts);
+        assert_eq!(plan[0].path, "docs/review-packet.md");
+        assert_eq!(plan[0].priority, 1);
+        assert_eq!(
+            plan[0].reason,
+            "source-of-truth contract changed; 5 lines changed"
+        );
+        assert_eq!(plan[1].path, "src/large.rs");
+        assert_eq!(plan[2].path, "docs/tutorial.md");
+    }
+
+    #[test]
+    fn test_review_plan_boosts_contract_and_policy_paths() {
+        let stats = vec![
+            make_stat("src/large.rs", 150, 100),
+            make_stat("docs/schema.json", 1, 1),
+            make_stat("ci/proof.toml", 1, 1),
+            make_stat("crates/tokmd/src/commands/cockpit.rs", 1, 1),
+            make_stat("crates/tokmd-core/src/lib.rs", 1, 1),
+        ];
+        let contracts = Contracts {
+            api_changed: true,
+            cli_changed: true,
+            schema_changed: true,
+            breaking_indicators: 2,
+        };
+        let plan = generate_review_plan(&stats, &contracts);
+        assert_eq!(plan[0].path, "docs/schema.json");
+        assert_eq!(plan[0].priority, 1);
+        assert_eq!(plan[1].path, "ci/proof.toml");
+        assert_eq!(plan[1].priority, 1);
+        assert_eq!(plan[2].path, "crates/tokmd/src/commands/cockpit.rs");
+        assert_eq!(plan[2].priority, 1);
+        assert_eq!(plan[3].path, "src/large.rs");
+        assert_eq!(plan[3].priority, 1);
+        assert_eq!(plan[4].path, "crates/tokmd-core/src/lib.rs");
+        assert_eq!(plan[4].priority, 2);
+        assert_eq!(plan[4].reason, "API surface changed; 2 lines changed");
     }
 
     #[test]

--- a/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_comment_with_contracts.snap
+++ b/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_comment_with_contracts.snap
@@ -22,4 +22,6 @@ expression: comment
 - [ ] Confirm breaking changes are documented
 
 **Priority review items**:
-- crates/tokmd/src/commands/new_cmd.rs (100 lines changed)
+- docs/schema.json (schema contract changed; 30 lines changed)
+- crates/tokmd/src/commands/new_cmd.rs (CLI contract changed; 100 lines changed)
+- src/lib.rs (API surface changed; 15 lines changed)

--- a/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_multi_file.snap
+++ b/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_multi_file.snap
@@ -60,7 +60,7 @@ expression: md
 ### Review Plan
 
 - **src/lib.rs** (priority: 2)
-  - Reason: 130 lines changed
+  - Reason: API surface changed; 130 lines changed
   - Complexity: 3
   - Lines changed: 130
 - **tests/integration_test.rs** (priority: 2)

--- a/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_with_failed_gates.snap
+++ b/crates/tokmd-cockpit/tests/snapshots/snapshot_w45__snapshot_cockpit_md_with_failed_gates.snap
@@ -60,6 +60,6 @@ expression: md
 ### Review Plan
 
 - **src/lib.rs** (priority: 2)
-  - Reason: 60 lines changed
+  - Reason: API surface changed; 60 lines changed
   - Complexity: 1
   - Lines changed: 60

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -51,7 +51,10 @@ The review packet directory is:
 ```
 
 `review-map.json` and `review-map.md` are derived from the existing cockpit
-`review_plan`. They do not add a new scoring model.
+`review_plan`. The plan keeps the existing priority fields, but may boost
+source-of-truth, schema, proof-policy, CLI-contract, and API-surface changes
+ahead of ordinary line-count ordering so reviewers see contract/control-plane
+changes early.
 
 The `proof/` directory is present only when explicit proof evidence artifacts
 are supplied. Missing optional proof artifacts are represented in evidence


### PR DESCRIPTION
## Summary
- rank cockpit review-plan items with deterministic contract/control-plane signals before ordinary line-count ties
- surface source-of-truth, schema, proof-policy, CLI-contract, and API-surface reasons in review-plan output
- update review-packet contract docs and snapshots for the new review-first wording

## Validation
- cargo test -p tokmd-cockpit review_plan --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo fmt-check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
- cargo run -p tokmd -- cockpit --base origin/main --head HEAD --doc-artifacts-check target/docs/doc-artifacts-check.json --review-packet-dir target/review-plan-evidence-smoke
- cargo xtask review-packet-check --dir target/review-plan-evidence-smoke
- cargo xtask proof-artifacts-check
- cargo xtask publish-surface --json --verify-publish
- git diff --check origin/main..HEAD