### PR TITLE
docs: close proof observation decision lane

### DIFF
--- a/.jules/goals/active.toml
+++ b/.jules/goals/active.toml
@@ -1,5 +1,5 @@
 schema = "tokmd.jules.active_goal.v1"
-status = "active"
+status = "complete"
 program = "code_intelligence"
 lane = "proof_observation_decision_readiness"
 
@@ -31,6 +31,7 @@ cockpit_proof_evidence = "docs/cockpit-proof-evidence.md"
 proof_observation_decision_plan = "docs/plans/proof-observation-decision-readiness.md"
 proof_observation_artifacts = "docs/ci/proof-observation-artifacts.md"
 proof_observation_decision_spec = "docs/specs/proof-observation-decision-packet.md"
+proof_observation_decision_adr = "docs/adr/0009-proof-observation-promotion-boundary.md"
 proof_policy = "ci/proof.toml"
 
 [rules]
@@ -57,3 +58,10 @@ affected_plan = "cargo xtask affected --base origin/main --head HEAD --json"
 proof_plan = "cargo xtask proof --profile affected --base origin/main --head HEAD --plan"
 proof_artifacts = "do_not_treat_advisory_or_planned_evidence_as_passing_proof"
 browser_boundary = "do_not_claim_browser_wasm_ast_capability_without_capability_and_bundle_evidence"
+
+[completion]
+completed_on = "2026-05-15"
+closeout_plan = "docs/plans/proof-observation-decision-readiness.md"
+decision_record = "docs/adr/0009-proof-observation-promotion-boundary.md"
+outcome = "continued_observation_no_promotion"
+evidence = "status/check receipts and manual collector upload path exist; ADR-0009 keeps advisory proof non-required until a future maintainer decision cites fresh verified evidence"

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -81,20 +81,21 @@ closed plan lives in `docs/plans/ast-function-boundary-corpus-expansion.md`;
 the earlier candidate decision is recorded in
 `docs/plans/ast-function-boundary-candidate.md`.
 
-The proof-observation decision-readiness lane is active again. It now has a
-Rust-owned `cargo xtask proof-observation-status` aggregate plus
-`cargo xtask proof-observation-status-check` verifier. The manual observation
-collector writes both receipts from downloaded executor observation collections,
-so maintainers can review one verified advisory decision packet without
-executing proof, changing required gates, or enabling default Codecov upload.
+The proof-observation decision-readiness lane is closed. It now has a
+Rust-owned `cargo xtask proof-observation-status` aggregate,
+`cargo xtask proof-observation-status-check` verifier, manual collector upload
+path, and ADR-0009 decision record. The outcome is continued observation, not
+promotion: advisory fast proof, scoped coverage, mutation, coverage telemetry,
+and Codecov upload remain non-required until a future maintainer decision cites
+fresh verified decision evidence and changes checked policy deliberately.
 
 ## Next Work Packets
 
 1. Choose the next active lane deliberately; do not reopen AST productization
    without a fresh proposal grounded in the shadow evidence.
-2. Continue proof-observation decision readiness by verifying the new aggregate
-   and its check receipt from real collected observation artifacts before any
-   cockpit/handoff integration or promotion proposal.
+2. Choose the next proof-orchestration slice deliberately; do not promote
+   advisory proof, default Codecov upload, or cockpit/handoff consumption from
+   the closed decision-readiness lane.
 3. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence
    shows a product, verifier, or hosted-comment issue.
 4. Preserve `tokmd cockpit` as the review evidence implementation surface until

--- a/docs/adr/0009-proof-observation-promotion-boundary.md
+++ b/docs/adr/0009-proof-observation-promotion-boundary.md
@@ -1,0 +1,97 @@
+# ADR-0009: Proof observation promotion boundary
+
+- Status: accepted
+- Date: 2026-05-15
+
+## Context
+
+tokmd now has a Rust-owned proof-control plane that can classify changed files,
+plan affected proof, execute explicitly opted-in required proof, collect
+advisory executor observations, summarize promotion-readiness thresholds, and
+verify an aggregate proof-observation decision packet.
+
+The current artifact chain includes:
+
+- `affected.json` from `cargo xtask affected`;
+- `proof-plan.json` and `proof-evidence.json` from `cargo xtask proof`;
+- `proof-run-summary.json` and `proof-run-observation.json` for required proof
+  when a lane explicitly opts in;
+- `proof-executor-observation-collection.json` for downloaded advisory
+  executor observations;
+- `proof-executor-promotion-readiness.json` for checked policy thresholds;
+- `proof-observation-decision.json` from `cargo xtask proof-observation-status`;
+- `proof-observation-decision-check.json` from
+  `cargo xtask proof-observation-status-check`.
+
+That makes observations reviewable, but it does not make them gates. The
+important durable decision is whether the existence of this machinery changes
+the current proof policy.
+
+## Decision
+
+Proof observations remain in routine observation mode.
+
+The current decision is **continued observation, not promotion**. Advisory fast
+proof, scoped coverage, mutation, coverage telemetry, and Codecov upload remain
+advisory unless a future maintainer decision changes checked policy and
+workflow behavior deliberately.
+
+The proof-observation decision packet is a review artifact. It may summarize
+criteria as met or missing, but it does not:
+
+- execute proof;
+- make advisory evidence required;
+- enable default Codecov upload;
+- increase the default PR executor command limit;
+- replace source artifact verifiers;
+- produce a merge verdict;
+- make cockpit or handoff treat advisory proof as passing proof.
+
+A future promotion proposal must cite fresh source receipts and a verified
+decision packet from the post-verifier collector flow before changing
+`ci/proof.toml` or GitHub workflow defaults.
+
+## Consequences
+
+- Maintainers get one verified advisory surface for proof-observation review
+  without changing CI gates.
+- GitHub Actions remains the runner, cache, artifact upload, and external
+  GitHub API shell; Rust-owned `xtask` commands own receipt semantics.
+- Cockpit and handoff may later link verified decision receipts as evidence
+  handles, but they must not treat advisory proof as a merge decision.
+- Promotion work needs a separate proposal or ADR that names the proof family,
+  policy change, workflow change, rollback path, and fresh evidence.
+- Missing, stale, skipped, or advisory evidence remains visible as evidence
+  state, not as proof that a requirement passed.
+
+## Alternatives
+
+- Promote scoped coverage or fast proof immediately because the collector and
+  decision packet exist.
+- Remove the collector because advisory evidence is not a gate.
+- Move decision-packet semantics into GitHub Actions YAML.
+
+These alternatives were rejected. Immediate promotion would confuse evidence
+visibility with gate readiness. Removing the collector would discard useful
+review evidence. Encoding semantics in workflow YAML would move receipt logic
+out of the Rust-owned proof-control plane.
+
+## Enforcement
+
+- `ci/proof.toml` remains the checked policy source for proof scopes, executor
+  defaults, and promotion thresholds.
+- `cargo xtask proof-policy --check` must continue rejecting required-gate or
+  default-Codecov behavior unless the policy explicitly supports it.
+- `cargo xtask proof-observation-status-check` verifies only the aggregate
+  decision packet; source artifacts keep their own verifiers.
+- Workflow changes may upload observation and decision receipts, but they must
+  not silently promote advisory checks.
+- Cockpit or handoff integration requires a separate plan and must link the
+  verified receipt rather than replacing its verifier.
+
+## Related specs
+
+- `docs/specs/proof-observation-decision-packet.md`
+- `docs/ci/proof-observation-artifacts.md`
+- `docs/plans/proof-observation-decision-readiness.md`
+- `ci/proof.toml`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ For the broader documentation routing model, see
 | [0006](0006-deterministic-receipts.md) | accepted | Deterministic receipts and renderers |
 | [0007](0007-schema-family-versioning.md) | accepted | Independent schema-family versioning |
 | [0008](0008-ast-foundation.md) | proposed | AST foundation and shadow rollout |
+| [0009](0009-proof-observation-promotion-boundary.md) | accepted | Proof observation promotion boundary |
 
 ## House Style
 

--- a/docs/plans/proof-observation-decision-readiness.md
+++ b/docs/plans/proof-observation-decision-readiness.md
@@ -1,9 +1,9 @@
 # Plan: Proof Observation Decision Readiness
 
-- Status: active
+- Status: complete
 - Related proposal:
-- Related spec:
-- Related ADR:
+- Related spec: `docs/specs/proof-observation-decision-packet.md`
+- Related ADR: `docs/adr/0009-proof-observation-promotion-boundary.md`
 - Related issues:
 
 ## Goal
@@ -68,7 +68,7 @@ What command or artifact reproduces each claim?
      upload coverage, or change workflow gates.
 4. Connect the decision evidence to review surfaces only after a verifier
    exists.
-   - Status: pending; workflow artifact prerequisite complete.
+   - Status: deferred; workflow artifact prerequisite complete.
    - The manual proof-observation collector now emits both
      `proof-observation-decision.json` and
      `proof-observation-decision-check.json` from real downloaded executor
@@ -76,11 +76,11 @@ What command or artifact reproduces each claim?
    - Future cockpit or handoff integration should link verified decision
      receipts as evidence handles, not treat them as merge verdicts.
 5. Close the lane with an explicit decision record.
-   - Status: pending.
-   - Record whether the evidence supports promotion, continued observation, or
-     rollback/simplification.
-   - If promotion is not justified, preserve the advisory state and document
-     the missing evidence.
+   - Status: complete.
+   - ADR-0009 records the outcome: continued observation, not promotion.
+   - Advisory evidence remains visible, but fast proof, scoped coverage,
+     mutation, Codecov upload, cockpit, and handoff behavior remain unchanged
+     until a future proposal cites fresh verified decision evidence.
 
 ## Validation
 
@@ -147,3 +147,7 @@ the relevant proof artifact verifier on generated receipts.
   executor observations. The workflow still only observes and uploads evidence;
   it does not promote advisory proof, enable default Codecov upload, or change
   required gates.
+- 2026-05-15: Closed the lane with ADR-0009. The decision is continued
+  observation: the proof-observation decision surface is ready for maintainer
+  review, but current evidence does not justify making advisory proof required,
+  enabling default Codecov upload, or changing cockpit/handoff behavior.


### PR DESCRIPTION
## Summary

- add ADR-0009 to record the proof observation promotion boundary
- close the proof-observation decision-readiness plan with outcome `continued observation, not promotion`
- mark the active Jules goal complete and point it at the decision record

## Boundaries

- no proof promotion
- no default Codecov upload
- no required gate changes
- no cockpit or handoff behavior change
- no product receipt/schema behavior change

## Validation

- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target\proof\affected-proof-observation-decision-closeout.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target\proof\proof-plan-proof-observation-decision-closeout.json --evidence-json target\proof\proof-evidence-proof-observation-decision-closeout.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target\proof\proof-run-summary-proof-observation-decision-closeout.json`
- `cargo xtask proof-run-artifacts-check --proof-run-summary target\proof\proof-run-summary-proof-observation-decision-closeout.json`