### PR TITLE
feat(analysis): summarize ast shadow diffs

### DIFF
--- a/crates/tokmd-analysis/src/ast/shadow.rs
+++ b/crates/tokmd-analysis/src/ast/shadow.rs
@@ -132,6 +132,7 @@ pub fn build_shadow_artifacts(
     let mut heuristic_files = Vec::with_capacity(inputs.len());
     let mut ast_files = Vec::with_capacity(inputs.len());
     let mut diff_files = Vec::with_capacity(inputs.len());
+    let mut diff_summary = ShadowDiffSummary::default();
 
     for (path, input) in inputs {
         let mut heuristic_landmarks = input.heuristic_landmarks.to_vec();
@@ -145,6 +146,7 @@ pub fn build_shadow_artifacts(
 
         let diff = compare_landmarks(&heuristic_landmarks, &ast_landmarks);
         let parse_degraded = ast_shadow.has_error;
+        diff_summary.add_file(&diff, parse_degraded, false);
 
         heuristic_files.push(json!({
             "path": path,
@@ -186,6 +188,7 @@ pub fn build_shadow_artifacts(
         diff: json!({
             "schema": AST_SHADOW_SCHEMA_VERSION,
             "kind": "diff",
+            "summary": diff_summary.value(),
             "files": diff_files,
         }),
     })
@@ -286,6 +289,38 @@ struct LandmarkDiff {
     ast_only: Vec<ShadowLandmark>,
 }
 
+#[derive(Default)]
+struct ShadowDiffSummary {
+    files: usize,
+    matched: usize,
+    heuristic_only: usize,
+    ast_only: usize,
+    parse_degraded: usize,
+    unsupported: usize,
+}
+
+impl ShadowDiffSummary {
+    fn add_file(&mut self, diff: &LandmarkDiff, parse_degraded: bool, unsupported: bool) {
+        self.files += 1;
+        self.matched += diff.matches.len();
+        self.heuristic_only += diff.heuristic_only.len();
+        self.ast_only += diff.ast_only.len();
+        self.parse_degraded += usize::from(parse_degraded);
+        self.unsupported += usize::from(unsupported);
+    }
+
+    fn value(&self) -> Value {
+        json!({
+            "files": self.files,
+            "matched": self.matched,
+            "heuristic_only": self.heuristic_only,
+            "ast_only": self.ast_only,
+            "parse_degraded": self.parse_degraded,
+            "unsupported": self.unsupported,
+        })
+    }
+}
+
 fn compare_landmarks(heuristic: &[ShadowLandmark], ast: &[ShadowLandmark]) -> LandmarkDiff {
     let heuristic = heuristic.iter().cloned().collect::<BTreeSet<_>>();
     let ast = ast.iter().cloned().collect::<BTreeSet<_>>();
@@ -361,9 +396,51 @@ mod tests {
             artifacts.diff["files"][0]["ast_only"][0]["name"],
             "ast_only"
         );
+        assert_eq!(artifacts.diff["summary"]["files"], 2);
+        assert_eq!(artifacts.diff["summary"]["matched"], 1);
+        assert_eq!(artifacts.diff["summary"]["heuristic_only"], 0);
+        assert_eq!(artifacts.diff["summary"]["ast_only"], 2);
+        assert_eq!(artifacts.diff["summary"]["parse_degraded"], 0);
+        assert_eq!(artifacts.diff["summary"]["unsupported"], 0);
         assert!(artifacts.heuristic.get("generated_at").is_none());
         assert!(artifacts.ast.get("generated_at").is_none());
         assert!(artifacts.diff.get("generated_at").is_none());
+    }
+
+    #[test]
+    fn diff_summary_counts_match_comparison_entries() {
+        let heuristic = [ShadowLandmark::function("heuristic_only", 1, 1)];
+        let files = [ShadowFileInput {
+            path: "src/lib.rs",
+            language: AstLanguage::Rust,
+            source: "fn ast_only() {}\n",
+            heuristic_landmarks: &heuristic,
+        }];
+
+        let artifacts = build_shadow_artifacts(&files).expect("shadow artifacts should build");
+
+        assert_eq!(artifacts.diff["summary"]["files"], 1);
+        assert_eq!(artifacts.diff["summary"]["matched"], 0);
+        assert_eq!(artifacts.diff["summary"]["heuristic_only"], 1);
+        assert_eq!(artifacts.diff["summary"]["ast_only"], 1);
+        assert_eq!(artifacts.diff["summary"]["parse_degraded"], 0);
+        assert_eq!(artifacts.diff["summary"]["unsupported"], 0);
+        assert_eq!(
+            artifacts.diff["summary"]["heuristic_only"]
+                .as_u64()
+                .unwrap(),
+            artifacts.diff["files"][0]["heuristic_only"]
+                .as_array()
+                .unwrap()
+                .len() as u64
+        );
+        assert_eq!(
+            artifacts.diff["summary"]["ast_only"].as_u64().unwrap(),
+            artifacts.diff["files"][0]["ast_only"]
+                .as_array()
+                .unwrap()
+                .len() as u64
+        );
     }
 
     #[test]
@@ -380,6 +457,7 @@ mod tests {
         assert_eq!(artifacts.ast["files"][0]["has_error"], true);
         assert_eq!(artifacts.diff["files"][0]["status"], "parse_degraded");
         assert_eq!(artifacts.diff["files"][0]["parse_degraded"], true);
+        assert_eq!(artifacts.diff["summary"]["parse_degraded"], 1);
     }
 
     #[test]

--- a/docs/plans/ast-shadow-comparison-runner.md
+++ b/docs/plans/ast-shadow-comparison-runner.md
@@ -57,7 +57,10 @@ equivalence, call graphs, type resolution, or complexity replacement.
    - Cover a Rust fixture with functions, imports, and simple control flow.
    - Route the runner through the existing `analysis_ast_shadow` proof scope.
 5. Collect comparison evidence without product adoption.
-   - Status: pending.
+   - Status: active.
+   - Keep `diff.json` human- and agent-readable enough for early evidence
+     collection by adding aggregate counts before wiring the artifacts into
+     cockpit, handoff, evidencebus, or public receipts.
    - Use runner output to decide whether function, import, or control-flow
      landmarks are accurate enough for a later public schema proposal.
 
@@ -110,3 +113,7 @@ cargo xtask publish-surface --json --verify-publish
   `heuristic.json`, `ast.json`, and `diff.json` artifacts, and routes the
   runner plus fixture corpus through `analysis_ast_shadow` proof. The slice does
   not add a public `tokmd` CLI command or change default receipt behavior.
+- 2026-05-14: Added `diff.json` summary counts for files, matched landmarks,
+  heuristic-only landmarks, AST-only landmarks, parse-degraded files, and
+  unsupported files. This keeps the shadow artifact useful for evidence
+  collection without turning it into a gate or merge verdict.

--- a/docs/specs/ast-shadow.md
+++ b/docs/specs/ast-shadow.md
@@ -67,6 +67,10 @@ control-flow landmarks, parser status, and recoverable parse-error state.
 `diff.json` should record deterministic comparison results between heuristic
 and AST facts. It should distinguish exact matches, AST-only facts,
 heuristic-only facts, parse-degraded files, and unsupported files.
+It also includes a top-level `summary` object with aggregate counts for files,
+matched landmarks, heuristic-only landmarks, AST-only landmarks,
+parse-degraded files, and unsupported files so maintainers can judge a
+comparison without scanning every file entry.
 
 All three artifacts must avoid timestamps, absolute paths, environment-specific
 temporary directories, and nondeterministic ordering.


### PR DESCRIPTION
## Summary
- add top-level `summary` counts to `tokmd.ast_shadow.v1` diff artifacts
- cover matched, heuristic-only, AST-only, parse-degraded, unsupported, and file counts in AST shadow tests
- document the diff summary in the AST shadow spec and active comparison-runner plan

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-analysis --features ast ast --verbose`
- `cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --path fixtures/ast-shadow/rust/parse-degraded.rs --out target/tokmd-ast-shadow`
- `cargo test -p xtask ast_shadow --verbose`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo clippy -p tokmd-analysis --features ast --all-targets -- -D warnings`
- `cargo fmt-check`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow-diff-summary.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-shadow-diff-summary.json --evidence-json target/proof/proof-evidence-ast-shadow-diff-summary.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-ast-shadow-diff-summary.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-ast-shadow-diff-summary.json`
- `git diff --check origin/main..HEAD`