### PR TITLE
test(git): disable signing in fixture repos

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -778,6 +778,7 @@ paths = [
   "crates/tokmd-git/src/command.rs",
   "crates/tokmd-git/src/lib.rs",
   "crates/tokmd-git/src/refs.rs",
+  "crates/tokmd-git/tests/**",
   "crates/tokmd-scan/src/walk/git.rs",
   "crates/tokmd-scan/src/walk/mod.rs",
   "crates/tokmd/src/git_support.rs",
@@ -785,9 +786,22 @@ paths = [
 packages = ["tokmd-git", "tokmd-scan", "tokmd"]
 proof = [
   "cargo test -p tokmd-git git_cmd_removes --verbose",
+  "cargo test -p tokmd-git --test integration --verbose",
   "cargo test -p tokmd-scan git_cmd_removes --verbose",
   "cargo test -p tokmd git_cmd_removes --verbose",
 ]
+mutation = true
+coverage = true
+
+[[scope]]
+name = "tokmd_core_context_git"
+kind = "rust"
+paths = [
+  "crates/tokmd-core/src/context_git/**",
+  "crates/tokmd-core/src/context_git.rs",
+]
+packages = ["tokmd-core"]
+proof = ["cargo test -p tokmd-core --features git context_git --verbose"]
 mutation = true
 coverage = true
 

--- a/crates/tokmd-analysis/tests/feature_matrix.rs
+++ b/crates/tokmd-analysis/tests/feature_matrix.rs
@@ -64,6 +64,15 @@ fn make_git_context(export: ExportData) -> (AnalysisContext, tempfile::TempDir) 
             .expect("git config user.name")
             .success()
     );
+    // Disable commit signing so global signing configs don't break this fixture.
+    let _ = Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo_root)
+        .status();
+    let _ = Command::new("git")
+        .args(["config", "tag.gpgsign", "false"])
+        .current_dir(repo_root)
+        .status();
 
     assert!(
         Command::new("git")

--- a/crates/tokmd-analysis/tests/git.rs
+++ b/crates/tokmd-analysis/tests/git.rs
@@ -29,6 +29,9 @@ mod git_tests {
         let dir = tempdir().expect("tempdir");
         let root = dir.path();
         git_cmd(root, &["init"]);
+        // Disable host commit-signing config from leaking into this fixture.
+        git_cmd(root, &["config", "commit.gpgsign", "false"]);
+        git_cmd(root, &["config", "tag.gpgsign", "false"]);
 
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "fn a() {}\n").unwrap();

--- a/crates/tokmd-cockpit/tests/git_env_boundaries.rs
+++ b/crates/tokmd-cockpit/tests/git_env_boundaries.rs
@@ -66,6 +66,13 @@ fn get_file_stats_ignores_inherited_git_env_overrides() {
         .status()
         .unwrap();
     assert!(status.success(), "git config user.name failed");
+    // Disable commit signing so host signing config doesn't break the fixture.
+    let _ = git_in(repo.path())
+        .args(["config", "commit.gpgsign", "false"])
+        .status();
+    let _ = git_in(repo.path())
+        .args(["config", "tag.gpgsign", "false"])
+        .status();
 
     std::fs::write(repo.path().join("tracked.txt"), "one\n").unwrap();
     let status = git_in(repo.path()).args(["add", "."]).status().unwrap();

--- a/crates/tokmd-core/src/context_git/mod.rs
+++ b/crates/tokmd-core/src/context_git/mod.rs
@@ -141,6 +141,19 @@ mod tests {
             .current_dir(root)
             .output()
             .ok()?;
+        // Disable commit signing so environments with a global signing key
+        // do not turn this test repo into a no-commit setup that makes
+        // downstream assertions flaky.
+        Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(root)
+            .output()
+            .ok()?;
+        Command::new("git")
+            .args(["config", "tag.gpgsign", "false"])
+            .current_dir(root)
+            .output()
+            .ok()?;
 
         // main.rs: 2 commits (3 lines initially, then 4)
         std::fs::write(root.join("main.rs"), "1\n2\n3").ok()?;

--- a/crates/tokmd-core/tests/cockpit_workflow.rs
+++ b/crates/tokmd-core/tests/cockpit_workflow.rs
@@ -60,6 +60,9 @@ fn cockpit_workflow_computes_receipt_from_settings() {
     git(repo.path(), &["init", "-b", "main"]);
     git(repo.path(), &["config", "user.email", "tokmd@example.com"]);
     git(repo.path(), &["config", "user.name", "tokmd"]);
+    // Avoid host commit-signing config bleeding into this fixture repo.
+    git(repo.path(), &["config", "commit.gpgsign", "false"]);
+    git(repo.path(), &["config", "tag.gpgsign", "false"]);
 
     write(&repo.path().join("README.md"), "# Demo\n");
     git(repo.path(), &["add", "README.md"]);

--- a/crates/tokmd-git/tests/integration.rs
+++ b/crates/tokmd-git/tests/integration.rs
@@ -124,6 +124,16 @@ fn create_test_repo() -> Option<TempGitRepo> {
         .args(["config", "user.name", "Test User"])
         .output()
         .ok()?;
+    // Disable commit signing so a host-global signing config can't break
+    // this fixture's ability to record commits.
+    git_in(&temp_dir)
+        .args(["config", "commit.gpgsign", "false"])
+        .output()
+        .ok()?;
+    git_in(&temp_dir)
+        .args(["config", "tag.gpgsign", "false"])
+        .output()
+        .ok()?;
 
     // Create first commit with a file
     let file1 = temp_dir.join("file1.txt");
@@ -407,6 +417,16 @@ fn create_test_repo_with_multi_file_commits() -> Option<TempGitRepo> {
         .ok()?;
     git_in(&temp_dir)
         .args(["config", "user.name", "Test User"])
+        .output()
+        .ok()?;
+    // Disable commit signing so a host-global signing config can't break
+    // this fixture's ability to record commits.
+    git_in(&temp_dir)
+        .args(["config", "commit.gpgsign", "false"])
+        .output()
+        .ok()?;
+    git_in(&temp_dir)
+        .args(["config", "tag.gpgsign", "false"])
         .output()
         .ok()?;
 


### PR DESCRIPTION
## Summary
- disable local commit/tag signing inside temporary Git fixture repos so host-global signing config cannot break fixture commits
- route `tokmd-core` context-git and `tokmd-git` integration fixture paths through explicit proof scopes
- keep this as a narrow #2299 keeper slice with no product behavior, schema, proof-promotion, Codecov, AST, or release default changes

## Validation
- cargo test -p tokmd-analysis --all-features git --verbose
- cargo test -p tokmd-analysis --all-features feature --verbose
- cargo test -p tokmd-cockpit --test git_env_boundaries --verbose
- cargo test -p tokmd-core context_git --verbose
- cargo test -p tokmd-core --features git context_git --verbose
- cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose
- cargo test -p tokmd-git --test integration --verbose
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-git-fixture-signing-keeper.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-git-fixture-signing-keeper.json --evidence-json target/proof/proof-evidence-git-fixture-signing-keeper.json
- cargo test -p tokmd-git git_cmd_removes --verbose
- cargo test -p tokmd-scan git_cmd_removes --verbose
- cargo test -p tokmd git_cmd_removes --verbose
- cargo test -p tokmd-cockpit --verbose
- cargo test -p tokmd-types cockpit --verbose
- cargo test -p tokmd --test cockpit_integration --verbose
- cargo test -p tokmd-core workflow --verbose
- cargo test -p tokmd-core --all-features analyze_workflow --verbose
- cargo test -p tokmd-core ffi --verbose
- cargo test -p tokmd-core --test ffi_parity_w53 --verbose
- cargo test -p xtask proof_policy --verbose
- cargo test -p xtask affected --verbose
- cargo test -p xtask proof_plan --verbose
- cargo clippy -p tokmd-analysis -p tokmd-cockpit -p tokmd-core -p tokmd-git -p xtask --all-targets --all-features -- -D warnings
- cargo fmt-check
- cargo xtask proof-policy --check
- git diff --check HEAD~1..HEAD

Note: a broad `cargo test -p tokmd-core --all-features --verbose` attempt timed out after 20 minutes without useful output; leftover processes from that attempt were stopped and replaced with the focused routed core checks listed above.