### PR TITLE
docs: close publishing evidence readiness lane

### DIFF
--- a/.jules/goals/archive/2026-05-15-publishing-evidence-readiness.toml
+++ b/.jules/goals/archive/2026-05-15-publishing-evidence-readiness.toml
@@ -2,6 +2,7 @@ schema = "tokmd.jules.active_goal.v1"
 status = "complete"
 program = "code_intelligence"
 lane = "publishing_evidence_readiness"
+outcome = "docs_only_guidance_existing_evidence"
 
 [links]
 source_of_truth = "docs/source-of-truth.md"
@@ -14,7 +15,6 @@ adr_readme = "docs/adr/README.md"
 plan = "docs/plans/publishing-evidence-readiness.md"
 publishing_evidence_spec = "docs/specs/publishing-evidence.md"
 publishing_evidence_guide = "docs/publishing-evidence.md"
-proof_observation_artifacts = "docs/ci/proof-observation-artifacts.md"
 artifact_glossary = "docs/artifacts.md"
 proof_policy = "ci/proof.toml"
 next_program = "docs/NEXT.md"
@@ -43,3 +43,8 @@ proof_plan = "cargo xtask proof --profile affected --base origin/main --head HEA
 publish_surface = "cargo xtask publish-surface --json --verify-publish"
 fmt = "cargo fmt-check"
 diff_hygiene = "git diff --check"
+
+[decision]
+summary = "No Rust-owned wrapper receipt is needed yet."
+reason = "The spec, guide, artifact glossary, existing publish-surface JSON, version-consistency command, affected proof routing, CI lane policy, and release workflow artifacts give maintainers enough publishing evidence without changing release behavior or schemas."
+reopen_when = "A concrete consumer cannot use the current docs-only surface and names the missing artifact contract."

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -121,11 +121,11 @@ objective to live artifacts and verifier coverage, did not mark the platform
 complete as a single finished program, and selected publishing evidence
 readiness as the next plan-first lane.
 
-The active lane is now publishing evidence readiness. The plan in
-`docs/plans/publishing-evidence-readiness.md` should make release and
-publishing facts easier to consume without publishing crates, tagging releases,
-changing release workflow behavior, changing public receipt schemas, or
-promoting advisory proof.
+The publishing evidence readiness lane is closed. The plan in
+`docs/plans/publishing-evidence-readiness.md` made release and publishing facts
+easier to consume without publishing crates, tagging releases, changing release
+workflow behavior, changing public receipt schemas, or promoting advisory
+proof.
 
 The first publishing evidence contract is now recorded in
 `docs/specs/publishing-evidence.md`. Current publishing evidence uses
@@ -145,10 +145,17 @@ publish-surface JSON, version consistency output, `release_metadata` proof
 scope routing, CI release lane policy, and intentional release workflow
 artifacts.
 
+The closeout decision is docs-only: no Rust-owned publishing evidence wrapper
+receipt is needed yet. Existing artifacts remain authoritative for their
+domains. Reopen publishing evidence only from a fresh proposal naming a
+consumer and a gap that the current publish-surface, version-consistency, CI
+lane, release workflow, and affected-proof evidence cannot cover.
+
 ## Next Work Packets
 
-1. Decide whether the publishing evidence lane needs a Rust-owned wrapper
-   receipt or should close as docs-only guidance plus existing proof routing.
+1. Choose the next lane deliberately from fresh evidence; do not continue
+   publishing evidence work unless a consumer proves the current docs-only
+   surface is insufficient.
 2. Do not reopen AST productization without a fresh proposal grounded in the
    shadow evidence.
 3. Choose the next proof-orchestration slice deliberately; do not promote

--- a/docs/plans/publishing-evidence-readiness.md
+++ b/docs/plans/publishing-evidence-readiness.md
@@ -1,6 +1,6 @@
 # Plan: Publishing Evidence Readiness
 
-- Status: active
+- Status: complete
 - Related proposal:
 - Related spec: `docs/specs/publishing-evidence.md`
 - Related ADR: `docs/adr/0001-production-package-publishability.md`, `docs/adr/0003-publish-surface-taxonomy.md`, `docs/adr/0005-release-train-and-rc-semantics.md`
@@ -57,9 +57,12 @@ prove, and which command reproduces it without reading release workflow YAML.
    - Include `publish-surface` JSON output, version consistency output, release
      metadata scope, and release workflow artifacts if they are current.
 4. Decide whether a Rust-owned publishing evidence receipt is needed.
-   - Status: active.
-   - If needed, write a proposal/spec before implementation.
-   - If not needed, close the lane with docs-only guidance and proof routing.
+   - Status: complete.
+   - Decision: no new wrapper receipt is needed yet.
+   - Close the lane as docs-only guidance plus existing proof routing. Reopen
+     only if a concrete consumer cannot use the current publish-surface,
+     version-consistency, CI lane, release workflow, and affected-proof
+     evidence set.
 
 ## Validation
 
@@ -104,3 +107,10 @@ release workflow, or version docs change.
   publish-surface JSON, version consistency output, `release_metadata` proof
   scope routing, CI release lane policy, and intentional release workflow
   artifacts.
+- 2026-05-15: Closed the lane. The current evidence set is useful without a
+  wrapper receipt: `publish-surface --json --verify-publish` owns package
+  surface and closure facts, version consistency owns metadata alignment,
+  affected/proof planning owns release-file routing, CI lane policy owns
+  release-check obligations, and release workflow artifacts remain the
+  intentional mutation evidence. A new receipt should start from a fresh
+  proposal naming the consumer and gap.


### PR DESCRIPTION
## Summary
- close the publishing evidence readiness lane as a docs-only guidance surface
- archive the completed active goal and mark the current active goal complete
- record the decision that a new wrapper receipt is not needed until a concrete consumer gap appears
- update NEXT so the next lane is chosen deliberately instead of extending publishing evidence by inertia

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask publish-surface --json --verify-publish > target\publish-surface-publishing-evidence-closeout.json
- cargo xtask version-consistency
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-publishing-evidence-closeout.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-publishing-evidence-closeout.json --evidence-json target/proof/proof-evidence-publishing-evidence-closeout.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-publishing-evidence-closeout.json
- cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-publishing-evidence-closeout.json --json-output target/proof/proof-run-artifacts-check-publishing-evidence-closeout.json
- cargo fmt-check
- git diff --check

## Boundaries
- no publishing, tagging, GitHub release, Docker, or release workflow changes
- no public CLI, schema, or product behavior changes
- no proof promotion or Codecov default changes