### PR TITLE
docs: add artifact glossary

### DIFF
--- a/.jules/goals/active.toml
+++ b/.jules/goals/active.toml
@@ -1,7 +1,7 @@
 schema = "tokmd.jules.active_goal.v1"
 status = "complete"
 program = "product_readiness"
-lane = "user_path_simplification"
+lane = "artifact_glossary"
 
 [links]
 source_of_truth = "docs/source-of-truth.md"
@@ -12,6 +12,8 @@ proposal_readme = "docs/proposals/README.md"
 spec_readme = "docs/specs/README.md"
 adr_readme = "docs/adr/README.md"
 product_readiness_plan = "docs/plans/product-readiness.md"
+artifact_glossary_plan = "docs/plans/artifact-glossary.md"
+artifact_glossary = "docs/artifacts.md"
 handoff_guide = "docs/handoff.md"
 handoff_schema = "docs/handoff-schema.md"
 review_packet_contract = "docs/review-packet.md"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ For a job-oriented walkthrough, start with [Start Here](docs/start-here.md).
 | Baselines | Ratchet-ready baseline JSON |
 | LLM context | Bounded bundles, redaction, [handoff directories](docs/handoff.md) |
 
+For the receipt and packet names you will see in these workflows, use the
+[artifact glossary](docs/artifacts.md).
+
 ## Choose a Path
 
 | If you need to... | Start with... | Typical output |

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1052,6 +1052,7 @@ coverage = false
 name = "user_guides"
 kind = "non_rust"
 paths = [
+  "docs/artifacts.md",
   "docs/browser.md",
   "docs/start-here.md",
   "docs/handoff.md",

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -43,7 +43,10 @@ checker plan is closed out. Agent handoff readiness has also closed through
 linked review/proof artifacts and `work-order.md`. The first product-readiness
 user-path pass is complete: README, Start Here, review-packet docs, tutorial,
 recipes, browser guidance, and handoff guidance now start from user jobs instead
-of control-plane internals.
+of control-plane internals. The artifact glossary lane is complete as a
+follow-on compression pass, giving users one dictionary for review packets,
+proof receipts, handoff bundles, documentation-control receipts, and browser
+artifacts.
 
 ## Next Work Packets
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,104 @@
+# Artifact Glossary
+
+Use this page when a `tokmd`, cockpit, proof, CI, or handoff workflow gives you
+an artifact name and you need to know what it means before acting on it.
+
+This is a user-facing dictionary, not the formal schema source. Formal receipt
+contracts live in the schema files, command docs, and verifier docs linked from
+each section.
+
+## Reading Rules
+
+- A receipt means a tool wrote a structured fact. It is not automatically a
+  merge verdict.
+- A verifier receipt means a checker inspected a specific artifact or packet.
+  It does not prove unrelated files, external artifacts, or future runs.
+- A proof plan is expected work. A proof run summary is executed work.
+- Advisory evidence remains advisory unless a maintainer explicitly promotes it
+  through policy.
+- Packet-local artifacts can be hash-verified by their packet verifier.
+  Linked artifacts remain external evidence handles.
+
+## Open First
+
+| Job | Open first | Why |
+| --- | --- | --- |
+| Inspect a repo | Markdown command output or `receipt.json` | Gives the smallest stable repo-shape fact set. |
+| Review a PR | `.tokmd/review/comment.md`, then `.tokmd/review/review-map.md` | Gives the summary, review-first order, evidence state, and reproduction commands. |
+| Verify a review packet | `target/tokmd/review-packet-check.json` | Shows whether packet-local manifest paths, schemas, and hashes were checked. |
+| Understand CI evidence | `target/proof/affected.json`, then `target/proof/proof-plan.json` | Shows changed files, matched proof scopes, and selected proof commands. |
+| Check executed required proof | `target/proof-run/proof-run-summary.json` | Shows which required proof commands actually ran and passed or failed. |
+| Prepare an agent | `.handoff/work-order.md`, then `.handoff/manifest.json` | Gives the agent task map, linked evidence summary, bundle index, and guardrails. |
+| Audit docs/source-of-truth changes | `target/docs/doc-artifacts-check.json` | Shows source-of-truth artifact shape, links, active-goal state, and policy checks. |
+
+## Core Repo And Change Receipts
+
+| Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |
+| --- | --- | --- | --- | --- | --- |
+| `receipt.json` | `.runs/<name>/receipt.json` or a context bundle sidecar | `tokmd run`, context bundle workflows | Inventory for a saved run, usually pointing at generated language, module, export, or analysis artifacts. | It is not proof that a PR is safe, tested, or reviewed. | Use `tokmd diff <old>/receipt.json <new>/receipt.json` or inspect schema docs in [SCHEMA](SCHEMA.md). |
+| `analysis.json` | Output from `tokmd analyze --format json` or run directories | `tokmd analyze`, `tokmd run --analysis ...` | Deterministic derived analysis facts such as risk, complexity, churn, dependencies, topics, or supply signals depending on preset. | It is not a linter, SAST result, or legal/license opinion. | Re-run the same analyze command and compare stable JSON. |
+| `diff.json` | `tokmd diff --format json` output when redirected or saved | `tokmd diff` | Structured before/after change facts between receipts, runs, or refs. | It is not review prioritization by itself. | Re-run `tokmd diff <before> <after> --format json`. |
+| `gate.json` | `tokmd gate --format json` output when saved | `tokmd gate` | Policy evaluation result for a receipt and a TOML policy or baseline ratchet. | It does not replace the underlying test/build tools named by policy. | Re-run `tokmd gate ... --format json` with the same policy and receipt. |
+| `baseline.json` | `.tokmd/baseline.json` or user-selected baseline path | `tokmd baseline`, `tokmd gate` ratchet flows | Stored comparison point for ratchets and drift checks. | It is not a current scan; it can become stale. | Recreate from the intended reference state before relying on it. |
+
+## Cockpit Review Packet
+
+| Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |
+| --- | --- | --- | --- | --- | --- |
+| `manifest.json` | `.tokmd/review/manifest.json` | `tokmd cockpit --review-packet-dir` | Packet inventory: artifact paths, schemas, generated metadata, and BLAKE3 hashes for packet-local files. | It does not verify itself or external linked receipts. | `cargo xtask review-packet-check --dir .tokmd/review`. |
+| `cockpit.json` | `.tokmd/review/cockpit.json` | `tokmd cockpit --review-packet-dir` | Full cockpit receipt with change surface, composition, contracts, review plan, and gate data. | It is not the easiest first review surface for humans. | Open when `comment.md` or `review-map.md` needs deeper source data. |
+| `evidence.json` | `.tokmd/review/evidence.json` | `tokmd cockpit --review-packet-dir` | Evidence availability, gate status, imported proof/doc evidence, and missing/degraded/stale/skipped/unavailable buckets. | Missing evidence is not passing proof; advisory evidence is not a required gate. | Validate through `review-packet-check`; inspect when the review map flags missing or stale evidence. |
+| `review-map.json` | `.tokmd/review/review-map.json` | `tokmd cockpit --review-packet-dir` | Machine-readable review-first routing with item reasons, evidence status, refs, proof refs, and reproduction commands. | It is not a merge queue or reviewer assignment system. | Validate through `review-packet-check`; use for tools and agents. |
+| `review-map.md` | `.tokmd/review/review-map.md` | `tokmd cockpit --review-packet-dir` | Human review work order: what to inspect first, why, what evidence exists or is missing, and how to reproduce evidence. | It does not execute the reproduction commands for you. | Open after `comment.md`; run the listed commands before claiming evidence is repaired. |
+| `comment.md` | `.tokmd/review/comment.md` | `tokmd cockpit --review-packet-dir` | Compact PR-comment-ready summary that points at the packet artifacts. | It is not the whole packet and is intentionally short. | Follow its links to `review-map.md`, `evidence.json`, and `cockpit.json`. |
+| `proof/*.json` | `.tokmd/review/proof/*.json` | `tokmd cockpit` when proof inputs are supplied | Packet-local copies of imported proof artifacts, listed and hash-verified by `manifest.json`. | Their presence does not promote proof gates or prove unrelated scopes. | Verify packet hashes with `review-packet-check`; inspect proof freshness and scope fields. |
+| `docs/doc-artifacts-check.json` | `.tokmd/review/docs/doc-artifacts-check.json` | `tokmd cockpit --doc-artifacts-check ...` | Packet-local copy of documentation-control evidence imported into the review packet. | It is not generated by cockpit; cockpit only imports it. | Reproduce with `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json`. |
+
+## Review Packet Verification
+
+| Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |
+| --- | --- | --- | --- | --- | --- |
+| `review-packet-check.json` | `target/tokmd/review-packet-check.json` | `cargo xtask review-packet-check --json <path>` | Verifier receipt for a specific review packet: schema checks, packet-local path checks, artifact count, and hash verification. | It does not verify artifacts outside the packet, hosted comment copies, or future packet mutations. | Open this before trusting a packet; regenerate after any packet-local artifact changes. |
+
+## Proof And CI Evidence
+
+| Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |
+| --- | --- | --- | --- | --- | --- |
+| `affected.json` | `target/proof/affected.json` | `cargo xtask affected --json-output <path>` | Changed files mapped to `ci/proof.toml` scopes, including unknown files. | It does not run any proof commands. | Unknown files should be resolved before trusting scoped proof routing. |
+| `proof-plan.json` | `target/proof/proof-plan.json` | `cargo xtask proof --plan --plan-json <path>` | Planned proof commands for affected scopes, including required and advisory commands. | It is planned evidence, not executed proof. | Use with `proof-evidence.json` or run required proof explicitly. |
+| `proof-evidence.json` | `target/proof/proof-evidence.json` | `cargo xtask proof --plan --evidence-json <path>` | Machine-readable planned evidence state for coverage, mutation, and other proof families. | Planned advisory evidence is not a pass. | Inspect status fields; execute and verify proof separately when needed. |
+| `proof-plan.md` | `target/proof/proof-plan.md` | `cargo xtask proof --plan --summary-md <path>` | Human-readable summary of the proof plan for PR comments and CI summaries. | It is not the source artifact for machine routing. | Compare with `proof-plan.json` if commands or counts matter. |
+| `proof-run-summary.json` | `target/proof-run/proof-run-summary.json` or `target/proof/proof-run-summary.json` | `cargo xtask proof --run-required --proof-run-summary <path>` | Executed required proof commands, statuses, guard reason, changed files, and unknown files. | It excludes advisory coverage/mutation commands and does not make advisory proof required. | `cargo xtask proof-run-artifacts-check --proof-run-summary <path>`. |
+| `proof-run-observation.json` | `target/proof-run/proof-run-observation.json` | `cargo xtask proof-run-observation --proof-run-summary <path>` | Compact observation derived from a verified required proof-run summary. | It is an observation for collection, not a new proof run. | Verify the source `proof-run-summary.json` first. |
+| `executor-summary.json` | `target/proof/executor-summary.json` | `cargo xtask proof --executor-summary <path>` or proof executor workflow | Selected non-required executor commands and their execution/skipped status. | It is advisory and not part of the required aggregate. | Use `proof-artifacts-check` for no-execution artifacts or `proof-execution-artifacts-check` for executed artifacts. |
+| `executor-manifest.json` | `target/proof/executor-manifest.json` | `cargo xtask proof --executor-manifest <path>` | Stable manifest for planner-selected executor commands and policy guard state. | It does not by itself prove coverage artifacts exist. | Check it against `executor-summary.json`. |
+| `proof-executor-observation.json` | `target/proof/proof-executor-observation.json` | `cargo xtask proof-execution-observation ...` | Observation of an executed non-required proof executor run. | It does not promote scoped coverage to a required gate. | Collect with observation-summary tooling before any promotion decision. |
+| `coverage-receipt.json` | `target/coverage/coverage-receipt.json` | `cargo xtask coverage-receipt` | Inventory and byte-count receipt for coverage artifacts such as JSON, text, and LCOV files. | It does not say coverage is required, sufficient, or uploaded to Codecov. | Inspect artifact paths and byte counts; pair with coverage workflow logs if needed. |
+| `doc-artifacts-check.json` | `target/docs/doc-artifacts-check.json` | `cargo xtask doc-artifacts --check --json <path>` | Source-of-truth docs/control-plane checker receipt: required docs, artifact family shape, active-goal links, status vocabulary, and errors. | It does not judge prose quality or merge readiness. | Re-run `cargo xtask doc-artifacts --check` or `cargo xtask docs --check`. |
+
+## Handoff And Agent Artifacts
+
+| Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |
+| --- | --- | --- | --- | --- | --- |
+| `manifest.json` | `.handoff/manifest.json` | `tokmd handoff` | Authoritative handoff bundle index: inputs, token budget, included/excluded files, capabilities, artifacts, and BLAKE3 hashes. | It does not verify external review or proof receipts linked beside the bundle. | Open first for bundle scope and artifact hashes. |
+| `work-order.md` | `.handoff/work-order.md` | `tokmd handoff` | Agent-readable task map, selected-file summary, linked-evidence summary, and guardrails. | It is not a verifier and should not be treated as proof execution. | Give this to the coding agent first. |
+| `code.txt` | `.handoff/code.txt` | `tokmd handoff` | Token-budgeted source bundle selected for the agent. | It is not the whole repository unless the budget and policy allow it. | Check `.handoff/manifest.json` for included and excluded files. |
+| `map.jsonl` | `.handoff/map.jsonl` | `tokmd handoff` | Full file inventory sidecar for path lookup and downstream tooling. | It is not the selected source bundle. | Use when the agent needs to locate paths beyond `code.txt`. |
+| `intelligence.json` | `.handoff/intelligence.json` | `tokmd handoff` | Repository shape, hotspot, complexity, and derived signals for the bundle. | It is a warning label, not a proof result. | Use alongside `work-order.md` and review/proof receipts. |
+| `review-links.json` | `.handoff/review-links.json` | `tokmd handoff --review-packet-dir/--review-packet-check` | Packet-local pointers to external cockpit review packet artifacts and verifier receipt. | It does not copy or verify the external review packet. | Open linked `review-packet-check.json` before trusting the review packet. |
+| `proof-links.json` | `.handoff/proof-links.json` | `tokmd handoff --affected/--proof-plan` | Packet-local pointers to external affected-proof and proof-plan receipts. | It does not run proof or make planned proof pass. | Open linked `affected.json` and `proof-plan.json`; run required proof when needed. |
+
+## Browser Artifacts
+
+| Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |
+| --- | --- | --- | --- | --- | --- |
+| Browser-safe receipt download | Browser runner download | `web/runner` with `tokmd-wasm` | No-install summary, export, or browser-safe analysis over GitHub-loaded or uploaded inputs. | It does not include native filesystem, git-history, cockpit, gate, context, or handoff behavior. | Compare against [Browser runner](browser.md) and the [WASM capability matrix](capabilities/wasm.json). |
+
+## Related References
+
+- [Start Here](start-here.md) for job-based entry points.
+- [Review packet contract](review-packet.md) for packet layout and verifier semantics.
+- [Handoff bundles](handoff.md) for agent bundle consumption.
+- [Proof evidence import contract](cockpit-proof-evidence.md) for cockpit proof inputs.
+- [Coverage guidance](ci/coverage.md) for coverage receipts and Codecov boundaries.
+- [Evidencebus integration](evidencebus-integration.md) for the stack boundary.

--- a/docs/plans/artifact-glossary.md
+++ b/docs/plans/artifact-glossary.md
@@ -1,0 +1,70 @@
+# Plan: Artifact Glossary
+
+- Status: complete
+- Related proposal:
+- Related spec:
+- Related ADR:
+- Related issues:
+
+## Goal
+
+Give users and agents one dictionary for the artifacts they see across repo
+inspection, PR review, CI proof, documentation-control, browser, and handoff
+workflows.
+
+The glossary should answer:
+
+```text
+what writes this artifact
+where it usually lives
+what it means
+what it does not mean
+what verifies or reproduces it
+```
+
+## Non-goals
+
+- Do not change any receipt schema or product behavior.
+- Do not add a new command.
+- Do not promote proof gates, scoped coverage, mutation, or Codecov upload.
+- Do not implement evidencebus export.
+- Do not replace formal schema docs with the glossary.
+
+## Work Packets
+
+1. Add `docs/artifacts.md`.
+   - Status: complete.
+   - Cover review packet, proof/CI, documentation-control, handoff, browser,
+     and core repo/change artifacts.
+2. Link the glossary from user-path entry points.
+   - Status: complete.
+   - Add links from README and `docs/start-here.md` so users can find the
+     dictionary from the first-run path.
+3. Record the lane checkpoint.
+   - Status: complete.
+   - Keep `docs/NEXT.md` and `.jules/goals/active.toml` aligned without
+     reopening the completed first product-readiness pass.
+
+## Validation
+
+```bash
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-artifact-glossary.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-artifact-glossary.json --evidence-json target/proof/proof-evidence-artifact-glossary.json
+cargo fmt-check
+git diff --check
+```
+
+## Stop Conditions
+
+- Stop if the glossary requires behavior the CLI does not currently support.
+- Stop if a listed artifact cannot be traced to a current command, workflow, or
+  doc contract.
+- Stop if affected planning reports unknown files for this docs-only lane.
+
+## Checkpoint History
+
+- 2026-05-14: Added the artifact glossary as a one-PR product-readiness
+  compression lane after the first user-path pass completed.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -3,6 +3,9 @@
 Use this page when you know the job you want `tokmd` to do, but do not want to
 learn the whole control plane first.
 
+If a workflow gives you an artifact name and you need to know what it means,
+open the [Artifact glossary](artifacts.md).
+
 ## 1. Tell Me What This Repo Is
 
 Start with the smallest useful receipt:
@@ -26,6 +29,7 @@ More detail:
 
 - [Tutorial](tutorial.md) for a first walkthrough.
 - [Recipes](recipes.md) for analysis and export examples.
+- [Artifact glossary](artifacts.md) for receipt and packet names.
 - [Schema](SCHEMA.md) for receipt contracts.
 
 ## 2. Tell Me What Changed
@@ -100,6 +104,7 @@ promoting advisory checks.
 More detail:
 
 - [Review packet contract](review-packet.md).
+- [Artifact glossary](artifacts.md) for packet and verifier names.
 - [tokmd in Cockpit](tokmd-in-cockpit.md).
 - [Proof evidence import contract](cockpit-proof-evidence.md).
 
@@ -138,6 +143,7 @@ maintainer explicitly promotes them.
 More detail:
 
 - [GitHub Action reference](github-action.md).
+- [Artifact glossary](artifacts.md) for proof and coverage receipts.
 - [Coverage guidance](ci/coverage.md).
 - [Proof policy](../ci/proof.toml).
 
@@ -181,6 +187,7 @@ More detail:
 
 - [Handoff bundles](handoff.md).
 - [Handoff schema](handoff-schema.md).
+- [Artifact glossary](artifacts.md) for handoff, review, and proof links.
 - [Agent source-of-truth workflow](agent-workflows/source-of-truth.md).
 
 ## Browser Or No-Install Evaluation


### PR DESCRIPTION
## Summary
- add `docs/artifacts.md` as a user-facing dictionary for repo, review-packet, proof/CI, handoff, doc-control, and browser artifacts
- link the glossary from the README and Start Here user paths, and record the short product-readiness checkpoint plan
- route `docs/artifacts.md` through the existing `user_guides` proof scope so affected planning has zero unknown files

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-artifact-glossary.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-artifact-glossary.json --evidence-json target/proof/proof-evidence-artifact-glossary.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-artifact-glossary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-artifact-glossary.json`
- `cargo fmt-check`
- `git diff --check`