### PR TITLE
test(tokmd-cockpit): unit-cover diff_coverage and change_surface

### DIFF
--- a/crates/tokmd-cockpit/src/change_surface.rs
+++ b/crates/tokmd-cockpit/src/change_surface.rs
@@ -106,3 +106,289 @@ pub(crate) fn compute_change_surface(
         change_concentration,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_stat(path: &str, insertions: usize, deletions: usize) -> FileStat {
+        FileStat {
+            path: path.to_string(),
+            insertions,
+            deletions,
+        }
+    }
+
+    /// Initialise a temp git repository with two commits so the change surface
+    /// helpers have a real range to walk. Returns the temp dir handle (which
+    /// owns the lifetime of the repository).
+    fn init_repo_with_two_commits(file_changes: &[(&str, &str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let run_git = |args: &[&str]| {
+            let status = tokmd_git::git_cmd()
+                .args(args)
+                .current_dir(dir.path())
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {:?} failed", args);
+        };
+
+        run_git(&["init", "-b", "main"]);
+        run_git(&["config", "user.email", "tokmd@example.com"]);
+        run_git(&["config", "user.name", "tokmd"]);
+        run_git(&["config", "commit.gpgsign", "false"]);
+
+        // Seed each file with its "base" content and commit.
+        for (path, base_content, _) in file_changes {
+            let full = dir.path().join(path);
+            if let Some(parent) = full.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&full, base_content).unwrap();
+        }
+        run_git(&["add", "."]);
+        run_git(&["commit", "-m", "base"]);
+
+        // Overwrite with "head" content and commit again. The commit must
+        // succeed even if no files actually changed (some tests pass identical
+        // base/head content to exercise the change-surface bookkeeping
+        // independently of the git diff), so use --allow-empty.
+        for (path, _, head_content) in file_changes {
+            std::fs::write(dir.path().join(path), head_content).unwrap();
+        }
+        run_git(&["add", "."]);
+        run_git(&["commit", "--allow-empty", "-m", "head"]);
+
+        dir
+    }
+
+    #[test]
+    fn compute_change_surface_empty_stats() {
+        let dir = init_repo_with_two_commits(&[("src/lib.rs", "fn a() {}\n", "fn a() {}\n")]);
+        let surface = compute_change_surface(
+            dir.path(),
+            "HEAD~1",
+            "HEAD",
+            &[],
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        assert_eq!(surface.files_changed, 0);
+        assert_eq!(surface.insertions, 0);
+        assert_eq!(surface.deletions, 0);
+        assert_eq!(surface.net_lines, 0);
+        // 0 changes / N commits is still 0.0.
+        assert_eq!(surface.churn_velocity, 0.0);
+        // No files -> no concentration to report.
+        assert_eq!(surface.change_concentration, 0.0);
+    }
+
+    #[test]
+    fn compute_change_surface_single_file_sums_and_averages() {
+        let dir = init_repo_with_two_commits(&[("src/lib.rs", "fn a() {}\n", "fn b() {}\n")]);
+        let stats = vec![make_stat("src/lib.rs", 10, 4)];
+
+        let surface = compute_change_surface(
+            dir.path(),
+            "HEAD~1",
+            "HEAD",
+            &stats,
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        assert_eq!(surface.commits, 1, "HEAD~1..HEAD spans one commit");
+        assert_eq!(surface.files_changed, 1);
+        assert_eq!(surface.insertions, 10);
+        assert_eq!(surface.deletions, 4);
+        assert_eq!(surface.net_lines, 6);
+        // 1 file: churn = (10 + 4) / 1 commit = 14.0; all changes are
+        // concentrated in the single file → 100%.
+        assert_eq!(surface.churn_velocity, 14.0);
+        assert_eq!(surface.change_concentration, 1.0);
+    }
+
+    #[test]
+    fn compute_change_surface_negative_net_lines() {
+        let dir = init_repo_with_two_commits(&[("src/lib.rs", "fn a() {}\n", "fn b() {}\n")]);
+        let stats = vec![make_stat("src/lib.rs", 3, 20)];
+
+        let surface = compute_change_surface(
+            dir.path(),
+            "HEAD~1",
+            "HEAD",
+            &stats,
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        assert_eq!(surface.insertions, 3);
+        assert_eq!(surface.deletions, 20);
+        assert_eq!(surface.net_lines, -17);
+    }
+
+    #[test]
+    fn compute_change_surface_concentration_in_top_files() {
+        // 5 files: top 20% = ceil(5 * 0.2) = 1 file. The largest file
+        // contributes 50/(50+10+5+3+2) = 50/70 of the changes.
+        let dir = init_repo_with_two_commits(&[("src/a.rs", "x\n", "x\n")]);
+        let stats = vec![
+            make_stat("src/a.rs", 30, 20), // 50
+            make_stat("src/b.rs", 5, 5),   // 10
+            make_stat("src/c.rs", 4, 1),   // 5
+            make_stat("src/d.rs", 2, 1),   // 3
+            make_stat("src/e.rs", 1, 1),   // 2
+        ];
+
+        let surface = compute_change_surface(
+            dir.path(),
+            "HEAD~1",
+            "HEAD",
+            &stats,
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        assert_eq!(surface.files_changed, 5);
+        let expected = 50.0_f64 / 70.0;
+        assert!(
+            (surface.change_concentration - expected).abs() < 1e-9,
+            "concentration {} should be ~{}",
+            surface.change_concentration,
+            expected
+        );
+    }
+
+    #[test]
+    fn compute_change_surface_handles_no_change_files() {
+        // file_stats reports two zero-line files: total_changes = 0, so
+        // change_concentration short-circuits to 0.0 without dividing.
+        let dir = init_repo_with_two_commits(&[("src/lib.rs", "x\n", "x\n")]);
+        let stats = vec![make_stat("a.rs", 0, 0), make_stat("b.rs", 0, 0)];
+
+        let surface = compute_change_surface(
+            dir.path(),
+            "HEAD~1",
+            "HEAD",
+            &stats,
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        assert_eq!(surface.files_changed, 2);
+        assert_eq!(surface.insertions, 0);
+        assert_eq!(surface.deletions, 0);
+        assert_eq!(surface.change_concentration, 0.0);
+        assert_eq!(surface.churn_velocity, 0.0);
+    }
+
+    #[test]
+    fn compute_change_surface_zero_commits_short_circuits_velocity() {
+        // HEAD..HEAD has zero commits, so the `commits > 0` guard must keep
+        // churn_velocity at 0.0 instead of triggering a division by zero.
+        let dir = init_repo_with_two_commits(&[("src/lib.rs", "x\n", "y\n")]);
+        let stats = vec![make_stat("src/lib.rs", 10, 5)];
+
+        let surface = compute_change_surface(
+            dir.path(),
+            "HEAD",
+            "HEAD",
+            &stats,
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        assert_eq!(surface.commits, 0);
+        assert_eq!(surface.insertions, 10);
+        assert_eq!(surface.deletions, 5);
+        assert_eq!(surface.churn_velocity, 0.0);
+    }
+
+    #[test]
+    fn get_file_stats_reports_per_file_numstat() {
+        let dir = init_repo_with_two_commits(&[
+            ("a.txt", "one\n", "one\ntwo\nthree\n"),
+            ("b.txt", "alpha\nbeta\ngamma\n", "alpha\n"),
+        ]);
+
+        let stats = get_file_stats(
+            dir.path(),
+            "HEAD~1",
+            "HEAD",
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        let a = stats
+            .iter()
+            .find(|s| s.path == "a.txt")
+            .expect("a.txt should appear in numstat");
+        let b = stats
+            .iter()
+            .find(|s| s.path == "b.txt")
+            .expect("b.txt should appear in numstat");
+
+        // a.txt: added two lines, deleted zero.
+        assert_eq!(a.insertions, 2);
+        assert_eq!(a.deletions, 0);
+        // b.txt: kept one of three lines.
+        assert_eq!(b.insertions, 0);
+        assert_eq!(b.deletions, 2);
+    }
+
+    #[test]
+    fn get_file_stats_invalid_range_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        // No git repo here: git diff must fail and bubble up an Err.
+        let err = get_file_stats(
+            dir.path(),
+            "main",
+            "feature",
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("git"),
+            "expected error to mention git, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn get_file_stats_empty_diff_returns_empty_vec() {
+        // Same commit on both sides → no numstat output → empty Vec.
+        let dir = init_repo_with_two_commits(&[("src/lib.rs", "x\n", "y\n")]);
+        let stats =
+            get_file_stats(dir.path(), "HEAD", "HEAD", tokmd_git::GitRangeMode::TwoDot).unwrap();
+        assert!(stats.is_empty());
+    }
+
+    #[test]
+    fn change_surface_top_count_ceiling_picks_at_least_one() {
+        // 3 files: ceil(3 * 0.2) = 1, the largest contributes 100/(100+1+1).
+        let dir = init_repo_with_two_commits(&[("src/lib.rs", "x\n", "y\n")]);
+        let stats = vec![
+            make_stat("big.rs", 60, 40),
+            make_stat("tiny_a.rs", 1, 0),
+            make_stat("tiny_b.rs", 0, 1),
+        ];
+
+        let surface = compute_change_surface(
+            dir.path(),
+            "HEAD~1",
+            "HEAD",
+            &stats,
+            tokmd_git::GitRangeMode::TwoDot,
+        )
+        .unwrap();
+
+        let expected = 100.0_f64 / 102.0;
+        assert!(
+            (surface.change_concentration - expected).abs() < 1e-9,
+            "concentration {} should be ~{}",
+            surface.change_concentration,
+            expected
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline unit tests to `tokmd-cockpit` for the `change_surface` module, which had **0 inline unit tests** despite being a core piece of cockpit metrics computation.

When I read the task plan it nominated five files in priority order. Four of them (`gates/diff_coverage/intersect.rs`, `gates/diff_coverage/lcov.rs`, `gates/diff_coverage/artifact.rs`, `gates/diff_coverage/mod.rs`) already received inline `#[cfg(test)] mod tests` blocks in the refactor that landed as #2297 and follow-up cockpit test PRs (#2302, #2304, #2305). Their existing tests already cover the edge cases enumerated in the plan (empty/identical/partial-overlap/disjoint/single-line hunks, multi-DA records, malformed lines, non-LCOV short-circuit, etc.), so adding more there would only duplicate coverage. I deliberately left those files untouched and concentrated effort where the gap actually is.

### What's covered

`crates/tokmd-cockpit/src/change_surface.rs` — 10 inline tests covering both public helpers:

- `compute_change_surface` — empty stats, single file, negative `net_lines`, change-concentration with top-20% ceiling (5-file and 3-file cases that exercise `ceil(N * 0.2)`), zero-changes short-circuit on the concentration divisor, `HEAD..HEAD` zero-commits short-circuit on `churn_velocity`.
- `get_file_stats` — per-file numstat happy path, invalid range bubbling an `Err` (no git repo), and an empty diff returning an empty `Vec`.

Tests use a shared `init_repo_with_two_commits` helper that spins up a temp git repo (same pattern as the existing `diff_coverage_gate_flushes_unterminated_final_lcov_record` test in `gates/diff_coverage/mod.rs`), with `commit.gpgsign=false` for host-independence and `--allow-empty` on the head commit so test scenarios that don't need to vary file contents still get a valid two-commit range.

### Notes for reviewers

- No behavior changes — tests only. The signature and visibility of `compute_change_surface` / `get_file_stats` are unchanged; the inline test module just sits at the bottom of `change_surface.rs`.
- Files covered under PR #2299 (`determinism_gate.rs`, `proof_evidence/model.rs`) are deliberately left alone per the task scope.
- An unrelated pre-existing integration test, `tests/git_env_boundaries.rs::get_file_stats_ignores_inherited_git_env_overrides`, fails on this host in the same way it fails on `main` (git refusing the base commit, likely a host gpgsign default). Not touched here; flagging it for follow-up.

## Test plan

- [x] `cargo test -p tokmd-cockpit --all-features --lib` — 108 passed (10 new, 98 prior)
- [x] `cargo clippy -p tokmd-cockpit --all-features --tests -- -D warnings` — clean
- [x] `cargo fmt -p tokmd-cockpit -- --check` — clean

https://claude.ai/code/session_015SadBwwvW3BQH28ZqerR1z

---
_Generated by [Claude Code](https://claude.ai/code/session_015SadBwwvW3BQH28ZqerR1z)_