### PR TITLE
docs: add GitHub Action quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ Use the root composite Action when you want `tokmd` receipts, PR summaries, arti
     paths: .
 ```
 
-For all Action modes, inputs, outputs, artifacts, checkout guidance, and release-asset behavior, see [GitHub Action reference](docs/github-action.md).
+For a copy-ready adoption workflow, see
+[GitHub Action quickstart](docs/action-quickstart.md). For all Action modes,
+inputs, outputs, artifacts, checkout guidance, and release-asset behavior, see
+[GitHub Action reference](docs/github-action.md).
 
 ## Why It Exists
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1097,6 +1097,7 @@ name = "user_guides"
 kind = "non_rust"
 paths = [
   "docs/artifacts.md",
+  "docs/action-quickstart.md",
   "docs/browser.md",
   "docs/examples/**",
   "docs/install-and-try.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ schemas, and verification policy for `tokmd`.
 - [workflows.md](workflows.md) — copy-ready command sequences for inspection,
   PR review, proof planning, proof observations, agent handoff, browser trial,
   and publishing evidence.
+- [action-quickstart.md](action-quickstart.md) — copy-ready GitHub Action
+  workflows for receipt artifacts and cockpit review packets.
 - [examples/](examples/README.md) — small artifact-tree walkthroughs for
   review packets, handoff bundles, proof status, browser receipts, and
   publishing evidence.

--- a/docs/action-quickstart.md
+++ b/docs/action-quickstart.md
@@ -1,0 +1,137 @@
+# GitHub Action Quickstart
+
+Use the root `EffortlessMetrics/tokmd` Action when you want CI to install a
+released `tokmd` binary, produce artifacts, and optionally post a pull request
+comment.
+
+This page is the adoption path. For every input, output, and mode, use the
+[GitHub Action reference](github-action.md).
+
+## Minimal Receipt Workflow
+
+Use this when you want a repository summary and machine-readable receipt
+without introducing review comments or gates:
+
+```yaml
+name: tokmd receipt
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tokmd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: EffortlessMetrics/tokmd@v1
+        with:
+          version: '1.11.0'
+          paths: .
+          artifact: 'true'
+          comment: 'false'
+```
+
+Open first: the `tokmd-receipts` artifact, then `tokmd-summary.md`.
+
+This produces a summary and receipt for the checked-out tree. It does not review
+a PR, execute repo tests, promote advisory proof, upload Codecov by default, or
+make a merge verdict.
+
+## PR Review Packet Workflow
+
+Use this when reviewers should start from a cockpit review packet:
+
+```yaml
+name: tokmd review packet
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  tokmd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: EffortlessMetrics/tokmd@v1
+        with:
+          version: '1.11.0'
+          mode: cockpit
+          head: HEAD
+          review-packet: 'true'
+          artifact: 'true'
+          comment: 'false'
+```
+
+Open first:
+
+1. the `tokmd-receipts` artifact;
+2. `.tokmd/review/review-map.md`;
+3. `.tokmd/review/comment.md`;
+4. `.tokmd/review/evidence.json`;
+5. `target/tokmd/review-packet-check.json`.
+
+With `review-packet: 'true'`, the Action runs `tokmd cockpit` with
+`--review-packet-dir .tokmd/review`, verifies the packet, writes
+`target/tokmd/review-packet-check.json`, and uploads the packet and verifier
+receipt when `artifact: 'true'`.
+
+Set `comment: 'true'` only when you want the Action to post the packet summary
+back to the pull request. The posted comment is still review evidence, not a
+merge verdict.
+
+## Base And Head
+
+For pull request events, the Action can infer the base ref. Use
+`fetch-depth: 0` for cockpit review packets so the base and head commits are
+available.
+
+Set `base` only when you need an explicit compare ref:
+
+```yaml
+      - uses: EffortlessMetrics/tokmd@v1
+        with:
+          version: '1.11.0'
+          mode: cockpit
+          base: origin/main
+          head: HEAD
+          review-packet: 'true'
+          artifact: 'true'
+          comment: 'false'
+```
+
+## What The Action Proves
+
+The Action can prove:
+
+- a released `tokmd` binary was installed or already available;
+- the selected `tokmd` mode produced its expected files;
+- requested artifacts were uploaded;
+- review packets were verified when `mode: cockpit` and
+  `review-packet: 'true'` are used.
+
+It does not prove:
+
+- repository tests passed;
+- affected proof executed;
+- advisory proof became required;
+- scoped coverage, mutation, or Codecov upload is a gate;
+- a PR is safe to merge;
+- release or publishing mutation is approved.
+
+## Next Actions
+
+- For local first-run usage, use [Install and try tokmd](install-and-try.md).
+- For every Action input and output, use [GitHub Action reference](github-action.md).
+- For review-packet artifact meanings, use [Review packet contract](review-packet.md).
+- For proof planning and evidence reading order, use [Copy-Ready Workflows](workflows.md).

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -2,6 +2,10 @@
 
 The root `EffortlessMetrics/tokmd` composite Action installs a released `tokmd` binary, runs one workflow mode, and optionally uploads generated files or posts a pull request comment.
 
+For a shorter adoption path with copy-ready receipt and review-packet workflows,
+start with [GitHub Action quickstart](action-quickstart.md). This page is the
+complete reference for inputs, outputs, modes, artifacts, and failure behavior.
+
 ## Quick Start
 
 ```yaml

--- a/docs/install-and-try.md
+++ b/docs/install-and-try.md
@@ -26,7 +26,7 @@ Other install paths:
   ```
 
 - Use the GitHub Action when you want CI artifacts. See
-  [GitHub Action reference](github-action.md).
+  [GitHub Action quickstart](action-quickstart.md).
 
 ## 2. Inspect A Repo
 
@@ -141,7 +141,8 @@ For PR review packets, use `mode: cockpit` and `review-packet: 'true'`. The
 Action can upload artifacts and optionally comment on a PR. It does not promote
 advisory proof, enable Codecov upload by default, or make a merge verdict.
 
-See [GitHub Action reference](github-action.md) for all inputs and outputs.
+See [GitHub Action quickstart](action-quickstart.md) for copy-ready workflows
+or [GitHub Action reference](github-action.md) for all inputs and outputs.
 
 ## 7. Check Release-Facing Evidence
 

--- a/docs/plans/release-distribution-readiness.md
+++ b/docs/plans/release-distribution-readiness.md
@@ -62,11 +62,11 @@ what is the next action?
      `docs/install.md`, and
      `docs/user-paths.md` without duplicating all command details.
 2. Add a GitHub Action quickstart.
-   - Status: pending.
-   - Create `docs/action-quickstart.md` for the adoption path from Action
+   - Status: complete.
+   - Added `docs/action-quickstart.md` for the adoption path from Action
      install to review packet artifact, optional comment, and verifier receipt.
-   - Keep the full Action reference in `docs/github-action.md`.
-   - Explain required/advisory proof boundaries, no merge verdict, and no
+   - Kept the full Action reference in `docs/github-action.md`.
+   - Explained required/advisory proof boundaries, no merge verdict, and no
      default Codecov upload.
 3. Record a real user-path smoke run.
    - Status: pending.
@@ -174,3 +174,6 @@ Run required affected proof if the affected proof plan selects it.
 - 2026-05-17: Added the install-and-try guide and linked it from the public
   entry points. The guide keeps install, inspect, PR review, handoff, browser,
   CI, and release-facing evidence paths on existing commands and artifacts.
+- 2026-05-17: Added the GitHub Action quickstart and linked it from the public
+  docs entry points. The guide shows minimal receipt and PR review-packet
+  workflows while keeping the full Action reference separate.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -151,6 +151,7 @@ maintainer explicitly promotes them.
 
 More detail:
 
+- [GitHub Action quickstart](action-quickstart.md).
 - [GitHub Action reference](github-action.md).
 - [Artifact glossary](artifacts.md) for proof and coverage receipts.
 - [Publishing evidence](publishing-evidence.md) for release-facing package

--- a/docs/user-paths.md
+++ b/docs/user-paths.md
@@ -209,6 +209,8 @@ Does not mean:
 
 Next action:
 
+- Use [GitHub Action quickstart](action-quickstart.md) when you want hosted
+  artifacts before wiring deeper proof workflows.
 - Resolve unknown files before relying on scoped proof.
 - Run required proof when the work needs executed evidence.
 - Verify source receipts and status packets with their matching checkers.


### PR DESCRIPTION
## Summary
- add `docs/action-quickstart.md` with minimal receipt and cockpit review-packet Action workflows
- link the quickstart from README, docs index, Start Here, install-and-try, user paths, and the full Action reference
- mark the Action quickstart packet complete in the release/distribution readiness plan
- route the new guide through the existing `user_guides` proof scope

## Linked lane
Release and distribution readiness.

## Changed surface
Docs and proof routing only:
- `docs/action-quickstart.md`
- Action-related public docs links
- `docs/plans/release-distribution-readiness.md`
- `ci/proof.toml` user-guide routing

## User job improved
Maintainers now have a copy-ready GitHub Action adoption path for receipt artifacts and PR review packets without reading the full Action reference first.

## Behavior change
None.

## Schema change
None.

## Proof
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-action-quickstart.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-action-quickstart.json --evidence-json target/proof/proof-evidence-action-quickstart.json`
- `cargo test -p tokmd --test docs --verbose`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

## Non-goals
- no Action behavior change
- no product CLI behavior change
- no public receipt schema change
- no proof promotion
- no default Codecov upload
- no merge verdict
- no release mutation