### PR TITLE
refactor(handoff): split linked-evidence rendering into SRP submodules

### DIFF
--- a/crates/tokmd/src/commands/handoff/output.rs
+++ b/crates/tokmd/src/commands/handoff/output.rs
@@ -12,6 +12,10 @@ use tokmd_types::{
     HandoffManifest, InclusionPolicy,
 };
 
+mod linked_evidence;
+
+use linked_evidence::LinkedEvidenceSummary;
+
 pub(super) struct HandoffPayloads {
     pub(super) map_bytes: u64,
     pub(super) intelligence_bytes: u64,
@@ -37,51 +41,6 @@ pub(super) struct HandoffWorkOrderInputs<'a> {
     pub(super) total_files: usize,
     pub(super) selected: &'a [ContextFileRow],
     pub(super) links: &'a HandoffLinkInputs<'a>,
-}
-
-#[derive(Default)]
-struct LinkedEvidenceSummary {
-    review_map: Option<ReviewMapSummary>,
-    review_packet_check: Option<ReviewPacketCheckSummary>,
-    affected: Option<AffectedSummary>,
-    proof_plan: Option<ProofPlanSummary>,
-}
-
-struct ReviewMapSummary {
-    item_count: usize,
-    first_items: Vec<ReviewMapItemSummary>,
-    available: Option<u64>,
-    missing: Option<u64>,
-    degraded: Option<u64>,
-    stale: Option<u64>,
-    skipped: Option<u64>,
-    unavailable: Option<u64>,
-}
-
-struct ReviewMapItemSummary {
-    path: String,
-    reason: Option<String>,
-}
-
-struct ReviewPacketCheckSummary {
-    ok: Option<bool>,
-    artifact_count: Option<u64>,
-    hashes_verified: Option<u64>,
-}
-
-struct AffectedSummary {
-    changed_files: usize,
-    scopes: usize,
-    unknown_files: usize,
-    changed_file_paths: Vec<String>,
-    scope_names: Vec<String>,
-}
-
-struct ProofPlanSummary {
-    commands: usize,
-    required: usize,
-    advisory: usize,
-    first_commands: Vec<String>,
 }
 
 pub(super) fn write_payloads(
@@ -187,7 +146,7 @@ pub(super) fn write_work_order(
     out_dir: &Path,
     order: &HandoffWorkOrderInputs<'_>,
 ) -> Result<ArtifactEntry> {
-    let linked_evidence = summarize_linked_evidence(order.links);
+    let linked_evidence = linked_evidence::summarize(order.links);
     write_text_artifact(
         out_dir,
         "work-order",
@@ -260,7 +219,7 @@ fn render_work_order(
     push_bundle_summary_section(&mut out, order);
     push_changed_surfaces_section(&mut out, order.links, linked_evidence);
     push_linked_evidence_section(&mut out, order.links);
-    render_linked_evidence_summary(&mut out, order.links, linked_evidence);
+    linked_evidence::render(&mut out, order.links, linked_evidence);
     push_review_evidence_section(&mut out, order.links, linked_evidence);
     push_proof_expectations_section(&mut out, order.links, linked_evidence);
     push_missing_evidence_section(&mut out, linked_evidence);
@@ -549,261 +508,6 @@ fn push_agent_guardrails_section(out: &mut String) {
         "- Keep generated receipts with the work when they explain review or proof state.\n",
     );
     out.push_str("- Do not promote advisory proof, enable default Codecov upload, or turn this handoff into a merge verdict.\n");
-}
-
-fn render_linked_evidence_summary(
-    out: &mut String,
-    links: &HandoffLinkInputs<'_>,
-    summary: &LinkedEvidenceSummary,
-) {
-    if !has_any_link(links) {
-        return;
-    }
-
-    out.push_str("\n## Linked Evidence Summary\n\n");
-    out.push_str("These summaries are best-effort hints from linked receipts. They do not replace the linked verifier or proof artifacts.\n\n");
-
-    if let Some(check) = &summary.review_packet_check {
-        out.push_str("- Review packet verifier:");
-        if let Some(ok) = check.ok {
-            out.push_str(&format!(" ok={ok}"));
-        } else {
-            out.push_str(" ok=unknown");
-        }
-        if let Some(artifact_count) = check.artifact_count {
-            out.push_str(&format!(", artifacts={artifact_count}"));
-        }
-        if let Some(hashes_verified) = check.hashes_verified {
-            out.push_str(&format!(", hashes_verified={hashes_verified}"));
-        }
-        out.push('\n');
-    } else if links.review_packet_check.is_some() {
-        out.push_str("- Review packet verifier: linked but not readable\n");
-    }
-
-    if let Some(review_map) = &summary.review_map {
-        out.push_str(&format!("- Review map: {} item(s)", review_map.item_count));
-        if review_map.available.is_some()
-            || review_map.missing.is_some()
-            || review_map.degraded.is_some()
-            || review_map.stale.is_some()
-            || review_map.skipped.is_some()
-            || review_map.unavailable.is_some()
-        {
-            out.push_str(" (");
-            push_count(out, "available", review_map.available);
-            push_count(out, "missing", review_map.missing);
-            push_count(out, "degraded", review_map.degraded);
-            push_count(out, "stale", review_map.stale);
-            push_count(out, "skipped", review_map.skipped);
-            push_count(out, "unavailable", review_map.unavailable);
-            trim_trailing_separator(out);
-            out.push(')');
-        }
-        out.push('\n');
-        if !review_map.first_items.is_empty() {
-            out.push_str("  - Review first:\n");
-            for item in &review_map.first_items {
-                out.push_str(&format!("    - `{}`", item.path));
-                if let Some(reason) = &item.reason {
-                    out.push_str(&format!(": {reason}"));
-                }
-                out.push('\n');
-            }
-        }
-    } else if links.review_packet_dir.is_some() {
-        out.push_str("- Review map: linked but not readable\n");
-    }
-
-    if let Some(affected) = &summary.affected {
-        out.push_str(&format!(
-            "- Affected proof: {} changed file(s), {} scope(s), {} unknown file(s)\n",
-            affected.changed_files, affected.scopes, affected.unknown_files
-        ));
-        if !affected.scope_names.is_empty() {
-            out.push_str("  - Scopes: ");
-            out.push_str(&affected.scope_names.join(", "));
-            out.push('\n');
-        }
-    } else if links.affected.is_some() {
-        out.push_str("- Affected proof: linked but not readable\n");
-    }
-
-    if let Some(proof_plan) = &summary.proof_plan {
-        out.push_str(&format!(
-            "- Proof plan: {} command(s), {} required, {} advisory\n",
-            proof_plan.commands, proof_plan.required, proof_plan.advisory
-        ));
-        if !proof_plan.first_commands.is_empty() {
-            out.push_str("  - First commands:\n");
-            for command in &proof_plan.first_commands {
-                out.push_str(&format!("    - `{command}`\n"));
-            }
-            if proof_plan.commands > proof_plan.first_commands.len() {
-                out.push_str(&format!(
-                    "    - ... {} more command(s); open the proof plan for the full list.\n",
-                    proof_plan.commands - proof_plan.first_commands.len()
-                ));
-            }
-        }
-        out.push_str("  - A proof plan is planned evidence, not execution proof.\n");
-    } else if links.proof_plan.is_some() {
-        out.push_str("- Proof plan: linked but not readable\n");
-    }
-}
-
-fn summarize_linked_evidence(links: &HandoffLinkInputs<'_>) -> LinkedEvidenceSummary {
-    LinkedEvidenceSummary {
-        review_map: links
-            .review_packet_dir
-            .and_then(|dir| read_json_value(&dir.join("review-map.json")))
-            .and_then(|value| summarize_review_map(&value)),
-        review_packet_check: links
-            .review_packet_check
-            .and_then(read_json_value)
-            .map(|value| summarize_review_packet_check(&value)),
-        affected: links
-            .affected
-            .and_then(read_json_value)
-            .map(|value| summarize_affected(&value)),
-        proof_plan: links
-            .proof_plan
-            .and_then(read_json_value)
-            .map(|value| summarize_proof_plan(&value)),
-    }
-}
-
-fn read_json_value(path: &Path) -> Option<Value> {
-    let content = fs::read_to_string(path).ok()?;
-    serde_json::from_str(&content).ok()
-}
-
-fn summarize_review_map(value: &Value) -> Option<ReviewMapSummary> {
-    let items = value.get("items")?.as_array()?;
-    let item_count = value
-        .get("item_count")
-        .and_then(Value::as_u64)
-        .map(|count| count as usize)
-        .unwrap_or(items.len());
-    let first_items = items
-        .iter()
-        .take(5)
-        .filter_map(|item| {
-            let path = item.get("path")?.as_str()?.to_string();
-            let reason = item
-                .get("reason")
-                .and_then(Value::as_str)
-                .map(str::to_string);
-            Some(ReviewMapItemSummary { path, reason })
-        })
-        .collect();
-    let evidence_summary = value.get("evidence").and_then(|e| e.get("summary"));
-
-    Some(ReviewMapSummary {
-        item_count,
-        first_items,
-        available: count_field(evidence_summary, "available"),
-        missing: count_field(evidence_summary, "missing"),
-        degraded: count_field(evidence_summary, "degraded"),
-        stale: count_field(evidence_summary, "stale"),
-        skipped: count_field(evidence_summary, "skipped"),
-        unavailable: count_field(evidence_summary, "unavailable"),
-    })
-}
-
-fn summarize_review_packet_check(value: &Value) -> ReviewPacketCheckSummary {
-    ReviewPacketCheckSummary {
-        ok: value.get("ok").and_then(Value::as_bool),
-        artifact_count: value.get("artifact_count").and_then(Value::as_u64),
-        hashes_verified: value.get("hashes_verified").and_then(Value::as_u64),
-    }
-}
-
-fn summarize_affected(value: &Value) -> AffectedSummary {
-    let changed_files = array_len(value.get("changed_files"));
-    let changed_file_paths = value
-        .get("changed_files")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flat_map(|paths| paths.iter())
-        .filter_map(Value::as_str)
-        .take(10)
-        .map(str::to_string)
-        .collect::<Vec<_>>();
-    let scopes_array = value.get("scopes").and_then(Value::as_array);
-    let scope_names = scopes_array
-        .into_iter()
-        .flat_map(|scopes| scopes.iter())
-        .filter_map(|scope| scope.get("name").and_then(Value::as_str))
-        .take(8)
-        .map(str::to_string)
-        .collect::<Vec<_>>();
-
-    AffectedSummary {
-        changed_files,
-        scopes: array_len(value.get("scopes")),
-        unknown_files: array_len(value.get("unknown_files")),
-        changed_file_paths,
-        scope_names,
-    }
-}
-
-fn summarize_proof_plan(value: &Value) -> ProofPlanSummary {
-    let Some(commands) = value.get("commands").and_then(Value::as_array) else {
-        return ProofPlanSummary {
-            commands: 0,
-            required: 0,
-            advisory: 0,
-            first_commands: Vec::new(),
-        };
-    };
-    let required = commands
-        .iter()
-        .filter(|command| command.get("required").and_then(Value::as_bool) == Some(true))
-        .count();
-    let advisory = commands.len().saturating_sub(required);
-    let first_commands = commands
-        .iter()
-        .filter_map(|command| command.get("command").and_then(Value::as_str))
-        .take(5)
-        .map(str::to_string)
-        .collect();
-
-    ProofPlanSummary {
-        commands: commands.len(),
-        required,
-        advisory,
-        first_commands,
-    }
-}
-
-fn has_any_link(links: &HandoffLinkInputs<'_>) -> bool {
-    links.review_packet_dir.is_some()
-        || links.review_packet_check.is_some()
-        || links.affected.is_some()
-        || links.proof_plan.is_some()
-}
-
-fn count_field(value: Option<&Value>, field: &str) -> Option<u64> {
-    value
-        .and_then(|value| value.get(field))
-        .and_then(Value::as_u64)
-}
-
-fn array_len(value: Option<&Value>) -> usize {
-    value.and_then(Value::as_array).map_or(0, Vec::len)
-}
-
-fn push_count(out: &mut String, label: &str, count: Option<u64>) {
-    if let Some(count) = count {
-        out.push_str(&format!("{label}={count}, "));
-    }
-}
-
-fn trim_trailing_separator(out: &mut String) {
-    if out.ends_with(", ") {
-        out.truncate(out.len() - 2);
-    }
 }
 
 fn review_links_json(

--- a/crates/tokmd/src/commands/handoff/output/linked_evidence.rs
+++ b/crates/tokmd/src/commands/handoff/output/linked_evidence.rs
@@ -1,0 +1,94 @@
+//! Linked-evidence summary rendering for the handoff work order.
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+mod affected;
+mod proof_plan;
+mod review_map;
+mod review_packet_check;
+
+pub(in crate::commands::handoff) use affected::AffectedSummary;
+pub(in crate::commands::handoff) use proof_plan::ProofPlanSummary;
+pub(in crate::commands::handoff) use review_map::ReviewMapSummary;
+pub(in crate::commands::handoff) use review_packet_check::ReviewPacketCheckSummary;
+
+#[derive(Default)]
+pub(in crate::commands::handoff) struct LinkedEvidenceSummary {
+    pub(in crate::commands::handoff) review_map: Option<ReviewMapSummary>,
+    pub(in crate::commands::handoff) review_packet_check: Option<ReviewPacketCheckSummary>,
+    pub(in crate::commands::handoff) affected: Option<AffectedSummary>,
+    pub(in crate::commands::handoff) proof_plan: Option<ProofPlanSummary>,
+}
+
+pub(super) fn summarize(links: &super::HandoffLinkInputs<'_>) -> LinkedEvidenceSummary {
+    LinkedEvidenceSummary {
+        review_map: links
+            .review_packet_dir
+            .and_then(|dir| read_json_value(&dir.join("review-map.json")))
+            .and_then(|value| review_map::summarize(&value)),
+        review_packet_check: links
+            .review_packet_check
+            .and_then(read_json_value)
+            .map(|value| review_packet_check::summarize(&value)),
+        affected: links
+            .affected
+            .and_then(read_json_value)
+            .map(|value| affected::summarize(&value)),
+        proof_plan: links
+            .proof_plan
+            .and_then(read_json_value)
+            .map(|value| proof_plan::summarize(&value)),
+    }
+}
+
+pub(super) fn render(
+    out: &mut String,
+    links: &super::HandoffLinkInputs<'_>,
+    summary: &LinkedEvidenceSummary,
+) {
+    if !has_any_link(links) {
+        return;
+    }
+
+    out.push_str("\n## Linked Evidence Summary\n\n");
+    out.push_str("These summaries are best-effort hints from linked receipts. They do not replace the linked verifier or proof artifacts.\n\n");
+
+    if let Some(check) = &summary.review_packet_check {
+        review_packet_check::render(out, check);
+    } else if links.review_packet_check.is_some() {
+        out.push_str("- Review packet verifier: linked but not readable\n");
+    }
+
+    if let Some(review_map) = &summary.review_map {
+        review_map::render(out, review_map);
+    } else if links.review_packet_dir.is_some() {
+        out.push_str("- Review map: linked but not readable\n");
+    }
+
+    if let Some(affected) = &summary.affected {
+        affected::render(out, affected);
+    } else if links.affected.is_some() {
+        out.push_str("- Affected proof: linked but not readable\n");
+    }
+
+    if let Some(proof_plan) = &summary.proof_plan {
+        proof_plan::render(out, proof_plan);
+    } else if links.proof_plan.is_some() {
+        out.push_str("- Proof plan: linked but not readable\n");
+    }
+}
+
+fn has_any_link(links: &super::HandoffLinkInputs<'_>) -> bool {
+    links.review_packet_dir.is_some()
+        || links.review_packet_check.is_some()
+        || links.affected.is_some()
+        || links.proof_plan.is_some()
+}
+
+fn read_json_value(path: &Path) -> Option<Value> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}

--- a/crates/tokmd/src/commands/handoff/output/linked_evidence/affected.rs
+++ b/crates/tokmd/src/commands/handoff/output/linked_evidence/affected.rs
@@ -1,0 +1,56 @@
+//! Affected-proof report summary.
+
+use serde_json::Value;
+
+pub(in crate::commands::handoff) struct AffectedSummary {
+    pub(in crate::commands::handoff) changed_files: usize,
+    pub(in crate::commands::handoff) scopes: usize,
+    pub(in crate::commands::handoff) unknown_files: usize,
+    pub(in crate::commands::handoff) changed_file_paths: Vec<String>,
+    pub(in crate::commands::handoff) scope_names: Vec<String>,
+}
+
+pub(super) fn summarize(value: &Value) -> AffectedSummary {
+    let changed_files = array_len(value.get("changed_files"));
+    let changed_file_paths = value
+        .get("changed_files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flat_map(|paths| paths.iter())
+        .filter_map(Value::as_str)
+        .take(10)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let scopes_array = value.get("scopes").and_then(Value::as_array);
+    let scope_names = scopes_array
+        .into_iter()
+        .flat_map(|scopes| scopes.iter())
+        .filter_map(|scope| scope.get("name").and_then(Value::as_str))
+        .take(8)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    AffectedSummary {
+        changed_files,
+        scopes: array_len(value.get("scopes")),
+        unknown_files: array_len(value.get("unknown_files")),
+        changed_file_paths,
+        scope_names,
+    }
+}
+
+pub(super) fn render(out: &mut String, affected: &AffectedSummary) {
+    out.push_str(&format!(
+        "- Affected proof: {} changed file(s), {} scope(s), {} unknown file(s)\n",
+        affected.changed_files, affected.scopes, affected.unknown_files
+    ));
+    if !affected.scope_names.is_empty() {
+        out.push_str("  - Scopes: ");
+        out.push_str(&affected.scope_names.join(", "));
+        out.push('\n');
+    }
+}
+
+fn array_len(value: Option<&Value>) -> usize {
+    value.and_then(Value::as_array).map_or(0, Vec::len)
+}

--- a/crates/tokmd/src/commands/handoff/output/linked_evidence/proof_plan.rs
+++ b/crates/tokmd/src/commands/handoff/output/linked_evidence/proof_plan.rs
@@ -1,0 +1,59 @@
+//! Proof plan report summary.
+
+use serde_json::Value;
+
+pub(in crate::commands::handoff) struct ProofPlanSummary {
+    pub(in crate::commands::handoff) commands: usize,
+    pub(in crate::commands::handoff) required: usize,
+    pub(in crate::commands::handoff) advisory: usize,
+    pub(in crate::commands::handoff) first_commands: Vec<String>,
+}
+
+pub(super) fn summarize(value: &Value) -> ProofPlanSummary {
+    let Some(commands) = value.get("commands").and_then(Value::as_array) else {
+        return ProofPlanSummary {
+            commands: 0,
+            required: 0,
+            advisory: 0,
+            first_commands: Vec::new(),
+        };
+    };
+    let required = commands
+        .iter()
+        .filter(|command| command.get("required").and_then(Value::as_bool) == Some(true))
+        .count();
+    let advisory = commands.len().saturating_sub(required);
+    let first_commands = commands
+        .iter()
+        .filter_map(|command| command.get("command").and_then(Value::as_str))
+        .take(5)
+        .map(str::to_string)
+        .collect();
+
+    ProofPlanSummary {
+        commands: commands.len(),
+        required,
+        advisory,
+        first_commands,
+    }
+}
+
+pub(super) fn render(out: &mut String, proof_plan: &ProofPlanSummary) {
+    out.push_str(&format!(
+        "- Proof plan: {} command(s), {} required, {} advisory\n",
+        proof_plan.commands, proof_plan.required, proof_plan.advisory
+    ));
+    if !proof_plan.first_commands.is_empty() {
+        out.push_str("  - First commands:\n");
+        for command in &proof_plan.first_commands {
+            out.push_str(&format!("    - `{command}`\n"));
+        }
+        if proof_plan.commands > proof_plan.first_commands.len() {
+            out.push_str(&format!(
+                "    - ... {} more command(s); open the proof plan for the full list.\n",
+                proof_plan.commands - proof_plan.first_commands.len()
+            ));
+        }
+    }
+    out.push_str("  - A proof plan is planned evidence, not execution proof.\n");
+}

--- a/crates/tokmd/src/commands/handoff/output/linked_evidence/review_map.rs
+++ b/crates/tokmd/src/commands/handoff/output/linked_evidence/review_map.rs
@@ -1,0 +1,102 @@
+//! Review map (cockpit review packet) summary.
+
+use serde_json::Value;
+
+pub(in crate::commands::handoff) struct ReviewMapSummary {
+    pub(in crate::commands::handoff) item_count: usize,
+    pub(in crate::commands::handoff) first_items: Vec<ReviewMapItemSummary>,
+    pub(in crate::commands::handoff) available: Option<u64>,
+    pub(in crate::commands::handoff) missing: Option<u64>,
+    pub(in crate::commands::handoff) degraded: Option<u64>,
+    pub(in crate::commands::handoff) stale: Option<u64>,
+    pub(in crate::commands::handoff) skipped: Option<u64>,
+    pub(in crate::commands::handoff) unavailable: Option<u64>,
+}
+
+pub(in crate::commands::handoff) struct ReviewMapItemSummary {
+    pub(in crate::commands::handoff) path: String,
+    pub(in crate::commands::handoff) reason: Option<String>,
+}
+
+pub(super) fn summarize(value: &Value) -> Option<ReviewMapSummary> {
+    let items = value.get("items")?.as_array()?;
+    let item_count = value
+        .get("item_count")
+        .and_then(Value::as_u64)
+        .map(|count| count as usize)
+        .unwrap_or(items.len());
+    let first_items = items
+        .iter()
+        .take(5)
+        .filter_map(|item| {
+            let path = item.get("path")?.as_str()?.to_string();
+            let reason = item
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            Some(ReviewMapItemSummary { path, reason })
+        })
+        .collect();
+    let evidence_summary = value.get("evidence").and_then(|e| e.get("summary"));
+
+    Some(ReviewMapSummary {
+        item_count,
+        first_items,
+        available: count_field(evidence_summary, "available"),
+        missing: count_field(evidence_summary, "missing"),
+        degraded: count_field(evidence_summary, "degraded"),
+        stale: count_field(evidence_summary, "stale"),
+        skipped: count_field(evidence_summary, "skipped"),
+        unavailable: count_field(evidence_summary, "unavailable"),
+    })
+}
+
+pub(super) fn render(out: &mut String, review_map: &ReviewMapSummary) {
+    out.push_str(&format!("- Review map: {} item(s)", review_map.item_count));
+    if review_map.available.is_some()
+        || review_map.missing.is_some()
+        || review_map.degraded.is_some()
+        || review_map.stale.is_some()
+        || review_map.skipped.is_some()
+        || review_map.unavailable.is_some()
+    {
+        out.push_str(" (");
+        push_count(out, "available", review_map.available);
+        push_count(out, "missing", review_map.missing);
+        push_count(out, "degraded", review_map.degraded);
+        push_count(out, "stale", review_map.stale);
+        push_count(out, "skipped", review_map.skipped);
+        push_count(out, "unavailable", review_map.unavailable);
+        trim_trailing_separator(out);
+        out.push(')');
+    }
+    out.push('\n');
+    if !review_map.first_items.is_empty() {
+        out.push_str("  - Review first:\n");
+        for item in &review_map.first_items {
+            out.push_str(&format!("    - `{}`", item.path));
+            if let Some(reason) = &item.reason {
+                out.push_str(&format!(": {reason}"));
+            }
+            out.push('\n');
+        }
+    }
+}
+
+fn count_field(value: Option<&Value>, field: &str) -> Option<u64> {
+    value
+        .and_then(|value| value.get(field))
+        .and_then(Value::as_u64)
+}
+
+fn push_count(out: &mut String, label: &str, count: Option<u64>) {
+    if let Some(count) = count {
+        out.push_str(&format!("{label}={count}, "));
+    }
+}
+
+fn trim_trailing_separator(out: &mut String) {
+    if out.ends_with(", ") {
+        out.truncate(out.len() - 2);
+    }
+}

--- a/crates/tokmd/src/commands/handoff/output/linked_evidence/review_packet_check.rs
+++ b/crates/tokmd/src/commands/handoff/output/linked_evidence/review_packet_check.rs
@@ -1,0 +1,33 @@
+//! Review packet verifier receipt summary.
+
+use serde_json::Value;
+
+pub(in crate::commands::handoff) struct ReviewPacketCheckSummary {
+    pub(in crate::commands::handoff) ok: Option<bool>,
+    pub(in crate::commands::handoff) artifact_count: Option<u64>,
+    pub(in crate::commands::handoff) hashes_verified: Option<u64>,
+}
+
+pub(super) fn summarize(value: &Value) -> ReviewPacketCheckSummary {
+    ReviewPacketCheckSummary {
+        ok: value.get("ok").and_then(Value::as_bool),
+        artifact_count: value.get("artifact_count").and_then(Value::as_u64),
+        hashes_verified: value.get("hashes_verified").and_then(Value::as_u64),
+    }
+}
+
+pub(super) fn render(out: &mut String, check: &ReviewPacketCheckSummary) {
+    out.push_str("- Review packet verifier:");
+    if let Some(ok) = check.ok {
+        out.push_str(&format!(" ok={ok}"));
+    } else {
+        out.push_str(" ok=unknown");
+    }
+    if let Some(artifact_count) = check.artifact_count {
+        out.push_str(&format!(", artifacts={artifact_count}"));
+    }
+    if let Some(hashes_verified) = check.hashes_verified {
+        out.push_str(&format!(", hashes_verified={hashes_verified}"));
+    }
+    out.push('\n');
+}


### PR DESCRIPTION
## Summary

`render_linked_evidence_summary` in `crates/tokmd/src/commands/handoff/output.rs` previously inlined four evidence kinds (review packet verifier, review map, affected proof, proof plan) plus their JSON parsers and per-kind summary structs into one ~100-line function. Each kind is now its own submodule under `output/linked_evidence/`, owning its summary type, JSON parser, and renderer. The module root orchestrates dispatch and keeps the section header plus the "linked but not readable" fallbacks.

- `output.rs`: 1061 → 765 lines.
- 4 new files under `output/linked_evidence/` (review_packet_check, review_map, affected, proof_plan), each ~30–100 lines and single-responsibility.
- Module root `output/linked_evidence.rs` exposes `summarize` and `render` plus the four `*Summary` types via `pub(in crate::commands::handoff)` so the rest of `output.rs` can still read fields like `summary.review_map.first_items`.

## Behavior

Byte-identical work-order markdown. No public-API or wire-format changes. Existing handoff integration tests verify output stability.

## Test plan

- [x] `cargo build -p tokmd` (zero warnings)
- [x] `cargo test -p tokmd --lib` (516 passed)
- [x] `cargo test -p tokmd` — all integration + doc tests pass, including `handoff_writes_to_output_dir` and `cockpit_cli_*` suites
- [x] `cargo clippy -p tokmd --all-features -- -D warnings` (clean)
- [x] `cargo fmt -p tokmd` (no diffs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bhf59hLrFTGK2THoxFEbJM)_