### PR TITLE
test(cockpit): unit-cover review_map predicates and ordering

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -557,3 +557,338 @@ fn write_evidence_list(s: &mut String, label: &str, gates: &[&str]) {
 
     let _ = writeln!(s, "   {label}: {}", gates.join(", "));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(path: &str, priority: u32) -> ReviewItem {
+        ReviewItem {
+            path: path.to_string(),
+            reason: "test".to_string(),
+            priority,
+            complexity: None,
+            lines_changed: None,
+        }
+    }
+
+    // ---------- review_priority_label ----------
+
+    #[test]
+    fn priority_label_one_is_highest() {
+        assert_eq!(review_priority_label(1), "highest");
+    }
+
+    #[test]
+    fn priority_label_two_is_medium() {
+        assert_eq!(review_priority_label(2), "medium");
+    }
+
+    #[test]
+    fn priority_label_zero_is_low() {
+        assert_eq!(review_priority_label(0), "low");
+    }
+
+    #[test]
+    fn priority_label_three_is_low() {
+        assert_eq!(review_priority_label(3), "low");
+    }
+
+    #[test]
+    fn priority_label_large_is_low() {
+        assert_eq!(review_priority_label(99), "low");
+    }
+
+    // ---------- schema_review_path ----------
+
+    #[test]
+    fn schema_review_path_exact_docs_schema_json() {
+        assert!(schema_review_path("docs/schema.json"));
+    }
+
+    #[test]
+    fn schema_review_path_exact_docs_schema_md() {
+        assert!(schema_review_path("docs/SCHEMA.md"));
+    }
+
+    #[test]
+    fn schema_review_path_docs_dot_schema_json() {
+        assert!(schema_review_path("docs/foo.schema.json"));
+    }
+
+    #[test]
+    fn schema_review_path_crates_schemas_dir() {
+        assert!(schema_review_path("crates/tokmd/schemas/x.json"));
+    }
+
+    #[test]
+    fn schema_review_path_rejects_unrelated_paths() {
+        assert!(!schema_review_path("src/lib.rs"));
+        assert!(!schema_review_path("docs/guide.md"));
+        assert!(!schema_review_path("schemas/x.json"));
+    }
+
+    // ---------- policy_review_path ----------
+
+    #[test]
+    fn policy_review_path_ci_proof_toml() {
+        assert!(policy_review_path("ci/proof.toml"));
+    }
+
+    #[test]
+    fn policy_review_path_codecov_yml() {
+        assert!(policy_review_path("codecov.yml"));
+    }
+
+    #[test]
+    fn policy_review_path_policy_prefix() {
+        assert!(policy_review_path("policy/x.toml"));
+    }
+
+    #[test]
+    fn policy_review_path_github_workflows() {
+        assert!(policy_review_path(".github/workflows/x.yml"));
+    }
+
+    #[test]
+    fn policy_review_path_rejects_unrelated_paths() {
+        assert!(!policy_review_path("src/lib.rs"));
+        assert!(!policy_review_path("ci/other.toml"));
+        assert!(!policy_review_path(".github/dependabot.yml"));
+    }
+
+    // ---------- cli_review_path ----------
+
+    #[test]
+    fn cli_review_path_commands_dir() {
+        assert!(cli_review_path("crates/tokmd/src/commands/run.rs"));
+    }
+
+    #[test]
+    fn cli_review_path_cli_dir() {
+        assert!(cli_review_path("crates/tokmd/src/cli/parser.rs"));
+    }
+
+    #[test]
+    fn cli_review_path_config_rs() {
+        assert!(cli_review_path("crates/tokmd/src/config.rs"));
+    }
+
+    #[test]
+    fn cli_review_path_rejects_unrelated_paths() {
+        assert!(!cli_review_path("crates/tokmd/src/lib.rs"));
+        assert!(!cli_review_path("crates/tokmd-cockpit/src/cli/parser.rs"));
+        assert!(!cli_review_path("src/config.rs"));
+    }
+
+    // ---------- api_review_path ----------
+
+    #[test]
+    fn api_review_path_lib_rs() {
+        assert!(api_review_path("crates/foo/src/lib.rs"));
+    }
+
+    #[test]
+    fn api_review_path_mod_rs() {
+        assert!(api_review_path("crates/foo/src/mod.rs"));
+    }
+
+    #[test]
+    fn api_review_path_rejects_unrelated_paths() {
+        assert!(!api_review_path("crates/foo/src/main.rs"));
+        assert!(!api_review_path("crates/foo/src/util.rs"));
+        assert!(!api_review_path("README.md"));
+    }
+
+    // ---------- review_contract_path ----------
+
+    #[test]
+    fn review_contract_path_matches_schema_predicate() {
+        assert!(review_contract_path("docs/schema.json"));
+    }
+
+    #[test]
+    fn review_contract_path_matches_policy_predicate() {
+        assert!(review_contract_path("policy/x.toml"));
+    }
+
+    #[test]
+    fn review_contract_path_matches_cli_predicate() {
+        assert!(review_contract_path("crates/tokmd/src/config.rs"));
+    }
+
+    #[test]
+    fn review_contract_path_matches_api_predicate() {
+        assert!(review_contract_path("crates/foo/src/lib.rs"));
+    }
+
+    #[test]
+    fn review_contract_path_rejects_unrelated_path() {
+        assert!(!review_contract_path("src/main.rs"));
+    }
+
+    // ---------- review_map_evidence_refs ----------
+
+    #[test]
+    fn evidence_refs_only_gates_when_no_extras() {
+        let refs = review_map_evidence_refs(false, false);
+        assert_eq!(refs, vec!["evidence.json#/gates"]);
+    }
+
+    #[test]
+    fn evidence_refs_adds_proof_only() {
+        let refs = review_map_evidence_refs(true, false);
+        assert_eq!(refs, vec!["evidence.json#/gates", "evidence.json#/proof"]);
+    }
+
+    #[test]
+    fn evidence_refs_adds_doc_artifacts_only() {
+        let refs = review_map_evidence_refs(false, true);
+        assert_eq!(
+            refs,
+            vec!["evidence.json#/gates", "evidence.json#/doc_artifacts"]
+        );
+    }
+
+    #[test]
+    fn evidence_refs_adds_both_proof_and_doc_artifacts() {
+        let refs = review_map_evidence_refs(true, true);
+        assert_eq!(
+            refs,
+            vec![
+                "evidence.json#/gates",
+                "evidence.json#/proof",
+                "evidence.json#/doc_artifacts",
+            ]
+        );
+    }
+
+    // ---------- ReviewMapItemEvidence::status ----------
+
+    #[test]
+    fn evidence_status_defaults_to_unavailable() {
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(ev.status(), "unavailable");
+    }
+
+    #[test]
+    fn evidence_status_missing_takes_priority() {
+        let mut ev = ReviewMapItemEvidence::default();
+        ev.missing.push("g");
+        ev.stale.push("g");
+        ev.degraded.push("g");
+        ev.present.push("g");
+        ev.skipped.push("g");
+        ev.unavailable.push("g");
+        assert_eq!(ev.status(), "missing");
+    }
+
+    #[test]
+    fn evidence_status_stale_when_no_missing() {
+        let mut ev = ReviewMapItemEvidence::default();
+        ev.stale.push("g");
+        ev.degraded.push("g");
+        ev.present.push("g");
+        assert_eq!(ev.status(), "stale");
+    }
+
+    #[test]
+    fn evidence_status_degraded_when_no_stale_or_missing() {
+        let mut ev = ReviewMapItemEvidence::default();
+        ev.degraded.push("g");
+        ev.present.push("g");
+        assert_eq!(ev.status(), "degraded");
+    }
+
+    #[test]
+    fn evidence_status_available_when_only_present() {
+        let mut ev = ReviewMapItemEvidence::default();
+        ev.present.push("g");
+        assert_eq!(ev.status(), "available");
+    }
+
+    #[test]
+    fn evidence_status_skipped_when_only_skipped() {
+        let mut ev = ReviewMapItemEvidence::default();
+        ev.skipped.push("g");
+        assert_eq!(ev.status(), "skipped");
+    }
+
+    #[test]
+    fn evidence_status_unavailable_when_only_unavailable() {
+        let mut ev = ReviewMapItemEvidence::default();
+        ev.unavailable.push("g");
+        assert_eq!(ev.status(), "unavailable");
+    }
+
+    // ---------- review_order_bucket / review_order_reason ----------
+
+    #[test]
+    fn order_bucket_priority_one_falls_in_bucket_six() {
+        let it = item("src/main.rs", 1);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(review_order_bucket(&it, &ev), 6);
+    }
+
+    #[test]
+    fn order_reason_priority_one_is_highest_priority_message() {
+        let it = item("src/main.rs", 1);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(
+            review_order_reason(&it, &ev),
+            "Highest cockpit priority from the source review plan."
+        );
+    }
+
+    #[test]
+    fn order_bucket_priority_two_falls_in_bucket_seven() {
+        let it = item("src/main.rs", 2);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(review_order_bucket(&it, &ev), 7);
+    }
+
+    #[test]
+    fn order_reason_priority_two_is_medium_priority_message() {
+        let it = item("src/main.rs", 2);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(
+            review_order_reason(&it, &ev),
+            "Medium cockpit priority from the source review plan."
+        );
+    }
+
+    #[test]
+    fn order_bucket_default_low_priority_is_ten() {
+        let it = item("src/main.rs", 5);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(review_order_bucket(&it, &ev), 10);
+    }
+
+    #[test]
+    fn order_reason_default_low_priority_message() {
+        let it = item("src/main.rs", 5);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(
+            review_order_reason(&it, &ev),
+            "Lower-priority source review item; review after higher-risk signals."
+        );
+    }
+
+    #[test]
+    fn order_bucket_contract_path_falls_in_bucket_five() {
+        // `ci/proof.toml` is a policy contract path, but not a source-of-truth path.
+        let it = item("ci/proof.toml", 3);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(review_order_bucket(&it, &ev), 5);
+    }
+
+    #[test]
+    fn order_reason_contract_path_message() {
+        let it = item("ci/proof.toml", 3);
+        let ev = ReviewMapItemEvidence::default();
+        assert_eq!(
+            review_order_reason(&it, &ev),
+            "Contract or policy path changed; review before ordinary implementation changes."
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds 44 inline unit tests to `crates/tokmd-cockpit/src/render/review_map.rs`, which previously had no direct unit coverage (only one indirect mention in `bdd.rs`).

Covers the pure helpers:

- `review_priority_label` — 1/2/0/3/99
- `schema_review_path`, `policy_review_path`, `cli_review_path`, `api_review_path` — positive and negative cases per predicate
- `review_contract_path` — one case per sub-predicate + negative
- `review_map_evidence_refs` — all four boolean combinations
- `ReviewMapItemEvidence::status` — every branch (missing / stale / degraded / available / skipped / unavailable / default)
- `review_order_bucket` and `review_order_reason` — priority≤1, priority==2, default, and contract-path buckets

No source behaviour was changed; only the new `#[cfg(test)] mod tests` block was added.

## Test plan

- [x] `cargo test -p tokmd-cockpit --lib` — 158 passed, 0 failed
- [x] `cargo fmt --all` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_0199ZE3NjtsBoCnVnsEo9tv7)_