### PR TITLE
docs: checkpoint agent handoff readiness

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -228,6 +228,10 @@ surface.
   hashes in `manifest.json`. These artifacts link adjacent review and proof
   receipts for agent workflows; they do not copy or verify the external
   receipts.
+- `tokmd handoff` now emits `work-order.md` as a BLAKE3-hashed handoff
+  artifact. It gives coding agents an ordered consumption map, selected-file
+  summary, linked review/proof evidence handles, and guardrails while leaving
+  external receipt verification to the review-packet and proof verifiers.
 - Cockpit `review-map.json` and `review-map.md` now surface packet-level evidence counts and item-level evidence status, so maintainers can see what proof is present or missing while deciding what to review first.
 - Cockpit review packets now keep imported proof artifacts packet-local under
   `.tokmd/review/proof/*.json`, list those artifacts in `manifest.json`, and

--- a/docs/plans/agent-handoff-readiness.md
+++ b/docs/plans/agent-handoff-readiness.md
@@ -43,12 +43,20 @@ Give my coding agent the right context and proof expectations.
      CLI reference docs describe the link flags and verifier boundary.
 3. Decide whether a named agent workflow should be CLI syntax, docs-only
    convention, or config-profile convention.
+   - Status: complete through #2227.
+   - Decision: keep the named agent workflow as a docs-owned convention using
+     the existing `tokmd handoff --preset risk --budget 128k --strategy spread`
+     flow plus explicit review/proof link inputs.
    - Constraint: the existing global `--profile` flag already means
      configuration profile, so do not overload it casually.
 4. Consider a compact agent work-order artifact only after link artifacts have
    been used in at least one review workflow.
-   - Candidate: `agent-work-order.json` derived from linked review/proof
-     receipts.
+   - Status: complete through #2227.
+   - Evidence: `work-order.md` is emitted as a packet-local, BLAKE3-hashed
+     handoff artifact listed in `manifest.json`. It summarizes bundle inputs,
+     selected files, linked review/proof evidence handles, and agent guardrails.
+   - Deferred: a machine-readable `agent-work-order.json` remains unnecessary
+     until a downstream tool needs a separate structured work-order contract.
    - Constraint: stale or missing external receipts must stay visible as
      missing/degraded evidence, not passing proof.
 5. Keep source-of-truth state aligned as the lane moves.
@@ -103,3 +111,6 @@ git diff --check
 - 2026-05-13: #2224 added optional handoff link artifacts for cockpit review
   packets, review-packet verifier receipts, affected proof reports, and proof
   plans.
+- 2026-05-13: #2227 added `work-order.md` to handoff bundles as the
+  agent-readable work map, kept linked receipts external, and preserved the
+  no-merge-verdict/no-proof-promotion boundary.


### PR DESCRIPTION
## Summary
- checkpoint the agent handoff plan after #2227 shipped `work-order.md`
- record the docs-owned agent workflow convention instead of adding new CLI syntax
- add `work-order.md` to the current `docs/NEXT.md` checkpoint list as an external-evidence-handle artifact, not a verifier replacement

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --evidence-json target/proof/proof-evidence.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary.json`