### PR TITLE
docs: add sample artifact walkthroughs

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1081,6 +1081,7 @@ kind = "non_rust"
 paths = [
   "docs/artifacts.md",
   "docs/browser.md",
+  "docs/examples/**",
   "docs/publishing-evidence.md",
   "docs/start-here.md",
   "docs/handoff.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,9 @@ schemas, and verification policy for `tokmd`.
   inspection, PR review, CI evidence, agent handoff, or browser evaluation.
 - [user-paths.md](user-paths.md) — map each job to the command, primary
   artifact, first file to open, meaning, non-meaning, and next action.
+- [examples/](examples/README.md) — small artifact-tree walkthroughs for
+  review packets, handoff bundles, proof status, browser receipts, and
+  publishing evidence.
 - [browser.md](browser.md) — no-install browser workflow and native-only
   boundaries.
 - [VERIFICATION.md](VERIFICATION.md) — README badge meanings, generated endpoints, and PR evidence boundaries.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -125,6 +125,8 @@ each section.
 
 - [Start Here](start-here.md) for job-based entry points.
 - [User paths](user-paths.md) for command-to-artifact reading order by job.
+- [Sample artifact trees](examples/README.md) for small physical layout
+  walkthroughs.
 - [Review packet contract](review-packet.md) for packet layout and verifier semantics.
 - [Handoff bundles](handoff.md) for agent bundle consumption.
 - [Proof evidence import contract](cockpit-proof-evidence.md) for cockpit proof inputs.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,26 @@
+# Sample Artifact Trees
+
+Use these examples when you need to see the physical shape of a `tokmd`
+artifact set before generating one locally.
+
+These are small layout walkthroughs, not checked-in generated packets. They
+show what to open first, what each file owns, and what not to infer from the
+artifact set.
+
+## Trees
+
+- [Review packet tree](review-packet-tree.md)
+- [Handoff tree](handoff-tree.md)
+- [Proof status tree](proof-status-tree.md)
+- [Browser receipt tree](browser-receipt-tree.md)
+- [Publishing evidence tree](publishing-evidence-tree.md)
+
+## Rules
+
+- Treat generated receipts as evidence for the run that produced them, not as
+  merge approval.
+- Treat advisory proof, coverage, mutation, and browser output as advisory
+  unless policy explicitly promotes them.
+- Regenerate verifier receipts after changing packet-local files.
+- Use [User paths](../user-paths.md) to choose the right workflow before using
+  these examples.

--- a/docs/examples/browser-receipt-tree.md
+++ b/docs/examples/browser-receipt-tree.md
@@ -1,0 +1,46 @@
+# Browser Receipt Tree
+
+Use this when your job is:
+
+```text
+Try tokmd in the browser before installing native tooling.
+```
+
+Run first: open the browser runner, then load a GitHub repository or local
+files.
+
+Sample layout after download:
+
+```text
+downloads/
+  tokmd-browser-receipt.json
+  tokmd-browser-summary.md
+```
+
+Open first:
+
+1. Browser UI summary
+2. `tokmd-browser-summary.md`
+3. `tokmd-browser-receipt.json`
+
+What each file owns:
+
+| File | Owns |
+| --- | --- |
+| Browser UI summary | Immediate no-install interpretation. |
+| `tokmd-browser-summary.md` | Saved human-readable browser-safe summary, when downloaded. |
+| `tokmd-browser-receipt.json` | Machine-readable browser-safe receipt, when downloaded. |
+
+What not to infer:
+
+- Browser mode is not native mode.
+- Browser receipts do not include native filesystem behavior.
+- Browser receipts do not include git-history enrichers, cockpit packets,
+  gates, handoff bundles, or AST shadow evidence.
+- A browser receipt is not CI proof.
+
+Next action:
+
+- Move to native `tokmd cockpit` for real PR review.
+- Move to native `tokmd handoff` for coding-agent context.
+- Check the browser capability matrix before relying on a browser result.

--- a/docs/examples/handoff-tree.md
+++ b/docs/examples/handoff-tree.md
@@ -1,0 +1,68 @@
+# Handoff Tree
+
+Use this when your job is:
+
+```text
+Prepare a coding-agent handoff.
+```
+
+Run first:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --review-packet-dir .tokmd/review \
+  --review-packet-check target/tokmd/review-packet-check.json \
+  --affected target/proof/affected.json \
+  --proof-plan target/proof/proof-plan.json \
+  --out-dir .handoff
+```
+
+Sample layout:
+
+```text
+.handoff/
+  manifest.json
+  work-order.md
+  code.txt
+  map.jsonl
+  intelligence.json
+  review-links.json
+  proof-links.json
+```
+
+Open first:
+
+1. `.handoff/work-order.md`
+2. `.handoff/manifest.json`
+3. `.handoff/code.txt`
+4. `.handoff/review-links.json`
+5. `.handoff/proof-links.json`
+
+What each file owns:
+
+| File | Owns |
+| --- | --- |
+| `work-order.md` | Agent starting brief, linked evidence summary, and guardrails. |
+| `manifest.json` | Bundle inventory, token budget, included files, excluded files, and hashes. |
+| `code.txt` | Token-budgeted source bundle. |
+| `map.jsonl` | Full path inventory for lookup. |
+| `intelligence.json` | Repo shape, hotspot, and derived analysis signals. |
+| `review-links.json` | Pointers to external review packet artifacts and verifier receipt. |
+| `proof-links.json` | Pointers to external affected-proof and proof-plan artifacts. |
+
+What not to infer:
+
+- The handoff does not verify external review or proof receipts.
+- The source bundle is not necessarily the whole repository.
+- A proof plan is not executed proof.
+- Linked missing, stale, degraded, skipped, or unavailable evidence is agent
+  work, not a pass.
+
+Next action:
+
+- Give the agent `work-order.md` first.
+- Tell the agent to use `code.txt` as the bounded source bundle.
+- Verify linked review and proof receipts with their own checkers.

--- a/docs/examples/proof-status-tree.md
+++ b/docs/examples/proof-status-tree.md
@@ -1,0 +1,77 @@
+# Proof Status Tree
+
+Use this when your job is:
+
+```text
+Read CI proof evidence.
+```
+
+Run first:
+
+```bash
+cargo xtask affected \
+  --base origin/main \
+  --head HEAD \
+  --json-output target/proof/affected.json
+
+cargo xtask proof \
+  --profile affected \
+  --base origin/main \
+  --head HEAD \
+  --plan \
+  --plan-json target/proof/proof-plan.json \
+  --evidence-json target/proof/proof-evidence.json
+```
+
+Sample layout:
+
+```text
+target/proof/
+  affected.json
+  proof-plan.json
+  proof-evidence.json
+  proof-run-summary.json
+  proof-run-artifacts-check.json
+  executor-summary.json
+  executor-manifest.json
+  proof-artifacts-check.json
+
+target/proof-observations/
+  proof-observation-decision.json
+  proof-observation-decision.md
+  proof-observation-decision-check.json
+```
+
+Open first:
+
+1. `target/proof/affected.json`
+2. `target/proof/proof-plan.json`
+3. `target/proof/proof-evidence.json`
+4. `target/proof-observations/proof-observation-decision.md`
+
+What each file owns:
+
+| File | Owns |
+| --- | --- |
+| `affected.json` | Changed files, matched scopes, and unknown files. |
+| `proof-plan.json` | Planned required and advisory commands. |
+| `proof-evidence.json` | Planned evidence state for proof families. |
+| `proof-run-summary.json` | Executed required proof commands, when run. |
+| `proof-run-artifacts-check.json` | Verifier receipt for executed required proof summary. |
+| `executor-summary.json` | Advisory executor command status. |
+| `proof-observation-decision.md` | Human-readable observation/promotion-readiness summary. |
+| `proof-observation-decision-check.json` | Verifier receipt for the observation decision packet. |
+
+What not to infer:
+
+- A proof plan does not mean proof ran.
+- Advisory scoped coverage and mutation are not gates by default.
+- Codecov upload is not enabled by default.
+- Promotion criteria are evidence for a maintainer decision, not an automatic
+  policy change.
+
+Next action:
+
+- Resolve unknown files before trusting scoped proof routing.
+- Run required proof when the PR needs executed evidence.
+- Verify source receipts before relying on a status or decision packet.

--- a/docs/examples/publishing-evidence-tree.md
+++ b/docs/examples/publishing-evidence-tree.md
@@ -1,0 +1,56 @@
+# Publishing Evidence Tree
+
+Use this when your job is:
+
+```text
+Check publishing or release readiness without mutating release state.
+```
+
+Run first:
+
+```bash
+cargo xtask publish-surface --json --verify-publish
+cargo xtask version-consistency
+```
+
+Sample layout when output is saved by CI or a maintainer script:
+
+```text
+target/publishing/
+  publish-surface.json
+  version-consistency.txt
+
+target/proof/
+  affected.json
+  proof-plan.json
+```
+
+Open first:
+
+1. `target/publishing/publish-surface.json`
+2. `target/publishing/version-consistency.txt`
+3. `target/proof/affected.json` when release metadata changed
+4. `target/proof/proof-plan.json` when release metadata changed
+
+What each file owns:
+
+| File | Owns |
+| --- | --- |
+| `publish-surface.json` | Package-surface taxonomy, non-dev workspace closure, package-list checks, and violations. |
+| `version-consistency.txt` | Version alignment output for workspace, crates, bindings, and release metadata. |
+| `affected.json` | Release metadata or workflow routing, including unknown files. |
+| `proof-plan.json` | Required publishing/release proof commands selected by policy. |
+
+What not to infer:
+
+- These checks do not publish crates.
+- These checks do not create tags, GitHub releases, or Docker images.
+- A clean publish-surface check is not approval to mutate release state.
+- Release workflow artifacts exist only after an explicit release run.
+
+Next action:
+
+- Fix publish-surface violations before release work.
+- Pair publishing evidence with affected proof when release metadata changes.
+- Treat publish, tag, and release creation as separate explicit maintainer
+  decisions.

--- a/docs/examples/review-packet-tree.md
+++ b/docs/examples/review-packet-tree.md
@@ -1,0 +1,74 @@
+# Review Packet Tree
+
+Use this when your job is:
+
+```text
+Review this PR.
+```
+
+Run first:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+Sample layout:
+
+```text
+.tokmd/review/
+  manifest.json
+  cockpit.json
+  evidence.json
+  comment.md
+  review-map.json
+  review-map.md
+  docs/
+    doc-artifacts-check.json
+  proof/
+    proof-run-summary.json
+    proof-run-observation.json
+    proof-executor-observation.json
+    coverage-receipt.json
+
+target/tokmd/
+  review-packet-check.json
+```
+
+Open first:
+
+1. `.tokmd/review/review-map.md`
+2. `.tokmd/review/comment.md`
+3. `.tokmd/review/evidence.json`
+4. `target/tokmd/review-packet-check.json`
+
+What each file owns:
+
+| File | Owns |
+| --- | --- |
+| `review-map.md` | Human review order, reasons, evidence state, and reproduction commands. |
+| `comment.md` | Compact PR-comment-ready summary. |
+| `evidence.json` | Exact evidence availability: present, missing, stale, degraded, skipped, or unavailable. |
+| `manifest.json` | Packet-local inventory and hashes. |
+| `cockpit.json` | Full machine-readable cockpit receipt. |
+| `review-packet-check.json` | Verifier receipt for packet-local schemas, paths, and hashes. |
+
+What not to infer:
+
+- The packet is not a merge verdict.
+- Missing evidence is not passing proof.
+- Advisory proof does not become required because it appears in the packet.
+- The verifier receipt checks packet-local artifacts, not external CI state.
+
+Next action:
+
+- Run reproduction commands from `review-map.md`.
+- Repair missing, stale, or degraded evidence before claiming the packet is
+  complete.
+- Keep the verifier receipt with the review artifacts when sharing the packet.

--- a/docs/plans/user-path-evidence-consumption.md
+++ b/docs/plans/user-path-evidence-consumption.md
@@ -49,13 +49,13 @@ what is the next action?
 ## Work Packets
 
 1. Add the user-path chooser.
-   - Status: in progress.
+   - Status: complete.
    - Add `docs/user-paths.md` as the command-to-artifact map for inspect,
      review, handoff, CI proof, browser, and publishing jobs.
    - Link it from README, Start Here, and the docs index without duplicating
      all command details.
 2. Add small sample artifact trees.
-   - Status: pending.
+   - Status: complete.
    - Add concise examples for review packets, handoff bundles, proof status,
      browser receipts, and publishing evidence.
    - Do not check in large generated dumps.
@@ -114,3 +114,5 @@ tests named by the affected proof plan and the relevant packet verifier.
 - 2026-05-16: Started after the code-intelligence platform audit refresh
   selected no automatic implementation lane. The first packet defines the lane
   and adds the user-path evidence chooser.
+- 2026-05-16: Added small sample artifact trees for review packets, handoff
+  bundles, proof status, browser receipts, and publishing evidence.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -9,6 +9,9 @@ open the [Artifact glossary](artifacts.md).
 If you need the shortest map from user job to command, artifact, meaning, and
 next action, open [User paths](user-paths.md).
 
+If you need to see the physical output layout before running a workflow, open
+[Sample artifact trees](examples/README.md).
+
 ## 1. Tell Me What This Repo Is
 
 Start with the smallest useful receipt:

--- a/docs/user-paths.md
+++ b/docs/user-paths.md
@@ -4,7 +4,8 @@ Use this page when you know the job, but not which `tokmd` artifact to trust
 first. It is a consumption map, not a command reference.
 
 For artifact definitions, use the [Artifact glossary](artifacts.md). For the
-first guided walkthrough, use [Start Here](start-here.md).
+first guided walkthrough, use [Start Here](start-here.md). For small physical
+layouts, use [Sample artifact trees](examples/README.md).
 
 ## At A Glance
 


### PR DESCRIPTION
## Summary
- add small sample artifact-tree walkthroughs for review packets, handoff bundles, proof status, browser receipts, and publishing evidence
- link the examples from Start Here, User Paths, the docs index, and the artifact glossary
- mark the user-path chooser and sample-tree packets complete in the active lane plan
- route `docs/examples/**` through the existing user-guides proof scope

## Boundaries
- docs/proof-routing only; no product CLI behavior change
- no proof promotion, Codecov default change, AST productization, merge verdict, or `tokmd review` command
- sample trees are illustrative layouts, not checked-in generated packet dumps

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-sample-artifact-walkthroughs.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-sample-artifact-walkthroughs.json --evidence-json target/proof/proof-evidence-sample-artifact-walkthroughs.json`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo fmt-check`
- `git diff --check HEAD~1..HEAD`