### PR TITLE
fix(analysis): avoid panic on ternary `?` after multi-byte chars

### DIFF
--- a/crates/tokmd-analysis/src/content/complexity/cyclomatic/scoring.rs
+++ b/crates/tokmd-analysis/src/content/complexity/cyclomatic/scoring.rs
@@ -133,7 +133,7 @@ fn count_ternary_op(line: &str) -> usize {
             let next = chars.get(i + 1);
             let is_optional_chain = next == Some(&'.');
             let at_end = next.is_none() || matches!(next, Some(';') | Some(')'));
-            let has_colon = line[i..].contains(':');
+            let has_colon = chars[i..].contains(&':');
 
             if !is_optional_chain && !at_end && has_colon {
                 count += 1;

--- a/crates/tokmd-analysis/src/content/complexity/tests/unit/cyclomatic.rs
+++ b/crates/tokmd-analysis/src/content/complexity/tests/unit/cyclomatic.rs
@@ -358,6 +358,18 @@ function max(a, b) {
 }
 
 #[test]
+fn cc_js_ternary_with_multibyte_chars() {
+    // Regression: byte-vs-char index mismatch in count_ternary_op
+    // used to panic when multi-byte UTF-8 characters preceded a `?`
+    // on the same line.
+    let code = "function pick(x) {\n    return x === \"🎉🎉🎉\" ? \"ok\" : \"no\";\n}\n";
+    let result = estimate_cyclomatic_complexity(code, "javascript");
+    assert_eq!(result.function_count, 1);
+    // 1 base + 1 ternary = 2
+    assert_eq!(result.total_cc, 2);
+}
+
+#[test]
 fn cc_js_logical_operators() {
     let code = r#"
 function check(a, b) {


### PR DESCRIPTION
## Summary

`count_ternary_op` in cyclomatic complexity scoring iterated a line by `chars` but sliced the original `&str` with that char index (`line[i..]`) when looking for the ternary `:`. A multi-byte UTF-8 character before `?` makes the char index differ from the byte boundary and can panic while analyzing JS/TS source.

Minimal repro that panics before this fix:

```js
function pick(x) {
    return x === "🎉🎉🎉" ? "ok" : "no";
}
```

## Fix

Reuse the collected `Vec<char>` for ternary lookahead: `chars[i..].contains(&':')`. ASCII behavior stays the same and the UTF-8 byte-boundary trap is removed.

## Validation

- [x] `cargo test -p tokmd-analysis --features content cc_js_ternary --verbose`
- [x] `cargo test -p tokmd-analysis --features content cyclomatic --verbose`
- [x] `cargo xtask proof-policy --check`
- [x] `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-utf8-ternary.json`
- [x] `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-utf8-ternary.json --evidence-json target/proof/proof-evidence-utf8-ternary.json`
- [x] `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-utf8-ternary.json`
- [x] `cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-utf8-ternary.json`
- [x] `cargo clippy -p tokmd-analysis --features content --tests -- -D warnings`
- [x] `cargo fmt-check`
- [x] `git diff --check origin/main...HEAD`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDAZ6nuAy2y8ahJb1Xcuz7); rebased and validated on current main by Codex._