### PR TITLE
ci: route mutation scope through xtask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,21 +599,24 @@ jobs:
         id: changed
         run: |
           set -euo pipefail
-          git fetch origin "${{ github.base_ref }}":"refs/remotes/origin/${{ github.base_ref }}" || true
 
-          git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- '*.rs' \
-            | grep -v '/tests/' \
-            | grep -v '_test\.rs$' \
-            | grep -v '^fuzz/' \
-            | grep -v '/fuzz/' \
-            > changed_files.txt || true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.base_ref }}"
+          else
+            BASE_REF="main"
+          fi
 
-          COUNT="$(wc -l < changed_files.txt | tr -d ' ')"
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          git fetch origin "$BASE_REF":"refs/remotes/origin/$BASE_REF" || true
 
-          echo "files<<EOF" >> "$GITHUB_OUTPUT"
-          cat changed_files.txt >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          cargo xtask mutation-scope \
+            --base-ref "$BASE_REF" \
+            --base "origin/$BASE_REF" \
+            --head HEAD \
+            --max-files 20 \
+            --all-changed-files all_changed_files.txt \
+            --changed-files changed_files.txt \
+            --json-output target/mutation/mutation-scope.json \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Mutation Testing
         if: steps.changed.outputs.count != '0'
@@ -646,8 +649,12 @@ jobs:
           echo "✓ All mutations caught or unviable (0 MISSED)"
 
       - name: Skip notice
-        if: steps.changed.outputs.count == '0'
+        if: steps.changed.outputs.count == '0' && steps.changed.outputs.scope_exceeded != 'true'
         run: echo "No production Rust files changed - skipping mutation testing"
+
+      - name: Scope exceeded notice
+        if: steps.changed.outputs.scope_exceeded == 'true'
+        run: echo "Mutation scope exceeded - selected files were cleared. See target/mutation/mutation-scope.json."
 
       - name: Upload mutants report
         if: always()
@@ -655,6 +662,9 @@ jobs:
         with:
           name: mutants-report
           path: |
+            target/mutation/mutation-scope.json
+            all_changed_files.txt
+            changed_files.txt
             mutants.out/
             crates/**/mutants.out/
           if-no-files-found: ignore

--- a/.jules/goals/active.toml
+++ b/.jules/goals/active.toml
@@ -1,5 +1,5 @@
 schema = "tokmd.jules.active_goal.v1"
-status = "active"
+status = "complete"
 program = "code_intelligence"
 lane = "ci_mutation_scope_routing"
 outcome = "route_ci_mutation_selection_through_xtask"

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -131,12 +131,13 @@ future plan identifies a concrete consumer or maintenance problem. Mutation
 testing remains advisory; Codecov behavior, public `tokmd` CLI behavior, and
 receipt schemas are unchanged.
 
-The proof-orchestration gap audit is complete. It selected CI mutation scope
-routing as the next narrow implementation slice: the CI mutation job still owns
-an inline changed-file classifier, while the manual mutation workflow already
-uses Rust-owned `cargo xtask mutation-scope`. Draft generated PR #2299 remains
-parked: it is broad coverage/test work, dirty against main, and touches the
-pre-split diff-coverage path.
+The proof-orchestration gap audit is complete. The selected CI mutation scope
+routing slice is also complete: the CI mutation job now uses Rust-owned
+`cargo xtask mutation-scope` instead of an inline `git diff | grep` classifier,
+while preserving the existing `cargo-mutants` execution loop, workflow
+`count` / `files` outputs, advisory mutation status, and Codecov default-off
+behavior. Draft generated coverage PRs remain parked unless deliberately
+restacked into narrow keeper slices.
 
 The code-intelligence platform audit is closed. It mapped the broad platform
 objective to live artifacts and verifier coverage, did not mark the platform
@@ -175,29 +176,25 @@ lane, release workflow, and affected-proof evidence cannot cover.
 
 ## Next Work Packets
 
-1. Complete `docs/plans/ci-mutation-scope-routing.md`: replace only the CI
-   mutation job's inline changed-file classifier with `cargo xtask
-   mutation-scope`, preserving mutation execution, advisory status, Codecov
-   defaults, workflow outputs, and public receipt behavior.
+1. Choose the next proof-orchestration slice deliberately; do not promote
+   advisory proof, default Codecov upload, or cockpit/handoff consumption from
+   the closed decision-readiness lanes.
 2. Do not reopen AST productization without a fresh proposal grounded in the
    shadow evidence.
-3. Choose the next proof-orchestration slice deliberately; do not promote
-   advisory proof, default Codecov upload, or cockpit/handoff consumption from
-   the closed decision-readiness lane.
-4. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence
+3. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence
    shows a product, verifier, or hosted-comment issue.
-5. Preserve `tokmd cockpit` as the review evidence implementation surface until
+4. Preserve `tokmd cockpit` as the review evidence implementation surface until
    a separate review orchestrator has a real contract.
-6. Continue architecture consolidation in batches, preserving `ci/proof.toml`
+5. Continue architecture consolidation in batches, preserving `ci/proof.toml`
    scope granularity as implementation microcrates collapse into SRP modules.
-7. Use bounded performance timing receipts before optimizing hot paths.
-8. Keep source-of-truth docs, active goal state, and proof-policy routing
+6. Use bounded performance timing receipts before optimizing hot paths.
+7. Keep source-of-truth docs, active goal state, and proof-policy routing
    aligned as new lanes start; do not reopen the doc-artifacts checker lane
    unless the spec changes.
-9. Keep product-readiness docs aligned as workflows change, but start any new
+8. Keep product-readiness docs aligned as workflows change, but start any new
    product lane from a fresh plan rather than extending the completed first-pass
    user-path cleanup by inertia.
-10. Keep AST foundation work in shadow mode until comparison evidence justifies
+9. Keep AST foundation work in shadow mode until comparison evidence justifies
    any public receipt or default behavior change.
 
 ## Directional Rules

--- a/docs/plans/ci-mutation-scope-routing.md
+++ b/docs/plans/ci-mutation-scope-routing.md
@@ -1,6 +1,6 @@
 # Plan: CI Mutation Scope Routing
 
-- Status: active
+- Status: complete
 - Related proposal:
 - Related spec:
 - Related ADR:
@@ -41,7 +41,7 @@ existing mutation execution loop.
 ## Work Packets
 
 1. Replace the CI mutation changed-file classifier.
-   - Status: pending.
+   - Status: complete.
    - In `.github/workflows/ci.yml`, update the mutation job's
      `Get changed Rust files` step to call `cargo xtask mutation-scope`.
    - Preserve `steps.changed.outputs.count` and `steps.changed.outputs.files`
@@ -49,13 +49,13 @@ existing mutation execution loop.
    - Preserve `changed_files.txt` as the file consumed by the existing
      `cargo-mutants` loop.
 2. Emit CI mutation scope evidence.
-   - Status: pending.
+   - Status: complete.
    - Write `target/mutation/mutation-scope.json` from the CI mutation job, using
      the same `tokmd.mutation_scope.v1` shape as the manual mutation workflow.
-   - Upload it with the existing mutation artifacts if practical; if upload
-     behavior stays unchanged, document why.
+   - Upload it with the existing mutation artifact bundle alongside
+     `all_changed_files.txt` and `changed_files.txt`.
 3. Validate policy and affected routing.
-   - Status: pending.
+   - Status: complete.
    - Ensure `.github/workflows/ci.yml` still routes through the proof-control
      scope and produces zero unknown files.
    - Keep mutation advisory and Codecov default-off.
@@ -94,3 +94,8 @@ specifically requires it.
   `.github/workflows/ci.yml` still owns a duplicate inline changed-file
   classifier for the label/push mutation job, while the manual mutation
   workflow already uses the Rust-owned `cargo xtask mutation-scope` selector.
+- 2026-05-15: Implemented by replacing the CI mutation job selector with
+  `cargo xtask mutation-scope`, preserving the existing `cargo-mutants`
+  execution loop and workflow `count` / `files` outputs, and uploading
+  `target/mutation/mutation-scope.json` with the existing mutation artifact
+  bundle. Mutation testing remains advisory and Codecov behavior is unchanged.

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -581,6 +581,74 @@ fn fast_proof_run_ci_job_is_advisory_and_verified() {
 }
 
 #[test]
+fn ci_mutation_job_uses_rust_owned_mutation_scope_selector() {
+    let ci = fs::read_to_string(workspace_root().join(".github/workflows/ci.yml"))
+        .expect("ci workflow should be readable");
+    let mutation_section = ci
+        .split("  mutation:")
+        .nth(1)
+        .and_then(|section| section.split("  ci-required:").next())
+        .expect("CI workflow should define mutation and required aggregate jobs");
+
+    assert!(
+        mutation_section.contains("cargo xtask mutation-scope"),
+        "CI mutation job should route file selection through xtask"
+    );
+    assert!(
+        mutation_section.contains("--base-ref \"$BASE_REF\""),
+        "CI mutation job should record the human base ref"
+    );
+    assert!(
+        mutation_section.contains("--base \"origin/$BASE_REF\""),
+        "CI mutation job should diff against the fetched base ref"
+    );
+    assert!(
+        mutation_section.contains("--head HEAD"),
+        "CI mutation job should diff against checked-out HEAD"
+    );
+    assert!(
+        mutation_section.contains("--all-changed-files all_changed_files.txt"),
+        "CI mutation job should preserve the all-changed-files evidence path"
+    );
+    assert!(
+        mutation_section.contains("--changed-files changed_files.txt"),
+        "CI mutation job should preserve the changed_files.txt execution input"
+    );
+    assert!(
+        mutation_section.contains("--json-output target/mutation/mutation-scope.json"),
+        "CI mutation job should emit the mutation scope JSON receipt"
+    );
+    assert!(
+        mutation_section.contains("--github-output \"$GITHUB_OUTPUT\""),
+        "CI mutation job should preserve workflow-compatible count/files outputs"
+    );
+    assert!(
+        mutation_section.contains("steps.changed.outputs.count != '0'"),
+        "CI mutation execution should still branch on the Rust-owned count output"
+    );
+    assert!(
+        mutation_section.contains("done < changed_files.txt"),
+        "CI mutation execution should keep consuming changed_files.txt"
+    );
+    assert!(
+        mutation_section.contains("target/mutation/mutation-scope.json"),
+        "CI mutation artifacts should include the mutation scope receipt"
+    );
+    assert!(
+        mutation_section.contains("all_changed_files.txt"),
+        "CI mutation artifacts should include all changed-file evidence"
+    );
+    assert!(
+        !mutation_section.contains("git diff --name-only"),
+        "CI mutation job should not keep the inline git diff classifier"
+    );
+    assert!(
+        !mutation_section.contains("grep -v '/tests/'"),
+        "CI mutation job should not keep duplicate shell filter logic"
+    );
+}
+
+#[test]
 fn scoped_coverage_executor_is_pr_visible_but_not_required() {
     let root = workspace_root();
     let executor = fs::read_to_string(root.join(".github/workflows/proof-executor.yml"))


### PR DESCRIPTION
## Summary
- route the CI mutation job's changed-file selection through `cargo xtask mutation-scope`
- preserve the existing `cargo-mutants` execution loop, `changed_files.txt` input, and workflow `count` / `files` outputs
- upload `target/mutation/mutation-scope.json`, `all_changed_files.txt`, and `changed_files.txt` with the existing mutation artifact bundle
- mark the CI mutation scope routing plan and active goal complete without promoting mutation, Codecov, or public receipt behavior

## Validation
- cargo test -p xtask mutation_scope --verbose
- cargo xtask mutation-scope --base origin/main --head HEAD --json-output target/mutation/mutation-scope.json --github-output target/mutation/mutation-scope.outputs
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ci-mutation-scope-routing.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ci-mutation-scope-routing.json --evidence-json target/proof/proof-evidence-ci-mutation-scope-routing.json
- cargo xtask ci-lane-whitelist
- cargo fmt-check
- git diff --check origin/main...HEAD
- cargo test -p xtask --verbose

## Notes
- Mutation remains label/push scoped and advisory; this does not add a gate, Codecov upload, or public `tokmd` CLI/receipt surface.
- Local generated `target/proof`, `target/mutation`, `changed_files.txt`, `all_changed_files.txt`, and `xtask/target` scratch artifacts were cleaned before push.