### PR TITLE
feat(handoff): make work order actionable

### DIFF
--- a/crates/tokmd/src/commands/handoff/output.rs
+++ b/crates/tokmd/src/commands/handoff/output.rs
@@ -73,6 +73,7 @@ struct AffectedSummary {
     changed_files: usize,
     scopes: usize,
     unknown_files: usize,
+    changed_file_paths: Vec<String>,
     scope_names: Vec<String>,
 }
 
@@ -257,9 +258,14 @@ fn render_work_order(
     push_work_order_header(&mut out);
     push_start_here_section(&mut out, order.links);
     push_bundle_summary_section(&mut out, order);
+    push_changed_surfaces_section(&mut out, order.links, linked_evidence);
     push_linked_evidence_section(&mut out, order.links);
     render_linked_evidence_summary(&mut out, order.links, linked_evidence);
+    push_review_evidence_section(&mut out, order.links, linked_evidence);
+    push_proof_expectations_section(&mut out, order.links, linked_evidence);
+    push_missing_evidence_section(&mut out, linked_evidence);
     push_included_files_section(&mut out, order.selected);
+    push_agent_stop_conditions_section(&mut out, order.links, linked_evidence);
     push_agent_guardrails_section(&mut out);
     out
 }
@@ -308,6 +314,41 @@ fn push_bundle_summary_section(out: &mut String, order: &HandoffWorkOrderInputs<
     out.push_str(&format!("- Total scanned files: {}\n", order.total_files));
 }
 
+fn push_changed_surfaces_section(
+    out: &mut String,
+    links: &HandoffLinkInputs<'_>,
+    summary: &LinkedEvidenceSummary,
+) {
+    out.push_str("\n## Changed Surfaces\n\n");
+    if let Some(affected) = &summary.affected {
+        out.push_str(&format!(
+            "- Affected proof reports {} changed file(s), {} matched scope(s), and {} unknown file(s).\n",
+            affected.changed_files, affected.scopes, affected.unknown_files
+        ));
+        if !affected.scope_names.is_empty() {
+            out.push_str("- Matched scopes: ");
+            out.push_str(&affected.scope_names.join(", "));
+            out.push('\n');
+        }
+        if !affected.changed_file_paths.is_empty() {
+            out.push_str("- Changed files to inspect first:\n");
+            for path in &affected.changed_file_paths {
+                out.push_str(&format!("  - `{path}`\n"));
+            }
+            if affected.changed_files > affected.changed_file_paths.len() {
+                out.push_str(&format!(
+                    "  - ... {} more changed file(s); open the affected report for the full list.\n",
+                    affected.changed_files - affected.changed_file_paths.len()
+                ));
+            }
+        }
+    } else if links.affected.is_some() {
+        out.push_str("- Affected proof report is linked but not readable; regenerate or inspect `proof-links.json`.\n");
+    } else {
+        out.push_str("- No affected-proof report linked. Treat bundled files as context, not a complete change list.\n");
+    }
+}
+
 fn push_linked_evidence_section(out: &mut String, links: &HandoffLinkInputs<'_>) {
     out.push_str("\n## Linked Evidence\n\n");
     push_linked_path_line(out, "Review packet directory", links.review_packet_dir);
@@ -325,6 +366,128 @@ fn push_linked_path_line(out: &mut String, label: &str, path: Option<&Path>) {
         Some(path) => out.push_str(&format!("- {}: `{}`\n", label, path_string(path))),
         None => out.push_str(&format!("- {}: not linked\n", label)),
     }
+}
+
+fn push_review_evidence_section(
+    out: &mut String,
+    links: &HandoffLinkInputs<'_>,
+    summary: &LinkedEvidenceSummary,
+) {
+    out.push_str("\n## Review Evidence\n\n");
+    if links.review_packet_dir.is_none() && links.review_packet_check.is_none() {
+        out.push_str("- Review packet: not linked.\n");
+        out.push_str("- Open first: `work-order.md`, then `code.txt`.\n");
+        return;
+    }
+
+    if let Some(check) = &summary.review_packet_check {
+        match check.ok {
+            Some(true) => out.push_str("- Review packet verifier: linked and ok.\n"),
+            Some(false) => out.push_str("- Review packet verifier: linked and failing.\n"),
+            None => out.push_str("- Review packet verifier: linked with unknown status.\n"),
+        }
+    } else if links.review_packet_check.is_some() {
+        out.push_str("- Review packet verifier: linked but not readable.\n");
+    } else {
+        out.push_str("- Review packet verifier: not linked.\n");
+    }
+
+    if let Some(review_map) = &summary.review_map {
+        out.push_str(&format!(
+            "- Review map: linked with {} item(s).\n",
+            review_map.item_count
+        ));
+        if !review_map.first_items.is_empty() {
+            out.push_str("- Open first from review packet: `review-map.md`.\n");
+        }
+    } else if links.review_packet_dir.is_some() {
+        out.push_str("- Review map: linked but not readable.\n");
+    }
+
+    out.push_str("- Reproduce review evidence with commands listed in the linked review map.\n");
+}
+
+fn push_proof_expectations_section(
+    out: &mut String,
+    links: &HandoffLinkInputs<'_>,
+    summary: &LinkedEvidenceSummary,
+) {
+    out.push_str("\n## Proof Expectations\n\n");
+    if links.affected.is_none() && links.proof_plan.is_none() {
+        out.push_str("- Affected proof and proof plan: not linked.\n");
+        out.push_str("- Do not claim scoped proof coverage from this handoff alone.\n");
+        return;
+    }
+
+    if let Some(affected) = &summary.affected {
+        out.push_str(&format!(
+            "- Affected proof: {} changed file(s), {} scope(s), {} unknown file(s).\n",
+            affected.changed_files, affected.scopes, affected.unknown_files
+        ));
+    } else if links.affected.is_some() {
+        out.push_str("- Affected proof: linked but not readable.\n");
+    }
+
+    if let Some(proof_plan) = &summary.proof_plan {
+        out.push_str(&format!(
+            "- Proof plan: {} command(s), {} required, {} advisory.\n",
+            proof_plan.commands, proof_plan.required, proof_plan.advisory
+        ));
+        if !proof_plan.first_commands.is_empty() {
+            out.push_str("- Run expected proof before claiming done:\n");
+            for command in &proof_plan.first_commands {
+                out.push_str(&format!("  - `{command}`\n"));
+            }
+            if proof_plan.commands > proof_plan.first_commands.len() {
+                out.push_str(&format!(
+                    "  - ... {} more command(s); open the proof plan for the full list.\n",
+                    proof_plan.commands - proof_plan.first_commands.len()
+                ));
+            }
+        }
+    } else if links.proof_plan.is_some() {
+        out.push_str("- Proof plan: linked but not readable.\n");
+    }
+
+    out.push_str("- Treat proof plans as expectations until an executed proof receipt exists.\n");
+}
+
+fn push_missing_evidence_section(out: &mut String, summary: &LinkedEvidenceSummary) {
+    out.push_str("\n## Missing / Stale / Degraded Evidence\n\n");
+    let mut emitted = false;
+
+    if let Some(review_map) = &summary.review_map {
+        emitted |= push_issue_count(out, "Review evidence missing", review_map.missing);
+        emitted |= push_issue_count(out, "Review evidence stale", review_map.stale);
+        emitted |= push_issue_count(out, "Review evidence degraded", review_map.degraded);
+        emitted |= push_issue_count(out, "Review evidence skipped", review_map.skipped);
+        emitted |= push_issue_count(out, "Review evidence unavailable", review_map.unavailable);
+    }
+
+    if let Some(affected) = &summary.affected
+        && affected.unknown_files > 0
+    {
+        out.push_str(&format!(
+            "- Affected proof has {} unknown file(s); update proof routing before trusting scoped proof.\n",
+            affected.unknown_files
+        ));
+        emitted = true;
+    }
+
+    if !emitted {
+        out.push_str("- No missing, stale, degraded, skipped, unavailable, or unknown-file evidence was reported by linked summaries.\n");
+    }
+}
+
+fn push_issue_count(out: &mut String, label: &str, count: Option<u64>) -> bool {
+    let Some(count) = count else {
+        return false;
+    };
+    if count == 0 {
+        return false;
+    }
+    out.push_str(&format!("- {label}: {count}\n"));
+    true
 }
 
 fn push_included_files_section(out: &mut String, selected: &[ContextFileRow]) {
@@ -353,6 +516,29 @@ fn push_included_files_section(out: &mut String, selected: &[ContextFileRow]) {
             selected.len() - 20
         ));
     }
+}
+
+fn push_agent_stop_conditions_section(
+    out: &mut String,
+    links: &HandoffLinkInputs<'_>,
+    summary: &LinkedEvidenceSummary,
+) {
+    out.push_str("\n## Agent Stop Conditions\n\n");
+    out.push_str("- Stop after the requested repair or review slice is complete; do not broaden the lane by default.\n");
+    if links.review_packet_check.is_some() {
+        out.push_str(
+            "- Stop if the linked review-packet verifier is missing, unreadable, or failing.\n",
+        );
+    }
+    if let Some(affected) = &summary.affected
+        && affected.unknown_files > 0
+    {
+        out.push_str("- Stop before claiming proof if affected routing still has unknown files.\n");
+    }
+    if links.proof_plan.is_some() {
+        out.push_str("- Stop before claiming done until required proof commands are run or explicitly deferred.\n");
+    }
+    out.push_str("- Stop before promoting advisory proof, enabling Codecov defaults, adding AST defaults, or treating cockpit/handoff output as a merge verdict.\n");
 }
 
 fn push_agent_guardrails_section(out: &mut String) {
@@ -535,6 +721,15 @@ fn summarize_review_packet_check(value: &Value) -> ReviewPacketCheckSummary {
 
 fn summarize_affected(value: &Value) -> AffectedSummary {
     let changed_files = array_len(value.get("changed_files"));
+    let changed_file_paths = value
+        .get("changed_files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flat_map(|paths| paths.iter())
+        .filter_map(Value::as_str)
+        .take(10)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
     let scopes_array = value.get("scopes").and_then(Value::as_array);
     let scope_names = scopes_array
         .into_iter()
@@ -548,6 +743,7 @@ fn summarize_affected(value: &Value) -> AffectedSummary {
         changed_files,
         scopes: array_len(value.get("scopes")),
         unknown_files: array_len(value.get("unknown_files")),
+        changed_file_paths,
         scope_names,
     }
 }

--- a/crates/tokmd/tests/handoff_integration.rs
+++ b/crates/tokmd/tests/handoff_integration.rs
@@ -217,6 +217,16 @@ fn test_handoff_links_review_and_proof_artifacts() {
     assert!(work_order.contains("Review packet verifier: ok=true"));
     assert!(work_order.contains("Review map: 1 item(s)"));
     assert!(work_order.contains("`docs/handoff.md`: handoff behavior changed"));
+    assert!(work_order.contains("## Changed Surfaces"));
+    assert!(work_order.contains("Changed files to inspect first:"));
+    assert!(work_order.contains("## Review Evidence"));
+    assert!(work_order.contains("Review packet verifier: linked and ok."));
+    assert!(work_order.contains("## Proof Expectations"));
+    assert!(work_order.contains("Run expected proof before claiming done:"));
+    assert!(work_order.contains("## Missing / Stale / Degraded Evidence"));
+    assert!(work_order.contains("Review evidence missing: 1"));
+    assert!(work_order.contains("Review evidence unavailable: 1"));
+    assert!(work_order.contains("## Agent Stop Conditions"));
     assert!(
         work_order.contains("Affected proof: 1 changed file(s), 1 scope(s), 0 unknown file(s)")
     );

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -123,9 +123,12 @@ has already verified everything:
    ```
 
 3. Use the `Linked Evidence Summary` section in `.handoff/work-order.md` as a
-   quick triage view of readable review/proof receipts, then open the linked
-   receipts for source-of-truth details. Missing, stale, degraded, skipped, or
-   unavailable evidence is a task for the agent, not passing proof.
+   quick triage view of readable review/proof receipts. The `Changed
+   Surfaces`, `Review Evidence`, `Proof Expectations`, `Missing / Stale /
+   Degraded Evidence`, and `Agent Stop Conditions` sections turn those handles
+   into the agent work order. Open the linked receipts for source-of-truth
+   details. Missing, stale, degraded, skipped, or unavailable evidence is a
+   task for the agent, not passing proof.
 4. Use `.tokmd/review/review-map.md` for review order and reproduction
    commands.
 5. Use `target/proof/affected.json` to see which proof scopes matched the
@@ -144,7 +147,7 @@ sources.
 ```
 <out-dir>/
 ├── manifest.json      # authoritative index (schema v5)
-├── work-order.md      # agent work map and evidence guardrails
+├── work-order.md      # agent work map, evidence summary, and stop conditions
 ├── map.jsonl          # full file inventory (JSONL)
 ├── intelligence.json  # summary signals (payload-only)
 ├── code.txt           # token-budgeted code bundle
@@ -156,8 +159,9 @@ sources.
 
 1. **Read `manifest.json` first.**  
    It is the authoritative index, lists artifacts, included files, and exclusions.
-2. **Read `work-order.md`** for the agent task map, best-effort linked
-   evidence summary, evidence handles, and guardrails.
+2. **Read `work-order.md`** for the agent task map, changed surfaces,
+   best-effort linked evidence summary, proof expectations, missing evidence,
+   stop conditions, and guardrails.
 3. **Use `map.jsonl`** for full inventory or downstream tooling.
 4. **Use `intelligence.json`** as a warning label (tree, hotspots, derived).
 5. **Use `code.txt`** as the LLM bundle content.

--- a/docs/plans/user-path-evidence-consumption.md
+++ b/docs/plans/user-path-evidence-consumption.md
@@ -66,7 +66,7 @@ what is the next action?
    - Preserve cockpit as evidence, not a merge verdict.
 4. Improve handoff `work-order.md` readability when the current linked-evidence
    summary still leaves agent tasks ambiguous.
-   - Status: pending.
+   - Status: complete.
    - Summarize external evidence handles; do not make handoff verify those
      external receipts.
 5. Add a proof evidence reading-order guide if the user-path chooser and
@@ -116,3 +116,6 @@ tests named by the affected proof plan and the relevant packet verifier.
   and adds the user-path evidence chooser.
 - 2026-05-16: Added small sample artifact trees for review packets, handoff
   bundles, proof status, browser receipts, and publishing evidence.
+- 2026-05-16: Made `work-order.md` more directly actionable with changed
+  surfaces, review evidence, proof expectations, missing-evidence, and stop
+  condition sections.


### PR DESCRIPTION
## Summary
- Adds explicit `work-order.md` sections for changed surfaces, review evidence, proof expectations, missing/stale/degraded evidence, and agent stop conditions.
- Summarizes linked affected/review/proof receipts without verifying external artifacts inside handoff.
- Updates the handoff guide and user-path lane plan, with focused integration coverage for the new work-order shape.

## Boundaries
- No new public command.
- No schema change.
- No proof promotion or Codecov default change.
- No AST productization, release default change, or merge verdict.

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd test_handoff_links_review_and_proof_artifacts --verbose`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-handoff-work-order-actionable.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-handoff-work-order-actionable.json --evidence-json target/proof/proof-evidence-handoff-work-order-actionable.json`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo test -p tokmd-types context --verbose`
- `cargo test -p tokmd-types handoff --verbose`
- `cargo test -p tokmd context_pack --verbose`
- `cargo test -p tokmd --test context_e2e --verbose`
- `cargo test -p tokmd --test context_handoff_deep --verbose`
- `cargo test -p tokmd --test handoff_integration --verbose`
- `cargo test -p tokmd --test cli_snapshot_golden --verbose`
- `cargo test -p tokmd --test cli_e2e --verbose`
- `cargo test -p tokmd --test cli_parser_properties --verbose`
- `cargo test -p tokmd --test config_resolution --verbose`
- `git diff --check HEAD~1..HEAD`