### PR TITLE
docs: add review packet quickstart

### DIFF
--- a/docs/plans/product-readiness.md
+++ b/docs/plans/product-readiness.md
@@ -34,9 +34,13 @@ new product commands or promote advisory proof.
 ## Work Packets
 
 1. Add a cockpit review-packet quickstart.
+   - Status: complete.
    - Show the local commands for generating doc-artifacts evidence when
      available, running `tokmd cockpit`, and checking the review packet.
    - Explain which packet files a reviewer should open first.
+   - Evidence: `docs/review-packet.md` now starts with a reviewer quickstart,
+     while README, tutorial, recipes, and `docs/tokmd-in-cockpit.md` keep the
+     same workflow available from their user-facing entry points.
 2. Simplify README first-run paths around the five user jobs.
    - Keep the command inventory available, but lead with the smallest useful
      commands for inspection, PR review, CI evidence, and agent handoff.
@@ -82,3 +86,6 @@ the relevant generator/checker listed by `cargo xtask docs --check`.
 - 2026-05-13: Created after the agent-handoff readiness lane completed. The
   next product-readiness slice should make existing review, CI, browser, and
   agent workflows easier to start without expanding the control plane.
+- 2026-05-13: Added a reviewer quickstart to `docs/review-packet.md`, keeping
+  the first review-packet path visible on the packet contract page without
+  adding a new command or changing proof policy.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -14,6 +14,51 @@ missing or degraded, and which files deserve attention first.
 `tokmd review` command should not be introduced unless it becomes a distinct
 orchestrator over this packet instead of duplicating cockpit computation.
 
+## Reviewer Quickstart
+
+For a local PR checkout, start with the review packet and verify its manifest
+before treating it as review evidence:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+Open the packet in this order:
+
+1. `.tokmd/review/comment.md` for the compact summary.
+2. `.tokmd/review/review-map.md` for review-first ordering and reproduction
+   commands.
+3. `.tokmd/review/evidence.json` for exact available, missing, stale,
+   degraded, skipped, or unavailable evidence.
+4. `.tokmd/review/manifest.json` for packet-local artifact paths and hashes.
+5. `target/tokmd/review-packet-check.json` for the verifier receipt.
+
+If the PR changes source-of-truth docs, plans, ADRs, templates,
+`.jules/goals/**`, or doc-artifact policy, generate and import the
+documentation-control receipt first:
+
+```bash
+cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
+
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --doc-artifacts-check target/docs/doc-artifacts-check.json \
+  --review-packet-dir .tokmd/review
+```
+
+This imports documentation-control evidence into the packet. It is not a merge
+verdict and does not promote advisory proof, coverage, mutation, or Codecov
+upload into a required gate. For proof imports and hosted Action artifacts,
+see [tokmd in Cockpit](tokmd-in-cockpit.md).
+
 ## Existing Cockpit Artifacts
 
 `tokmd cockpit --artifacts-dir <dir>` writes:


### PR DESCRIPTION
## Summary
- add a reviewer-first quickstart to the review-packet contract page
- document the local packet verification receipt path and the packet files to open first
- checkpoint the product-readiness plan work packet without changing proof policy or product behavior

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-review-packet-quickstart.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-review-packet-quickstart.json --evidence-json target/proof/proof-evidence-review-packet-quickstart.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-review-packet-quickstart.json
- cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-review-packet-quickstart.json
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings