### PR TITLE
docs: clarify handoff evidence links

### DIFF
--- a/.jules/goals/active.toml
+++ b/.jules/goals/active.toml
@@ -1,5 +1,5 @@
 schema = "tokmd.jules.active_goal.v1"
-status = "active"
+status = "complete"
 program = "product_readiness"
 lane = "user_path_simplification"
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -40,8 +40,10 @@ requirements, ADRs own durable architecture decisions, plans own sequencing,
 `.jules/goals/active.toml` owns small machine-readable active-agent state, and
 checked policy TOMLs own machine-enforced rules. The completed doc-artifacts
 checker plan is closed out. Agent handoff readiness has also closed through
-linked review/proof artifacts and `work-order.md`; the current active goal now
-points at product-readiness user paths.
+linked review/proof artifacts and `work-order.md`. The first product-readiness
+user-path pass is complete: README, Start Here, review-packet docs, tutorial,
+recipes, browser guidance, and handoff guidance now start from user jobs instead
+of control-plane internals.
 
 ## Next Work Packets
 
@@ -57,9 +59,9 @@ points at product-readiness user paths.
 6. Keep source-of-truth docs, active goal state, and proof-policy routing
    aligned as new lanes start; do not reopen the doc-artifacts checker lane
    unless the spec changes.
-7. Continue product-readiness work by making existing inspection, PR review,
-   CI evidence, browser, and agent workflows easier to start without adding new
-   commands or promoting advisory proof.
+7. Keep product-readiness docs aligned as workflows change, but start any new
+   product lane from a fresh plan rather than extending the completed first-pass
+   user-path cleanup by inertia.
 8. Draft AST foundation work only after the review packet and consolidation
    direction are stable.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,9 +1,13 @@
 # Handoff Bundles
 
-`tokmd handoff` creates a **self-contained bundle** for LLM review and
-automation. It is intended to be pasted or uploaded as a stable, deterministic
-artifact when a coding agent needs the right source slice without the whole
-repository.
+`tokmd handoff` creates a **self-contained source/context bundle** for LLM
+review and automation. It is intended to be pasted or uploaded as a stable,
+deterministic artifact when a coding agent needs the right source slice without
+the whole repository.
+
+When you pass review or proof inputs, the bundle also writes link artifacts that
+point at adjacent evidence. Those links are handles, not copied proof. The
+review-packet verifier and proof receipts remain the sources of evidence truth.
 
 Use handoff when the job is:
 
@@ -103,9 +107,34 @@ Then give the agent the handoff plus the linked review evidence:
 - `.handoff/proof-links.json` for packet-local pointers to affected-proof and
   proof-plan receipts.
 
-The link artifacts do not copy or verify external receipts. They make the
-handoff bundle point at adjacent review/proof evidence while preserving the
-review packet verifier as the source of packet-integrity evidence.
+## Consuming Linked Evidence
+
+Use linked evidence as a review map, not as a hidden assertion that the handoff
+has already verified everything:
+
+1. Read `.handoff/review-links.json` and `.handoff/proof-links.json` to find the
+   adjacent receipt paths. If a linked path has `exists: false`, treat that
+   evidence as missing until it is regenerated.
+2. Open `target/tokmd/review-packet-check.json` before trusting a linked review
+   packet. If the verifier receipt is absent, rerun:
+
+   ```bash
+   cargo xtask review-packet-check --dir .tokmd/review --json target/tokmd/review-packet-check.json
+   ```
+
+3. Use `.tokmd/review/review-map.md` for review order and reproduction
+   commands. Missing, stale, degraded, skipped, or unavailable evidence is a
+   task for the agent, not passing proof.
+4. Use `target/proof/affected.json` to see which proof scopes matched the
+   change and `target/proof/proof-plan.json` to see expected commands. A proof
+   plan is planned evidence; it is not an execution result.
+5. Keep the regenerated receipts with the repair so reviewers can follow the
+   same handles from handoff to review packet to proof artifacts.
+
+The link artifacts do not copy, normalize, or verify external receipts. They
+make the handoff bundle point at adjacent review/proof evidence while
+preserving the review-packet verifier and proof artifacts as their own evidence
+sources.
 
 ## Output Tree
 

--- a/docs/plans/product-readiness.md
+++ b/docs/plans/product-readiness.md
@@ -1,6 +1,6 @@
 # Plan: Product Readiness User Paths
 
-- Status: active
+- Status: complete
 - Related proposal:
 - Related spec:
 - Related ADR:
@@ -63,8 +63,13 @@ new product commands or promote advisory proof.
      modes, input model, downloadable artifact role, and native-only boundaries,
      with links from README, docs index, and Start Here.
 5. Keep handoff docs aligned with the shipped link artifacts and `work-order.md`.
+   - Status: complete.
    - The guide should tell agents how to consume links, not imply handoff
      verifies external receipts.
+   - Evidence: `docs/handoff.md` now distinguishes the self-contained
+     source/context bundle from external review/proof evidence handles, tells
+     agents how to consume `review-links.json` and `proof-links.json`, and keeps
+     verification authority with the review-packet verifier and proof receipts.
 
 ## Validation
 
@@ -109,3 +114,6 @@ the relevant generator/checker listed by `cargo xtask docs --check`.
 - 2026-05-14: Added browser/native guidance that keeps browser mode framed as a
   no-install artifact generator and leaves git-backed review, gates, baselines,
   context, and handoff native-first.
+- 2026-05-14: Completed the first product-readiness pass by clarifying how
+  coding agents should consume handoff link artifacts without treating handoff
+  as a verifier for external review or proof receipts.


### PR DESCRIPTION
## Summary
- clarify that `tokmd handoff` is a self-contained source/context bundle, while linked review and proof receipts remain external evidence handles
- add a concrete linked-evidence consumption sequence for `review-links.json`, `proof-links.json`, review-packet verifier receipts, review maps, and proof plans
- close the first product-readiness user-path pass in the plan, active goal, and NEXT status

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-handoff-link-consumption.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-handoff-link-consumption.json --evidence-json target/proof/proof-evidence-handoff-link-consumption.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-handoff-link-consumption.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-handoff-link-consumption.json`

## Notes
- No product behavior, receipt schema, proof-promotion, Codecov default, merge verdict, or new command change.