### PR TITLE
fix(cockpit): reproduce actual review packet dir

### DIFF
--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -20,12 +20,19 @@ pub(super) fn review_packet_review_map(
     receipt: &CockpitReceipt,
     proof_inputs: &[ProofEvidenceInput],
     doc_artifacts: Option<&DocArtifactsEvidenceInput>,
+    review_packet_dir: &str,
 ) -> Value {
     let proof_refs = review_map_proof_refs(receipt, proof_inputs);
     let has_doc_artifacts_evidence = doc_artifacts.is_some() || doc_artifacts_expected(receipt);
     let evidence_refs =
         review_map_evidence_refs(!proof_refs.is_empty(), has_doc_artifacts_evidence);
     let ordered_items = ordered_review_map_items(receipt);
+    let context = ReviewMapRenderContext {
+        receipt,
+        proof_refs: &proof_refs,
+        doc_artifacts,
+        review_packet_dir,
+    };
     let items: Vec<_> = ordered_items
         .iter()
         .enumerate()
@@ -34,10 +41,8 @@ pub(super) fn review_packet_review_map(
                 rank + 1,
                 ordered.source_index,
                 ordered.item,
-                receipt,
                 &ordered.evidence,
-                &proof_refs,
-                doc_artifacts,
+                &context,
             )
         })
         .collect();
@@ -57,18 +62,23 @@ pub(super) fn review_packet_review_map(
     })
 }
 
+struct ReviewMapRenderContext<'a> {
+    receipt: &'a CockpitReceipt,
+    proof_refs: &'a [ReviewMapProofRef],
+    doc_artifacts: Option<&'a DocArtifactsEvidenceInput>,
+    review_packet_dir: &'a str,
+}
+
 fn review_map_item(
     rank: usize,
     source_index: usize,
     item: &ReviewItem,
-    receipt: &CockpitReceipt,
     evidence: &ReviewMapItemEvidence,
-    proof_refs: &[ReviewMapProofRef],
-    doc_artifacts: Option<&DocArtifactsEvidenceInput>,
+    context: &ReviewMapRenderContext<'_>,
 ) -> Value {
-    let proof = review_map_item_proof(item, proof_refs);
-    let doc_artifacts_refs = review_map_item_doc_artifacts_refs(item, doc_artifacts);
-    let reproduce = review_map_item_reproduce(item, receipt);
+    let proof = review_map_item_proof(item, context.proof_refs);
+    let doc_artifacts_refs = review_map_item_doc_artifacts_refs(item, context.doc_artifacts);
+    let reproduce = review_map_item_reproduce(item, context.receipt, context.review_packet_dir);
 
     json!({
         "rank": rank,
@@ -223,15 +233,19 @@ fn api_review_path(path: &str) -> bool {
     path.ends_with("lib.rs") || path.ends_with("mod.rs")
 }
 
-fn review_map_item_reproduce(item: &ReviewItem, receipt: &CockpitReceipt) -> Vec<String> {
+fn review_map_item_reproduce(
+    item: &ReviewItem,
+    receipt: &CockpitReceipt,
+    review_packet_dir: &str,
+) -> Vec<String> {
     let mut commands = vec![
         format!(
             "tokmd cockpit --base {} --head {} --format json",
             receipt.base_ref, receipt.head_ref
         ),
         format!(
-            "tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review",
-            receipt.base_ref, receipt.head_ref
+            "tokmd cockpit --base {} --head {} --review-packet-dir {}",
+            receipt.base_ref, receipt.head_ref, review_packet_dir
         ),
     ];
 
@@ -343,6 +357,7 @@ pub(super) fn render_review_map_md(
     receipt: &CockpitReceipt,
     proof_inputs: &[ProofEvidenceInput],
     doc_artifacts: Option<&DocArtifactsEvidenceInput>,
+    review_packet_dir: &str,
 ) -> String {
     use std::fmt::Write;
 
@@ -427,8 +442,8 @@ pub(super) fn render_review_map_md(
         );
         let _ = writeln!(
             s,
-            "   - `tokmd cockpit --base {} --head {} --review-packet-dir .tokmd/review`",
-            receipt.base_ref, receipt.head_ref
+            "   - `tokmd cockpit --base {} --head {} --review-packet-dir {}`",
+            receipt.base_ref, receipt.head_ref, review_packet_dir
         );
         if review_item_is_source_of_truth(item) {
             let _ = writeln!(

--- a/crates/tokmd-cockpit/src/render/review_packet.rs
+++ b/crates/tokmd-cockpit/src/render/review_packet.rs
@@ -44,6 +44,7 @@ pub fn write_review_packet_with_imported_evidence(
     doc_artifacts: Option<&DocArtifactsEvidenceInput>,
 ) -> Result<()> {
     std::fs::create_dir_all(dir)?;
+    let review_packet_dir = review_packet_dir_for_reproduction(dir);
     let proof_artifacts = packet_proof_artifacts(proof_evidence)?;
     let packet_proof_inputs: Vec<_> = proof_artifacts
         .iter()
@@ -61,8 +62,14 @@ pub fn write_review_packet_with_imported_evidence(
         receipt,
         &packet_proof_inputs,
         doc_artifacts.as_ref(),
+        &review_packet_dir,
     ))?;
-    let review_map_md = render_review_map_md(receipt, &packet_proof_inputs, doc_artifacts.as_ref());
+    let review_map_md = render_review_map_md(
+        receipt,
+        &packet_proof_inputs,
+        doc_artifacts.as_ref(),
+        &review_packet_dir,
+    );
     let comment_md =
         render_review_packet_comment_md(receipt, &packet_proof_inputs, doc_artifacts.as_ref());
 
@@ -121,6 +128,18 @@ pub fn write_review_packet_with_imported_evidence(
     )?;
 
     Ok(())
+}
+
+fn review_packet_dir_for_reproduction(dir: &Path) -> String {
+    if dir.is_absolute() {
+        return "<REVIEW_PACKET_DIR>".to_string();
+    }
+    let rendered = dir.to_string_lossy().replace('\\', "/");
+    if rendered.is_empty() {
+        ".tokmd/review".to_string()
+    } else {
+        rendered
+    }
 }
 
 fn packet_doc_artifacts_input(

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -912,10 +912,9 @@ fn scenario_write_review_packet_creates_contract_files() {
     assert!(review_map_md.contains("evidence.json#/gates"));
     assert!(review_map_md.contains("Reproduce:"));
     assert!(review_map_md.contains("tokmd cockpit --base main --head feature --format json"));
-    assert!(
-        review_map_md
-            .contains("tokmd cockpit --base main --head feature --review-packet-dir .tokmd/review")
-    );
+    assert!(review_map_md.contains(
+        "tokmd cockpit --base main --head feature --review-packet-dir <REVIEW_PACKET_DIR>"
+    ));
 
     let comment_md = std::fs::read_to_string(out.join("comment.md")).unwrap();
     assert!(comment_md.contains("Evidence availability"));

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -980,7 +980,7 @@ fn test_cockpit_artifacts_dir() {
 #[test]
 fn test_cockpit_review_packet_dir() {
     // Given: A git repository with a main branch and a test branch with code changes
-    // When: User runs `tokmd cockpit --base main --review-packet-dir .tokmd/review`
+    // When: User runs `tokmd cockpit --base main --review-packet-dir .tokmd/custom-review`
     // Then: The review packet directory should contain the initial packet artifacts
     if !common::git_available() {
         return;
@@ -1007,7 +1007,8 @@ fn test_cockpit_review_packet_dir() {
         return;
     }
 
-    let packet_dir = dir.path().join(".tokmd").join("review");
+    let packet_dir_arg = std::path::PathBuf::from(".tokmd").join("custom-review");
+    let packet_dir = dir.path().join(&packet_dir_arg);
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
     cmd.current_dir(dir.path())
@@ -1015,7 +1016,7 @@ fn test_cockpit_review_packet_dir() {
         .arg("--base")
         .arg("main")
         .arg("--review-packet-dir")
-        .arg(&packet_dir)
+        .arg(&packet_dir_arg)
         .assert()
         .success();
 
@@ -1170,6 +1171,16 @@ fn test_cockpit_review_packet_dir() {
             .all(|item| item["evidence"]["status"].is_string()),
         "each review-map item should expose compact evidence status"
     );
+    assert!(
+        items[0]["reproduce"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|command| command.as_str().unwrap_or("").contains(
+                "tokmd cockpit --base main --head HEAD --review-packet-dir .tokmd/custom-review"
+            )),
+        "review-map JSON should reproduce the actual packet directory"
+    );
 
     let review_map_md = std::fs::read_to_string(packet_dir.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("# Review Map"));
@@ -1182,10 +1193,9 @@ fn test_cockpit_review_packet_dir() {
     assert!(review_map_md.contains("evidence.json#/gates"));
     assert!(review_map_md.contains("Reproduce:"));
     assert!(review_map_md.contains("tokmd cockpit --base main --head HEAD --format json"));
-    assert!(
-        review_map_md
-            .contains("tokmd cockpit --base main --head HEAD --review-packet-dir .tokmd/review")
-    );
+    assert!(review_map_md.contains(
+        "tokmd cockpit --base main --head HEAD --review-packet-dir .tokmd/custom-review"
+    ));
 
     let comment_md = std::fs::read_to_string(packet_dir.join("comment.md")).unwrap();
     assert!(comment_md.contains("Evidence availability"));


### PR DESCRIPTION
Linked lane: user-path evidence consumption pressure test
Changed surface: cockpit review-map reproduction commands
User job improved: Review PR / prepare agent handoff
Behavior change: review-map JSON and Markdown now reproduce the actual relative `--review-packet-dir`; absolute packet dirs render `<REVIEW_PACKET_DIR>` so packet artifacts do not leak machine-local paths.
Schema change: none

Proof:
- `cargo test -p tokmd-cockpit --test bdd scenario_write_review_packet_creates_contract_files --verbose`
- `cargo test -p tokmd --test cockpit_integration test_cockpit_review_packet_dir --verbose`
- `cargo test -p tokmd-cockpit review_map --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo clippy -p tokmd-cockpit --all-targets -- -D warnings`
- `cargo clippy -p tokmd --all-targets -- -D warnings`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-review-map-reproduce-dir.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-review-map-reproduce-dir.json --evidence-json target/proof/proof-evidence-review-map-reproduce-dir.json`
- `cargo xtask proof-policy --check`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

Non-goals:
- no new `tokmd review` command
- no proof promotion
- no Codecov default change
- no AST or evidencebus runtime change
- no merge verdict