### PR TITLE
docs: clarify agent handoff workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ tokmd context --budget 128k --mode bundle --output context.txt
 | Analysis | Risk, effort, complexity, duplication, git, and API-surface reports |
 | Review reports | Cockpit reports, sensor reports, gate verdicts |
 | Baselines | Ratchet-ready baseline JSON |
-| LLM context | Bounded bundles, redaction, handoff directories |
+| LLM context | Bounded bundles, redaction, [handoff directories](docs/handoff.md) |
 
 ## Choose a Path
 
@@ -219,6 +219,7 @@ The machine-readable capability contract lives in [`docs/capabilities/wasm.json`
 
 - [Install tokmd](docs/install.md) for Cargo, release binaries, Nix, and CI entry points
 - [Recipes](docs/recipes.md) for practical usage patterns
+- [Handoff bundles](docs/handoff.md) for coding-agent context and proof expectations
 - [Troubleshooting](docs/troubleshooting.md) for common problems and fixes
 - [Contributing](CONTRIBUTING.md) for local development and release work
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1044,6 +1044,7 @@ coverage = false
 name = "user_guides"
 kind = "non_rust"
 paths = [
+  "docs/handoff.md",
   "docs/recipes.md",
   "docs/tutorial.md",
   "docs/troubleshooting.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ schemas, and verification policy for `tokmd`.
 
 - [VERIFICATION.md](VERIFICATION.md) — README badge meanings, generated endpoints, and PR evidence boundaries.
 - [agent-workflows/source-of-truth.md](agent-workflows/source-of-truth.md) — maintainer and agent workflow for following source-of-truth artifacts.
+- [handoff.md](handoff.md) — coding-agent handoff bundle workflow and guardrails.
 - [reference-cli.md](reference-cli.md) — generated CLI flag reference.
 - [SCHEMA.md](SCHEMA.md) — receipt format documentation.
 - [architecture.md](architecture.md) — crate hierarchy and data flow.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,7 +1,15 @@
 # Handoff Bundles
 
-`tokmd handoff` creates a **self-contained bundle** for LLM review and automation.  
-It is intended to be pasted or uploaded as a stable, deterministic artifact.
+`tokmd handoff` creates a **self-contained bundle** for LLM review and
+automation. It is intended to be pasted or uploaded as a stable, deterministic
+artifact when a coding agent needs the right source slice without the whole
+repository.
+
+Use handoff when the job is:
+
+```text
+Give my coding agent the right context and proof expectations.
+```
 
 ## CLI
 
@@ -18,6 +26,68 @@ tokmd handoff --budget 128k --strategy spread
 # Disable git enrichment
 tokmd handoff --no-git
 ```
+
+## Agent Workflow
+
+For a plain repository handoff, start with the current risk preset and a bounded
+budget:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --out-dir .handoff
+```
+
+Give the agent these files in order:
+
+1. `.handoff/manifest.json` for the authoritative artifact index, token budget,
+   exclusions, and included-file list.
+2. `.handoff/intelligence.json` for tree, hotspot, complexity, and derived
+   signals.
+3. `.handoff/code.txt` for the selected source bundle.
+4. `.handoff/map.jsonl` when the agent needs full inventory or path lookup.
+
+For PR repair or review work in this repository, pair the handoff with cockpit
+and proof receipts:
+
+```bash
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan \
+  > target/proof/proof-plan.json
+
+cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
+
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --doc-artifacts-check target/docs/doc-artifacts-check.json \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --out-dir .handoff
+```
+
+Then give the agent the handoff plus the review evidence:
+
+- `.tokmd/review/comment.md` for the short review summary.
+- `.tokmd/review/review-map.md` for what to inspect first and reproduction
+  commands.
+- `.tokmd/review/evidence.json` for available, missing, stale, degraded,
+  skipped, and unavailable evidence.
+- `target/proof/proof-plan.json` for expected proof commands.
+- `target/tokmd/review-packet-check.json` for packet verification.
+
+The current `handoff` command does not yet import review-map or proof-plan
+artifacts into `.handoff/` automatically. Keep the directories adjacent and pass
+both to the agent when proof state matters.
 
 ## Output Tree
 
@@ -36,6 +106,18 @@ tokmd handoff --no-git
 2. **Use `map.jsonl`** for full inventory or downstream tooling.
 3. **Use `intelligence.json`** as a warning label (tree, hotspots, derived).
 4. **Use `code.txt`** as the LLM bundle content.
+
+## Agent Guardrails
+
+When using handoff output as an agent work order:
+
+- Treat missing, stale, degraded, skipped, or unavailable evidence as work to
+  resolve, not as passing proof.
+- Run reproduction commands from `.tokmd/review/review-map.md` before claiming a
+  repair is proven.
+- Keep generated receipts with the work when they explain review or proof state.
+- Do not promote advisory proof, enable default Codecov upload, or turn cockpit
+  into a merge verdict from a handoff bundle.
 
 ## Determinism Notes
 


### PR DESCRIPTION
## Summary
- Document a current, blessed `tokmd handoff` workflow for coding-agent context bundles.
- Show how to pair `.handoff/` with cockpit review packets, proof plans, doc-artifacts receipts, and review-packet verification receipts for PR repair work.
- Link the handoff guide from the README and docs index.
- Route `docs/handoff.md` through the user-guide proof scope so future handoff-doc changes are not unknown files.

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan
- cargo test -p xtask --verbose
- cargo xtask ci-lane-whitelist

## Notes
- Docs/proof-routing only; no product behavior, receipt schema, proof promotion, Codecov default, or handoff CLI change.
- Left unrelated local `.playwright-mcp/` untracked and unstaged.