### PR TITLE
docs(release): add evidence quickstart

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1103,6 +1103,7 @@ paths = [
   "docs/examples/**",
   "docs/install-and-try.md",
   "docs/publishing-evidence.md",
+  "docs/release-readiness.md",
   "docs/start-here.md",
   "docs/handoff.md",
   "docs/recipes.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ schemas, and verification policy for `tokmd`.
 - [handoff.md](handoff.md) — coding-agent handoff bundle workflow and guardrails.
 - [publishing-evidence.md](publishing-evidence.md) — release-facing package
   surface, metadata, and CI ownership evidence before release mutation.
+- [release-readiness.md](release-readiness.md) — quickstart for pre-release
+  evidence checks without publishing, tagging, or creating releases.
 - [reference-cli.md](reference-cli.md) — generated CLI flag reference.
 - [SCHEMA.md](SCHEMA.md) — receipt format documentation.
 - [architecture.md](architecture.md) — crate hierarchy and data flow.

--- a/docs/examples/publishing-evidence-tree.md
+++ b/docs/examples/publishing-evidence-tree.md
@@ -50,6 +50,8 @@ What not to infer:
 
 Next action:
 
+- Use [Release readiness](../release-readiness.md) for the short pre-release
+  evidence command sequence.
 - Fix publish-surface violations before release work.
 - Pair publishing evidence with affected proof when release metadata changes.
 - Treat publish, tag, and release creation as separate explicit maintainer

--- a/docs/install-and-try.md
+++ b/docs/install-and-try.md
@@ -162,7 +162,8 @@ crates, create tags, create GitHub releases, move release aliases, or approve
 release mutation.
 
 See [Publishing evidence](publishing-evidence.md) for the release-facing
-reading order.
+reading order or [Release readiness](release-readiness.md) for the shorter
+pre-release evidence quickstart.
 
 ## Where To Go Next
 

--- a/docs/plans/release-distribution-readiness.md
+++ b/docs/plans/release-distribution-readiness.md
@@ -99,10 +99,11 @@ what is the next action?
    - Kept browser mode as a no-install trial lens and native mode as the
      review, proof, and handoff instrument.
 7. Add a release evidence quickstart.
-   - Status: pending.
-   - Compose existing publishing evidence, version consistency, affected proof,
-     and proof-plan commands.
-   - Make clear that these are pre-release evidence, not release mutation or
+   - Status: complete.
+   - Added `docs/release-readiness.md` as a short pre-release evidence
+     quickstart that composes publish-surface, version consistency, affected
+     proof, and proof-plan commands.
+   - Made clear that these are pre-release evidence, not release mutation or
      release approval.
 8. Decide whether a release-readiness wrapper receipt is needed.
    - Status: pending.
@@ -193,3 +194,6 @@ Run required affected proof if the affected proof plan selects it.
 - 2026-05-17: Added browser-to-native adoption guidance so browser trials end
   with concrete native review, handoff, and CI evidence next actions without
   implying browser/native parity.
+- 2026-05-17: Added the release-readiness quickstart for pre-release package,
+  version, affected-proof, and proof-plan evidence without publishing, tagging,
+  creating releases, or approving mutation.

--- a/docs/publishing-evidence.md
+++ b/docs/publishing-evidence.md
@@ -16,6 +16,10 @@ push Docker images, or approve a release by itself.
 
 ## Start Here
 
+For the shortest command-first path, use
+[Release readiness](release-readiness.md). This page explains the evidence
+model and reading order in more detail.
+
 Run the package-surface check first:
 
 ```bash

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,0 +1,101 @@
+# Release Readiness
+
+Use this path when you need pre-release evidence before any release mutation.
+
+This guide composes existing `xtask` checks. It does not publish crates, create
+tags, create GitHub releases, move release aliases, push images, or approve a
+release.
+
+## Run First
+
+Check the package surface:
+
+```bash
+cargo xtask publish-surface --json --verify-publish
+```
+
+Check version alignment:
+
+```bash
+cargo xtask version-consistency
+```
+
+If release metadata, workflow files, package manifests, `CHANGELOG.md`, or
+publishing docs changed, plan affected proof:
+
+```bash
+cargo xtask affected \
+  --base origin/main \
+  --head HEAD \
+  --json-output target/proof/affected-release.json
+
+cargo xtask proof \
+  --profile affected \
+  --base origin/main \
+  --head HEAD \
+  --plan \
+  --plan-json target/proof/proof-plan-release.json \
+  --evidence-json target/proof/proof-evidence-release.json
+```
+
+## Open First
+
+1. `publish-surface --json --verify-publish` output.
+2. `version-consistency` output.
+3. `target/proof/affected-release.json`, when release-facing files changed.
+4. `target/proof/proof-plan-release.json`, when you need the required and
+   advisory proof command list.
+5. `target/proof/proof-evidence-release.json`, when you need the planned
+   evidence receipt.
+
+If a CI job or maintainer script saves the first two outputs, use:
+
+```text
+target/publishing/publish-surface.json
+target/publishing/version-consistency.txt
+```
+
+## What It Means
+
+| Check | Means | Does not mean |
+| --- | --- | --- |
+| `publish-surface --json --verify-publish` | Package taxonomy, non-dev publish closure, and package-list checks are valid for the checked workspace state. | Crates were published, crates.io has the version, or release mutation is approved. |
+| `version-consistency` | Workspace, package, binding, and release metadata versions are aligned. | Package closure is valid or artifacts were uploaded. |
+| `affected` | Changed files route to proof scopes, and unknown files are explicit. | Proof commands ran. |
+| `proof --profile affected --plan` | Required and advisory proof commands selected for the changed surface. | Planned proof passed. |
+
+## Stop Conditions
+
+Stop before release mutation when:
+
+- `publish-surface` reports any violation;
+- `version-consistency` fails;
+- affected planning reports unknown release or publishing files;
+- required proof selected by the affected plan has not run or is failing;
+- release approval, tag creation, GitHub release creation, crates.io publish,
+  alias movement, or image publication has not been explicitly requested.
+
+## Next Action
+
+For an ordinary PR:
+
+1. Keep package-surface and version checks green.
+2. Confirm release-facing files route to known proof scopes.
+3. Do not change release workflow behavior unless the PR is explicitly about
+   release automation.
+
+For release preparation:
+
+1. Run the checks above.
+2. Save the outputs as evidence if the release process needs an artifact trail.
+3. Review required affected proof and hosted release checks separately.
+4. Treat publish, tag, GitHub release creation, alias movement, and image
+   publication as separate explicit maintainer decisions.
+
+Related:
+
+- [Publishing evidence](publishing-evidence.md)
+- [Publish surface policy](publish-surface.md)
+- [Publishing evidence tree](examples/publishing-evidence-tree.md)
+- [Copy-ready workflows](workflows.md)
+- [GitHub Action quickstart](action-quickstart.md)

--- a/docs/user-paths.md
+++ b/docs/user-paths.md
@@ -280,6 +280,8 @@ Does not mean:
 
 Next action:
 
+- Use [Release readiness](release-readiness.md) for the short pre-release
+  evidence command sequence.
 - Use [Publishing evidence](publishing-evidence.md) for the release-facing
   reading order.
 - Treat release mutation as a separate explicit decision.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -156,3 +156,6 @@ output.
 
 This checks package-surface and version-readiness evidence. It does not publish
 crates, create tags, create GitHub releases, or approve release mutation.
+
+For release-facing files, pair this with affected proof planning as shown in
+[Release readiness](release-readiness.md).


### PR DESCRIPTION
Linked lane: release/distribution readiness

Changed surface:
- Release-facing adoption docs
- User-path navigation docs
- Proof routing for the new release-readiness guide

User job improved:
- Release/publishing evidence: maintainers get a short command-first pre-release evidence path that composes publish-surface, version consistency, affected proof, and proof-plan artifacts without mutating release state.

Behavior change: none
Schema change: none

Proof:
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-evidence-quickstart.json` (0 unknown files)
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-evidence-quickstart.json --evidence-json target/proof/proof-evidence-release-evidence-quickstart.json`
- `cargo xtask publish-surface --json --verify-publish` (violations empty)
- `cargo xtask version-consistency`
- `cargo xtask ci-lane-whitelist`
- `cargo test -p xtask doc_artifacts --verbose`
- `cargo test -p xtask --verbose`
- `cargo fmt-check`
- `git diff --check origin/main..HEAD`

Non-goals:
- No crates publish, tag, GitHub release, release alias movement, or image push
- No release workflow behavior or package membership change
- No new public CLI command or wrapper receipt
- No proof promotion or Codecov default change
- No AST default behavior