### PR TITLE
ci: wire scoped proof workflow status packet

### DIFF
--- a/.github/workflows/proof-executor.yml
+++ b/.github/workflows/proof-executor.yml
@@ -111,6 +111,36 @@ jobs:
             echo "executor artifacts did not pass verification" > target/proof/proof-execution-observations-summary.txt
           fi
 
+          cargo xtask proof-workflow-status \
+            --workflow-kind scoped-coverage-executor \
+            --status "affected_status=${affected_status}" \
+            --status "executor_status=${executor_status}" \
+            --status "verifier_status=${verifier_status}" \
+            --status "observation_status=${observation_status}" \
+            --status "collection_status=${collection_status}" \
+            --proof-policy target/proof/proof-policy.json \
+            --affected target/proof/affected.json \
+            --proof-plan target/proof/proof-plan.json \
+            --executor-summary target/proof/executor-summary.json \
+            --executor-manifest target/proof/executor-manifest.json \
+            --proof-execution-artifacts-check target/proof/proof-execution-artifacts-check.json \
+            --proof-executor-observation target/proof/proof-executor-observation.json \
+            --proof-executor-observation-collection target/proof/proof-executor-observation-collection.json \
+            --json target/proof/proof-workflow-status.json \
+            --summary-md target/proof/proof-workflow-status.md \
+            --env-output target/proof/proof-workflow-status.env > target/proof/proof-workflow-status.txt 2>&1
+          proof_workflow_status_status=$?
+
+          if [ "${proof_workflow_status_status}" -eq 0 ]; then
+            cargo xtask proof-workflow-status-check \
+              --status target/proof/proof-workflow-status.json \
+              --json target/proof/proof-workflow-status-check.json > target/proof/proof-workflow-status-check.txt 2>&1
+            proof_workflow_status_check_status=$?
+          else
+            printf 'proof-workflow-status-check skipped because proof-workflow-status exited %s\n' "${proof_workflow_status_status}" > target/proof/proof-workflow-status-check.txt
+            proof_workflow_status_check_status=0
+          fi
+
           {
             echo "affected_status=${affected_status}"
             echo "executor_status=${executor_status}"
@@ -149,6 +179,14 @@ jobs:
               echo ""
               cat target/proof/proof-executor-observation-collection.md
             fi
+            if [ -f target/proof/proof-workflow-status.txt ]; then
+              echo ""
+              cat target/proof/proof-workflow-status.txt
+            fi
+            if [ -f target/proof/proof-workflow-status-check.txt ]; then
+              echo ""
+              cat target/proof/proof-workflow-status-check.txt
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${affected_status}" -ne 0 ]; then
@@ -165,6 +203,14 @@ jobs:
           fi
           if [ "${collection_status}" -ne 0 ]; then
             exit "${collection_status}"
+          fi
+
+          if [ "${proof_workflow_status_status}" -ne 0 ]; then
+            exit "${proof_workflow_status_status}"
+          fi
+
+          if [ "${proof_workflow_status_check_status}" -ne 0 ]; then
+            exit "${proof_workflow_status_check_status}"
           fi
 
           exit 0

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -139,14 +139,14 @@ while preserving the existing `cargo-mutants` execution loop, workflow
 behavior. Draft generated coverage PRs remain parked unless deliberately
 restacked into narrow keeper slices.
 
-The next proof-orchestration slice is proof run status packet. The plan and
-draft spec are in place, and the fast proof-run workflow now writes and
-verifies the developer-facing `tokmd.proof_workflow_status.v1` packet through
+The current proof-orchestration slice is proof run status packet. The plan and
+draft spec are in place, and the fast proof-run and scoped coverage executor
+workflows now write and verify the developer-facing
+`tokmd.proof_workflow_status.v1` packet through
 `cargo xtask proof-workflow-status` /
-`cargo xtask proof-workflow-status-check`. Scoped coverage executor wiring
-remains next, while GitHub Actions stays responsible for runner setup, cache,
-tool installation, artifact upload, GitHub API calls, and Codecov service
-integration.
+`cargo xtask proof-workflow-status-check`. GitHub Actions still owns runner
+setup, cache, tool installation, artifact upload, GitHub API calls, and
+Codecov service integration.
 
 The code-intelligence platform audit is closed. It mapped the broad platform
 objective to live artifacts and verifier coverage, did not mark the platform
@@ -185,9 +185,9 @@ lane, release workflow, and affected-proof evidence cannot cover.
 
 ## Next Work Packets
 
-1. Extend `tokmd.proof_workflow_status.v1` to the scoped coverage executor
-   workflow only after preserving its non-required status, manual-only Codecov
-   behavior, artifact names, and current exit priority.
+1. Observe the proof workflow status packet in hosted fast proof-run and scoped
+   coverage executor artifacts before extending it to any other workflow.
+   Preserve advisory/non-required behavior and manual-only Codecov upload.
 2. Do not reopen AST productization without a fresh proposal grounded in the
    shadow evidence.
 3. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence

--- a/docs/plans/proof-run-status-packet.md
+++ b/docs/plans/proof-run-status-packet.md
@@ -66,7 +66,7 @@ advisory proof, upload Codecov by default, or change required CI gates.
      behavior for failed generated/verifier/observation artifacts.
 4. Extend to scoped coverage executor only after the fast proof-run job is
    stable.
-   - Status: pending.
+   - Status: complete.
    - Preserve PR-visible, non-required status and manual-only Codecov upload.
    - Do not change executor command selection or coverage execution.
 5. Validate policy and affected routing.
@@ -127,3 +127,9 @@ reproduction specifically requires it.
   workflow. The workflow still uploads the same `fast-proof-run` artifact
   directory, preserves the existing fallback exit priority, and leaves scoped
   coverage executor wiring for a later slice.
+- 2026-05-16: Extended the proof workflow status packet to the scoped coverage
+  executor workflow. The executor still uploads the same
+  `proof-executor-artifacts` directory, keeps Codecov upload manual-only,
+  remains outside the required CI aggregate, and preserves the existing
+  affected/executor/verifier/observation/collection exit priority before the
+  additive status packet/check exits.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -940,6 +940,54 @@ pub struct ProofWorkflowStatusArgs {
     )]
     pub proof_run_observation: std::path::PathBuf,
 
+    /// Affected-scope artifact to include for scoped coverage executor workflows
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/affected.json"
+    )]
+    pub affected: std::path::PathBuf,
+
+    /// Executor summary artifact to include for scoped coverage executor workflows
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/executor-summary.json"
+    )]
+    pub executor_summary: std::path::PathBuf,
+
+    /// Executor manifest artifact to include for scoped coverage executor workflows
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/executor-manifest.json"
+    )]
+    pub executor_manifest: std::path::PathBuf,
+
+    /// Executed proof artifact verifier receipt to include for scoped coverage executor workflows
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/proof-execution-artifacts-check.json"
+    )]
+    pub proof_execution_artifacts_check: std::path::PathBuf,
+
+    /// Executor observation artifact to include for scoped coverage executor workflows
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/proof-executor-observation.json"
+    )]
+    pub proof_executor_observation: std::path::PathBuf,
+
+    /// Executor observation collection artifact to include for scoped coverage executor workflows
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/proof/proof-executor-observation-collection.json"
+    )]
+    pub proof_executor_observation_collection: std::path::PathBuf,
+
     /// Write the workflow status packet to this path
     #[arg(
         long,

--- a/xtask/src/tasks/proof_workflow_status.rs
+++ b/xtask/src/tasks/proof_workflow_status.rs
@@ -14,10 +14,20 @@ const MODE: &str = "workflow_status_only";
 const FAST_PROOF_RUN_LABEL: &str = "fast_proof_run";
 const FAST_PROOF_RUN_TITLE: &str = "Fast Proof Run";
 const FAST_PROOF_RUN_ADVISORY_NOTE: &str = "Fast proof-run artifact generation is advisory and is not part of the required CI aggregate yet.";
+const SCOPED_COVERAGE_EXECUTOR_LABEL: &str = "scoped_coverage_executor";
+const SCOPED_COVERAGE_EXECUTOR_TITLE: &str = "Scoped Coverage Executor";
+const SCOPED_COVERAGE_EXECUTOR_ADVISORY_NOTE: &str = "Scoped coverage executor is an explicitly non-required PR/manual experiment. It runs only planner-selected non-required coverage commands and does not replace required PR proof jobs.";
 const FAST_PROOF_REQUIRED_STATUSES: [&str; 3] = [
     "proof_run_status",
     "proof_run_artifacts_status",
     "proof_run_observation_status",
+];
+const SCOPED_COVERAGE_REQUIRED_STATUSES: [&str; 5] = [
+    "affected_status",
+    "executor_status",
+    "verifier_status",
+    "observation_status",
+    "collection_status",
 ];
 
 pub fn run(args: ProofWorkflowStatusArgs) -> Result<()> {
@@ -140,6 +150,15 @@ struct SourceRole {
     expected_schema: &'static str,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct WorkflowContract {
+    label: &'static str,
+    title: &'static str,
+    advisory_note: &'static str,
+    statuses: &'static [&'static str],
+    sources: &'static [SourceRole],
+}
+
 const FAST_PROOF_SOURCE_ROLES: [SourceRole; 5] = [
     SourceRole {
         role: "proof_policy",
@@ -163,59 +182,135 @@ const FAST_PROOF_SOURCE_ROLES: [SourceRole; 5] = [
     },
 ];
 
-fn build_packet(args: &ProofWorkflowStatusArgs) -> Result<ProofWorkflowStatusPacket> {
-    if args.workflow_kind != ProofWorkflowKind::FastProofRun {
-        bail!(
-            "proof-workflow-status currently supports fast-proof-run only; scoped coverage executor status is a later slice"
-        );
-    }
+const SCOPED_COVERAGE_SOURCE_ROLES: [SourceRole; 8] = [
+    SourceRole {
+        role: "proof_policy",
+        expected_schema: "tokmd.proof_policy.v1",
+    },
+    SourceRole {
+        role: "affected",
+        expected_schema: "tokmd.affected.v1",
+    },
+    SourceRole {
+        role: "proof_plan",
+        expected_schema: "tokmd.proof_plan.v1",
+    },
+    SourceRole {
+        role: "executor_summary",
+        expected_schema: "tokmd.proof_executor_summary.v1",
+    },
+    SourceRole {
+        role: "executor_manifest",
+        expected_schema: "tokmd.proof_executor_manifest.v1",
+    },
+    SourceRole {
+        role: "proof_execution_artifacts_check",
+        expected_schema: "tokmd.proof_execution_artifacts_check.v1",
+    },
+    SourceRole {
+        role: "proof_executor_observation",
+        expected_schema: "tokmd.proof_executor_observation.v1",
+    },
+    SourceRole {
+        role: "proof_executor_observation_collection",
+        expected_schema: "tokmd.proof_executor_observation_collection.v1",
+    },
+];
 
-    let source_artifacts = load_fast_proof_sources(args)?;
+const FAST_PROOF_CONTRACT: WorkflowContract = WorkflowContract {
+    label: FAST_PROOF_RUN_LABEL,
+    title: FAST_PROOF_RUN_TITLE,
+    advisory_note: FAST_PROOF_RUN_ADVISORY_NOTE,
+    statuses: &FAST_PROOF_REQUIRED_STATUSES,
+    sources: &FAST_PROOF_SOURCE_ROLES,
+};
+
+const SCOPED_COVERAGE_CONTRACT: WorkflowContract = WorkflowContract {
+    label: SCOPED_COVERAGE_EXECUTOR_LABEL,
+    title: SCOPED_COVERAGE_EXECUTOR_TITLE,
+    advisory_note: SCOPED_COVERAGE_EXECUTOR_ADVISORY_NOTE,
+    statuses: &SCOPED_COVERAGE_REQUIRED_STATUSES,
+    sources: &SCOPED_COVERAGE_SOURCE_ROLES,
+};
+
+fn build_packet(args: &ProofWorkflowStatusArgs) -> Result<ProofWorkflowStatusPacket> {
+    let contract = workflow_contract(args.workflow_kind);
+    let source_artifacts = load_sources(args, contract.sources)?;
     let policy = read_json_file(&args.proof_policy, "proof policy")?;
-    let guardrails = policy_guardrails(&policy)?;
+    let guardrails = policy_guardrails(args.workflow_kind, &policy)?;
     if guardrails.required_gate {
-        bail!("fast proof-run policy must remain advisory; proof_run.pr.required must be false");
+        bail!(
+            "{} policy must remain advisory; required gate must be false",
+            contract.label
+        );
     }
     if guardrails.codecov_default_upload {
         bail!("Codecov default upload must remain disabled for proof workflow status packets");
     }
 
-    let statuses = parse_command_statuses(&args.statuses, &FAST_PROOF_REQUIRED_STATUSES)?;
-    let recommended_exit_code = recommended_exit_code(&statuses, &FAST_PROOF_REQUIRED_STATUSES);
+    let statuses = parse_command_statuses(&args.statuses, contract.statuses, contract.label)?;
+    let recommended_exit_code = recommended_exit_code(&statuses, contract.statuses);
     let summary = WorkflowSummary {
-        title: FAST_PROOF_RUN_TITLE,
-        advisory_note: FAST_PROOF_RUN_ADVISORY_NOTE,
-        commands: summary_commands(&statuses, &FAST_PROOF_REQUIRED_STATUSES),
+        title: contract.title,
+        advisory_note: contract.advisory_note,
+        commands: summary_commands(&statuses, contract.statuses),
     };
 
     Ok(ProofWorkflowStatusPacket {
         schema: STATUS_SCHEMA,
         ok: true,
         mode: MODE,
-        workflow_kind: FAST_PROOF_RUN_LABEL,
+        workflow_kind: contract.label,
         required: false,
         advisory: true,
         policy_guardrails: guardrails,
         source_artifacts,
-        command_statuses: command_statuses(&statuses, &FAST_PROOF_REQUIRED_STATUSES),
+        command_statuses: command_statuses(&statuses, contract.statuses),
         recommended_exit_code,
         summary,
         errors: Vec::new(),
     })
 }
 
-fn load_fast_proof_sources(args: &ProofWorkflowStatusArgs) -> Result<Vec<SourceArtifact>> {
-    let sources = [
-        (FAST_PROOF_SOURCE_ROLES[0], &args.proof_policy),
-        (FAST_PROOF_SOURCE_ROLES[1], &args.proof_plan),
-        (FAST_PROOF_SOURCE_ROLES[2], &args.proof_run_summary),
-        (FAST_PROOF_SOURCE_ROLES[3], &args.proof_run_artifacts_check),
-        (FAST_PROOF_SOURCE_ROLES[4], &args.proof_run_observation),
-    ];
+fn workflow_contract(kind: ProofWorkflowKind) -> &'static WorkflowContract {
+    match kind {
+        ProofWorkflowKind::FastProofRun => &FAST_PROOF_CONTRACT,
+        ProofWorkflowKind::ScopedCoverageExecutor => &SCOPED_COVERAGE_CONTRACT,
+    }
+}
 
-    sources
-        .into_iter()
-        .map(|(role, path)| load_source_artifact(role, path))
+fn workflow_contract_by_label(label: &str) -> Option<&'static WorkflowContract> {
+    match label {
+        FAST_PROOF_RUN_LABEL => Some(&FAST_PROOF_CONTRACT),
+        SCOPED_COVERAGE_EXECUTOR_LABEL => Some(&SCOPED_COVERAGE_CONTRACT),
+        _ => None,
+    }
+}
+
+fn source_path<'a>(args: &'a ProofWorkflowStatusArgs, role: &str) -> &'a Path {
+    match role {
+        "proof_policy" => &args.proof_policy,
+        "proof_plan" => &args.proof_plan,
+        "proof_run_summary" => &args.proof_run_summary,
+        "proof_run_artifacts_check" => &args.proof_run_artifacts_check,
+        "proof_run_observation" => &args.proof_run_observation,
+        "affected" => &args.affected,
+        "executor_summary" => &args.executor_summary,
+        "executor_manifest" => &args.executor_manifest,
+        "proof_execution_artifacts_check" => &args.proof_execution_artifacts_check,
+        "proof_executor_observation" => &args.proof_executor_observation,
+        "proof_executor_observation_collection" => &args.proof_executor_observation_collection,
+        _ => unreachable!("unknown proof workflow source role: {role}"),
+    }
+}
+
+fn load_sources(
+    args: &ProofWorkflowStatusArgs,
+    roles: &'static [SourceRole],
+) -> Result<Vec<SourceArtifact>> {
+    roles
+        .iter()
+        .map(|role| load_source_artifact(*role, source_path(args, role.role)))
         .collect()
 }
 
@@ -243,9 +338,15 @@ fn load_source_artifact(role: SourceRole, path: &Path) -> Result<SourceArtifact>
     })
 }
 
-fn policy_guardrails(policy: &Value) -> Result<PolicyGuardrails> {
-    let required_gate = bool_at(policy, &["proof_run", "pr", "required"])
-        .context("proof policy JSON is missing proof_run.pr.required")?;
+fn policy_guardrails(kind: ProofWorkflowKind, policy: &Value) -> Result<PolicyGuardrails> {
+    let required_gate = match kind {
+        ProofWorkflowKind::FastProofRun => bool_at(policy, &["proof_run", "pr", "required"])
+            .context("proof policy JSON is missing proof_run.pr.required")?,
+        ProofWorkflowKind::ScopedCoverageExecutor => {
+            bool_at(policy, &["executor", "pr", "required"])
+                .context("proof policy JSON is missing executor.pr.required")?
+        }
+    };
     let codecov_default_upload =
         bool_at(policy, &["executor", "promotion", "default_codecov_upload"])
             .or_else(|| bool_at(policy, &["executor", "pr", "codecov_upload"]))
@@ -268,6 +369,7 @@ fn bool_at(value: &Value, path: &[&str]) -> Option<bool> {
 fn parse_command_statuses(
     raw: &[String],
     required_order: &[&'static str],
+    workflow_label: &str,
 ) -> Result<BTreeMap<String, i32>> {
     let allowed: BTreeSet<&str> = required_order.iter().copied().collect();
     let mut statuses = BTreeMap::new();
@@ -280,7 +382,7 @@ fn parse_command_statuses(
             bail!("status name must not be empty");
         }
         if !allowed.contains(name) {
-            bail!("unsupported status `{name}` for fast-proof-run");
+            bail!("unsupported status `{name}` for {workflow_label}");
         }
         let exit_code = value
             .parse::<i32>()
@@ -338,6 +440,11 @@ fn status_label(name: &str) -> &'static str {
         "proof_run_status" => "proof run",
         "proof_run_artifacts_status" => "proof run artifacts",
         "proof_run_observation_status" => "proof run observation",
+        "affected_status" => "affected",
+        "executor_status" => "proof executor",
+        "verifier_status" => "execution artifact verifier",
+        "observation_status" => "execution observation",
+        "collection_status" => "observation collection",
         _ => "unknown",
     }
 }
@@ -404,19 +511,19 @@ fn validate_status_packet(value: &Value, path: &Path) -> Result<ProofWorkflowSta
 
     let workflow_kind =
         require_string_field(value, "workflow_kind", &mut errors).unwrap_or_default();
-    if workflow_kind != FAST_PROOF_RUN_LABEL {
-        errors.push(format!(
-            "workflow_kind `{workflow_kind}` is not supported by this verifier slice"
-        ));
-    }
+    let contract = workflow_contract_by_label(&workflow_kind).unwrap_or_else(|| {
+        errors.push(format!("workflow_kind `{workflow_kind}` is not supported"));
+        &FAST_PROOF_CONTRACT
+    });
 
     require_bool_value(value, "required", false, &mut errors);
     require_bool_value(value, "advisory", true, &mut errors);
     validate_policy_guardrails(value, &mut errors);
-    let source_artifacts = validate_source_artifacts(value, &mut errors);
-    let (command_statuses, parsed_statuses) = validate_command_statuses(value, &mut errors);
+    let source_artifacts = validate_source_artifacts(value, contract.sources, &mut errors);
+    let (command_statuses, parsed_statuses) =
+        validate_command_statuses(value, contract.statuses, &mut errors);
     let recommended_exit_code = validate_recommended_exit_code(value, &mut errors);
-    validate_summary(value, &parsed_statuses, &mut errors);
+    validate_summary(value, contract, &parsed_statuses, &mut errors);
     validate_embedded_errors(value, &mut errors);
 
     if !errors.is_empty() {
@@ -469,13 +576,17 @@ fn validate_policy_guardrails(value: &Value, errors: &mut Vec<String>) {
     }
 }
 
-fn validate_source_artifacts(value: &Value, errors: &mut Vec<String>) -> usize {
+fn validate_source_artifacts(
+    value: &Value,
+    expected_roles: &'static [SourceRole],
+    errors: &mut Vec<String>,
+) -> usize {
     let Some(artifacts) = value.get("source_artifacts").and_then(Value::as_array) else {
         errors.push("missing array field `source_artifacts`".to_string());
         return 0;
     };
 
-    let expected: BTreeMap<&str, &str> = FAST_PROOF_SOURCE_ROLES
+    let expected: BTreeMap<&str, &str> = expected_roles
         .iter()
         .map(|role| (role.role, role.expected_schema))
         .collect();
@@ -529,6 +640,7 @@ fn validate_source_artifacts(value: &Value, errors: &mut Vec<String>) -> usize {
 
 fn validate_command_statuses(
     value: &Value,
+    expected_statuses: &[&'static str],
     errors: &mut Vec<String>,
 ) -> (usize, BTreeMap<String, i32>) {
     let Some(statuses) = value.get("command_statuses").and_then(Value::as_array) else {
@@ -562,13 +674,13 @@ fn validate_command_statuses(
         }
     }
 
-    for required in FAST_PROOF_REQUIRED_STATUSES {
-        if !parsed.contains_key(required) {
+    for required in expected_statuses {
+        if !parsed.contains_key(*required) {
             errors.push(format!("missing command status `{required}`"));
         }
     }
 
-    let expected_exit = recommended_exit_code(&parsed, &FAST_PROOF_REQUIRED_STATUSES);
+    let expected_exit = recommended_exit_code(&parsed, expected_statuses);
     match value.get("recommended_exit_code").and_then(Value::as_i64) {
         Some(actual) if actual == i64::from(expected_exit) => {}
         Some(actual) => errors.push(format!(
@@ -594,20 +706,26 @@ fn validate_recommended_exit_code(value: &Value, errors: &mut Vec<String>) -> i3
     }
 }
 
-fn validate_summary(value: &Value, statuses: &BTreeMap<String, i32>, errors: &mut Vec<String>) {
+fn validate_summary(
+    value: &Value,
+    contract: &WorkflowContract,
+    statuses: &BTreeMap<String, i32>,
+    errors: &mut Vec<String>,
+) {
     let Some(summary) = value.get("summary").and_then(Value::as_object) else {
         errors.push("missing object field `summary`".to_string());
         return;
     };
     match summary.get("title").and_then(Value::as_str) {
-        Some(FAST_PROOF_RUN_TITLE) => {}
+        Some(title) if title == contract.title => {}
         Some(title) => errors.push(format!(
-            "summary.title `{title}` does not match fast proof run"
+            "summary.title `{title}` does not match {}",
+            contract.label
         )),
         None => errors.push("missing string field `summary.title`".to_string()),
     }
     match summary.get("advisory_note").and_then(Value::as_str) {
-        Some(FAST_PROOF_RUN_ADVISORY_NOTE) => {}
+        Some(note) if note == contract.advisory_note => {}
         Some(_) => {
             errors.push("summary.advisory_note does not match advisory boundary".to_string())
         }
@@ -617,10 +735,10 @@ fn validate_summary(value: &Value, statuses: &BTreeMap<String, i32>, errors: &mu
         errors.push("missing array field `summary.commands`".to_string());
         return;
     };
-    if commands.len() != FAST_PROOF_REQUIRED_STATUSES.len() {
+    if commands.len() != contract.statuses.len() {
         errors.push("summary.commands length does not match command statuses".to_string());
     }
-    for (index, expected) in FAST_PROOF_REQUIRED_STATUSES.iter().enumerate() {
+    for (index, expected) in contract.statuses.iter().enumerate() {
         let Some(command) = commands.get(index).and_then(Value::as_object) else {
             continue;
         };
@@ -751,7 +869,6 @@ fn write_text(path: &Path, text: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::ProofWorkflowStatusArgs;
 
     #[test]
     fn parses_statuses_and_preserves_priority() {
@@ -762,6 +879,7 @@ mod tests {
                 "proof_run_observation_status=3".to_string(),
             ],
             &FAST_PROOF_REQUIRED_STATUSES,
+            FAST_PROOF_RUN_LABEL,
         )
         .unwrap();
 
@@ -785,22 +903,23 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_workflow_kind_for_first_slice() {
-        let args = ProofWorkflowStatusArgs {
-            workflow_kind: ProofWorkflowKind::ScopedCoverageExecutor,
-            statuses: Vec::new(),
-            proof_policy: "target/proof-run/proof-policy.json".into(),
-            proof_plan: "target/proof-run/proof-plan.json".into(),
-            proof_run_summary: "target/proof-run/proof-run-summary.json".into(),
-            proof_run_artifacts_check: "target/proof-run/proof-run-artifacts-check.json".into(),
-            proof_run_observation: "target/proof-run/proof-run-observation.json".into(),
-            json: "target/proof-run/proof-workflow-status.json".into(),
-            summary_md: None,
-            env_output: None,
-        };
+    fn scoped_statuses_preserve_executor_priority() {
+        let statuses = parse_command_statuses(
+            &[
+                "affected_status=0".to_string(),
+                "executor_status=0".to_string(),
+                "verifier_status=9".to_string(),
+                "observation_status=7".to_string(),
+                "collection_status=5".to_string(),
+            ],
+            &SCOPED_COVERAGE_REQUIRED_STATUSES,
+            SCOPED_COVERAGE_EXECUTOR_LABEL,
+        )
+        .unwrap();
 
-        let error = build_packet(&args).unwrap_err().to_string();
-
-        assert!(error.contains("fast-proof-run only"), "{error}");
+        assert_eq!(
+            recommended_exit_code(&statuses, &SCOPED_COVERAGE_REQUIRED_STATUSES),
+            9
+        );
     }
 }

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -813,6 +813,116 @@ fn scoped_coverage_executor_is_pr_visible_but_not_required() {
         "executor workflow should write affected.json through xtask instead of shell redirection"
     );
     assert!(
+        executor.contains("cargo xtask proof-workflow-status"),
+        "executor workflow should summarize status arbitration through xtask"
+    );
+    assert!(
+        executor.contains("--workflow-kind scoped-coverage-executor"),
+        "executor workflow should identify the scoped coverage status packet kind"
+    );
+    assert!(
+        executor.contains("--status \"affected_status=${affected_status}\""),
+        "executor workflow should pass affected status to the status packet"
+    );
+    assert!(
+        executor.contains("--status \"executor_status=${executor_status}\""),
+        "executor workflow should pass executor status to the status packet"
+    );
+    assert!(
+        executor.contains("--status \"verifier_status=${verifier_status}\""),
+        "executor workflow should pass verifier status to the status packet"
+    );
+    assert!(
+        executor.contains("--status \"observation_status=${observation_status}\""),
+        "executor workflow should pass observation status to the status packet"
+    );
+    assert!(
+        executor.contains("--status \"collection_status=${collection_status}\""),
+        "executor workflow should pass collection status to the status packet"
+    );
+    assert!(
+        executor.contains("--affected target/proof/affected.json"),
+        "executor workflow should pass the affected artifact"
+    );
+    assert!(
+        executor.contains("--executor-summary target/proof/executor-summary.json"),
+        "executor workflow should pass the executor summary"
+    );
+    assert!(
+        executor.contains("--executor-manifest target/proof/executor-manifest.json"),
+        "executor workflow should pass the executor manifest"
+    );
+    assert!(
+        executor.contains(
+            "--proof-execution-artifacts-check target/proof/proof-execution-artifacts-check.json"
+        ),
+        "executor workflow should pass the execution artifact verifier receipt"
+    );
+    assert!(
+        executor
+            .contains("--proof-executor-observation target/proof/proof-executor-observation.json"),
+        "executor workflow should pass the executor observation"
+    );
+    assert!(
+        executor.contains("--proof-executor-observation-collection target/proof/proof-executor-observation-collection.json"),
+        "executor workflow should pass the executor observation collection"
+    );
+    assert!(
+        executor.contains("--json target/proof/proof-workflow-status.json"),
+        "executor workflow should write the workflow status packet"
+    );
+    assert!(
+        executor.contains("--summary-md target/proof/proof-workflow-status.md"),
+        "executor workflow should write a Rust-rendered workflow status summary"
+    );
+    assert!(
+        executor.contains("--env-output target/proof/proof-workflow-status.env"),
+        "executor workflow should write workflow-compatible status output"
+    );
+    assert!(
+        executor.contains("cargo xtask proof-workflow-status-check"),
+        "executor workflow should verify the workflow status packet"
+    );
+    assert!(
+        executor.contains("--json target/proof/proof-workflow-status-check.json"),
+        "executor workflow should write the workflow status verifier receipt"
+    );
+    assert!(
+        executor
+            .contains("proof-workflow-status-check skipped because proof-workflow-status exited"),
+        "executor workflow should skip checker cleanly when status packet generation fails"
+    );
+    let affected_exit = executor
+        .find("if [ \"${affected_status}\" -ne 0 ]; then")
+        .expect("affected_status exit check should remain");
+    let executor_exit = executor
+        .find("if [ \"${executor_status}\" -ne 0 ]; then")
+        .expect("executor_status exit check should remain");
+    let verifier_exit = executor
+        .find("if [ \"${verifier_status}\" -ne 0 ]; then")
+        .expect("verifier_status exit check should remain");
+    let observation_exit = executor
+        .find("if [ \"${observation_status}\" -ne 0 ]; then")
+        .expect("observation_status exit check should remain");
+    let collection_exit = executor
+        .find("if [ \"${collection_status}\" -ne 0 ]; then")
+        .expect("collection_status exit check should remain");
+    let workflow_status_exit = executor
+        .find("if [ \"${proof_workflow_status_status}\" -ne 0 ]; then")
+        .expect("proof_workflow_status_status exit check should be present");
+    let workflow_status_check_exit = executor
+        .find("if [ \"${proof_workflow_status_check_status}\" -ne 0 ]; then")
+        .expect("proof_workflow_status_check_status exit check should be present");
+    assert!(
+        affected_exit < executor_exit
+            && executor_exit < verifier_exit
+            && verifier_exit < observation_exit
+            && observation_exit < collection_exit
+            && collection_exit < workflow_status_exit
+            && workflow_status_exit < workflow_status_check_exit,
+        "executor workflow should preserve exit priority: affected, executor, verifier, observation, collection, status packet, status check"
+    );
+    assert!(
         !executor.contains("--json > target/proof/affected.json"),
         "executor workflow should not capture affected.json with shell redirection"
     );

--- a/xtask/tests/proof_workflow_status_w98.rs
+++ b/xtask/tests/proof_workflow_status_w98.rs
@@ -49,6 +49,21 @@ fn proof_workflow_status_help_mentions_fast_inputs() {
         stdout.contains("--proof-run-observation"),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("--affected"), "stdout: {stdout}");
+    assert!(stdout.contains("--executor-summary"), "stdout: {stdout}");
+    assert!(stdout.contains("--executor-manifest"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("--proof-execution-artifacts-check"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("--proof-executor-observation"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("--proof-executor-observation-collection"),
+        "stdout: {stdout}"
+    );
     assert!(stdout.contains("--summary-md"), "stdout: {stdout}");
     assert!(stdout.contains("--env-output"), "stdout: {stdout}");
 }
@@ -195,6 +210,156 @@ fn proof_workflow_status_preserves_first_nonzero_fast_status_priority() {
 }
 
 #[test]
+fn proof_workflow_status_writes_and_checks_scoped_executor_packet() {
+    let paths = FixturePaths::new("proof-workflow-status-scoped-ok");
+    paths.reset();
+    paths.write_sources();
+
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-workflow-status",
+        "--workflow-kind",
+        "scoped-coverage-executor",
+        "--status",
+        "affected_status=0",
+        "--status",
+        "executor_status=0",
+        "--status",
+        "verifier_status=0",
+        "--status",
+        "observation_status=0",
+        "--status",
+        "collection_status=0",
+        "--proof-policy",
+        paths.proof_policy_arg(),
+        "--affected",
+        paths.affected_arg(),
+        "--proof-plan",
+        paths.proof_plan_arg(),
+        "--executor-summary",
+        paths.executor_summary_arg(),
+        "--executor-manifest",
+        paths.executor_manifest_arg(),
+        "--proof-execution-artifacts-check",
+        paths.proof_execution_artifacts_check_arg(),
+        "--proof-executor-observation",
+        paths.proof_executor_observation_arg(),
+        "--proof-executor-observation-collection",
+        paths.proof_executor_observation_collection_arg(),
+        "--json",
+        paths.status_arg(),
+        "--summary-md",
+        paths.summary_md_arg(),
+        "--env-output",
+        paths.env_output_arg(),
+    ]);
+
+    assert!(
+        success,
+        "proof-workflow-status failed. stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("recommended_exit_code=0"),
+        "stdout: {stdout}"
+    );
+
+    let packet = read_json(&paths.status);
+    assert_eq!(packet["schema"], "tokmd.proof_workflow_status.v1");
+    assert_eq!(packet["workflow_kind"], "scoped_coverage_executor");
+    assert_eq!(packet["advisory"], true);
+    assert_eq!(packet["required"], false);
+    assert_eq!(packet["policy_guardrails"]["required_gate"], false);
+    assert_eq!(packet["policy_guardrails"]["codecov_default_upload"], false);
+    assert_eq!(packet["recommended_exit_code"], 0);
+    assert_eq!(packet["source_artifacts"].as_array().unwrap().len(), 8);
+    assert_eq!(packet["command_statuses"].as_array().unwrap().len(), 5);
+
+    let markdown = fs::read_to_string(&paths.summary_md).expect("summary should be readable");
+    assert!(
+        markdown.contains("## Scoped Coverage Executor"),
+        "{markdown}"
+    );
+    assert!(
+        markdown.contains("explicitly non-required PR/manual experiment"),
+        "{markdown}"
+    );
+    assert!(markdown.contains("| proof executor | 0 |"), "{markdown}");
+
+    let env_output = fs::read_to_string(&paths.env_output).expect("env output should be readable");
+    assert_eq!(
+        env_output,
+        "ok=true\nrecommended_exit_code=0\nworkflow_kind=scoped_coverage_executor\n"
+    );
+
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-workflow-status-check",
+        "--status",
+        paths.status_arg(),
+        "--json",
+        paths.check_arg(),
+    ]);
+
+    assert!(
+        success,
+        "proof-workflow-status-check failed. stdout: {stdout}\nstderr: {stderr}"
+    );
+    let receipt = read_json(&paths.check);
+    assert_eq!(receipt["schema"], "tokmd.proof_workflow_status_check.v1");
+    assert_eq!(receipt["ok"], true);
+    assert_eq!(receipt["source_artifacts"], 8);
+    assert_eq!(receipt["command_statuses"], 5);
+    assert_eq!(receipt["recommended_exit_code"], 0);
+}
+
+#[test]
+fn proof_workflow_status_preserves_first_nonzero_scoped_status_priority() {
+    let paths = FixturePaths::new("proof-workflow-status-scoped-nonzero");
+    paths.reset();
+    paths.write_sources();
+
+    let (stdout, stderr, success) = run_xtask(&[
+        "proof-workflow-status",
+        "--workflow-kind",
+        "scoped-coverage-executor",
+        "--status",
+        "affected_status=0",
+        "--status",
+        "executor_status=0",
+        "--status",
+        "verifier_status=9",
+        "--status",
+        "observation_status=7",
+        "--status",
+        "collection_status=5",
+        "--proof-policy",
+        paths.proof_policy_arg(),
+        "--affected",
+        paths.affected_arg(),
+        "--proof-plan",
+        paths.proof_plan_arg(),
+        "--executor-summary",
+        paths.executor_summary_arg(),
+        "--executor-manifest",
+        paths.executor_manifest_arg(),
+        "--proof-execution-artifacts-check",
+        paths.proof_execution_artifacts_check_arg(),
+        "--proof-executor-observation",
+        paths.proof_executor_observation_arg(),
+        "--proof-executor-observation-collection",
+        paths.proof_executor_observation_collection_arg(),
+        "--json",
+        paths.status_arg(),
+    ]);
+
+    assert!(
+        success,
+        "proof-workflow-status failed. stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let packet = read_json(&paths.status);
+    assert_eq!(packet["recommended_exit_code"], 9);
+}
+
+#[test]
 fn proof_workflow_status_check_rejects_absolute_source_paths() {
     let paths = FixturePaths::new("proof-workflow-status-bad-path");
     paths.reset();
@@ -251,6 +416,12 @@ struct FixturePaths {
     proof_run_summary: PathBuf,
     proof_run_artifacts_check: PathBuf,
     proof_run_observation: PathBuf,
+    affected: PathBuf,
+    executor_summary: PathBuf,
+    executor_manifest: PathBuf,
+    proof_execution_artifacts_check: PathBuf,
+    proof_executor_observation: PathBuf,
+    proof_executor_observation_collection: PathBuf,
     status: PathBuf,
     summary_md: PathBuf,
     env_output: PathBuf,
@@ -266,6 +437,13 @@ impl FixturePaths {
             proof_run_summary: root.join("proof-run-summary.json"),
             proof_run_artifacts_check: root.join("proof-run-artifacts-check.json"),
             proof_run_observation: root.join("proof-run-observation.json"),
+            affected: root.join("affected.json"),
+            executor_summary: root.join("executor-summary.json"),
+            executor_manifest: root.join("executor-manifest.json"),
+            proof_execution_artifacts_check: root.join("proof-execution-artifacts-check.json"),
+            proof_executor_observation: root.join("proof-executor-observation.json"),
+            proof_executor_observation_collection: root
+                .join("proof-executor-observation-collection.json"),
             status: root.join("proof-workflow-status.json"),
             summary_md: root.join("proof-workflow-status.md"),
             env_output: root.join("proof-workflow-status.env"),
@@ -295,7 +473,7 @@ impl FixturePaths {
                     }
                 },
                 "executor": {
-                    "pr": {"codecov_upload": false},
+                    "pr": {"required": false, "codecov_upload": false},
                     "promotion": {"default_codecov_upload": false}
                 }
             }),
@@ -312,6 +490,30 @@ impl FixturePaths {
         write_json(
             &self.proof_run_observation,
             &json!({"schema": "tokmd.proof_run_observation.v1", "entries": []}),
+        );
+        write_json(
+            &self.affected,
+            &json!({"schema": "tokmd.affected.v1", "unknown_files": []}),
+        );
+        write_json(
+            &self.executor_summary,
+            &json!({"schema": "tokmd.proof_executor_summary.v1", "commands": []}),
+        );
+        write_json(
+            &self.executor_manifest,
+            &json!({"schema": "tokmd.proof_executor_manifest.v1", "commands": []}),
+        );
+        write_json(
+            &self.proof_execution_artifacts_check,
+            &json!({"schema": "tokmd.proof_execution_artifacts_check.v1", "ok": true}),
+        );
+        write_json(
+            &self.proof_executor_observation,
+            &json!({"schema": "tokmd.proof_executor_observation.v1", "entries": []}),
+        );
+        write_json(
+            &self.proof_executor_observation_collection,
+            &json!({"schema": "tokmd.proof_executor_observation_collection.v1", "entries": []}),
         );
     }
 
@@ -333,6 +535,30 @@ impl FixturePaths {
 
     fn proof_run_observation_arg(&self) -> &str {
         rel_str(&self.proof_run_observation)
+    }
+
+    fn affected_arg(&self) -> &str {
+        rel_str(&self.affected)
+    }
+
+    fn executor_summary_arg(&self) -> &str {
+        rel_str(&self.executor_summary)
+    }
+
+    fn executor_manifest_arg(&self) -> &str {
+        rel_str(&self.executor_manifest)
+    }
+
+    fn proof_execution_artifacts_check_arg(&self) -> &str {
+        rel_str(&self.proof_execution_artifacts_check)
+    }
+
+    fn proof_executor_observation_arg(&self) -> &str {
+        rel_str(&self.proof_executor_observation)
+    }
+
+    fn proof_executor_observation_collection_arg(&self) -> &str {
+        rel_str(&self.proof_executor_observation_collection)
     }
 
     fn status_arg(&self) -> &str {


### PR DESCRIPTION
## Summary
- extend `cargo xtask proof-workflow-status` / `proof-workflow-status-check` to support `scoped-coverage-executor` packets
- wire `.github/workflows/proof-executor.yml` to emit and verify `proof-workflow-status.json` in the existing `proof-executor-artifacts` upload
- preserve non-required executor behavior, manual-only Codecov upload, existing artifact names, and affected/executor/verifier/observation/collection exit priority

## Boundaries
- no proof promotion
- no default Codecov upload
- no required CI aggregate change
- no public `tokmd` CLI behavior change
- no coverage command selection or execution behavior change

## Validation
- `cargo fmt-fix`
- `cargo test -p xtask proof_workflow_status --verbose`
- `cargo test -p xtask --test proof_plan_w92 scoped_coverage_executor_is_pr_visible_but_not_required --verbose`
- `cargo test -p xtask proof_run --verbose`
- `cargo xtask proof-policy --check`
- `cargo xtask ci-lane-whitelist`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-scoped-proof-workflow-status.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-scoped-proof-workflow-status.json --evidence-json target/proof/proof-evidence-scoped-proof-workflow-status.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-scoped-proof-workflow-status.json`