### PR TITLE
feat(handoff): summarize linked evidence in work order

### DIFF
--- a/crates/tokmd/src/commands/handoff/output.rs
+++ b/crates/tokmd/src/commands/handoff/output.rs
@@ -39,6 +39,50 @@ pub(super) struct HandoffWorkOrderInputs<'a> {
     pub(super) links: &'a HandoffLinkInputs<'a>,
 }
 
+#[derive(Default)]
+struct LinkedEvidenceSummary {
+    review_map: Option<ReviewMapSummary>,
+    review_packet_check: Option<ReviewPacketCheckSummary>,
+    affected: Option<AffectedSummary>,
+    proof_plan: Option<ProofPlanSummary>,
+}
+
+struct ReviewMapSummary {
+    item_count: usize,
+    first_items: Vec<ReviewMapItemSummary>,
+    available: Option<u64>,
+    missing: Option<u64>,
+    degraded: Option<u64>,
+    stale: Option<u64>,
+    skipped: Option<u64>,
+    unavailable: Option<u64>,
+}
+
+struct ReviewMapItemSummary {
+    path: String,
+    reason: Option<String>,
+}
+
+struct ReviewPacketCheckSummary {
+    ok: Option<bool>,
+    artifact_count: Option<u64>,
+    hashes_verified: Option<u64>,
+}
+
+struct AffectedSummary {
+    changed_files: usize,
+    scopes: usize,
+    unknown_files: usize,
+    scope_names: Vec<String>,
+}
+
+struct ProofPlanSummary {
+    commands: usize,
+    required: usize,
+    advisory: usize,
+    first_commands: Vec<String>,
+}
+
 pub(super) fn write_payloads(
     out_dir: &Path,
     export: &ExportData,
@@ -142,12 +186,13 @@ pub(super) fn write_work_order(
     out_dir: &Path,
     order: &HandoffWorkOrderInputs<'_>,
 ) -> Result<ArtifactEntry> {
+    let linked_evidence = summarize_linked_evidence(order.links);
     write_text_artifact(
         out_dir,
         "work-order",
         "work-order.md",
         "Agent work order and consumption guide",
-        &render_work_order(order),
+        &render_work_order(order, &linked_evidence),
     )
 }
 
@@ -204,7 +249,10 @@ fn write_text_artifact(
     })
 }
 
-fn render_work_order(order: &HandoffWorkOrderInputs<'_>) -> String {
+fn render_work_order(
+    order: &HandoffWorkOrderInputs<'_>,
+    linked_evidence: &LinkedEvidenceSummary,
+) -> String {
     let mut out = String::new();
     out.push_str("# Agent Work Order\n\n");
     out.push_str("This handoff is a deterministic source/context bundle for coding-agent work.\n");
@@ -275,6 +323,8 @@ fn render_work_order(order: &HandoffWorkOrderInputs<'_>) -> String {
         out.push_str("- Proof plan report: not linked\n");
     }
 
+    render_linked_evidence_summary(&mut out, order.links, linked_evidence);
+
     out.push_str("\n## Included Files\n\n");
     if order.selected.is_empty() {
         out.push_str("- No files were bundled.\n");
@@ -310,6 +360,251 @@ fn render_work_order(order: &HandoffWorkOrderInputs<'_>) -> String {
     out.push_str("- Do not promote advisory proof, enable default Codecov upload, or turn this handoff into a merge verdict.\n");
 
     out
+}
+
+fn render_linked_evidence_summary(
+    out: &mut String,
+    links: &HandoffLinkInputs<'_>,
+    summary: &LinkedEvidenceSummary,
+) {
+    if !has_any_link(links) {
+        return;
+    }
+
+    out.push_str("\n## Linked Evidence Summary\n\n");
+    out.push_str("These summaries are best-effort hints from linked receipts. They do not replace the linked verifier or proof artifacts.\n\n");
+
+    if let Some(check) = &summary.review_packet_check {
+        out.push_str("- Review packet verifier:");
+        if let Some(ok) = check.ok {
+            out.push_str(&format!(" ok={ok}"));
+        } else {
+            out.push_str(" ok=unknown");
+        }
+        if let Some(artifact_count) = check.artifact_count {
+            out.push_str(&format!(", artifacts={artifact_count}"));
+        }
+        if let Some(hashes_verified) = check.hashes_verified {
+            out.push_str(&format!(", hashes_verified={hashes_verified}"));
+        }
+        out.push('\n');
+    } else if links.review_packet_check.is_some() {
+        out.push_str("- Review packet verifier: linked but not readable\n");
+    }
+
+    if let Some(review_map) = &summary.review_map {
+        out.push_str(&format!("- Review map: {} item(s)", review_map.item_count));
+        if review_map.available.is_some()
+            || review_map.missing.is_some()
+            || review_map.degraded.is_some()
+            || review_map.stale.is_some()
+            || review_map.skipped.is_some()
+            || review_map.unavailable.is_some()
+        {
+            out.push_str(" (");
+            push_count(out, "available", review_map.available);
+            push_count(out, "missing", review_map.missing);
+            push_count(out, "degraded", review_map.degraded);
+            push_count(out, "stale", review_map.stale);
+            push_count(out, "skipped", review_map.skipped);
+            push_count(out, "unavailable", review_map.unavailable);
+            trim_trailing_separator(out);
+            out.push(')');
+        }
+        out.push('\n');
+        if !review_map.first_items.is_empty() {
+            out.push_str("  - Review first:\n");
+            for item in &review_map.first_items {
+                out.push_str(&format!("    - `{}`", item.path));
+                if let Some(reason) = &item.reason {
+                    out.push_str(&format!(": {reason}"));
+                }
+                out.push('\n');
+            }
+        }
+    } else if links.review_packet_dir.is_some() {
+        out.push_str("- Review map: linked but not readable\n");
+    }
+
+    if let Some(affected) = &summary.affected {
+        out.push_str(&format!(
+            "- Affected proof: {} changed file(s), {} scope(s), {} unknown file(s)\n",
+            affected.changed_files, affected.scopes, affected.unknown_files
+        ));
+        if !affected.scope_names.is_empty() {
+            out.push_str("  - Scopes: ");
+            out.push_str(&affected.scope_names.join(", "));
+            out.push('\n');
+        }
+    } else if links.affected.is_some() {
+        out.push_str("- Affected proof: linked but not readable\n");
+    }
+
+    if let Some(proof_plan) = &summary.proof_plan {
+        out.push_str(&format!(
+            "- Proof plan: {} command(s), {} required, {} advisory\n",
+            proof_plan.commands, proof_plan.required, proof_plan.advisory
+        ));
+        if !proof_plan.first_commands.is_empty() {
+            out.push_str("  - First commands:\n");
+            for command in &proof_plan.first_commands {
+                out.push_str(&format!("    - `{command}`\n"));
+            }
+            if proof_plan.commands > proof_plan.first_commands.len() {
+                out.push_str(&format!(
+                    "    - ... {} more command(s); open the proof plan for the full list.\n",
+                    proof_plan.commands - proof_plan.first_commands.len()
+                ));
+            }
+        }
+        out.push_str("  - A proof plan is planned evidence, not execution proof.\n");
+    } else if links.proof_plan.is_some() {
+        out.push_str("- Proof plan: linked but not readable\n");
+    }
+}
+
+fn summarize_linked_evidence(links: &HandoffLinkInputs<'_>) -> LinkedEvidenceSummary {
+    LinkedEvidenceSummary {
+        review_map: links
+            .review_packet_dir
+            .and_then(|dir| read_json_value(&dir.join("review-map.json")))
+            .and_then(|value| summarize_review_map(&value)),
+        review_packet_check: links
+            .review_packet_check
+            .and_then(read_json_value)
+            .map(|value| summarize_review_packet_check(&value)),
+        affected: links
+            .affected
+            .and_then(read_json_value)
+            .map(|value| summarize_affected(&value)),
+        proof_plan: links
+            .proof_plan
+            .and_then(read_json_value)
+            .map(|value| summarize_proof_plan(&value)),
+    }
+}
+
+fn read_json_value(path: &Path) -> Option<Value> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn summarize_review_map(value: &Value) -> Option<ReviewMapSummary> {
+    let items = value.get("items")?.as_array()?;
+    let item_count = value
+        .get("item_count")
+        .and_then(Value::as_u64)
+        .map(|count| count as usize)
+        .unwrap_or(items.len());
+    let first_items = items
+        .iter()
+        .take(5)
+        .filter_map(|item| {
+            let path = item.get("path")?.as_str()?.to_string();
+            let reason = item
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            Some(ReviewMapItemSummary { path, reason })
+        })
+        .collect();
+    let evidence_summary = value.get("evidence").and_then(|e| e.get("summary"));
+
+    Some(ReviewMapSummary {
+        item_count,
+        first_items,
+        available: count_field(evidence_summary, "available"),
+        missing: count_field(evidence_summary, "missing"),
+        degraded: count_field(evidence_summary, "degraded"),
+        stale: count_field(evidence_summary, "stale"),
+        skipped: count_field(evidence_summary, "skipped"),
+        unavailable: count_field(evidence_summary, "unavailable"),
+    })
+}
+
+fn summarize_review_packet_check(value: &Value) -> ReviewPacketCheckSummary {
+    ReviewPacketCheckSummary {
+        ok: value.get("ok").and_then(Value::as_bool),
+        artifact_count: value.get("artifact_count").and_then(Value::as_u64),
+        hashes_verified: value.get("hashes_verified").and_then(Value::as_u64),
+    }
+}
+
+fn summarize_affected(value: &Value) -> AffectedSummary {
+    let changed_files = array_len(value.get("changed_files"));
+    let scopes_array = value.get("scopes").and_then(Value::as_array);
+    let scope_names = scopes_array
+        .into_iter()
+        .flat_map(|scopes| scopes.iter())
+        .filter_map(|scope| scope.get("name").and_then(Value::as_str))
+        .take(8)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    AffectedSummary {
+        changed_files,
+        scopes: array_len(value.get("scopes")),
+        unknown_files: array_len(value.get("unknown_files")),
+        scope_names,
+    }
+}
+
+fn summarize_proof_plan(value: &Value) -> ProofPlanSummary {
+    let Some(commands) = value.get("commands").and_then(Value::as_array) else {
+        return ProofPlanSummary {
+            commands: 0,
+            required: 0,
+            advisory: 0,
+            first_commands: Vec::new(),
+        };
+    };
+    let required = commands
+        .iter()
+        .filter(|command| command.get("required").and_then(Value::as_bool) == Some(true))
+        .count();
+    let advisory = commands.len().saturating_sub(required);
+    let first_commands = commands
+        .iter()
+        .filter_map(|command| command.get("command").and_then(Value::as_str))
+        .take(5)
+        .map(str::to_string)
+        .collect();
+
+    ProofPlanSummary {
+        commands: commands.len(),
+        required,
+        advisory,
+        first_commands,
+    }
+}
+
+fn has_any_link(links: &HandoffLinkInputs<'_>) -> bool {
+    links.review_packet_dir.is_some()
+        || links.review_packet_check.is_some()
+        || links.affected.is_some()
+        || links.proof_plan.is_some()
+}
+
+fn count_field(value: Option<&Value>, field: &str) -> Option<u64> {
+    value
+        .and_then(|value| value.get(field))
+        .and_then(Value::as_u64)
+}
+
+fn array_len(value: Option<&Value>) -> usize {
+    value.and_then(Value::as_array).map_or(0, Vec::len)
+}
+
+fn push_count(out: &mut String, label: &str, count: Option<u64>) {
+    if let Some(count) = count {
+        out.push_str(&format!("{label}={count}, "));
+    }
+}
+
+fn trim_trailing_separator(out: &mut String) {
+    if out.ends_with(", ") {
+        out.truncate(out.len() - 2);
+    }
 }
 
 fn review_links_json(

--- a/crates/tokmd/tests/handoff_integration.rs
+++ b/crates/tokmd/tests/handoff_integration.rs
@@ -85,7 +85,30 @@ fn test_handoff_links_review_and_proof_artifacts() {
 
     fs::write(review_dir.join("comment.md"), "summary").unwrap();
     fs::write(review_dir.join("review-map.md"), "review map").unwrap();
-    fs::write(review_dir.join("review-map.json"), "{}").unwrap();
+    fs::write(
+        review_dir.join("review-map.json"),
+        r#"{
+          "schema":"tokmd.review_map.v1",
+          "item_count":1,
+          "evidence":{
+            "summary":{
+              "available":2,
+              "missing":1,
+              "degraded":0,
+              "stale":0,
+              "skipped":0,
+              "unavailable":1
+            }
+          },
+          "items":[
+            {
+              "path":"docs/handoff.md",
+              "reason":"handoff behavior changed"
+            }
+          ]
+        }"#,
+    )
+    .unwrap();
     fs::write(review_dir.join("evidence.json"), "{}").unwrap();
     fs::write(review_dir.join("manifest.json"), "{}").unwrap();
     fs::write(review_dir.join("cockpit.json"), "{}").unwrap();
@@ -95,11 +118,30 @@ fn test_handoff_links_review_and_proof_artifacts() {
     let proof_plan = proof_dir.join("proof-plan.json");
     fs::write(
         &review_check,
-        r#"{"schema":"tokmd.review_packet_check.v1"}"#,
+        r#"{"schema":"tokmd.review_packet_check.v1","ok":true,"artifact_count":7,"hashes_verified":7}"#,
     )
     .unwrap();
-    fs::write(&affected, r#"{"schema":"tokmd.affected.v1"}"#).unwrap();
-    fs::write(&proof_plan, r#"{"schema":"tokmd.proof_plan.v1"}"#).unwrap();
+    fs::write(
+        &affected,
+        r#"{
+          "schema":"tokmd.affected.v1",
+          "changed_files":["docs/handoff.md"],
+          "scopes":[{"name":"user_guides"}],
+          "unknown_files":[]
+        }"#,
+    )
+    .unwrap();
+    fs::write(
+        &proof_plan,
+        r#"{
+          "schema":"tokmd.proof_plan.v1",
+          "commands":[
+            {"command":"cargo xtask docs --check","required":true},
+            {"command":"cargo xtask proof --profile affected --plan","required":false}
+          ]
+        }"#,
+    )
+    .unwrap();
 
     let mut cmd = tokmd_cmd();
     cmd.arg("handoff")
@@ -171,6 +213,15 @@ fn test_handoff_links_review_and_proof_artifacts() {
     assert!(
         work_order.contains("Treat linked review and proof receipts as external evidence handles")
     );
+    assert!(work_order.contains("## Linked Evidence Summary"));
+    assert!(work_order.contains("Review packet verifier: ok=true"));
+    assert!(work_order.contains("Review map: 1 item(s)"));
+    assert!(work_order.contains("`docs/handoff.md`: handoff behavior changed"));
+    assert!(
+        work_order.contains("Affected proof: 1 changed file(s), 1 scope(s), 0 unknown file(s)")
+    );
+    assert!(work_order.contains("Proof plan: 2 command(s), 1 required, 1 advisory"));
+    assert!(work_order.contains("A proof plan is planned evidence, not execution proof."));
 }
 
 #[test]

--- a/docs/handoff-schema.md
+++ b/docs/handoff-schema.md
@@ -60,8 +60,9 @@ Artifacts listed in `manifest.json`:
 
 Artifacts include size and optional hash. Hashing uses **blake3**.
 `work-order.md` is an agent-readable consumption guide generated from the
-manifest inputs, selected files, and optional review/proof link inputs. It does
-not verify external receipts.
+manifest inputs, selected files, and optional review/proof link inputs. It may
+summarize readable linked receipts for triage, but it does not verify external
+receipts and does not replace their source artifacts.
 The link artifacts are packet-local JSON files that point at external review or
 proof receipts. They do not copy those external receipts into the handoff and
 do not replace the review-packet verifier.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -48,8 +48,8 @@ Give the agent these files in order:
 
 1. `.handoff/manifest.json` for the authoritative artifact index, token budget,
    exclusions, and included-file list.
-2. `.handoff/work-order.md` for the agent task map, linked evidence handles,
-   and guardrails.
+2. `.handoff/work-order.md` for the agent task map, best-effort linked
+   evidence summary, evidence handles, and guardrails.
 3. `.handoff/intelligence.json` for tree, hotspot, complexity, and derived
    signals.
 4. `.handoff/code.txt` for the selected source bundle.
@@ -92,8 +92,8 @@ tokmd handoff \
 
 Then give the agent the handoff plus the linked review evidence:
 
-- `.handoff/work-order.md` for the ordered agent work map and evidence
-  guardrails.
+- `.handoff/work-order.md` for the ordered agent work map, compact linked
+  evidence summary, and evidence guardrails.
 - `.tokmd/review/comment.md` for the short review summary.
 - `.tokmd/review/review-map.md` for what to inspect first and reproduction
   commands.
@@ -122,13 +122,16 @@ has already verified everything:
    cargo xtask review-packet-check --dir .tokmd/review --json target/tokmd/review-packet-check.json
    ```
 
-3. Use `.tokmd/review/review-map.md` for review order and reproduction
-   commands. Missing, stale, degraded, skipped, or unavailable evidence is a
-   task for the agent, not passing proof.
-4. Use `target/proof/affected.json` to see which proof scopes matched the
+3. Use the `Linked Evidence Summary` section in `.handoff/work-order.md` as a
+   quick triage view of readable review/proof receipts, then open the linked
+   receipts for source-of-truth details. Missing, stale, degraded, skipped, or
+   unavailable evidence is a task for the agent, not passing proof.
+4. Use `.tokmd/review/review-map.md` for review order and reproduction
+   commands.
+5. Use `target/proof/affected.json` to see which proof scopes matched the
    change and `target/proof/proof-plan.json` to see expected commands. A proof
    plan is planned evidence; it is not an execution result.
-5. Keep the regenerated receipts with the repair so reviewers can follow the
+6. Keep the regenerated receipts with the repair so reviewers can follow the
    same handles from handoff to review packet to proof artifacts.
 
 The link artifacts do not copy, normalize, or verify external receipts. They
@@ -153,8 +156,8 @@ sources.
 
 1. **Read `manifest.json` first.**  
    It is the authoritative index, lists artifacts, included files, and exclusions.
-2. **Read `work-order.md`** for the agent task map, linked evidence handles,
-   and guardrails.
+2. **Read `work-order.md`** for the agent task map, best-effort linked
+   evidence summary, evidence handles, and guardrails.
 3. **Use `map.jsonl`** for full inventory or downstream tooling.
 4. **Use `intelligence.json`** as a warning label (tree, hotspots, derived).
 5. **Use `code.txt`** as the LLM bundle content.


### PR DESCRIPTION
## Summary
- add a best-effort linked evidence summary to handoff `work-order.md`
- summarize readable review packet verifier, review map, affected proof, and proof plan receipts without copying or verifying external artifacts
- update handoff docs and integration coverage for the linked evidence summary contract

## Validation
- cargo test -p tokmd --test handoff_integration --verbose
- cargo test -p tokmd handoff --verbose
- cargo clippy -p tokmd --all-targets -- -D warnings
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-handoff-evidence-summary.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-handoff-evidence-summary.json --evidence-json target/proof/proof-evidence-handoff-evidence-summary.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-handoff-evidence-summary.json
- cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-handoff-evidence-summary.json

## Notes
- affected proof mapped 4 files to 4 scopes with 0 unknown files
- required proof executed 15 commands; artifact check passed
- no proof promotion, Codecov default, receipt schema, or merge-verdict behavior changes