### PR TITLE
docs: align active goal with agent handoff

### DIFF
--- a/.jules/goals/archive/2026-05-13-cockpit-review-usefulness.toml
+++ b/.jules/goals/archive/2026-05-13-cockpit-review-usefulness.toml
@@ -1,7 +1,15 @@
 schema = "tokmd.jules.active_goal.v1"
-status = "active"
-program = "agent_handoff_product"
-lane = "context_proof_handoff"
+status = "complete"
+program = "review_packet_product"
+lane = "cockpit_review_usefulness"
+completed = "2026-05-13"
+closeout_plan = "docs/plans/agent-handoff-readiness.md"
+
+completed_prs = [
+  2221,
+  2223,
+  2224,
+]
 
 [links]
 source_of_truth = "docs/source-of-truth.md"
@@ -11,9 +19,6 @@ plan_readme = "docs/plans/README.md"
 proposal_readme = "docs/proposals/README.md"
 spec_readme = "docs/specs/README.md"
 adr_readme = "docs/adr/README.md"
-agent_handoff_plan = "docs/plans/agent-handoff-readiness.md"
-handoff_guide = "docs/handoff.md"
-handoff_schema = "docs/handoff-schema.md"
 review_packet_contract = "docs/review-packet.md"
 cockpit_proof_evidence = "docs/cockpit-proof-evidence.md"
 
@@ -22,12 +27,10 @@ proof_promotion = "do_not_promote_without_maintainer_decision"
 codecov_default_upload = "do_not_enable_without_maintainer_decision"
 product_behavior = "preserve_receipt_semantics"
 review_surface = "cockpit_remains_review_evidence_surface"
-handoff_integrity = "link_review_and_proof_receipts_without_replacing_their_verifiers"
 
 [stop_conditions]
 open_pr_queue = "must_be_empty_before_starting_new_lane"
 docs_check = "cargo xtask docs --check"
 proof_policy = "cargo xtask proof-policy --check"
 affected_plan = "cargo xtask affected --base origin/main --head HEAD --json"
-handoff_tests = "cargo test -p tokmd --test handoff_integration --verbose"
-context_handoff_tests = "cargo test -p tokmd --test context_handoff_deep --verbose"
+review_packet_check = "cargo xtask review-packet-check --dir .tokmd/review"

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -39,8 +39,9 @@ own exploratory rationale, specs own behavior contracts and proof
 requirements, ADRs own durable architecture decisions, plans own sequencing,
 `.jules/goals/active.toml` owns small machine-readable active-agent state, and
 checked policy TOMLs own machine-enforced rules. The completed doc-artifacts
-checker plan is closed out; the current active goal now points at cockpit
-review usefulness.
+checker plan is closed out; the current active goal now points at agent handoff
+readiness after cockpit review-packet usefulness landed its first product
+surface.
 
 ## Next Work Packets
 
@@ -56,7 +57,10 @@ review usefulness.
 6. Keep source-of-truth docs, active goal state, and proof-policy routing
    aligned as new lanes start; do not reopen the doc-artifacts checker lane
    unless the spec changes.
-7. Draft AST foundation work only after the review packet and consolidation
+7. Continue agent handoff readiness only in narrow slices that link review and
+   proof receipts without replacing their verifiers or turning handoff into a
+   merge verdict.
+8. Draft AST foundation work only after the review packet and consolidation
    direction are stable.
 
 ## Directional Rules
@@ -218,6 +222,12 @@ review usefulness.
   evidencebus producer inputs, preserving the boundary that tokmd emits code
   evidence while evidencebus validates, inventories, bundles, and exports
   cross-tool evidence.
+- `tokmd handoff` now accepts optional `--review-packet-dir`,
+  `--review-packet-check`, `--affected`, and `--proof-plan` inputs and writes
+  packet-local `review-links.json` / `proof-links.json` artifacts with BLAKE3
+  hashes in `manifest.json`. These artifacts link adjacent review and proof
+  receipts for agent workflows; they do not copy or verify the external
+  receipts.
 - Cockpit `review-map.json` and `review-map.md` now surface packet-level evidence counts and item-level evidence status, so maintainers can see what proof is present or missing while deciding what to review first.
 - Cockpit review packets now keep imported proof artifacts packet-local under
   `.tokmd/review/proof/*.json`, list those artifacts in `manifest.json`, and

--- a/docs/plans/agent-handoff-readiness.md
+++ b/docs/plans/agent-handoff-readiness.md
@@ -1,0 +1,105 @@
+# Plan: Agent Handoff Readiness
+
+- Status: active
+- Related proposal:
+- Related spec: [Handoff schema](../handoff-schema.md)
+- Related ADR:
+- Related issues:
+
+## Goal
+
+Make `tokmd handoff` the boring starting point for coding agents that need a
+bounded source slice plus review and proof expectations. The handoff bundle
+should point agents at the review packet, packet verifier receipt, affected
+proof report, and proof plan without copying those receipts or pretending to
+verify them itself.
+
+The user-facing job is:
+
+```text
+Give my coding agent the right context and proof expectations.
+```
+
+## Non-goals
+
+- Do not promote proof, fast proof, mutation, scoped coverage, or Codecov
+  upload from this lane.
+- Do not turn handoff output into a merge verdict.
+- Do not make `tokmd handoff` replace `cargo xtask review-packet-check` or
+  other packet/proof verifiers.
+- Do not add an evidencebus implementation before the review and handoff
+  artifact contracts are stable.
+- Do not broaden AST or architecture-consolidation work from this lane.
+
+## Work Packets
+
+1. Land external review/proof link artifacts in handoff bundles.
+   - Status: complete through #2224.
+   - Evidence: `review-links.json` and `proof-links.json` are optional
+     handoff artifacts listed in `manifest.json` with BLAKE3 hashes.
+2. Make the linked-review/proof workflow obvious in handoff docs.
+   - Status: complete through #2224.
+   - Evidence: `docs/handoff.md`, `docs/handoff-schema.md`, and generated
+     CLI reference docs describe the link flags and verifier boundary.
+3. Decide whether a named agent workflow should be CLI syntax, docs-only
+   convention, or config-profile convention.
+   - Constraint: the existing global `--profile` flag already means
+     configuration profile, so do not overload it casually.
+4. Consider a compact agent work-order artifact only after link artifacts have
+   been used in at least one review workflow.
+   - Candidate: `agent-work-order.json` derived from linked review/proof
+     receipts.
+   - Constraint: stale or missing external receipts must stay visible as
+     missing/degraded evidence, not passing proof.
+5. Keep source-of-truth state aligned as the lane moves.
+   - Active state lives in `.jules/goals/active.toml`.
+   - Historical cockpit-review state is archived under `.jules/goals/archive/`.
+
+## Validation
+
+Use the affected proof plan for each PR. For handoff implementation changes,
+expect at least:
+
+```bash
+cargo test -p tokmd --test handoff_integration --verbose
+cargo test -p tokmd --test context_handoff_deep --verbose
+cargo test -p tokmd context_pack --verbose
+cargo test -p tokmd-types context --verbose
+cargo test -p tokmd-types handoff --verbose
+cargo xtask docs --check
+cargo xtask doc-artifacts --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan
+cargo fmt-check
+git diff --check
+```
+
+For docs/control-plane-only changes, run:
+
+```bash
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan
+cargo fmt-check
+git diff --check
+```
+
+## Stop Conditions
+
+- Stop the lane if handoff starts duplicating cockpit or proof verifier
+  semantics instead of linking to their receipts.
+- Stop before adding new public CLI syntax when the behavior can be proven with
+  the existing `--preset`, `--strategy`, and link inputs.
+- Stop if affected planning reports unknown files for handoff, source-of-truth,
+  or proof-policy changes.
+- Stop before promoting proof gates or Codecov defaults; that requires a
+  separate maintainer decision backed by collected observation receipts.
+
+## Checkpoint History
+
+- 2026-05-13: #2224 added optional handoff link artifacts for cockpit review
+  packets, review-packet verifier receipts, affected proof reports, and proof
+  plans.


### PR DESCRIPTION
## Summary
- move `.jules/goals/active.toml` from cockpit review usefulness to the next agent handoff readiness lane
- archive the completed cockpit review usefulness active goal with the relevant merged PR checkpoints
- add an agent handoff readiness plan and update `docs/NEXT.md` with the #2224 handoff-link checkpoint

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --evidence-json target/proof/proof-evidence.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json` (25 required executed, 25 passed, 0 failed)