### PR TITLE
docs: align next state with paused goal

### DIFF
--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -212,8 +212,9 @@ lane, release workflow, and affected-proof evidence cannot cover.
    shows a product, verifier, or hosted-comment issue.
 4. Preserve `tokmd cockpit` as the review evidence implementation surface until
    a separate review orchestrator has a real contract.
-5. Continue architecture consolidation in batches, preserving `ci/proof.toml`
-   scope granularity as implementation microcrates collapse into SRP modules.
+5. Do not continue architecture consolidation by inertia. If fresh product or
+   proof evidence shows a real owner-module problem, preserve `ci/proof.toml`
+   scope granularity while changing implementation modules.
 6. Use bounded performance timing receipts before optimizing hot paths.
 7. Keep source-of-truth docs, active goal state, and proof-policy routing
    aligned as new lanes start; do not reopen the doc-artifacts checker lane
@@ -359,7 +360,8 @@ lane, release workflow, and affected-proof evidence cannot cover.
 - The documentation source-of-truth lane is closed through first enforcement:
   `docs/plans/doc-artifacts-check.md` is complete, the completed goal is
   archived in `.jules/goals/archive/2026-05-13-doc-artifacts-check.toml`, and
-  `.jules/goals/active.toml` now points at cockpit review usefulness.
+  `.jules/goals/active.toml` then moved on to cockpit review usefulness. The
+  current active-goal state is authoritative in `.jules/goals/active.toml`.
 - The cockpit review packet comment now points directly to `evidence.json`, `review-map.md`, and `cockpit.json`, so hosted PR comments have a short path from the summary to the full packet artifacts.
 - Cockpit review-packet evidence availability now uses the `missing` bucket for pending gates with relevant scope but no tested scope, keeping absent optional gates separate as `unavailable`.
 - The composite Action now adds hosted packet metadata to review-packet PR comments, pointing reviewers to the workflow run, `tokmd-receipts` artifact, and `.tokmd/review` packet path when artifacts are uploaded.


### PR DESCRIPTION
## Summary
- align `docs/NEXT.md` next-work wording with the parked active-goal state
- remove stale “now points at cockpit review usefulness” wording from the historical source-of-truth checkpoint
- preserve no-new-lane / fresh-evidence boundaries

## Linked lane
No selected implementation lane. This is a narrow source-of-truth alignment from a current docs/active-goal consistency audit.

## Changed surface
`docs/NEXT.md` only.

## User job improved
Future maintainers and agents reading `docs/NEXT.md` and `.jules/goals/active.toml` get the same instruction: no architecture or implementation continuation by inertia.

## Behavior change
None.

## Schema change
None.

## Proof
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-next-paused-state-alignment.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-next-paused-state-alignment.json --evidence-json target/proof/proof-evidence-next-paused-state-alignment.json`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask proof_policy --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

## Non-goals
- no implementation lane
- no proof promotion
- no Codecov default change
- no public CLI or receipt schema change
- no architecture work