### PR TITLE
test(tokmd-types): add serde roundtrip + invariant unit tests

### DIFF
--- a/crates/tokmd-types/src/cockpit/evidence.rs
+++ b/crates/tokmd-types/src/cockpit/evidence.rs
@@ -239,3 +239,593 @@ pub struct HighComplexityFile {
     /// Maximum function length in lines.
     pub max_function_length: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_scope() -> ScopeCoverage {
+        ScopeCoverage {
+            relevant: vec!["src/a.rs".into(), "src/b.rs".into()],
+            tested: vec!["src/a.rs".into()],
+            ratio: 0.5,
+            lines_relevant: Some(100),
+            lines_tested: Some(50),
+        }
+    }
+
+    fn sample_meta() -> GateMeta {
+        GateMeta {
+            status: GateStatus::Pass,
+            source: EvidenceSource::CiArtifact,
+            commit_match: CommitMatch::Exact,
+            scope: sample_scope(),
+            evidence_commit: Some("abc123".into()),
+            evidence_generated_at_ms: Some(1_700_000_000_000),
+        }
+    }
+
+    fn sample_mutation_gate() -> MutationGate {
+        MutationGate {
+            meta: sample_meta(),
+            survivors: vec![MutationSurvivor {
+                file: "src/a.rs".into(),
+                line: 42,
+                mutation: "replace + with -".into(),
+            }],
+            killed: 10,
+            timeout: 1,
+            unviable: 2,
+        }
+    }
+
+    // ── Enum stability + roundtrips ─────────────────────────────────
+    #[test]
+    fn gate_status_uses_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&GateStatus::Pass).unwrap(),
+            "\"pass\""
+        );
+        assert_eq!(
+            serde_json::to_string(&GateStatus::Skipped).unwrap(),
+            "\"skipped\""
+        );
+        assert_eq!(
+            serde_json::to_string(&GateStatus::Pending).unwrap(),
+            "\"pending\""
+        );
+    }
+
+    #[test]
+    fn gate_status_all_variants_roundtrip() {
+        for variant in [
+            GateStatus::Pass,
+            GateStatus::Warn,
+            GateStatus::Fail,
+            GateStatus::Skipped,
+            GateStatus::Pending,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: GateStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn evidence_source_uses_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&EvidenceSource::CiArtifact).unwrap(),
+            "\"ci_artifact\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EvidenceSource::RanLocal).unwrap(),
+            "\"ran_local\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EvidenceSource::Cached).unwrap(),
+            "\"cached\""
+        );
+    }
+
+    #[test]
+    fn evidence_source_all_variants_roundtrip() {
+        for variant in [
+            EvidenceSource::CiArtifact,
+            EvidenceSource::Cached,
+            EvidenceSource::RanLocal,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: EvidenceSource = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn commit_match_uses_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&CommitMatch::Exact).unwrap(),
+            "\"exact\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CommitMatch::Stale).unwrap(),
+            "\"stale\""
+        );
+    }
+
+    #[test]
+    fn commit_match_all_variants_roundtrip() {
+        for variant in [
+            CommitMatch::Exact,
+            CommitMatch::Partial,
+            CommitMatch::Stale,
+            CommitMatch::Unknown,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: CommitMatch = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    // ── ScopeCoverage ───────────────────────────────────────────────
+    #[test]
+    fn scope_coverage_serde_roundtrip() {
+        let s = sample_scope();
+        let json = serde_json::to_string(&s).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in ["relevant", "tested", "ratio"] {
+            assert!(value.get(key).is_some(), "missing key `{key}`");
+        }
+        assert_eq!(value["lines_relevant"], 100);
+        assert_eq!(value["lines_tested"], 50);
+    }
+
+    #[test]
+    fn scope_coverage_omits_optional_line_fields_when_none() {
+        let s = ScopeCoverage {
+            relevant: vec![],
+            tested: vec![],
+            ratio: 0.0,
+            lines_relevant: None,
+            lines_tested: None,
+        };
+        let value = serde_json::to_value(&s).unwrap();
+        assert!(value.get("lines_relevant").is_none());
+        assert!(value.get("lines_tested").is_none());
+    }
+
+    #[test]
+    fn scope_coverage_preserves_file_order() {
+        let s = ScopeCoverage {
+            relevant: vec!["c".into(), "a".into(), "b".into()],
+            tested: vec!["z".into(), "y".into()],
+            ratio: 0.5,
+            lines_relevant: None,
+            lines_tested: None,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: ScopeCoverage = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.relevant, vec!["c", "a", "b"]);
+        assert_eq!(back.tested, vec!["z", "y"]);
+    }
+
+    // ── GateMeta ────────────────────────────────────────────────────
+    #[test]
+    fn gate_meta_with_evidence_metadata_roundtrip() {
+        let m = sample_meta();
+        let json = serde_json::to_string(&m).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in [
+            "status",
+            "source",
+            "commit_match",
+            "scope",
+            "evidence_commit",
+            "evidence_generated_at_ms",
+        ] {
+            assert!(value.get(key).is_some(), "missing key `{key}` in GateMeta");
+        }
+        assert_eq!(value["evidence_commit"], "abc123");
+    }
+
+    #[test]
+    fn gate_meta_without_optional_metadata_omits_keys() {
+        let m = GateMeta {
+            status: GateStatus::Warn,
+            source: EvidenceSource::RanLocal,
+            commit_match: CommitMatch::Unknown,
+            scope: sample_scope(),
+            evidence_commit: None,
+            evidence_generated_at_ms: None,
+        };
+        let value = serde_json::to_value(&m).unwrap();
+        assert!(value.get("evidence_commit").is_none());
+        assert!(value.get("evidence_generated_at_ms").is_none());
+    }
+
+    // ── MutationGate ────────────────────────────────────────────────
+    #[test]
+    fn mutation_gate_flattens_meta_fields() {
+        let m = sample_mutation_gate();
+        let value = serde_json::to_value(&m).unwrap();
+        // GateMeta fields are flattened into the gate JSON
+        for key in ["status", "source", "commit_match", "scope"] {
+            assert!(
+                value.get(key).is_some(),
+                "missing flattened meta key `{key}`"
+            );
+        }
+        // Mutation-specific fields
+        for key in ["survivors", "killed", "timeout", "unviable"] {
+            assert!(
+                value.get(key).is_some(),
+                "missing mutation gate key `{key}`"
+            );
+        }
+        let json = value.to_string();
+        let back: MutationGate = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.killed, 10);
+        assert_eq!(back.survivors.len(), 1);
+        assert_eq!(back.survivors[0].line, 42);
+    }
+
+    #[test]
+    fn mutation_survivor_field_names_stable() {
+        let s = MutationSurvivor {
+            file: "src/x.rs".into(),
+            line: 1,
+            mutation: "swap".into(),
+        };
+        let value = serde_json::to_value(&s).unwrap();
+        for key in ["file", "line", "mutation"] {
+            assert!(value.get(key).is_some());
+        }
+        let json = serde_json::to_string(&s).unwrap();
+        let back: MutationSurvivor = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.file, "src/x.rs");
+        assert_eq!(back.line, 1);
+    }
+
+    // ── DiffCoverageGate ────────────────────────────────────────────
+    #[test]
+    fn diff_coverage_gate_flattens_meta() {
+        let g = DiffCoverageGate {
+            meta: sample_meta(),
+            lines_added: 100,
+            lines_covered: 70,
+            coverage_pct: 0.7,
+            uncovered_hunks: vec![UncoveredHunk {
+                file: "src/x.rs".into(),
+                start_line: 10,
+                end_line: 20,
+            }],
+        };
+        let value = serde_json::to_value(&g).unwrap();
+        assert!(value.get("status").is_some());
+        assert!(value.get("lines_added").is_some());
+        assert!(value.get("coverage_pct").is_some());
+        assert!(value.get("uncovered_hunks").is_some());
+        let back: DiffCoverageGate = serde_json::from_value(value).unwrap();
+        assert_eq!(back.lines_added, 100);
+        assert_eq!(back.uncovered_hunks[0].start_line, 10);
+        assert_eq!(back.uncovered_hunks[0].end_line, 20);
+    }
+
+    #[test]
+    fn uncovered_hunk_roundtrip() {
+        let h = UncoveredHunk {
+            file: "f".into(),
+            start_line: 5,
+            end_line: 7,
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        let back: UncoveredHunk = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.file, "f");
+        assert_eq!(back.start_line, 5);
+        assert_eq!(back.end_line, 7);
+    }
+
+    // ── ContractDiffGate + sub-gates ────────────────────────────────
+    #[test]
+    fn contract_diff_gate_with_all_sub_gates_present() {
+        let g = ContractDiffGate {
+            meta: sample_meta(),
+            semver: Some(SemverSubGate {
+                status: GateStatus::Fail,
+                breaking_changes: vec![BreakingChange {
+                    kind: "removal".into(),
+                    path: "foo::bar".into(),
+                    message: "function removed".into(),
+                }],
+            }),
+            cli: Some(CliSubGate {
+                status: GateStatus::Pass,
+                diff_summary: Some("no change".into()),
+            }),
+            schema: Some(SchemaSubGate {
+                status: GateStatus::Pass,
+                diff_summary: None,
+            }),
+            failures: 1,
+        };
+        let value = serde_json::to_value(&g).unwrap();
+        assert!(value.get("semver").is_some());
+        assert!(value.get("cli").is_some());
+        assert!(value.get("schema").is_some());
+        assert_eq!(value["failures"], 1);
+        // Flattened meta
+        assert!(value.get("status").is_some());
+        let back: ContractDiffGate = serde_json::from_value(value).unwrap();
+        assert_eq!(back.failures, 1);
+        let semver = back.semver.expect("semver present");
+        assert_eq!(semver.status, GateStatus::Fail);
+        assert_eq!(semver.breaking_changes[0].kind, "removal");
+    }
+
+    #[test]
+    fn contract_diff_gate_with_no_sub_gates_omits_them() {
+        let g = ContractDiffGate {
+            meta: sample_meta(),
+            semver: None,
+            cli: None,
+            schema: None,
+            failures: 0,
+        };
+        let value = serde_json::to_value(&g).unwrap();
+        assert!(value.get("semver").is_none());
+        assert!(value.get("cli").is_none());
+        assert!(value.get("schema").is_none());
+    }
+
+    #[test]
+    fn breaking_change_field_names_stable() {
+        let b = BreakingChange {
+            kind: "rename".into(),
+            path: "x::y".into(),
+            message: "x renamed".into(),
+        };
+        let value = serde_json::to_value(&b).unwrap();
+        for key in ["kind", "path", "message"] {
+            assert!(value.get(key).is_some());
+        }
+    }
+
+    // ── SupplyChainGate ─────────────────────────────────────────────
+    #[test]
+    fn supply_chain_gate_roundtrip() {
+        let g = SupplyChainGate {
+            meta: sample_meta(),
+            vulnerabilities: vec![Vulnerability {
+                id: "CVE-2025-1".into(),
+                package: "libfoo".into(),
+                severity: "high".into(),
+                title: "use after free".into(),
+            }],
+            denied: vec!["GPL-3.0".into()],
+            advisory_db_version: Some("2025-05-01".into()),
+        };
+        let json = serde_json::to_string(&g).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["vulnerabilities"][0]["id"], "CVE-2025-1");
+        assert_eq!(value["denied"][0], "GPL-3.0");
+        assert_eq!(value["advisory_db_version"], "2025-05-01");
+        let back: SupplyChainGate = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.vulnerabilities.len(), 1);
+        assert_eq!(back.denied, vec!["GPL-3.0".to_string()]);
+    }
+
+    #[test]
+    fn supply_chain_gate_omits_advisory_db_when_none() {
+        let g = SupplyChainGate {
+            meta: sample_meta(),
+            vulnerabilities: vec![],
+            denied: vec![],
+            advisory_db_version: None,
+        };
+        let value = serde_json::to_value(&g).unwrap();
+        assert!(value.get("advisory_db_version").is_none());
+    }
+
+    // ── DeterminismGate ─────────────────────────────────────────────
+    #[test]
+    fn determinism_gate_roundtrip_with_hashes() {
+        let g = DeterminismGate {
+            meta: sample_meta(),
+            expected_hash: Some("aaaa".into()),
+            actual_hash: Some("bbbb".into()),
+            algo: "sha256".into(),
+            differences: vec!["file1.txt: bytes differ".into()],
+        };
+        let json = serde_json::to_string(&g).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["expected_hash"], "aaaa");
+        assert_eq!(value["actual_hash"], "bbbb");
+        assert_eq!(value["algo"], "sha256");
+        let back: DeterminismGate = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.expected_hash.as_deref(), Some("aaaa"));
+        assert_eq!(back.differences.len(), 1);
+    }
+
+    #[test]
+    fn determinism_gate_omits_hashes_when_none() {
+        let g = DeterminismGate {
+            meta: sample_meta(),
+            expected_hash: None,
+            actual_hash: None,
+            algo: "blake3".into(),
+            differences: vec![],
+        };
+        let value = serde_json::to_value(&g).unwrap();
+        assert!(value.get("expected_hash").is_none());
+        assert!(value.get("actual_hash").is_none());
+        assert_eq!(value["algo"], "blake3");
+    }
+
+    // ── ComplexityGate ──────────────────────────────────────────────
+    #[test]
+    fn complexity_gate_roundtrip() {
+        let g = ComplexityGate {
+            meta: sample_meta(),
+            files_analyzed: 25,
+            high_complexity_files: vec![HighComplexityFile {
+                path: "src/big.rs".into(),
+                cyclomatic: 35,
+                function_count: 12,
+                max_function_length: 250,
+            }],
+            avg_cyclomatic: 6.5,
+            max_cyclomatic: 35,
+            threshold_exceeded: true,
+        };
+        let json = serde_json::to_string(&g).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in [
+            "files_analyzed",
+            "high_complexity_files",
+            "avg_cyclomatic",
+            "max_cyclomatic",
+            "threshold_exceeded",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in ComplexityGate"
+            );
+        }
+        let back: ComplexityGate = serde_json::from_str(&json).unwrap();
+        assert!(back.threshold_exceeded);
+        assert_eq!(back.high_complexity_files[0].cyclomatic, 35);
+        assert_eq!(back.high_complexity_files[0].max_function_length, 250);
+    }
+
+    #[test]
+    fn high_complexity_file_field_names_stable() {
+        let f = HighComplexityFile {
+            path: "p".into(),
+            cyclomatic: 1,
+            function_count: 2,
+            max_function_length: 3,
+        };
+        let value = serde_json::to_value(&f).unwrap();
+        for key in [
+            "path",
+            "cyclomatic",
+            "function_count",
+            "max_function_length",
+        ] {
+            assert!(value.get(key).is_some());
+        }
+    }
+
+    // ── Evidence (top-level) ────────────────────────────────────────
+    #[test]
+    fn evidence_only_mutation_required() {
+        let e = Evidence {
+            overall_status: GateStatus::Pass,
+            mutation: sample_mutation_gate(),
+            diff_coverage: None,
+            contracts: None,
+            supply_chain: None,
+            determinism: None,
+            complexity: None,
+        };
+        let value = serde_json::to_value(&e).unwrap();
+        // mutation is always present
+        assert!(value.get("mutation").is_some());
+        assert!(value.get("overall_status").is_some());
+        // Other optional gates are omitted when None
+        assert!(value.get("diff_coverage").is_none());
+        assert!(value.get("contracts").is_none());
+        assert!(value.get("supply_chain").is_none());
+        assert!(value.get("determinism").is_none());
+        assert!(value.get("complexity").is_none());
+        let back: Evidence = serde_json::from_value(value).unwrap();
+        assert_eq!(back.overall_status, GateStatus::Pass);
+        assert_eq!(back.mutation.killed, 10);
+    }
+
+    #[test]
+    fn evidence_with_all_gates_serde_roundtrip() {
+        let e = Evidence {
+            overall_status: GateStatus::Fail,
+            mutation: sample_mutation_gate(),
+            diff_coverage: Some(DiffCoverageGate {
+                meta: sample_meta(),
+                lines_added: 1,
+                lines_covered: 1,
+                coverage_pct: 1.0,
+                uncovered_hunks: vec![],
+            }),
+            contracts: Some(ContractDiffGate {
+                meta: sample_meta(),
+                semver: None,
+                cli: None,
+                schema: None,
+                failures: 0,
+            }),
+            supply_chain: Some(SupplyChainGate {
+                meta: sample_meta(),
+                vulnerabilities: vec![],
+                denied: vec![],
+                advisory_db_version: None,
+            }),
+            determinism: Some(DeterminismGate {
+                meta: sample_meta(),
+                expected_hash: None,
+                actual_hash: None,
+                algo: "sha256".into(),
+                differences: vec![],
+            }),
+            complexity: Some(ComplexityGate {
+                meta: sample_meta(),
+                files_analyzed: 0,
+                high_complexity_files: vec![],
+                avg_cyclomatic: 0.0,
+                max_cyclomatic: 0,
+                threshold_exceeded: false,
+            }),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let back: Evidence = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.overall_status, GateStatus::Fail);
+        assert!(back.diff_coverage.is_some());
+        assert!(back.contracts.is_some());
+        assert!(back.supply_chain.is_some());
+        assert!(back.determinism.is_some());
+        assert!(back.complexity.is_some());
+    }
+
+    #[test]
+    fn semver_sub_gate_with_status_only() {
+        let s = SemverSubGate {
+            status: GateStatus::Pass,
+            breaking_changes: vec![],
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: SemverSubGate = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.status, GateStatus::Pass);
+        assert!(back.breaking_changes.is_empty());
+    }
+
+    #[test]
+    fn cli_sub_gate_with_diff_summary_none_still_emits_null() {
+        // CliSubGate does not have skip_serializing_if on diff_summary
+        let s = CliSubGate {
+            status: GateStatus::Skipped,
+            diff_summary: None,
+        };
+        let value = serde_json::to_value(&s).unwrap();
+        assert!(value.get("diff_summary").is_some());
+        assert!(value["diff_summary"].is_null());
+    }
+
+    #[test]
+    fn schema_sub_gate_serde_roundtrip() {
+        let s = SchemaSubGate {
+            status: GateStatus::Warn,
+            diff_summary: Some("schema changed".into()),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: SchemaSubGate = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.status, GateStatus::Warn);
+        assert_eq!(back.diff_summary.as_deref(), Some("schema changed"));
+    }
+}

--- a/crates/tokmd-types/src/context.rs
+++ b/crates/tokmd-types/src/context.rs
@@ -462,3 +462,716 @@ pub struct ArtifactHash {
     pub algo: String,
     pub hash: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_tool() -> ToolInfo {
+        ToolInfo {
+            name: "tokmd".into(),
+            version: "1.0.0".into(),
+        }
+    }
+
+    fn sample_context_file_row() -> ContextFileRow {
+        ContextFileRow {
+            path: "src/main.rs".into(),
+            module: "src".into(),
+            lang: "Rust".into(),
+            tokens: 100,
+            code: 50,
+            lines: 65,
+            bytes: 2_000,
+            value: 75,
+            rank_reason: String::new(),
+            policy: InclusionPolicy::Full,
+            effective_tokens: None,
+            policy_reason: None,
+            classifications: vec![],
+        }
+    }
+
+    // ── Schema version constants ────────────────────────────────────
+    #[test]
+    fn handoff_schema_version_constant() {
+        assert_eq!(HANDOFF_SCHEMA_VERSION, 5);
+    }
+
+    #[test]
+    fn context_bundle_schema_version_constant() {
+        assert_eq!(CONTEXT_BUNDLE_SCHEMA_VERSION, 2);
+    }
+
+    #[test]
+    fn context_schema_version_constant() {
+        assert_eq!(CONTEXT_SCHEMA_VERSION, 4);
+    }
+
+    // ── ContextReceipt ──────────────────────────────────────────────
+    #[test]
+    fn context_receipt_serde_roundtrip_minimal() {
+        let receipt = ContextReceipt {
+            schema_version: CONTEXT_SCHEMA_VERSION,
+            generated_at_ms: 1_700_000_000_000,
+            tool: sample_tool(),
+            mode: "context".into(),
+            budget_tokens: 8_000,
+            used_tokens: 4_000,
+            utilization_pct: 50.0,
+            strategy: "value-greedy".into(),
+            rank_by: "value".into(),
+            file_count: 1,
+            files: vec![sample_context_file_row()],
+            rank_by_effective: None,
+            fallback_reason: None,
+            excluded_by_policy: vec![],
+            token_estimation: None,
+            bundle_audit: None,
+        };
+        let json = serde_json::to_string(&receipt).unwrap();
+        let back: ContextReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.schema_version, CONTEXT_SCHEMA_VERSION);
+        assert_eq!(back.mode, "context");
+        assert_eq!(back.files.len(), 1);
+        assert_eq!(back.budget_tokens, 8_000);
+    }
+
+    #[test]
+    fn context_receipt_omits_optional_when_empty_or_none() {
+        let receipt = ContextReceipt {
+            schema_version: CONTEXT_SCHEMA_VERSION,
+            generated_at_ms: 0,
+            tool: sample_tool(),
+            mode: "context".into(),
+            budget_tokens: 0,
+            used_tokens: 0,
+            utilization_pct: 0.0,
+            strategy: String::new(),
+            rank_by: String::new(),
+            file_count: 0,
+            files: vec![],
+            rank_by_effective: None,
+            fallback_reason: None,
+            excluded_by_policy: vec![],
+            token_estimation: None,
+            bundle_audit: None,
+        };
+        let value = serde_json::to_value(&receipt).unwrap();
+        assert!(value.get("rank_by_effective").is_none());
+        assert!(value.get("fallback_reason").is_none());
+        assert!(value.get("excluded_by_policy").is_none());
+        assert!(value.get("token_estimation").is_none());
+        assert!(value.get("bundle_audit").is_none());
+    }
+
+    #[test]
+    fn context_receipt_field_names_stable() {
+        let receipt = ContextReceipt {
+            schema_version: CONTEXT_SCHEMA_VERSION,
+            generated_at_ms: 0,
+            tool: sample_tool(),
+            mode: "context".into(),
+            budget_tokens: 100,
+            used_tokens: 50,
+            utilization_pct: 0.5,
+            strategy: "s".into(),
+            rank_by: "r".into(),
+            file_count: 0,
+            files: vec![],
+            rank_by_effective: None,
+            fallback_reason: None,
+            excluded_by_policy: vec![],
+            token_estimation: None,
+            bundle_audit: None,
+        };
+        let value = serde_json::to_value(&receipt).unwrap();
+        for key in [
+            "schema_version",
+            "generated_at_ms",
+            "tool",
+            "mode",
+            "budget_tokens",
+            "used_tokens",
+            "utilization_pct",
+            "strategy",
+            "rank_by",
+            "file_count",
+            "files",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in ContextReceipt"
+            );
+        }
+    }
+
+    // ── ContextFileRow ──────────────────────────────────────────────
+    #[test]
+    fn context_file_row_omits_default_policy() {
+        let row = sample_context_file_row();
+        let value = serde_json::to_value(&row).unwrap();
+        assert!(value.get("policy").is_none());
+        assert!(value.get("rank_reason").is_none());
+        assert!(value.get("effective_tokens").is_none());
+        assert!(value.get("policy_reason").is_none());
+        assert!(value.get("classifications").is_none());
+    }
+
+    #[test]
+    fn context_file_row_keeps_non_default_fields() {
+        let row = ContextFileRow {
+            policy: InclusionPolicy::HeadTail,
+            effective_tokens: Some(40),
+            policy_reason: Some("budget".into()),
+            rank_reason: "high churn".into(),
+            classifications: vec![FileClassification::Generated],
+            ..sample_context_file_row()
+        };
+        let value = serde_json::to_value(&row).unwrap();
+        assert_eq!(value["policy"], "head_tail");
+        assert_eq!(value["effective_tokens"], 40);
+        assert_eq!(value["policy_reason"], "budget");
+        assert_eq!(value["rank_reason"], "high churn");
+        assert_eq!(value["classifications"][0], "generated");
+    }
+
+    #[test]
+    fn context_file_row_serde_roundtrip() {
+        let row = sample_context_file_row();
+        let json = serde_json::to_string(&row).unwrap();
+        let back: ContextFileRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.path, row.path);
+        assert_eq!(back.tokens, row.tokens);
+        assert_eq!(back.policy, row.policy);
+    }
+
+    // ── ContextLogRecord ────────────────────────────────────────────
+    #[test]
+    fn context_log_record_serde_roundtrip() {
+        let rec = ContextLogRecord {
+            schema_version: CONTEXT_SCHEMA_VERSION,
+            generated_at_ms: 1_700_000_000_000,
+            tool: sample_tool(),
+            budget_tokens: 10_000,
+            used_tokens: 9_000,
+            utilization_pct: 90.0,
+            strategy: "greedy".into(),
+            rank_by: "value".into(),
+            file_count: 12,
+            total_bytes: 35_000,
+            output_destination: "stdout".into(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in [
+            "schema_version",
+            "generated_at_ms",
+            "tool",
+            "budget_tokens",
+            "used_tokens",
+            "utilization_pct",
+            "strategy",
+            "rank_by",
+            "file_count",
+            "total_bytes",
+            "output_destination",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in ContextLogRecord"
+            );
+        }
+        let back: ContextLogRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.file_count, 12);
+        assert_eq!(back.output_destination, "stdout");
+    }
+
+    // ── TokenEstimationMeta ─────────────────────────────────────────
+    #[test]
+    fn token_estimation_default_divisor_constants() {
+        assert_eq!(TokenEstimationMeta::DEFAULT_BPT_EST, 4.0);
+        assert_eq!(TokenEstimationMeta::DEFAULT_BPT_LOW, 3.0);
+        assert_eq!(TokenEstimationMeta::DEFAULT_BPT_HIGH, 5.0);
+    }
+
+    #[test]
+    fn token_estimation_invariant_min_le_est_le_max() {
+        let est = TokenEstimationMeta::from_bytes(12_345, 4.0);
+        assert!(est.tokens_min <= est.tokens_est);
+        assert!(est.tokens_est <= est.tokens_max);
+    }
+
+    #[test]
+    fn token_estimation_serde_roundtrip_keeps_invariant() {
+        let est = TokenEstimationMeta::from_bytes_with_bounds(10_000, 4.0, 3.0, 5.0);
+        let json = serde_json::to_string(&est).unwrap();
+        let back: TokenEstimationMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.source_bytes, 10_000);
+        assert_eq!(back.bytes_per_token_est, 4.0);
+        assert_eq!(back.tokens_min, est.tokens_min);
+        assert_eq!(back.tokens_est, est.tokens_est);
+        assert_eq!(back.tokens_max, est.tokens_max);
+        assert!(back.tokens_min <= back.tokens_est);
+        assert!(back.tokens_est <= back.tokens_max);
+    }
+
+    #[test]
+    fn token_estimation_accepts_legacy_aliases() {
+        let json = r#"{
+            "bytes_per_token_est": 4.0,
+            "bytes_per_token_low": 3.0,
+            "bytes_per_token_high": 5.0,
+            "tokens_high": 200,
+            "tokens_est": 250,
+            "tokens_low": 333,
+            "source_bytes": 1000
+        }"#;
+        let est: TokenEstimationMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(est.tokens_min, 200);
+        assert_eq!(est.tokens_est, 250);
+        assert_eq!(est.tokens_max, 333);
+    }
+
+    // ── TokenAudit ──────────────────────────────────────────────────
+    #[test]
+    fn token_audit_serde_roundtrip() {
+        let audit = TokenAudit::from_output(5_000, 4_500);
+        let json = serde_json::to_string(&audit).unwrap();
+        let back: TokenAudit = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.output_bytes, 5_000);
+        assert_eq!(back.overhead_bytes, 500);
+        assert!(back.tokens_min <= back.tokens_est);
+        assert!(back.tokens_est <= back.tokens_max);
+    }
+
+    #[test]
+    fn token_audit_accepts_legacy_aliases() {
+        let json = r#"{
+            "output_bytes": 1000,
+            "tokens_high": 200,
+            "tokens_est": 250,
+            "tokens_low": 333,
+            "overhead_bytes": 100,
+            "overhead_pct": 0.1
+        }"#;
+        let audit: TokenAudit = serde_json::from_str(json).unwrap();
+        assert_eq!(audit.tokens_min, 200);
+        assert_eq!(audit.tokens_max, 333);
+    }
+
+    // ── FileClassification ──────────────────────────────────────────
+    #[test]
+    fn file_classification_uses_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&FileClassification::DataBlob).unwrap(),
+            "\"data_blob\""
+        );
+        assert_eq!(
+            serde_json::to_string(&FileClassification::Sourcemap).unwrap(),
+            "\"sourcemap\""
+        );
+    }
+
+    #[test]
+    fn file_classification_all_variants_roundtrip() {
+        for variant in [
+            FileClassification::Generated,
+            FileClassification::Fixture,
+            FileClassification::Vendored,
+            FileClassification::Lockfile,
+            FileClassification::Minified,
+            FileClassification::DataBlob,
+            FileClassification::Sourcemap,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: FileClassification = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn file_classification_ord_is_stable() {
+        let mut variants = [
+            FileClassification::Sourcemap,
+            FileClassification::Generated,
+            FileClassification::Lockfile,
+        ];
+        variants.sort();
+        assert_eq!(variants[0], FileClassification::Generated);
+        assert_eq!(variants[1], FileClassification::Lockfile);
+        assert_eq!(variants[2], FileClassification::Sourcemap);
+    }
+
+    // ── InclusionPolicy ─────────────────────────────────────────────
+    #[test]
+    fn inclusion_policy_default_is_full() {
+        assert_eq!(InclusionPolicy::default(), InclusionPolicy::Full);
+    }
+
+    #[test]
+    fn inclusion_policy_uses_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&InclusionPolicy::HeadTail).unwrap(),
+            "\"head_tail\""
+        );
+        assert_eq!(
+            serde_json::to_string(&InclusionPolicy::Full).unwrap(),
+            "\"full\""
+        );
+    }
+
+    #[test]
+    fn inclusion_policy_all_variants_roundtrip() {
+        for variant in [
+            InclusionPolicy::Full,
+            InclusionPolicy::HeadTail,
+            InclusionPolicy::Summary,
+            InclusionPolicy::Skip,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: InclusionPolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn is_default_policy_helper_only_true_for_full() {
+        assert!(is_default_policy(&InclusionPolicy::Full));
+        assert!(!is_default_policy(&InclusionPolicy::HeadTail));
+        assert!(!is_default_policy(&InclusionPolicy::Summary));
+        assert!(!is_default_policy(&InclusionPolicy::Skip));
+    }
+
+    // ── PolicyExcludedFile ──────────────────────────────────────────
+    #[test]
+    fn policy_excluded_file_serde_roundtrip() {
+        let f = PolicyExcludedFile {
+            path: "vendor/big.json".into(),
+            original_tokens: 10_000,
+            policy: InclusionPolicy::Skip,
+            reason: "data_blob".into(),
+            classifications: vec![FileClassification::DataBlob, FileClassification::Vendored],
+        };
+        let json = serde_json::to_string(&f).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["policy"], "skip");
+        assert_eq!(value["classifications"][0], "data_blob");
+        assert_eq!(value["classifications"][1], "vendored");
+        let back: PolicyExcludedFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.path, f.path);
+        assert_eq!(back.policy, f.policy);
+    }
+
+    // ── HandoffManifest ─────────────────────────────────────────────
+    #[test]
+    fn handoff_manifest_minimal_serde_roundtrip() {
+        let m = HandoffManifest {
+            schema_version: HANDOFF_SCHEMA_VERSION,
+            generated_at_ms: 1_700_000_000_000,
+            tool: sample_tool(),
+            mode: "handoff".into(),
+            inputs: vec![".".into()],
+            output_dir: "/tmp/out".into(),
+            budget_tokens: 8_000,
+            used_tokens: 4_000,
+            utilization_pct: 50.0,
+            strategy: "value-greedy".into(),
+            rank_by: "value".into(),
+            capabilities: vec![CapabilityStatus {
+                name: "git".into(),
+                status: CapabilityState::Available,
+                reason: None,
+            }],
+            artifacts: vec![ArtifactEntry {
+                name: "summary.md".into(),
+                path: "out/summary.md".into(),
+                description: "Markdown summary".into(),
+                bytes: 256,
+                hash: None,
+            }],
+            included_files: vec![sample_context_file_row()],
+            excluded_paths: vec![],
+            excluded_patterns: vec![],
+            smart_excluded_files: vec![],
+            total_files: 10,
+            bundled_files: 5,
+            intelligence_preset: "compact".into(),
+            rank_by_effective: None,
+            fallback_reason: None,
+            excluded_by_policy: vec![],
+            token_estimation: None,
+            code_audit: None,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in [
+            "schema_version",
+            "generated_at_ms",
+            "tool",
+            "mode",
+            "inputs",
+            "output_dir",
+            "budget_tokens",
+            "used_tokens",
+            "utilization_pct",
+            "strategy",
+            "rank_by",
+            "capabilities",
+            "artifacts",
+            "included_files",
+            "excluded_paths",
+            "excluded_patterns",
+            "smart_excluded_files",
+            "total_files",
+            "bundled_files",
+            "intelligence_preset",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in HandoffManifest"
+            );
+        }
+        assert!(value.get("rank_by_effective").is_none());
+        assert!(value.get("fallback_reason").is_none());
+        assert!(value.get("excluded_by_policy").is_none());
+        assert!(value.get("token_estimation").is_none());
+        assert!(value.get("code_audit").is_none());
+        let back: HandoffManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.schema_version, HANDOFF_SCHEMA_VERSION);
+        assert_eq!(back.bundled_files, 5);
+        assert_eq!(back.intelligence_preset, "compact");
+    }
+
+    // ── ContextBundleManifest ───────────────────────────────────────
+    #[test]
+    fn context_bundle_manifest_serde_roundtrip() {
+        let m = ContextBundleManifest {
+            schema_version: CONTEXT_BUNDLE_SCHEMA_VERSION,
+            generated_at_ms: 0,
+            tool: sample_tool(),
+            mode: "context".into(),
+            budget_tokens: 0,
+            used_tokens: 0,
+            utilization_pct: 0.0,
+            strategy: "value".into(),
+            rank_by: "value".into(),
+            file_count: 0,
+            bundle_bytes: 0,
+            artifacts: vec![],
+            included_files: vec![],
+            excluded_paths: vec![ContextExcludedPath {
+                path: "secret".into(),
+                reason: "redacted".into(),
+            }],
+            excluded_patterns: vec!["target".into()],
+            rank_by_effective: None,
+            fallback_reason: None,
+            excluded_by_policy: vec![],
+            token_estimation: None,
+            bundle_audit: None,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: ContextBundleManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.excluded_paths.len(), 1);
+        assert_eq!(back.excluded_paths[0].path, "secret");
+        assert_eq!(back.excluded_patterns, vec!["target".to_string()]);
+    }
+
+    // ── ContextExcludedPath / HandoffExcludedPath / SmartExcludedFile ──
+    #[test]
+    fn context_excluded_path_serde_roundtrip() {
+        let v = ContextExcludedPath {
+            path: "p".into(),
+            reason: "r".into(),
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        let back: ContextExcludedPath = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.path, "p");
+        assert_eq!(back.reason, "r");
+    }
+
+    #[test]
+    fn handoff_excluded_path_serde_roundtrip() {
+        let v = HandoffExcludedPath {
+            path: "p".into(),
+            reason: "r".into(),
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        let back: HandoffExcludedPath = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.path, "p");
+        assert_eq!(back.reason, "r");
+    }
+
+    #[test]
+    fn smart_excluded_file_serde_roundtrip() {
+        let v = SmartExcludedFile {
+            path: "vendor/x.min.js".into(),
+            reason: "minified".into(),
+            tokens: 999,
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in ["path", "reason", "tokens"] {
+            assert!(value.get(key).is_some());
+        }
+        let back: SmartExcludedFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.tokens, 999);
+    }
+
+    // ── HandoffIntelligence + sub-types ─────────────────────────────
+    #[test]
+    fn handoff_intelligence_full_roundtrip() {
+        let intel = HandoffIntelligence {
+            tree: Some("root\n  a\n  b".into()),
+            tree_depth: Some(2),
+            hotspots: Some(vec![HandoffHotspot {
+                path: "src/main.rs".into(),
+                commits: 10,
+                lines: 100,
+                score: 42,
+            }]),
+            complexity: Some(HandoffComplexity {
+                total_functions: 100,
+                avg_function_length: 12.5,
+                max_function_length: 80,
+                avg_cyclomatic: 3.5,
+                max_cyclomatic: 30,
+                high_risk_files: 2,
+            }),
+            derived: Some(HandoffDerived {
+                total_files: 50,
+                total_code: 5_000,
+                total_lines: 6_500,
+                total_tokens: 12_000,
+                lang_count: 3,
+                dominant_lang: "Rust".into(),
+                dominant_pct: 80.0,
+            }),
+            warnings: vec!["no git".into()],
+        };
+        let json = serde_json::to_string(&intel).unwrap();
+        let back: HandoffIntelligence = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.tree_depth, Some(2));
+        let hotspots = back.hotspots.expect("hotspots present");
+        assert_eq!(hotspots.len(), 1);
+        assert_eq!(hotspots[0].score, 42);
+        let complexity = back.complexity.expect("complexity present");
+        assert_eq!(complexity.high_risk_files, 2);
+        let derived = back.derived.expect("derived present");
+        assert_eq!(derived.dominant_lang, "Rust");
+        assert_eq!(back.warnings, vec!["no git".to_string()]);
+    }
+
+    #[test]
+    fn handoff_intelligence_all_none_serializes() {
+        let intel = HandoffIntelligence {
+            tree: None,
+            tree_depth: None,
+            hotspots: None,
+            complexity: None,
+            derived: None,
+            warnings: vec![],
+        };
+        let json = serde_json::to_string(&intel).unwrap();
+        let back: HandoffIntelligence = serde_json::from_str(&json).unwrap();
+        assert!(back.tree.is_none());
+        assert!(back.hotspots.is_none());
+        assert!(back.warnings.is_empty());
+    }
+
+    // ── CapabilityState / CapabilityStatus ──────────────────────────
+    #[test]
+    fn capability_state_uses_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&CapabilityState::Available).unwrap(),
+            "\"available\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CapabilityState::Skipped).unwrap(),
+            "\"skipped\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CapabilityState::Unavailable).unwrap(),
+            "\"unavailable\""
+        );
+    }
+
+    #[test]
+    fn capability_state_all_variants_roundtrip() {
+        for variant in [
+            CapabilityState::Available,
+            CapabilityState::Skipped,
+            CapabilityState::Unavailable,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: CapabilityState = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn capability_status_with_reason_keeps_field() {
+        let s = CapabilityStatus {
+            name: "git".into(),
+            status: CapabilityState::Unavailable,
+            reason: Some("not a repo".into()),
+        };
+        let value = serde_json::to_value(&s).unwrap();
+        assert_eq!(value["reason"], "not a repo");
+        let back: CapabilityStatus = serde_json::from_str(&value.to_string()).unwrap();
+        assert_eq!(back.reason.as_deref(), Some("not a repo"));
+    }
+
+    #[test]
+    fn capability_status_without_reason_omits_field() {
+        let s = CapabilityStatus {
+            name: "git".into(),
+            status: CapabilityState::Available,
+            reason: None,
+        };
+        let value = serde_json::to_value(&s).unwrap();
+        assert!(value.get("reason").is_none());
+    }
+
+    // ── ArtifactEntry / ArtifactHash ────────────────────────────────
+    #[test]
+    fn artifact_entry_with_hash_roundtrip() {
+        let a = ArtifactEntry {
+            name: "bundle.txt".into(),
+            path: "out/bundle.txt".into(),
+            description: "Concatenated source".into(),
+            bytes: 1_024,
+            hash: Some(ArtifactHash {
+                algo: "sha256".into(),
+                hash: "deadbeef".into(),
+            }),
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in ["name", "path", "description", "bytes", "hash"] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in ArtifactEntry"
+            );
+        }
+        assert_eq!(value["hash"]["algo"], "sha256");
+        let back: ArtifactEntry = serde_json::from_str(&json).unwrap();
+        let h = back.hash.expect("hash present");
+        assert_eq!(h.algo, "sha256");
+        assert_eq!(h.hash, "deadbeef");
+    }
+
+    #[test]
+    fn artifact_entry_without_hash_omits_field() {
+        let a = ArtifactEntry {
+            name: "x".into(),
+            path: "y".into(),
+            description: "z".into(),
+            bytes: 0,
+            hash: None,
+        };
+        let value = serde_json::to_value(&a).unwrap();
+        assert!(value.get("hash").is_none());
+    }
+}

--- a/crates/tokmd-types/src/diff.rs
+++ b/crates/tokmd-types/src/diff.rs
@@ -88,3 +88,214 @@ pub struct DiffReceipt {
     pub diff_rows: Vec<DiffRow>,
     pub totals: DiffTotals,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_diff_row() -> DiffRow {
+        DiffRow {
+            lang: "Rust".to_string(),
+            old_code: 100,
+            new_code: 150,
+            delta_code: 50,
+            old_lines: 200,
+            new_lines: 260,
+            delta_lines: 60,
+            old_files: 5,
+            new_files: 7,
+            delta_files: 2,
+            old_bytes: 5_000,
+            new_bytes: 6_500,
+            delta_bytes: 1_500,
+            old_tokens: 1_200,
+            new_tokens: 1_700,
+            delta_tokens: 500,
+        }
+    }
+
+    fn sample_diff_totals() -> DiffTotals {
+        DiffTotals {
+            old_code: 1_000,
+            new_code: 1_200,
+            delta_code: 200,
+            old_lines: 1_500,
+            new_lines: 1_800,
+            delta_lines: 300,
+            old_files: 10,
+            new_files: 12,
+            delta_files: 2,
+            old_bytes: 40_000,
+            new_bytes: 48_000,
+            delta_bytes: 8_000,
+            old_tokens: 10_000,
+            new_tokens: 12_000,
+            delta_tokens: 2_000,
+        }
+    }
+
+    // ── DiffRow ──────────────────────────────────────────────────────
+    #[test]
+    fn diff_row_serde_roundtrip() {
+        let row = sample_diff_row();
+        let json = serde_json::to_string(&row).expect("serialize");
+        let back: DiffRow = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, row);
+    }
+
+    #[test]
+    fn diff_row_field_names_stable() {
+        let row = sample_diff_row();
+        let value = serde_json::to_value(&row).expect("to_value");
+        for key in [
+            "lang",
+            "old_code",
+            "new_code",
+            "delta_code",
+            "old_lines",
+            "new_lines",
+            "delta_lines",
+            "old_files",
+            "new_files",
+            "delta_files",
+            "old_bytes",
+            "new_bytes",
+            "delta_bytes",
+            "old_tokens",
+            "new_tokens",
+            "delta_tokens",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing expected field `{key}` in DiffRow JSON: {value}"
+            );
+        }
+    }
+
+    // ── DiffTotals ───────────────────────────────────────────────────
+    #[test]
+    fn diff_totals_serde_roundtrip() {
+        let totals = sample_diff_totals();
+        let json = serde_json::to_string(&totals).expect("serialize");
+        let back: DiffTotals = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, totals);
+    }
+
+    #[test]
+    fn diff_totals_default_is_all_zero() {
+        let totals = DiffTotals::default();
+        let value = serde_json::to_value(&totals).expect("to_value");
+        for key in [
+            "old_code",
+            "new_code",
+            "delta_code",
+            "old_lines",
+            "new_lines",
+            "delta_lines",
+            "old_files",
+            "new_files",
+            "delta_files",
+            "old_bytes",
+            "new_bytes",
+            "delta_bytes",
+            "old_tokens",
+            "new_tokens",
+            "delta_tokens",
+        ] {
+            assert_eq!(
+                value[key], 0,
+                "expected default DiffTotals.{key} to serialize to 0, got {}",
+                value[key]
+            );
+        }
+    }
+
+    #[test]
+    fn diff_totals_negative_deltas_roundtrip() {
+        let totals = DiffTotals {
+            old_code: 200,
+            new_code: 50,
+            delta_code: -150,
+            old_files: 8,
+            new_files: 4,
+            delta_files: -4,
+            ..DiffTotals::default()
+        };
+        let json = serde_json::to_string(&totals).expect("serialize");
+        let back: DiffTotals = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, totals);
+        assert_eq!(back.delta_code, -150);
+        assert_eq!(back.delta_files, -4);
+    }
+
+    // ── DiffReceipt ──────────────────────────────────────────────────
+    #[test]
+    fn diff_receipt_serde_roundtrip() {
+        let receipt = DiffReceipt {
+            schema_version: crate::SCHEMA_VERSION,
+            generated_at_ms: 1_700_000_000_000,
+            tool: ToolInfo {
+                name: "tokmd".into(),
+                version: "1.2.3".into(),
+            },
+            mode: "diff".into(),
+            from_source: "old.json".into(),
+            to_source: "new.json".into(),
+            diff_rows: vec![sample_diff_row()],
+            totals: sample_diff_totals(),
+        };
+
+        let json = serde_json::to_string(&receipt).expect("serialize");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("to value");
+        // Field stability check
+        for key in [
+            "schema_version",
+            "generated_at_ms",
+            "tool",
+            "mode",
+            "from_source",
+            "to_source",
+            "diff_rows",
+            "totals",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing expected field `{key}` in DiffReceipt JSON"
+            );
+        }
+
+        let back: DiffReceipt = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.schema_version, receipt.schema_version);
+        assert_eq!(back.mode, "diff");
+        assert_eq!(back.from_source, "old.json");
+        assert_eq!(back.to_source, "new.json");
+        assert_eq!(back.diff_rows.len(), 1);
+        assert_eq!(back.diff_rows[0], receipt.diff_rows[0]);
+        assert_eq!(back.totals, receipt.totals);
+    }
+
+    #[test]
+    fn diff_receipt_preserves_row_order() {
+        let mut rows = Vec::new();
+        for (i, lang) in ["Rust", "Go", "C++", "Python"].iter().enumerate() {
+            let mut row = sample_diff_row();
+            row.lang = (*lang).to_string();
+            row.delta_code = i as i64;
+            rows.push(row);
+        }
+        let receipt = DiffReceipt {
+            schema_version: crate::SCHEMA_VERSION,
+            generated_at_ms: 0,
+            tool: ToolInfo::default(),
+            mode: "diff".into(),
+            from_source: "a".into(),
+            to_source: "b".into(),
+            diff_rows: rows.clone(),
+            totals: DiffTotals::default(),
+        };
+        let json = serde_json::to_string(&receipt).expect("serialize");
+        let back: DiffReceipt = serde_json::from_str(&json).expect("deserialize");
+        let back_langs: Vec<_> = back.diff_rows.iter().map(|r| r.lang.as_str()).collect();
+        assert_eq!(back_langs, vec!["Rust", "Go", "C++", "Python"]);
+    }
+}

--- a/crates/tokmd-types/src/inventory.rs
+++ b/crates/tokmd-types/src/inventory.rs
@@ -483,3 +483,597 @@ pub enum AnalysisFormat {
     Tree,
     Html,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_totals() -> Totals {
+        Totals {
+            code: 100,
+            lines: 200,
+            files: 10,
+            bytes: 5_000,
+            tokens: 250,
+            avg_lines: 20,
+        }
+    }
+
+    fn sample_lang_row() -> LangRow {
+        LangRow {
+            lang: "Rust".into(),
+            code: 100,
+            lines: 150,
+            files: 5,
+            bytes: 3_000,
+            tokens: 200,
+            avg_lines: 30,
+        }
+    }
+
+    fn sample_module_row() -> ModuleRow {
+        ModuleRow {
+            module: "src".into(),
+            code: 80,
+            lines: 120,
+            files: 4,
+            bytes: 2_500,
+            tokens: 160,
+            avg_lines: 30,
+        }
+    }
+
+    fn sample_file_row() -> FileRow {
+        FileRow {
+            path: "src/main.rs".into(),
+            module: "src".into(),
+            lang: "Rust".into(),
+            kind: FileKind::Parent,
+            code: 50,
+            comments: 10,
+            blanks: 5,
+            lines: 65,
+            bytes: 2_000,
+            tokens: 100,
+        }
+    }
+
+    fn sample_scan_args() -> ScanArgs {
+        ScanArgs {
+            paths: vec!["src".into(), "tests".into()],
+            excluded: vec!["target".into()],
+            excluded_redacted: false,
+            config: ConfigMode::Auto,
+            hidden: false,
+            no_ignore: false,
+            no_ignore_parent: false,
+            no_ignore_dot: false,
+            no_ignore_vcs: false,
+            treat_doc_strings_as_comments: false,
+        }
+    }
+
+    // ── Totals ───────────────────────────────────────────────────────
+    #[test]
+    fn totals_serde_roundtrip() {
+        let t = sample_totals();
+        let json = serde_json::to_string(&t).unwrap();
+        let back: Totals = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn totals_field_names_stable() {
+        let value = serde_json::to_value(sample_totals()).unwrap();
+        for key in ["code", "lines", "files", "bytes", "tokens", "avg_lines"] {
+            assert!(value.get(key).is_some(), "missing key `{key}` in Totals");
+        }
+    }
+
+    // ── LangRow / LangReport ─────────────────────────────────────────
+    #[test]
+    fn lang_row_serde_roundtrip() {
+        let r = sample_lang_row();
+        let json = serde_json::to_string(&r).unwrap();
+        let back: LangRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn lang_row_field_names_stable() {
+        let value = serde_json::to_value(sample_lang_row()).unwrap();
+        for key in [
+            "lang",
+            "code",
+            "lines",
+            "files",
+            "bytes",
+            "tokens",
+            "avg_lines",
+        ] {
+            assert!(value.get(key).is_some(), "missing key `{key}` in LangRow");
+        }
+    }
+
+    #[test]
+    fn lang_report_serde_roundtrip() {
+        let report = LangReport {
+            rows: vec![sample_lang_row()],
+            total: sample_totals(),
+            with_files: false,
+            children: ChildrenMode::Collapse,
+            top: 10,
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in ["rows", "total", "with_files", "children", "top"] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in LangReport"
+            );
+        }
+        let back: LangReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.rows.len(), 1);
+        assert_eq!(back.rows[0], report.rows[0]);
+        assert_eq!(back.total, report.total);
+        assert_eq!(back.top, 10);
+    }
+
+    // ── ModuleRow / ModuleReport ─────────────────────────────────────
+    #[test]
+    fn module_row_serde_roundtrip() {
+        let r = sample_module_row();
+        let json = serde_json::to_string(&r).unwrap();
+        let back: ModuleRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn module_row_field_names_stable() {
+        let value = serde_json::to_value(sample_module_row()).unwrap();
+        for key in [
+            "module",
+            "code",
+            "lines",
+            "files",
+            "bytes",
+            "tokens",
+            "avg_lines",
+        ] {
+            assert!(value.get(key).is_some(), "missing key `{key}` in ModuleRow");
+        }
+    }
+
+    #[test]
+    fn module_report_serde_roundtrip() {
+        let report = ModuleReport {
+            rows: vec![sample_module_row()],
+            total: sample_totals(),
+            module_roots: vec!["crates".into()],
+            module_depth: 2,
+            children: ChildIncludeMode::ParentsOnly,
+            top: 5,
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in [
+            "rows",
+            "total",
+            "module_roots",
+            "module_depth",
+            "children",
+            "top",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in ModuleReport"
+            );
+        }
+        let back: ModuleReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.rows.len(), 1);
+        assert_eq!(back.module_depth, 2);
+        assert_eq!(back.top, 5);
+    }
+
+    // ── FileRow / ExportData ─────────────────────────────────────────
+    #[test]
+    fn file_row_serde_roundtrip_parent() {
+        let r = sample_file_row();
+        let json = serde_json::to_string(&r).unwrap();
+        let back: FileRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn file_row_serde_roundtrip_child() {
+        let r = FileRow {
+            kind: FileKind::Child,
+            ..sample_file_row()
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let back: FileRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+        assert_eq!(back.kind, FileKind::Child);
+    }
+
+    #[test]
+    fn file_row_field_names_stable() {
+        let value = serde_json::to_value(sample_file_row()).unwrap();
+        for key in [
+            "path", "module", "lang", "kind", "code", "comments", "blanks", "lines", "bytes",
+            "tokens",
+        ] {
+            assert!(value.get(key).is_some(), "missing key `{key}` in FileRow");
+        }
+    }
+
+    #[test]
+    fn export_data_serde_roundtrip_preserves_row_order() {
+        let mut rows = Vec::new();
+        for path in ["a.rs", "b.rs", "c.rs", "d.rs"] {
+            let mut row = sample_file_row();
+            row.path = path.to_string();
+            rows.push(row);
+        }
+        let data = ExportData {
+            rows: rows.clone(),
+            module_roots: vec![],
+            module_depth: 1,
+            children: ChildIncludeMode::Separate,
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        let back: ExportData = serde_json::from_str(&json).unwrap();
+        let paths: Vec<_> = back.rows.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(paths, vec!["a.rs", "b.rs", "c.rs", "d.rs"]);
+        assert_eq!(back.children, ChildIncludeMode::Separate);
+        assert_eq!(back.module_depth, 1);
+    }
+
+    // ── Enums ────────────────────────────────────────────────────────
+    #[test]
+    fn file_kind_uses_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&FileKind::Parent).unwrap(),
+            "\"parent\""
+        );
+        assert_eq!(
+            serde_json::to_string(&FileKind::Child).unwrap(),
+            "\"child\""
+        );
+    }
+
+    #[test]
+    fn scan_status_uses_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ScanStatus::Complete).unwrap(),
+            "\"complete\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ScanStatus::Partial).unwrap(),
+            "\"partial\""
+        );
+        for variant in [ScanStatus::Complete, ScanStatus::Partial] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: ScanStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn child_include_mode_uses_kebab_case_for_parents_only() {
+        assert_eq!(
+            serde_json::to_string(&ChildIncludeMode::ParentsOnly).unwrap(),
+            "\"parents-only\""
+        );
+        for variant in [ChildIncludeMode::Separate, ChildIncludeMode::ParentsOnly] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: ChildIncludeMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn analysis_format_kebab_case_check() {
+        assert_eq!(
+            serde_json::to_string(&AnalysisFormat::Jsonld).unwrap(),
+            "\"jsonld\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AnalysisFormat::Mermaid).unwrap(),
+            "\"mermaid\""
+        );
+    }
+
+    #[test]
+    fn commit_intent_kind_all_variants_roundtrip() {
+        for variant in [
+            CommitIntentKind::Feat,
+            CommitIntentKind::Fix,
+            CommitIntentKind::Refactor,
+            CommitIntentKind::Docs,
+            CommitIntentKind::Test,
+            CommitIntentKind::Chore,
+            CommitIntentKind::Ci,
+            CommitIntentKind::Build,
+            CommitIntentKind::Perf,
+            CommitIntentKind::Style,
+            CommitIntentKind::Revert,
+            CommitIntentKind::Other,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: CommitIntentKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn config_mode_default_is_auto() {
+        assert_eq!(ConfigMode::default(), ConfigMode::Auto);
+        assert_eq!(
+            serde_json::to_string(&ConfigMode::Auto).unwrap(),
+            "\"auto\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ConfigMode::None).unwrap(),
+            "\"none\""
+        );
+    }
+
+    // ── ToolInfo ─────────────────────────────────────────────────────
+    #[test]
+    fn tool_info_default_serde() {
+        let tool = ToolInfo::default();
+        let json = serde_json::to_string(&tool).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value.get("name").is_some());
+        assert!(value.get("version").is_some());
+        assert_eq!(value["name"], "");
+        assert_eq!(value["version"], "");
+    }
+
+    #[test]
+    fn tool_info_current_has_tokmd_name() {
+        let tool = ToolInfo::current();
+        assert_eq!(tool.name, "tokmd");
+        assert!(!tool.version.is_empty());
+        let json = serde_json::to_string(&tool).unwrap();
+        let back: ToolInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name, tool.name);
+        assert_eq!(back.version, tool.version);
+    }
+
+    // ── ScanArgs ─────────────────────────────────────────────────────
+    #[test]
+    fn scan_args_roundtrip_preserves_paths_order() {
+        let args = sample_scan_args();
+        let json = serde_json::to_string(&args).unwrap();
+        let back: ScanArgs = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.paths, vec!["src".to_string(), "tests".to_string()]);
+        assert_eq!(back.excluded, vec!["target".to_string()]);
+        assert_eq!(back.config, ConfigMode::Auto);
+    }
+
+    #[test]
+    fn scan_args_excluded_redacted_omitted_when_false() {
+        let args = sample_scan_args();
+        let value = serde_json::to_value(&args).unwrap();
+        assert!(value.get("excluded_redacted").is_none());
+    }
+
+    #[test]
+    fn scan_args_excluded_redacted_present_when_true() {
+        let args = ScanArgs {
+            excluded_redacted: true,
+            ..sample_scan_args()
+        };
+        let value = serde_json::to_value(&args).unwrap();
+        assert_eq!(value["excluded_redacted"], true);
+    }
+
+    // ── Receipts ─────────────────────────────────────────────────────
+    #[test]
+    fn lang_receipt_flattens_report_fields() {
+        let receipt = LangReceipt {
+            schema_version: crate::SCHEMA_VERSION,
+            generated_at_ms: 1_700_000_000_000,
+            tool: ToolInfo::current(),
+            mode: "lang".into(),
+            status: ScanStatus::Complete,
+            warnings: vec![],
+            scan: sample_scan_args(),
+            args: LangArgsMeta {
+                format: "md".into(),
+                top: 10,
+                with_files: true,
+                children: ChildrenMode::Separate,
+            },
+            report: LangReport {
+                rows: vec![sample_lang_row()],
+                total: sample_totals(),
+                with_files: true,
+                children: ChildrenMode::Separate,
+                top: 10,
+            },
+        };
+        let value = serde_json::to_value(&receipt).unwrap();
+        // Envelope fields
+        for key in [
+            "schema_version",
+            "generated_at_ms",
+            "tool",
+            "mode",
+            "status",
+            "warnings",
+            "scan",
+            "args",
+        ] {
+            assert!(value.get(key).is_some(), "missing envelope key `{key}`");
+        }
+        // Flattened report fields
+        for key in ["rows", "total", "with_files", "children", "top"] {
+            assert!(
+                value.get(key).is_some(),
+                "missing flattened report key `{key}`"
+            );
+        }
+        // Roundtrip
+        let json = serde_json::to_string(&receipt).unwrap();
+        let back: LangReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mode, "lang");
+        assert_eq!(back.report.rows.len(), 1);
+    }
+
+    #[test]
+    fn module_receipt_flattens_report_fields() {
+        let receipt = ModuleReceipt {
+            schema_version: crate::SCHEMA_VERSION,
+            generated_at_ms: 0,
+            tool: ToolInfo::default(),
+            mode: "module".into(),
+            status: ScanStatus::Partial,
+            warnings: vec!["something".into()],
+            scan: sample_scan_args(),
+            args: ModuleArgsMeta {
+                format: "json".into(),
+                module_roots: vec!["crates".into()],
+                module_depth: 3,
+                children: ChildIncludeMode::Separate,
+                top: 20,
+            },
+            report: ModuleReport {
+                rows: vec![sample_module_row()],
+                total: sample_totals(),
+                module_roots: vec!["crates".into()],
+                module_depth: 3,
+                children: ChildIncludeMode::Separate,
+                top: 20,
+            },
+        };
+        let json = serde_json::to_string(&receipt).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["status"], "partial");
+        // Flattened ModuleReport fields
+        for key in [
+            "rows",
+            "total",
+            "module_roots",
+            "module_depth",
+            "children",
+            "top",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing flattened key `{key}` in ModuleReceipt JSON"
+            );
+        }
+        let back: ModuleReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mode, "module");
+        assert_eq!(back.report.module_depth, 3);
+        assert_eq!(back.warnings, vec!["something".to_string()]);
+    }
+
+    #[test]
+    fn export_receipt_flattens_data_fields() {
+        let receipt = ExportReceipt {
+            schema_version: crate::SCHEMA_VERSION,
+            generated_at_ms: 0,
+            tool: ToolInfo::default(),
+            mode: "export".into(),
+            status: ScanStatus::Complete,
+            warnings: vec![],
+            scan: sample_scan_args(),
+            args: ExportArgsMeta {
+                format: ExportFormat::Json,
+                module_roots: vec![],
+                module_depth: 1,
+                children: ChildIncludeMode::Separate,
+                min_code: 0,
+                max_rows: 100,
+                redact: RedactMode::None,
+                strip_prefix: None,
+                strip_prefix_redacted: false,
+            },
+            data: ExportData {
+                rows: vec![sample_file_row()],
+                module_roots: vec![],
+                module_depth: 1,
+                children: ChildIncludeMode::Separate,
+            },
+        };
+        let json = serde_json::to_string(&receipt).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        // Flattened ExportData fields
+        for key in ["rows", "module_roots", "module_depth", "children"] {
+            assert!(
+                value.get(key).is_some(),
+                "missing flattened key `{key}` in ExportReceipt JSON"
+            );
+        }
+        let back: ExportReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mode, "export");
+        assert_eq!(back.data.rows.len(), 1);
+    }
+
+    #[test]
+    fn export_args_meta_strip_prefix_omitted_when_false() {
+        let meta = ExportArgsMeta {
+            format: ExportFormat::Csv,
+            module_roots: vec![],
+            module_depth: 0,
+            children: ChildIncludeMode::Separate,
+            min_code: 0,
+            max_rows: 0,
+            redact: RedactMode::None,
+            strip_prefix: None,
+            strip_prefix_redacted: false,
+        };
+        let value = serde_json::to_value(&meta).unwrap();
+        assert!(value.get("strip_prefix_redacted").is_none());
+    }
+
+    #[test]
+    fn export_args_meta_strip_prefix_present_when_true() {
+        let meta = ExportArgsMeta {
+            format: ExportFormat::Csv,
+            module_roots: vec![],
+            module_depth: 0,
+            children: ChildIncludeMode::Separate,
+            min_code: 0,
+            max_rows: 0,
+            redact: RedactMode::None,
+            strip_prefix: Some("abc".into()),
+            strip_prefix_redacted: true,
+        };
+        let value = serde_json::to_value(&meta).unwrap();
+        assert_eq!(value["strip_prefix_redacted"], true);
+        assert_eq!(value["strip_prefix"], "abc");
+    }
+
+    #[test]
+    fn run_receipt_serde_roundtrip() {
+        let receipt = RunReceipt {
+            schema_version: crate::SCHEMA_VERSION,
+            generated_at_ms: 1_700_000_000_000,
+            lang_file: "lang.json".into(),
+            module_file: "module.json".into(),
+            export_file: "export.json".into(),
+        };
+        let json = serde_json::to_string(&receipt).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in [
+            "schema_version",
+            "generated_at_ms",
+            "lang_file",
+            "module_file",
+            "export_file",
+        ] {
+            assert!(
+                value.get(key).is_some(),
+                "missing key `{key}` in RunReceipt JSON"
+            );
+        }
+        let back: RunReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.lang_file, "lang.json");
+        assert_eq!(back.export_file, "export.json");
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline unit tests to `tokmd-types` source files that previously had **zero `#[test]` markers inside `src/`** (the crate's 37 integration-test files cover behavior across boundaries, but the DTOs themselves had no direct serde-roundtrip / field-stability tests).

### What's covered

- `src/diff.rs` — diff receipt DTOs (7 new tests)
- `src/inventory.rs` — `Totals`, `LangRow`, `ModuleRow`, `FileRow`, etc. (29 new tests)
- `src/context.rs` — context bundle + handoff DTOs (37 new tests)
- `src/cockpit/evidence.rs` — gate evidence type hierarchy (29 new tests)

Each public DTO gets at least:
- A serde roundtrip test
- A field-name stability test (catches accidental `#[serde(rename = ...)]` drift)
- A default-value test where `Default` is implemented
- Enum variants are exercised one-by-one

Total: **102 new inline `#[test]` functions** across the four files.

No behavior changes; tests only. The CLAUDE.md schema-version sync test continues to pass unchanged.

## Test plan

- [x] `cargo test -p tokmd-types --all-features` passes
- [x] `cargo clippy -p tokmd-types --all-features --tests -- -D warnings` clean
- [x] `cargo fmt -p tokmd-types` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_015SadBwwvW3BQH28ZqerR1z)_