### PR TITLE
docs: add copy-ready user workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ For the command-to-artifact reading order, use [User paths](docs/user-paths.md).
 
 For the receipt and packet names you will see in these workflows, use the
 [artifact glossary](docs/artifacts.md). For which artifact to open first for a
-specific job, use [User paths](docs/user-paths.md).
+specific job, use [User paths](docs/user-paths.md). For copy-ready command
+sequences, use [Copy-Ready Workflows](docs/workflows.md).
 
 ## Choose a Path
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1089,6 +1089,7 @@ paths = [
   "docs/tutorial.md",
   "docs/troubleshooting.md",
   "docs/user-paths.md",
+  "docs/workflows.md",
 ]
 proof = ["cargo xtask docs --check"]
 reason = "User-facing tutorial, recipe, and troubleshooting docs should route to documentation checks instead of appearing as unknown files."

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,9 @@ schemas, and verification policy for `tokmd`.
   inspection, PR review, CI evidence, agent handoff, or browser evaluation.
 - [user-paths.md](user-paths.md) — map each job to the command, primary
   artifact, first file to open, meaning, non-meaning, and next action.
+- [workflows.md](workflows.md) — copy-ready command sequences for inspection,
+  PR review, proof planning, proof observations, agent handoff, browser trial,
+  and publishing evidence.
 - [examples/](examples/README.md) — small artifact-tree walkthroughs for
   review packets, handoff bundles, proof status, browser receipts, and
   publishing evidence.

--- a/docs/plans/user-path-evidence-consumption.md
+++ b/docs/plans/user-path-evidence-consumption.md
@@ -74,7 +74,12 @@ what is the next action?
    - Status: pending.
    - Keep required proof, advisory proof, scoped coverage, mutation, coverage,
      and promotion-readiness boundaries explicit.
-6. Close or split #2299.
+6. Add copy-ready workflow sequences when the path chooser still leaves users
+   assembling commands from multiple pages.
+   - Status: complete.
+   - Compose existing `tokmd` and `xtask` commands; do not add new CLI
+     behavior.
+7. Close or split #2299.
    - Status: pending.
    - Keep #2299 parked unless a slice is restacked on current `main`, has zero
      unknown affected files, and drops placeholder-pinning or misleading test
@@ -121,3 +126,6 @@ tests named by the affected proof plan and the relevant packet verifier.
   condition sections.
 - 2026-05-16: Made `review-map.md` more explicit about review-first signals
   and the packet's non-verdict boundary.
+- 2026-05-16: Added copy-ready workflows for inspection, PR review, proof
+  planning, proof observation summaries, agent handoff, browser-to-native
+  review, and publishing evidence.

--- a/docs/user-paths.md
+++ b/docs/user-paths.md
@@ -5,7 +5,8 @@ first. It is a consumption map, not a command reference.
 
 For artifact definitions, use the [Artifact glossary](artifacts.md). For the
 first guided walkthrough, use [Start Here](start-here.md). For small physical
-layouts, use [Sample artifact trees](examples/README.md).
+layouts, use [Sample artifact trees](examples/README.md). For copy-ready command
+sequences, use [Copy-Ready Workflows](workflows.md).
 
 ## At A Glance
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,158 @@
+# Copy-Ready Workflows
+
+Use this page after choosing a path from [User Paths](user-paths.md). These are
+short command sequences for common jobs. They do not add new behavior; they
+compose existing `tokmd` and `xtask` surfaces.
+
+## Inspect A Repository
+
+Run:
+
+```bash
+tokmd --format md --top 8
+tokmd analyze --preset risk --format md
+```
+
+Open first: terminal output.
+
+This gives a quick repo shape, then a risk-oriented analysis pass. It does not
+run tests, review a PR, or prove release readiness.
+
+## Review A PR
+
+Run:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+Open first:
+
+1. `.tokmd/review/review-map.md`
+2. `.tokmd/review/comment.md`
+3. `.tokmd/review/evidence.json`
+4. `target/tokmd/review-packet-check.json`
+
+This gives a review work order, packet summary, evidence state, and packet
+verifier receipt. It is not a merge verdict.
+
+## Plan CI Proof Evidence
+
+Run:
+
+```bash
+cargo xtask affected \
+  --base origin/main \
+  --head HEAD \
+  --json-output target/proof/affected.json
+
+cargo xtask proof \
+  --profile affected \
+  --base origin/main \
+  --head HEAD \
+  --plan \
+  --plan-json target/proof/proof-plan.json \
+  --evidence-json target/proof/proof-evidence.json
+```
+
+Open first:
+
+1. `target/proof/affected.json`
+2. `target/proof/proof-plan.json`
+3. `target/proof/proof-evidence.json`
+
+This tells you which files changed, which proof scopes matched, and which
+commands are required or advisory. It does not execute the planned proof.
+
+## Summarize Proof Observations
+
+Run when observation artifacts already exist:
+
+```bash
+cargo xtask proof-observation-status \
+  --observations-dir target/proof-observations \
+  --json target/proof-observations/proof-observation-decision.json \
+  --summary-md target/proof-observations/proof-observation-decision.md
+
+cargo xtask proof-observation-status-check \
+  --decision target/proof-observations/proof-observation-decision.json \
+  --json target/proof-observations/proof-observation-decision-check.json
+```
+
+Open first:
+
+1. `target/proof-observations/proof-observation-decision.md`
+2. `target/proof-observations/proof-observation-decision.json`
+3. `target/proof-observations/proof-observation-decision-check.json`
+
+This summarizes observed proof status and promotion criteria. It does not
+promote proof, enable Codecov upload, or make advisory proof required.
+
+## Prepare A Coding-Agent Handoff
+
+Run after generating review and proof artifacts:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --review-packet-dir .tokmd/review \
+  --review-packet-check target/tokmd/review-packet-check.json \
+  --affected target/proof/affected.json \
+  --proof-plan target/proof/proof-plan.json \
+  --out-dir .handoff
+```
+
+Open first:
+
+1. `.handoff/work-order.md`
+2. `.handoff/manifest.json`
+3. `.handoff/code.txt`
+4. `.handoff/review-links.json`
+5. `.handoff/proof-links.json`
+
+Give the agent `work-order.md` first. Treat missing, stale, degraded, or
+unavailable evidence as work to resolve, not as passing proof.
+
+## Try Browser Mode, Then Move Native
+
+Run: open the browser runner, load a GitHub repo or local files, and download
+the browser-safe receipt.
+
+Open first: the browser UI summary, then the downloaded receipt.
+
+Next native command for real PR review:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+```
+
+Browser mode is a no-install trial lens. It does not provide native filesystem
+access, git-history enrichers, cockpit packets, gates, context bundles, handoff
+bundles, or AST capability claims.
+
+## Check Publishing Evidence
+
+Run:
+
+```bash
+cargo xtask publish-surface --json --verify-publish
+cargo xtask version-consistency
+```
+
+Open first: publish-surface output or saved JSON, then version-consistency
+output.
+
+This checks package-surface and version-readiness evidence. It does not publish
+crates, create tags, create GitHub releases, or approve release mutation.


### PR DESCRIPTION
## Summary
- adds `docs/workflows.md` with copy-ready sequences for repo inspection, PR review, proof planning/observation, agent handoff, browser-to-native, and publishing evidence paths
- links the workflow page from the README, docs index, and `docs/user-paths.md`
- routes `docs/workflows.md` through the `user_guides` proof scope so affected planning has zero unknown files

## Boundaries
- docs/proof-routing only
- no product behavior change
- no new public `tokmd review` command
- no proof promotion or default Codecov upload
- no AST productization, evidencebus runtime, or release mutation

## Validation
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-copy-ready-user-workflows.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-copy-ready-user-workflows.json --evidence-json target/proof/proof-evidence-copy-ready-user-workflows.json`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask bump --verbose`
- `cargo test -p xtask --test deep_w71 --verbose`
- `cargo test -p xtask --test xtask_contract_w65 --verbose`
- `cargo test -p xtask proof_policy --verbose`
- `cargo test -p xtask affected --verbose`
- `cargo test -p xtask ci_actuals --verbose`
- `cargo test -p xtask --test docs_schema_w72 --verbose`
- `cargo test -p xtask --test docs_w43 --verbose`
- `cargo test -p xtask fixture_blob --verbose`
- `cargo test -p xtask jules_index --verbose`
- `cargo test -p xtask mutation_scope --verbose`
- `cargo test -p xtask mutation_summary --verbose`
- `cargo test -p xtask perf_smoke --verbose`
- `cargo test -p xtask proof_artifacts --verbose`
- `cargo test -p xtask proof_executor_pr_policy --verbose`
- `cargo test -p xtask proof_observation_run_ids --verbose`
- `cargo test -p xtask proof_observation_status --verbose`
- `cargo test -p xtask proof_observation_thresholds --verbose`
- `cargo test -p xtask proof_plan --verbose`
- `cargo test -p xtask proof_run_pr_policy --verbose`
- `cargo test -p xtask proof_workflow_status --verbose`
- `cargo fmt-check`
- `git diff --check HEAD~1..HEAD`