### PR TITLE
ci: wire fast proof workflow status packet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,31 @@ jobs:
           cargo xtask proof-run-observation --proof-run-summary target/proof-run/proof-run-summary.json --output target/proof-run/proof-run-observation.json > target/proof-run/proof-run-observation.txt 2>&1
           proof_run_observation_status=$?
 
+          cargo xtask proof-workflow-status \
+            --workflow-kind fast-proof-run \
+            --status "proof_run_status=${proof_run_status}" \
+            --status "proof_run_artifacts_status=${proof_run_artifacts_status}" \
+            --status "proof_run_observation_status=${proof_run_observation_status}" \
+            --proof-policy target/proof-run/proof-policy.json \
+            --proof-plan target/proof-run/proof-plan.json \
+            --proof-run-summary target/proof-run/proof-run-summary.json \
+            --proof-run-artifacts-check target/proof-run/proof-run-artifacts-check.json \
+            --proof-run-observation target/proof-run/proof-run-observation.json \
+            --json target/proof-run/proof-workflow-status.json \
+            --summary-md target/proof-run/proof-workflow-status.md \
+            --env-output target/proof-run/proof-workflow-status.env > target/proof-run/proof-workflow-status.txt 2>&1
+          proof_workflow_status_status=$?
+
+          if [ "${proof_workflow_status_status}" -eq 0 ]; then
+            cargo xtask proof-workflow-status-check \
+              --status target/proof-run/proof-workflow-status.json \
+              --json target/proof-run/proof-workflow-status-check.json > target/proof-run/proof-workflow-status-check.txt 2>&1
+            proof_workflow_status_check_status=$?
+          else
+            printf 'proof-workflow-status-check skipped because proof-workflow-status exited %s\n' "${proof_workflow_status_status}" > target/proof-run/proof-workflow-status-check.txt
+            proof_workflow_status_check_status=0
+          fi
+
           {
             echo "proof_run_status=${proof_run_status}"
             echo "proof_run_artifacts_status=${proof_run_artifacts_status}"
@@ -337,6 +362,14 @@ jobs:
               echo ""
               cat target/proof-run/proof-run-observation.txt
             fi
+            if [ -f target/proof-run/proof-workflow-status.txt ]; then
+              echo ""
+              cat target/proof-run/proof-workflow-status.txt
+            fi
+            if [ -f target/proof-run/proof-workflow-status-check.txt ]; then
+              echo ""
+              cat target/proof-run/proof-workflow-status-check.txt
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${proof_run_status}" -ne 0 ]; then
@@ -349,6 +382,14 @@ jobs:
 
           if [ "${proof_run_observation_status}" -ne 0 ]; then
             exit "${proof_run_observation_status}"
+          fi
+
+          if [ "${proof_workflow_status_status}" -ne 0 ]; then
+            exit "${proof_workflow_status_status}"
+          fi
+
+          if [ "${proof_workflow_status_check_status}" -ne 0 ]; then
+            exit "${proof_workflow_status_check_status}"
           fi
 
           exit 0

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -140,13 +140,13 @@ behavior. Draft generated coverage PRs remain parked unless deliberately
 restacked into narrow keeper slices.
 
 The next proof-orchestration slice is proof run status packet. The plan and
-draft spec are in place, and the first Rust implementation slice now provides
-developer-facing `cargo xtask proof-workflow-status` /
-`cargo xtask proof-workflow-status-check` support for fast proof-run status
-arbitration. Workflow wiring remains next: move the fast proof-run job in
-`.github/workflows/ci.yml` to consume the Rust-owned packet while keeping
-GitHub Actions responsible for runner setup, cache, tool installation, artifact
-upload, GitHub API calls, and Codecov service integration.
+draft spec are in place, and the fast proof-run workflow now writes and
+verifies the developer-facing `tokmd.proof_workflow_status.v1` packet through
+`cargo xtask proof-workflow-status` /
+`cargo xtask proof-workflow-status-check`. Scoped coverage executor wiring
+remains next, while GitHub Actions stays responsible for runner setup, cache,
+tool installation, artifact upload, GitHub API calls, and Codecov service
+integration.
 
 The code-intelligence platform audit is closed. It mapped the broad platform
 objective to live artifacts and verifier coverage, did not mark the platform
@@ -185,10 +185,9 @@ lane, release workflow, and affected-proof evidence cannot cover.
 
 ## Next Work Packets
 
-1. Wire the fast proof-run workflow to the new
-   `tokmd.proof_workflow_status.v1` packet/checker while preserving current
-   proof execution, artifact names, exit priority, advisory/default-off
-   boundaries, and Codecov behavior.
+1. Extend `tokmd.proof_workflow_status.v1` to the scoped coverage executor
+   workflow only after preserving its non-required status, manual-only Codecov
+   behavior, artifact names, and current exit priority.
 2. Do not reopen AST productization without a fresh proposal grounded in the
    shadow evidence.
 3. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence

--- a/docs/plans/proof-run-status-packet.md
+++ b/docs/plans/proof-run-status-packet.md
@@ -59,7 +59,7 @@ advisory proof, upload Codecov by default, or change required CI gates.
    - Keep execution in the existing workflows; the command should summarize
      and arbitrate status only.
 3. Wire one workflow first.
-   - Status: pending.
+   - Status: complete.
    - Start with the fast proof-run job in `.github/workflows/ci.yml` because it
      has fewer status inputs than the scoped coverage executor.
    - Preserve artifact names, advisory wording, and the current fail-fast
@@ -122,3 +122,8 @@ reproduction specifically requires it.
   source artifact paths and command exit statuses, writes JSON/Markdown/env
   outputs, preserves current fast proof-run exit priority, and leaves workflow
   wiring for the next slice.
+- 2026-05-16: Wired the fast proof-run job to write and verify
+  `proof-workflow-status.json` while keeping proof execution in the existing
+  workflow. The workflow still uploads the same `fast-proof-run` artifact
+  directory, preserves the existing fallback exit priority, and leaves scoped
+  coverage executor wiring for a later slice.

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -565,6 +565,88 @@ fn fast_proof_run_ci_job_is_advisory_and_verified() {
         "fast proof job should emit a compact proof-run observation"
     );
     assert!(
+        ci.contains("cargo xtask proof-workflow-status"),
+        "fast proof job should summarize status arbitration through xtask"
+    );
+    assert!(
+        ci.contains("--status \"proof_run_status=${proof_run_status}\""),
+        "fast proof job should pass proof run status to the status packet"
+    );
+    assert!(
+        ci.contains("--status \"proof_run_artifacts_status=${proof_run_artifacts_status}\""),
+        "fast proof job should pass artifact verifier status to the status packet"
+    );
+    assert!(
+        ci.contains("--status \"proof_run_observation_status=${proof_run_observation_status}\""),
+        "fast proof job should pass observation status to the status packet"
+    );
+    assert!(
+        ci.contains("--proof-policy target/proof-run/proof-policy.json"),
+        "fast proof job should pass the proof policy artifact"
+    );
+    assert!(
+        ci.contains("--proof-plan target/proof-run/proof-plan.json"),
+        "fast proof job should pass the proof plan artifact"
+    );
+    assert!(
+        ci.contains("--proof-run-summary target/proof-run/proof-run-summary.json"),
+        "fast proof job should pass the proof-run summary artifact"
+    );
+    assert!(
+        ci.contains("--proof-run-artifacts-check target/proof-run/proof-run-artifacts-check.json"),
+        "fast proof job should pass the proof-run verifier receipt"
+    );
+    assert!(
+        ci.contains("--proof-run-observation target/proof-run/proof-run-observation.json"),
+        "fast proof job should pass the proof-run observation artifact"
+    );
+    assert!(
+        ci.contains("--json target/proof-run/proof-workflow-status.json"),
+        "fast proof job should write the workflow status packet"
+    );
+    assert!(
+        ci.contains("--summary-md target/proof-run/proof-workflow-status.md"),
+        "fast proof job should write a Rust-rendered workflow summary"
+    );
+    assert!(
+        ci.contains("--env-output target/proof-run/proof-workflow-status.env"),
+        "fast proof job should write workflow-compatible status outputs"
+    );
+    assert!(
+        ci.contains("cargo xtask proof-workflow-status-check"),
+        "fast proof job should verify the workflow status packet"
+    );
+    assert!(
+        ci.contains("--json target/proof-run/proof-workflow-status-check.json"),
+        "fast proof job should write the workflow status verifier receipt"
+    );
+    assert!(
+        ci.contains("proof-workflow-status-check skipped because proof-workflow-status exited"),
+        "fast proof job should skip checker cleanly when status packet generation fails"
+    );
+    let proof_run_exit = ci
+        .find("if [ \"${proof_run_status}\" -ne 0 ]; then")
+        .expect("proof_run_status exit check should remain");
+    let proof_run_artifacts_exit = ci
+        .find("if [ \"${proof_run_artifacts_status}\" -ne 0 ]; then")
+        .expect("proof_run_artifacts_status exit check should remain");
+    let proof_run_observation_exit = ci
+        .find("if [ \"${proof_run_observation_status}\" -ne 0 ]; then")
+        .expect("proof_run_observation_status exit check should remain");
+    let proof_workflow_status_exit = ci
+        .find("if [ \"${proof_workflow_status_status}\" -ne 0 ]; then")
+        .expect("proof_workflow_status_status exit check should be present");
+    let proof_workflow_status_check_exit = ci
+        .find("if [ \"${proof_workflow_status_check_status}\" -ne 0 ]; then")
+        .expect("proof_workflow_status_check_status exit check should be present");
+    assert!(
+        proof_run_exit < proof_run_artifacts_exit
+            && proof_run_artifacts_exit < proof_run_observation_exit
+            && proof_run_observation_exit < proof_workflow_status_exit
+            && proof_workflow_status_exit < proof_workflow_status_check_exit,
+        "fast proof job should preserve exit priority: proof run, artifacts, observation, status packet, status check"
+    );
+    assert!(
         ci.contains("Fast proof-run artifact generation is advisory"),
         "fast proof job summary should state advisory status"
     );


### PR DESCRIPTION
## Summary
- wire the fast proof-run workflow to emit `tokmd.proof_workflow_status.v1` via `cargo xtask proof-workflow-status`
- verify that packet with `cargo xtask proof-workflow-status-check` while preserving the existing proof-run summary table, `status.env`, upload path, advisory wording, and exit priority
- update the proof-run status packet plan and NEXT checkpoint now that fast proof-run wiring is complete

## Boundaries
- no proof promotion
- no Codecov default change
- no scoped coverage executor wiring yet
- no public `tokmd` CLI behavior change

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask --test proof_plan_w92 fast_proof_run_ci_job_is_advisory_and_verified --verbose`
- `cargo test -p xtask proof_run --verbose`
- `cargo test -p xtask proof_workflow_status --verbose`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-fast-proof-workflow-status.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-fast-proof-workflow-status.json --evidence-json target/proof/proof-evidence-fast-proof-workflow-status.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-fast-proof-workflow-status.json`