### PR TITLE
docs: plan AST function-boundary candidate evidence

### DIFF
--- a/.jules/goals/active.toml
+++ b/.jules/goals/active.toml
@@ -1,7 +1,7 @@
 schema = "tokmd.jules.active_goal.v1"
 status = "active"
 program = "code_intelligence"
-lane = "proof_observation_decision_readiness"
+lane = "ast_function_boundary_candidate_evidence"
 
 [links]
 source_of_truth = "docs/source-of-truth.md"
@@ -20,6 +20,7 @@ ast_shadow_artifact_builder_plan = "docs/plans/ast-shadow-artifact-builder.md"
 ast_rust_landmark_coverage_plan = "docs/plans/ast-rust-landmark-coverage.md"
 ast_shadow_performance_plan = "docs/plans/ast-shadow-performance-benchmark.md"
 ast_shadow_comparison_runner_plan = "docs/plans/ast-shadow-comparison-runner.md"
+ast_function_boundary_candidate_plan = "docs/plans/ast-function-boundary-candidate.md"
 ast_foundation_adr = "docs/adr/0008-ast-foundation.md"
 handoff_guide = "docs/handoff.md"
 handoff_schema = "docs/handoff-schema.md"
@@ -39,6 +40,7 @@ handoff_integrity = "link_review_and_proof_receipts_without_replacing_their_veri
 ast_shadow = "developer_facing_shadow_artifacts_only"
 ast_default_behavior = "do_not_change_default_receipts_or_browser_capabilities"
 ast_schema = "public_ast_fields_require_schema_family_review"
+ast_function_boundary_candidate = "evidence_first_no_public_product_behavior"
 proof_observation = "summarize_existing_receipts_before_any_promotion_decision"
 github_actions_boundary = "keep_actions_as_runner_cache_artifact_shell"
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -63,17 +63,19 @@ function-boundary candidate decision are recorded in
 product workflows until a fresh plan uses broader comparison evidence to justify
 a public schema or behavior proposal. Control-flow evidence remains shadow-only.
 
-The active machine-readable goal now points at proof-observation decision
-readiness. The next proof-control work should inventory and summarize existing
-Rust-owned proof receipts before any maintainer decision about required gates,
-default Codecov upload, executor command limits, cockpit/handoff promotion, or
-workflow defaults. The plan lives in
-`docs/plans/proof-observation-decision-readiness.md`.
+The active machine-readable goal now points at AST function-boundary candidate
+evidence. The next AST work should use existing shadow artifacts, verifier
+receipts, corpus notes, mismatch classification, and timing evidence to decide
+whether Rust function-boundary precision is ready for a future public candidate
+proposal. This is evidence planning only: no default product workflow, public
+receipt schema, browser/WASM capability, proof gate, Codecov default, cockpit
+output, handoff output, or evidencebus runtime changes are in scope. The plan
+lives in `docs/plans/ast-function-boundary-candidate.md`.
 
 ## Next Work Packets
 
-1. Make routine proof observations decision-ready under the current advisory
-   shape; do not promote gates or Codecov defaults.
+1. Make AST function-boundary candidate evidence repeatable and decision-ready
+   under shadow mode; do not change public product behavior or receipt schemas.
 2. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence
    shows a product, verifier, or hosted-comment issue.
 3. Preserve `tokmd cockpit` as the review evidence implementation surface until

--- a/docs/plans/ast-function-boundary-candidate.md
+++ b/docs/plans/ast-function-boundary-candidate.md
@@ -1,0 +1,176 @@
+# Plan: AST Function-Boundary Candidate Evidence
+
+- Status: active
+- Related proposal:
+- Related spec: `docs/specs/ast-shadow.md`
+- Related ADR: `docs/adr/0008-ast-foundation.md`
+- Related issues:
+
+## Goal
+
+Decide, with repeatable shadow evidence, whether AST-backed Rust
+function-boundary facts are ready to move from developer-facing comparison
+artifacts into a future public candidate surface.
+
+The current AST shadow runner can already generate and verify
+`tokmd.ast_shadow.v1` heuristic, AST, and diff artifacts for explicit Rust
+files. This lane uses those artifacts to define the evidence bar for one fact
+family before any default product behavior, public receipt schema, cockpit
+output, handoff output, browser capability, or proof gate changes.
+
+The target decision is intentionally narrow:
+
+```text
+Are Rust function-boundary facts accurate, explainable, performant, and
+fallback-safe enough to justify a later public candidate proposal?
+```
+
+The answer may be yes, no, or not yet. It must be backed by checked shadow
+artifacts, corpus notes, mismatch classification, and timing evidence.
+
+## Non-goals
+
+- Do not add a public `tokmd ast`, `tokmd review`, or new product command.
+- Do not change default `tokmd analyze`, `cockpit`, `context`, `handoff`,
+  browser/WASM, FFI, Python, or Node outputs.
+- Do not add public receipt fields or change schema meaning.
+- Do not claim browser/WASM AST capability.
+- Do not promote proof gates, scoped coverage, mutation, fast proof, or Codecov
+  upload.
+- Do not build evidencebus runtime export or make tokmd carry evidencebus
+  responsibilities.
+- Do not build mergecode-style semantic graphs, call graphs, type resolution,
+  or cross-file semantic relationships.
+- Do not treat AST shadow diffs as merge verdicts, pass/fail proof, or review
+  blockers.
+- Do not implement cockpit or handoff AST integration before the candidate
+  evidence and contract justify it.
+
+## Work Packets
+
+1. Define the function-boundary candidate evidence bar.
+   - Status: complete.
+   - Record what evidence must exist before a public candidate proposal can be
+     drafted.
+   - Keep this first slice docs/control-plane only.
+2. Make the comparison corpus repeatable.
+   - Status: pending.
+   - Add a repo-owned corpus manifest with explicit repo-relative Rust paths
+     and selection reasons.
+   - Include production code, tests, fixtures, example-heavy parser code,
+     macro-ish shapes, generic functions, async/unsafe/extern signatures,
+     multi-line signatures, and docs-adjacent Rust snippets where available.
+3. Let the runner consume the corpus manifest.
+   - Status: pending.
+   - Preserve existing explicit `--path` mode.
+   - Keep manifest paths repo-relative, Rust-only, sorted, and rejected when
+     absolute or escaping the repository.
+4. Collect and classify function-boundary mismatch evidence.
+   - Status: pending.
+   - Run `ast-shadow-compare` and `ast-shadow-check` over the manifest corpus.
+   - Categorize heuristic-only function discoveries separately from AST-only
+     discoveries.
+   - Distinguish fixture-string false positives from comments/docs examples,
+     macro-ish patterns, malformed input, parser recovery, and true heuristic
+     misses or false positives.
+5. Define promotion criteria as a spec-level decision framework.
+   - Status: pending.
+   - Use the checked corpus evidence to define what would justify public
+     candidate work.
+   - Keep the framework advisory until maintainers explicitly accept a product
+     proposal.
+6. Draft a public candidate proposal only if evidence supports it.
+   - Status: pending.
+   - The proposal must identify the affected schema family, fallback behavior,
+     browser/WASM reporting, proof ownership, rollback plan, and first product
+     surface.
+   - A likely first product surface is optional cockpit or handoff evidence,
+     not default `analyze`.
+7. Close the lane with a durable decision.
+   - Status: pending.
+   - Record whether function boundaries are ready for a public candidate
+     proposal, need more corpus evidence, or should remain developer-only
+     shadow evidence.
+
+## Candidate Evidence Criteria
+
+Before function-boundary facts can move toward a public candidate surface, the
+lane needs evidence for all of the following:
+
+- The corpus is repeatable from a checked-in manifest and covers more than the
+  AST implementation files.
+- `cargo xtask ast-shadow-compare` produces deterministic artifact bytes for
+  the corpus.
+- `cargo xtask ast-shadow-check` accepts the generated artifacts and verifies
+  schema, relative paths, sorted entries, timestamp-free content, and summary
+  counts.
+- Parse degradation is zero or each degraded file is explained and categorized.
+- Unsupported files are explicit and not counted as successful AST evidence.
+- Function-kind by-kind counts are recorded separately from import and
+  control-flow counts.
+- Heuristic-only function landmarks are inspected and categorized as fixture
+  strings, comments/docs examples, macro-ish patterns, malformed input, parser
+  mismatch, or real heuristic false positives.
+- AST-only function landmarks are inspected and categorized as multi-line
+  signatures, visibility/async/unsafe/extern shapes, nested items, parser
+  recovery cases, or real heuristic misses.
+- Timing is bounded with `tokmd.ast_shadow_perf.v1` evidence or a clearly
+  scoped equivalent runner receipt.
+- Fallback behavior is documented for unsupported languages, unavailable AST
+  builds, and browser/WASM.
+- Any later public schema impact is additive or explicitly versioned, and the
+  affected schema family is named before implementation starts.
+
+## Validation
+
+Docs-only slices should run:
+
+```bash
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-function-boundary-candidate.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-function-boundary-candidate.json --evidence-json target/proof/proof-evidence-ast-function-boundary-candidate.json
+cargo fmt-check
+git diff --check
+```
+
+Corpus, runner, or AST-code slices should also run the relevant focused proof:
+
+```bash
+cargo test -p tokmd-analysis --features ast ast --verbose
+cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
+cargo test -p xtask ast_shadow --verbose
+cargo xtask ast-shadow-compare --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md --path <repo-relative-rust-path>
+cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
+```
+
+If public crate exports, dependencies, browser/WASM capability claims, schemas,
+bindings, or package surfaces move, also run the relevant owner checks and
+publish-surface verification.
+
+## Stop Conditions
+
+- Stop if the lane requires a public `tokmd` command before the evidence
+  decision exists.
+- Stop if AST evidence changes default product receipts or browser/WASM
+  capability claims.
+- Stop if a proposed public field lacks an identified schema family and
+  fallback story.
+- Stop if AST shadow artifacts include timestamps, absolute paths, temporary
+  directories, or nondeterministic ordering.
+- Stop if parser degradation is hidden or counted as available proof.
+- Stop if control-flow or import evidence is promoted by piggybacking on the
+  function-boundary decision.
+- Stop if proof, scoped coverage, mutation, fast proof, or Codecov upload is
+  promoted by this lane.
+- Stop if evidencebus runtime implementation becomes necessary.
+- Stop if affected planning reports unknown files.
+- Stop if generated `target/` artifacts are staged or committed.
+
+## Checkpoint History
+
+- 2026-05-14: Started after the AST shadow comparison-runner lane closed
+  through first enforcement. Existing evidence shows function-boundary
+  mismatches are the narrowest first candidate; control-flow remains noisier
+  and shadow-only.

--- a/docs/specs/ast-shadow.md
+++ b/docs/specs/ast-shadow.md
@@ -118,11 +118,15 @@ Rust source and heuristic landmarks. Its Rust parser records function, import,
 and simple control-flow landmarks, but it is not wired into default CLI,
 receipt, browser, FFI, Python, Node, or CI behavior.
 
-The next active implementation plan is
-`docs/plans/ast-shadow-comparison-runner.md`. It selects Rust landmark presence
-for functions, imports, and simple control-flow as the first comparison target
-and keeps the first runner in developer tooling rather than the public `tokmd`
-CLI while the artifact contract stabilizes.
+The comparison-runner implementation plan,
+`docs/plans/ast-shadow-comparison-runner.md`, is complete through first
+enforcement. The active follow-on plan is
+`docs/plans/ast-function-boundary-candidate.md`. It uses the existing runner,
+verifier, Markdown summary, corpus evidence, mismatch classification, and
+timing receipts to decide whether Rust function-boundary precision is ready for
+a later public candidate proposal. It does not change default `tokmd` CLI
+behavior, public receipts, browser/WASM capability, cockpit output, handoff
+output, proof gates, Codecov defaults, or evidencebus runtime behavior.
 
 `tokmd-analysis` also provides a developer-facing synthetic performance
 example:


### PR DESCRIPTION
## Summary
- add an active AST function-boundary candidate evidence plan
- retarget `.jules/goals/active.toml` and `docs/NEXT.md` from proof-observation readiness to the new AST candidate lane
- update the AST shadow spec to point from the completed comparison-runner plan to the follow-on candidate evidence plan

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-function-boundary-candidate.json` (4 changed files, 5 scopes, 0 unknown files)
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-function-boundary-candidate.json --evidence-json target/proof/proof-evidence-ast-function-boundary-candidate.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-ast-function-boundary-candidate.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-ast-function-boundary-candidate.json` (29 executed required commands)

## Guardrails
- no public `tokmd` CLI behavior changes
- no default analyze/cockpit/context/handoff/browser output changes
- no public receipt schema changes
- no proof promotion, Codecov default, merge verdict, or evidencebus runtime