### PR TITLE
docs: add handoff prompt template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ schemas, and verification policy for `tokmd`.
 - [browser.md](browser.md) — no-install browser workflow and native-only
   boundaries.
 - [VERIFICATION.md](VERIFICATION.md) — README badge meanings, generated endpoints, and PR evidence boundaries.
+- [agent-workflows/handoff-prompt.md](agent-workflows/handoff-prompt.md) —
+  copy-ready prompt template for coding agents consuming `.handoff/` bundles.
 - [agent-workflows/source-of-truth.md](agent-workflows/source-of-truth.md) — maintainer and agent workflow for following source-of-truth artifacts.
 - [handoff.md](handoff.md) — coding-agent handoff bundle workflow and guardrails.
 - [publishing-evidence.md](publishing-evidence.md) — release-facing package

--- a/docs/agent-workflows/README.md
+++ b/docs/agent-workflows/README.md
@@ -7,6 +7,9 @@ working inside tokmd's source-of-truth and evidence workflow.
 
 ## Guides
 
+- [handoff-prompt.md](handoff-prompt.md) - copy-ready prompt template for
+  coding agents consuming `.handoff/work-order.md`, `code.txt`, linked review
+  evidence, and proof expectations.
 - [source-of-truth.md](source-of-truth.md) - how to follow the proposal, spec,
   ADR, plan, active-goal, policy, and proof stack when starting or changing a
   lane.

--- a/docs/agent-workflows/handoff-prompt.md
+++ b/docs/agent-workflows/handoff-prompt.md
@@ -1,0 +1,63 @@
+# Handoff Prompt
+
+Status: active workflow guide.
+
+Use this when you have generated a `.handoff/` bundle and want Codex, Claude,
+Cursor, or another coding agent to consume it without inventing context from
+chat history.
+
+This is a prompt template, not a second planning system. The handoff bundle and
+linked receipts remain the evidence sources.
+
+## Copy-Ready Prompt
+
+```text
+Work only from the provided tokmd handoff bundle unless I explicitly give you
+additional repo context.
+
+Read `.handoff/work-order.md` first. Use it as the task map, evidence summary,
+and stop-condition list.
+
+Use `.handoff/code.txt` as the bounded source bundle. Use `.handoff/manifest.json`
+for the authoritative artifact index, included files, exclusions, and token
+budget. Use `.handoff/map.jsonl` only when you need full path lookup.
+
+If `.handoff/review-links.json` exists, treat it as a handle to cockpit review
+evidence. Open the linked `review-map.md` for review order and reproduction
+commands, and open the linked review-packet verifier receipt before trusting
+packet-local hashes.
+
+If `.handoff/proof-links.json` exists, treat it as a handle to affected-proof
+and proof-plan evidence. A proof plan is expected proof, not executed proof.
+Do not claim proof passed until required proof commands have run or are
+explicitly deferred.
+
+Treat missing, stale, degraded, skipped, or unavailable evidence as work to
+resolve, not as passing proof.
+
+Do not broaden the lane unless the work order asks for it. Do not promote
+advisory proof, enable default Codecov upload, add AST default behavior, create
+a merge verdict, or change release state.
+
+Stop when the requested change is complete and the listed proof expectations
+are satisfied or explicitly deferred with a clear reason.
+```
+
+## Required Guardrails
+
+- Linked review and proof evidence is a handle, not copied or verified proof.
+- `work-order.md` summarizes linked receipts, but the linked verifier and proof
+  receipts remain the evidence sources of truth.
+- Missing, stale, degraded, skipped, or unavailable evidence is not passing
+  proof.
+- Planned proof is not executed proof.
+- Cockpit and handoff outputs are not merge verdicts.
+- Advisory proof, coverage, mutation, browser output, and Codecov upload remain
+  advisory unless policy explicitly promotes them.
+
+## Related References
+
+- [Handoff bundles](../handoff.md)
+- [User paths](../user-paths.md)
+- [Artifact glossary](../artifacts.md)
+- [Source-of-truth workflow](source-of-truth.md)

--- a/docs/plans/release-distribution-readiness.md
+++ b/docs/plans/release-distribution-readiness.md
@@ -77,9 +77,9 @@ what is the next action?
      deferred without committing generated packets, CI logs, or large artifact
      dumps.
 4. Add an agent handoff prompt template.
-   - Status: pending.
-   - Add `docs/agent-workflows/handoff-prompt.md` as a short copy-ready prompt
-     for Codex, Claude, Cursor, or another coding agent consuming
+   - Status: complete.
+   - Added `docs/agent-workflows/handoff-prompt.md` as a short copy-ready
+     prompt for Codex, Claude, Cursor, or another coding agent consuming
      `.handoff/work-order.md`, `.handoff/code.txt`, `review-links.json`, and
      `proof-links.json`.
    - Keep it as a consumer bridge, not a second planning system.
@@ -182,3 +182,5 @@ Run required affected proof if the affected proof plan selects it.
   quickstart PR range. The run verified affected planning, proof planning,
   cockpit review-packet generation, review-packet checking, and handoff
   generation while keeping generated packets out of the repo.
+- 2026-05-17: Added a copy-ready handoff prompt template for coding agents
+  consuming `.handoff/` bundles and linked review/proof evidence.

--- a/docs/user-paths.md
+++ b/docs/user-paths.md
@@ -154,6 +154,9 @@ Next action:
 - Treat missing, stale, degraded, or unavailable evidence as a task, not as a
   pass.
 - Verify linked review/proof artifacts with their own checkers.
+- Use the [handoff prompt template](agent-workflows/handoff-prompt.md) when you
+  want a copy-ready instruction block for Codex, Claude, Cursor, or another
+  coding agent.
 
 ## Read CI Proof Evidence
 


### PR DESCRIPTION
## Summary
- add a copy-ready prompt template for agents consuming `.handoff/` bundles
- link the prompt from the agent workflow index, docs index, and user-path handoff section
- mark the release/distribution readiness handoff-prompt packet complete

## Linked lane
release/distribution readiness

## Changed surface
Docs only: agent workflow prompt, docs indexes, user-path pointer, lane plan.

## User job improved
Agent operators get a concise prompt for Codex, Claude, Cursor, or another coding agent that starts from `.handoff/work-order.md`, uses `code.txt` as the bounded source bundle, and treats linked review/proof evidence correctly.

## Behavior change
None.

## Schema change
None.

## Proof
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-handoff-prompt-template.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-handoff-prompt-template.json --evidence-json target/proof/proof-evidence-handoff-prompt-template.json
- cargo test -p xtask doc_artifacts --verbose
- git diff --check origin/main..HEAD

## Non-goals
- no product behavior change
- no handoff schema change
- no proof promotion or Codecov default
- no merge verdict
- no release mutation