### PR TITLE
docs: clarify browser native boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ storing raw tokens in cache keys.
 
 The machine-readable capability contract lives in [`docs/capabilities/wasm.json`](docs/capabilities/wasm.json).
 
+For the user-facing browser workflow and native-only boundaries, see
+[Browser runner](docs/browser.md).
+
 ## What tokmd Is Not
 
 - It is not a formatter, linter, or build system.

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1052,6 +1052,7 @@ coverage = false
 name = "user_guides"
 kind = "non_rust"
 paths = [
+  "docs/browser.md",
   "docs/start-here.md",
   "docs/handoff.md",
   "docs/recipes.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ schemas, and verification policy for `tokmd`.
 
 - [start-here.md](start-here.md) — choose the shortest path for repo
   inspection, PR review, CI evidence, agent handoff, or browser evaluation.
+- [browser.md](browser.md) — no-install browser workflow and native-only
+  boundaries.
 - [VERIFICATION.md](VERIFICATION.md) — README badge meanings, generated endpoints, and PR evidence boundaries.
 - [agent-workflows/source-of-truth.md](agent-workflows/source-of-truth.md) — maintainer and agent workflow for following source-of-truth artifacts.
 - [handoff.md](handoff.md) — coding-agent handoff bundle workflow and guardrails.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -1,0 +1,91 @@
+# Browser Runner
+
+Use the browser runner when you want a no-install, capability-honest way to
+inspect a repository or local file set and download a receipt. It is a front
+door for safe inspection, not a browser clone of the native CLI.
+
+## Best Fit
+
+Browser mode is useful when the job is:
+
+- tell me what this repo is;
+- inspect a public GitHub repo without installing Rust;
+- inspect selected local files or a local directory;
+- download a JSON artifact for later native, CI, or agent use;
+- demonstrate `tokmd` on a machine that should not run native tools.
+
+Use native `tokmd` instead when the job requires git history, filesystem
+baselines, PR review packets, policy gates, source context bundles, handoff
+directories, or host-backed sensors.
+
+## Supported Browser-Safe Modes
+
+The current browser-safe command set is intentionally narrow:
+
+| Mode | Browser status | Output |
+| --- | --- | --- |
+| `lang` | supported | language receipt |
+| `module` | supported | module receipt |
+| `export` | supported | file inventory |
+| `analyze` | partial | browser-safe `receipt` and `estimate` presets |
+
+The machine-readable contract is
+[`docs/capabilities/wasm.json`](capabilities/wasm.json). The browser UI should
+disable unavailable modes from the loaded bundle instead of pretending native
+capabilities exist.
+
+## Inputs
+
+The browser runner works from ordered in-memory inputs:
+
+- public GitHub repositories loaded through the GitHub tree and contents APIs;
+- optional session-only GitHub token auth for higher rate limits;
+- local file or directory selection from the browser.
+
+It does not use native filesystem paths as trust roots. Local selections are
+converted to normalized `{ path, text }` rows in memory.
+
+## Artifacts
+
+Use browser output as a downloadable receipt, then carry it to the next system
+that needs it:
+
+```text
+browser run
+  -> download JSON artifact
+  -> inspect locally, attach to review, or hand to a native workflow
+```
+
+Browser artifacts are useful inputs for inspection and handoff. They are not a
+replacement for native review packets, proof plans, baselines, or gates.
+
+## Native-Only Boundaries
+
+These stay native-first:
+
+- `cockpit` review packets;
+- `gate` policy evaluation;
+- `sensor` envelopes;
+- `baseline` persistence;
+- `context` bundles;
+- `handoff` directories;
+- git-history enrichers such as churn, hotspots, and freshness;
+- filesystem sensors and validated-root scans.
+
+If a workflow needs one of these, use the native CLI and treat the browser
+artifact as supporting evidence only.
+
+## Runner Development
+
+The browser runner lives in `web/runner`.
+
+```bash
+npm --prefix web/runner run build:wasm
+npm --prefix web/runner test
+```
+
+The release artifact `tokmd-wasm-<tag>.tar.gz` is extracted into
+`web/runner/vendor/tokmd-wasm/` for repeatable deployments. See
+[`web/runner/README.md`](../web/runner/README.md) for cache semantics, local
+file ingest, progress events, authenticated fetch behavior, and integration
+notes.

--- a/docs/plans/product-readiness.md
+++ b/docs/plans/product-readiness.md
@@ -56,8 +56,12 @@ new product commands or promote advisory proof.
      job-oriented routing tables that point users to the relevant existing
      workflow before explaining lower-level commands.
 4. Tighten browser/native capability guidance.
+   - Status: complete.
    - Keep browser mode as a no-install artifact generator with explicit
      native-only boundaries.
+   - Evidence: `docs/browser.md` now gives the browser-safe workflow, supported
+     modes, input model, downloadable artifact role, and native-only boundaries,
+     with links from README, docs index, and Start Here.
 5. Keep handoff docs aligned with the shipped link artifacts and `work-order.md`.
    - The guide should tell agents how to consume links, not imply handoff
      verifies external receipts.
@@ -102,3 +106,6 @@ the relevant generator/checker listed by `cargo xtask docs --check`.
   is routed through the `user_guides` proof scope.
 - 2026-05-14: Added job-routing tables to tutorial and recipes so the detailed
   docs now start from user jobs instead of command order alone.
+- 2026-05-14: Added browser/native guidance that keeps browser mode framed as a
+  no-install artifact generator and leaves git-backed review, gates, baselines,
+  context, and handoff native-first.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -197,5 +197,6 @@ Native filesystem flows, git-history enrichers, `cockpit`, `gate`, `sensor`,
 
 More detail:
 
+- [Browser runner](browser.md).
 - [Browser/WASM contract](architecture.md#wasm--browser-runner).
 - [Browser capability matrix](capabilities/wasm.json).


### PR DESCRIPTION
## Summary
- add `docs/browser.md` as the user-facing browser/no-install workflow guide
- link browser/native boundaries from README, docs index, and Start Here
- route the new browser guide through the `user_guides` proof scope and checkpoint the product-readiness browser packet

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-browser-native-guidance.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-browser-native-guidance.json --evidence-json target/proof/proof-evidence-browser-native-guidance.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-browser-native-guidance.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-browser-native-guidance.json`

## Notes
- No proof promotion, Codecov default change, native/browser capability widening, merge verdict behavior, or product command change.