### PR TITLE
test(cockpit): cover proof evidence model strings

### DIFF
--- a/crates/tokmd-cockpit/src/proof_evidence/model.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/model.rs
@@ -105,3 +105,76 @@ impl ProofEvidenceInput {
         self.artifact.kind()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ProofEvidenceAvailability, ProofEvidenceKind, ProofExecutionStatus};
+
+    #[test]
+    fn proof_evidence_kind_as_str_covers_all_variants() {
+        assert_eq!(
+            ProofEvidenceKind::ProofRunSummary.as_str(),
+            "proof_run_summary"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofRunObservation.as_str(),
+            "proof_run_observation"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofExecutorObservation.as_str(),
+            "proof_executor_observation"
+        );
+        assert_eq!(
+            ProofEvidenceKind::CoverageReceipt.as_str(),
+            "coverage_receipt"
+        );
+    }
+
+    #[test]
+    fn proof_evidence_kind_packet_file_name_covers_all_variants() {
+        assert_eq!(
+            ProofEvidenceKind::ProofRunSummary.packet_file_name(),
+            "proof-run-summary.json"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofRunObservation.packet_file_name(),
+            "proof-run-observation.json"
+        );
+        assert_eq!(
+            ProofEvidenceKind::ProofExecutorObservation.packet_file_name(),
+            "proof-executor-observation.json"
+        );
+        assert_eq!(
+            ProofEvidenceKind::CoverageReceipt.packet_file_name(),
+            "coverage-receipt.json"
+        );
+    }
+
+    #[test]
+    fn proof_evidence_availability_as_str_covers_all_variants() {
+        assert_eq!(ProofEvidenceAvailability::Available.as_str(), "available");
+        assert_eq!(ProofEvidenceAvailability::Missing.as_str(), "missing");
+        assert_eq!(ProofEvidenceAvailability::Skipped.as_str(), "skipped");
+        assert_eq!(ProofEvidenceAvailability::Stale.as_str(), "stale");
+        assert_eq!(ProofEvidenceAvailability::Degraded.as_str(), "degraded");
+        assert_eq!(
+            ProofEvidenceAvailability::Unavailable.as_str(),
+            "unavailable"
+        );
+    }
+
+    #[test]
+    fn proof_execution_status_as_str_covers_all_variants() {
+        assert_eq!(ProofExecutionStatus::Planned.as_str(), "planned");
+        assert_eq!(
+            ProofExecutionStatus::ExecutedPassed.as_str(),
+            "executed_passed"
+        );
+        assert_eq!(
+            ProofExecutionStatus::ExecutedFailed.as_str(),
+            "executed_failed"
+        );
+        assert_eq!(ProofExecutionStatus::NotExecuted.as_str(), "not_executed");
+        assert_eq!(ProofExecutionStatus::DryRun.as_str(), "dry_run");
+    }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for proof evidence kind string contracts
- pin packet-local proof evidence filenames for all current variants
- cover availability and execution-status string renderings

## Boundaries
- test-only keeper slice mined from broad draft coverage work
- no product behavior, schema, proof promotion, Codecov default, AST, or release changes

## Validation
- cargo test -p tokmd-cockpit proof_evidence --verbose
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-proof-evidence-model-keeper.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-proof-evidence-model-keeper.json --evidence-json target/proof/proof-evidence-proof-evidence-model-keeper.json
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo clippy -p tokmd-cockpit --all-targets -- -D warnings
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check HEAD~1..HEAD