### PR TITLE
feat(xtask): compare AST shadow corpus manifests

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -567,7 +567,7 @@ proof = [
   "cargo test -p tokmd-analysis --features ast ast --verbose",
   "cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json",
   "cargo test -p xtask ast_shadow --verbose",
-  "cargo xtask ast-shadow-check --path fixtures/ast-shadow/rust/basic.rs --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json",
+  "cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json",
 ]
 mutation = false
 coverage = false

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -72,6 +72,8 @@ receipt schema, browser/WASM capability, proof gate, Codecov default, cockpit
 output, handoff output, or evidencebus runtime changes are in scope. The plan
 lives in `docs/plans/ast-function-boundary-candidate.md`, and the first
 repo-owned draft corpus manifest lives in `policy/ast-shadow-corpus.toml`.
+`cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml`
+is the developer-facing collection path for that corpus.
 
 ## Next Work Packets
 

--- a/docs/plans/ast-function-boundary-candidate.md
+++ b/docs/plans/ast-function-boundary-candidate.md
@@ -62,7 +62,11 @@ artifacts, corpus notes, mismatch classification, and timing evidence.
      implementation code, parser code with fixture-string risk, review-surface
      logic, agent-context selection logic, and the comparison runner.
 3. Let the runner consume the corpus manifest.
-   - Status: pending.
+   - Status: complete.
+   - `cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml`
+     now expands the repo-owned corpus manifest into the same deterministic
+     `heuristic.json`, `ast.json`, `diff.json`, and optional `summary.md`
+     artifacts as explicit `--path` mode.
    - Preserve existing explicit `--path` mode.
    - Keep manifest paths repo-relative, Rust-only, sorted, and rejected when
      absolute or escaping the repository.
@@ -142,8 +146,8 @@ Corpus, runner, or AST-code slices should also run the relevant focused proof:
 cargo test -p tokmd-analysis --features ast ast --verbose
 cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
 cargo test -p xtask ast_shadow --verbose
-cargo xtask ast-shadow-compare --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md --path <repo-relative-rust-path>
-cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
+cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md
+cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
 ```
 
 If public crate exports, dependencies, browser/WASM capability claims, schemas,
@@ -179,3 +183,6 @@ publish-surface verification.
   `policy/ast-shadow-corpus.toml` and routed it through the
   `analysis_ast_shadow` proof scope. The manifest is repo-owned input for a
   later runner-consumption slice; it does not change public tokmd behavior.
+- 2026-05-14: Extended `cargo xtask ast-shadow-compare` to consume the corpus
+  manifest while preserving explicit `--path` mode. The manifest runner stays
+  developer-facing and keeps AST shadow output out of public tokmd workflows.

--- a/docs/specs/ast-shadow.md
+++ b/docs/specs/ast-shadow.md
@@ -88,6 +88,16 @@ cargo xtask ast-shadow-compare \
   --summary-md target/tokmd-ast-shadow/summary.md
 ```
 
+For repeatable candidate evidence, the runner may consume the repo-owned
+corpus manifest instead of listing every file on the command line:
+
+```bash
+cargo xtask ast-shadow-compare \
+  --manifest policy/ast-shadow-corpus.toml \
+  --out target/tokmd-ast-shadow \
+  --summary-md target/tokmd-ast-shadow/summary.md
+```
+
 The Markdown summary is a human review layer over `diff.json`. It should include
 aggregate counts, mismatch counts by landmark kind, per-file comparison status,
 artifact paths, and a reproduction command. It must not add pass/fail language,
@@ -110,9 +120,9 @@ verdict, proof promotion signal, browser capability claim, or evidencebus
 packet.
 
 For proof commands that need to be self-contained, `ast-shadow-check` may also
-accept the same explicit repo-relative Rust `--path` inputs as the comparison
-runner. In that mode it regenerates the three shadow artifacts into `--dir`
-before validating them.
+accept the same explicit repo-relative Rust `--path` inputs or repo-relative
+`--manifest` input as the comparison runner. In that mode it regenerates the
+three shadow artifacts into `--dir` before validating them.
 
 The first implementation lives in `tokmd-analysis` behind the existing `ast`
 feature. It builds and writes the three artifact JSON files for caller-provided
@@ -171,8 +181,8 @@ names should run:
 cargo test -p tokmd-analysis --features ast ast --verbose
 cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
 cargo test -p xtask ast_shadow --verbose
-cargo xtask ast-shadow-compare --path fixtures/ast-shadow/rust/basic.rs --out target/tokmd-ast-shadow --summary-md target/tokmd-ast-shadow/summary.md
-cargo xtask ast-shadow-check --path fixtures/ast-shadow/rust/basic.rs --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json
+cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow --summary-md target/tokmd-ast-shadow/summary.md
+cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json
 cargo xtask proof-policy --check
 cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow.json
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-shadow.json --evidence-json target/proof/proof-evidence-ast-shadow.json

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -104,8 +104,12 @@ pub enum Commands {
 #[derive(Args, Debug, Clone)]
 pub struct AstShadowCompareArgs {
     /// Repo-relative Rust source path to compare. Repeat for multiple files.
-    #[arg(long = "path", required = true)]
+    #[arg(long = "path")]
     pub paths: Vec<std::path::PathBuf>,
+
+    /// Repo-relative AST shadow corpus manifest to compare.
+    #[arg(long)]
+    pub manifest: Option<std::path::PathBuf>,
 
     /// Output directory for heuristic.json, ast.json, and diff.json.
     #[arg(long, default_value = "target/tokmd-ast-shadow")]
@@ -121,6 +125,10 @@ pub struct AstShadowCheckArgs {
     /// Optional repo-relative Rust source path to compare before checking artifacts.
     #[arg(long = "path")]
     pub paths: Vec<std::path::PathBuf>,
+
+    /// Optional repo-relative AST shadow corpus manifest to compare before checking artifacts.
+    #[arg(long)]
+    pub manifest: Option<std::path::PathBuf>,
 
     /// Directory containing heuristic.json, ast.json, and diff.json.
     #[arg(long, default_value = "target/tokmd-ast-shadow")]

--- a/xtask/src/tasks/ast_shadow_check.rs
+++ b/xtask/src/tasks/ast_shadow_check.rs
@@ -10,9 +10,10 @@ use tokmd_analysis::ast::{AST_SHADOW_SCHEMA_VERSION, default_shadow_artifacts};
 const AST_SHADOW_CHECK_SCHEMA: &str = "tokmd.ast_shadow_check.v1";
 
 pub fn run(args: AstShadowCheckArgs) -> Result<()> {
-    if !args.paths.is_empty() {
+    if !args.paths.is_empty() || args.manifest.is_some() {
         ast_shadow_compare::run(AstShadowCompareArgs {
             paths: args.paths.clone(),
+            manifest: args.manifest.clone(),
             out: args.dir.clone(),
             summary_md: None,
         })?;
@@ -509,6 +510,7 @@ mod tests {
 
         run(AstShadowCheckArgs {
             paths: vec![source],
+            manifest: None,
             dir: out.clone(),
             json: Some(receipt.clone()),
         })?;
@@ -522,6 +524,47 @@ mod tests {
             Some(AST_SHADOW_CHECK_SCHEMA)
         );
         assert_eq!(report["summary"]["files"], json!(1));
+        Ok(())
+    }
+
+    #[test]
+    fn check_can_generate_manifest_artifacts_before_verifying() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let current_dir = std::env::current_dir()?;
+        let scratch_root = current_dir.join("target");
+        fs::create_dir_all(&scratch_root)?;
+        let source_root = tempfile::tempdir_in(scratch_root)?;
+        let source_dir = source_root.path().join("fixtures");
+        fs::create_dir_all(&source_dir)?;
+        fs::write(
+            source_dir.join("input.rs"),
+            "use std::fs;\npub fn fixture() {}\n",
+        )?;
+        let source = source_dir
+            .join("input.rs")
+            .strip_prefix(&current_dir)?
+            .to_path_buf();
+        let manifest = source_root.path().join("ast-shadow-corpus.toml");
+        fs::write(
+            &manifest,
+            format!(
+                "schema = \"tokmd.ast_shadow_corpus.v1\"\nlanguage = \"rust\"\n\n[[file]]\npath = \"{}\"\n",
+                source.to_string_lossy().replace('\\', "/")
+            ),
+        )?;
+        let manifest = manifest.strip_prefix(&current_dir)?.to_path_buf();
+        let out = temp.path().join("ast-shadow");
+
+        run(AstShadowCheckArgs {
+            paths: Vec::new(),
+            manifest: Some(manifest),
+            dir: out.clone(),
+            json: None,
+        })?;
+
+        assert!(out.join("heuristic.json").is_file());
+        assert!(out.join("ast.json").is_file());
+        assert!(out.join("diff.json").is_file());
         Ok(())
     }
 

--- a/xtask/src/tasks/ast_shadow_compare.rs
+++ b/xtask/src/tasks/ast_shadow_compare.rs
@@ -1,5 +1,6 @@
 use crate::cli::AstShadowCompareArgs;
 use anyhow::{Context, Result, bail};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
@@ -9,13 +10,16 @@ use tokmd_analysis::ast::{
     write_shadow_artifacts,
 };
 
+const AST_SHADOW_CORPUS_SCHEMA: &str = "tokmd.ast_shadow_corpus.v1";
+
 pub fn run(args: AstShadowCompareArgs) -> Result<()> {
     let root = std::env::current_dir().context("resolve current directory")?;
     run_with_root(args, &root)
 }
 
 fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
-    let inputs = collect_inputs(&args.paths, root)?;
+    let input_paths = input_paths_from_args(&args, root)?;
+    let inputs = collect_inputs(&input_paths, root)?;
     let shadow_inputs = inputs
         .iter()
         .map(|input| ShadowFileInput {
@@ -169,6 +173,10 @@ fn render_summary_md(
     markdown.push_str("\n## Reproduce\n\n");
     markdown.push_str("```bash\n");
     markdown.push_str("cargo xtask ast-shadow-compare");
+    if let Some(manifest) = &args.manifest {
+        markdown.push_str(" \\\n  --manifest ");
+        markdown.push_str(&summary_display_path(manifest, root)?);
+    }
     for path in &args.paths {
         markdown.push_str(" \\\n  --path ");
         markdown.push_str(&summary_display_path(path, root)?);
@@ -288,6 +296,99 @@ struct RunnerInput {
     heuristic_landmarks: Vec<ShadowLandmark>,
 }
 
+#[derive(Debug, Deserialize)]
+struct AstShadowCorpusManifest {
+    schema: String,
+    language: String,
+    #[serde(default)]
+    rules: AstShadowCorpusRules,
+    #[serde(default)]
+    file: Vec<AstShadowCorpusFile>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct AstShadowCorpusRules {
+    supported_extension: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AstShadowCorpusFile {
+    path: String,
+}
+
+fn input_paths_from_args(args: &AstShadowCompareArgs, root: &Path) -> Result<Vec<PathBuf>> {
+    if args.paths.is_empty() && args.manifest.is_none() {
+        bail!("AST shadow compare requires at least one --path or --manifest");
+    }
+
+    let mut paths = args.paths.clone();
+    if let Some(manifest) = &args.manifest {
+        paths.extend(read_manifest_paths(manifest, root)?);
+    }
+
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+fn read_manifest_paths(manifest_path: &Path, root: &Path) -> Result<Vec<PathBuf>> {
+    let manifest_path = validate_repo_relative_toml_path(manifest_path, root)?;
+    let full_path = root.join(&manifest_path);
+    let content = fs::read_to_string(&full_path).with_context(|| {
+        format!(
+            "read AST shadow corpus manifest {}",
+            manifest_path.display()
+        )
+    })?;
+    let manifest: AstShadowCorpusManifest = toml::from_str(&content).with_context(|| {
+        format!(
+            "parse AST shadow corpus manifest {}",
+            manifest_path.display()
+        )
+    })?;
+
+    if manifest.schema != AST_SHADOW_CORPUS_SCHEMA {
+        bail!(
+            "AST shadow corpus manifest schema `{}` does not match `{AST_SHADOW_CORPUS_SCHEMA}`",
+            manifest.schema
+        );
+    }
+    if manifest.language != "rust" {
+        bail!(
+            "AST shadow corpus manifest currently supports only Rust, found `{}`",
+            manifest.language
+        );
+    }
+    if let Some(extension) = &manifest.rules.supported_extension
+        && extension != ".rs"
+    {
+        bail!(
+            "AST shadow corpus manifest currently supports only `.rs` files, found `{extension}`"
+        );
+    }
+    if manifest.file.is_empty() {
+        bail!(
+            "AST shadow corpus manifest contains no [[file]] entries: {}",
+            manifest_path.display()
+        );
+    }
+
+    manifest
+        .file
+        .iter()
+        .map(|entry| {
+            if entry.path.contains('\\') {
+                bail!(
+                    "AST shadow corpus paths must use `/` separators: {}",
+                    entry.path
+                );
+            }
+            validate_repo_relative_rust_path(Path::new(&entry.path), root)
+                .with_context(|| format!("validate AST shadow corpus path {}", entry.path))
+        })
+        .collect()
+}
+
 fn collect_inputs(paths: &[PathBuf], root: &Path) -> Result<Vec<RunnerInput>> {
     let mut inputs = paths
         .iter()
@@ -310,6 +411,50 @@ fn collect_input(path: &Path, root: &Path) -> Result<RunnerInput> {
         source,
         heuristic_landmarks,
     })
+}
+
+fn validate_repo_relative_toml_path(path: &Path, root: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        bail!(
+            "AST shadow corpus manifest path must be repo-relative: {}",
+            path.display()
+        );
+    }
+
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir
+        )
+    }) {
+        bail!(
+            "AST shadow corpus manifest path must stay inside the repo: {}",
+            path.display()
+        );
+    }
+
+    if path.extension() != Some(OsStr::new("toml")) {
+        bail!(
+            "AST shadow corpus manifest must be a TOML file: {}",
+            path.display()
+        );
+    }
+
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("canonicalize repo root {}", root.display()))?;
+    let full_path = root.join(path);
+    let canonical = full_path
+        .canonicalize()
+        .with_context(|| format!("canonicalize manifest path {}", path.display()))?;
+    if !canonical.starts_with(&root) {
+        bail!(
+            "AST shadow corpus manifest resolves outside the repo: {}",
+            path.display()
+        );
+    }
+
+    Ok(path.to_path_buf())
 }
 
 fn validate_repo_relative_rust_path(path: &Path, root: &Path) -> Result<PathBuf> {
@@ -524,6 +669,38 @@ mod tests {
     }
 
     #[test]
+    fn requires_path_or_manifest() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let args = AstShadowCompareArgs {
+            paths: Vec::new(),
+            manifest: None,
+            out: PathBuf::from("target/tokmd-ast-shadow"),
+            summary_md: None,
+        };
+
+        let error = input_paths_from_args(&args, root.path())
+            .expect_err("missing path and manifest should fail");
+
+        assert!(error.to_string().contains("--path or --manifest"));
+    }
+
+    #[test]
+    fn rejects_absolute_manifest_paths() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let args = AstShadowCompareArgs {
+            paths: Vec::new(),
+            manifest: Some(root.path().join("policy/ast-shadow-corpus.toml")),
+            out: PathBuf::from("target/tokmd-ast-shadow"),
+            summary_md: None,
+        };
+
+        let error = input_paths_from_args(&args, root.path())
+            .expect_err("absolute manifest path should fail");
+
+        assert!(error.to_string().contains("repo-relative"));
+    }
+
+    #[test]
     fn heuristic_extracts_first_slice_landmarks() {
         let source = r#"
 use std::{
@@ -578,6 +755,7 @@ pub fn compute(value: usize) -> usize {
         let out = root.path().join("target/tokmd-ast-shadow");
         let args = AstShadowCompareArgs {
             paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
+            manifest: None,
             out: out.clone(),
             summary_md: None,
         };
@@ -609,6 +787,7 @@ pub fn compute(value: usize) -> usize {
         let summary_md = root.path().join("target/tokmd-ast-shadow/summary.md");
         let args = AstShadowCompareArgs {
             paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
+            manifest: None,
             out,
             summary_md: Some(summary_md.clone()),
         };
@@ -626,6 +805,95 @@ pub fn compute(value: usize) -> usize {
     }
 
     #[test]
+    fn runner_accepts_corpus_manifest() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let fixture_dir = root.path().join("fixtures/ast-shadow/rust");
+        fs::create_dir_all(&fixture_dir)?;
+        fs::write(
+            fixture_dir.join("b.rs"),
+            "use std::path::Path;\npub fn beta() {}\n",
+        )?;
+        fs::write(
+            fixture_dir.join("a.rs"),
+            "use std::fs;\npub fn alpha() {}\n",
+        )?;
+        let policy_dir = root.path().join("policy");
+        fs::create_dir_all(&policy_dir)?;
+        fs::write(
+            policy_dir.join("ast-shadow-corpus.toml"),
+            r#"schema = "tokmd.ast_shadow_corpus.v1"
+language = "rust"
+
+[rules]
+supported_extension = ".rs"
+
+[[file]]
+path = "fixtures/ast-shadow/rust/b.rs"
+
+[[file]]
+path = "fixtures/ast-shadow/rust/a.rs"
+"#,
+        )?;
+
+        let out = root.path().join("target/tokmd-ast-shadow");
+        let summary_md = root.path().join("target/tokmd-ast-shadow/summary.md");
+        let args = AstShadowCompareArgs {
+            paths: Vec::new(),
+            manifest: Some(PathBuf::from("policy/ast-shadow-corpus.toml")),
+            out,
+            summary_md: Some(summary_md.clone()),
+        };
+
+        run_with_root(args, root.path())?;
+        let diff = fs::read_to_string(root.path().join("target/tokmd-ast-shadow/diff.json"))?;
+        let summary = fs::read_to_string(summary_md)?;
+        let first_path = diff
+            .find("\"path\": \"fixtures/ast-shadow/rust/a.rs\"")
+            .context("missing sorted a.rs path")?;
+        let second_path = diff
+            .find("\"path\": \"fixtures/ast-shadow/rust/b.rs\"")
+            .context("missing sorted b.rs path")?;
+
+        assert!(diff.contains("\"files\": 2"));
+        assert!(first_path < second_path);
+        assert!(summary.contains("--manifest policy/ast-shadow-corpus.toml"));
+        assert!(summary.contains("- Files compared: 2"));
+        Ok(())
+    }
+
+    #[test]
+    fn manifest_rejects_parent_paths() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let policy_dir = root.path().join("policy");
+        fs::create_dir_all(&policy_dir)?;
+        fs::write(
+            policy_dir.join("ast-shadow-corpus.toml"),
+            r#"schema = "tokmd.ast_shadow_corpus.v1"
+language = "rust"
+
+[[file]]
+path = "../outside.rs"
+"#,
+        )?;
+        let args = AstShadowCompareArgs {
+            paths: Vec::new(),
+            manifest: Some(PathBuf::from("policy/ast-shadow-corpus.toml")),
+            out: PathBuf::from("target/tokmd-ast-shadow"),
+            summary_md: None,
+        };
+
+        let error = input_paths_from_args(&args, root.path())
+            .expect_err("manifest parent path should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("validate AST shadow corpus path")
+        );
+        Ok(())
+    }
+
+    #[test]
     fn summary_includes_landmark_kind_counts() -> Result<()> {
         let root = tempfile::tempdir()?;
         let paths = tokmd_analysis::ast::ShadowArtifactPaths {
@@ -635,6 +903,7 @@ pub fn compute(value: usize) -> usize {
         };
         let args = AstShadowCompareArgs {
             paths: vec![PathBuf::from("src/lib.rs")],
+            manifest: None,
             out: PathBuf::from("target/tokmd-ast-shadow"),
             summary_md: Some(PathBuf::from("target/tokmd-ast-shadow/summary.md")),
         };
@@ -689,6 +958,7 @@ pub fn compute(value: usize) -> usize {
         )?;
         let args = AstShadowCompareArgs {
             paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
+            manifest: None,
             out: root.path().join("target/tokmd-ast-shadow"),
             summary_md: Some(outside.path().join("summary.md")),
         };


### PR DESCRIPTION
## Summary
- add `--manifest` support to `cargo xtask ast-shadow-compare` for repo-owned AST shadow corpus manifests
- let `cargo xtask ast-shadow-check --manifest ...` regenerate and verify the corpus artifacts as one self-contained proof command
- update AST shadow docs, active plan, and `analysis_ast_shadow` proof routing to use the manifest-backed corpus path

## Validation
- `cargo test -p xtask ast_shadow --verbose`
- `cargo test -p tokmd-analysis --features ast ast --verbose`
- `cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md`
- `cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json`
- `cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow-manifest-runner.json` (7 files, 6 scopes, 0 unknown files)
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-shadow-manifest-runner.json --evidence-json target/proof/proof-evidence-ast-shadow-manifest-runner.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-ast-shadow-manifest-runner.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-ast-shadow-manifest-runner.json` (36 executed required commands)

## Boundaries
- no public `tokmd` CLI changes
- no default analyze/cockpit/context/handoff/browser output changes
- no public receipt schema changes
- no proof promotion, Codecov default, or evidencebus runtime change