### PR TITLE
docs(browser): add native adoption path

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1099,6 +1099,7 @@ paths = [
   "docs/artifacts.md",
   "docs/action-quickstart.md",
   "docs/browser.md",
+  "docs/browser-to-native.md",
   "docs/examples/**",
   "docs/install-and-try.md",
   "docs/publishing-evidence.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ schemas, and verification policy for `tokmd`.
   publishing evidence.
 - [browser.md](browser.md) — no-install browser workflow and native-only
   boundaries.
+- [browser-to-native.md](browser-to-native.md) — move from a browser trial to
+  native review packets, handoff bundles, and CI evidence.
 - [VERIFICATION.md](VERIFICATION.md) — README badge meanings, generated endpoints, and PR evidence boundaries.
 - [agent-workflows/handoff-prompt.md](agent-workflows/handoff-prompt.md) —
   copy-ready prompt template for coding agents consuming `.handoff/` bundles.

--- a/docs/browser-to-native.md
+++ b/docs/browser-to-native.md
@@ -1,0 +1,174 @@
+# Browser To Native
+
+Use this path after a browser trial when the next job needs native `tokmd`,
+CI, or a coding-agent handoff.
+
+Browser mode is a no-install inspection lens. Native mode is the review, proof,
+and handoff instrument.
+
+## Start In Browser
+
+Run first: open the browser runner and load a public GitHub repository, local
+files, or a local directory.
+
+Open first: the browser UI summary.
+
+Download when you need a saved trail:
+
+```text
+tokmd-browser-summary.md
+tokmd-browser-receipt.json
+```
+
+The browser receipt is useful supporting evidence for an inspection. It is not
+CI proof, a PR review packet, a policy gate, or an agent handoff.
+
+## What Browser Mode Can Prove
+
+Browser mode can show:
+
+- language, module, and file inventory for browser-loaded inputs;
+- browser-safe analysis presets exposed by the loaded WASM capability matrix;
+- deterministic downloadable receipts for that browser run.
+
+This is enough to answer:
+
+```text
+What is in this repo or file set?
+Is it worth installing native tokmd for review, proof, or handoff work?
+```
+
+## What Requires Native Mode
+
+Move to native `tokmd` when the next job needs:
+
+- PR review packets from `tokmd cockpit`;
+- review-packet verification from `cargo xtask review-packet-check`;
+- git-history enrichers such as churn, hotspots, or freshness;
+- policy gates and baselines;
+- source context bundles or `.handoff/` directories;
+- proof planning, proof observations, or publishing evidence.
+
+Browser receipts can support those workflows, but they do not replace the
+native artifacts.
+
+## Move To PR Review
+
+Run from a native checkout:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+Open first:
+
+1. `.tokmd/review/review-map.md`
+2. `.tokmd/review/comment.md`
+3. `.tokmd/review/evidence.json`
+4. `target/tokmd/review-packet-check.json`
+
+This packet tells you what to review first, what evidence is present or
+missing, and which commands reproduce the evidence. It is not a merge verdict.
+
+## Move To Agent Handoff
+
+Run from a native checkout:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --out-dir .handoff
+```
+
+When review and proof artifacts exist, link them:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --review-packet-dir .tokmd/review \
+  --review-packet-check target/tokmd/review-packet-check.json \
+  --affected target/proof/affected.json \
+  --proof-plan target/proof/proof-plan.json \
+  --out-dir .handoff
+```
+
+Open first:
+
+1. `.handoff/work-order.md`
+2. `.handoff/code.txt`
+3. `.handoff/review-links.json` and `.handoff/proof-links.json`, when present
+
+The handoff tells an agent what source bundle it has, what evidence is linked,
+what proof is expected, and when to stop. It does not verify the linked review
+or proof artifacts itself.
+
+## Move To CI Evidence
+
+Use the GitHub Action when you want hosted artifacts:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    version: '1.11.0'
+    mode: cockpit
+    review-packet: 'true'
+    artifact: 'true'
+    comment: 'false'
+```
+
+Use contributor proof planning when you are working inside this repository:
+
+```bash
+cargo xtask affected \
+  --base origin/main \
+  --head HEAD \
+  --json-output target/proof/affected.json
+
+cargo xtask proof \
+  --profile affected \
+  --base origin/main \
+  --head HEAD \
+  --plan \
+  --plan-json target/proof/proof-plan.json \
+  --evidence-json target/proof/proof-evidence.json
+```
+
+Proof planning tells you what should run. It does not mean proof has executed.
+Advisory fast proof, scoped coverage, mutation, and Codecov upload stay
+advisory unless policy explicitly promotes them.
+
+## Reading Order
+
+Use this order when moving from browser to native:
+
+1. Browser UI summary: decide whether the repo or file set is worth deeper
+   native inspection.
+2. `tokmd-browser-summary.md`: save the browser-safe human summary if needed.
+3. `tokmd-browser-receipt.json`: save machine-readable browser evidence if a
+   later workflow needs it.
+4. `.tokmd/review/review-map.md`: review PR work in native mode.
+5. `.handoff/work-order.md`: give a coding agent the bounded work order.
+6. `target/proof/affected.json` and `target/proof/proof-plan.json`: read proof
+   routing and required/advisory expectations.
+
+## Boundaries
+
+- Browser mode does not claim native filesystem behavior.
+- Browser mode does not produce cockpit packets, gates, handoff bundles, or
+  proof receipts.
+- Browser mode does not make AST-backed capability claims.
+- Native cockpit and handoff artifacts are review and agent evidence, not merge
+  verdicts.
+- CI proof and coverage artifacts remain advisory unless policy explicitly
+  promotes them.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -59,6 +59,11 @@ browser run
 Browser artifacts are useful inputs for inspection and handoff. They are not a
 replacement for native review packets, proof plans, baselines, or gates.
 
+When the browser result shows the repo needs real PR review, proof routing, or
+agent context, use [Browser to native](browser-to-native.md) for the shortest
+bridge from browser receipts to native `cockpit`, `handoff`, and CI evidence
+workflows.
+
 ## Native-Only Boundaries
 
 These stay native-first:

--- a/docs/examples/browser-receipt-tree.md
+++ b/docs/examples/browser-receipt-tree.md
@@ -44,3 +44,5 @@ Next action:
 - Move to native `tokmd cockpit` for real PR review.
 - Move to native `tokmd handoff` for coding-agent context.
 - Check the browser capability matrix before relying on a browser result.
+- Use [Browser to native](../browser-to-native.md) for the shortest bridge from
+  browser output to native review, handoff, and CI evidence workflows.

--- a/docs/install-and-try.md
+++ b/docs/install-and-try.md
@@ -122,7 +122,8 @@ tokmd cockpit \
 ```
 
 See [Browser runner](browser.md) for supported modes and native-only
-boundaries.
+boundaries, or [Browser to native](browser-to-native.md) when a browser trial
+needs to become PR review, handoff, or CI evidence.
 
 ## 6. Use CI Evidence
 

--- a/docs/plans/release-distribution-readiness.md
+++ b/docs/plans/release-distribution-readiness.md
@@ -93,9 +93,11 @@ what is the next action?
      verifier for proof or review packets.
 6. Add browser-to-native adoption guidance if current browser docs still leave
    the trial-to-native path ambiguous.
-   - Status: pending.
-   - Keep browser mode as a no-install trial lens.
-   - Keep native mode as the review, proof, and handoff instrument.
+   - Status: complete.
+   - Added `docs/browser-to-native.md` as the bridge from no-install browser
+     inspection to native `cockpit`, `handoff`, and CI evidence workflows.
+   - Kept browser mode as a no-install trial lens and native mode as the
+     review, proof, and handoff instrument.
 7. Add a release evidence quickstart.
    - Status: pending.
    - Compose existing publishing evidence, version consistency, affected proof,
@@ -188,3 +190,6 @@ Run required affected proof if the affected proof plan selects it.
 - 2026-05-17: Strengthened handoff work-order integration coverage so the
   agent-facing linked-evidence sections, stop conditions, and guardrails stay
   stable through future refactors.
+- 2026-05-17: Added browser-to-native adoption guidance so browser trials end
+  with concrete native review, handoff, and CI evidence next actions without
+  implying browser/native parity.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -217,5 +217,6 @@ Native filesystem flows, git-history enrichers, `cockpit`, `gate`, `sensor`,
 More detail:
 
 - [Browser runner](browser.md).
+- [Browser to native](browser-to-native.md).
 - [Browser/WASM contract](architecture.md#wasm--browser-runner).
 - [Browser capability matrix](capabilities/wasm.json).

--- a/docs/user-paths.md
+++ b/docs/user-paths.md
@@ -247,6 +247,8 @@ Next action:
 - Move to native `tokmd handoff` when preparing agent context.
 - Check [Browser runner](browser.md) and the capability matrix before relying
   on a browser result.
+- Use [Browser to native](browser-to-native.md) when the trial needs to become
+  review, handoff, or CI evidence.
 
 ## Publish Or Release Safely
 


### PR DESCRIPTION
Linked lane: release/distribution readiness

Changed surface:
- Browser adoption docs
- User-path navigation docs
- Proof routing for the new browser-to-native guide

User job improved:
- Browser trial: users can move from a no-install browser result to the right native PR review, agent handoff, or CI evidence path without assuming browser/native parity.

Behavior change: none
Schema change: none

Proof:
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-browser-to-native.json` (0 unknown files)
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-browser-to-native.json --evidence-json target/proof/proof-evidence-browser-to-native.json`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo test -p xtask --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

Non-goals:
- No browser feature or capability change
- No public CLI change
- No proof promotion or Codecov default change
- No AST default behavior or browser AST claim
- No release mutation