### PR TITLE
feat(xtask): add AST shadow comparison runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
+ "tokmd-analysis",
  "tokmd-analysis-types",
  "tokmd-core",
  "toml 1.1.2+spec-1.1.0",

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -549,13 +549,22 @@ paths = [
   "crates/tokmd-analysis/Cargo.toml",
   "crates/tokmd-analysis/examples/ast_shadow_perf.rs",
   "crates/tokmd-analysis/src/ast/**",
+  "fixtures/ast-shadow/**",
   "docs/adr/0008-ast-foundation.md",
+  "docs/plans/ast-shadow-comparison-runner.md",
   "docs/specs/ast-shadow.md",
+  "xtask/Cargo.toml",
+  "xtask/src/cli.rs",
+  "xtask/src/main.rs",
+  "xtask/src/tasks/ast_shadow_compare.rs",
+  "xtask/src/tasks/mod.rs",
 ]
-packages = ["tokmd-analysis"]
+packages = ["tokmd-analysis", "xtask"]
 proof = [
   "cargo test -p tokmd-analysis --features ast ast --verbose",
   "cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json",
+  "cargo test -p xtask ast_shadow --verbose",
+  "cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --out target/tokmd-ast-shadow",
 ]
 mutation = false
 coverage = false

--- a/docs/plans/ast-shadow-comparison-runner.md
+++ b/docs/plans/ast-shadow-comparison-runner.md
@@ -41,19 +41,19 @@ equivalence, call graphs, type resolution, or complexity replacement.
    - Keep `docs/NEXT.md` and `docs/specs/ast-shadow.md` aligned with the
      runner boundary.
 2. Add the first runner behind developer tooling.
-   - Status: pending.
+   - Status: active.
    - Prefer `cargo xtask ast-shadow-compare` for the first runner so the public
      `tokmd` CLI stays unchanged while the artifact contract stabilizes.
    - Inputs should be explicit repo-relative Rust source paths and an output
      directory, with no network, GitHub, Codecov, or evidencebus dependency.
 3. Generate the existing artifact set.
-   - Status: pending.
+   - Status: active.
    - Reuse the `tokmd-analysis` AST shadow artifact builder to write
      `heuristic.json`, `ast.json`, and `diff.json`.
    - Avoid timestamps, absolute paths, temporary directories, and
      nondeterministic ordering.
 4. Add a small fixture corpus and focused proof.
-   - Status: pending.
+   - Status: active.
    - Cover a Rust fixture with functions, imports, and simple control flow.
    - Route the runner through the existing `analysis_ast_shadow` proof scope.
 5. Collect comparison evidence without product adoption.
@@ -105,3 +105,8 @@ cargo xtask publish-surface --json --verify-publish
   functions, imports, and simple control-flow as the first comparison target and
   keeps the first runner in developer tooling rather than the public `tokmd`
   CLI.
+- 2026-05-14: Added the first `cargo xtask ast-shadow-compare` runner slice.
+  It accepts explicit repo-relative Rust paths, writes the existing
+  `heuristic.json`, `ast.json`, and `diff.json` artifacts, and routes the
+  runner plus fixture corpus through `analysis_ast_shadow` proof. The slice does
+  not add a public `tokmd` CLI command or change default receipt behavior.

--- a/fixtures/ast-shadow/rust/basic.rs
+++ b/fixtures/ast-shadow/rust/basic.rs
@@ -1,0 +1,20 @@
+use std::{fs, path::Path};
+
+pub fn compute(value: usize) -> usize {
+    if value == 0 {
+        return 0;
+    }
+
+    for item in 0..value {
+        while item > 1 {
+            break;
+        }
+    }
+
+    match value {
+        1 => loop {
+            break 1;
+        },
+        _ => value,
+    }
+}

--- a/fixtures/ast-shadow/rust/parse-degraded.rs
+++ b/fixtures/ast-shadow/rust/parse-degraded.rs
@@ -1,0 +1,3 @@
+pub fn ok() {}
+
+pub fn broken(

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,6 +25,7 @@ proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 walkdir = "2"
 tokmd-core = { workspace = true, features = ["analysis"] }
+tokmd-analysis = { path = "../crates/tokmd-analysis", version = "1.11.0", default-features = false, features = ["ast"] }
 tokmd-analysis-types.workspace = true
 
 [dev-dependencies]

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -89,12 +89,25 @@ pub enum Commands {
     TrimTarget(TrimTargetArgs),
     /// Emit a small phase-timing receipt for core inventory and optional analysis workflows
     PerfSmoke(PerfSmokeArgs),
+    /// Compare heuristic and AST-backed Rust landmarks for explicit files
+    AstShadowCompare(AstShadowCompareArgs),
     /// Generate or check committed public Shields badge endpoints
     Badges(BadgesArgs),
     /// Generate or check PR-scoped RIPR evidence artifacts
     RiprPr(RiprPrArgs),
     /// Generate or check RIPR review guidance artifacts
     RiprReviewComments(RiprReviewCommentsArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct AstShadowCompareArgs {
+    /// Repo-relative Rust source path to compare. Repeat for multiple files.
+    #[arg(long = "path", required = true)]
+    pub paths: Vec<std::path::PathBuf>,
+
+    /// Output directory for heuristic.json, ast.json, and diff.json.
+    #[arg(long, default_value = "target/tokmd-ast-shadow")]
+    pub out: std::path::PathBuf,
 }
 
 #[derive(Args, Debug, Clone, Default)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::Sccache(args)) => tasks::sccache::run(args),
         Some(cli::Commands::TrimTarget(args)) => tasks::trim_target::run(args),
         Some(cli::Commands::PerfSmoke(args)) => tasks::perf_smoke::run(args),
+        Some(cli::Commands::AstShadowCompare(args)) => tasks::ast_shadow_compare::run(args),
         Some(cli::Commands::Badges(args)) => tasks::badges::run(args),
         Some(cli::Commands::RiprPr(args)) => tasks::ripr_pr::run_pr(args),
         Some(cli::Commands::RiprReviewComments(args)) => tasks::ripr_pr::run_review_comments(args),

--- a/xtask/src/tasks/ast_shadow_compare.rs
+++ b/xtask/src/tasks/ast_shadow_compare.rs
@@ -1,0 +1,369 @@
+use crate::cli::AstShadowCompareArgs;
+use anyhow::{Context, Result, bail};
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use tokmd_analysis::ast::{
+    AstLanguage, ShadowFileInput, ShadowLandmark, build_shadow_artifacts, normalize_shadow_path,
+    write_shadow_artifacts,
+};
+
+pub fn run(args: AstShadowCompareArgs) -> Result<()> {
+    let root = std::env::current_dir().context("resolve current directory")?;
+    run_with_root(args, &root)
+}
+
+fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
+    let inputs = collect_inputs(&args.paths, root)?;
+    let shadow_inputs = inputs
+        .iter()
+        .map(|input| ShadowFileInput {
+            path: input.path.as_str(),
+            language: AstLanguage::Rust,
+            source: input.source.as_str(),
+            heuristic_landmarks: &input.heuristic_landmarks,
+        })
+        .collect::<Vec<_>>();
+
+    let artifacts = build_shadow_artifacts(&shadow_inputs).context("build AST shadow artifacts")?;
+    let paths = write_shadow_artifacts(&args.out, &artifacts)
+        .with_context(|| format!("write AST shadow artifacts to {}", args.out.display()))?;
+
+    let ast_files = artifacts
+        .ast
+        .get("files")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    let diff_files = artifacts
+        .diff
+        .get("files")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+
+    println!(
+        "AST shadow comparison written to {} ({} input file(s), {} diff file(s))",
+        args.out.display(),
+        ast_files,
+        diff_files
+    );
+    println!("  heuristic: {}", paths.heuristic.display());
+    println!("  ast: {}", paths.ast.display());
+    println!("  diff: {}", paths.diff.display());
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct RunnerInput {
+    path: String,
+    source: String,
+    heuristic_landmarks: Vec<ShadowLandmark>,
+}
+
+fn collect_inputs(paths: &[PathBuf], root: &Path) -> Result<Vec<RunnerInput>> {
+    let mut inputs = paths
+        .iter()
+        .map(|path| collect_input(path, root))
+        .collect::<Result<Vec<_>>>()?;
+    inputs.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(inputs)
+}
+
+fn collect_input(path: &Path, root: &Path) -> Result<RunnerInput> {
+    let rel_path = validate_repo_relative_rust_path(path, root)?;
+    let full_path = root.join(&rel_path);
+    let source =
+        fs::read_to_string(&full_path).with_context(|| format!("read {}", rel_path.display()))?;
+    let normalized = normalize_shadow_path(&rel_path.to_string_lossy());
+    let heuristic_landmarks = heuristic_rust_landmarks(&source);
+
+    Ok(RunnerInput {
+        path: normalized,
+        source,
+        heuristic_landmarks,
+    })
+}
+
+fn validate_repo_relative_rust_path(path: &Path, root: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        bail!(
+            "AST shadow input paths must be repo-relative: {}",
+            path.display()
+        );
+    }
+
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir
+        )
+    }) {
+        bail!(
+            "AST shadow input paths must stay inside the repo: {}",
+            path.display()
+        );
+    }
+
+    if path.extension() != Some(OsStr::new("rs")) {
+        bail!(
+            "AST shadow compare currently accepts only Rust `.rs` files: {}",
+            path.display()
+        );
+    }
+
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("canonicalize repo root {}", root.display()))?;
+    let full_path = root.join(path);
+    let canonical = full_path
+        .canonicalize()
+        .with_context(|| format!("canonicalize input path {}", path.display()))?;
+    if !canonical.starts_with(&root) {
+        bail!(
+            "AST shadow input path resolves outside the repo: {}",
+            path.display()
+        );
+    }
+
+    Ok(path.to_path_buf())
+}
+
+fn heuristic_rust_landmarks(source: &str) -> Vec<ShadowLandmark> {
+    let lines = source.lines().collect::<Vec<_>>();
+    let mut landmarks = Vec::new();
+    let mut line_index = 0usize;
+
+    while line_index < lines.len() {
+        let line = lines[line_index];
+        let trimmed = line.trim_start();
+        let line_number = line_index + 1;
+
+        if trimmed.starts_with("use ") {
+            let end_line = collect_use_end_line(&lines, line_index);
+            let name = normalize_use_text(&lines[line_index..=end_line - 1]);
+            landmarks.push(ShadowLandmark {
+                kind: "import".to_owned(),
+                name,
+                start_line: line_number,
+                end_line,
+            });
+            line_index = end_line;
+            continue;
+        }
+
+        if let Some(name) = function_name_from_line(trimmed) {
+            landmarks.push(ShadowLandmark {
+                kind: "function".to_owned(),
+                name,
+                start_line: line_number,
+                end_line: block_end_line(&lines, line_index),
+            });
+        }
+
+        for control_flow in ["if", "for", "while", "match", "loop"] {
+            if contains_token(trimmed, control_flow) {
+                landmarks.push(ShadowLandmark {
+                    kind: "control_flow".to_owned(),
+                    name: control_flow.to_owned(),
+                    start_line: line_number,
+                    end_line: block_end_line(&lines, line_index),
+                });
+            }
+        }
+
+        line_index += 1;
+    }
+
+    landmarks.sort();
+    landmarks.dedup();
+    landmarks
+}
+
+fn collect_use_end_line(lines: &[&str], start: usize) -> usize {
+    lines
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find_map(|(index, line)| line.contains(';').then_some(index + 1))
+        .unwrap_or(start + 1)
+}
+
+fn normalize_use_text(lines: &[&str]) -> String {
+    lines
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .strip_prefix("use ")
+        .unwrap_or("")
+        .trim_end_matches(';')
+        .trim()
+        .to_owned()
+}
+
+fn function_name_from_line(line: &str) -> Option<String> {
+    let fn_start = find_token(line, "fn")?;
+    let after_fn = line.get(fn_start + 2..)?.trim_start();
+    let name = after_fn
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+        .collect::<String>();
+    (!name.is_empty()).then_some(name)
+}
+
+fn contains_token(line: &str, token: &str) -> bool {
+    find_token(line, token).is_some()
+}
+
+fn find_token(line: &str, token: &str) -> Option<usize> {
+    line.match_indices(token)
+        .find(|(index, _)| token_boundary(line, *index, token.len()))
+        .map(|(index, _)| index)
+}
+
+fn token_boundary(line: &str, start: usize, len: usize) -> bool {
+    let before = start
+        .checked_sub(1)
+        .and_then(|index| line.as_bytes().get(index))
+        .copied();
+    let after = line.as_bytes().get(start + len).copied();
+    !is_ident_byte(before) && !is_ident_byte(after)
+}
+
+fn is_ident_byte(byte: Option<u8>) -> bool {
+    byte.is_some_and(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn block_end_line(lines: &[&str], start: usize) -> usize {
+    let mut depth = 0isize;
+    let mut saw_open = false;
+
+    for (index, line) in lines.iter().enumerate().skip(start) {
+        for byte in line.bytes() {
+            match byte {
+                b'{' => {
+                    saw_open = true;
+                    depth += 1;
+                }
+                b'}' if saw_open => {
+                    depth -= 1;
+                    if depth <= 0 {
+                        return index + 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    start + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn rejects_absolute_paths() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let absolute = root.path().join("src/lib.rs");
+        let error = validate_repo_relative_rust_path(&absolute, root.path())
+            .expect_err("absolute paths should be rejected");
+
+        assert!(error.to_string().contains("repo-relative"));
+    }
+
+    #[test]
+    fn rejects_parent_paths() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let error = validate_repo_relative_rust_path(Path::new("../lib.rs"), root.path())
+            .expect_err("parent paths should be rejected");
+
+        assert!(error.to_string().contains("inside the repo"));
+    }
+
+    #[test]
+    fn rejects_non_rust_paths() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        fs::write(root.path().join("README.md"), "# docs\n")?;
+
+        let error = validate_repo_relative_rust_path(Path::new("README.md"), root.path())
+            .expect_err("non-Rust paths should be rejected");
+
+        assert!(error.to_string().contains("`.rs` files"));
+        Ok(())
+    }
+
+    #[test]
+    fn heuristic_extracts_first_slice_landmarks() {
+        let source = r#"
+use std::{
+    fs,
+    path::Path,
+};
+
+pub fn compute(value: usize) -> usize {
+    if value == 0 {
+        return 0;
+    }
+
+    for item in 0..value {
+        while item > 1 {
+            break;
+        }
+    }
+
+    match value {
+        1 => loop {
+            break 1;
+        },
+        _ => value,
+    }
+}
+"#;
+
+        let landmarks = heuristic_rust_landmarks(source);
+        let observed = landmarks
+            .iter()
+            .map(|landmark| (landmark.kind.as_str(), landmark.name.as_str()))
+            .collect::<Vec<_>>();
+
+        assert!(observed.contains(&("import", "std::{ fs, path::Path, }")));
+        assert!(observed.contains(&("function", "compute")));
+        assert!(observed.contains(&("control_flow", "if")));
+        assert!(observed.contains(&("control_flow", "for")));
+        assert!(observed.contains(&("control_flow", "while")));
+        assert!(observed.contains(&("control_flow", "match")));
+        assert!(observed.contains(&("control_flow", "loop")));
+    }
+
+    #[test]
+    fn runner_writes_deterministic_artifacts() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let fixture_dir = root.path().join("fixtures/ast-shadow/rust");
+        fs::create_dir_all(&fixture_dir)?;
+        fs::write(
+            fixture_dir.join("basic.rs"),
+            "use std::fs;\n\npub fn compute(value: usize) -> usize {\n    if value > 0 {\n        value\n    } else {\n        0\n    }\n}\n",
+        )?;
+        let out = root.path().join("target/tokmd-ast-shadow");
+        let args = AstShadowCompareArgs {
+            paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
+            out: out.clone(),
+        };
+
+        run_with_root(args.clone(), root.path())?;
+        let first = fs::read_to_string(out.join("diff.json"))?;
+        run_with_root(args, root.path())?;
+        let second = fs::read_to_string(out.join("diff.json"))?;
+
+        assert_eq!(first, second);
+        assert!(out.join("heuristic.json").exists());
+        assert!(out.join("ast.json").exists());
+        assert!(out.join("diff.json").exists());
+        assert!(first.contains("\"schema\": \"tokmd.ast_shadow.v1\""));
+        assert!(!first.contains(root.path().to_string_lossy().as_ref()));
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,4 +1,5 @@
 pub mod affected;
+pub mod ast_shadow_compare;
 pub mod badges;
 pub mod boundaries_check;
 pub mod build_guard;


### PR DESCRIPTION
## Summary

- Add developer-facing `cargo xtask ast-shadow-compare` for explicit repo-relative Rust files.
- Reuse the feature-gated `tokmd-analysis` AST shadow builder to write `heuristic.json`, `ast.json`, and `diff.json`.
- Add a small Rust fixture corpus and route the runner through `analysis_ast_shadow` proof.

## Boundaries

- No public `tokmd` CLI command.
- No default analyze/cockpit/context/handoff/browser output changes.
- No proof promotion, Codecov default, merge verdict, or evidencebus runtime dependency.
- AST artifacts remain developer-facing `tokmd.ast_shadow.v1` shadow evidence.

## Validation

- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo test -p xtask ast_shadow --verbose`
- `cargo test -p tokmd-analysis --features ast ast --verbose`
- `cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --out target/tokmd-ast-shadow`
- `cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json`
- `cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --path fixtures/ast-shadow/rust/parse-degraded.rs --out target/tokmd-ast-shadow`
- `cargo fmt-check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow-compare-runner.json` (10 changed files, 7 scopes, 0 unknown)
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-shadow-compare-runner.json --evidence-json target/proof/proof-evidence-ast-shadow-compare-runner.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-ast-shadow-compare-runner.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-ast-shadow-compare-runner.json` (40 executed required commands)
- `git diff --check origin/main..HEAD`
