### PR TITLE
feat(xtask): write proof plan json artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
           cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json > target/proof/affected.json
           affected_status=$?
 
-          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json
+          cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --plan-json target/proof/proof-plan.json --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json
           proof_plan_status=$?
 
           cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-artifacts-check.txt 2>&1
@@ -362,7 +362,7 @@ jobs:
           set +e
           mkdir -p target/proof-run
 
-          cargo xtask proof --profile "${PROOF_RUN_PROFILE}" --run-required --allow-ci-required-execution --proof-run-summary target/proof-run/proof-run-summary.json > target/proof-run/proof-plan.json
+          cargo xtask proof --profile "${PROOF_RUN_PROFILE}" --run-required --allow-ci-required-execution --plan-json target/proof-run/proof-plan.json --proof-run-summary target/proof-run/proof-run-summary.json
           proof_run_status=$?
 
           cargo xtask proof-run-artifacts-check --proof-run-summary target/proof-run/proof-run-summary.json > target/proof-run/proof-run-artifacts-check.txt 2>&1

--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -114,7 +114,7 @@ jobs:
           cargo xtask affected --base "origin/${PROOF_BASE_REF}" --head HEAD --json > target/proof/affected.json
           affected_status=$?
 
-          cargo xtask proof --profile affected --base "origin/${PROOF_BASE_REF}" --head HEAD --executor-mode execute --executor-max-commands "${PROOF_EXECUTOR_MAX_COMMANDS}" --allow-ci-evidence-execution --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json > target/proof/proof-plan.json
+          cargo xtask proof --profile affected --base "origin/${PROOF_BASE_REF}" --head HEAD --executor-mode execute --executor-max-commands "${PROOF_EXECUTOR_MAX_COMMANDS}" --allow-ci-evidence-execution --plan-json target/proof/proof-plan.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json
           executor_status=$?
 
           if [ -f target/proof/executor-summary.json ] && [ -f target/proof/executor-manifest.json ]; then

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -73,6 +73,7 @@ review usefulness.
 - Fixture-blob checks now read `ci/proof.toml` while preserving the existing crypto extension and marker detection plus the `.claude`, `.jules`, `vendor`, proof-policy source, and checker-source allowlist behavior.
 - `cargo xtask affected --base origin/main --head HEAD --json` now maps changed files to proof scopes from `ci/proof.toml`, reports unknown files, and keeps non-Rust unknown handling policy-driven.
 - `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` now prints a stable proof plan without running commands; `fast`, `release`, and `deep` profiles are plan-only placeholders for the next CI integration slices.
+- `cargo xtask proof --plan --plan-json <path>` now writes the same `tokmd.proof_plan.v1` report as a Rust-owned JSON artifact, so CI and handoff workflows do not need to rely on shell redirection to capture `proof-plan.json`.
 - CI now validates `cargo xtask proof-policy --check` as part of the required aggregate and uploads PR-only affected proof artifacts while keeping existing jobs authoritative.
 - The proof scope registry now covers first-class product/control-plane surfaces for CLI, gate, cockpit, WASM, browser runner, the composite GitHub Action, schema contracts, and the proof control plane.
 - Release, mutation, Nix validation, and label-sync workflows now have explicit proof-scope routing so Dependabot or workflow-only action updates do not fail affected planning as unknown files before they reach their relevant release, policy, or documentation proof.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -54,7 +54,7 @@ and proof receipts:
 
 ```bash
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan \
-  > target/proof/proof-plan.json
+  --plan-json target/proof/proof-plan.json
 
 cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -595,6 +595,10 @@ pub struct ProofArgs {
     #[arg(long, value_name = "PATH")]
     pub summary_md: Option<std::path::PathBuf>,
 
+    /// Write the generated proof plan JSON report to this path
+    #[arg(long, value_name = "PATH")]
+    pub plan_json: Option<std::path::PathBuf>,
+
     /// Write a machine-readable planned evidence summary for the generated proof plan
     #[arg(long, value_name = "PATH")]
     pub evidence_json: Option<std::path::PathBuf>,

--- a/xtask/src/tasks/proof_plan.rs
+++ b/xtask/src/tasks/proof_plan.rs
@@ -265,6 +265,10 @@ pub fn run(args: ProofArgs) -> Result<()> {
     let policy = load_checked_policy(&args.policy)?;
     let report = proof_plan_report(&policy, &args)?;
 
+    if let Some(path) = &args.plan_json {
+        write_plan_json(path, &report)?;
+    }
+
     if args.executor_mode == ProofExecutorMode::Execute {
         let executor_config = proof_executor_config(&policy, args.executor_max_commands)?;
         run_executor_mode(&args, &report, &executor_config)?;
@@ -583,6 +587,12 @@ fn write_markdown_summary(
 ) -> Result<()> {
     ensure_parent_dir(path)?;
     fs::write(path, render_markdown_summary(report, executor_summary))?;
+    Ok(())
+}
+
+fn write_plan_json(path: &Path, report: &ProofPlanReport) -> Result<()> {
+    ensure_parent_dir(path)?;
+    fs::write(path, serde_json::to_string_pretty(report)?)?;
     Ok(())
 }
 

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -51,6 +51,7 @@ fn proof_help_mentions_profile_and_plan() {
         "stdout: {stdout}"
     );
     assert!(stdout.contains("--summary-md"), "stdout: {stdout}");
+    assert!(stdout.contains("--plan-json"), "stdout: {stdout}");
     assert!(stdout.contains("--evidence-json"), "stdout: {stdout}");
     assert!(stdout.contains("--executor-summary"), "stdout: {stdout}");
     assert!(stdout.contains("--executor-manifest"), "stdout: {stdout}");
@@ -203,6 +204,45 @@ fn affected_plan_ci_blocks_on_planner_generation_failures() {
 }
 
 #[test]
+fn proof_plan_json_writes_plan_report_artifact() {
+    let root = workspace_root();
+    let path = root
+        .join("target")
+        .join("proof-plan-w92")
+        .join("proof-plan.json");
+    if path.exists() {
+        fs::remove_file(&path).expect("stale proof-plan fixture should be removable");
+    }
+
+    let path_arg = path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof",
+        "--profile",
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--plan",
+        "--plan-json",
+        &path_arg,
+    ]);
+
+    assert!(success, "proof --plan-json failed. stderr: {stderr}");
+    assert!(stdout.contains("\"schema\": \"tokmd.proof_plan.v1\""));
+    assert!(path.exists(), "proof plan artifact should be written");
+
+    let written = fs::read_to_string(&path).expect("proof plan artifact should be readable");
+    let stdout_json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout proof plan should be JSON");
+    let written_json: serde_json::Value =
+        serde_json::from_str(&written).expect("written proof plan should be JSON");
+
+    assert_eq!(written_json["schema"], "tokmd.proof_plan.v1");
+    assert_eq!(written_json, stdout_json);
+}
+
+#[test]
 fn fast_proof_run_ci_job_is_advisory_and_verified() {
     let ci = fs::read_to_string(workspace_root().join(".github/workflows/ci.yml"))
         .expect("ci workflow should be readable");
@@ -227,6 +267,10 @@ fn fast_proof_run_ci_job_is_advisory_and_verified() {
     assert!(
         ci.contains("cargo xtask proof --profile \"${PROOF_RUN_PROFILE}\" --run-required --allow-ci-required-execution"),
         "fast proof job should use the policy-selected required proof runner"
+    );
+    assert!(
+        ci.contains("--plan-json target/proof-run/proof-plan.json"),
+        "fast proof job should write the proof plan as a Rust-owned JSON artifact"
     );
     assert!(
         ci.contains("cargo xtask proof-run-artifacts-check --proof-run-summary target/proof-run/proof-run-summary.json"),
@@ -297,6 +341,10 @@ fn scoped_coverage_executor_is_pr_visible_but_not_required() {
     assert!(
         executor.contains("cargo xtask proof-policy --json > target/proof/proof-policy.json"),
         "executor workflow should resolve PR defaults from proof policy"
+    );
+    assert!(
+        executor.contains("--plan-json target/proof/proof-plan.json"),
+        "executor workflow should write the proof plan as a Rust-owned JSON artifact"
     );
     assert!(
         executor.contains("pr.get(\"default_enabled\") is not True"),


### PR DESCRIPTION
## Summary
- Add `cargo xtask proof --plan-json <path>` so xtask writes the `tokmd.proof_plan.v1` report directly as a JSON artifact.
- Update affected-plan, fast-proof-run, and proof-executor workflow steps to use Rust-owned plan artifact generation instead of shell stdout redirection.
- Update handoff/NEXT docs to point at the new artifact path.

## Guardrails
- No proof promotion.
- No default Codecov upload.
- No merge verdict behavior.
- No proof plan schema change.

## Validation
- `cargo test -p xtask proof_plan_json_writes_plan_report_artifact --verbose`
- `cargo test -p xtask proof_help_mentions_profile_and_plan --verbose`
- `cargo test -p xtask --test proof_plan_w92 --verbose`
- `cargo test -p xtask --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask proof-policy --check`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask ci-lane-whitelist`
- `cargo xtask check-clippy-exceptions`
- `cargo xtask check-lint-policy`
- `cargo xtask check-no-panic-family`
- `cargo xtask affected --base origin/main --head HEAD --json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo fmt-check`
- `git diff --check`