### PR TITLE
ci: avoid cached cargo bin on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        cache-bin: false
 
     - name: Run tests
       run: cargo test --all-features --verbose


### PR DESCRIPTION
## Summary
- disable `Swatinem/rust-cache` bin caching for the push-only macOS build/test job
- keep the change scoped to the macOS leg that restored a cached `~/.cargo/bin` and made `cargo test` resolve to `rustup-init`

## Failure evidence
- main CI for `3eae5ebd` failed in `Build & Test (macOS)` before compiling
- failing command: `cargo test --all-features --verbose`
- log error: `unexpected argument 'test' found` from `rustup-init[EXE]`
- same run shows rust-cache restored `/Users/runner/.cargo/bin` with `cache-bin: true`

## Validation
- `cargo xtask proof-policy --check`
- `cargo xtask ci-lane-whitelist`
- `cargo fmt-check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-macos-cache-bin-fix.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-macos-cache-bin-fix.json --evidence-json target/proof/proof-evidence-macos-cache-bin-fix.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-macos-cache-bin-fix.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-macos-cache-bin-fix.json`
- `git diff --check`