### PR TITLE
test(tokmd-gate): add unit tests for ratchet, compare, and policy modules

### DIFF
--- a/crates/tokmd-gate/src/evaluate/compare.rs
+++ b/crates/tokmd-gate/src/evaluate/compare.rs
@@ -82,3 +82,285 @@ pub(super) fn compare_contains(
         _ => Err("contains is only valid for string or array actual values"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── compare_numeric ────────────────────────────────────────────────
+    #[test]
+    fn compare_numeric_gt_true_when_actual_exceeds_expected() {
+        let result = compare_numeric(&json!(10), Some(&json!(5)), |a, b| a > b);
+        assert_eq!(result, Ok(true));
+    }
+
+    #[test]
+    fn compare_numeric_gt_false_when_actual_equals_expected() {
+        let result = compare_numeric(&json!(5), Some(&json!(5)), |a, b| a > b);
+        assert_eq!(result, Ok(false));
+    }
+
+    #[test]
+    fn compare_numeric_gte_true_at_boundary() {
+        let result = compare_numeric(&json!(5), Some(&json!(5)), |a, b| a >= b);
+        assert_eq!(result, Ok(true));
+    }
+
+    #[test]
+    fn compare_numeric_lt_true_when_actual_below_expected() {
+        let result = compare_numeric(&json!(3), Some(&json!(5)), |a, b| a < b);
+        assert_eq!(result, Ok(true));
+    }
+
+    #[test]
+    fn compare_numeric_lte_true_at_boundary() {
+        let result = compare_numeric(&json!(5), Some(&json!(5)), |a, b| a <= b);
+        assert_eq!(result, Ok(true));
+    }
+
+    #[test]
+    fn compare_numeric_coerces_numeric_strings() {
+        // Numeric strings should coerce via value_to_f64.
+        let result = compare_numeric(&json!("12.5"), Some(&json!(10)), |a, b| a > b);
+        assert_eq!(result, Ok(true));
+    }
+
+    #[test]
+    fn compare_numeric_errors_when_actual_not_numeric() {
+        let result = compare_numeric(&json!("abc"), Some(&json!(1)), |a, b| a > b);
+        assert_eq!(result, Err("actual value is not numeric"));
+    }
+
+    #[test]
+    fn compare_numeric_errors_when_expected_missing() {
+        let result = compare_numeric(&json!(1), None, |a, b| a > b);
+        assert_eq!(result, Err("expected value is missing or not numeric"));
+    }
+
+    #[test]
+    fn compare_numeric_errors_when_expected_not_numeric() {
+        let result = compare_numeric(&json!(1), Some(&json!(true)), |a, b| a > b);
+        assert_eq!(result, Err("expected value is missing or not numeric"));
+    }
+
+    #[test]
+    fn compare_numeric_nan_string_breaks_ordering() {
+        // "NaN" as a string coerces via str::parse::<f64>, which DOES parse to
+        // f64::NAN. All ordering comparisons against NaN must return false.
+        let nan = json!("NaN");
+        assert_eq!(
+            compare_numeric(&nan, Some(&json!(1)), |a, b| a > b),
+            Ok(false)
+        );
+        assert_eq!(
+            compare_numeric(&nan, Some(&json!(1)), |a, b| a < b),
+            Ok(false)
+        );
+        assert_eq!(
+            compare_numeric(&nan, Some(&json!(1)), |a, b| (a - b).abs() < f64::EPSILON),
+            Ok(false)
+        );
+    }
+
+    // ── compare_equal ──────────────────────────────────────────────────
+    #[test]
+    fn compare_equal_strings_match_case_sensitively() {
+        assert_eq!(compare_equal(&json!("Foo"), Some(&json!("Foo"))), Ok(true));
+        assert_eq!(compare_equal(&json!("Foo"), Some(&json!("foo"))), Ok(false));
+    }
+
+    #[test]
+    fn compare_equal_special_numeric_strings_compared_as_strings() {
+        // "inf" and "nan" must not be coerced to f64 when both sides are strings.
+        assert_eq!(compare_equal(&json!("inf"), Some(&json!("inf"))), Ok(true));
+        assert_eq!(compare_equal(&json!("nan"), Some(&json!("nan"))), Ok(true));
+        assert_eq!(compare_equal(&json!("inf"), Some(&json!("INF"))), Ok(false));
+    }
+
+    #[test]
+    fn compare_equal_numeric_int_float_mismatch_is_equal() {
+        // 42 (int) == 42.0 (float) via f64 coercion.
+        assert_eq!(compare_equal(&json!(42), Some(&json!(42.0))), Ok(true));
+    }
+
+    #[test]
+    fn compare_equal_numeric_strings_coerce() {
+        // Mixed: one side string, one side number — falls through to numeric.
+        assert_eq!(compare_equal(&json!("42"), Some(&json!(42))), Ok(true));
+    }
+
+    #[test]
+    fn compare_equal_epsilon_boundary_is_strict() {
+        let a = 1.0_f64;
+        let b = a + f64::EPSILON;
+        assert_eq!(
+            compare_equal(&json!(a), Some(&json!(b))),
+            Ok(false),
+            "difference of exactly EPSILON must not be treated as equal"
+        );
+    }
+
+    #[test]
+    fn compare_equal_falls_back_to_json_equality_for_arrays() {
+        assert_eq!(
+            compare_equal(&json!([1, 2, 3]), Some(&json!([1, 2, 3]))),
+            Ok(true)
+        );
+        assert_eq!(
+            compare_equal(&json!([1, 2, 3]), Some(&json!([3, 2, 1]))),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn compare_equal_falls_back_to_json_equality_for_objects() {
+        assert_eq!(
+            compare_equal(&json!({"a": 1}), Some(&json!({"a": 1}))),
+            Ok(true)
+        );
+        assert_eq!(
+            compare_equal(&json!({"a": 1}), Some(&json!({"a": 2}))),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn compare_equal_booleans_match_via_json_equality() {
+        assert_eq!(compare_equal(&json!(true), Some(&json!(true))), Ok(true));
+        assert_eq!(compare_equal(&json!(true), Some(&json!(false))), Ok(false));
+    }
+
+    #[test]
+    fn compare_equal_null_matches_null() {
+        assert_eq!(compare_equal(&json!(null), Some(&json!(null))), Ok(true));
+    }
+
+    #[test]
+    fn compare_equal_type_mismatch_returns_false_not_error() {
+        // string vs object — falls through to JSON equality which is false.
+        assert_eq!(
+            compare_equal(&json!("foo"), Some(&json!({"foo": 1}))),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn compare_equal_errors_when_expected_missing() {
+        assert_eq!(
+            compare_equal(&json!(1), None),
+            Err("expected value is missing")
+        );
+    }
+
+    // ── compare_in ─────────────────────────────────────────────────────
+    #[test]
+    fn compare_in_finds_string_member() {
+        let list = vec![json!("MIT"), json!("Apache-2.0")];
+        assert_eq!(compare_in(&json!("MIT"), Some(&list)), Ok(true));
+    }
+
+    #[test]
+    fn compare_in_returns_false_for_non_member() {
+        let list = vec![json!("MIT"), json!("Apache-2.0")];
+        assert_eq!(compare_in(&json!("GPL"), Some(&list)), Ok(false));
+    }
+
+    #[test]
+    fn compare_in_empty_list_is_never_member() {
+        let list: Vec<Value> = vec![];
+        assert_eq!(compare_in(&json!("anything"), Some(&list)), Ok(false));
+    }
+
+    #[test]
+    fn compare_in_errors_when_list_missing() {
+        assert_eq!(
+            compare_in(&json!("MIT"), None),
+            Err("expected values list is missing")
+        );
+    }
+
+    #[test]
+    fn compare_in_finds_numeric_member_with_coercion() {
+        let list = vec![json!(1), json!(2), json!(3)];
+        // int vs float should coerce.
+        assert_eq!(compare_in(&json!(2.0), Some(&list)), Ok(true));
+    }
+
+    #[test]
+    fn compare_in_skips_uncomparable_items_without_error() {
+        // The unwrap_or(false) inside compare_in must swallow errors mid-iteration.
+        // Construct a list where an early item would error against actual but a
+        // later one matches via JSON equality.
+        let list = vec![json!({"unexpected": "object"}), json!("target")];
+        assert_eq!(compare_in(&json!("target"), Some(&list)), Ok(true));
+    }
+
+    // ── compare_contains ───────────────────────────────────────────────
+    #[test]
+    fn compare_contains_substring_in_string() {
+        assert_eq!(
+            compare_contains(&json!("hello world"), Some(&json!("world"))),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn compare_contains_string_misses() {
+        assert_eq!(
+            compare_contains(&json!("hello world"), Some(&json!("nope"))),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn compare_contains_empty_substring_matches_any_string() {
+        // String::contains("") is always true.
+        assert_eq!(compare_contains(&json!("abc"), Some(&json!(""))), Ok(true));
+    }
+
+    #[test]
+    fn compare_contains_array_member_match() {
+        let arr = json!(["a", "b", "c"]);
+        assert_eq!(compare_contains(&arr, Some(&json!("b"))), Ok(true));
+    }
+
+    #[test]
+    fn compare_contains_array_member_miss() {
+        let arr = json!(["a", "b", "c"]);
+        assert_eq!(compare_contains(&arr, Some(&json!("z"))), Ok(false));
+    }
+
+    #[test]
+    fn compare_contains_string_actual_with_non_string_needle_errors() {
+        let result = compare_contains(&json!("abc"), Some(&json!(1)));
+        assert_eq!(
+            result,
+            Err("expected value must be a string for string contains checks")
+        );
+    }
+
+    #[test]
+    fn compare_contains_errors_for_non_string_non_array_actual() {
+        let result = compare_contains(&json!(42), Some(&json!(1)));
+        assert_eq!(
+            result,
+            Err("contains is only valid for string or array actual values")
+        );
+    }
+
+    #[test]
+    fn compare_contains_errors_when_expected_missing() {
+        assert_eq!(
+            compare_contains(&json!("abc"), None),
+            Err("expected value is missing")
+        );
+    }
+
+    #[test]
+    fn compare_contains_array_with_mixed_types_uses_compare_equal() {
+        // Verify integer/float coercion inside array contains.
+        let arr = json!([1, 2, 3]);
+        assert_eq!(compare_contains(&arr, Some(&json!(2.0))), Ok(true));
+    }
+}

--- a/crates/tokmd-gate/src/ratchet/evaluate.rs
+++ b/crates/tokmd-gate/src/ratchet/evaluate.rs
@@ -173,3 +173,327 @@ pub(super) fn evaluate_ratchet_with_options(
         message,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::RuleLevel;
+    use serde_json::json;
+
+    fn make_rule(
+        pointer: &str,
+        max_increase_pct: Option<f64>,
+        max_value: Option<f64>,
+    ) -> RatchetRule {
+        RatchetRule {
+            pointer: pointer.to_string(),
+            max_increase_pct,
+            max_value,
+            level: RuleLevel::Error,
+            description: None,
+        }
+    }
+
+    // ── evaluate_ratchet (strict wrapper) ──────────────────────────────
+    #[test]
+    fn passes_when_current_is_within_max_increase() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"metric": 105.0}); // 5% increase
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.baseline_value, Some(100.0));
+        assert_eq!(result.current_value, 105.0);
+        let pct = result.change_pct.expect("change_pct should be set");
+        assert!((pct - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fails_when_current_exceeds_max_increase() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"metric": 150.0}); // 50% increase
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+        assert!(
+            result.message.contains("50.00%"),
+            "expected message to mention 50.00%, got: {}",
+            result.message
+        );
+        assert!(result.message.contains("exceeds"));
+    }
+
+    #[test]
+    fn passes_at_exact_max_increase_boundary() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"metric": 110.0}); // exactly 10%
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(
+            result.passed,
+            "10% increase against 10% threshold should pass (>, not >=)"
+        );
+    }
+
+    #[test]
+    fn fails_just_over_max_increase_boundary() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"metric": 110.01});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn fails_when_current_exceeds_absolute_max_value() {
+        let rule = make_rule("/metric", None, Some(50.0));
+        let baseline = json!({"metric": 10.0});
+        let current = json!({"metric": 100.0});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+        assert!(result.message.contains("exceeds maximum allowed value"));
+        assert!(result.message.contains("100"));
+        assert!(result.message.contains("50"));
+    }
+
+    #[test]
+    fn passes_at_exact_max_value_boundary() {
+        let rule = make_rule("/metric", None, Some(50.0));
+        let baseline = json!({"metric": 10.0});
+        let current = json!({"metric": 50.0});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed, "exact max should pass (>, not >=)");
+    }
+
+    #[test]
+    fn fails_when_current_value_missing_by_default() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"other": 0});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+        assert!(result.current_value.is_nan());
+        assert!(result.message.contains("Current value not found"));
+    }
+
+    #[test]
+    fn fails_when_current_value_not_numeric() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"metric": [1, 2, 3]}); // array, not numeric
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+        assert!(result.current_value.is_nan());
+        assert!(result.message.contains("not numeric") || result.message.contains("not found"));
+    }
+
+    #[test]
+    fn fails_when_baseline_missing_for_max_increase_rule() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"other": 0});
+        let current = json!({"metric": 100.0});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+        assert_eq!(result.baseline_value, None);
+        assert!(result.message.contains("Baseline value not found"));
+    }
+
+    #[test]
+    fn passes_when_only_max_value_rule_and_no_baseline() {
+        // No baseline needed if only an absolute ceiling is checked.
+        let rule = make_rule("/metric", None, Some(1000.0));
+        let baseline = json!({});
+        let current = json!({"metric": 500.0});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.baseline_value, None);
+        assert_eq!(result.current_value, 500.0);
+    }
+
+    #[test]
+    fn coerces_numeric_strings_for_baseline_and_current() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": "100"});
+        let current = json!({"metric": "105"});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.baseline_value, Some(100.0));
+        assert_eq!(result.current_value, 105.0);
+    }
+
+    #[test]
+    fn uses_rule_description_in_success_message() {
+        let rule = RatchetRule {
+            pointer: "/metric".into(),
+            max_increase_pct: Some(10.0),
+            max_value: None,
+            level: RuleLevel::Error,
+            description: Some("Cyclomatic complexity".into()),
+        };
+        let baseline = json!({"metric": 10.0});
+        let current = json!({"metric": 10.5});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed);
+        assert!(result.message.contains("Cyclomatic complexity"));
+    }
+
+    #[test]
+    fn default_success_message_when_no_description() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 10.0});
+        let current = json!({"metric": 10.5});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed);
+        assert!(result.message.contains("Ratchet check passed"));
+    }
+
+    #[test]
+    fn negative_change_is_reported_and_passes() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"metric": 80.0});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed);
+        let pct = result.change_pct.expect("change_pct");
+        assert!(pct < 0.0, "expected negative change_pct, got {pct}");
+    }
+
+    #[test]
+    fn zero_baseline_with_nonzero_current_is_infinite_increase() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 0});
+        let current = json!({"metric": 5});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+        assert!(
+            result
+                .change_pct
+                .expect("change_pct should be Some")
+                .is_infinite()
+        );
+    }
+
+    #[test]
+    fn zero_baseline_and_zero_current_passes() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 0});
+        let current = json!({"metric": 0});
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.change_pct, Some(0.0));
+    }
+
+    #[test]
+    fn max_value_takes_priority_over_max_increase_check() {
+        // If both rules are present and max_value is exceeded, fail with max_value message
+        // BEFORE evaluating percentage (which would also fail).
+        let rule = make_rule("/metric", Some(10.0), Some(50.0));
+        let baseline = json!({"metric": 100.0});
+        let current = json!({"metric": 200.0}); // 100% over baseline, 4x max_value
+
+        let result = evaluate_ratchet(&rule, &baseline, &current);
+        assert!(!result.passed);
+        assert!(
+            result.message.contains("exceeds maximum allowed value"),
+            "max_value check should win; got: {}",
+            result.message
+        );
+    }
+
+    // ── evaluate_ratchet_with_options ──────────────────────────────────
+    #[test]
+    fn allow_missing_current_returns_pass_with_baseline_recorded() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({"metric": 42.0});
+        let current = json!({});
+
+        let result = evaluate_ratchet_with_options(&rule, &baseline, &current, false, true);
+        assert!(result.passed);
+        assert_eq!(result.baseline_value, Some(42.0));
+        assert!(result.current_value.is_nan());
+        assert!(result.change_pct.is_none());
+        assert!(result.message.contains("(allowed)"));
+    }
+
+    #[test]
+    fn allow_missing_baseline_returns_pass_with_current_recorded() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({});
+        let current = json!({"metric": 7.0});
+
+        let result = evaluate_ratchet_with_options(&rule, &baseline, &current, true, false);
+        assert!(result.passed);
+        assert_eq!(result.baseline_value, None);
+        assert_eq!(result.current_value, 7.0);
+        assert!(result.change_pct.is_none());
+    }
+
+    #[test]
+    fn allow_missing_baseline_uses_description_when_provided() {
+        let rule = RatchetRule {
+            pointer: "/metric".into(),
+            max_increase_pct: Some(10.0),
+            max_value: None,
+            level: RuleLevel::Error,
+            description: Some("My check".into()),
+        };
+        let baseline = json!({});
+        let current = json!({"metric": 7.0});
+
+        let result = evaluate_ratchet_with_options(&rule, &baseline, &current, true, false);
+        assert!(result.passed);
+        assert!(result.message.contains("My check"));
+    }
+
+    #[test]
+    fn allow_missing_current_does_not_mask_disallowed_baseline() {
+        // allow_missing_current=true, allow_missing_baseline=false — current path wins.
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({});
+        let current = json!({});
+
+        let result = evaluate_ratchet_with_options(&rule, &baseline, &current, false, true);
+        // current is missing first, so allowed-current branch returns passed=true
+        assert!(result.passed);
+        assert!(result.message.contains("(allowed)"));
+    }
+
+    #[test]
+    fn strict_mode_fails_when_both_baseline_and_current_missing() {
+        let rule = make_rule("/metric", Some(10.0), None);
+        let baseline = json!({});
+        let current = json!({});
+
+        let result = evaluate_ratchet_with_options(&rule, &baseline, &current, false, false);
+        assert!(!result.passed);
+        assert!(result.current_value.is_nan());
+    }
+
+    #[test]
+    fn max_value_only_rule_passes_when_baseline_missing_strict() {
+        // A max_value-only rule has no baseline dependency, so it passes
+        // even when baseline is missing and allow_missing_baseline is false.
+        let rule = make_rule("/metric", None, Some(100.0));
+        let baseline = json!({});
+        let current = json!({"metric": 50.0});
+
+        let result = evaluate_ratchet_with_options(&rule, &baseline, &current, false, false);
+        assert!(result.passed);
+    }
+}

--- a/crates/tokmd-gate/src/ratchet/policy.rs
+++ b/crates/tokmd-gate/src/ratchet/policy.rs
@@ -39,3 +39,216 @@ pub fn evaluate_ratchet_policy(
 
     RatchetGateResult::from_results(ratchet_results)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{RatchetRule, RuleLevel};
+    use serde_json::json;
+
+    fn make_rule(
+        pointer: &str,
+        max_increase_pct: Option<f64>,
+        max_value: Option<f64>,
+        level: RuleLevel,
+    ) -> RatchetRule {
+        RatchetRule {
+            pointer: pointer.to_string(),
+            max_increase_pct,
+            max_value,
+            level,
+            description: None,
+        }
+    }
+
+    fn make_config(rules: Vec<RatchetRule>, fail_fast: bool) -> RatchetConfig {
+        RatchetConfig {
+            rules,
+            fail_fast,
+            allow_missing_baseline: false,
+            allow_missing_current: false,
+        }
+    }
+
+    #[test]
+    fn empty_rules_passes_with_no_results() {
+        let config = make_config(vec![], false);
+        let result = evaluate_ratchet_policy(&config, &json!({}), &json!({}));
+        assert!(result.passed);
+        assert!(result.ratchet_results.is_empty());
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn all_rules_pass_when_within_thresholds() {
+        let baseline = json!({"a": 10.0, "b": 100.0});
+        let current = json!({"a": 10.0, "b": 105.0});
+        let config = make_config(
+            vec![
+                make_rule("/a", Some(10.0), None, RuleLevel::Error),
+                make_rule("/b", Some(10.0), None, RuleLevel::Error),
+            ],
+            false,
+        );
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.ratchet_results.len(), 2);
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn any_error_fails_overall_when_mixed_with_passes() {
+        let baseline = json!({"a": 10.0, "b": 100.0});
+        let current = json!({"a": 10.0, "b": 200.0}); // /b is 100% over
+        let config = make_config(
+            vec![
+                make_rule("/a", Some(10.0), None, RuleLevel::Error),
+                make_rule("/b", Some(10.0), None, RuleLevel::Error),
+            ],
+            false,
+        );
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+        assert_eq!(result.errors, 1);
+        assert_eq!(result.ratchet_results.len(), 2);
+    }
+
+    #[test]
+    fn warn_level_failures_do_not_fail_overall() {
+        let baseline = json!({"a": 10.0});
+        let current = json!({"a": 20.0});
+        let config = make_config(
+            vec![make_rule("/a", Some(10.0), None, RuleLevel::Warn)],
+            false,
+        );
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed); // warn-only failures don't fail the gate
+        assert_eq!(result.warnings, 1);
+        assert_eq!(result.errors, 0);
+    }
+
+    #[test]
+    fn fail_fast_stops_after_first_error_level_failure() {
+        let baseline = json!({"a": 10.0, "b": 10.0, "c": 10.0});
+        let current = json!({"a": 20.0, "b": 20.0, "c": 20.0});
+        let config = make_config(
+            vec![
+                make_rule("/a", Some(10.0), None, RuleLevel::Error),
+                make_rule("/b", Some(10.0), None, RuleLevel::Error),
+                make_rule("/c", Some(10.0), None, RuleLevel::Error),
+            ],
+            true,
+        );
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+        assert_eq!(
+            result.ratchet_results.len(),
+            1,
+            "fail_fast should stop after first error"
+        );
+        assert_eq!(result.errors, 1);
+    }
+
+    #[test]
+    fn fail_fast_does_not_stop_on_warn_failure() {
+        // A failing warn rule should NOT trigger early exit because it's not error-level.
+        let baseline = json!({"a": 10.0, "b": 10.0});
+        let current = json!({"a": 20.0, "b": 20.0});
+        let config = make_config(
+            vec![
+                make_rule("/a", Some(10.0), None, RuleLevel::Warn), // fails as warn
+                make_rule("/b", Some(10.0), None, RuleLevel::Error), // fails as error
+            ],
+            true,
+        );
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+        assert_eq!(
+            result.ratchet_results.len(),
+            2,
+            "fail_fast must continue past warn-level failures"
+        );
+        assert_eq!(result.warnings, 1);
+        assert_eq!(result.errors, 1);
+    }
+
+    #[test]
+    fn fail_fast_does_not_stop_on_pass() {
+        let baseline = json!({"a": 10.0, "b": 10.0});
+        let current = json!({"a": 10.0, "b": 20.0}); // /a passes, /b fails
+        let config = make_config(
+            vec![
+                make_rule("/a", Some(10.0), None, RuleLevel::Error),
+                make_rule("/b", Some(10.0), None, RuleLevel::Error),
+            ],
+            true,
+        );
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(!result.passed);
+        assert_eq!(
+            result.ratchet_results.len(),
+            2,
+            "fail_fast must not stop after a passing rule"
+        );
+    }
+
+    #[test]
+    fn allow_missing_baseline_is_forwarded_to_evaluation() {
+        let baseline = json!({}); // no /value
+        let current = json!({"value": 5.0});
+        let config = RatchetConfig {
+            rules: vec![make_rule("/value", Some(10.0), None, RuleLevel::Error)],
+            fail_fast: false,
+            allow_missing_baseline: true,
+            allow_missing_current: false,
+        };
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.errors, 0);
+    }
+
+    #[test]
+    fn allow_missing_current_is_forwarded_to_evaluation() {
+        let baseline = json!({"value": 5.0});
+        let current = json!({}); // no /value
+        let config = RatchetConfig {
+            rules: vec![make_rule("/value", Some(10.0), None, RuleLevel::Error)],
+            fail_fast: false,
+            allow_missing_baseline: false,
+            allow_missing_current: true,
+        };
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert!(result.passed);
+        assert_eq!(result.errors, 0);
+    }
+
+    #[test]
+    fn results_preserve_rule_order() {
+        let baseline = json!({"a": 10.0, "b": 10.0, "c": 10.0});
+        let current = json!({"a": 10.0, "b": 10.0, "c": 10.0});
+        let config = make_config(
+            vec![
+                make_rule("/a", Some(10.0), None, RuleLevel::Error),
+                make_rule("/b", Some(10.0), None, RuleLevel::Error),
+                make_rule("/c", Some(10.0), None, RuleLevel::Error),
+            ],
+            false,
+        );
+
+        let result = evaluate_ratchet_policy(&config, &baseline, &current);
+        assert_eq!(result.ratchet_results.len(), 3);
+        assert_eq!(result.ratchet_results[0].rule.pointer, "/a");
+        assert_eq!(result.ratchet_results[1].rule.pointer, "/b");
+        assert_eq!(result.ratchet_results[2].rule.pointer, "/c");
+    }
+}


### PR DESCRIPTION
## Summary

Adds focused unit tests to `tokmd-gate` for previously untested pure-policy modules. The crate had ~24 integration-test files but **zero `#[test]` markers inside `src/`** at the per-file level for the three target modules — this fills that gap for the smallest and most deterministic units.

### What's covered

- `ratchet/evaluate.rs` — rule evaluation pass/fail/warn branches, missing baseline/current handling under both strict and permissive modes, boundary conditions, max_value priority, zero-baseline edges
- `ratchet/policy.rs` — policy aggregation combinators (empty/all-pass/any-fail/mixed), fail_fast semantics (stop on error, continue past warn or pass), config option forwarding, result ordering
- `evaluate/compare.rs` — every comparator (gt/gte/lt/lte/eq/ne/in/contains) plus boundary/type-mismatch edges, EPSILON strictness, NaN-string handling, JSON-equality fallback for arrays/objects/null/bool

No behavior changes; tests only. No new dependencies.

## Test plan

- [x] `cargo test -p tokmd-gate --all-features` passes (155 lib tests, +~75 new)
- [x] `cargo clippy -p tokmd-gate --all-features --tests -- -D warnings` clean
- [x] `cargo fmt -p tokmd-gate -- --check` clean

https://claude.ai/code/session_015SadBwwvW3BQH28ZqerR1z

---
_Generated by [Claude Code](https://claude.ai/code/session_015SadBwwvW3BQH28ZqerR1z)_