### PR TITLE
docs: close mutation scope selection lane

### DIFF
--- a/.jules/goals/archive/2026-05-15-mutation-scope-selection.toml
+++ b/.jules/goals/archive/2026-05-15-mutation-scope-selection.toml
@@ -19,6 +19,7 @@ mutation_workflow = ".github/workflows/mutants.yml"
 xtask_cli = "xtask/src/cli.rs"
 xtask_main = "xtask/src/main.rs"
 mutation_scope_task = "xtask/src/tasks/mutation_scope.rs"
+artifact_glossary = "docs/artifacts.md"
 
 [rules]
 github_actions_boundary = "keep_actions_as_runner_cache_artifact_shell"
@@ -37,3 +38,8 @@ affected_plan = "cargo xtask affected --base origin/main --head HEAD --json-outp
 proof_plan = "cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-mutation-scope-selection.json --evidence-json target/proof/proof-evidence-mutation-scope-selection.json"
 fmt = "cargo fmt-check"
 diff_hygiene = "git diff --check"
+
+[decision]
+summary = "Mutation changed-file selection is now Rust-owned."
+reason = "PR #2292 added cargo xtask mutation-scope, wired the manual mutation workflow to consume workflow-compatible outputs from xtask, uploaded mutation-scope.json with the existing mutation summary, and preserved advisory mutation behavior."
+reopen_when = "A concrete workflow or consumer needs survivor-summary parsing, mutation execution orchestration, or cockpit/handoff consumption moved into Rust-owned evidence; start that as a fresh plan."

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -116,13 +116,12 @@ Codecov defaults, public `tokmd` CLI behavior, and source proof artifact
 schemas. At closeout there was no active proof-orchestration implementation
 slice; the next one should be chosen deliberately from fresh evidence.
 
-The mutation scope selection lane is active. Fresh workflow audit found the
-manual mutation workflow still owns production Rust changed-file selection in
-inline shell while the rest of the proof control plane has moved toward
-Rust-owned planning and receipt generation. The next narrow slice is
-`cargo xtask mutation-scope`: preserve current mutation workflow behavior, keep
-mutation advisory, and move only the changed-file scope selection plus
-workflow-compatible outputs into tested Rust code.
+The mutation scope selection lane is closed. PR #2292 added Rust-owned
+`cargo xtask mutation-scope`, wired the manual mutation workflow to consume
+workflow-compatible outputs from xtask, uploaded `mutation-scope.json` beside
+the existing mutation summary, and preserved advisory mutation behavior. The
+workflow still owns mutation execution and survivor-summary parsing; move those
+only from a fresh plan with a concrete consumer or maintenance problem.
 
 The code-intelligence platform audit is closed. It mapped the broad platform
 objective to live artifacts and verifier coverage, did not mark the platform
@@ -161,11 +160,10 @@ lane, release workflow, and affected-proof evidence cannot cover.
 
 ## Next Work Packets
 
-1. Finish the active mutation scope selection slice: replace
-   `.github/workflows/mutants.yml` changed-file shell filtering with
-   `cargo xtask mutation-scope`, preserve existing workflow outputs and
-   advisory mutation behavior, and do not rewrite survivor-summary parsing in
-   the same PR.
+1. Choose the next lane deliberately from fresh evidence; do not continue
+   mutation workflow Rustification unless survivor-summary parsing, mutation
+   execution orchestration, or artifact consumption proves to be the next
+   concrete gap.
 2. Do not reopen AST productization without a fresh proposal grounded in the
    shadow evidence.
 3. Choose the next proof-orchestration slice deliberately; do not promote

--- a/docs/plans/mutation-scope-selection.md
+++ b/docs/plans/mutation-scope-selection.md
@@ -1,6 +1,6 @@
 # Plan: Mutation Scope Selection
 
-- Status: active
+- Status: complete
 - Related proposal:
 - Related spec:
 - Related ADR:
@@ -36,7 +36,7 @@ whether mutation is advisory, required, or product-visible.
 ## Work Packets
 
 1. Add Rust-owned mutation scope selection.
-   - Status: active.
+   - Status: complete.
    - Add `cargo xtask mutation-scope`.
    - Preserve the current production Rust file filters from
      `.github/workflows/mutants.yml`.
@@ -44,13 +44,38 @@ whether mutation is advisory, required, or product-visible.
      `count`, and `files` outputs.
    - Write deterministic `tokmd.mutation_scope.v1` JSON when requested.
 2. Wire the manual mutation workflow.
-   - Status: active.
+   - Status: complete.
    - Keep `cargo-mutants` execution behavior unchanged.
    - Upload `mutation-scope.json` beside the existing mutation summary.
 3. Checkpoint the remaining mutation workflow shell.
-   - Status: pending.
-   - Decide from fresh evidence whether survivor-summary parsing should move
-     into `xtask` later.
+   - Status: complete.
+   - Decision: survivor-summary parsing stays in the workflow for now; move it
+     only from a fresh plan with a concrete consumer or maintenance problem.
+
+## Decision
+
+Outcome: **complete; mutation changed-file selection is Rust-owned**.
+
+PR #2292 added `cargo xtask mutation-scope`, preserving the manual mutation
+workflow's existing selection contract:
+
+```text
+base_ref
+total_count
+scope_exceeded
+count
+files
+```
+
+The workflow still runs `cargo-mutants` the same way and still generates the
+existing `mutants-summary.json`; it now asks `xtask` to select production Rust
+candidate files and to write `target/mutation/mutation-scope.json` for review
+evidence. The JSON scope receipt is a workflow artifact, not a public `tokmd`
+receipt schema.
+
+The slice did not promote mutation testing, change Codecov behavior, change
+public `tokmd` CLI behavior, replace `cargo xtask proof --plan` mutation
+planning, or make mutation scope output a cockpit, handoff, or merge verdict.
 
 ## Validation
 
@@ -84,3 +109,6 @@ Run required affected proof if the affected plan selects it.
   selection in Bash even though proof planning already records mutation as
   advisory evidence. The first slice makes selection Rust-owned and leaves
   mutation execution plus summary parsing unchanged.
+- 2026-05-15: Closed through PR #2292. Hosted PR checks passed, post-merge
+  required CI passed, and the main mutation workflow accepted the new
+  `mutation-scope.json` artifact while preserving advisory mutation behavior.


### PR DESCRIPTION
## Summary
- close the mutation scope selection lane after #2292
- archive the active goal and mark the current lane complete
- record the decision that survivor-summary parsing and mutation execution stay in the workflow until a future concrete gap justifies moving them
- update NEXT so the next lane is selected deliberately from fresh evidence

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-mutation-scope-closeout.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-mutation-scope-closeout.json --evidence-json target/proof/proof-evidence-mutation-scope-closeout.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-mutation-scope-closeout.json
- cargo xtask proof-run-artifacts-check --proof-run-summary target/proof/proof-run-summary-mutation-scope-closeout.json --json-output target/proof/proof-run-artifacts-check-mutation-scope-closeout.json
- cargo fmt-check
- git diff --check

## Boundaries
- no mutation gate promotion
- no Codecov default change
- no workflow behavior change beyond source-of-truth closeout
- no public `tokmd` CLI or receipt schema changes