### PR TITLE
docs: refresh proof status specs

### DIFF
--- a/docs/plans/proof-artifact-check-receipts.md
+++ b/docs/plans/proof-artifact-check-receipts.md
@@ -3,7 +3,7 @@
 - Status: complete
 - Related proposal:
 - Related spec: `docs/ci/proof-observation-artifacts.md`
-- Related ADR: `docs/adr/0009-proof-observation-decision.md`
+- Related ADR: `docs/adr/0009-proof-observation-promotion-boundary.md`
 - Related issues:
 
 ## Goal

--- a/docs/specs/proof-observation-decision-packet.md
+++ b/docs/specs/proof-observation-decision-packet.md
@@ -1,16 +1,16 @@
 # Spec: Proof Observation Decision Packet
 
-- Status: draft
+- Status: active
 - Schema family, if any: `tokmd.proof_observation_decision.v1`;
   verifier receipt `tokmd.proof_observation_decision_check.v1`
-- Related ADRs:
+- Related ADRs: `docs/adr/0009-proof-observation-promotion-boundary.md`
 - Related proof scopes: `proof_control_plane`, `project_truth_docs`
 
 ## Contract
 
-A proof observation decision packet is a future advisory summary artifact for
-maintainers deciding whether proof observations are ready for promotion,
-continued observation, rollback, or simplification.
+A proof observation decision packet is an advisory summary artifact for
+maintainers deciding whether proof observations support promotion, continued
+observation, rollback, or simplification.
 
 The packet must aggregate existing Rust-owned proof receipts. It must not run
 proof commands, upload coverage, change required gates, enable default Codecov
@@ -63,7 +63,7 @@ source references. The packet should not require network access, GitHub API
 access, hidden workflow state, timestamps, absolute local paths, or downloaded
 artifact directories that are not named by the caller.
 
-The first implementation is developer tooling under `cargo xtask`. It accepts
+The implementation is developer tooling under `cargo xtask`. It accepts
 explicit source artifacts instead of discovering hidden workflow state:
 
 ```bash
@@ -144,7 +144,7 @@ receipts. Existing outputs remain authoritative for their own domains:
 The decision packet is an aggregate. Consumers must be able to ignore it and
 keep using the source artifacts directly.
 
-The first implementation should stay in `xtask`. It must not add a public
+The implementation stays in `xtask`. It must not add a public
 `tokmd review` command, change `tokmd cockpit`, change `tokmd handoff`, enable
 default Codecov upload, or make advisory evidence required. Cockpit or handoff
 integration may come later only when the decision packet and its verifier
@@ -152,7 +152,7 @@ receipt are supplied as explicit evidence handles.
 
 ## Proof Requirements
 
-For this draft spec, validation is documentation-control proof:
+For spec-only changes, validation is documentation-control proof:
 
 ```bash
 cargo xtask doc-artifacts --check
@@ -164,8 +164,8 @@ cargo fmt-check
 git diff --check
 ```
 
-If a Rust-owned command is added later, the implementation PR should also add
-focused `xtask` tests covering:
+Implementation changes to the Rust-owned command should also include focused
+`xtask` tests covering:
 
 - valid aggregate output from minimal source artifacts;
 - missing optional evidence reported as missing or unavailable, not passing;
@@ -186,10 +186,11 @@ The verifier should also cover both success and failure fixtures:
 
 ## Open Questions
 
-- Whether the first implementation should accept many explicit input flags or a
-  single observations directory plus named source artifacts.
+- Whether a future convenience mode should accept a single observations
+  directory plus named source artifacts in addition to the current explicit
+  input flags.
 - Whether required proof-run observations and executor observations should share
-  one freshness classifier in the first implementation.
+  one freshness classifier in a future revision.
 - Whether readiness should be expressed only as `criteria_met` /
   `criteria_missing`, or whether a small `state` enum such as
   `observe`, `needs_more_data`, and `ready_for_maintainer_review` is useful.

--- a/docs/specs/proof-workflow-status.md
+++ b/docs/specs/proof-workflow-status.md
@@ -1,6 +1,6 @@
 # Spec: Proof Workflow Status
 
-- Status: draft
+- Status: active
 - Schema family, if any: `tokmd.proof_workflow_status.v1`;
   verifier receipt `tokmd.proof_workflow_status_check.v1`
 - Related ADRs:
@@ -8,7 +8,7 @@
 
 ## Contract
 
-A proof workflow status packet is a future developer/CI-facing receipt that
+A proof workflow status packet is a developer/CI-facing receipt that
 summarizes status arbitration for existing proof workflows. It consumes
 already-generated proof artifacts and explicit command exit codes, then emits a
 small JSON receipt, optional Markdown summary, and workflow-friendly final exit
@@ -24,7 +24,7 @@ The first consumers are GitHub Actions workflow steps:
 - `.github/workflows/ci.yml` `fast-proof-run`;
 - `.github/workflows/proof-executor.yml` `scoped-coverage-executor`.
 
-The first producer should be `cargo xtask`, not the public `tokmd` CLI. The
+The producer is `cargo xtask`, not the public `tokmd` CLI. The
 workflow remains responsible for runner setup, cache, tool installation,
 artifact upload, and service integration. The Rust-owned packet owns only:
 
@@ -37,7 +37,7 @@ artifact upload, and service integration. The Rust-owned packet owns only:
 
 ## Inputs
 
-The status command should accept explicit inputs. It should not discover hidden
+The status command accepts explicit inputs. It must not discover hidden
 state from the filesystem, workflow environment, GitHub APIs, timestamps, or
 downloaded artifact directories.
 
@@ -133,8 +133,8 @@ consistent. It does not mean proof should be promoted, coverage should upload,
 or a PR should merge.
 
 `recommended_exit_code` mirrors the current workflow shell behavior. For the
-first implementation, any non-zero blocking command status should produce the
-first non-zero status in current workflow priority order. That keeps the
+current implementation, any non-zero blocking command status should produce
+the first non-zero status in current workflow priority order. That keeps the
 workflow behavior compatible while moving arbitration into a testable Rust
 surface.
 
@@ -177,8 +177,8 @@ remain authoritative for their own domains:
 - observations own compact evidence for later aggregation;
 - `ci/proof.toml` owns policy.
 
-The first implementation must preserve current workflow artifact names,
-summary wording, and exit behavior unless the PR explicitly documents a
+The implementation must preserve current workflow artifact names, summary
+wording, and exit behavior unless the PR explicitly documents a
 behavior-compatible rewrite. Consumers must be able to ignore the status packet
 and keep reading the source artifacts.
 
@@ -188,7 +188,7 @@ Codecov upload, and does not make advisory evidence required.
 
 ## Proof Requirements
 
-For this draft spec, validation is documentation-control proof:
+For spec-only changes, validation is documentation-control proof:
 
 ```bash
 cargo xtask doc-artifacts --check
@@ -200,8 +200,8 @@ cargo fmt-check
 git diff --check
 ```
 
-When the Rust command is added, implementation proof should include focused
-`xtask` tests for:
+Implementation proof for the Rust command should include focused `xtask` tests
+for:
 
 - valid fast proof-run packet output;
 - valid scoped coverage executor packet output;
@@ -224,14 +224,14 @@ Workflow integration proof should also cover:
 
 ## Open Questions
 
-- Whether the first command should support both workflow kinds immediately or
-  land fast proof-run first with the enum already reserved.
-- Whether verifier output should land in the same PR as the generator or as a
-  separate slice.
+- Whether future proof workflow kinds should reuse this packet shape or get a
+  separate status family.
+- Whether future verifier fields should include deeper source-artifact
+  cross-checks beyond the current packet-level consistency checks.
 - Whether the env output should include a rendered `status` string in addition
   to `recommended_exit_code`.
-- Whether source artifact schema validation should parse only top-level schema
-  fields in the first implementation or delegate to existing verifiers when
-  their receipts are supplied.
+- Whether future source artifact schema validation should parse deeper than
+  top-level schema fields or delegate to existing verifiers when their receipts
+  are supplied.
 - Whether the Markdown summary should preserve exact current wording or use a
   new compact summary after the first behavior-compatible migration.


### PR DESCRIPTION
## Summary
- mark proof-observation decision and proof-workflow status specs as active now that their `xtask` generators/checkers are live
- refresh future-only wording so open questions describe future revisions, not already-shipped first implementations
- fix the proof artifact receipt plan's ADR link to ADR-0009's actual filename

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-proof-spec-status-refresh.json` (3 changed files, 2 scopes, 0 unknown)
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-proof-spec-status-refresh.json --evidence-json target/proof/proof-evidence-proof-spec-status-refresh.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --proof-run-summary target/proof/proof-run-summary-proof-spec-status-refresh.json` (5 required commands executed, 5 passed)