### PR TITLE
feat(xtask): summarize AST shadow comparisons

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -88,6 +88,16 @@ each section.
 | `review-links.json` | `.handoff/review-links.json` | `tokmd handoff --review-packet-dir/--review-packet-check` | Packet-local pointers to external cockpit review packet artifacts and verifier receipt. | It does not copy or verify the external review packet. | Open linked `review-packet-check.json` before trusting the review packet. |
 | `proof-links.json` | `.handoff/proof-links.json` | `tokmd handoff --affected/--proof-plan` | Packet-local pointers to external affected-proof and proof-plan receipts. | It does not run proof or make planned proof pass. | Open linked `affected.json` and `proof-plan.json`; run required proof when needed. |
 
+## AST Shadow Evidence
+
+| Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |
+| --- | --- | --- | --- | --- | --- |
+| `heuristic.json` | `target/tokmd-ast-shadow/heuristic.json` | `cargo xtask ast-shadow-compare` | Developer-facing view of the heuristic Rust landmarks selected for AST comparison. | It is not a public `tokmd` receipt or default analysis output. | Pair with `ast.json` and `diff.json`; verify with `cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow`. |
+| `ast.json` | `target/tokmd-ast-shadow/ast.json` | `cargo xtask ast-shadow-compare` | Feature-gated AST-backed Rust landmarks for the same explicit file selection. | It does not claim browser/WASM AST support or replace heuristic defaults. | Inspect parser status and parse-degraded files before drawing conclusions. |
+| `diff.json` | `target/tokmd-ast-shadow/diff.json` | `cargo xtask ast-shadow-compare` | Deterministic comparison of heuristic and AST landmarks, including matched, heuristic-only, AST-only, parse-degraded, and unsupported counts. | It is not a merge verdict or proof-promotion signal. | Read `summary.md` first if present; verify summary counts with `ast-shadow-check`. |
+| `summary.md` | `target/tokmd-ast-shadow/summary.md` | `cargo xtask ast-shadow-compare --summary-md <path>` | Human review layer over `diff.json` with aggregate counts, per-file status, artifact paths, and reproduction command. | It is not machine authority; use JSON artifacts for tooling. | Re-run the command shown in the summary and then run `ast-shadow-check`. |
+| `check.json` | `target/tokmd-ast-shadow/check.json` | `cargo xtask ast-shadow-check --json <path>` | Verifier receipt for the AST shadow artifact set: required files, schema/kind, sorted relative paths, timestamp-free content, and matching summary counts. | It does not make AST evidence public product behavior. | Regenerate after any artifact change and keep it with the compared artifact set. |
+
 ## Browser Artifacts
 
 | Artifact | Usual path | Writer | Means | Does not mean | Verify or inspect |

--- a/docs/plans/ast-shadow-comparison-runner.md
+++ b/docs/plans/ast-shadow-comparison-runner.md
@@ -61,6 +61,8 @@ equivalence, call graphs, type resolution, or complexity replacement.
    - Keep `diff.json` human- and agent-readable enough for early evidence
      collection by adding aggregate counts before wiring the artifacts into
      cockpit, handoff, evidencebus, or public receipts.
+   - Add an optional Markdown summary output for maintainer review of aggregate
+     counts, per-file status, artifact paths, and the reproduction command.
    - Use runner output to decide whether function, import, or control-flow
      landmarks are accurate enough for a later public schema proposal.
 6. Verify the generated artifact set.
@@ -93,7 +95,7 @@ For the later runner implementation slice, add:
 cargo test -p tokmd-analysis --features ast ast --verbose
 cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
 cargo test -p xtask ast_shadow --verbose
-cargo xtask ast-shadow-compare --out target/tokmd-ast-shadow --path <fixture-rust-path>
+cargo xtask ast-shadow-compare --out target/tokmd-ast-shadow --summary-md target/tokmd-ast-shadow/summary.md --path <fixture-rust-path>
 cargo xtask ast-shadow-check --path <fixture-rust-path> --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json
 cargo xtask publish-surface --json --verify-publish
 ```
@@ -133,3 +135,7 @@ cargo xtask publish-surface --json --verify-publish
   validates the generated shadow artifact set and can emit a
   `tokmd.ast_shadow_check.v1` receipt without changing default product
   behavior.
+- 2026-05-14: Added optional Markdown summary output for the comparison runner.
+  `--summary-md` renders aggregate counts, per-file status, artifact paths, and
+  the reproduction command without changing the JSON artifact contract or any
+  public `tokmd` output.

--- a/docs/specs/ast-shadow.md
+++ b/docs/specs/ast-shadow.md
@@ -51,6 +51,7 @@ target/tokmd-ast-shadow/
   heuristic.json
   ast.json
   diff.json
+  summary.md         # optional human summary
   check.json          # optional verifier receipt
 ```
 
@@ -75,6 +76,20 @@ comparison without scanning every file entry.
 
 All three artifacts must avoid timestamps, absolute paths, environment-specific
 temporary directories, and nondeterministic ordering.
+
+The comparison runner may also write an optional `summary.md`:
+
+```bash
+cargo xtask ast-shadow-compare \
+  --path fixtures/ast-shadow/rust/basic.rs \
+  --out target/tokmd-ast-shadow \
+  --summary-md target/tokmd-ast-shadow/summary.md
+```
+
+The Markdown summary is a human review layer over `diff.json`. It should include
+aggregate counts, per-file comparison status, artifact paths, and a reproduction
+command. It must not add pass/fail language, merge verdicts, proof-promotion
+claims, or public receipt semantics.
 
 The verifier is developer-facing xtask tooling:
 
@@ -150,7 +165,7 @@ names should run:
 cargo test -p tokmd-analysis --features ast ast --verbose
 cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
 cargo test -p xtask ast_shadow --verbose
-cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --out target/tokmd-ast-shadow
+cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --out target/tokmd-ast-shadow --summary-md target/tokmd-ast-shadow/summary.md
 cargo xtask ast-shadow-check --path fixtures/ast-shadow/rust/basic.rs --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json
 cargo xtask proof-policy --check
 cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow.json

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -110,6 +110,10 @@ pub struct AstShadowCompareArgs {
     /// Output directory for heuristic.json, ast.json, and diff.json.
     #[arg(long, default_value = "target/tokmd-ast-shadow")]
     pub out: std::path::PathBuf,
+
+    /// Optional Markdown summary path for human review of comparison counts.
+    #[arg(long)]
+    pub summary_md: Option<std::path::PathBuf>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/xtask/src/tasks/ast_shadow_check.rs
+++ b/xtask/src/tasks/ast_shadow_check.rs
@@ -14,6 +14,7 @@ pub fn run(args: AstShadowCheckArgs) -> Result<()> {
         ast_shadow_compare::run(AstShadowCompareArgs {
             paths: args.paths.clone(),
             out: args.dir.clone(),
+            summary_md: None,
         })?;
     }
 

--- a/xtask/src/tasks/ast_shadow_compare.rs
+++ b/xtask/src/tasks/ast_shadow_compare.rs
@@ -28,6 +28,10 @@ fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
     let artifacts = build_shadow_artifacts(&shadow_inputs).context("build AST shadow artifacts")?;
     let paths = write_shadow_artifacts(&args.out, &artifacts)
         .with_context(|| format!("write AST shadow artifacts to {}", args.out.display()))?;
+    if let Some(summary_path) = &args.summary_md {
+        write_summary_md(summary_path, &args, &paths, &artifacts.diff, root)
+            .with_context(|| format!("write AST shadow summary to {}", summary_path.display()))?;
+    }
 
     let ast_files = artifacts
         .ast
@@ -49,8 +53,177 @@ fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
     println!("  heuristic: {}", paths.heuristic.display());
     println!("  ast: {}", paths.ast.display());
     println!("  diff: {}", paths.diff.display());
+    if let Some(summary_path) = &args.summary_md {
+        println!("  summary: {}", summary_path.display());
+    }
 
     Ok(())
+}
+
+fn write_summary_md(
+    summary_path: &Path,
+    args: &AstShadowCompareArgs,
+    paths: &tokmd_analysis::ast::ShadowArtifactPaths,
+    diff: &serde_json::Value,
+    root: &Path,
+) -> Result<()> {
+    let summary = render_summary_md(args, paths, diff, root)?;
+
+    if let Some(parent) = summary_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create summary parent {}", parent.display()))?;
+    }
+
+    fs::write(summary_path, summary)
+        .with_context(|| format!("write summary {}", summary_path.display()))
+}
+
+fn render_summary_md(
+    args: &AstShadowCompareArgs,
+    paths: &tokmd_analysis::ast::ShadowArtifactPaths,
+    diff: &serde_json::Value,
+    root: &Path,
+) -> Result<String> {
+    let summary = diff
+        .get("summary")
+        .and_then(serde_json::Value::as_object)
+        .context("diff artifact is missing summary object")?;
+    let files = diff
+        .get("files")
+        .and_then(serde_json::Value::as_array)
+        .context("diff artifact is missing files array")?;
+
+    let mut markdown = String::new();
+    markdown.push_str("# AST Shadow Comparison\n\n");
+    markdown.push_str("Developer-facing heuristic-vs-AST comparison evidence. ");
+    markdown.push_str("This is not a merge verdict, proof promotion, or public receipt.\n\n");
+
+    markdown.push_str("## Summary\n\n");
+    push_count_line(&mut markdown, "Files compared", summary, "files")?;
+    push_count_line(&mut markdown, "Matched landmarks", summary, "matched")?;
+    push_count_line(
+        &mut markdown,
+        "Heuristic-only landmarks",
+        summary,
+        "heuristic_only",
+    )?;
+    push_count_line(&mut markdown, "AST-only landmarks", summary, "ast_only")?;
+    push_count_line(
+        &mut markdown,
+        "Parse-degraded files",
+        summary,
+        "parse_degraded",
+    )?;
+    push_count_line(&mut markdown, "Unsupported files", summary, "unsupported")?;
+
+    markdown.push_str("\n## Artifacts\n\n");
+    markdown.push_str(&format!(
+        "- heuristic: `{}`\n",
+        summary_display_path(&paths.heuristic, root)?
+    ));
+    markdown.push_str(&format!(
+        "- ast: `{}`\n",
+        summary_display_path(&paths.ast, root)?
+    ));
+    markdown.push_str(&format!(
+        "- diff: `{}`\n",
+        summary_display_path(&paths.diff, root)?
+    ));
+
+    markdown.push_str("\n## Files\n\n");
+    for file in files {
+        let path = string_field(file, "path")?;
+        let status = string_field(file, "status")?;
+        let matches = array_len(file, "matches")?;
+        let heuristic_only = array_len(file, "heuristic_only")?;
+        let ast_only = array_len(file, "ast_only")?;
+        let parse_degraded = bool_field(file, "parse_degraded")?;
+        let unsupported = bool_field(file, "unsupported")?;
+
+        markdown.push_str(&format!("- `{path}`\n"));
+        markdown.push_str(&format!("  - status: `{status}`\n"));
+        markdown.push_str(&format!("  - matched landmarks: {matches}\n"));
+        markdown.push_str(&format!("  - heuristic-only landmarks: {heuristic_only}\n"));
+        markdown.push_str(&format!("  - AST-only landmarks: {ast_only}\n"));
+        markdown.push_str(&format!("  - parse degraded: {parse_degraded}\n"));
+        markdown.push_str(&format!("  - unsupported: {unsupported}\n"));
+    }
+
+    markdown.push_str("\n## Reproduce\n\n");
+    markdown.push_str("```bash\n");
+    markdown.push_str("cargo xtask ast-shadow-compare");
+    for path in &args.paths {
+        markdown.push_str(" \\\n  --path ");
+        markdown.push_str(&summary_display_path(path, root)?);
+    }
+    markdown.push_str(" \\\n  --out ");
+    markdown.push_str(&summary_display_path(&args.out, root)?);
+    if let Some(summary_md) = &args.summary_md {
+        markdown.push_str(" \\\n  --summary-md ");
+        markdown.push_str(&summary_display_path(summary_md, root)?);
+    }
+    markdown.push_str("\n```\n");
+
+    Ok(markdown)
+}
+
+fn push_count_line(
+    markdown: &mut String,
+    label: &str,
+    summary: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<()> {
+    let count = summary
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .with_context(|| format!("diff summary is missing numeric field `{key}`"))?;
+    markdown.push_str(&format!("- {label}: {count}\n"));
+    Ok(())
+}
+
+fn string_field<'a>(value: &'a serde_json::Value, field: &str) -> Result<&'a str> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .with_context(|| format!("diff file entry is missing string field `{field}`"))
+}
+
+fn bool_field(value: &serde_json::Value, field: &str) -> Result<bool> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_bool)
+        .with_context(|| format!("diff file entry is missing bool field `{field}`"))
+}
+
+fn array_len(value: &serde_json::Value, field: &str) -> Result<usize> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .with_context(|| format!("diff file entry is missing array field `{field}`"))
+}
+
+fn normalize_display_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn summary_display_path(path: &Path, root: &Path) -> Result<String> {
+    let display_path = if path.is_absolute() {
+        path.strip_prefix(root)
+            .with_context(|| {
+                format!(
+                    "AST shadow summary paths must stay under the repo root: {}",
+                    path.display()
+                )
+            })?
+            .to_path_buf()
+    } else {
+        path.to_path_buf()
+    };
+    Ok(normalize_display_path(&display_path))
 }
 
 #[derive(Debug)]
@@ -351,6 +524,7 @@ pub fn compute(value: usize) -> usize {
         let args = AstShadowCompareArgs {
             paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
             out: out.clone(),
+            summary_md: None,
         };
 
         run_with_root(args.clone(), root.path())?;
@@ -364,6 +538,59 @@ pub fn compute(value: usize) -> usize {
         assert!(out.join("diff.json").exists());
         assert!(first.contains("\"schema\": \"tokmd.ast_shadow.v1\""));
         assert!(!first.contains(root.path().to_string_lossy().as_ref()));
+        Ok(())
+    }
+
+    #[test]
+    fn runner_writes_markdown_summary_when_requested() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let fixture_dir = root.path().join("fixtures/ast-shadow/rust");
+        fs::create_dir_all(&fixture_dir)?;
+        fs::write(
+            fixture_dir.join("basic.rs"),
+            "use std::fs;\n\npub fn compute(value: usize) -> usize {\n    if value > 0 {\n        value\n    } else {\n        0\n    }\n}\n",
+        )?;
+        let out = root.path().join("target/tokmd-ast-shadow");
+        let summary_md = root.path().join("target/tokmd-ast-shadow/summary.md");
+        let args = AstShadowCompareArgs {
+            paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
+            out,
+            summary_md: Some(summary_md.clone()),
+        };
+
+        run_with_root(args, root.path())?;
+        let summary = fs::read_to_string(summary_md)?;
+
+        assert!(summary.contains("# AST Shadow Comparison"));
+        assert!(summary.contains("- Files compared: 1"));
+        assert!(summary.contains("- `fixtures/ast-shadow/rust/basic.rs`"));
+        assert!(summary.contains("cargo xtask ast-shadow-compare"));
+        assert!(summary.contains("--summary-md"));
+        assert!(!summary.contains(&normalize_display_path(root.path())));
+        Ok(())
+    }
+
+    #[test]
+    fn summary_rejects_paths_outside_repo_root() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let outside = tempfile::tempdir()?;
+        let fixture_dir = root.path().join("fixtures/ast-shadow/rust");
+        fs::create_dir_all(&fixture_dir)?;
+        fs::write(
+            fixture_dir.join("basic.rs"),
+            "use std::fs;\n\npub fn compute() {}\n",
+        )?;
+        let args = AstShadowCompareArgs {
+            paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
+            out: root.path().join("target/tokmd-ast-shadow"),
+            summary_md: Some(outside.path().join("summary.md")),
+        };
+
+        let error = run_with_root(args, root.path())
+            .expect_err("summary paths outside the repo should fail");
+
+        assert!(error.to_string().contains("AST shadow summary"));
+        assert!(!outside.path().join("summary.md").exists());
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add optional `--summary-md` output for `cargo xtask ast-shadow-compare`
- render aggregate diff counts, per-file comparison status, artifact paths, and the reproduction command
- document the Markdown summary in the AST shadow spec, runner plan, and artifact glossary

## Guardrails
- no public `tokmd` CLI command
- no default analyze/cockpit/context/handoff/browser output changes
- no public receipt schema change, proof promotion, Codecov default, or merge verdict behavior

## Validation
- `cargo fmt-fix`
- `cargo test -p xtask ast_shadow --verbose`
- `cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --path fixtures/ast-shadow/rust/parse-degraded.rs --out target/tokmd-ast-shadow-summary-md --summary-md target/tokmd-ast-shadow-summary-md/summary.md`
- `cargo xtask ast-shadow-check --path fixtures/ast-shadow/rust/basic.rs --dir target/tokmd-ast-shadow-summary-md-check --json target/tokmd-ast-shadow-summary-md-check/check.json`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo test -p tokmd-analysis --features ast ast --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow-summary-md.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-shadow-summary-md.json --evidence-json target/proof/proof-evidence-ast-shadow-summary-md.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-ast-shadow-summary-md.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-ast-shadow-summary-md.json`
- `cargo xtask publish-surface --json --verify-publish`
- `git diff --check`