### PR TITLE
feat(xtask): time AST shadow corpus comparisons

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -567,7 +567,8 @@ proof = [
   "cargo test -p tokmd-analysis --features ast ast --verbose",
   "cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json",
   "cargo test -p xtask ast_shadow --verbose",
-  "cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json",
+  "cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow --summary-md target/tokmd-ast-shadow/summary.md --timing-json target/tokmd-ast-shadow/timing.json",
+  "cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json",
 ]
 mutation = false
 coverage = false

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -72,7 +72,7 @@ developer-facing shadow evidence.
 The active machine-readable goal now points at AST function-boundary corpus
 expansion. The next AST work should broaden the repo-owned Rust corpus, rerun
 the same `ast-shadow-compare` / `ast-shadow-check` evidence loop, classify
-function-boundary mismatches, and record candidate-corpus timing before any
+function-boundary mismatches, and use scoped candidate-corpus timing before any
 public proposal. This is evidence planning only: no default product workflow,
 public receipt schema, browser/WASM capability, proof gate, Codecov default,
 cockpit output, handoff output, or evidencebus runtime changes are in scope.

--- a/docs/plans/ast-function-boundary-candidate.md
+++ b/docs/plans/ast-function-boundary-candidate.md
@@ -249,8 +249,8 @@ Corpus, runner, or AST-code slices should also run the relevant focused proof:
 cargo test -p tokmd-analysis --features ast ast --verbose
 cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
 cargo test -p xtask ast_shadow --verbose
-cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md
-cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
+cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md --timing-json target/tokmd-ast-shadow-corpus/timing.json
+cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
 ```
 
 If public crate exports, dependencies, browser/WASM capability claims, schemas,

--- a/docs/plans/ast-function-boundary-corpus-expansion.md
+++ b/docs/plans/ast-function-boundary-corpus-expansion.md
@@ -60,9 +60,12 @@ broader explicit Rust corpus
    - Run `ast-shadow-compare` and `ast-shadow-check` over the expanded manifest.
    - Record counts by landmark kind and function-boundary mismatch class.
 4. Add candidate-corpus timing evidence.
-   - Status: pending.
-   - Use existing `tokmd.ast_shadow_perf.v1` evidence or add a scoped timing
-     receipt for the expanded explicit corpus before making performance claims.
+   - Status: complete.
+   - Added an opt-in `cargo xtask ast-shadow-compare --timing-json <PATH>`
+     receipt for the expanded explicit corpus.
+   - Kept the receipt developer-facing and outside public `tokmd` CLI,
+     default outputs, public receipts, browser/WASM capability, and proof
+     promotion.
 5. Reclassify function-boundary mismatches.
    - Status: pending.
    - Categorize heuristic-only and AST-only function landmarks using the
@@ -92,8 +95,8 @@ Corpus, runner, or AST-code slices should also run the relevant focused proof:
 cargo test -p tokmd-analysis --features ast ast --verbose
 cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
 cargo test -p xtask ast_shadow --verbose
-cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md
-cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
+cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md --timing-json target/tokmd-ast-shadow-corpus/timing.json
+cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
 ```
 
 If public crate exports, dependencies, browser/WASM capability claims, schemas,
@@ -127,6 +130,9 @@ publish-surface verification.
 - 2026-05-14: Collected verified expanded-corpus evidence from the 14-file
   manifest. Function landmarks had 225 matches, 24 heuristic-only entries,
   and 0 AST-only entries; one parser-degraded fixture remained explicit.
+- 2026-05-15: Added scoped candidate-corpus timing evidence via
+  `tokmd.ast_shadow_compare_timing.v1`. The timing receipt covers the explicit
+  manifest corpus and remains developer-facing shadow evidence only.
 
 ## Corpus Expansion Categories
 
@@ -218,3 +224,52 @@ Interpretation:
   than available AST proof.
 - Control-flow remains noisier than function boundaries and stays out of this
   candidate decision.
+
+## Candidate-Corpus Timing Evidence
+
+The scoped timing slice used the same expanded manifest and wrote a
+developer-facing timing receipt:
+
+```bash
+cargo xtask ast-shadow-compare \
+  --manifest policy/ast-shadow-corpus.toml \
+  --out target/tokmd-ast-shadow-corpus \
+  --summary-md target/tokmd-ast-shadow-corpus/summary.md \
+  --timing-json target/tokmd-ast-shadow-corpus/timing.json
+
+cargo xtask ast-shadow-check \
+  --dir target/tokmd-ast-shadow-corpus \
+  --json target/tokmd-ast-shadow-corpus/check.json
+```
+
+Receipt summary:
+
+| Field | Value |
+| --- | ---: |
+| Schema | `tokmd.ast_shadow_compare_timing.v1` |
+| Input files | 14 |
+| Source bytes | 194799 |
+| Matched landmarks | 453 |
+| Heuristic-only landmarks | 210 |
+| AST-only landmarks | 32 |
+| Parse-degraded files | 1 |
+| Unsupported files | 0 |
+| Total comparison runtime | 116 ms |
+
+Phase timings from the same local receipt:
+
+| Phase | Duration |
+| --- | ---: |
+| Path selection | 2 ms |
+| Input collection | 25 ms |
+| Artifact build | 80 ms |
+| Artifact write | 6 ms |
+| Summary write | 0 ms |
+
+The timing receipt records no timestamps, absolute paths, temporary
+directories, or public product verdicts. It is suitable for candidate-corpus
+evidence and proof routing, not a production performance budget. Duration
+values are local observations and are expected to vary by machine, cache state,
+and run. Counts differ from the first expanded manifest run because this slice
+added timing-receipt code to `xtask/src/tasks/ast_shadow_compare.rs`, which is
+itself part of the repo-owned corpus.

--- a/docs/specs/ast-shadow.md
+++ b/docs/specs/ast-shadow.md
@@ -54,6 +54,7 @@ target/tokmd-ast-shadow/
   ast.json
   diff.json
   summary.md         # optional human summary
+  timing.json        # optional scoped comparison timing receipt
   check.json          # optional verifier receipt
 ```
 
@@ -95,13 +96,33 @@ corpus manifest instead of listing every file on the command line:
 cargo xtask ast-shadow-compare \
   --manifest policy/ast-shadow-corpus.toml \
   --out target/tokmd-ast-shadow \
-  --summary-md target/tokmd-ast-shadow/summary.md
+  --summary-md target/tokmd-ast-shadow/summary.md \
+  --timing-json target/tokmd-ast-shadow/timing.json
 ```
 
 The Markdown summary is a human review layer over `diff.json`. It should include
 aggregate counts, mismatch counts by landmark kind, per-file comparison status,
 artifact paths, and a reproduction command. It must not add pass/fail language,
 merge verdicts, proof-promotion claims, or public receipt semantics.
+
+The optional comparison timing receipt is developer-facing xtask evidence:
+
+```bash
+cargo xtask ast-shadow-compare \
+  --manifest policy/ast-shadow-corpus.toml \
+  --out target/tokmd-ast-shadow \
+  --summary-md target/tokmd-ast-shadow/summary.md \
+  --timing-json target/tokmd-ast-shadow/timing.json
+```
+
+It emits `tokmd.ast_shadow_compare_timing.v1` for the explicit corpus selected
+by `--path` or `--manifest`. The receipt records repo-relative artifact paths,
+input-file and source-byte counts, diff summary counts, and bounded phase
+durations for path selection, input collection, artifact construction, artifact
+writing, summary writing, and total comparison runtime. It must not include
+timestamps, absolute paths, temporary directories, environment variables,
+pass/fail product language, merge verdicts, proof-promotion claims, or public
+receipt semantics.
 
 The verifier is developer-facing xtask tooling:
 
@@ -233,8 +254,8 @@ names should run:
 cargo test -p tokmd-analysis --features ast ast --verbose
 cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
 cargo test -p xtask ast_shadow --verbose
-cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow --summary-md target/tokmd-ast-shadow/summary.md
-cargo xtask ast-shadow-check --manifest policy/ast-shadow-corpus.toml --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json
+cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow --summary-md target/tokmd-ast-shadow/summary.md --timing-json target/tokmd-ast-shadow/timing.json
+cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow --json target/tokmd-ast-shadow/check.json
 cargo xtask proof-policy --check
 cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-shadow.json
 cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-shadow.json --evidence-json target/proof/proof-evidence-ast-shadow.json

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -118,6 +118,10 @@ pub struct AstShadowCompareArgs {
     /// Optional Markdown summary path for human review of comparison counts.
     #[arg(long)]
     pub summary_md: Option<std::path::PathBuf>,
+
+    /// Optional JSON timing receipt path for the explicit comparison run.
+    #[arg(long)]
+    pub timing_json: Option<std::path::PathBuf>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/xtask/src/tasks/ast_shadow_check.rs
+++ b/xtask/src/tasks/ast_shadow_check.rs
@@ -16,6 +16,7 @@ pub fn run(args: AstShadowCheckArgs) -> Result<()> {
             manifest: args.manifest.clone(),
             out: args.dir.clone(),
             summary_md: None,
+            timing_json: None,
         })?;
     }
 

--- a/xtask/src/tasks/ast_shadow_compare.rs
+++ b/xtask/src/tasks/ast_shadow_compare.rs
@@ -1,16 +1,18 @@
 use crate::cli::AstShadowCompareArgs;
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::time::Instant;
 use tokmd_analysis::ast::{
     AstLanguage, ShadowFileInput, ShadowLandmark, build_shadow_artifacts, normalize_shadow_path,
     write_shadow_artifacts,
 };
 
 const AST_SHADOW_CORPUS_SCHEMA: &str = "tokmd.ast_shadow_corpus.v1";
+const AST_SHADOW_COMPARE_TIMING_SCHEMA: &str = "tokmd.ast_shadow_compare_timing.v1";
 
 pub fn run(args: AstShadowCompareArgs) -> Result<()> {
     let root = std::env::current_dir().context("resolve current directory")?;
@@ -18,8 +20,15 @@ pub fn run(args: AstShadowCompareArgs) -> Result<()> {
 }
 
 fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
+    let total_start = Instant::now();
+
+    let path_selection_start = Instant::now();
     let input_paths = input_paths_from_args(&args, root)?;
+    let path_selection_us = path_selection_start.elapsed().as_micros();
+
+    let input_collection_start = Instant::now();
     let inputs = collect_inputs(&input_paths, root)?;
+    let input_collection_us = input_collection_start.elapsed().as_micros();
     let shadow_inputs = inputs
         .iter()
         .map(|input| ShadowFileInput {
@@ -30,12 +39,46 @@ fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
         })
         .collect::<Vec<_>>();
 
+    let artifact_build_start = Instant::now();
     let artifacts = build_shadow_artifacts(&shadow_inputs).context("build AST shadow artifacts")?;
+    let artifact_build_us = artifact_build_start.elapsed().as_micros();
+
+    let artifact_write_start = Instant::now();
     let paths = write_shadow_artifacts(&args.out, &artifacts)
         .with_context(|| format!("write AST shadow artifacts to {}", args.out.display()))?;
+    let artifact_write_us = artifact_write_start.elapsed().as_micros();
+
+    let summary_write_start = Instant::now();
     if let Some(summary_path) = &args.summary_md {
         write_summary_md(summary_path, &args, &paths, &artifacts.diff, root)
             .with_context(|| format!("write AST shadow summary to {}", summary_path.display()))?;
+    }
+    let summary_write_us = summary_write_start.elapsed().as_micros();
+
+    if let Some(timing_path) = &args.timing_json {
+        let timings = CompareTimingPhases {
+            path_selection_us,
+            input_collection_us,
+            artifact_build_us,
+            artifact_write_us,
+            summary_write_us,
+            total_us: total_start.elapsed().as_micros(),
+        };
+        write_timing_json(
+            timing_path,
+            &args,
+            &paths,
+            &artifacts.diff,
+            &inputs,
+            timings,
+            root,
+        )
+        .with_context(|| {
+            format!(
+                "write AST shadow timing receipt to {}",
+                timing_path.display()
+            )
+        })?;
     }
 
     let ast_files = artifacts
@@ -61,6 +104,9 @@ fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
     if let Some(summary_path) = &args.summary_md {
         println!("  summary: {}", summary_path.display());
     }
+    if let Some(timing_path) = &args.timing_json {
+        println!("  timing: {}", timing_path.display());
+    }
 
     Ok(())
 }
@@ -84,6 +130,174 @@ fn write_summary_md(
 
     fs::write(summary_path, summary)
         .with_context(|| format!("write summary {}", summary_path.display()))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CompareTimingPhases {
+    path_selection_us: u128,
+    input_collection_us: u128,
+    artifact_build_us: u128,
+    artifact_write_us: u128,
+    summary_write_us: u128,
+    total_us: u128,
+}
+
+#[derive(Debug, Serialize)]
+struct AstShadowCompareTimingReceipt {
+    schema: &'static str,
+    schema_version: u32,
+    command: &'static str,
+    language: &'static str,
+    corpus: TimingCorpus,
+    counts: TimingCounts,
+    timings: TimingReceiptPhases,
+    artifacts: TimingArtifacts,
+    status: TimingStatus,
+}
+
+#[derive(Debug, Serialize)]
+struct TimingCorpus {
+    manifest: Option<String>,
+    explicit_paths: usize,
+    input_files: usize,
+    source_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct TimingCounts {
+    files: u64,
+    matched: u64,
+    heuristic_only: u64,
+    ast_only: u64,
+    parse_degraded: u64,
+    unsupported: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct TimingReceiptPhases {
+    path_selection: TimingPhase,
+    input_collection: TimingPhase,
+    artifact_build: TimingPhase,
+    artifact_write: TimingPhase,
+    summary_write: TimingPhase,
+    total: TimingPhase,
+}
+
+#[derive(Debug, Serialize)]
+struct TimingPhase {
+    operation: &'static str,
+    duration_ms: u128,
+    duration_us: u128,
+}
+
+#[derive(Debug, Serialize)]
+struct TimingArtifacts {
+    heuristic: String,
+    ast: String,
+    diff: String,
+    summary_md: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TimingStatus {
+    ok: bool,
+    parse_degraded_files: u64,
+    unsupported_files: u64,
+}
+
+fn write_timing_json(
+    timing_path: &Path,
+    args: &AstShadowCompareArgs,
+    paths: &tokmd_analysis::ast::ShadowArtifactPaths,
+    diff: &serde_json::Value,
+    inputs: &[RunnerInput],
+    timings: CompareTimingPhases,
+    root: &Path,
+) -> Result<()> {
+    let counts = diff_summary_counts(diff)?;
+    let receipt = AstShadowCompareTimingReceipt {
+        schema: AST_SHADOW_COMPARE_TIMING_SCHEMA,
+        schema_version: 1,
+        command: "cargo xtask ast-shadow-compare",
+        language: "rust",
+        corpus: TimingCorpus {
+            manifest: args
+                .manifest
+                .as_deref()
+                .map(|path| summary_display_path(path, root))
+                .transpose()?,
+            explicit_paths: args.paths.len(),
+            input_files: inputs.len(),
+            source_bytes: inputs.iter().map(|input| input.source.len()).sum(),
+        },
+        counts,
+        timings: TimingReceiptPhases {
+            path_selection: timing_phase("select_input_paths", timings.path_selection_us),
+            input_collection: timing_phase("collect_inputs", timings.input_collection_us),
+            artifact_build: timing_phase("build_shadow_artifacts", timings.artifact_build_us),
+            artifact_write: timing_phase("write_shadow_artifacts", timings.artifact_write_us),
+            summary_write: timing_phase("write_summary_md", timings.summary_write_us),
+            total: timing_phase("ast_shadow_compare", timings.total_us),
+        },
+        artifacts: TimingArtifacts {
+            heuristic: summary_display_path(&paths.heuristic, root)?,
+            ast: summary_display_path(&paths.ast, root)?,
+            diff: summary_display_path(&paths.diff, root)?,
+            summary_md: args
+                .summary_md
+                .as_deref()
+                .map(|path| summary_display_path(path, root))
+                .transpose()?,
+        },
+        status: TimingStatus {
+            ok: true,
+            parse_degraded_files: counts.parse_degraded,
+            unsupported_files: counts.unsupported,
+        },
+    };
+
+    if let Some(parent) = timing_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create timing receipt parent {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(&receipt)
+        .context("serialize AST shadow comparison timing receipt")?;
+    fs::write(timing_path, format!("{json}\n"))
+        .with_context(|| format!("write timing receipt {}", timing_path.display()))
+}
+
+fn timing_phase(operation: &'static str, duration_us: u128) -> TimingPhase {
+    TimingPhase {
+        operation,
+        duration_ms: duration_us / 1_000,
+        duration_us,
+    }
+}
+
+fn diff_summary_counts(diff: &serde_json::Value) -> Result<TimingCounts> {
+    let summary = diff
+        .get("summary")
+        .and_then(serde_json::Value::as_object)
+        .context("diff artifact is missing summary object")?;
+    Ok(TimingCounts {
+        files: summary_count(summary, "files")?,
+        matched: summary_count(summary, "matched")?,
+        heuristic_only: summary_count(summary, "heuristic_only")?,
+        ast_only: summary_count(summary, "ast_only")?,
+        parse_degraded: summary_count(summary, "parse_degraded")?,
+        unsupported: summary_count(summary, "unsupported")?,
+    })
+}
+
+fn summary_count(summary: &serde_json::Map<String, serde_json::Value>, key: &str) -> Result<u64> {
+    summary
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .with_context(|| format!("diff summary is missing numeric field `{key}`"))
 }
 
 fn render_summary_md(
@@ -186,6 +400,10 @@ fn render_summary_md(
     if let Some(summary_md) = &args.summary_md {
         markdown.push_str(" \\\n  --summary-md ");
         markdown.push_str(&summary_display_path(summary_md, root)?);
+    }
+    if let Some(timing_json) = &args.timing_json {
+        markdown.push_str(" \\\n  --timing-json ");
+        markdown.push_str(&summary_display_path(timing_json, root)?);
     }
     markdown.push_str("\n```\n");
 
@@ -676,6 +894,7 @@ mod tests {
             manifest: None,
             out: PathBuf::from("target/tokmd-ast-shadow"),
             summary_md: None,
+            timing_json: None,
         };
 
         let error = input_paths_from_args(&args, root.path())
@@ -692,6 +911,7 @@ mod tests {
             manifest: Some(root.path().join("policy/ast-shadow-corpus.toml")),
             out: PathBuf::from("target/tokmd-ast-shadow"),
             summary_md: None,
+            timing_json: None,
         };
 
         let error = input_paths_from_args(&args, root.path())
@@ -758,6 +978,7 @@ pub fn compute(value: usize) -> usize {
             manifest: None,
             out: out.clone(),
             summary_md: None,
+            timing_json: None,
         };
 
         run_with_root(args.clone(), root.path())?;
@@ -790,6 +1011,7 @@ pub fn compute(value: usize) -> usize {
             manifest: None,
             out,
             summary_md: Some(summary_md.clone()),
+            timing_json: None,
         };
 
         run_with_root(args, root.path())?;
@@ -801,6 +1023,49 @@ pub fn compute(value: usize) -> usize {
         assert!(summary.contains("cargo xtask ast-shadow-compare"));
         assert!(summary.contains("--summary-md"));
         assert!(!summary.contains(&normalize_display_path(root.path())));
+        Ok(())
+    }
+
+    #[test]
+    fn runner_writes_timing_receipt_when_requested() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let fixture_dir = root.path().join("fixtures/ast-shadow/rust");
+        fs::create_dir_all(&fixture_dir)?;
+        fs::write(
+            fixture_dir.join("basic.rs"),
+            "use std::fs;\n\npub fn compute(value: usize) -> usize {\n    value\n}\n",
+        )?;
+        let out = root.path().join("target/tokmd-ast-shadow");
+        let summary_md = root.path().join("target/tokmd-ast-shadow/summary.md");
+        let timing_json = root.path().join("target/tokmd-ast-shadow/timing.json");
+        let args = AstShadowCompareArgs {
+            paths: vec![PathBuf::from("fixtures/ast-shadow/rust/basic.rs")],
+            manifest: None,
+            out,
+            summary_md: Some(summary_md.clone()),
+            timing_json: Some(timing_json.clone()),
+        };
+
+        run_with_root(args, root.path())?;
+        let timing = fs::read_to_string(&timing_json)?;
+        let value: serde_json::Value = serde_json::from_str(&timing)?;
+        let summary = fs::read_to_string(summary_md)?;
+
+        assert_eq!(value["schema"], "tokmd.ast_shadow_compare_timing.v1");
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["command"], "cargo xtask ast-shadow-compare");
+        assert_eq!(value["language"], "rust");
+        assert_eq!(value["corpus"]["explicit_paths"], 1);
+        assert_eq!(value["corpus"]["input_files"], 1);
+        assert_eq!(value["counts"]["files"], 1);
+        assert_eq!(
+            value["artifacts"]["diff"],
+            "target/tokmd-ast-shadow/diff.json"
+        );
+        assert_eq!(value["status"]["ok"], true);
+        assert!(value["timings"]["total"]["duration_us"].as_u64().is_some());
+        assert!(summary.contains("--timing-json target/tokmd-ast-shadow/timing.json"));
+        assert!(!timing.contains(root.path().to_string_lossy().as_ref()));
         Ok(())
     }
 
@@ -842,6 +1107,7 @@ path = "fixtures/ast-shadow/rust/a.rs"
             manifest: Some(PathBuf::from("policy/ast-shadow-corpus.toml")),
             out,
             summary_md: Some(summary_md.clone()),
+            timing_json: None,
         };
 
         run_with_root(args, root.path())?;
@@ -880,6 +1146,7 @@ path = "../outside.rs"
             manifest: Some(PathBuf::from("policy/ast-shadow-corpus.toml")),
             out: PathBuf::from("target/tokmd-ast-shadow"),
             summary_md: None,
+            timing_json: None,
         };
 
         let error = input_paths_from_args(&args, root.path())
@@ -906,6 +1173,7 @@ path = "../outside.rs"
             manifest: None,
             out: PathBuf::from("target/tokmd-ast-shadow"),
             summary_md: Some(PathBuf::from("target/tokmd-ast-shadow/summary.md")),
+            timing_json: None,
         };
         let diff = serde_json::json!({
             "summary": {
@@ -961,6 +1229,7 @@ path = "../outside.rs"
             manifest: None,
             out: root.path().join("target/tokmd-ast-shadow"),
             summary_md: Some(outside.path().join("summary.md")),
+            timing_json: None,
         };
 
         let error = run_with_root(args, root.path())


### PR DESCRIPTION
## Summary
- adds optional `cargo xtask ast-shadow-compare --timing-json <PATH>` developer evidence for explicit AST shadow comparisons
- records the expanded corpus timing receipt and keeps it shadow-only, outside public tokmd CLI/default outputs/receipt schemas/browser behavior
- routes the analysis_ast_shadow proof scope through compare + timing receipt before verifier check

## Evidence
- `tokmd.ast_shadow_compare_timing.v1` records repo-relative artifact paths, input/source counts, diff counts, phase timings, and no timestamps or absolute paths
- expanded corpus timing run covered 14 files / 194799 source bytes with 453 matched landmarks, 210 heuristic-only, 32 AST-only, 1 parse-degraded, 0 unsupported
- function-boundary promotion remains pending mismatch classification and candidate decision; no product integration is added

## Validation
- cargo test -p xtask ast_shadow --verbose
- cargo xtask ast-shadow-compare --manifest policy/ast-shadow-corpus.toml --out target/tokmd-ast-shadow-corpus --summary-md target/tokmd-ast-shadow-corpus/summary.md --timing-json target/tokmd-ast-shadow-corpus/timing.json
- cargo xtask ast-shadow-check --dir target/tokmd-ast-shadow-corpus --json target/tokmd-ast-shadow-corpus/check.json
- cargo test -p tokmd-analysis --features ast ast --verbose
- cargo run -p tokmd-analysis --features ast --example ast_shadow_perf -- --iterations 2 --files 2 --functions-per-file 3 --out target/perf/ast-shadow-perf.json
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ast-function-boundary-corpus-timing.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ast-function-boundary-corpus-timing.json --evidence-json target/proof/proof-evidence-ast-function-boundary-corpus-timing.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-ast-function-boundary-corpus-timing.json
- cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-ast-function-boundary-corpus-timing.json