### PR TITLE
docs: record hosted proof workflow status evidence

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -144,9 +144,14 @@ draft spec are in place, and the fast proof-run and scoped coverage executor
 workflows now write and verify the developer-facing
 `tokmd.proof_workflow_status.v1` packet through
 `cargo xtask proof-workflow-status` /
-`cargo xtask proof-workflow-status-check`. GitHub Actions still owns runner
-setup, cache, tool installation, artifact upload, GitHub API calls, and
-Codecov service integration.
+`cargo xtask proof-workflow-status-check`. Hosted fast proof-run artifact
+`fast-proof-run` from CI run `25954863938` and hosted scoped coverage artifact
+`proof-executor-artifacts` from Proof Executor Experiment run `25954863931`
+both carried verifiable `tokmd.proof_workflow_status.v1` packets and
+`tokmd.proof_workflow_status_check.v1` receipts with `ok = true` and
+`recommended_exit_code = 0`. GitHub Actions still owns runner setup, cache,
+tool installation, artifact upload, GitHub API calls, and Codecov service
+integration.
 
 The code-intelligence platform audit is closed. It mapped the broad platform
 objective to live artifacts and verifier coverage, did not mark the platform
@@ -185,9 +190,10 @@ lane, release workflow, and affected-proof evidence cannot cover.
 
 ## Next Work Packets
 
-1. Observe the proof workflow status packet in hosted fast proof-run and scoped
-   coverage executor artifacts before extending it to any other workflow.
-   Preserve advisory/non-required behavior and manual-only Codecov upload.
+1. Treat the proof workflow status packet lane as observed for hosted
+   fast proof-run and scoped coverage executor artifacts. Do not extend it to
+   any other workflow without fresh evidence of a real status-arbitration gap;
+   preserve advisory/non-required behavior and manual-only Codecov upload.
 2. Do not reopen AST productization without a fresh proposal grounded in the
    shadow evidence.
 3. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence

--- a/docs/plans/proof-run-status-packet.md
+++ b/docs/plans/proof-run-status-packet.md
@@ -70,7 +70,7 @@ advisory proof, upload Codecov by default, or change required CI gates.
    - Preserve PR-visible, non-required status and manual-only Codecov upload.
    - Do not change executor command selection or coverage execution.
 5. Validate policy and affected routing.
-   - Status: pending.
+   - Status: complete.
    - Ensure workflow, `xtask`, docs, and policy changes route through existing
      proof-control scopes with zero unknown files.
 
@@ -133,3 +133,17 @@ reproduction specifically requires it.
   remains outside the required CI aggregate, and preserves the existing
   affected/executor/verifier/observation/collection exit priority before the
   additive status packet/check exits.
+- 2026-05-16: Observed the packet in hosted artifacts for both wired
+  workflows. CI run `25954863938` uploaded `fast-proof-run` with
+  `tokmd.proof_workflow_status.v1` (`workflow_kind = fast_proof_run`, 5 source
+  artifacts, 3 command statuses, `recommended_exit_code = 0`) and
+  `tokmd.proof_workflow_status_check.v1` (`ok = true`). Proof Executor
+  Experiment run `25954863931` uploaded `proof-executor-artifacts` with
+  `tokmd.proof_workflow_status.v1`
+  (`workflow_kind = scoped_coverage_executor`, 8 source artifacts, 5 command
+  statuses, `recommended_exit_code = 0`) and
+  `tokmd.proof_workflow_status_check.v1` (`ok = true`). Downloaded copies of
+  both status packets also passed
+  `cargo xtask proof-workflow-status-check`, confirming hosted fast proof-run
+  and scoped coverage executor artifacts carry verifiable status evidence while
+  preserving advisory/non-required behavior and manual-only Codecov upload.


### PR DESCRIPTION
## Summary
- record hosted fast proof-run status packet evidence from CI run `25954863938`
- record hosted scoped coverage executor status packet evidence from run `25954863931`
- mark the proof workflow status packet routing/observation packet complete for the wired workflows while preserving advisory/non-required and manual-only Codecov boundaries

## Validation
- downloaded `fast-proof-run` and `proof-executor-artifacts` hosted artifacts
- `cargo xtask proof-workflow-status-check --status target\hosted-proof-workflow-status\fast\proof-workflow-status.json --json target\hosted-proof-workflow-status\fast\local-proof-workflow-status-check.json`
- `cargo xtask proof-workflow-status-check --status target\hosted-proof-workflow-status\scoped\proof-workflow-status.json --json target\hosted-proof-workflow-status\scoped\local-proof-workflow-status-check.json`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target\proof\affected-proof-workflow-status-hosted.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target\proof\proof-plan-proof-workflow-status-hosted.json --evidence-json target\proof\proof-evidence-proof-workflow-status-hosted.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target\proof\proof-run-summary-proof-workflow-status-hosted.json`

## Guardrails
- docs only
- no proof promotion
- no Codecov default change
- no required CI gate change
- no public tokmd CLI behavior change