### PR TITLE
docs: add start here user paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,24 +39,27 @@ tokmd --version
 
 See [Install tokmd](docs/install.md) for release binaries, Nix, and CI usage.
 
-## First Run
+## Start With One Job
 
 ```bash
-# Summarize the current repo
+# Tell me what this repo is
 tokmd --format md --top 8
 
-# Save deterministic run artifacts
+# Tell me what changed
+tokmd diff origin/main HEAD
+
+# Help me review this PR
+tokmd cockpit --base origin/main --head HEAD --review-packet-dir .tokmd/review
+
+# Give CI stable evidence and gates
 tokmd run --analysis receipt --output-dir .runs/current
+tokmd gate --receipt .runs/current/receipt.json --policy tokmd-gate.toml
 
-# Compare two states
-tokmd diff main HEAD
-
-# Analyze risk
-tokmd analyze --preset risk --format md
-
-# Pack code for an LLM budget
-tokmd context --budget 128k --mode bundle --output context.txt
+# Give my coding agent context and proof expectations
+tokmd handoff --preset risk --budget 128k --strategy spread --out-dir .handoff
 ```
+
+For a job-oriented walkthrough, start with [Start Here](docs/start-here.md).
 
 ## What tokmd Produces
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1052,6 +1052,7 @@ coverage = false
 name = "user_guides"
 kind = "non_rust"
 paths = [
+  "docs/start-here.md",
   "docs/handoff.md",
   "docs/recipes.md",
   "docs/tutorial.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ schemas, and verification policy for `tokmd`.
 
 ## Key references
 
+- [start-here.md](start-here.md) — choose the shortest path for repo
+  inspection, PR review, CI evidence, agent handoff, or browser evaluation.
 - [VERIFICATION.md](VERIFICATION.md) — README badge meanings, generated endpoints, and PR evidence boundaries.
 - [agent-workflows/source-of-truth.md](agent-workflows/source-of-truth.md) — maintainer and agent workflow for following source-of-truth artifacts.
 - [handoff.md](handoff.md) — coding-agent handoff bundle workflow and guardrails.

--- a/docs/plans/product-readiness.md
+++ b/docs/plans/product-readiness.md
@@ -94,4 +94,5 @@ the relevant generator/checker listed by `cargo xtask docs --check`.
   the first review-packet path visible on the packet contract page without
   adding a new command or changing proof policy.
 - 2026-05-13: Added `docs/start-here.md` and changed README's first-run block
-  to lead with the five user jobs instead of a command inventory.
+  to lead with the five user jobs instead of a command inventory. The new guide
+  is routed through the `user_guides` proof scope.

--- a/docs/plans/product-readiness.md
+++ b/docs/plans/product-readiness.md
@@ -42,8 +42,12 @@ new product commands or promote advisory proof.
      while README, tutorial, recipes, and `docs/tokmd-in-cockpit.md` keep the
      same workflow available from their user-facing entry points.
 2. Simplify README first-run paths around the five user jobs.
+   - Status: complete.
    - Keep the command inventory available, but lead with the smallest useful
      commands for inspection, PR review, CI evidence, and agent handoff.
+   - Evidence: README now leads with the five user jobs, and
+     `docs/start-here.md` provides the job-oriented bridge into tutorial,
+     review-packet, Action, handoff, and browser/native docs.
 3. Refresh tutorial and recipes around job-to-be-done flows.
    - Prefer short workflows that produce a visible receipt before explaining
      the underlying proof or schema machinery.
@@ -89,3 +93,5 @@ the relevant generator/checker listed by `cargo xtask docs --check`.
 - 2026-05-13: Added a reviewer quickstart to `docs/review-packet.md`, keeping
   the first review-packet path visible on the packet contract page without
   adding a new command or changing proof policy.
+- 2026-05-13: Added `docs/start-here.md` and changed README's first-run block
+  to lead with the five user jobs instead of a command inventory.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,0 +1,201 @@
+# Start Here
+
+Use this page when you know the job you want `tokmd` to do, but do not want to
+learn the whole control plane first.
+
+## 1. Tell Me What This Repo Is
+
+Start with the smallest useful receipt:
+
+```bash
+tokmd --format md --top 8
+```
+
+Then widen the view only if you need it:
+
+```bash
+tokmd module --module-depth 2
+tokmd export --format jsonl --max-rows 500 > repo-files.jsonl
+tokmd analyze --preset risk --format md
+```
+
+Open the Markdown summary first. Use JSON or JSONL only when another tool needs
+stable input.
+
+More detail:
+
+- [Tutorial](tutorial.md) for a first walkthrough.
+- [Recipes](recipes.md) for analysis and export examples.
+- [Schema](SCHEMA.md) for receipt contracts.
+
+## 2. Tell Me What Changed
+
+For a quick branch comparison:
+
+```bash
+tokmd diff origin/main HEAD
+```
+
+For a saved before/after trail, write run artifacts first:
+
+```bash
+tokmd run --analysis receipt --output-dir .runs/baseline
+tokmd run --analysis receipt --output-dir .runs/current
+tokmd diff .runs/baseline .runs/current
+```
+
+Use this path when you need a deterministic change receipt. Use cockpit when
+the next step is PR review.
+
+More detail:
+
+- [CLI reference](reference-cli.md) for diff inputs and output formats.
+- [Recipes](recipes.md) for saved receipts and comparisons.
+
+## 3. Help Me Review This PR
+
+Generate a cockpit review packet:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+```
+
+Verify the packet before treating it as review evidence:
+
+```bash
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+Open these files in order:
+
+1. `.tokmd/review/comment.md`
+2. `.tokmd/review/review-map.md`
+3. `.tokmd/review/evidence.json`
+4. `.tokmd/review/manifest.json`
+5. `target/tokmd/review-packet-check.json`
+
+If the PR changes source-of-truth docs, plans, ADRs, templates,
+`.jules/goals/**`, or doc-artifact policy, generate the documentation-control
+receipt first and import it:
+
+```bash
+cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
+
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --doc-artifacts-check target/docs/doc-artifacts-check.json \
+  --review-packet-dir .tokmd/review
+```
+
+The packet is review evidence, not a merge verdict. It can show missing,
+degraded, stale, skipped, unavailable, required, and advisory evidence without
+promoting advisory checks.
+
+More detail:
+
+- [Review packet contract](review-packet.md).
+- [tokmd in Cockpit](tokmd-in-cockpit.md).
+- [Proof evidence import contract](cockpit-proof-evidence.md).
+
+## 4. Give CI Stable Evidence And Gates
+
+Start with artifact-producing CI before adding gates:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    version: '1.11.0'
+    mode: cockpit
+    review-packet: 'true'
+    artifact: 'true'
+    comment: 'false'
+```
+
+Use policy gates only when you have a clear policy file and a rollback path:
+
+```bash
+tokmd run --analysis receipt --output-dir .runs/current
+tokmd gate --receipt .runs/current/receipt.json --policy tokmd-gate.toml
+```
+
+For this repository's contributor workflow, affected proof planning is owned by
+`xtask`:
+
+```bash
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json
+```
+
+Fast proof, scoped coverage, mutation, and Codecov upload stay advisory unless a
+maintainer explicitly promotes them.
+
+More detail:
+
+- [GitHub Action reference](github-action.md).
+- [Coverage guidance](ci/coverage.md).
+- [Proof policy](../ci/proof.toml).
+
+## 5. Give My Coding Agent Context And Proof Expectations
+
+For a plain bounded source bundle:
+
+```bash
+tokmd context --budget 128k --mode bundle --output context.txt
+```
+
+For a coding-agent handoff with an artifact manifest and work order:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --out-dir .handoff
+```
+
+When review or proof artifacts exist, link them instead of pasting logs:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --review-packet-dir .tokmd/review \
+  --review-packet-check target/tokmd/review-packet-check.json \
+  --affected target/proof/affected.json \
+  --proof-plan target/proof/proof-plan.json \
+  --out-dir .handoff
+```
+
+Give the agent `.handoff/work-order.md` first, then `.handoff/manifest.json`.
+The handoff bundle points at review and proof evidence; it does not verify those
+external receipts itself.
+
+More detail:
+
+- [Handoff bundles](handoff.md).
+- [Handoff schema](handoff-schema.md).
+- [Agent source-of-truth workflow](agent-workflows/source-of-truth.md).
+
+## Browser Or No-Install Evaluation
+
+Use the browser runner when the job is safe, rootless inspection:
+
+- language summary;
+- module summary;
+- file export;
+- browser-safe analysis presets over uploaded or GitHub-loaded inputs.
+
+Native filesystem flows, git-history enrichers, `cockpit`, `gate`, `sensor`,
+`baseline`, `context`, and `handoff` remain native-first.
+
+More detail:
+
+- [Browser/WASM contract](architecture.md#wasm--browser-runner).
+- [Browser capability matrix](capabilities/wasm.json).


### PR DESCRIPTION
## Summary
- add `docs/start-here.md` as a job-oriented entry point for repo inspection, change review, PR review, CI evidence, agent handoff, and browser evaluation
- change the README first-run block to lead with the five user jobs instead of an internal command inventory
- route the new Start Here guide through the `user_guides` proof scope and checkpoint the product-readiness plan

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-start-here-user-jobs.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-start-here-user-jobs.json --evidence-json target/proof/proof-evidence-start-here-user-jobs.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-start-here-user-jobs.json
- cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-start-here-user-jobs.json

## Notes
- No proof promotion, Codecov default change, merge verdict behavior, or product command change.