### PR TITLE
chore(release): clean up 1.11.0 surfaces

### DIFF
--- a/crates/tokmd-cockpit/Cargo.toml
+++ b/crates/tokmd-cockpit/Cargo.toml
@@ -22,7 +22,7 @@ ignore = "0.4.23"
 serde.workspace = true
 serde_json.workspace = true
 time = { version = "0.3.41", features = ["formatting"] }
-tokmd-analysis = { path = "../tokmd-analysis", version = "1.10.0", default-features = false }
+tokmd-analysis = { path = "../tokmd-analysis", version = "1.11.0", default-features = false }
 tokmd-analysis-types.workspace = true
 tokmd-envelope.workspace = true
 tokmd-types.workspace = true

--- a/crates/tokmd-wasm/README.md
+++ b/crates/tokmd-wasm/README.md
@@ -39,7 +39,7 @@ The JavaScript object helpers also accept raw JSON strings for callers that alre
 
 The current release path is:
 
-- GitHub release asset: `tokmd-wasm-<tag>.tar.gz` such as `tokmd-wasm-v1.9.0.tar.gz`
+- GitHub release asset: `tokmd-wasm-<tag>.tar.gz` such as `tokmd-wasm-v1.11.0.tar.gz`
 - Extract contents into `web/runner/vendor/tokmd-wasm/`
 
 The runner expects the `web/runner/vendor/tokmd-wasm` layout with `tokmd_wasm.js` and `tokmd_wasm_bg.wasm` present, plus the `wasm-pack` companion files.

--- a/docs/audits/rust-1.95-compatibility.md
+++ b/docs/audits/rust-1.95-compatibility.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-08
 **Auditor:** Claude (automated)
 **Toolchain tested:** `rustc 1.95.0 (59807616e 2026-04-14)`
-**Workspace version at audit:** `1.10.0`
+**Workspace version at audit:** `1.11.0`
 
 ## Summary
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # tokmd Implementation Plan
 
-This document records completed implementation phases through `1.10.0` and the next active buildout aligned with the roadmap.
+This document records completed implementation phases through `1.11.0` and the next active buildout aligned with the roadmap.
 
 ## Phase 1: Baseline & Ratchet System (v1.5.0) ✅ Complete
 
@@ -393,16 +393,25 @@ authenticated fetch.
 
 ---
 
-## Phase 5d: Cockpit Hardening & Architecture Consolidation (Active)
+## Phase 5d: Cockpit Hardening & Architecture Consolidation (v1.11.0) ✅ Complete
 
-**Goal**: Improve cockpit as the PR-review evidence surface before adding a separate review orchestrator, and consolidate implementation microcrates into SRP modules.
+**Goal**: Improve cockpit as the PR-review evidence surface before adding a
+separate review orchestrator, consolidate implementation microcrates into SRP
+modules, and keep proof observations advisory while artifacts mature.
 
 ### Work Items
 
-- [ ] Finish small cockpit review-packet and Action-hosting gaps
-- [ ] Preserve `tokmd cockpit` as the review evidence implementation surface
-- [ ] Consolidate architecture in batches, preserving `ci/proof.toml` scope granularity
-- [ ] Ensure proof-run and scoped coverage observations remain advisory
+- [x] Finish cockpit review-packet and Action-hosting gaps, including packet
+      manifests, review maps, verifier receipts, hosted artifact comments, and
+      optional proof/doc-artifact imports
+- [x] Preserve `tokmd cockpit` as the review evidence implementation surface
+      without adding a separate public `tokmd review` command
+- [x] Consolidate architecture in batches, preserving `ci/proof.toml` scope
+      granularity and owner-module boundaries
+- [x] Ensure proof-run, scoped coverage, mutation, and Codecov observations
+      remain advisory until a separate promotion decision is made
+- [x] Add source-of-truth, user-path, handoff, release-readiness, and AST-shadow
+      planning/evidence surfaces without changing default product behavior
 
 ---
 

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -54,7 +54,7 @@ The release asset is named:
 tokmd-wasm-<tag>.tar.gz
 ```
 
-`v1.9.0` becomes `tokmd-wasm-v1.9.0.tar.gz`. Extracting this archive into `vendor/tokmd-wasm` gives the exact layout expected by `web/runner/worker.js` without rebuilding from source.
+`v1.11.0` becomes `tokmd-wasm-v1.11.0.tar.gz`. Extracting this archive into `vendor/tokmd-wasm` gives the exact layout expected by `web/runner/worker.js` without rebuilding from source.
 
 ## GitHub ingest cache semantics
 


### PR DESCRIPTION
## Summary
- align the remaining `tokmd-cockpit` workspace dependency pin with the 1.11.0 workspace version
- update current-facing WASM/browser release artifact examples to `v1.11.0`
- mark the implementation plan current through the completed 1.11.0 cockpit/proof/source-of-truth/adoption/AST-shadow surface work
- correct the Rust 1.95 audit workspace version to the release-prep version

## Proof
- `cargo xtask version-consistency`
- `cargo xtask publish-surface --json --verify-publish`
- `cargo xtask doc-artifacts --check`
- `cargo xtask docs --check`
- `cargo xtask proof-policy --check`
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-1-11-surface-cleanup.json`
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-1-11-surface-cleanup.json --evidence-json target/proof/proof-evidence-release-1-11-surface-cleanup.json`
- `npm --prefix web/runner test`
- `npm --prefix web/runner run check`
- `cargo deny --all-features check`
- `cargo xtask boundaries-check`
- `cargo xtask publish-surface --json`
- `cargo check -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-cockpit --verbose`
- `cargo test -p tokmd-core --features cockpit --test cockpit_workflow --verbose`
- `cargo test -p tokmd-types cockpit --verbose`
- `cargo test -p tokmd --test cockpit_integration --verbose`
- `cargo test -p tokmd-wasm --verbose`
- `cargo test -p tokmd-types manifest_stays_clap_free --verbose`
- `cargo fmt-check`
- `git diff --check HEAD~1..HEAD`
- `cargo trim-target`

## Non-goals
- no release mutation, tag, crates.io publish, GitHub release, or Action alias movement
- no changelog expansion; that is waiting on the parallel history mine
- no proof promotion, Codecov default, AST default behavior, or new public command