### PR TITLE
feat(xtask): write affected json artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
           set +e
           mkdir -p target/proof
 
-          cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json > target/proof/affected.json
+          cargo xtask affected --base "origin/${{ github.base_ref }}" --head HEAD --json-output target/proof/affected.json
           affected_status=$?
 
           cargo xtask proof --profile affected --base "origin/${{ github.base_ref }}" --head HEAD --plan --plan-json target/proof/proof-plan.json --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json

--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -111,7 +111,7 @@ jobs:
           mkdir -p target/proof
           cargo llvm-cov clean --workspace
 
-          cargo xtask affected --base "origin/${PROOF_BASE_REF}" --head HEAD --json > target/proof/affected.json
+          cargo xtask affected --base "origin/${PROOF_BASE_REF}" --head HEAD --json-output target/proof/affected.json
           affected_status=$?
 
           cargo xtask proof --profile affected --base "origin/${PROOF_BASE_REF}" --head HEAD --executor-mode execute --executor-max-commands "${PROOF_EXECUTOR_MAX_COMMANDS}" --allow-ci-evidence-execution --plan-json target/proof/proof-plan.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -72,6 +72,7 @@ review usefulness.
 - Dependency-boundary checks now read `ci/proof.toml` while preserving the existing sorted `tokmd-analysis*` manifest scan and `dependencies` / `dev-dependencies` / `build-dependencies` coverage.
 - Fixture-blob checks now read `ci/proof.toml` while preserving the existing crypto extension and marker detection plus the `.claude`, `.jules`, `vendor`, proof-policy source, and checker-source allowlist behavior.
 - `cargo xtask affected --base origin/main --head HEAD --json` now maps changed files to proof scopes from `ci/proof.toml`, reports unknown files, and keeps non-Rust unknown handling policy-driven.
+- `cargo xtask affected --base origin/main --head HEAD --json-output <path>` now writes the same `tokmd.affected.v1` report as a Rust-owned JSON artifact, so CI and handoff workflows do not need shell redirection to capture `affected.json`.
 - `cargo xtask proof --profile affected --base origin/main --head HEAD --plan` now prints a stable proof plan without running commands; `fast`, `release`, and `deep` profiles are plan-only placeholders for the next CI integration slices.
 - `cargo xtask proof --plan --plan-json <path>` now writes the same `tokmd.proof_plan.v1` report as a Rust-owned JSON artifact, so CI and handoff workflows do not need to rely on shell redirection to capture `proof-plan.json`.
 - CI now validates `cargo xtask proof-policy --check` as part of the required aggregate and uploads PR-only affected proof artifacts while keeping existing jobs authoritative.

--- a/docs/agent-workflows/source-of-truth.md
+++ b/docs/agent-workflows/source-of-truth.md
@@ -69,7 +69,7 @@ Use the relevant subset:
 cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
 cargo xtask docs --check
 cargo xtask proof-policy --check
-cargo xtask affected --base origin/main --head HEAD --json
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan
 cargo fmt-check
 git diff --check

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -53,6 +53,11 @@ For PR repair or review work in this repository, pair the handoff with cockpit
 and proof receipts:
 
 ```bash
+cargo xtask affected \
+  --base origin/main \
+  --head HEAD \
+  --json-output target/proof/affected.json
+
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan \
   --plan-json target/proof/proof-plan.json
 
@@ -82,6 +87,7 @@ Then give the agent the handoff plus the review evidence:
   commands.
 - `.tokmd/review/evidence.json` for available, missing, stale, degraded,
   skipped, and unavailable evidence.
+- `target/proof/affected.json` for changed files and matched proof scopes.
 - `target/proof/proof-plan.json` for expected proof commands.
 - `target/tokmd/review-packet-check.json` for packet verification.
 

--- a/docs/plans/doc-artifacts-check.md
+++ b/docs/plans/doc-artifacts-check.md
@@ -111,7 +111,7 @@ Each implementation PR should run the relevant subset of:
 cargo xtask doc-artifacts --check
 cargo xtask docs --check
 cargo xtask proof-policy --check
-cargo xtask affected --base origin/main --head HEAD --json
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan
 cargo fmt-check
 git diff --check

--- a/docs/specs/doc-artifacts.md
+++ b/docs/specs/doc-artifacts.md
@@ -167,7 +167,7 @@ The implementation PR for `cargo xtask doc-artifacts --check` should run:
 cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
 cargo xtask docs --check
 cargo xtask proof-policy --check
-cargo xtask affected --base origin/main --head HEAD --json
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan
 cargo fmt-check
 git diff --check

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -28,7 +28,7 @@ Each implementation PR should run the relevant subset of:
 cargo xtask doc-artifacts --check
 cargo xtask docs --check
 cargo xtask proof-policy --check
-cargo xtask affected --base origin/main --head HEAD --json
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan
 cargo fmt-check
 git diff --check

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -548,6 +548,10 @@ pub struct AffectedArgs {
     #[arg(long)]
     pub json: bool,
 
+    /// Write the machine-readable affected-scope report to a JSON artifact
+    #[arg(long, value_name = "PATH")]
+    pub json_output: Option<std::path::PathBuf>,
+
     /// Policy file to use for scope matching
     #[arg(long, default_value = "ci/proof.toml")]
     pub policy: std::path::PathBuf,

--- a/xtask/src/tasks/affected.rs
+++ b/xtask/src/tasks/affected.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result, bail};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -43,6 +44,10 @@ pub fn run(args: AffectedArgs) -> Result<()> {
     let changed_files = changed_files(&args.base, &args.head)?;
     let report = affected_report(&policy, &args.base, &args.head, changed_files)?;
 
+    if let Some(path) = &args.json_output {
+        write_json_output(path, &report)?;
+    }
+
     if args.json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
@@ -57,6 +62,16 @@ pub fn run(args: AffectedArgs) -> Result<()> {
             report.unknown_files.len()
         )
     }
+}
+
+fn write_json_output(path: &Path, report: &AffectedReport) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_string_pretty(report)?)?;
+    Ok(())
 }
 
 pub(crate) fn load_checked_policy(path: &Path) -> Result<ProofPolicy> {

--- a/xtask/tests/affected_w91.rs
+++ b/xtask/tests/affected_w91.rs
@@ -31,6 +31,7 @@ fn affected_help_mentions_base_head_and_json() {
     assert!(stdout.contains("--base"), "stdout: {stdout}");
     assert!(stdout.contains("--head"), "stdout: {stdout}");
     assert!(stdout.contains("--json"), "stdout: {stdout}");
+    assert!(stdout.contains("--json-output"), "stdout: {stdout}");
 }
 
 #[test]
@@ -49,6 +50,43 @@ fn affected_json_reports_no_changes_for_same_ref() {
     assert!(value["changed_files"].as_array().unwrap().is_empty());
     assert!(value["scopes"].as_array().unwrap().is_empty());
     assert!(value["unknown_files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn affected_json_output_writes_report_artifact() {
+    let root = workspace_root();
+    let path = root
+        .join("target")
+        .join("affected-w91")
+        .join("affected.json");
+    if path.exists() {
+        std::fs::remove_file(&path).expect("stale affected fixture should be removable");
+    }
+
+    let path_arg = path.to_string_lossy().to_string();
+    let (stdout, stderr, success) = run_xtask(&[
+        "affected",
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--json",
+        "--json-output",
+        &path_arg,
+    ]);
+
+    assert!(success, "affected --json-output failed. stderr: {stderr}");
+    assert!(stdout.contains("\"schema\": \"tokmd.affected.v1\""));
+    assert!(path.exists(), "affected artifact should be written");
+
+    let written = std::fs::read_to_string(&path).expect("affected artifact should be readable");
+    let stdout_json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout affected report should be JSON");
+    let written_json: serde_json::Value =
+        serde_json::from_str(&written).expect("written affected report should be JSON");
+
+    assert_eq!(written_json["schema"], "tokmd.affected.v1");
+    assert_eq!(written_json, stdout_json);
 }
 
 #[test]

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -184,6 +184,14 @@ fn affected_plan_ci_blocks_on_planner_generation_failures() {
         "affected-plan summary should keep executor command execution disabled"
     );
     assert!(
+        ci.contains("--json-output target/proof/affected.json"),
+        "affected-plan job should write affected.json through xtask instead of shell redirection"
+    );
+    assert!(
+        !ci.contains("--json > target/proof/affected.json"),
+        "affected-plan job should not capture affected.json with shell redirection"
+    );
+    assert!(
         ci.contains(
             "if [ \"${affected_status}\" -ne 0 ]; then\n            exit \"${affected_status}\"\n          fi"
         ),
@@ -345,6 +353,14 @@ fn scoped_coverage_executor_is_pr_visible_but_not_required() {
     assert!(
         executor.contains("--plan-json target/proof/proof-plan.json"),
         "executor workflow should write the proof plan as a Rust-owned JSON artifact"
+    );
+    assert!(
+        executor.contains("--json-output target/proof/affected.json"),
+        "executor workflow should write affected.json through xtask instead of shell redirection"
+    );
+    assert!(
+        !executor.contains("--json > target/proof/affected.json"),
+        "executor workflow should not capture affected.json with shell redirection"
     );
     assert!(
         executor.contains("pr.get(\"default_enabled\") is not True"),


### PR DESCRIPTION
## Summary
- Add `cargo xtask affected --json-output <path>` so `tokmd.affected.v1` can be written directly as a Rust-owned artifact while preserving existing `--json` stdout behavior.
- Update affected-plan CI and proof-executor workflows to create `target/proof/affected.json` through xtask instead of shell redirection.
- Update handoff/source-of-truth docs and workflow tests to use the artifact path.

## Guardrails
- No proof promotion.
- No default Codecov upload.
- No merge verdict behavior.
- No affected report schema change.

## Validation
- `cargo test -p xtask --test affected_w91 --verbose`
- `cargo test -p xtask --test proof_plan_w92 --verbose`
- `cargo test -p xtask --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-policy --check`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask ci-lane-whitelist`
- `cargo xtask check-clippy-exceptions`
- `cargo xtask check-lint-policy`
- `cargo xtask check-no-panic-family`
- `cargo fmt-check`
- `git diff --check`