### PR TITLE
docs: add install and try guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ cargo install tokmd --locked
 tokmd --version
 ```
 
-See [Install tokmd](docs/install.md) for release binaries, Nix, and CI usage.
+See [Install and try tokmd](docs/install-and-try.md) for the first-run path, or
+[Install tokmd](docs/install.md) for release binaries, Nix, and CI usage.
 
 ## Start With One Job
 
@@ -59,7 +60,8 @@ tokmd gate --receipt .runs/current/receipt.json --policy tokmd-gate.toml
 tokmd handoff --preset risk --budget 128k --strategy spread --out-dir .handoff
 ```
 
-For a job-oriented walkthrough, start with [Start Here](docs/start-here.md).
+For a job-oriented walkthrough, start with [Start Here](docs/start-here.md) or
+[Install and try tokmd](docs/install-and-try.md).
 For the command-to-artifact reading order, use [User paths](docs/user-paths.md).
 
 ## What tokmd Produces

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1099,6 +1099,7 @@ paths = [
   "docs/artifacts.md",
   "docs/browser.md",
   "docs/examples/**",
+  "docs/install-and-try.md",
   "docs/publishing-evidence.md",
   "docs/start-here.md",
   "docs/handoff.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@ schemas, and verification policy for `tokmd`.
 
 - [start-here.md](start-here.md) — choose the shortest path for repo
   inspection, PR review, CI evidence, agent handoff, or browser evaluation.
+- [install-and-try.md](install-and-try.md) — install tokmd, run the first
+  useful commands, and move from local trial to review, handoff, CI, browser,
+  or release-facing evidence.
 - [user-paths.md](user-paths.md) — map each job to the command, primary
   artifact, first file to open, meaning, non-meaning, and next action.
 - [workflows.md](workflows.md) — copy-ready command sequences for inspection,

--- a/docs/install-and-try.md
+++ b/docs/install-and-try.md
@@ -1,0 +1,172 @@
+# Install And Try tokmd
+
+Use this path when you want a fast first run before learning the rest of the
+repo evidence system.
+
+This guide gives you one useful command first, then shows where to go when the
+job becomes PR review, agent handoff, CI evidence, or browser evaluation.
+
+## 1. Install
+
+Install from crates.io:
+
+```bash
+cargo install tokmd --locked
+tokmd --version
+```
+
+Other install paths:
+
+- Download release binaries from
+  <https://github.com/EffortlessMetrics/tokmd/releases>.
+- Use Nix:
+
+  ```bash
+  nix run github:EffortlessMetrics/tokmd -- --version
+  ```
+
+- Use the GitHub Action when you want CI artifacts. See
+  [GitHub Action reference](github-action.md).
+
+## 2. Inspect A Repo
+
+Run:
+
+```bash
+tokmd --format md --top 8
+```
+
+Open first: terminal output.
+
+This shows the language mix, total size, and largest surfaces. It does not run
+tests, review a PR, or prove release readiness.
+
+Next useful command:
+
+```bash
+tokmd analyze --preset risk --format md
+```
+
+Use the risk preset when you want derived risk, effort, complexity, and
+git-backed signals before choosing what to inspect next.
+
+## 3. Review A PR
+
+Run:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+```
+
+Open first:
+
+1. `.tokmd/review/review-map.md`
+2. `.tokmd/review/comment.md`
+3. `.tokmd/review/evidence.json`
+
+In a tokmd contributor checkout, verify the packet:
+
+```bash
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+The packet tells you what to review first, what evidence exists, what evidence
+is missing or degraded, and which commands reproduce the evidence. It is not a
+merge verdict.
+
+## 4. Prepare A Coding-Agent Handoff
+
+Run:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --out-dir .handoff
+```
+
+Open first:
+
+1. `.handoff/work-order.md`
+2. `.handoff/code.txt`
+3. `.handoff/manifest.json`
+
+Give the agent `work-order.md` first and `code.txt` as the bounded source
+bundle. The handoff does not prove that tests passed. When review or proof
+artifacts exist, link them with the flags shown in [Handoff bundles](handoff.md)
+instead of pasting logs into the prompt.
+
+## 5. Try Browser Mode
+
+Use the browser runner when you want no-install inspection over browser-safe
+inputs. It can summarize supported GitHub-loaded or local-file inputs and
+download a browser-safe receipt.
+
+Browser mode is not native mode. It does not produce cockpit packets, gates,
+context bundles, handoff directories, git-history enrichers, or AST-backed
+claims.
+
+Next native command for real PR review:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+```
+
+See [Browser runner](browser.md) for supported modes and native-only
+boundaries.
+
+## 6. Use CI Evidence
+
+Use the GitHub Action when you want the first CI adoption path:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    version: '1.11.0'
+    paths: .
+    artifact: 'true'
+    comment: 'false'
+```
+
+For PR review packets, use `mode: cockpit` and `review-packet: 'true'`. The
+Action can upload artifacts and optionally comment on a PR. It does not promote
+advisory proof, enable Codecov upload by default, or make a merge verdict.
+
+See [GitHub Action reference](github-action.md) for all inputs and outputs.
+
+## 7. Check Release-Facing Evidence
+
+Run:
+
+```bash
+cargo xtask publish-surface --json --verify-publish
+cargo xtask version-consistency
+```
+
+Open first: publish-surface output or saved JSON, then version-consistency
+output.
+
+This checks package-surface and version-readiness evidence. It does not publish
+crates, create tags, create GitHub releases, move release aliases, or approve
+release mutation.
+
+See [Publishing evidence](publishing-evidence.md) for the release-facing
+reading order.
+
+## Where To Go Next
+
+- [User paths](user-paths.md) maps each job to the command, primary artifact,
+  first file to open, meaning, non-meaning, and next action.
+- [Copy-Ready Workflows](workflows.md) gives complete command sequences.
+- [Artifact glossary](artifacts.md) explains receipt and packet names.
+- [Review packet contract](review-packet.md) explains cockpit review packets.
+- [Handoff bundles](handoff.md) explains coding-agent work orders.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,8 @@
 # Install tokmd
 
+For a first-run path after installation, use
+[Install and try tokmd](install-and-try.md).
+
 ## Cargo
 
 ```bash

--- a/docs/plans/release-distribution-readiness.md
+++ b/docs/plans/release-distribution-readiness.md
@@ -54,11 +54,12 @@ what is the next action?
 ## Work Packets
 
 1. Add an install-and-try guide.
-   - Status: pending.
-   - Create `docs/install-and-try.md` as the first-run path for Cargo install,
+   - Status: complete.
+   - Added `docs/install-and-try.md` as the first-run path for Cargo install,
      release binaries, Nix, basic repo inspection, risk analysis, cockpit PR
      review, handoff, and browser mode.
-   - Link from README, `docs/README.md`, `docs/start-here.md`, and
+   - Linked from README, `docs/README.md`, `docs/start-here.md`,
+     `docs/install.md`, and
      `docs/user-paths.md` without duplicating all command details.
 2. Add a GitHub Action quickstart.
    - Status: pending.
@@ -170,3 +171,6 @@ Run required affected proof if the affected proof plan selects it.
 - 2026-05-17: Started from the parked active-goal state after queue hygiene and
   source-of-truth alignment. The selected fresh gap is adoption and release
   readiness from real user workflows, not new internal control-plane machinery.
+- 2026-05-17: Added the install-and-try guide and linked it from the public
+  entry points. The guide keeps install, inspect, PR review, handoff, browser,
+  CI, and release-facing evidence paths on existing commands and artifacts.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -6,6 +6,9 @@ learn the whole control plane first.
 If a workflow gives you an artifact name and you need to know what it means,
 open the [Artifact glossary](artifacts.md).
 
+If you have not installed `tokmd` yet or want the first useful local command,
+open [Install and try tokmd](install-and-try.md).
+
 If you need the shortest map from user job to command, artifact, meaning, and
 next action, open [User paths](user-paths.md).
 

--- a/docs/user-paths.md
+++ b/docs/user-paths.md
@@ -6,7 +6,9 @@ first. It is a consumption map, not a command reference.
 For artifact definitions, use the [Artifact glossary](artifacts.md). For the
 first guided walkthrough, use [Start Here](start-here.md). For small physical
 layouts, use [Sample artifact trees](examples/README.md). For copy-ready command
-sequences, use [Copy-Ready Workflows](workflows.md).
+sequences, use [Copy-Ready Workflows](workflows.md). If you still need to
+install the tool or run the first local command, use
+[Install and try tokmd](install-and-try.md).
 
 ## At A Glance
 


### PR DESCRIPTION
## Summary
- add `docs/install-and-try.md` as the first-run adoption path from install to inspect, review, handoff, browser, CI, and release-facing evidence
- link the guide from README, docs index, Start Here, install docs, and user paths
- mark the install-and-try packet complete in the release/distribution readiness plan
- route the new guide through the existing `user_guides` proof scope

## Linked lane
Release and distribution readiness.

## Changed surface
Docs and proof routing only:
- `docs/install-and-try.md`
- public docs entry-point links
- `docs/plans/release-distribution-readiness.md`
- `ci/proof.toml` user-guide routing

## User job improved
Outside maintainers now have one first-run path after installation: inspect the repo, widen to risk analysis, move to cockpit PR review, prepare handoff, try browser mode, use CI evidence, or check release-facing evidence.

## Behavior change
None.

## Schema change
None.

## Proof
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-install-and-try-guide.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-install-and-try-guide.json --evidence-json target/proof/proof-evidence-install-and-try-guide.json`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

## Non-goals
- no product CLI behavior change
- no public receipt schema change
- no crates publish, tags, GitHub release, alias movement, or image push
- no proof promotion
- no default Codecov upload
- no AST productization
- no public `tokmd review` command