### PR TITLE
feat(handoff): emit agent work order

### DIFF
--- a/crates/tokmd/src/commands/handoff.rs
+++ b/crates/tokmd/src/commands/handoff.rs
@@ -28,7 +28,10 @@ mod output;
 
 use capabilities::{detect_capabilities, should_compute_git};
 use intelligence::build_intelligence;
-use output::{HandoffLinkInputs, write_link_artifacts, write_manifest_json, write_payloads};
+use output::{
+    HandoffLinkInputs, HandoffWorkOrderInputs, write_link_artifacts, write_manifest_json,
+    write_payloads, write_work_order,
+};
 
 const DEFAULT_TREE_DEPTH: usize = 4;
 
@@ -151,16 +154,39 @@ pub(crate) fn handle(args: cli::HandoffArgs, global: &cli::GlobalArgs) -> Result
         &selected,
         args.compress,
     )?;
-    let mut link_artifacts = write_link_artifacts(
+    let link_inputs = HandoffLinkInputs {
+        review_packet_dir: args.review_packet_dir.as_deref(),
+        review_packet_check: args.review_packet_check.as_deref(),
+        affected: args.affected.as_deref(),
+        proof_plan: args.proof_plan.as_deref(),
+    };
+    let mut link_artifacts = write_link_artifacts(&args.out_dir, &link_inputs)?;
+    payloads.artifacts.append(&mut link_artifacts);
+    let total_files = export
+        .rows
+        .iter()
+        .filter(|r| r.kind == FileKind::Parent)
+        .count();
+    let input_paths: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
+    let strategy = format!("{:?}", args.strategy).to_lowercase();
+    let rank_by = format!("{:?}", args.rank_by).to_lowercase();
+    let intelligence_preset = format!("{:?}", args.preset).to_lowercase();
+    let work_order_artifact = write_work_order(
         &args.out_dir,
-        &HandoffLinkInputs {
-            review_packet_dir: args.review_packet_dir.as_deref(),
-            review_packet_check: args.review_packet_check.as_deref(),
-            affected: args.affected.as_deref(),
-            proof_plan: args.proof_plan.as_deref(),
+        &HandoffWorkOrderInputs {
+            inputs: &input_paths,
+            budget_tokens: budget,
+            used_tokens,
+            utilization_pct: round_f64(utilization, 2),
+            strategy: &strategy,
+            rank_by: &rank_by,
+            intelligence_preset: &intelligence_preset,
+            total_files,
+            selected: &selected,
+            links: &link_inputs,
         },
     )?;
-    payloads.artifacts.append(&mut link_artifacts);
+    payloads.artifacts.push(work_order_artifact);
 
     // Compute token estimation and audit
     let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
@@ -174,26 +200,22 @@ pub(crate) fn handle(args: cli::HandoffArgs, global: &cli::GlobalArgs) -> Result
         generated_at_ms: timestamp,
         tool: ToolInfo::current(),
         mode: "handoff".to_string(),
-        inputs: paths.iter().map(|p| p.display().to_string()).collect(),
+        inputs: input_paths,
         output_dir: args.out_dir.display().to_string(),
         budget_tokens: budget,
         used_tokens,
         utilization_pct: round_f64(utilization, 2),
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
+        strategy,
+        rank_by,
         capabilities: capabilities.clone(),
         artifacts: payloads.artifacts,
         included_files: selected.clone(),
         excluded_paths: excluded_paths.clone(),
         excluded_patterns: scan_args.excluded.clone(),
         smart_excluded_files,
-        total_files: export
-            .rows
-            .iter()
-            .filter(|r| r.kind == FileKind::Parent)
-            .count(),
+        total_files,
         bundled_files: selected.len(),
-        intelligence_preset: format!("{:?}", args.preset).to_lowercase(),
+        intelligence_preset,
         rank_by_effective: if select_result.fallback_reason.is_some() {
             Some(select_result.rank_by_effective.clone())
         } else {

--- a/crates/tokmd/src/commands/handoff/output.rs
+++ b/crates/tokmd/src/commands/handoff/output.rs
@@ -26,6 +26,19 @@ pub(super) struct HandoffLinkInputs<'a> {
     pub(super) proof_plan: Option<&'a Path>,
 }
 
+pub(super) struct HandoffWorkOrderInputs<'a> {
+    pub(super) inputs: &'a [String],
+    pub(super) budget_tokens: usize,
+    pub(super) used_tokens: usize,
+    pub(super) utilization_pct: f64,
+    pub(super) strategy: &'a str,
+    pub(super) rank_by: &'a str,
+    pub(super) intelligence_preset: &'a str,
+    pub(super) total_files: usize,
+    pub(super) selected: &'a [ContextFileRow],
+    pub(super) links: &'a HandoffLinkInputs<'a>,
+}
+
 pub(super) fn write_payloads(
     out_dir: &Path,
     export: &ExportData,
@@ -125,6 +138,19 @@ pub(super) fn write_link_artifacts(
     Ok(artifacts)
 }
 
+pub(super) fn write_work_order(
+    out_dir: &Path,
+    order: &HandoffWorkOrderInputs<'_>,
+) -> Result<ArtifactEntry> {
+    write_text_artifact(
+        out_dir,
+        "work-order",
+        "work-order.md",
+        "Agent work order and consumption guide",
+        &render_work_order(order),
+    )
+}
+
 pub(super) fn write_manifest_json(out_dir: &Path, manifest: &HandoffManifest) -> Result<usize> {
     let manifest_path = out_dir.join("manifest.json");
     let manifest_json = serde_json::to_string_pretty(manifest)?;
@@ -154,6 +180,136 @@ fn write_json_artifact(
             hash: hash_bytes(json.as_bytes()),
         }),
     })
+}
+
+fn write_text_artifact(
+    out_dir: &Path,
+    name: &str,
+    relative_path: &str,
+    description: &str,
+    content: &str,
+) -> Result<ArtifactEntry> {
+    let path = out_dir.join(relative_path);
+    fs::write(&path, content).with_context(|| format!("Failed to write {}", path.display()))?;
+
+    Ok(ArtifactEntry {
+        name: name.to_string(),
+        path: relative_path.to_string(),
+        description: description.to_string(),
+        bytes: content.len() as u64,
+        hash: Some(ArtifactHash {
+            algo: "blake3".to_string(),
+            hash: hash_bytes(content.as_bytes()),
+        }),
+    })
+}
+
+fn render_work_order(order: &HandoffWorkOrderInputs<'_>) -> String {
+    let mut out = String::new();
+    out.push_str("# Agent Work Order\n\n");
+    out.push_str("This handoff is a deterministic source/context bundle for coding-agent work.\n");
+    out.push_str("Treat linked review and proof receipts as external evidence handles; this file does not verify them.\n\n");
+
+    out.push_str("## Start Here\n\n");
+    let mut steps = vec![
+        "Read `manifest.json` for the authoritative artifact index, token budget, included files, and exclusions.",
+        "Read `work-order.md` for the agent task map and guardrails.",
+        "Read `code.txt` for the bounded source bundle.",
+        "Use `map.jsonl` for full file inventory and path lookup.",
+        "Use `intelligence.json` for repository shape, hotspots, complexity, and derived signals.",
+    ];
+    if order.links.review_packet_dir.is_some() || order.links.review_packet_check.is_some() {
+        steps.push(
+            "Use `review-links.json` for cockpit review packet and verifier receipt pointers.",
+        );
+    }
+    if order.links.affected.is_some() || order.links.proof_plan.is_some() {
+        steps.push("Use `proof-links.json` for affected-proof and proof-plan pointers.");
+    }
+    for (index, step) in steps.iter().enumerate() {
+        out.push_str(&format!("{}. {}\n", index + 1, step));
+    }
+
+    out.push_str("\n## Bundle Summary\n\n");
+    out.push_str(&format!("- Inputs: {}\n", order.inputs.join(", ")));
+    out.push_str(&format!("- Budget tokens: {}\n", order.budget_tokens));
+    out.push_str(&format!("- Used tokens: {}\n", order.used_tokens));
+    out.push_str(&format!("- Utilization: {:.2}%\n", order.utilization_pct));
+    out.push_str(&format!("- Strategy: `{}`\n", order.strategy));
+    out.push_str(&format!("- Rank metric: `{}`\n", order.rank_by));
+    out.push_str(&format!(
+        "- Intelligence preset: `{}`\n",
+        order.intelligence_preset
+    ));
+    out.push_str(&format!("- Bundled files: {}\n", order.selected.len()));
+    out.push_str(&format!("- Total scanned files: {}\n", order.total_files));
+
+    out.push_str("\n## Linked Evidence\n\n");
+    if let Some(path) = order.links.review_packet_dir {
+        out.push_str(&format!(
+            "- Review packet directory: `{}`\n",
+            path_string(path)
+        ));
+    } else {
+        out.push_str("- Review packet directory: not linked\n");
+    }
+    if let Some(path) = order.links.review_packet_check {
+        out.push_str(&format!(
+            "- Review packet verifier receipt: `{}`\n",
+            path_string(path)
+        ));
+    } else {
+        out.push_str("- Review packet verifier receipt: not linked\n");
+    }
+    if let Some(path) = order.links.affected {
+        out.push_str(&format!(
+            "- Affected proof report: `{}`\n",
+            path_string(path)
+        ));
+    } else {
+        out.push_str("- Affected proof report: not linked\n");
+    }
+    if let Some(path) = order.links.proof_plan {
+        out.push_str(&format!("- Proof plan report: `{}`\n", path_string(path)));
+    } else {
+        out.push_str("- Proof plan report: not linked\n");
+    }
+
+    out.push_str("\n## Included Files\n\n");
+    if order.selected.is_empty() {
+        out.push_str("- No files were bundled.\n");
+    } else {
+        for file in order.selected.iter().take(20) {
+            let effective_tokens = file.effective_tokens.unwrap_or(file.tokens);
+            out.push_str(&format!(
+                "- `{}`: {}, policy `{}`, {} effective tokens",
+                file.path,
+                file.lang,
+                policy_label(file.policy),
+                effective_tokens
+            ));
+            if !file.rank_reason.is_empty() {
+                out.push_str(&format!(", reason: {}", file.rank_reason));
+            }
+            out.push('\n');
+        }
+        if order.selected.len() > 20 {
+            out.push_str(&format!(
+                "- ... {} more bundled file(s); see `manifest.json` for the full list.\n",
+                order.selected.len() - 20
+            ));
+        }
+    }
+
+    out.push_str("\n## Agent Guardrails\n\n");
+    out.push_str("- Treat missing, stale, degraded, skipped, or unavailable evidence as work to resolve, not as passing proof.\n");
+    out.push_str("- Run reproduction commands from the linked review map before claiming a repair is proven.\n");
+    out.push_str(
+        "- Keep generated receipts with the work when they explain review or proof state.\n",
+    );
+    out.push_str("- Do not promote advisory proof, enable default Codecov upload, or turn this handoff into a merge verdict.\n");
+
+    out
 }
 
 fn review_links_json(
@@ -226,6 +382,15 @@ fn path_link(name: &str, path: &Path) -> Value {
 
 fn path_string(path: &Path) -> String {
     path.display().to_string().replace('\\', "/")
+}
+
+fn policy_label(policy: InclusionPolicy) -> &'static str {
+    match policy {
+        InclusionPolicy::Full => "full",
+        InclusionPolicy::HeadTail => "head_tail",
+        InclusionPolicy::Summary => "summary",
+        InclusionPolicy::Skip => "skip",
+    }
 }
 
 fn write_map_jsonl(path: &Path, export: &ExportData) -> Result<u64> {

--- a/crates/tokmd/tests/context_handoff_deep.rs
+++ b/crates/tokmd/tests/context_handoff_deep.rs
@@ -308,6 +308,10 @@ fn handoff_artifacts_have_expected_names() {
         "should have intelligence artifact"
     );
     assert!(names.contains(&"code"), "should have code artifact");
+    assert!(
+        names.contains(&"work-order"),
+        "should have work-order artifact"
+    );
 }
 
 #[test]
@@ -334,7 +338,7 @@ fn handoff_artifact_map_has_blake3_hash() {
 }
 
 #[test]
-fn handoff_produces_all_four_files() {
+fn handoff_produces_expected_files() {
     let dir = tempdir().unwrap();
     let out_dir = dir.path().join("hoff_files");
 
@@ -348,6 +352,7 @@ fn handoff_produces_all_four_files() {
     assert!(out_dir.join("map.jsonl").exists());
     assert!(out_dir.join("intelligence.json").exists());
     assert!(out_dir.join("code.txt").exists());
+    assert!(out_dir.join("work-order.md").exists());
 }
 
 #[test]

--- a/crates/tokmd/tests/handoff_integration.rs
+++ b/crates/tokmd/tests/handoff_integration.rs
@@ -24,11 +24,12 @@ fn test_handoff_creates_expected_files() {
         .assert()
         .success();
 
-    // Verify all 4 artifacts exist
+    // Verify core artifacts exist
     assert!(out_dir.join("manifest.json").exists());
     assert!(out_dir.join("map.jsonl").exists());
     assert!(out_dir.join("intelligence.json").exists());
     assert!(out_dir.join("code.txt").exists());
+    assert!(out_dir.join("work-order.md").exists());
 }
 
 #[test]
@@ -65,6 +66,12 @@ fn test_handoff_manifest_valid_json() {
     let map = artifacts.iter().find(|a| a["name"] == "map").unwrap();
     assert!(map["hash"]["algo"] == "blake3");
     assert!(map["hash"]["hash"].is_string());
+    let work_order = artifacts
+        .iter()
+        .find(|a| a["name"] == "work-order")
+        .unwrap();
+    assert_eq!(work_order["path"].as_str(), Some("work-order.md"));
+    assert_eq!(work_order["hash"]["algo"].as_str(), Some("blake3"));
 }
 
 #[test]
@@ -156,6 +163,13 @@ fn test_handoff_links_review_and_proof_artifacts() {
         artifacts
             .iter()
             .any(|entry| entry["path"] == "proof-links.json")
+    );
+
+    let work_order = fs::read_to_string(out_dir.join("work-order.md")).unwrap();
+    assert!(work_order.contains("review-links.json"));
+    assert!(work_order.contains("proof-links.json"));
+    assert!(
+        work_order.contains("Treat linked review and proof receipts as external evidence handles")
     );
 }
 
@@ -267,6 +281,7 @@ fn test_handoff_graceful_no_git() {
     assert!(out_dir.join("map.jsonl").exists());
     assert!(out_dir.join("intelligence.json").exists());
     assert!(out_dir.join("code.txt").exists());
+    assert!(out_dir.join("work-order.md").exists());
 
     // Verify capabilities show git as skipped
     let manifest_content = fs::read_to_string(out_dir.join("manifest.json")).unwrap();

--- a/docs/handoff-schema.md
+++ b/docs/handoff-schema.md
@@ -49,6 +49,7 @@ The following fields are required in `manifest.json`:
 Artifacts listed in `manifest.json`:
 
 - `manifest.json` (self)
+- `work-order.md`
 - `map.jsonl`
 - `intelligence.json`
 - `code.txt`
@@ -58,6 +59,9 @@ Artifacts listed in `manifest.json`:
   `--proof-plan`
 
 Artifacts include size and optional hash. Hashing uses **blake3**.
+`work-order.md` is an agent-readable consumption guide generated from the
+manifest inputs, selected files, and optional review/proof link inputs. It does
+not verify external receipts.
 The link artifacts are packet-local JSON files that point at external review or
 proof receipts. They do not copy those external receipts into the handoff and
 do not replace the review-packet verifier.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -44,10 +44,12 @@ Give the agent these files in order:
 
 1. `.handoff/manifest.json` for the authoritative artifact index, token budget,
    exclusions, and included-file list.
-2. `.handoff/intelligence.json` for tree, hotspot, complexity, and derived
+2. `.handoff/work-order.md` for the agent task map, linked evidence handles,
+   and guardrails.
+3. `.handoff/intelligence.json` for tree, hotspot, complexity, and derived
    signals.
-3. `.handoff/code.txt` for the selected source bundle.
-4. `.handoff/map.jsonl` when the agent needs full inventory or path lookup.
+4. `.handoff/code.txt` for the selected source bundle.
+5. `.handoff/map.jsonl` when the agent needs full inventory or path lookup.
 
 For PR repair or review work in this repository, pair the handoff with cockpit
 and proof receipts:
@@ -86,6 +88,8 @@ tokmd handoff \
 
 Then give the agent the handoff plus the linked review evidence:
 
+- `.handoff/work-order.md` for the ordered agent work map and evidence
+  guardrails.
 - `.tokmd/review/comment.md` for the short review summary.
 - `.tokmd/review/review-map.md` for what to inspect first and reproduction
   commands.
@@ -108,6 +112,7 @@ review packet verifier as the source of packet-integrity evidence.
 ```
 <out-dir>/
 ├── manifest.json      # authoritative index (schema v5)
+├── work-order.md      # agent work map and evidence guardrails
 ├── map.jsonl          # full file inventory (JSONL)
 ├── intelligence.json  # summary signals (payload-only)
 ├── code.txt           # token-budgeted code bundle
@@ -119,9 +124,11 @@ review packet verifier as the source of packet-integrity evidence.
 
 1. **Read `manifest.json` first.**  
    It is the authoritative index, lists artifacts, included files, and exclusions.
-2. **Use `map.jsonl`** for full inventory or downstream tooling.
-3. **Use `intelligence.json`** as a warning label (tree, hotspots, derived).
-4. **Use `code.txt`** as the LLM bundle content.
+2. **Read `work-order.md`** for the agent task map, linked evidence handles,
+   and guardrails.
+3. **Use `map.jsonl`** for full inventory or downstream tooling.
+4. **Use `intelligence.json`** as a warning label (tree, hotspots, derived).
+5. **Use `code.txt`** as the LLM bundle content.
 
 ## Agent Guardrails
 


### PR DESCRIPTION
## Summary
- add `work-order.md` to `tokmd handoff` bundles as an agent-readable task map and guardrail artifact
- list `work-order.md` in the handoff manifest with a BLAKE3 hash
- update handoff docs and tests so the bundle contract includes the work order alongside review/proof link artifacts

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd --test handoff_integration --verbose`
- `cargo test -p tokmd --test context_handoff_deep --verbose`
- `cargo test -p tokmd context_pack --verbose`
- `cargo test -p tokmd-types context --verbose`
- `cargo test -p tokmd-types handoff --verbose`
- `cargo test -p tokmd --test schema_validation test_handoff_manifest_validates_against_schema --verbose`
- `cargo xtask docs --check`
- `cargo xtask doc-artifacts --check`
- `cargo xtask proof-policy --check`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --evidence-json target/proof/proof-evidence.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask publish-surface --json --verify-publish`