### PR TITLE
docs: compress readme first run path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Metrics evidence stack. It turns a source tree into stable Markdown and JSON
 artifacts: language and module summaries, file receipts, analysis reports,
 diffs, policy gates, baselines, sensor reports, and LLM-ready context bundles.
 
-Use it from the CLI first; wire the same surfaces into CI when you want automated receipts, comments, and gates.
+Use it from the CLI first; wire the same surfaces into CI when you want
+automated receipts, comments, and gates.
 
 ## Install
 
@@ -40,29 +41,44 @@ tokmd --version
 See [Install and try tokmd](docs/install-and-try.md) for the first-run path, or
 [Install tokmd](docs/install.md) for release binaries, Nix, and CI usage.
 
-## Start With One Job
+## Quick Start
 
 ```bash
-# Tell me what this repo is
+# Install
+cargo install tokmd --locked
+
+# Inspect this repo
 tokmd --format md --top 8
 
-# Tell me what changed
-tokmd diff origin/main HEAD
-
-# Help me review this PR
+# Review this PR
 tokmd cockpit --base origin/main --head HEAD --review-packet-dir .tokmd/review
 
-# Give CI stable evidence and gates
-tokmd run --analysis receipt --output-dir .runs/current
-tokmd gate --receipt .runs/current/receipt.json --policy tokmd-gate.toml
-
-# Give my coding agent context and proof expectations
+# Prepare a coding-agent handoff
 tokmd handoff --preset risk --budget 128k --strategy spread --out-dir .handoff
 ```
 
-For a job-oriented walkthrough, start with [Start Here](docs/start-here.md) or
-[Install and try tokmd](docs/install-and-try.md).
-For the command-to-artifact reading order, use [User paths](docs/user-paths.md).
+For CI adoption, start with the GitHub Action quickstart:
+
+```yaml
+- uses: EffortlessMetrics/tokmd@v1
+  with:
+    version: '1.11.0'
+    paths: .
+    artifact: 'true'
+```
+
+For browser/no-install trial, use [Browser runner](docs/browser.md) and then
+[Browser to native](docs/browser-to-native.md) when the job becomes PR review,
+handoff, or CI evidence.
+
+For release-facing evidence, start with
+[Release readiness](docs/release-readiness.md). It checks package and version
+readiness without publishing, tagging, or creating releases.
+
+For a job-oriented walkthrough, start with
+[Install and try tokmd](docs/install-and-try.md) or
+[Start Here](docs/start-here.md). For the command-to-artifact reading order,
+use [User paths](docs/user-paths.md).
 
 ## What tokmd Produces
 
@@ -103,8 +119,8 @@ tokmd cockpit \
   --review-packet-dir .tokmd/review
 ```
 
-Start with `.tokmd/review/comment.md`, then use
-`.tokmd/review/review-map.md` for the review order and reproduction commands.
+Start with `.tokmd/review/review-map.md` for the review order and reproduction
+commands, then read `.tokmd/review/comment.md` for the PR summary.
 `.tokmd/review/evidence.json` and `.tokmd/review/manifest.json` carry the
 machine-readable evidence state and hash-indexed packet inventory.
 

--- a/docs/plans/release-distribution-readiness.md
+++ b/docs/plans/release-distribution-readiness.md
@@ -114,10 +114,12 @@ what is the next action?
      are sufficient until a named release, Action, or downstream consumer needs
      one stable JSON envelope.
 9. Compress the README first-run path after the adoption guides exist.
-   - Status: pending.
-   - Keep README above the fold focused on install, inspect, review, handoff,
-     and CI entry points.
-   - Link deeper reference pages instead of explaining the control plane inline.
+   - Status: complete.
+   - Compressed the README quick-start path around install, repo inspection, PR
+     review, agent handoff, CI adoption, browser-to-native, and release
+     readiness links.
+   - Kept deeper command inventory and control-plane references below the first
+     user path instead of making them the first decision surface.
 10. Close the lane.
     - Status: pending.
     - Close only when install/try, Action adoption, real smoke evidence, agent
@@ -202,3 +204,6 @@ Run required affected proof if the affected proof plan selects it.
 - 2026-05-17: Recorded the release-readiness wrapper receipt proposal and
   chose "no wrapper yet" until a concrete consumer cannot use the existing
   release evidence artifacts directly.
+- 2026-05-17: Compressed the README first-run path so outside users see
+  install, inspect, review, handoff, CI, browser, and release-readiness entry
+  points before deeper command inventory.


### PR DESCRIPTION
Linked lane: release/distribution readiness

Changed surface:
- README first-run path
- release/distribution readiness plan checkpoint

User job improved:
- First-time adoption: outside users now see install, inspect, review, handoff, CI, browser, and release evidence entry points before deeper control-plane docs.

Behavior change: none
Schema change: none

Proof:
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-readme-first-run-compression.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-readme-first-run-compression.json --evidence-json target/proof/proof-evidence-readme-first-run-compression.json
- cargo test -p xtask doc_artifacts --verbose
- cargo fmt-check
- git diff --check origin/main..HEAD

Non-goals:
- no CLI behavior change
- no proof promotion or default Codecov upload
- no release mutation
- no AST or browser capability change