### PR TITLE
feat(cockpit): explain review-map priority reasons

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -166,6 +166,32 @@ fn review_order_bucket(item: &ReviewItem, evidence: &ReviewMapItemEvidence) -> u
     }
 }
 
+fn review_order_reason(item: &ReviewItem, evidence: &ReviewMapItemEvidence) -> &'static str {
+    if review_item_is_source_of_truth(item) {
+        "Source-of-truth artifact changed; review the governing contract before ordinary files."
+    } else if !evidence.missing.is_empty() {
+        "Evidence is missing for this item; repair or acknowledge the missing proof before relying on it."
+    } else if !evidence.stale.is_empty() {
+        "Evidence is stale for this item; regenerate it before treating the packet as current."
+    } else if !evidence.degraded.is_empty() {
+        "Evidence is degraded for this item; inspect the degraded receipt before relying on it."
+    } else if item.complexity.unwrap_or(0) >= 4 {
+        "High review complexity; inspect before lower-complexity changes."
+    } else if review_contract_path(&item.path) {
+        "Contract or policy path changed; review before ordinary implementation changes."
+    } else if item.priority <= 1 {
+        "Highest cockpit priority from the source review plan."
+    } else if item.priority == 2 {
+        "Medium cockpit priority from the source review plan."
+    } else if !evidence.present.is_empty() {
+        "Evidence is available; use the attached references to review efficiently."
+    } else if !evidence.skipped.is_empty() {
+        "Evidence was skipped; confirm the skip reason is expected."
+    } else {
+        "Lower-priority source review item; review after higher-risk signals."
+    }
+}
+
 fn review_contract_path(path: &str) -> bool {
     schema_review_path(path)
         || policy_review_path(path)
@@ -327,6 +353,11 @@ pub(super) fn render_review_map_md(
     let _ = writeln!(s, "Base: `{}`", receipt.base_ref);
     let _ = writeln!(s, "Head: `{}`", receipt.head_ref);
     let _ = writeln!(s);
+    let _ = writeln!(
+        s,
+        "Open this as a review work order: inspect items in order, regenerate the listed evidence when it is missing, stale, or degraded, and do not treat this packet as a merge verdict."
+    );
+    let _ = writeln!(s);
 
     let evidence = evidence_counts(receipt);
     let _ = writeln!(
@@ -360,11 +391,13 @@ pub(super) fn render_review_map_md(
             s,
             "{}. `{}`
    Priority: {} ({})
+   Review-first signal: {}
    Why it matters: {}",
             rank + 1,
             item.path,
             item.priority,
             review_priority_label(item.priority),
+            review_order_reason(item, evidence),
             item.reason
         );
 

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1009,6 +1009,10 @@ fn scenario_review_map_orders_review_first_by_evidence_risk() {
         missing_pos < available_pos,
         "review-map Markdown should order missing evidence before raw size"
     );
+    assert!(review_map_md.contains(
+        "Review-first signal: Evidence is missing for this item; repair or acknowledge the missing proof before relying on it."
+    ));
+    assert!(review_map_md.contains("do not treat this packet as a merge verdict"));
 }
 
 #[test]
@@ -1061,6 +1065,9 @@ fn scenario_review_map_orders_contract_paths_before_ordinary_low_priority_items(
         schema_pos < ordinary_pos,
         "schema contract paths should be reviewed before ordinary low-priority docs"
     );
+    assert!(review_map_md.contains(
+        "Review-first signal: Contract or policy path changed; review before ordinary implementation changes."
+    ));
 }
 
 #[test]
@@ -1510,6 +1517,9 @@ fn scenario_write_review_packet_marks_missing_doc_artifacts_for_source_of_truth_
     assert!(evidence["doc_artifacts"]["checked"].is_null());
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
+    assert!(review_map_md.contains(
+        "Review-first signal: Source-of-truth artifact changed; review the governing contract before ordinary files."
+    ));
     assert!(review_map_md.contains("Doc artifacts: missing for source-of-truth changes."));
     assert!(review_map_md.contains("   Doc artifacts: missing"));
     assert!(

--- a/docs/plans/user-path-evidence-consumption.md
+++ b/docs/plans/user-path-evidence-consumption.md
@@ -61,7 +61,7 @@ what is the next action?
    - Do not check in large generated dumps.
 3. Improve cockpit review-map readability when fresh evidence shows the user
    guide is still not enough.
-   - Status: pending.
+   - Status: complete.
    - Keep schema compatibility or version deliberately.
    - Preserve cockpit as evidence, not a merge verdict.
 4. Improve handoff `work-order.md` readability when the current linked-evidence
@@ -119,3 +119,5 @@ tests named by the affected proof plan and the relevant packet verifier.
 - 2026-05-16: Made `work-order.md` more directly actionable with changed
   surfaces, review evidence, proof expectations, missing-evidence, and stop
   condition sections.
+- 2026-05-16: Made `review-map.md` more explicit about review-first signals
+  and the packet's non-verdict boundary.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -266,10 +266,12 @@ compact item-level evidence status, evidence references, optional `proof_refs`,
 and reproduction commands. Proof refs are added only when imported proof
 evidence directly lists the item path as a changed file; scope-only or global
 proof stays packet-level until a policy-backed scope matcher exists.
-`review-map.md` is a Markdown rendering of the same ordered items, including a
-"Review First" section, evidence present/missing lines where applicable,
-matching proof evidence, proof references, evidence references, and reproduction
-commands for artifact browsing and local review.
+`review-map.md` is a Markdown rendering of the same ordered items. It starts
+with a short work-order note that the packet is not a merge verdict, then lists
+the "Review First" items with a review-first signal, the cockpit reason,
+evidence present/missing lines where applicable, matching proof evidence, proof
+references, evidence references, and reproduction commands for artifact browsing
+and local review.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary
- Adds a short review-work-order note to `review-map.md` that keeps the packet explicitly non-verdict.
- Adds per-item `Review-first signal` wording derived from the existing deterministic ordering buckets.
- Updates the review-packet docs and marks the review-map readability packet complete in the user-path lane plan.

## Boundaries
- No JSON schema version change.
- No new public command.
- No proof promotion or Codecov default change.
- No AST productization, evidencebus runtime, release default change, or merge verdict.

## Validation
- `cargo fmt-fix`
- `cargo test -p tokmd-cockpit review_map --verbose`
- `cargo test -p tokmd cockpit --verbose`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo fmt-check`
- `git diff --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-review-map-priority-explanations.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-review-map-priority-explanations.json --evidence-json target/proof/proof-evidence-review-map-priority-explanations.json`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `git diff --check HEAD~1..HEAD`