### PR TITLE
docs: record AST shadow comparison evidence

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -55,10 +55,11 @@ Rust shadow parser now records function, import, and simple control-flow
 landmarks behind the existing `ast` feature. The AST shadow lane also has a
 developer-facing synthetic performance receipt example so parser and artifact
 builder timings can be collected before any public behavior change is proposed.
-The active AST follow-on is now the comparison-runner lane: define the first
-developer-facing runner around Rust landmark presence for functions, imports,
-and simple control-flow, keeping it out of default product workflows until
-comparison evidence exists.
+The active AST follow-on is now the comparison-runner lane: the developer-facing
+runner and verifier exist, the first internal-corpus comparison evidence is
+recorded in `docs/plans/ast-shadow-comparison-runner.md`, and AST work must
+stay out of default product workflows until broader comparison evidence
+justifies a public schema or behavior proposal.
 
 ## Next Work Packets
 

--- a/docs/plans/ast-shadow-comparison-runner.md
+++ b/docs/plans/ast-shadow-comparison-runner.md
@@ -115,6 +115,56 @@ cargo xtask publish-surface --json --verify-publish
 - Stop if docs imply proof promotion, Codecov upload, merge verdicts, or
   default AST adoption.
 
+## Evidence Notes
+
+### 2026-05-14: Internal AST implementation files
+
+Command:
+
+```bash
+cargo xtask ast-shadow-compare \
+  --path crates/tokmd-analysis/src/ast/rust.rs \
+  --path crates/tokmd-analysis/src/ast/shadow.rs \
+  --out target/tokmd-ast-shadow-real-corpus \
+  --summary-md target/tokmd-ast-shadow-real-corpus/summary.md
+
+cargo xtask ast-shadow-check \
+  --dir target/tokmd-ast-shadow-real-corpus \
+  --json target/tokmd-ast-shadow-real-corpus/check.json
+```
+
+Observed summary:
+
+| Metric | Count |
+| --- | ---: |
+| Files compared | 2 |
+| Matched landmarks | 70 |
+| Heuristic-only landmarks | 33 |
+| AST-only landmarks | 0 |
+| Parse-degraded files | 0 |
+| Unsupported files | 0 |
+
+Per-file summary:
+
+| File | Matched | Heuristic-only | AST-only | Parse degraded |
+| --- | ---: | ---: | ---: | --- |
+| `crates/tokmd-analysis/src/ast/rust.rs` | 26 | 23 | 0 | false |
+| `crates/tokmd-analysis/src/ast/shadow.rs` | 44 | 10 | 0 | false |
+
+Interpretation:
+
+- This is comparison evidence only, not a product behavior change or merge
+  verdict.
+- The selected internal corpus had no parse degradation and no unsupported
+  files.
+- The first signal is heuristic over-reporting, not AST-only discovery: the
+  line heuristic reported extra function/import/control-flow landmarks in test
+  fixture strings and examples that the AST parser did not treat as Rust code.
+- The next decision should use a broader corpus before proposing any public
+  receipt field. Function-boundary precision remains the likely first
+  candidate because false positives from fixture strings are easy to explain
+  and review.
+
 ## Checkpoint History
 
 - 2026-05-14: Started the comparison-runner lane after the synthetic AST shadow
@@ -139,3 +189,8 @@ cargo xtask publish-surface --json --verify-publish
   `--summary-md` renders aggregate counts, per-file status, artifact paths, and
   the reproduction command without changing the JSON artifact contract or any
   public `tokmd` output.
+- 2026-05-14: Collected the first real internal-corpus comparison evidence on
+  `crates/tokmd-analysis/src/ast/rust.rs` and
+  `crates/tokmd-analysis/src/ast/shadow.rs`. The run found 70 matched
+  landmarks, 33 heuristic-only landmarks, zero AST-only landmarks, and no parse
+  degradation.


### PR DESCRIPTION
## Summary
- record the first real internal-corpus AST shadow comparison evidence
- note the exact runner and verifier commands used for the evidence collection
- update `docs/NEXT.md` so it reflects that the runner/verifier exist and initial comparison evidence has been collected

## Evidence recorded
- Corpus: `crates/tokmd-analysis/src/ast/rust.rs`, `crates/tokmd-analysis/src/ast/shadow.rs`
- Summary: 2 files, 70 matched landmarks, 33 heuristic-only landmarks, 0 AST-only landmarks, 0 parse-degraded files, 0 unsupported files
- Interpretation: first signal is heuristic over-reporting from fixture strings/examples, not AST-only discovery

## Guardrails
- docs-only
- no default receipt, browser, cockpit, handoff, or public CLI behavior change
- no proof promotion, Codecov default, merge verdict, or public AST schema proposal

## Validation
- `cargo xtask ast-shadow-compare --path crates/tokmd-analysis/src/ast/rust.rs --path crates/tokmd-analysis/src/ast/shadow.rs --out target/tokmd-ast-shadow-real-corpus --summary-md target/tokmd-ast-shadow-real-corpus/summary.md`
- `cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow-real-corpus --json target/tokmd-ast-shadow-real-corpus/check.json`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow-first-evidence.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-shadow-first-evidence.json --evidence-json target/proof/proof-evidence-ast-shadow-first-evidence.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-ast-shadow-first-evidence.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-ast-shadow-first-evidence.json`