### PR TITLE
docs: route tutorial and recipes by user job

### DIFF
--- a/docs/plans/product-readiness.md
+++ b/docs/plans/product-readiness.md
@@ -49,8 +49,12 @@ new product commands or promote advisory proof.
      `docs/start-here.md` provides the job-oriented bridge into tutorial,
      review-packet, Action, handoff, and browser/native docs.
 3. Refresh tutorial and recipes around job-to-be-done flows.
+   - Status: complete.
    - Prefer short workflows that produce a visible receipt before explaining
      the underlying proof or schema machinery.
+   - Evidence: `docs/tutorial.md` and `docs/recipes.md` now start with
+     job-oriented routing tables that point users to the relevant existing
+     workflow before explaining lower-level commands.
 4. Tighten browser/native capability guidance.
    - Keep browser mode as a no-install artifact generator with explicit
      native-only boundaries.
@@ -96,3 +100,5 @@ the relevant generator/checker listed by `cargo xtask docs --check`.
 - 2026-05-13: Added `docs/start-here.md` and changed README's first-run block
   to lead with the five user jobs instead of a command inventory. The new guide
   is routed through the `user_guides` proof scope.
+- 2026-05-14: Added job-routing tables to tutorial and recipes so the detailed
+  docs now start from user jobs instead of command order alone.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -2,6 +2,17 @@
 
 Examples of how to use `tokmd` in real-world scenarios.
 
+For the shortest job-oriented path, start with [Start Here](start-here.md).
+Use this recipe index when you need a specific variant or CI shape.
+
+| Job | Start with |
+| --- | --- |
+| Tell me what this repo is | [Quick Health Check](#3-quick-health-check-with-analysis), [Finding Heavy Files](#7-finding-heavy-files), [Architecture Visualization](#13-architecture-visualization) |
+| Tell me what changed | [Tracking Repo Growth Over Time](#5-tracking-repo-growth-over-time), [Quick PR Summary](#15-quick-pr-summary) |
+| Help me review this PR | [PR Review Packet](#15b-pr-review-packet), [One-command PR Artifact Bundle](#15c-one-command-pr-artifact-bundle) |
+| Give CI stable evidence and gates | [CI Gate: Policy-Based Quality Gates](#10-ci-gate-policy-based-quality-gates), [GitHub Actions Integration](#18-github-actions-integration), [Baseline Tracking Workflow](#22-baseline-tracking-workflow) |
+| Give my coding agent context and proof expectations | [Packing Code into an LLM Context Window](#1-packing-code-into-an-llm-context-window), [LLM Handoff Bundles](#21-llm-handoff-bundles) |
+
 ## 1. Packing Code into an LLM Context Window
 
 When you need to feed actual code to an LLM (not just metadata), use the `context` command to intelligently select files within a token budget.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,6 +6,17 @@ This guide will walk you through using `tokmd` to understand a codebase you've j
 - `tokmd` installed (see below)
 - A git repository to analyze (we'll assume you are in the root of one)
 
+If you already know the job, use the shorter [Start Here](start-here.md) page.
+This tutorial walks through the same product paths in more detail:
+
+| Job | Tutorial path |
+| --- | --- |
+| Tell me what this repo is | Steps 1-3, then Step 6 |
+| Tell me what changed | Step 10 |
+| Help me review this PR | Step 13 |
+| Give CI stable evidence and gates | Step 12, then Step 10 for saved receipts |
+| Give my coding agent context and proof expectations | Step 16, or Step 4 for a plain bundle |
+
 ## Step 0: Installation
 
 First, ensure the tool is installed.


### PR DESCRIPTION
## Summary
- add job-oriented routing tables to the tutorial and recipes pages
- point detailed docs back to the Start Here flow while preserving existing commands
- checkpoint product-readiness work packet 3 without changing CLI behavior or proof policy

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-job-flow-docs.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-job-flow-docs.json --evidence-json target/proof/proof-evidence-job-flow-docs.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-job-flow-docs.json
- cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-job-flow-docs.json

## Notes
- No proof promotion, Codecov default change, merge verdict behavior, or product command change.