### PR TITLE
feat(handoff): link review and proof artifacts

### DIFF
--- a/crates/tokmd/src/cli/parser/context.rs
+++ b/crates/tokmd/src/cli/parser/context.rs
@@ -191,6 +191,22 @@ pub struct HandoffArgs {
     /// Hard cap on tokens per file (overrides percentage-based cap).
     #[arg(long)]
     pub max_file_tokens: Option<usize>,
+
+    /// Link an existing cockpit review packet directory from the handoff bundle.
+    #[arg(long)]
+    pub review_packet_dir: Option<PathBuf>,
+
+    /// Link an existing review-packet verifier receipt from the handoff bundle.
+    #[arg(long)]
+    pub review_packet_check: Option<PathBuf>,
+
+    /// Link an existing affected-proof report from the handoff bundle.
+    #[arg(long)]
+    pub affected: Option<PathBuf>,
+
+    /// Link an existing proof-plan report from the handoff bundle.
+    #[arg(long)]
+    pub proof_plan: Option<PathBuf>,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/crates/tokmd/src/commands/handoff.rs
+++ b/crates/tokmd/src/commands/handoff.rs
@@ -28,7 +28,7 @@ mod output;
 
 use capabilities::{detect_capabilities, should_compute_git};
 use intelligence::build_intelligence;
-use output::{write_manifest_json, write_payloads};
+use output::{HandoffLinkInputs, write_link_artifacts, write_manifest_json, write_payloads};
 
 const DEFAULT_TREE_DEPTH: usize = 4;
 
@@ -144,13 +144,23 @@ pub(crate) fn handle(args: cli::HandoffArgs, global: &cli::GlobalArgs) -> Result
         .unwrap_or_default()
         .as_millis();
 
-    let payloads = write_payloads(
+    let mut payloads = write_payloads(
         &args.out_dir,
         &export,
         &intelligence,
         &selected,
         args.compress,
     )?;
+    let mut link_artifacts = write_link_artifacts(
+        &args.out_dir,
+        &HandoffLinkInputs {
+            review_packet_dir: args.review_packet_dir.as_deref(),
+            review_packet_check: args.review_packet_check.as_deref(),
+            affected: args.affected.as_deref(),
+            proof_plan: args.proof_plan.as_deref(),
+        },
+    )?;
+    payloads.artifacts.append(&mut link_artifacts);
 
     // Compute token estimation and audit
     let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();

--- a/crates/tokmd/src/commands/handoff/output.rs
+++ b/crates/tokmd/src/commands/handoff/output.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use blake3::Hasher;
+use serde_json::{Value, json};
 use tokmd_types::{
     ArtifactEntry, ArtifactHash, ContextFileRow, ExportData, FileKind, HandoffIntelligence,
     HandoffManifest, InclusionPolicy,
@@ -16,6 +17,13 @@ pub(super) struct HandoffPayloads {
     pub(super) intelligence_bytes: u64,
     pub(super) code_bytes: u64,
     pub(super) artifacts: Vec<ArtifactEntry>,
+}
+
+pub(super) struct HandoffLinkInputs<'a> {
+    pub(super) review_packet_dir: Option<&'a Path>,
+    pub(super) review_packet_check: Option<&'a Path>,
+    pub(super) affected: Option<&'a Path>,
+    pub(super) proof_plan: Option<&'a Path>,
 }
 
 pub(super) fn write_payloads(
@@ -88,12 +96,136 @@ pub(super) fn write_payloads(
     })
 }
 
+pub(super) fn write_link_artifacts(
+    out_dir: &Path,
+    links: &HandoffLinkInputs<'_>,
+) -> Result<Vec<ArtifactEntry>> {
+    let mut artifacts = Vec::new();
+
+    if links.review_packet_dir.is_some() || links.review_packet_check.is_some() {
+        artifacts.push(write_json_artifact(
+            out_dir,
+            "review-links",
+            "review-links.json",
+            "Linked cockpit review packet artifacts",
+            &review_links_json(links.review_packet_dir, links.review_packet_check),
+        )?);
+    }
+
+    if links.affected.is_some() || links.proof_plan.is_some() {
+        artifacts.push(write_json_artifact(
+            out_dir,
+            "proof-links",
+            "proof-links.json",
+            "Linked affected-proof and proof-plan artifacts",
+            &proof_links_json(links.affected, links.proof_plan),
+        )?);
+    }
+
+    Ok(artifacts)
+}
+
 pub(super) fn write_manifest_json(out_dir: &Path, manifest: &HandoffManifest) -> Result<usize> {
     let manifest_path = out_dir.join("manifest.json");
     let manifest_json = serde_json::to_string_pretty(manifest)?;
     fs::write(&manifest_path, &manifest_json)
         .with_context(|| format!("Failed to write {}", manifest_path.display()))?;
     Ok(manifest_json.len())
+}
+
+fn write_json_artifact(
+    out_dir: &Path,
+    name: &str,
+    relative_path: &str,
+    description: &str,
+    value: &Value,
+) -> Result<ArtifactEntry> {
+    let path = out_dir.join(relative_path);
+    let json = serde_json::to_string_pretty(value)?;
+    fs::write(&path, &json).with_context(|| format!("Failed to write {}", path.display()))?;
+
+    Ok(ArtifactEntry {
+        name: name.to_string(),
+        path: relative_path.to_string(),
+        description: description.to_string(),
+        bytes: json.len() as u64,
+        hash: Some(ArtifactHash {
+            algo: "blake3".to_string(),
+            hash: hash_bytes(json.as_bytes()),
+        }),
+    })
+}
+
+fn review_links_json(
+    review_packet_dir: Option<&Path>,
+    review_packet_check: Option<&Path>,
+) -> Value {
+    let packet_artifacts = review_packet_dir
+        .map(|dir| {
+            [
+                ("comment", "comment.md"),
+                ("review_map_md", "review-map.md"),
+                ("review_map_json", "review-map.json"),
+                ("evidence", "evidence.json"),
+                ("manifest", "manifest.json"),
+                ("cockpit", "cockpit.json"),
+            ]
+            .into_iter()
+            .map(|(name, relative)| path_link(name, &dir.join(relative)))
+            .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "schema": "tokmd.handoff_review_links.v1",
+        "review_packet_dir": review_packet_dir.map(path_string),
+        "review_packet_check": review_packet_check.map(|path| path_link("review_packet_check", path)),
+        "artifacts": packet_artifacts,
+        "semantics": {
+            "kind": "external_links",
+            "copied": false,
+            "integrity_source": "cargo xtask review-packet-check"
+        }
+    })
+}
+
+fn proof_links_json(affected: Option<&Path>, proof_plan: Option<&Path>) -> Value {
+    let mut artifacts = Vec::new();
+    if let Some(path) = affected {
+        artifacts.push(path_link("affected", path));
+    }
+    if let Some(path) = proof_plan {
+        artifacts.push(path_link("proof_plan", path));
+    }
+
+    json!({
+        "schema": "tokmd.handoff_proof_links.v1",
+        "artifacts": artifacts,
+        "semantics": {
+            "kind": "external_links",
+            "copied": false,
+            "integrity_source": "linked proof artifacts"
+        }
+    })
+}
+
+fn path_link(name: &str, path: &Path) -> Value {
+    let bytes = path
+        .metadata()
+        .ok()
+        .filter(|metadata| metadata.is_file())
+        .map(|metadata| metadata.len());
+
+    json!({
+        "name": name,
+        "path": path_string(path),
+        "exists": path.exists(),
+        "bytes": bytes,
+    })
+}
+
+fn path_string(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
 }
 
 fn write_map_jsonl(path: &Path, export: &ExportData) -> Result<u64> {

--- a/crates/tokmd/tests/handoff_integration.rs
+++ b/crates/tokmd/tests/handoff_integration.rs
@@ -68,6 +68,98 @@ fn test_handoff_manifest_valid_json() {
 }
 
 #[test]
+fn test_handoff_links_review_and_proof_artifacts() {
+    let dir = tempdir().unwrap();
+    let out_dir = dir.path().join("handoff_links");
+    let review_dir = dir.path().join("review");
+    let proof_dir = dir.path().join("proof");
+    fs::create_dir_all(&review_dir).unwrap();
+    fs::create_dir_all(&proof_dir).unwrap();
+
+    fs::write(review_dir.join("comment.md"), "summary").unwrap();
+    fs::write(review_dir.join("review-map.md"), "review map").unwrap();
+    fs::write(review_dir.join("review-map.json"), "{}").unwrap();
+    fs::write(review_dir.join("evidence.json"), "{}").unwrap();
+    fs::write(review_dir.join("manifest.json"), "{}").unwrap();
+    fs::write(review_dir.join("cockpit.json"), "{}").unwrap();
+
+    let review_check = proof_dir.join("review-packet-check.json");
+    let affected = proof_dir.join("affected.json");
+    let proof_plan = proof_dir.join("proof-plan.json");
+    fs::write(
+        &review_check,
+        r#"{"schema":"tokmd.review_packet_check.v1"}"#,
+    )
+    .unwrap();
+    fs::write(&affected, r#"{"schema":"tokmd.affected.v1"}"#).unwrap();
+    fs::write(&proof_plan, r#"{"schema":"tokmd.proof_plan.v1"}"#).unwrap();
+
+    let mut cmd = tokmd_cmd();
+    cmd.arg("handoff")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--review-packet-dir")
+        .arg(&review_dir)
+        .arg("--review-packet-check")
+        .arg(&review_check)
+        .arg("--affected")
+        .arg(&affected)
+        .arg("--proof-plan")
+        .arg(&proof_plan)
+        .assert()
+        .success();
+
+    let review_links: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_dir.join("review-links.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        review_links["schema"].as_str(),
+        Some("tokmd.handoff_review_links.v1")
+    );
+    assert_eq!(review_links["semantics"]["copied"].as_bool(), Some(false));
+    assert_eq!(
+        review_links["review_packet_check"]["exists"].as_bool(),
+        Some(true)
+    );
+    assert!(
+        review_links["artifacts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["name"] == "review_map_md" && entry["exists"] == true)
+    );
+
+    let proof_links: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_dir.join("proof-links.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        proof_links["schema"].as_str(),
+        Some("tokmd.handoff_proof_links.v1")
+    );
+    assert!(
+        proof_links["artifacts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["name"] == "proof_plan" && entry["exists"] == true)
+    );
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_dir.join("manifest.json")).unwrap()).unwrap();
+    let artifacts = manifest["artifacts"].as_array().unwrap();
+    assert!(
+        artifacts
+            .iter()
+            .any(|entry| entry["path"] == "review-links.json")
+    );
+    assert!(
+        artifacts
+            .iter()
+            .any(|entry| entry["path"] == "proof-links.json")
+    );
+}
+
+#[test]
 fn test_handoff_intelligence_valid_json() {
     let dir = tempdir().unwrap();
     let out_dir = dir.path().join("handoff_intel");

--- a/docs/handoff-schema.md
+++ b/docs/handoff-schema.md
@@ -52,8 +52,15 @@ Artifacts listed in `manifest.json`:
 - `map.jsonl`
 - `intelligence.json`
 - `code.txt`
+- `review-links.json` when `tokmd handoff` is given `--review-packet-dir` or
+  `--review-packet-check`
+- `proof-links.json` when `tokmd handoff` is given `--affected` or
+  `--proof-plan`
 
 Artifacts include size and optional hash. Hashing uses **blake3**.
+The link artifacts are packet-local JSON files that point at external review or
+proof receipts. They do not copy those external receipts into the handoff and
+do not replace the review-packet verifier.
 
 ## Related Docs
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -77,10 +77,14 @@ tokmd handoff \
   --preset risk \
   --budget 128k \
   --strategy spread \
+  --review-packet-dir .tokmd/review \
+  --review-packet-check target/tokmd/review-packet-check.json \
+  --affected target/proof/affected.json \
+  --proof-plan target/proof/proof-plan.json \
   --out-dir .handoff
 ```
 
-Then give the agent the handoff plus the review evidence:
+Then give the agent the handoff plus the linked review evidence:
 
 - `.tokmd/review/comment.md` for the short review summary.
 - `.tokmd/review/review-map.md` for what to inspect first and reproduction
@@ -90,10 +94,14 @@ Then give the agent the handoff plus the review evidence:
 - `target/proof/affected.json` for changed files and matched proof scopes.
 - `target/proof/proof-plan.json` for expected proof commands.
 - `target/tokmd/review-packet-check.json` for packet verification.
+- `.handoff/review-links.json` for packet-local pointers to the cockpit review
+  packet and verifier receipt.
+- `.handoff/proof-links.json` for packet-local pointers to affected-proof and
+  proof-plan receipts.
 
-The current `handoff` command does not yet import review-map or proof-plan
-artifacts into `.handoff/` automatically. Keep the directories adjacent and pass
-both to the agent when proof state matters.
+The link artifacts do not copy or verify external receipts. They make the
+handoff bundle point at adjacent review/proof evidence while preserving the
+review packet verifier as the source of packet-integrity evidence.
 
 ## Output Tree
 
@@ -102,7 +110,9 @@ both to the agent when proof state matters.
 ├── manifest.json      # authoritative index (schema v5)
 ├── map.jsonl          # full file inventory (JSONL)
 ├── intelligence.json  # summary signals (payload-only)
-└── code.txt           # token-budgeted code bundle
+├── code.txt           # token-budgeted code bundle
+├── review-links.json  # optional linked cockpit review packet artifacts
+└── proof-links.json   # optional linked affected/proof-plan artifacts
 ```
 
 ## Consumption Pattern

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -1066,6 +1066,18 @@ Options:
       --max-file-tokens <MAX_FILE_TOKENS>
           Hard cap on tokens per file (overrides percentage-based cap)
 
+      --review-packet-dir <REVIEW_PACKET_DIR>
+          Link an existing cockpit review packet directory from the handoff bundle
+
+      --review-packet-check <REVIEW_PACKET_CHECK>
+          Link an existing review-packet verifier receipt from the handoff bundle
+
+      --affected <AFFECTED>
+          Link an existing affected-proof report from the handoff bundle
+
+      --proof-plan <PROOF_PLAN>
+          Link an existing proof-plan report from the handoff bundle
+
       --profile <PROFILE>
           Configuration profile to use (e.g., "llm_safe", "ci")
 


### PR DESCRIPTION
## Summary
- add optional `tokmd handoff` link inputs for cockpit review packets, review-packet verifier receipts, affected reports, and proof plans
- emit packet-local `review-links.json` and `proof-links.json` artifacts with BLAKE3 hashes in the handoff manifest
- document the linked artifact workflow and refresh generated CLI reference docs

## Validation
- `cargo xtask docs --check`
- `cargo xtask doc-artifacts --check`
- `cargo xtask proof-policy --check`
- `cargo test -p tokmd --test handoff_integration --verbose`
- `cargo test -p tokmd --test context_handoff_deep --verbose`
- `cargo test -p tokmd context_pack --verbose`
- `cargo test -p tokmd-types context --verbose`
- `cargo test -p tokmd-types handoff --verbose`
- `cargo test -p tokmd --test schema_validation test_handoff_manifest_validates_against_schema --verbose`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --evidence-json target/proof/proof-evidence.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json` (15 required executed, 15 passed, 0 failed)