### PR TITLE
test: improve code coverage across analysis, cockpit, format crates

### DIFF
--- a/crates/tokmd-analysis/src/complexity/mod.rs
+++ b/crates/tokmd-analysis/src/complexity/mod.rs
@@ -24,7 +24,10 @@ mod summary;
 use debt::{average_parent_loc, compute_technical_debt_ratio};
 use details::extract_function_details;
 #[cfg(test)]
-use details::{detect_fn_spans_c_style, detect_fn_spans_python, detect_fn_spans_rust};
+use details::{
+    detect_fn_spans_c_style, detect_fn_spans_go, detect_fn_spans_js, detect_fn_spans_python,
+    detect_fn_spans_rust,
+};
 use functions::count_functions;
 #[cfg(test)]
 use functions::{count_python_functions, count_rust_functions, is_rust_fn_start};

--- a/crates/tokmd-analysis/src/complexity/tests/unit.rs
+++ b/crates/tokmd-analysis/src/complexity/tests/unit.rs
@@ -387,3 +387,161 @@ def nested():
     // Should start at @nested_decorator
     assert!(lines[start2].trim().starts_with("@nested_decorator"));
 }
+
+#[test]
+fn test_detect_fn_go_basic() {
+    let code = r#"
+package main
+
+func main() {
+    println("hello")
+}
+
+func add(a int, b int) int {
+    return a + b
+}
+"#;
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_go(&lines);
+    let names: Vec<&str> = spans.iter().map(|(_, _, n)| n.as_str()).collect();
+    assert_eq!(names, vec!["main", "add"]);
+}
+
+#[test]
+fn test_detect_fn_go_with_receiver() {
+    let code = r#"
+type T struct{}
+
+func (t *T) Method() string {
+    return "method"
+}
+
+func (T) ValueMethod() int {
+    return 0
+}
+"#;
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_go(&lines);
+    let names: Vec<&str> = spans.iter().map(|(_, _, n)| n.as_str()).collect();
+    assert_eq!(names, vec!["Method", "ValueMethod"]);
+}
+
+#[test]
+fn test_detect_fn_go_unknown_name() {
+    // Malformed: func keyword with no identifier; brace-end search still skips it.
+    let code = "func\n";
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_go(&lines);
+    assert!(spans.is_empty(), "no brace, no span");
+}
+
+#[test]
+fn test_detect_fn_go_open_brace_only_advances() {
+    // Function header with no matching close brace should be skipped without
+    // advancing into an infinite loop.
+    let code = r#"
+func incomplete() {
+"#;
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_go(&lines);
+    assert!(spans.is_empty());
+}
+
+#[test]
+fn test_detect_fn_js_basic() {
+    let code = r#"
+function foo() {
+    return 1;
+}
+
+async function bar() {
+    return 2;
+}
+
+export function baz() {
+    return 3;
+}
+
+export async function qux() {
+    return 4;
+}
+"#;
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_js(&lines);
+    let names: Vec<&str> = spans.iter().map(|(_, _, n)| n.as_str()).collect();
+    assert_eq!(names, vec!["foo", "bar", "baz", "qux"]);
+}
+
+#[test]
+fn test_detect_fn_js_arrow_with_brace() {
+    let code = r#"
+const greet = (name) => {
+    return "hi " + name;
+};
+
+const noop = () => {};
+"#;
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_js(&lines);
+    // Both arrow functions should be detected; names come from text before '('.
+    assert_eq!(spans.len(), 2);
+}
+
+#[test]
+fn test_detect_fn_js_skips_line_comment() {
+    let code = r#"
+// function commentedOut() { return 1; }
+function real() {
+    return 1;
+}
+"#;
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_js(&lines);
+    let names: Vec<&str> = spans.iter().map(|(_, _, n)| n.as_str()).collect();
+    assert_eq!(names, vec!["real"]);
+}
+
+#[test]
+fn test_detect_fn_js_anonymous_fallback() {
+    // `(...) => { ... }` with no identifier before `(` is anonymous.
+    let code = "((x) => {\n  return x;\n})(1);\n";
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_js(&lines);
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].2, "<anonymous>");
+}
+
+#[test]
+fn test_detect_fn_js_dollar_underscore_names() {
+    let code = "function $foo_bar() {\n  return 1;\n}\n";
+    let lines: Vec<&str> = code.lines().collect();
+    let spans = detect_fn_spans_js(&lines);
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].2, "$foo_bar");
+}
+
+#[test]
+fn test_extract_function_details_dispatches_languages() {
+    use super::details::extract_function_details;
+
+    // Each language should produce at least one detail entry, exercising the
+    // language-specific dispatcher in extract_function_details.
+    let rust_code = "pub fn foo() -> i32 {\n  if true { 1 } else { 2 }\n}\n";
+    assert!(!extract_function_details("rust", rust_code).is_empty());
+
+    let js_code = "function foo() {\n  return 1;\n}\n";
+    assert!(!extract_function_details("javascript", js_code).is_empty());
+    assert!(!extract_function_details("typescript", js_code).is_empty());
+
+    let py_code = "def foo():\n    return 1\n";
+    assert!(!extract_function_details("python", py_code).is_empty());
+
+    let go_code = "func main() {\n  println(\"hi\")\n}\n";
+    assert!(!extract_function_details("go", go_code).is_empty());
+
+    let c_code = "int main() {\n  return 0;\n}\n";
+    assert!(!extract_function_details("c", c_code).is_empty());
+
+    // Unknown language returns no details (matches the `_ => Vec::new()` arm).
+    assert!(extract_function_details("brainfuck", "+++.\n").is_empty());
+}

--- a/crates/tokmd-analysis/src/effort/classify.rs
+++ b/crates/tokmd-analysis/src/effort/classify.rs
@@ -79,3 +79,100 @@ pub(super) fn classify_row(
 
     (class, kind)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokmd_types::{FileKind as TokmdFileKind, FileRow};
+
+    fn make_row(path: &str) -> FileRow {
+        FileRow {
+            path: path.to_string(),
+            module: "src".to_string(),
+            lang: "Rust".to_string(),
+            kind: TokmdFileKind::Parent,
+            code: 10,
+            comments: 0,
+            blanks: 0,
+            lines: 10,
+            bytes: 40,
+            tokens: 20,
+        }
+    }
+
+    #[test]
+    fn class_kind_confidence_boost_pins_known_vs_unknown() {
+        assert_eq!(ClassKind::Generated.confidence_boost(), 1.0);
+        assert_eq!(ClassKind::Vendored.confidence_boost(), 1.0);
+        assert_eq!(ClassKind::Unknown.confidence_boost(), 0.0);
+    }
+
+    #[test]
+    fn classify_row_uses_gitattributes_rule_first_for_generated_match() {
+        // A matching gitattributes rule short-circuits the heuristic.
+        let rules = vec![GitAttrRule {
+            pattern: "src/lib.rs".to_string(),
+            kind: ClassKind::Generated,
+            source: "test".to_string(),
+        }];
+        let row = make_row("src/lib.rs");
+        let (class, kind) = classify_row(Path::new(""), "src/lib.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Generated);
+        assert!(matches!(kind, FileKind::Generated));
+    }
+
+    #[test]
+    fn classify_row_uses_gitattributes_rule_for_vendored_match() {
+        let rules = vec![GitAttrRule {
+            pattern: "vendor/foo.rs".to_string(),
+            kind: ClassKind::Vendored,
+            source: "test".to_string(),
+        }];
+        let row = make_row("vendor/foo.rs");
+        let (class, kind) = classify_row(Path::new(""), "vendor/foo.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Vendored);
+        assert!(matches!(kind, FileKind::Vendored));
+    }
+
+    #[test]
+    fn classify_row_unknown_rule_returns_core_filekind() {
+        // ClassKind::Unknown rules map to FileKind::Core (the documented
+        // catch-all in the match arm).
+        let rules = vec![GitAttrRule {
+            pattern: "src/lib.rs".to_string(),
+            kind: ClassKind::Unknown,
+            source: "test".to_string(),
+        }];
+        let row = make_row("src/lib.rs");
+        let (class, kind) = classify_row(Path::new(""), "src/lib.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Unknown);
+        assert!(matches!(kind, FileKind::Core));
+    }
+
+    #[test]
+    fn classify_row_falls_back_to_heuristic_when_no_rule_matches() {
+        // Empty rule set forces the heuristic path. `_test.rs` suffix routes
+        // through `looks_test_path` to FileKind::Tests / ClassKind::Unknown.
+        let rules: Vec<GitAttrRule> = Vec::new();
+        let row = make_row("src/foo_test.rs");
+        let (class, kind) = classify_row(Path::new(""), "src/foo_test.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Unknown);
+        assert!(matches!(kind, FileKind::Tests));
+    }
+
+    #[test]
+    fn classify_row_heuristic_flags_generated_artifacts() {
+        // A generated-looking path should fall through to the heuristic and
+        // be tagged as ClassKind::Generated even without a gitattributes rule.
+        let rules: Vec<GitAttrRule> = Vec::new();
+        let row = make_row("target/generated/bundle.min.js");
+        let (class, kind) = classify_row(
+            Path::new(""),
+            "target/generated/bundle.min.js",
+            &rules,
+            &row,
+        );
+        assert_eq!(class, ClassKind::Generated);
+        assert!(matches!(kind, FileKind::Generated));
+    }
+}

--- a/crates/tokmd-analysis/src/effort/cocomo2.rs
+++ b/crates/tokmd-analysis/src/effort/cocomo2.rs
@@ -71,3 +71,65 @@ pub fn cocomo2_baseline(kloc_authored: f64) -> EffortResults {
         staff_p80,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cocomo2_effort_pm_returns_zeros_for_non_positive_kloc() {
+        // Saturating exit on `kloc <= 0.0` is the only short-circuit.
+        let (e1, s1, p1, _) = cocomo2_effort_pm(0.0);
+        assert_eq!((e1, s1, p1), (0.0, 0.0, 0.0));
+        let (e2, s2, p2, _) = cocomo2_effort_pm(-5.0);
+        assert_eq!((e2, s2, p2), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn cocomo2_effort_pm_uses_documented_constants_at_one_kloc() {
+        // At 1 KLOC the powers collapse to constants, so we can pin them.
+        let (effort, schedule, staff, mirror) = cocomo2_effort_pm(1.0);
+        assert!((effort - A).abs() < 1e-9);
+        assert!((schedule - C * effort.powf(D)).abs() < 1e-9);
+        // staff = effort / schedule
+        assert!((staff - effort / schedule).abs() < 1e-9);
+        // 4th tuple slot mirrors the p50 effort value.
+        assert!((mirror - effort).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cocomo2_baseline_zero_kloc_returns_all_zeros() {
+        let r = cocomo2_baseline(0.0);
+        assert_eq!(r.effort_pm_p50, 0.0);
+        assert_eq!(r.schedule_months_p50, 0.0);
+        assert_eq!(r.staff_p50, 0.0);
+        assert_eq!(r.effort_pm_low, 0.0);
+        assert_eq!(r.effort_pm_p80, 0.0);
+        assert_eq!(r.schedule_months_low, 0.0);
+        assert_eq!(r.schedule_months_p80, 0.0);
+        assert_eq!(r.staff_low, 0.0);
+        assert_eq!(r.staff_p80, 0.0);
+    }
+
+    #[test]
+    fn cocomo2_baseline_clamps_negative_kloc_to_zero() {
+        let r_neg = cocomo2_baseline(-1.0);
+        let r_zero = cocomo2_baseline(0.0);
+        assert_eq!(r_neg.effort_pm_p50, r_zero.effort_pm_p50);
+        assert_eq!(r_neg.schedule_months_p50, r_zero.schedule_months_p50);
+    }
+
+    #[test]
+    fn cocomo2_baseline_low_p80_envelope_widens_around_p50() {
+        let r = cocomo2_baseline(10.0);
+        assert!(r.effort_pm_p50 > 0.0);
+        assert!(r.effort_pm_low < r.effort_pm_p50);
+        assert!(r.effort_pm_p80 > r.effort_pm_p50);
+        assert!(r.schedule_months_low < r.schedule_months_p50);
+        assert!(r.schedule_months_p80 > r.schedule_months_p50);
+        // staff_low uses schedule_high in denominator => smaller than staff_p50,
+        // staff_p80 uses schedule_low => larger than staff_p50.
+        assert!(r.staff_low < r.staff_p50);
+        assert!(r.staff_p80 > r.staff_p50);
+    }
+}

--- a/crates/tokmd-analysis/src/effort/delta.rs
+++ b/crates/tokmd-analysis/src/effort/delta.rs
@@ -169,3 +169,50 @@ fn classify_blast(blast_radius: f64) -> EffortDeltaClassification {
         EffortDeltaClassification::Critical
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_blast_boundaries() {
+        // Each bucket boundary is exclusive on the high end of the lower band.
+        assert_eq!(classify_blast(0.0), EffortDeltaClassification::Low);
+        assert_eq!(classify_blast(9.999), EffortDeltaClassification::Low);
+        assert_eq!(classify_blast(10.0), EffortDeltaClassification::Medium);
+        assert_eq!(classify_blast(19.999), EffortDeltaClassification::Medium);
+        assert_eq!(classify_blast(20.0), EffortDeltaClassification::High);
+        assert_eq!(classify_blast(34.999), EffortDeltaClassification::High);
+        assert_eq!(classify_blast(35.0), EffortDeltaClassification::Critical);
+        assert_eq!(classify_blast(100.0), EffortDeltaClassification::Critical);
+    }
+
+    #[test]
+    fn build_delta_requires_base_and_head() {
+        let export = ExportData {
+            rows: Vec::new(),
+            module_roots: Vec::new(),
+            module_depth: 1,
+            children: tokmd_types::ChildIncludeMode::Separate,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let err = build_delta(dir.path(), &export, None, "", "HEAD").unwrap_err();
+        assert!(err.to_string().contains("base_ref and head_ref"));
+        let err = build_delta(dir.path(), &export, None, "HEAD~1", "  ").unwrap_err();
+        assert!(err.to_string().contains("base_ref and head_ref"));
+    }
+
+    #[cfg(not(feature = "git"))]
+    #[test]
+    fn build_delta_without_git_feature_errors() {
+        let export = ExportData {
+            rows: Vec::new(),
+            module_roots: Vec::new(),
+            module_depth: 1,
+            children: tokmd_types::ChildIncludeMode::Separate,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let err = build_delta(dir.path(), &export, None, "HEAD~1", "HEAD").unwrap_err();
+        assert!(err.to_string().contains("tokmd-git feature"));
+    }
+}

--- a/crates/tokmd-analysis/src/effort/model.rs
+++ b/crates/tokmd-analysis/src/effort/model.rs
@@ -200,3 +200,58 @@ struct SizeContext {
     size_basis: EffortSizeBasis,
     basis_confidence: f64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_results(scale: f64) -> EffortResults {
+        EffortResults {
+            effort_pm_p50: 1.0 * scale,
+            schedule_months_p50: 2.0 * scale,
+            staff_p50: 0.5 * scale,
+            effort_pm_low: 0.5 * scale,
+            effort_pm_p80: 1.5 * scale,
+            schedule_months_low: 1.5 * scale,
+            schedule_months_p80: 2.5 * scale,
+            staff_low: 0.3 * scale,
+            staff_p80: 0.7 * scale,
+        }
+    }
+
+    #[test]
+    fn avg_models_averages_every_band_independently() {
+        let a = make_results(1.0);
+        let b = make_results(3.0);
+        let avg = avg_models(&a, &b);
+
+        assert!((avg.effort_pm_p50 - 2.0).abs() < 1e-9);
+        assert!((avg.schedule_months_p50 - 4.0).abs() < 1e-9);
+        assert!((avg.staff_p50 - 1.0).abs() < 1e-9);
+        assert!((avg.effort_pm_low - 1.0).abs() < 1e-9);
+        assert!((avg.effort_pm_p80 - 3.0).abs() < 1e-9);
+        assert!((avg.schedule_months_low - 3.0).abs() < 1e-9);
+        assert!((avg.schedule_months_p80 - 5.0).abs() < 1e-9);
+        assert!((avg.staff_low - 0.6).abs() < 1e-9);
+        assert!((avg.staff_p80 - 1.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn avg_models_is_symmetric() {
+        let a = make_results(1.0);
+        let b = make_results(7.0);
+        let ab = avg_models(&a, &b);
+        let ba = avg_models(&b, &a);
+
+        assert!((ab.effort_pm_p50 - ba.effort_pm_p50).abs() < 1e-9);
+        assert!((ab.schedule_months_p50 - ba.schedule_months_p50).abs() < 1e-9);
+        assert!((ab.staff_p80 - ba.staff_p80).abs() < 1e-9);
+    }
+
+    #[test]
+    fn has_host_root_detects_empty_path() {
+        assert!(!has_host_root(Path::new("")));
+        assert!(has_host_root(Path::new("/tmp")));
+        assert!(has_host_root(Path::new(".")));
+    }
+}

--- a/crates/tokmd-analysis/src/effort/request.rs
+++ b/crates/tokmd-analysis/src/effort/request.rs
@@ -116,3 +116,44 @@ impl Display for EffortLayer {
         write!(f, "{}", self.as_str())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effort_request_default_pins_engine_baseline() {
+        let req = EffortRequest::default();
+        assert_eq!(req.model, EffortModelKind::Cocomo81Basic);
+        assert_eq!(req.layer, EffortLayer::Full);
+        assert!(req.base_ref.is_none());
+        assert!(req.head_ref.is_none());
+        assert!(!req.monte_carlo);
+        assert_eq!(req.mc_iterations, 10_000);
+        assert!(req.mc_seed.is_none());
+    }
+
+    #[test]
+    fn effort_model_kind_string_forms_are_stable() {
+        for (kind, expected) in [
+            (EffortModelKind::Cocomo81Basic, "cocomo81-basic"),
+            (EffortModelKind::Cocomo2Early, "cocomo2-early"),
+            (EffortModelKind::Ensemble, "ensemble"),
+        ] {
+            assert_eq!(kind.as_str(), expected);
+            assert_eq!(kind.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn effort_layer_string_forms_are_stable() {
+        for (layer, expected) in [
+            (EffortLayer::Headline, "headline"),
+            (EffortLayer::Why, "why"),
+            (EffortLayer::Full, "full"),
+        ] {
+            assert_eq!(layer.as_str(), expected);
+            assert_eq!(layer.to_string(), expected);
+        }
+    }
+}

--- a/crates/tokmd-analysis/src/effort/tests/effort_engine.rs
+++ b/crates/tokmd-analysis/src/effort/tests/effort_engine.rs
@@ -757,6 +757,10 @@ fn effort_delta_infers_changed_files_modules_and_blast_radius() {
     git(&repo, &["init"]);
     git(&repo, &["config", "user.name", "tokmd-tests"]);
     git(&repo, &["config", "user.email", "tokmd-tests@example.com"]);
+    // Disable commit signing so environments with a global signing config
+    // (e.g. some sandboxes) don't make this fixture unable to record commits.
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    git(&repo, &["config", "tag.gpgsign", "false"]);
 
     write_file(&repo.join("src/main.rs"), "fn main() {}\n");
     git(&repo, &["add", "."]);
@@ -803,4 +807,81 @@ fn effort_delta_infers_changed_files_modules_and_blast_radius() {
     } else {
         assert!(report.delta.is_none());
     }
+}
+
+#[test]
+fn monte_carlo_request_threads_through_report_assumptions() {
+    // Reaches the `monte_carlo: true` branches in build_effort_report and
+    // assumptions_summary, including the apply_monte_carlo placeholder.
+    let export = make_export(2_000);
+    let derived = make_derived(2_000, 0.05, 1);
+    let root = mk_temp_dir("tokmd-effort-mc");
+    fs::create_dir_all(&root).unwrap();
+    let _guard = TempDirGuard(root.clone());
+
+    let req = EffortRequest {
+        model: EffortModelKind::Cocomo81Basic,
+        layer: EffortLayer::Full,
+        base_ref: None,
+        head_ref: None,
+        monte_carlo: true,
+        mc_iterations: 1_000,
+        mc_seed: Some(7),
+    };
+
+    let report =
+        build_effort_report(&root, &export, &derived, None, None, None, None, &req).unwrap();
+
+    // The Monte Carlo placeholder must keep the report consistent.
+    assert!(report.results.effort_pm_p50 > 0.0);
+    assert!(report.results.effort_pm_p80 >= report.results.effort_pm_p50);
+
+    let mc_note_present = report
+        .assumptions
+        .notes
+        .iter()
+        .any(|note| note.contains("Monte Carlo"));
+    assert!(
+        mc_note_present,
+        "expected Monte Carlo note in assumptions, got {:?}",
+        report.assumptions.notes
+    );
+
+    let mc_override = report.assumptions.overrides.get("monte_carlo");
+    assert!(mc_override.is_some(), "expected monte_carlo override entry");
+    let value = mc_override.unwrap();
+    assert!(value.contains("iterations=1000"));
+    assert!(value.contains("seed=Some(7)"));
+}
+
+#[test]
+fn monte_carlo_with_zero_iterations_returns_base_results() {
+    // mc_iterations=0 short-circuits apply_monte_carlo to clone base.
+    use crate::effort::monte_carlo::apply_monte_carlo;
+    use tokmd_analysis_types::{EffortConfidence, EffortConfidenceLevel, EffortResults};
+
+    let base = EffortResults {
+        effort_pm_p50: 12.5,
+        schedule_months_p50: 6.0,
+        staff_p50: 2.0,
+        effort_pm_low: 9.0,
+        effort_pm_p80: 16.0,
+        schedule_months_low: 4.0,
+        schedule_months_p80: 8.0,
+        staff_low: 1.5,
+        staff_p80: 2.5,
+    };
+    let confidence = EffortConfidence {
+        level: EffortConfidenceLevel::High,
+        reasons: Vec::new(),
+        data_coverage_pct: Some(0.8),
+    };
+    let result = apply_monte_carlo(&base, &[], &confidence, 0.8, 0, None);
+    assert_eq!(result.effort_pm_p50, base.effort_pm_p50);
+    assert_eq!(result.schedule_months_p50, base.schedule_months_p50);
+    assert_eq!(result.staff_p50, base.staff_p50);
+
+    let result_many = apply_monte_carlo(&base, &[], &confidence, 0.8, 100, Some(42));
+    // Current placeholder returns a clone regardless; this pins behavior.
+    assert_eq!(result_many.effort_pm_p50, base.effort_pm_p50);
 }

--- a/crates/tokmd-analysis/tests/feature_matrix.rs
+++ b/crates/tokmd-analysis/tests/feature_matrix.rs
@@ -65,6 +65,16 @@ fn make_git_context(export: ExportData) -> (AnalysisContext, tempfile::TempDir) 
             .success()
     );
 
+    // Disable commit signing so global signing configs don't break this fixture.
+    let _ = Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo_root)
+        .status();
+    let _ = Command::new("git")
+        .args(["config", "tag.gpgsign", "false"])
+        .current_dir(repo_root)
+        .status();
+
     assert!(
         Command::new("git")
             .args(["add", "."])

--- a/crates/tokmd-analysis/tests/git.rs
+++ b/crates/tokmd-analysis/tests/git.rs
@@ -29,6 +29,9 @@ mod git_tests {
         let dir = tempdir().expect("tempdir");
         let root = dir.path();
         git_cmd(root, &["init"]);
+        // Disable host commit-signing config from leaking into this fixture.
+        git_cmd(root, &["config", "commit.gpgsign", "false"]);
+        git_cmd(root, &["config", "tag.gpgsign", "false"]);
 
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "fn a() {}\n").unwrap();

--- a/crates/tokmd-cockpit/src/gates/diff_coverage.rs
+++ b/crates/tokmd-cockpit/src/gates/diff_coverage.rs
@@ -282,6 +282,8 @@ mod tests {
         git(&["init", "-b", "main"]);
         git(&["config", "user.email", "tokmd@example.com"]);
         git(&["config", "user.name", "tokmd"]);
+        git(&["config", "commit.gpgsign", "false"]);
+        git(&["config", "tag.gpgsign", "false"]);
         git(&["add", "."]);
         git(&["commit", "-m", "base"]);
 

--- a/crates/tokmd-cockpit/src/proof_evidence/model.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/model.rs
@@ -105,3 +105,76 @@ impl ProofEvidenceInput {
         self.artifact.kind()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_evidence_kind_as_str_covers_all_variants() {
+        assert_eq!(
+            ProofEvidenceKind::ProofRunSummary.as_str(),
+            "proof_run_summary"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofRunObservation.as_str(),
+            "proof_run_observation"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofExecutorObservation.as_str(),
+            "proof_executor_observation"
+        );
+        assert_eq!(
+            ProofEvidenceKind::CoverageReceipt.as_str(),
+            "coverage_receipt"
+        );
+    }
+
+    #[test]
+    fn proof_evidence_kind_packet_file_name_covers_all_variants() {
+        assert_eq!(
+            ProofEvidenceKind::ProofRunSummary.packet_file_name(),
+            "proof-run-summary.json"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofRunObservation.packet_file_name(),
+            "proof-run-observation.json"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofExecutorObservation.packet_file_name(),
+            "proof-executor-observation.json"
+        );
+        assert_eq!(
+            ProofEvidenceKind::CoverageReceipt.packet_file_name(),
+            "coverage-receipt.json"
+        );
+    }
+
+    #[test]
+    fn proof_evidence_availability_as_str_covers_all_variants() {
+        assert_eq!(ProofEvidenceAvailability::Available.as_str(), "available");
+        assert_eq!(ProofEvidenceAvailability::Missing.as_str(), "missing");
+        assert_eq!(ProofEvidenceAvailability::Skipped.as_str(), "skipped");
+        assert_eq!(ProofEvidenceAvailability::Stale.as_str(), "stale");
+        assert_eq!(ProofEvidenceAvailability::Degraded.as_str(), "degraded");
+        assert_eq!(
+            ProofEvidenceAvailability::Unavailable.as_str(),
+            "unavailable"
+        );
+    }
+
+    #[test]
+    fn proof_execution_status_as_str_covers_all_variants() {
+        assert_eq!(ProofExecutionStatus::Planned.as_str(), "planned");
+        assert_eq!(
+            ProofExecutionStatus::ExecutedPassed.as_str(),
+            "executed_passed"
+        );
+        assert_eq!(
+            ProofExecutionStatus::ExecutedFailed.as_str(),
+            "executed_failed"
+        );
+        assert_eq!(ProofExecutionStatus::NotExecuted.as_str(), "not_executed");
+        assert_eq!(ProofExecutionStatus::DryRun.as_str(), "dry_run");
+    }
+}

--- a/crates/tokmd-cockpit/tests/determinism_gate_branches.rs
+++ b/crates/tokmd-cockpit/tests/determinism_gate_branches.rs
@@ -1,0 +1,268 @@
+//! Branch-coverage tests for `compute_determinism_gate`.
+//!
+//! These tests cover the gate's resolution / parse / hash-mismatch
+//! branches without requiring git history, which the rest of the cockpit
+//! gates need.
+
+#![cfg(feature = "git")]
+
+use std::fs;
+use std::path::PathBuf;
+
+use tokmd_analysis_types::{ComplexityBaseline, DeterminismBaseline};
+use tokmd_cockpit::compute_determinism_gate;
+use tokmd_cockpit::determinism::hash_files_from_walk;
+use tokmd_types::cockpit::GateStatus;
+
+fn baseline_path(repo: &tempfile::TempDir) -> PathBuf {
+    let dir = repo.path().join(".tokmd");
+    fs::create_dir_all(&dir).expect("create .tokmd dir");
+    dir.join("baseline.json")
+}
+
+fn write_baseline(path: &std::path::Path, baseline: &ComplexityBaseline) {
+    let json = serde_json::to_string_pretty(baseline).expect("serialize baseline");
+    fs::write(path, json).expect("write baseline");
+}
+
+#[test]
+fn determinism_gate_returns_none_without_baseline_file() {
+    let repo = tempfile::tempdir().unwrap();
+    // No `.tokmd/baseline.json` and no explicit path => Ok(None).
+    let result = compute_determinism_gate(repo.path(), None).expect("gate runs");
+    assert!(result.is_none());
+}
+
+#[test]
+fn determinism_gate_returns_none_when_baseline_lacks_determinism_section() {
+    let repo = tempfile::tempdir().unwrap();
+    let path = baseline_path(&repo);
+    let baseline = ComplexityBaseline::new();
+    write_baseline(&path, &baseline);
+
+    let result = compute_determinism_gate(repo.path(), None).expect("gate runs");
+    assert!(
+        result.is_none(),
+        "baseline without determinism section returns None"
+    );
+}
+
+#[test]
+fn determinism_gate_returns_none_when_baseline_is_cockpit_receipt() {
+    let repo = tempfile::tempdir().unwrap();
+    let path = baseline_path(&repo);
+    // A cockpit receipt (not a ComplexityBaseline) should be tolerated and
+    // produce Ok(None) so trend-comparison flows keep working.
+    let cockpit_json = serde_json::json!({
+        "mode": "cockpit",
+        "schema_version": 3,
+    });
+    fs::write(&path, cockpit_json.to_string()).expect("write cockpit json");
+
+    let result = compute_determinism_gate(repo.path(), None).expect("gate runs");
+    assert!(result.is_none());
+}
+
+#[test]
+fn determinism_gate_errors_on_unrecognized_json() {
+    let repo = tempfile::tempdir().unwrap();
+    let path = baseline_path(&repo);
+    // Not a ComplexityBaseline and not a cockpit receipt either.
+    fs::write(&path, r#"{"hello": "world"}"#).expect("write garbage json");
+
+    let result = compute_determinism_gate(repo.path(), None);
+    let err = result.expect_err("unrecognized baseline should error");
+    assert!(
+        err.to_string().contains("not a ComplexityBaseline"),
+        "expected ComplexityBaseline error, got {err}"
+    );
+}
+
+#[test]
+fn determinism_gate_passes_when_source_hash_matches() {
+    let repo = tempfile::tempdir().unwrap();
+    fs::write(repo.path().join("hello.txt"), "stable\n").unwrap();
+
+    // Compute the hash the gate will compute, excluding the baseline file
+    // itself (which it always auto-excludes).
+    let actual_hash =
+        hash_files_from_walk(repo.path(), &[".tokmd/baseline.json"]).expect("hash walk");
+
+    let mut baseline = ComplexityBaseline::new();
+    baseline.determinism = Some(DeterminismBaseline {
+        baseline_version: 1,
+        generated_at: "2025-01-01T00:00:00Z".to_string(),
+        build_hash: "00".repeat(20),
+        source_hash: actual_hash.clone(),
+        cargo_lock_hash: None,
+    });
+
+    let path = baseline_path(&repo);
+    write_baseline(&path, &baseline);
+
+    let gate = compute_determinism_gate(repo.path(), None)
+        .expect("gate runs")
+        .expect("baseline produces gate");
+
+    assert_eq!(gate.meta.status, GateStatus::Pass);
+    assert_eq!(gate.expected_hash.as_deref(), Some(actual_hash.as_str()));
+    assert_eq!(gate.actual_hash.as_deref(), Some(actual_hash.as_str()));
+    assert!(gate.differences.is_empty());
+}
+
+#[test]
+fn determinism_gate_warns_on_source_hash_mismatch() {
+    let repo = tempfile::tempdir().unwrap();
+    fs::write(repo.path().join("hello.txt"), "stable\n").unwrap();
+
+    let mut baseline = ComplexityBaseline::new();
+    baseline.determinism = Some(DeterminismBaseline {
+        baseline_version: 1,
+        generated_at: "2025-01-01T00:00:00Z".to_string(),
+        build_hash: "00".repeat(20),
+        // Pin to a hash the walk will not produce.
+        source_hash: "ff".repeat(20),
+        cargo_lock_hash: None,
+    });
+
+    let path = baseline_path(&repo);
+    write_baseline(&path, &baseline);
+
+    let gate = compute_determinism_gate(repo.path(), None)
+        .expect("gate runs")
+        .expect("baseline produces gate");
+
+    assert_eq!(gate.meta.status, GateStatus::Warn);
+    assert!(
+        gate.differences
+            .iter()
+            .any(|d| d.contains("source hash mismatch")),
+        "expected source hash mismatch in differences: {:?}",
+        gate.differences
+    );
+}
+
+#[test]
+fn determinism_gate_explicit_path_overrides_default() {
+    let repo = tempfile::tempdir().unwrap();
+    fs::write(repo.path().join("hello.txt"), "stable\n").unwrap();
+
+    let actual_hash = hash_files_from_walk(repo.path(), &[]).expect("hash walk");
+
+    let mut baseline = ComplexityBaseline::new();
+    baseline.determinism = Some(DeterminismBaseline {
+        baseline_version: 1,
+        generated_at: "2025-01-01T00:00:00Z".to_string(),
+        build_hash: "00".repeat(20),
+        source_hash: actual_hash.clone(),
+        cargo_lock_hash: None,
+    });
+
+    // Put baseline somewhere outside `.tokmd/` so the strip_prefix branch
+    // resolves to an absolute path that isn't auto-exclusion-able.
+    let outside = tempfile::tempdir().unwrap();
+    let explicit = outside.path().join("custom-baseline.json");
+    write_baseline(&explicit, &baseline);
+
+    let gate = compute_determinism_gate(repo.path(), Some(&explicit))
+        .expect("gate runs")
+        .expect("baseline produces gate");
+
+    // With no `Cargo.lock` expectation, status reduces to source hash equality.
+    assert_eq!(gate.meta.status, GateStatus::Pass);
+    assert_eq!(gate.expected_hash.as_deref(), Some(actual_hash.as_str()));
+}
+
+#[test]
+fn determinism_gate_warns_when_cargo_lock_missing_but_expected() {
+    let repo = tempfile::tempdir().unwrap();
+    fs::write(repo.path().join("hello.txt"), "stable\n").unwrap();
+
+    let actual_hash =
+        hash_files_from_walk(repo.path(), &[".tokmd/baseline.json"]).expect("hash walk");
+
+    let mut baseline = ComplexityBaseline::new();
+    baseline.determinism = Some(DeterminismBaseline {
+        baseline_version: 1,
+        generated_at: "2025-01-01T00:00:00Z".to_string(),
+        build_hash: "00".repeat(20),
+        source_hash: actual_hash,
+        cargo_lock_hash: Some("deadbeef".repeat(8)),
+    });
+
+    let path = baseline_path(&repo);
+    write_baseline(&path, &baseline);
+
+    let gate = compute_determinism_gate(repo.path(), None)
+        .expect("gate runs")
+        .expect("baseline produces gate");
+
+    assert_eq!(gate.meta.status, GateStatus::Warn);
+    assert!(
+        gate.differences
+            .iter()
+            .any(|d| d.contains("Cargo.lock missing")),
+        "expected Cargo.lock missing difference, got {:?}",
+        gate.differences
+    );
+}
+
+#[test]
+fn determinism_gate_warns_when_cargo_lock_hash_mismatches() {
+    let repo = tempfile::tempdir().unwrap();
+    fs::write(repo.path().join("hello.txt"), "stable\n").unwrap();
+    fs::write(repo.path().join("Cargo.lock"), "# Cargo.lock contents").unwrap();
+
+    let actual_hash =
+        hash_files_from_walk(repo.path(), &[".tokmd/baseline.json"]).expect("hash walk");
+
+    let mut baseline = ComplexityBaseline::new();
+    baseline.determinism = Some(DeterminismBaseline {
+        baseline_version: 1,
+        generated_at: "2025-01-01T00:00:00Z".to_string(),
+        build_hash: "00".repeat(20),
+        source_hash: actual_hash,
+        // Wrong cargo lock hash on purpose.
+        cargo_lock_hash: Some("aa".repeat(32)),
+    });
+
+    let path = baseline_path(&repo);
+    write_baseline(&path, &baseline);
+
+    let gate = compute_determinism_gate(repo.path(), None)
+        .expect("gate runs")
+        .expect("baseline produces gate");
+
+    assert_eq!(gate.meta.status, GateStatus::Warn);
+    assert!(
+        gate.differences
+            .iter()
+            .any(|d| d.contains("Cargo.lock hash mismatch")),
+        "expected Cargo.lock mismatch difference, got {:?}",
+        gate.differences
+    );
+}
+
+#[test]
+fn determinism_gate_errors_on_unreadable_baseline() {
+    let repo = tempfile::tempdir().unwrap();
+    // Provide an explicit baseline path that does NOT exist; explicit
+    // missing paths return Ok(None) (we cover the "no path exists" branch).
+    let nonexistent = repo.path().join("missing-baseline.json");
+    let result = compute_determinism_gate(repo.path(), Some(&nonexistent)).expect("gate runs");
+    assert!(result.is_none());
+}
+
+#[test]
+fn determinism_gate_errors_on_invalid_baseline_json() {
+    let repo = tempfile::tempdir().unwrap();
+    let path = baseline_path(&repo);
+    // Malformed JSON triggers the parse error branch.
+    fs::write(&path, "{ this is not json").expect("write malformed json");
+
+    let err = compute_determinism_gate(repo.path(), None).expect_err("malformed json must error");
+    assert!(
+        err.to_string().contains("failed to parse baseline JSON"),
+        "expected parse-error message, got {err}"
+    );
+}

--- a/crates/tokmd-cockpit/tests/git_env_boundaries.rs
+++ b/crates/tokmd-cockpit/tests/git_env_boundaries.rs
@@ -66,6 +66,13 @@ fn get_file_stats_ignores_inherited_git_env_overrides() {
         .status()
         .unwrap();
     assert!(status.success(), "git config user.name failed");
+    // Disable commit signing so host signing config doesn't break the fixture.
+    let _ = git_in(repo.path())
+        .args(["config", "commit.gpgsign", "false"])
+        .status();
+    let _ = git_in(repo.path())
+        .args(["config", "tag.gpgsign", "false"])
+        .status();
 
     std::fs::write(repo.path().join("tracked.txt"), "one\n").unwrap();
     let status = git_in(repo.path()).args(["add", "."]).status().unwrap();

--- a/crates/tokmd-core/src/context_git/mod.rs
+++ b/crates/tokmd-core/src/context_git/mod.rs
@@ -141,6 +141,19 @@ mod tests {
             .current_dir(root)
             .output()
             .ok()?;
+        // Disable commit signing so environments with a global signing key
+        // (e.g. some sandboxes) do not turn this test repo into a no-commit
+        // setup that makes downstream assertions flaky.
+        Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(root)
+            .output()
+            .ok()?;
+        Command::new("git")
+            .args(["config", "tag.gpgsign", "false"])
+            .current_dir(root)
+            .output()
+            .ok()?;
 
         // main.rs: 2 commits (3 lines initially, then 4)
         std::fs::write(root.join("main.rs"), "1\n2\n3").ok()?;

--- a/crates/tokmd-core/tests/cockpit_workflow.rs
+++ b/crates/tokmd-core/tests/cockpit_workflow.rs
@@ -60,6 +60,9 @@ fn cockpit_workflow_computes_receipt_from_settings() {
     git(repo.path(), &["init", "-b", "main"]);
     git(repo.path(), &["config", "user.email", "tokmd@example.com"]);
     git(repo.path(), &["config", "user.name", "tokmd"]);
+    // Avoid host commit-signing config bleeding into this fixture repo.
+    git(repo.path(), &["config", "commit.gpgsign", "false"]);
+    git(repo.path(), &["config", "tag.gpgsign", "false"]);
 
     write(&repo.path().join("README.md"), "# Demo\n");
     git(repo.path(), &["add", "README.md"]);

--- a/crates/tokmd-format/tests/analysis_format/render_formats.rs
+++ b/crates/tokmd-format/tests/analysis_format/render_formats.rs
@@ -1207,3 +1207,224 @@ fn midi_format_requires_fun_feature() {
     let err = result.err().unwrap();
     assert!(err.to_string().contains("fun"));
 }
+
+// ---------------------------------------------------------------------------
+// Effort estimate rendering — exercises tokmd_format/analysis/markdown/effort.rs
+// ---------------------------------------------------------------------------
+
+fn full_effort_report() -> EffortEstimateReport {
+    let mut overrides = BTreeMap::new();
+    overrides.insert("monte_carlo".into(), "iterations=2500 seed=Some(7)".into());
+    EffortEstimateReport {
+        model: EffortModel::Cocomo81Basic,
+        size_basis: EffortSizeBasis {
+            total_lines: 500,
+            authored_lines: 460,
+            generated_lines: 20,
+            vendored_lines: 20,
+            kloc_total: 0.5,
+            kloc_authored: 0.46,
+            generated_pct: 0.04,
+            vendored_pct: 0.04,
+            classification_confidence: EffortConfidenceLevel::High,
+            warnings: vec!["minor classification warning".into()],
+            by_tag: vec![
+                EffortTagSizeRow {
+                    tag: "generated".into(),
+                    lines: 20,
+                    authored_lines: 0,
+                    pct_of_total: 0.04,
+                },
+                EffortTagSizeRow {
+                    tag: "vendored".into(),
+                    lines: 20,
+                    authored_lines: 0,
+                    pct_of_total: 0.04,
+                },
+            ],
+        },
+        results: EffortResults {
+            effort_pm_p50: 2.0,
+            schedule_months_p50: 3.5,
+            staff_p50: 1.5,
+            effort_pm_low: 1.5,
+            effort_pm_p80: 2.6,
+            schedule_months_low: 3.0,
+            schedule_months_p80: 4.0,
+            staff_low: 1.0,
+            staff_p80: 2.0,
+        },
+        confidence: EffortConfidence {
+            level: EffortConfidenceLevel::Medium,
+            reasons: vec!["test density missing".into(), "git data missing".into()],
+            data_coverage_pct: Some(0.62),
+        },
+        drivers: vec![
+            EffortDriver {
+                key: "complexity".into(),
+                label: "Complexity".into(),
+                weight: 1.4,
+                direction: EffortDriverDirection::Raises,
+                evidence: "avg cyclomatic 12".into(),
+            },
+            EffortDriver {
+                key: "tests".into(),
+                label: "Test coverage".into(),
+                weight: 0.9,
+                direction: EffortDriverDirection::Lowers,
+                evidence: "test ratio 0.4".into(),
+            },
+            EffortDriver {
+                key: "polyglot".into(),
+                label: "Polyglot mix".into(),
+                weight: 1.0,
+                direction: EffortDriverDirection::Neutral,
+                evidence: "single dominant language".into(),
+            },
+        ],
+        assumptions: EffortAssumptions {
+            notes: vec![
+                "default blended estimate".into(),
+                "size basis treats generated and vendored separately".into(),
+            ],
+            overrides,
+        },
+        delta: Some(EffortDeltaReport {
+            base: "HEAD~1".into(),
+            head: "HEAD".into(),
+            files_changed: 3,
+            modules_changed: 2,
+            langs_changed: 1,
+            hotspot_files_touched: 1,
+            coupled_neighbors_touched: 2,
+            blast_radius: 7.5,
+            classification: EffortDeltaClassification::Low,
+            effort_pm_low: 0.1,
+            effort_pm_est: 0.18,
+            effort_pm_high: 0.25,
+        }),
+    }
+}
+
+#[test]
+fn md_renders_effort_section_when_effort_present() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    receipt.effort = Some(full_effort_report());
+
+    let rendered = render(&receipt, AnalysisFormat::Md).expect("render md");
+    let text = match rendered {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text"),
+    };
+
+    assert!(text.contains("## Effort estimate"));
+    assert!(text.contains("### Size basis"));
+    assert!(text.contains("Model: `cocomo81-basic`"));
+    assert!(text.contains("Total LOC lines: `500`"));
+    assert!(text.contains("Authored LOC lines: `460`"));
+    assert!(text.contains("Generated LOC lines: `20`"));
+    assert!(text.contains("Vendored LOC lines: `20`"));
+    assert!(text.contains("Classification confidence: `high`"));
+
+    assert!(text.contains("### Size by tag"));
+    assert!(text.contains("|generated|20|0|"));
+    assert!(text.contains("|vendored|20|0|"));
+
+    assert!(text.contains("### Headline"));
+    assert!(text.contains("Effort p50:"));
+    assert!(text.contains("Schedule p50:"));
+    assert!(text.contains("Staff p50:"));
+
+    assert!(text.contains("### Why"));
+    assert!(text.contains("Confidence level: `medium`"));
+    assert!(text.contains("Data coverage:"));
+    assert!(text.contains("- Reasons:"));
+    assert!(text.contains("test density missing"));
+
+    assert!(text.contains("### Drivers"));
+    assert!(text.contains("|Complexity|raises|"));
+    assert!(text.contains("|Test coverage|lowers|"));
+    assert!(text.contains("|Polyglot mix|neutral|"));
+
+    assert!(text.contains("### Assumptions"));
+    assert!(text.contains("- default blended estimate"));
+
+    assert!(text.contains("### Assumption overrides"));
+    assert!(text.contains("|monte_carlo|iterations=2500 seed=Some(7)|"));
+
+    assert!(text.contains("### Delta"));
+    assert!(text.contains("Reference window: `HEAD~1`..`HEAD`"));
+    assert!(text.contains("Files changed: `3`"));
+    assert!(text.contains("Classification: `low`"));
+}
+
+#[test]
+fn md_renders_effort_without_drivers_or_delta() {
+    let mut receipt = minimal_receipt();
+    receipt.derived = Some(sample_derived());
+    let mut effort = full_effort_report();
+    effort.drivers.clear();
+    effort.delta = None;
+    effort.assumptions.notes.clear();
+    effort.assumptions.overrides.clear();
+    effort.size_basis.by_tag.clear();
+    effort.confidence.reasons.clear();
+    effort.confidence.data_coverage_pct = None;
+    receipt.effort = Some(effort);
+
+    let rendered = render(&receipt, AnalysisFormat::Md).expect("render md");
+    let text = match rendered {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text"),
+    };
+
+    assert!(text.contains("### Drivers"));
+    assert!(text.contains("- No material drivers were inferred."));
+    assert!(!text.contains("### Size by tag"));
+    assert!(!text.contains("### Assumptions"));
+    assert!(!text.contains("### Assumption overrides"));
+    assert!(!text.contains("Data coverage:"));
+    assert!(!text.contains("- Reasons:"));
+    assert!(text.contains("### Delta"));
+    assert!(text.contains("Baseline comparison is not available"));
+}
+
+#[test]
+fn md_renders_legacy_cocomo_block_when_effort_absent_but_cocomo_present() {
+    let mut receipt = minimal_receipt();
+    let mut derived = sample_derived();
+    derived.cocomo = Some(CocomoReport {
+        kloc: 0.5,
+        effort_pm: 1.5,
+        duration_months: 3.0,
+        staff: 1.5,
+        a: 2.4,
+        b: 1.05,
+        c: 2.5,
+        d: 0.38,
+        mode: "organic".into(),
+    });
+    receipt.derived = Some(derived);
+    // No effort section; legacy fallback should render.
+    receipt.effort = None;
+
+    let rendered = render(&receipt, AnalysisFormat::Md).expect("render md");
+    let text = match rendered {
+        RenderedOutput::Text(s) => s,
+        RenderedOutput::Binary(_) => panic!("expected text"),
+    };
+
+    assert!(text.contains("## Effort estimate"));
+    assert!(text.contains("### Size basis"));
+    assert!(text.contains("- KLOC: `0.5"));
+    assert!(text.contains("### Headline"));
+    assert!(text.contains("Effort: `1.5"));
+    assert!(text.contains("Duration: `3"));
+    assert!(text.contains("Staff: `1.5"));
+    assert!(text.contains("Model: `COCOMO` (`organic` mode)"));
+    // fmt_f64(value, 2) renders with two decimals (e.g. "2.40").
+    assert!(text.contains("Coefficients: `a=2.40`"));
+    assert!(text.contains("### Delta"));
+    assert!(text.contains("Baseline comparison is not available"));
+}

--- a/crates/tokmd-git/tests/integration.rs
+++ b/crates/tokmd-git/tests/integration.rs
@@ -124,6 +124,16 @@ fn create_test_repo() -> Option<TempGitRepo> {
         .args(["config", "user.name", "Test User"])
         .output()
         .ok()?;
+    // Disable commit signing so a host-global signing config can't break
+    // this fixture's ability to record commits.
+    git_in(&temp_dir)
+        .args(["config", "commit.gpgsign", "false"])
+        .output()
+        .ok()?;
+    git_in(&temp_dir)
+        .args(["config", "tag.gpgsign", "false"])
+        .output()
+        .ok()?;
 
     // Create first commit with a file
     let file1 = temp_dir.join("file1.txt");
@@ -407,6 +417,16 @@ fn create_test_repo_with_multi_file_commits() -> Option<TempGitRepo> {
         .ok()?;
     git_in(&temp_dir)
         .args(["config", "user.name", "Test User"])
+        .output()
+        .ok()?;
+    // Disable commit signing so a host-global signing config can't break
+    // this fixture's ability to record commits.
+    git_in(&temp_dir)
+        .args(["config", "commit.gpgsign", "false"])
+        .output()
+        .ok()?;
+    git_in(&temp_dir)
+        .args(["config", "tag.gpgsign", "false"])
         .output()
         .ok()?;
 


### PR DESCRIPTION
## Summary

Adds focused unit/integration tests for previously uncovered modules and branches found by running `cargo llvm-cov` on the workspace.

### Coverage wins

- **`tokmd-analysis/src/complexity/details/{go,javascript}.rs`** were at 0% coverage despite Rust/Python/C-style having tests. Added Go function-span tests (basic, methods with receivers, malformed input) and JavaScript/TypeScript tests (function declarations, arrow functions, anonymous fallback, `$` and `_` identifier characters, line-comment skipping). Also added an `extract_function_details` dispatch matrix covering every supported language plus the unknown-language fallback.
- **`tokmd-analysis/src/effort/monte_carlo.rs`** (previously 0%): pinned the placeholder Monte Carlo behavior with iterations=0 and iterations>0, plus an integration test that threads `monte_carlo: true` through `build_effort_report` and verifies the assumptions/overrides flow into the report.
- **`tokmd-analysis/src/effort/request.rs`** and **`effort/delta.rs`**: covered `Display`/`Default` surfaces, the `classify_blast` bucket boundaries, the trim/empty-arg guards in `build_delta`, and the no-git-feature error branch.
- **`tokmd-cockpit/src/gates/determinism_gate.rs`** (previously 9.78%): new test file covering all branches — missing baseline, missing `determinism` section, cockpit-receipt tolerance, malformed/garbage JSON errors, source-hash mismatch warn path, explicit baseline path resolution, Cargo.lock missing-but-expected and hash-mismatch warnings.
- **`tokmd-cockpit/src/proof_evidence/model.rs`**: exhaustively cover all enum variants of `ProofEvidenceKind::{as_str, packet_file_name}`, `ProofEvidenceAvailability::as_str`, and `ProofExecutionStatus::as_str`.
- **`tokmd-format/src/analysis/markdown/effort.rs`** (previously 19.7%): integration tests for both `render_effort_report` (rich path with drivers, assumptions, overrides, delta) and `render_legacy_cocomo_report` (fallback path).

### Test fixture robustness

Several git-using test fixtures left global git config bleed-through. Added local `commit.gpgsign=false` / `tag.gpgsign=false` so the fixtures stay deterministic in environments with host-global commit signing configured (e.g. some sandboxes):

- `tokmd-core/tests/cockpit_workflow.rs`
- `tokmd-core/src/context_git/mod.rs` (test helper)
- `tokmd-analysis/src/effort/tests/effort_engine.rs`
- `tokmd-analysis/tests/{git,feature_matrix}.rs`
- `tokmd-cockpit/src/gates/diff_coverage.rs`
- `tokmd-cockpit/tests/git_env_boundaries.rs`
- `tokmd-git/tests/integration.rs`

## Test plan

- [x] `cargo test -p tokmd-analysis --lib --all-features` passes
- [x] `cargo test -p tokmd-cockpit --all-features` passes
- [x] `cargo test -p tokmd-format --all-features` passes
- [x] `cargo test -p tokmd-core --all-features` passes
- [x] `cargo clippy --all-features` (changed crates) clean
- [x] `cargo fmt-check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01RdQynvwSoLJs7MWbUXC7Xf)_