### PR TITLE
feat(cockpit): rank review map by evidence risk

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -25,11 +25,21 @@ pub(super) fn review_packet_review_map(
     let has_doc_artifacts_evidence = doc_artifacts.is_some() || doc_artifacts_expected(receipt);
     let evidence_refs =
         review_map_evidence_refs(!proof_refs.is_empty(), has_doc_artifacts_evidence);
-    let items: Vec<_> = receipt
-        .review_plan
+    let ordered_items = ordered_review_map_items(receipt);
+    let items: Vec<_> = ordered_items
         .iter()
         .enumerate()
-        .map(|(idx, item)| review_map_item(idx, item, receipt, &proof_refs, doc_artifacts))
+        .map(|(rank, ordered)| {
+            review_map_item(
+                rank + 1,
+                ordered.source_index,
+                ordered.item,
+                receipt,
+                &ordered.evidence,
+                &proof_refs,
+                doc_artifacts,
+            )
+        })
         .collect();
 
     json!({
@@ -48,19 +58,21 @@ pub(super) fn review_packet_review_map(
 }
 
 fn review_map_item(
-    idx: usize,
+    rank: usize,
+    source_index: usize,
     item: &ReviewItem,
     receipt: &CockpitReceipt,
+    evidence: &ReviewMapItemEvidence,
     proof_refs: &[ReviewMapProofRef],
     doc_artifacts: Option<&DocArtifactsEvidenceInput>,
 ) -> Value {
-    let evidence = review_map_item_evidence(item, receipt);
     let proof = review_map_item_proof(item, proof_refs);
     let doc_artifacts_refs = review_map_item_doc_artifacts_refs(item, doc_artifacts);
     let reproduce = review_map_item_reproduce(item, receipt);
 
     json!({
-        "rank": idx + 1,
+        "rank": rank,
+        "source_index": source_index,
         "path": &item.path,
         "priority": item.priority,
         "priority_label": review_priority_label(item.priority),
@@ -68,23 +80,121 @@ fn review_map_item(
         "complexity": item.complexity,
         "lines_changed": item.lines_changed,
         "evidence_refs": [
-            format!("cockpit.json#/review_plan/{idx}"),
+            format!("cockpit.json#/review_plan/{source_index}"),
             "evidence.json#/gates",
         ],
         "proof_refs": proof.refs,
         "doc_artifacts_refs": doc_artifacts_refs,
         "evidence": {
             "status": evidence.status(),
-            "present": evidence.present,
-            "missing": evidence.missing,
-            "degraded": evidence.degraded,
-            "stale": evidence.stale,
-            "skipped": evidence.skipped,
-            "unavailable": evidence.unavailable,
+            "present": &evidence.present,
+            "missing": &evidence.missing,
+            "degraded": &evidence.degraded,
+            "stale": &evidence.stale,
+            "skipped": &evidence.skipped,
+            "unavailable": &evidence.unavailable,
             "refs": ["evidence.json#/gates"],
         },
         "reproduce": reproduce,
     })
+}
+
+struct OrderedReviewMapItem<'a> {
+    source_index: usize,
+    item: &'a ReviewItem,
+    evidence: ReviewMapItemEvidence,
+}
+
+fn ordered_review_map_items(receipt: &CockpitReceipt) -> Vec<OrderedReviewMapItem<'_>> {
+    let mut items: Vec<_> = receipt
+        .review_plan
+        .iter()
+        .enumerate()
+        .map(|(source_index, item)| OrderedReviewMapItem {
+            source_index,
+            item,
+            evidence: review_map_item_evidence(item, receipt),
+        })
+        .collect();
+
+    items.sort_by(|a, b| {
+        review_order_bucket(a.item, &a.evidence)
+            .cmp(&review_order_bucket(b.item, &b.evidence))
+            .then_with(|| a.item.priority.cmp(&b.item.priority))
+            .then_with(|| {
+                b.item
+                    .complexity
+                    .unwrap_or(0)
+                    .cmp(&a.item.complexity.unwrap_or(0))
+            })
+            .then_with(|| {
+                b.item
+                    .lines_changed
+                    .unwrap_or(0)
+                    .cmp(&a.item.lines_changed.unwrap_or(0))
+            })
+            .then_with(|| a.item.path.cmp(&b.item.path))
+            .then_with(|| a.source_index.cmp(&b.source_index))
+    });
+
+    items
+}
+
+fn review_order_bucket(item: &ReviewItem, evidence: &ReviewMapItemEvidence) -> u8 {
+    if review_item_is_source_of_truth(item) {
+        0
+    } else if !evidence.missing.is_empty() {
+        1
+    } else if !evidence.stale.is_empty() {
+        2
+    } else if !evidence.degraded.is_empty() {
+        3
+    } else if item.complexity.unwrap_or(0) >= 4 {
+        4
+    } else if review_contract_path(&item.path) {
+        5
+    } else if item.priority <= 1 {
+        6
+    } else if item.priority == 2 {
+        7
+    } else if !evidence.present.is_empty() {
+        8
+    } else if !evidence.skipped.is_empty() {
+        9
+    } else {
+        10
+    }
+}
+
+fn review_contract_path(path: &str) -> bool {
+    schema_review_path(path)
+        || policy_review_path(path)
+        || cli_review_path(path)
+        || api_review_path(path)
+}
+
+fn schema_review_path(path: &str) -> bool {
+    path == "docs/schema.json"
+        || path == "docs/SCHEMA.md"
+        || path.starts_with("docs/") && path.ends_with(".schema.json")
+        || path.starts_with("crates/tokmd/schemas/")
+}
+
+fn policy_review_path(path: &str) -> bool {
+    path == "ci/proof.toml"
+        || path == "codecov.yml"
+        || path.starts_with("policy/")
+        || path.starts_with(".github/workflows/")
+}
+
+fn cli_review_path(path: &str) -> bool {
+    path.starts_with("crates/tokmd/src/commands/")
+        || path.starts_with("crates/tokmd/src/cli/")
+        || path == "crates/tokmd/src/config.rs"
+}
+
+fn api_review_path(path: &str) -> bool {
+    path.ends_with("lib.rs") || path.ends_with("mod.rs")
 }
 
 fn review_map_item_reproduce(item: &ReviewItem, receipt: &CockpitReceipt) -> Vec<String> {
@@ -241,15 +351,17 @@ pub(super) fn render_review_map_md(
     let _ = writeln!(s, "## Review First");
     let _ = writeln!(s);
 
-    for (idx, item) in receipt.review_plan.iter().enumerate() {
-        let evidence = review_map_item_evidence(item, receipt);
+    for (rank, ordered) in ordered_review_map_items(receipt).iter().enumerate() {
+        let item = ordered.item;
+        let source_index = ordered.source_index;
+        let evidence = &ordered.evidence;
         let proof = review_map_item_proof(item, &proof_refs);
         let _ = writeln!(
             s,
             "{}. `{}`
    Priority: {} ({})
    Why it matters: {}",
-            idx + 1,
+            rank + 1,
             item.path,
             item.priority,
             review_priority_label(item.priority),
@@ -272,7 +384,7 @@ pub(super) fn render_review_map_md(
         write_doc_artifacts_block(&mut s, item, doc_artifacts);
         write_proof_block(&mut s, &proof);
         let _ = writeln!(s, "   Evidence references:");
-        let _ = writeln!(s, "   - cockpit.json#/review_plan/{idx}");
+        let _ = writeln!(s, "   - cockpit.json#/review_plan/{source_index}");
         let _ = writeln!(s, "   - evidence.json#/gates");
         let _ = writeln!(s, "   Reproduce:");
         let _ = writeln!(

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -930,6 +930,140 @@ fn scenario_write_review_packet_creates_contract_files() {
 }
 
 #[test]
+fn scenario_review_map_orders_review_first_by_evidence_risk() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut receipt = minimal_receipt();
+    receipt.evidence.mutation.meta.status = GateStatus::Pass;
+    receipt.evidence.mutation.meta.commit_match = CommitMatch::Exact;
+    receipt.evidence.diff_coverage = Some(DiffCoverageGate {
+        meta: GateMeta {
+            status: GateStatus::Pending,
+            source: EvidenceSource::CiArtifact,
+            commit_match: CommitMatch::Unknown,
+            scope: ScopeCoverage {
+                relevant: vec!["src/missing.rs".to_string()],
+                tested: Vec::new(),
+                ratio: 0.0,
+                lines_relevant: Some(12),
+                lines_tested: Some(0),
+            },
+            evidence_commit: None,
+            evidence_generated_at_ms: None,
+        },
+        lines_added: 12,
+        lines_covered: 0,
+        coverage_pct: 0.0,
+        uncovered_hunks: vec![UncoveredHunk {
+            file: "src/missing.rs".to_string(),
+            start_line: 1,
+            end_line: 12,
+        }],
+    });
+    receipt.review_plan = vec![
+        ReviewItem {
+            path: "src/available.rs".to_string(),
+            reason: "Large changed file".to_string(),
+            priority: 1,
+            complexity: Some(5),
+            lines_changed: Some(400),
+        },
+        ReviewItem {
+            path: "src/missing.rs".to_string(),
+            reason: "Diff coverage evidence is missing".to_string(),
+            priority: 2,
+            complexity: Some(1),
+            lines_changed: Some(12),
+        },
+    ];
+    let out = dir.path().join("review");
+
+    tokmd_cockpit::render::write_review_packet(&out, &receipt).unwrap();
+
+    let review_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
+            .unwrap();
+    assert_eq!(review_map["items"][0]["rank"], 1);
+    assert_eq!(review_map["items"][0]["path"], "src/missing.rs");
+    assert_eq!(review_map["items"][0]["source_index"], 1);
+    assert_eq!(
+        review_map["items"][0]["evidence_refs"][0],
+        "cockpit.json#/review_plan/1"
+    );
+    assert_eq!(review_map["items"][0]["evidence"]["status"], "missing");
+    assert_eq!(review_map["items"][1]["rank"], 2);
+    assert_eq!(review_map["items"][1]["path"], "src/available.rs");
+    assert_eq!(review_map["items"][1]["source_index"], 0);
+    assert_eq!(
+        review_map["items"][1]["evidence_refs"][0],
+        "cockpit.json#/review_plan/0"
+    );
+
+    let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    let missing_pos = review_map_md
+        .find("1. `src/missing.rs`")
+        .expect("missing-evidence item should be first");
+    let available_pos = review_map_md
+        .find("2. `src/available.rs`")
+        .expect("available-evidence item should be second");
+    assert!(
+        missing_pos < available_pos,
+        "review-map Markdown should order missing evidence before raw size"
+    );
+}
+
+#[test]
+fn scenario_review_map_orders_contract_paths_before_ordinary_low_priority_items() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut receipt = minimal_receipt();
+    receipt.review_plan = vec![
+        ReviewItem {
+            path: "docs/NEXT.md".to_string(),
+            reason: "Program note changed".to_string(),
+            priority: 3,
+            complexity: Some(1),
+            lines_changed: Some(4),
+        },
+        ReviewItem {
+            path: "crates/tokmd/schemas/review-map.schema.json".to_string(),
+            reason: "Review-map schema changed".to_string(),
+            priority: 3,
+            complexity: Some(1),
+            lines_changed: Some(1),
+        },
+    ];
+    let out = dir.path().join("review");
+
+    tokmd_cockpit::render::write_review_packet(&out, &receipt).unwrap();
+
+    let review_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("review-map.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        review_map["items"][0]["path"],
+        "crates/tokmd/schemas/review-map.schema.json"
+    );
+    assert_eq!(review_map["items"][0]["source_index"], 1);
+    assert_eq!(
+        review_map["items"][0]["evidence_refs"][0],
+        "cockpit.json#/review_plan/1"
+    );
+    assert_eq!(review_map["items"][1]["path"], "docs/NEXT.md");
+    assert_eq!(review_map["items"][1]["source_index"], 0);
+
+    let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    let schema_pos = review_map_md
+        .find("1. `crates/tokmd/schemas/review-map.schema.json`")
+        .expect("schema contract item should be first");
+    let ordinary_pos = review_map_md
+        .find("2. `docs/NEXT.md`")
+        .expect("ordinary low-priority item should be second");
+    assert!(
+        schema_pos < ordinary_pos,
+        "schema contract paths should be reviewed before ordinary low-priority docs"
+    );
+}
+
+#[test]
 fn scenario_write_review_packet_includes_imported_proof_evidence() {
     let dir = tempfile::tempdir().unwrap();
     let mut receipt = minimal_receipt();

--- a/crates/tokmd/schemas/review-map.schema.json
+++ b/crates/tokmd/schemas/review-map.schema.json
@@ -131,6 +131,7 @@
       ],
       "properties": {
         "rank": { "type": "integer", "minimum": 1 },
+        "source_index": { "type": "integer", "minimum": 0 },
         "path": { "type": "string", "minLength": 1 },
         "priority": { "type": "integer", "minimum": 0 },
         "priority_label": {

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -206,6 +206,11 @@ review usefulness.
 - Hosted review-packet comments now show verifier status, manifest hash status,
   and compact proof evidence counts while keeping packet-local `comment.md`
   immutable after manifest hashing.
+- Cockpit review maps now order packet items for review-first use by preserving
+  source-of-truth changes first, then missing/stale/degraded evidence,
+  high-complexity items, and contract paths, while keeping
+  `cockpit.json#/review_plan/<index>` refs pointed at the original receipt
+  order.
 - `docs/cockpit-proof-evidence.md` now includes the maintainer-facing local
   workflow for planning proof, optionally executing guarded required proof,
   importing proof artifacts, and verifying the review packet.

--- a/docs/review-map.schema.json
+++ b/docs/review-map.schema.json
@@ -131,6 +131,7 @@
       ],
       "properties": {
         "rank": { "type": "integer", "minimum": 1 },
+        "source_index": { "type": "integer", "minimum": 0 },
         "path": { "type": "string", "minLength": 1 },
         "priority": { "type": "integer", "minimum": 0 },
         "priority_label": {

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -51,10 +51,12 @@ The review packet directory is:
 ```
 
 `review-map.json` and `review-map.md` are derived from the existing cockpit
-`review_plan`. The plan keeps the existing priority fields, but may boost
-source-of-truth, schema, proof-policy, CLI-contract, and API-surface changes
-ahead of ordinary line-count ordering so reviewers see contract/control-plane
-changes early.
+`review_plan`. The packet keeps the original receipt order in `cockpit.json`,
+but the review map may reorder items for review-first use: source-of-truth
+items stay first, then missing/stale/degraded evidence, high-complexity items,
+contract paths, existing cockpit priority, changed lines, and path. Each item
+keeps evidence refs back to its original `cockpit.json#/review_plan/<index>`
+source.
 
 The `proof/` directory is present only when explicit proof evidence artifacts
 are supplied. Missing optional proof artifacts are represented in evidence


### PR DESCRIPTION
## Summary
- order `review-map.json` and `review-map.md` for review-first use without changing `cockpit.json` receipt order
- add `source_index` so reordered review-map items keep stable refs to the original `cockpit.json#/review_plan/<index>` entries
- prioritize source-of-truth changes, missing/stale/degraded evidence, high-complexity files, contract paths, then existing priority/size/path tie-breakers
- update schema/docs and add review-map ordering coverage

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit --test bdd review_map --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo test -p tokmd --test schema_doc_sync --verbose`
- `cargo test -p tokmd --test schema_sync --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask docs --check`
- `cargo xtask doc-artifacts --check`
- `cargo xtask proof-policy --check`
- `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json`
- `cargo run -p tokmd -- cockpit --base origin/main --head HEAD --doc-artifacts-check target/docs/doc-artifacts-check.json --review-packet-dir target/review-map-order-smoke`
- `cargo xtask review-packet-check --dir target/review-map-order-smoke --json target/tokmd/review-packet-check.json`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --summary-md target/proof/proof-plan.md --evidence-json target/proof/proof-evidence.json --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `cargo xtask proof-artifacts-check --executor-summary target/proof/executor-summary.json --executor-manifest target/proof/executor-manifest.json`
- `git diff --check HEAD~1..HEAD`

## Boundaries
- no proof promotion
- no default Codecov upload
- no merge verdict behavior
- no new `tokmd review` command