### PR TITLE
test(analysis): cover effort helper boundaries

### DIFF
--- a/crates/tokmd-analysis/src/effort/classify.rs
+++ b/crates/tokmd-analysis/src/effort/classify.rs
@@ -79,3 +79,100 @@ pub(super) fn classify_row(
 
     (class, kind)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokmd_types::{FileKind as TokmdFileKind, FileRow};
+
+    fn make_row(path: &str) -> FileRow {
+        FileRow {
+            path: path.to_string(),
+            module: "src".to_string(),
+            lang: "Rust".to_string(),
+            kind: TokmdFileKind::Parent,
+            code: 10,
+            comments: 0,
+            blanks: 0,
+            lines: 10,
+            bytes: 40,
+            tokens: 20,
+        }
+    }
+
+    #[test]
+    fn class_kind_confidence_boost_pins_known_vs_unknown() {
+        assert_eq!(ClassKind::Generated.confidence_boost(), 1.0);
+        assert_eq!(ClassKind::Vendored.confidence_boost(), 1.0);
+        assert_eq!(ClassKind::Unknown.confidence_boost(), 0.0);
+    }
+
+    #[test]
+    fn classify_row_uses_gitattributes_rule_first_for_generated_match() {
+        // A matching gitattributes rule short-circuits the heuristic.
+        let rules = vec![GitAttrRule {
+            pattern: "src/lib.rs".to_string(),
+            kind: ClassKind::Generated,
+            source: "test".to_string(),
+        }];
+        let row = make_row("src/lib.rs");
+        let (class, kind) = classify_row(Path::new(""), "src/lib.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Generated);
+        assert!(matches!(kind, FileKind::Generated));
+    }
+
+    #[test]
+    fn classify_row_uses_gitattributes_rule_for_vendored_match() {
+        let rules = vec![GitAttrRule {
+            pattern: "vendor/foo.rs".to_string(),
+            kind: ClassKind::Vendored,
+            source: "test".to_string(),
+        }];
+        let row = make_row("vendor/foo.rs");
+        let (class, kind) = classify_row(Path::new(""), "vendor/foo.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Vendored);
+        assert!(matches!(kind, FileKind::Vendored));
+    }
+
+    #[test]
+    fn classify_row_unknown_rule_returns_core_filekind() {
+        // ClassKind::Unknown rules map to FileKind::Core (the documented
+        // catch-all in the match arm).
+        let rules = vec![GitAttrRule {
+            pattern: "src/lib.rs".to_string(),
+            kind: ClassKind::Unknown,
+            source: "test".to_string(),
+        }];
+        let row = make_row("src/lib.rs");
+        let (class, kind) = classify_row(Path::new(""), "src/lib.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Unknown);
+        assert!(matches!(kind, FileKind::Core));
+    }
+
+    #[test]
+    fn classify_row_falls_back_to_heuristic_when_no_rule_matches() {
+        // Empty rule set forces the heuristic path. `_test.rs` suffix routes
+        // through `looks_test_path` to FileKind::Tests / ClassKind::Unknown.
+        let rules: Vec<GitAttrRule> = Vec::new();
+        let row = make_row("src/foo_test.rs");
+        let (class, kind) = classify_row(Path::new(""), "src/foo_test.rs", &rules, &row);
+        assert_eq!(class, ClassKind::Unknown);
+        assert!(matches!(kind, FileKind::Tests));
+    }
+
+    #[test]
+    fn classify_row_heuristic_flags_generated_artifacts() {
+        // A generated-looking path should fall through to the heuristic and
+        // be tagged as ClassKind::Generated even without a gitattributes rule.
+        let rules: Vec<GitAttrRule> = Vec::new();
+        let row = make_row("target/generated/bundle.min.js");
+        let (class, kind) = classify_row(
+            Path::new(""),
+            "target/generated/bundle.min.js",
+            &rules,
+            &row,
+        );
+        assert_eq!(class, ClassKind::Generated);
+        assert!(matches!(kind, FileKind::Generated));
+    }
+}

--- a/crates/tokmd-analysis/src/effort/cocomo2.rs
+++ b/crates/tokmd-analysis/src/effort/cocomo2.rs
@@ -71,3 +71,65 @@ pub fn cocomo2_baseline(kloc_authored: f64) -> EffortResults {
         staff_p80,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cocomo2_effort_pm_returns_zeros_for_non_positive_kloc() {
+        // Saturating exit on `kloc <= 0.0` is the only short-circuit.
+        let (e1, s1, p1, _) = cocomo2_effort_pm(0.0);
+        assert_eq!((e1, s1, p1), (0.0, 0.0, 0.0));
+        let (e2, s2, p2, _) = cocomo2_effort_pm(-5.0);
+        assert_eq!((e2, s2, p2), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn cocomo2_effort_pm_uses_documented_constants_at_one_kloc() {
+        // At 1 KLOC the powers collapse to constants, so we can pin them.
+        let (effort, schedule, staff, mirror) = cocomo2_effort_pm(1.0);
+        assert!((effort - A).abs() < 1e-9);
+        assert!((schedule - C * effort.powf(D)).abs() < 1e-9);
+        // staff = effort / schedule
+        assert!((staff - effort / schedule).abs() < 1e-9);
+        // 4th tuple slot mirrors the p50 effort value.
+        assert!((mirror - effort).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cocomo2_baseline_zero_kloc_returns_all_zeros() {
+        let r = cocomo2_baseline(0.0);
+        assert_eq!(r.effort_pm_p50, 0.0);
+        assert_eq!(r.schedule_months_p50, 0.0);
+        assert_eq!(r.staff_p50, 0.0);
+        assert_eq!(r.effort_pm_low, 0.0);
+        assert_eq!(r.effort_pm_p80, 0.0);
+        assert_eq!(r.schedule_months_low, 0.0);
+        assert_eq!(r.schedule_months_p80, 0.0);
+        assert_eq!(r.staff_low, 0.0);
+        assert_eq!(r.staff_p80, 0.0);
+    }
+
+    #[test]
+    fn cocomo2_baseline_clamps_negative_kloc_to_zero() {
+        let r_neg = cocomo2_baseline(-1.0);
+        let r_zero = cocomo2_baseline(0.0);
+        assert_eq!(r_neg.effort_pm_p50, r_zero.effort_pm_p50);
+        assert_eq!(r_neg.schedule_months_p50, r_zero.schedule_months_p50);
+    }
+
+    #[test]
+    fn cocomo2_baseline_low_p80_envelope_widens_around_p50() {
+        let r = cocomo2_baseline(10.0);
+        assert!(r.effort_pm_p50 > 0.0);
+        assert!(r.effort_pm_low < r.effort_pm_p50);
+        assert!(r.effort_pm_p80 > r.effort_pm_p50);
+        assert!(r.schedule_months_low < r.schedule_months_p50);
+        assert!(r.schedule_months_p80 > r.schedule_months_p50);
+        // staff_low uses schedule_high in denominator => smaller than staff_p50,
+        // staff_p80 uses schedule_low => larger than staff_p50.
+        assert!(r.staff_low < r.staff_p50);
+        assert!(r.staff_p80 > r.staff_p50);
+    }
+}

--- a/crates/tokmd-analysis/src/effort/delta.rs
+++ b/crates/tokmd-analysis/src/effort/delta.rs
@@ -169,3 +169,50 @@ fn classify_blast(blast_radius: f64) -> EffortDeltaClassification {
         EffortDeltaClassification::Critical
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_blast_boundaries() {
+        // Each bucket boundary is exclusive on the high end of the lower band.
+        assert_eq!(classify_blast(0.0), EffortDeltaClassification::Low);
+        assert_eq!(classify_blast(9.999), EffortDeltaClassification::Low);
+        assert_eq!(classify_blast(10.0), EffortDeltaClassification::Medium);
+        assert_eq!(classify_blast(19.999), EffortDeltaClassification::Medium);
+        assert_eq!(classify_blast(20.0), EffortDeltaClassification::High);
+        assert_eq!(classify_blast(34.999), EffortDeltaClassification::High);
+        assert_eq!(classify_blast(35.0), EffortDeltaClassification::Critical);
+        assert_eq!(classify_blast(100.0), EffortDeltaClassification::Critical);
+    }
+
+    #[test]
+    fn build_delta_requires_base_and_head() {
+        let export = ExportData {
+            rows: Vec::new(),
+            module_roots: Vec::new(),
+            module_depth: 1,
+            children: tokmd_types::ChildIncludeMode::Separate,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let err = build_delta(dir.path(), &export, None, "", "HEAD").unwrap_err();
+        assert!(err.to_string().contains("base_ref and head_ref"));
+        let err = build_delta(dir.path(), &export, None, "HEAD~1", "  ").unwrap_err();
+        assert!(err.to_string().contains("base_ref and head_ref"));
+    }
+
+    #[cfg(not(feature = "git"))]
+    #[test]
+    fn build_delta_without_git_feature_errors() {
+        let export = ExportData {
+            rows: Vec::new(),
+            module_roots: Vec::new(),
+            module_depth: 1,
+            children: tokmd_types::ChildIncludeMode::Separate,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let err = build_delta(dir.path(), &export, None, "HEAD~1", "HEAD").unwrap_err();
+        assert!(err.to_string().contains("tokmd-git feature"));
+    }
+}

--- a/crates/tokmd-analysis/src/effort/model.rs
+++ b/crates/tokmd-analysis/src/effort/model.rs
@@ -200,3 +200,58 @@ struct SizeContext {
     size_basis: EffortSizeBasis,
     basis_confidence: f64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_results(scale: f64) -> EffortResults {
+        EffortResults {
+            effort_pm_p50: 1.0 * scale,
+            schedule_months_p50: 2.0 * scale,
+            staff_p50: 0.5 * scale,
+            effort_pm_low: 0.5 * scale,
+            effort_pm_p80: 1.5 * scale,
+            schedule_months_low: 1.5 * scale,
+            schedule_months_p80: 2.5 * scale,
+            staff_low: 0.3 * scale,
+            staff_p80: 0.7 * scale,
+        }
+    }
+
+    #[test]
+    fn avg_models_averages_every_band_independently() {
+        let a = make_results(1.0);
+        let b = make_results(3.0);
+        let avg = avg_models(&a, &b);
+
+        assert!((avg.effort_pm_p50 - 2.0).abs() < 1e-9);
+        assert!((avg.schedule_months_p50 - 4.0).abs() < 1e-9);
+        assert!((avg.staff_p50 - 1.0).abs() < 1e-9);
+        assert!((avg.effort_pm_low - 1.0).abs() < 1e-9);
+        assert!((avg.effort_pm_p80 - 3.0).abs() < 1e-9);
+        assert!((avg.schedule_months_low - 3.0).abs() < 1e-9);
+        assert!((avg.schedule_months_p80 - 5.0).abs() < 1e-9);
+        assert!((avg.staff_low - 0.6).abs() < 1e-9);
+        assert!((avg.staff_p80 - 1.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn avg_models_is_symmetric() {
+        let a = make_results(1.0);
+        let b = make_results(7.0);
+        let ab = avg_models(&a, &b);
+        let ba = avg_models(&b, &a);
+
+        assert!((ab.effort_pm_p50 - ba.effort_pm_p50).abs() < 1e-9);
+        assert!((ab.schedule_months_p50 - ba.schedule_months_p50).abs() < 1e-9);
+        assert!((ab.staff_p80 - ba.staff_p80).abs() < 1e-9);
+    }
+
+    #[test]
+    fn has_host_root_detects_empty_path() {
+        assert!(!has_host_root(Path::new("")));
+        assert!(has_host_root(Path::new("/tmp")));
+        assert!(has_host_root(Path::new(".")));
+    }
+}

--- a/crates/tokmd-analysis/src/effort/request.rs
+++ b/crates/tokmd-analysis/src/effort/request.rs
@@ -116,3 +116,44 @@ impl Display for EffortLayer {
         write!(f, "{}", self.as_str())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effort_request_default_pins_engine_baseline() {
+        let req = EffortRequest::default();
+        assert_eq!(req.model, EffortModelKind::Cocomo81Basic);
+        assert_eq!(req.layer, EffortLayer::Full);
+        assert!(req.base_ref.is_none());
+        assert!(req.head_ref.is_none());
+        assert!(!req.monte_carlo);
+        assert_eq!(req.mc_iterations, 10_000);
+        assert!(req.mc_seed.is_none());
+    }
+
+    #[test]
+    fn effort_model_kind_string_forms_are_stable() {
+        for (kind, expected) in [
+            (EffortModelKind::Cocomo81Basic, "cocomo81-basic"),
+            (EffortModelKind::Cocomo2Early, "cocomo2-early"),
+            (EffortModelKind::Ensemble, "ensemble"),
+        ] {
+            assert_eq!(kind.as_str(), expected);
+            assert_eq!(kind.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn effort_layer_string_forms_are_stable() {
+        for (layer, expected) in [
+            (EffortLayer::Headline, "headline"),
+            (EffortLayer::Why, "why"),
+            (EffortLayer::Full, "full"),
+        ] {
+            assert_eq!(layer.as_str(), expected);
+            assert_eq!(layer.to_string(), expected);
+        }
+    }
+}

--- a/crates/tokmd-analysis/src/effort/tests/effort_engine.rs
+++ b/crates/tokmd-analysis/src/effort/tests/effort_engine.rs
@@ -757,6 +757,10 @@ fn effort_delta_infers_changed_files_modules_and_blast_radius() {
     git(&repo, &["init"]);
     git(&repo, &["config", "user.name", "tokmd-tests"]);
     git(&repo, &["config", "user.email", "tokmd-tests@example.com"]);
+    // Disable commit signing so environments with a global signing config
+    // (e.g. some sandboxes) don't make this fixture unable to record commits.
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    git(&repo, &["config", "tag.gpgsign", "false"]);
 
     write_file(&repo.join("src/main.rs"), "fn main() {}\n");
     git(&repo, &["add", "."]);
@@ -803,4 +807,49 @@ fn effort_delta_infers_changed_files_modules_and_blast_radius() {
     } else {
         assert!(report.delta.is_none());
     }
+}
+
+#[test]
+fn monte_carlo_request_threads_through_report_assumptions() {
+    // Reaches the `monte_carlo: true` branches in build_effort_report and
+    // assumptions_summary without pinning the stochastic implementation.
+    let export = make_export(2_000);
+    let derived = make_derived(2_000, 0.05, 1);
+    let root = mk_temp_dir("tokmd-effort-mc");
+    fs::create_dir_all(&root).unwrap();
+    let _guard = TempDirGuard(root.clone());
+
+    let req = EffortRequest {
+        model: EffortModelKind::Cocomo81Basic,
+        layer: EffortLayer::Full,
+        base_ref: None,
+        head_ref: None,
+        monte_carlo: true,
+        mc_iterations: 1_000,
+        mc_seed: Some(7),
+    };
+
+    let report =
+        build_effort_report(&root, &export, &derived, None, None, None, None, &req).unwrap();
+
+    // The Monte Carlo placeholder must keep the report consistent.
+    assert!(report.results.effort_pm_p50 > 0.0);
+    assert!(report.results.effort_pm_p80 >= report.results.effort_pm_p50);
+
+    let mc_note_present = report
+        .assumptions
+        .notes
+        .iter()
+        .any(|note| note.contains("Monte Carlo"));
+    assert!(
+        mc_note_present,
+        "expected Monte Carlo note in assumptions, got {:?}",
+        report.assumptions.notes
+    );
+
+    let mc_override = report.assumptions.overrides.get("monte_carlo");
+    assert!(mc_override.is_some(), "expected monte_carlo override entry");
+    let value = mc_override.unwrap();
+    assert!(value.contains("iterations=1000"));
+    assert!(value.contains("seed=Some(7)"));
 }


### PR DESCRIPTION
## Summary
- extracts the effort-only keeper tests from broad draft #2299 onto current `main`
- covers effort classification, COCOMO2 math boundaries, delta blast buckets, model averaging, request string/default surfaces, and Monte Carlo request threading
- hardens the effort delta git fixture against host-global commit/tag signing config

## Scope notes
- does not merge #2299 as-is
- drops the generated placeholder-pinning Monte Carlo test from #2299
- no product behavior, receipt, schema, proof promotion, Codecov, AST, or release behavior changes

## Validation
- `cargo test -p tokmd-analysis effort --verbose`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-effort-test-keeper.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-effort-test-keeper.json --evidence-json target/proof/proof-evidence-effort-test-keeper.json`
- `cargo test -p tokmd-analysis --all-features effort --verbose`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check HEAD~1..HEAD`