### PR TITLE
docs: close release distribution readiness lane

### DIFF
--- a/.jules/goals/archive/2026-05-17-release-distribution-readiness.toml
+++ b/.jules/goals/archive/2026-05-17-release-distribution-readiness.toml
@@ -1,8 +1,8 @@
 schema = "tokmd.jules.active_goal.v1"
-status = "paused"
+status = "complete"
 program = "code_intelligence"
-lane = "no_selected_implementation_lane"
-outcome = "paused_after_release_distribution_readiness_closeout"
+lane = "release_distribution_readiness"
+outcome = "completed_adoption_and_release_readiness_paths"
 
 [links]
 source_of_truth = "docs/source-of-truth.md"
@@ -24,7 +24,7 @@ ast_corpus_expansion_plan = "docs/plans/ast-function-boundary-corpus-expansion.m
 architecture_plan = "docs/architecture-consolidation-plan.md"
 
 [rules]
-scope = "select_next_lane_only_from_fresh_consumer_artifact_workflow_or_product_gap"
+scope = "plan_first_adoption_and_release_readiness"
 proof_promotion = "do_not_promote_without_maintainer_decision"
 codecov_default_upload = "do_not_enable_without_maintainer_decision"
 product_behavior = "do_not_change_public_tokmd_cli_or_receipt_schemas"
@@ -33,14 +33,19 @@ ast_shadow = "do_not_change_default_receipts_or_browser_capabilities"
 architecture = "do_not_continue_consolidation_without_fresh_evidence"
 release_mutation = "do_not_publish_tag_create_release_or_push_images"
 generated_prs = "review_as_candidate_evidence_not_roadmap_owners"
-release_distribution_readiness = "closed_reopen_only_from_named_consumer_gap"
 
 [stop_conditions]
 open_pr_queue = "must_stay_empty_or_have_explicit_disposition"
 doc_artifacts = "cargo xtask doc-artifacts --check"
 docs_check = "cargo xtask docs --check"
 proof_policy = "cargo xtask proof-policy --check"
-affected_plan = "cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-no-selected-lane.json"
-proof_plan = "cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-no-selected-lane.json --evidence-json target/proof/proof-evidence-no-selected-lane.json"
+affected_plan = "cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-distribution-readiness.json"
+proof_plan = "cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-distribution-readiness.json --evidence-json target/proof/proof-evidence-release-distribution-readiness.json"
 fmt = "cargo fmt-check"
 diff_hygiene = "git diff --check"
+
+[completion]
+completed_on = "2026-05-17"
+closeout_plan = "docs/plans/release-distribution-readiness.md"
+evidence = "install-and-try guide, GitHub Action quickstart, real user-path smoke transcript, handoff prompt template, handoff work-order contract coverage, browser-to-native guide, release-readiness quickstart, release-readiness receipt decision, README first-run compression"
+outcome = "closed_no_release_mutation_no_new_receipt_no_proof_promotion_no_codecov_default_no_ast_productization_no_tokmd_review_command"

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -201,25 +201,31 @@ domains. Reopen publishing evidence only from a fresh proposal naming a
 consumer and a gap that the current publish-surface, version-consistency, CI
 lane, release workflow, and affected-proof evidence cannot cover.
 
-The release and distribution readiness lane is now active. Its plan lives in
-`docs/plans/release-distribution-readiness.md` and starts from a fresh adoption
-gap: outside maintainers should be able to install or try tokmd, run it in
-GitHub Actions, review a PR, prepare an agent handoff, and check release-facing
-evidence without learning the internal control plane first. This lane is
-plan-first and docs-first. It must not publish crates, tag releases, create
-GitHub releases, push images, promote proof, enable default Codecov upload,
-productize AST, add `tokmd review`, or add a new receipt before a consumer gap
-proves existing artifacts are insufficient.
+The release and distribution readiness lane is closed. Its plan lives in
+`docs/plans/release-distribution-readiness.md` and records the adoption packet:
+install-and-try guide, GitHub Action quickstart, real user-path smoke
+transcript, agent handoff prompt, handoff work-order contract coverage,
+browser-to-native guide, release evidence quickstart, README first-run
+compression, and the release-readiness receipt decision. The outcome is no
+wrapper receipt yet: existing publish-surface, version-consistency, affected,
+proof-plan, and proof-evidence artifacts remain sufficient until a named
+consumer proves otherwise.
+
+There is no selected implementation lane. `.jules/goals/active.toml` is paused
+as the current machine-readable state, and new work should start only from a
+fresh consumer, missing artifact, workflow pain, or product gap. Do not reopen
+proof, AST, architecture, user-path, publishing, or release-readiness work by
+inertia.
 
 ## Next Work Packets
 
 1. Do not extend the closed proof workflow status packet lane to any other
    workflow without fresh evidence of a real status-arbitration gap; preserve
    advisory/non-required behavior and manual-only Codecov upload.
-2. Execute the active release and distribution readiness plan in small
-   user-path packets: install-and-try, GitHub Action quickstart, real smoke
-   transcript, agent handoff prompt, handoff contract test, browser-to-native
-   guide, release evidence quickstart, and receipt-need decision.
+2. Treat the release and distribution readiness lane as closed. Reopen
+   adoption or release-readiness work only from a fresh consumer, missing
+   artifact, workflow pain, or product gap; do not add a new wrapper receipt or
+   command unless existing artifacts cannot answer that named consumer.
 3. Do not reopen AST productization without a fresh proposal grounded in the
    shadow evidence.
 4. Fix cockpit review-packet and Action-hosting gaps only when fresh evidence
@@ -241,6 +247,8 @@ proves existing artifacts are insufficient.
 11. Treat the user-path evidence consumption lane as closed. Start the next
     product lane only from a fresh consumer, missing artifact, workflow pain, or
     product gap; do not extend the completed compression pass by inertia.
+12. Keep the active goal paused until a new implementation lane is deliberately
+    selected.
 
 ## Directional Rules
 

--- a/docs/plans/release-distribution-readiness.md
+++ b/docs/plans/release-distribution-readiness.md
@@ -1,6 +1,6 @@
 # Plan: Release And Distribution Readiness
 
-- Status: active
+- Status: complete
 - Related proposal: `docs/proposals/release-readiness-receipt.md`
 - Related spec: `docs/specs/publishing-evidence.md`
 - Related ADR: `docs/adr/0001-production-package-publishability.md`, `docs/adr/0003-publish-surface-taxonomy.md`, `docs/adr/0005-release-train-and-rc-semantics.md`
@@ -121,11 +121,15 @@ what is the next action?
    - Kept deeper command inventory and control-plane references below the first
      user path instead of making them the first decision surface.
 10. Close the lane.
-    - Status: pending.
-    - Close only when install/try, Action adoption, real smoke evidence, agent
+    - Status: complete.
+    - Closed after install/try, Action adoption, real smoke evidence, agent
       prompt guidance, handoff contract coverage, browser-to-native guidance,
-      release evidence quickstart, and the release-readiness receipt decision
-      are recorded.
+      release evidence quickstart, release-readiness receipt decision, and
+      README first-run compression were recorded.
+    - The completed active goal is archived in
+      `.jules/goals/archive/2026-05-17-release-distribution-readiness.toml`,
+      and `.jules/goals/active.toml` is paused with no selected implementation
+      lane.
 
 ## Validation
 
@@ -207,3 +211,9 @@ Run required affected proof if the affected proof plan selects it.
 - 2026-05-17: Compressed the README first-run path so outside users see
   install, inspect, review, handoff, CI, browser, and release-readiness entry
   points before deeper command inventory.
+- 2026-05-17: Closed the release and distribution readiness lane. The repo now
+  has the adoption packet needed for install/try, GitHub Action use, PR review,
+  agent handoff, browser-to-native transition, release evidence reading, and a
+  recorded "no wrapper yet" release-readiness receipt decision. Future work
+  should start from a fresh consumer, artifact, workflow, or product gap rather
+  than extending this lane by inertia.


### PR DESCRIPTION
Linked lane: release/distribution readiness

Changed surface:
- docs/plans/release-distribution-readiness.md
- docs/NEXT.md
- .jules/goals/active.toml
- .jules/goals/archive/2026-05-17-release-distribution-readiness.toml

User job improved:
- Closes the adoption/release-readiness lane and returns the repo to a paused state with no selected implementation lane until a fresh consumer, artifact, workflow, or product gap is named.

Behavior change: none
Schema change: none

Proof:
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-distribution-readiness-closeout.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-distribution-readiness-closeout.json --evidence-json target/proof/proof-evidence-release-distribution-readiness-closeout.json
- cargo xtask ci-lane-whitelist
- cargo test -p xtask --verbose
- cargo test -p xtask doc_artifacts --verbose
- git diff --check origin/main..HEAD
- cargo trim-target
- cargo trim-target --check

Non-goals:
- no CLI behavior change
- no proof promotion or default Codecov upload
- no release mutation
- no AST or browser capability change
- no new receipt or wrapper command