### PR TITLE
fix(cockpit): avoid ambiguous proof item refs

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_map_proof.rs
+++ b/crates/tokmd-cockpit/src/render/review_map_proof.rs
@@ -22,18 +22,13 @@ pub(super) fn review_map_proof_refs(
     let mut proof_index = 0;
 
     for input in proof_inputs {
-        let changed_files = input
-            .artifact
-            .changed_files()
-            .iter()
-            .map(|path| normalize_path_for_match(path))
-            .collect::<BTreeSet<_>>();
         let normalized = normalize_proof_evidence(
             &input.artifact,
             input.source_path.clone(),
             Some(&receipt.base_ref),
             Some(&receipt.head_ref),
         );
+        let changed_files = unambiguous_changed_files(input.artifact.changed_files(), &normalized);
 
         for proof in normalized {
             let mut refs = Vec::with_capacity(1 + proof.artifact_refs.len());
@@ -49,6 +44,25 @@ pub(super) fn review_map_proof_refs(
     }
 
     proof_refs
+}
+
+fn unambiguous_changed_files(
+    changed_files: &[String],
+    normalized: &[NormalizedProofEvidence],
+) -> BTreeSet<String> {
+    let scopes = normalized
+        .iter()
+        .filter_map(|proof| proof.scope.as_deref())
+        .collect::<BTreeSet<_>>();
+
+    if normalized.len() > 1 && scopes.len() > 1 {
+        return BTreeSet::new();
+    }
+
+    changed_files
+        .iter()
+        .map(|path| normalize_path_for_match(path))
+        .collect()
 }
 
 pub(super) struct ReviewMapItemProof {

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1092,6 +1092,115 @@ fn scenario_write_review_packet_includes_imported_proof_evidence() {
 }
 
 #[test]
+fn scenario_write_review_packet_keeps_ambiguous_multiscope_proof_packet_level() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut receipt = minimal_receipt();
+    receipt.review_plan = vec![
+        ReviewItem {
+            path: "crates/tokmd-cockpit/src/lib.rs".to_string(),
+            reason: "Cockpit review code changed".to_string(),
+            priority: 1,
+            complexity: Some(3),
+            lines_changed: Some(12),
+        },
+        ReviewItem {
+            path: "crates/tokmd/src/commands/cockpit.rs".to_string(),
+            reason: "CLI cockpit command changed".to_string(),
+            priority: 1,
+            complexity: Some(2),
+            lines_changed: Some(8),
+        },
+    ];
+    let out = dir.path().join("review");
+    let proof = tokmd_cockpit::parse_proof_evidence_input(
+        r#"{
+  "schema": "tokmd.proof_run_observation.v1",
+  "status": "passed",
+  "execution_status": "executed",
+  "profile": "fast",
+  "base": "main",
+  "head": "feature",
+  "ok": true,
+  "execution_guard": {
+    "enabled": true,
+    "ci": true,
+    "reason": "required proof-run summary verified"
+  },
+  "counts": {
+    "commands_total": 2,
+    "required_planned": 2,
+    "advisory_skipped": 0,
+    "executed": 2,
+    "passed": 2,
+    "failed": 0
+  },
+  "scopes": [
+    {
+      "name": "tokmd_cockpit",
+      "kind": "test",
+      "command": "cargo test -p tokmd-cockpit",
+      "status": "passed",
+      "exit_code": 0
+    },
+    {
+      "name": "tokmd_cli",
+      "kind": "test",
+      "command": "cargo test -p tokmd --test cockpit_integration",
+      "status": "passed",
+      "exit_code": 0
+    }
+  ],
+  "changed_files": [
+    "crates/tokmd-cockpit/src/lib.rs",
+    "crates/tokmd/src/commands/cockpit.rs"
+  ],
+  "unknown_files": []
+}"#,
+        "proof-run-observation.json",
+    )
+    .unwrap();
+
+    tokmd_cockpit::render::write_review_packet_with_proof_evidence(&out, &receipt, &[proof])
+        .unwrap();
+
+    let evidence: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("evidence.json")).unwrap()).unwrap();
+    let proof = evidence["proof"].as_array().expect("proof evidence array");
+    assert_eq!(proof.len(), 2);
+
+    let review_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
+            .unwrap();
+    let items = review_map["items"].as_array().expect("review-map items");
+    assert_eq!(items.len(), 2);
+    assert!(
+        review_map["evidence"]["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference == "evidence.json#/proof"),
+        "multi-scope proof should stay visible at packet level"
+    );
+    assert!(
+        items[0]["proof_refs"].as_array().unwrap().is_empty(),
+        "ambiguous top-level changed_files must not attach all scopes to the cockpit item"
+    );
+    assert!(
+        items[1]["proof_refs"].as_array().unwrap().is_empty(),
+        "ambiguous top-level changed_files must not attach all scopes to the CLI item"
+    );
+
+    let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    assert!(review_map_md.contains("Proof evidence overview:"));
+    assert!(review_map_md.contains("- Required proof: 2 passed, 0 failed, 0 missing"));
+    assert_eq!(
+        review_map_md.matches("   Proof:").count(),
+        0,
+        "ambiguous multi-scope proof should not render item-level proof blocks"
+    );
+}
+
+#[test]
 fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
     let dir = tempfile::tempdir().unwrap();
     let mut receipt = minimal_receipt();

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -215,6 +215,13 @@ The information should be visible in:
 - `review-map.md` item proof lines for review-first direct changed-file matches;
 - `comment.md` compact evidence availability and proof evidence totals.
 
+Item-level proof refs are intentionally conservative. Cockpit may attach proof
+to a review-map item when the imported proof artifact has unambiguous
+changed-file ownership, such as a single normalized proof item or multiple
+entries for one scope. Multi-scope artifacts with only a top-level
+`changed_files` list remain packet-level evidence until a policy-backed scope
+matcher can prove which files belong to which scope.
+
 Review map output should answer a reviewer-facing question:
 
 ```text


### PR DESCRIPTION
## Summary
- Keep imported multi-scope proof evidence packet-level when changed-file ownership is ambiguous.
- Continue emitting item-level proof refs only when proof ownership is unambiguous, preventing unrelated scope proof from appearing on review-map items.
- Document the conservative item-level proof-ref contract and add a regression packet test.

## Validation
- cargo test -p tokmd-cockpit scenario_write_review_packet_keeps_ambiguous_multiscope_proof_packet_level --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo fmt-check
- git diff --check
- cargo xtask publish-surface --json --verify-publish
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
- cargo run -p tokmd -- cockpit --base origin/main --head HEAD --doc-artifacts-check target/docs/doc-artifacts-check.json --review-packet-dir target/review-proof-disambiguation-smoke
- cargo xtask review-packet-check --dir target/review-proof-disambiguation-smoke
- cargo xtask proof-artifacts-check

## Notes
- No proof promotion, Codecov default, merge verdict, schema change, or new review command.
- Left unrelated local `.playwright-mcp/` untracked and unstaged.