### PR TITLE
Refactor context receipt construction

### DIFF
--- a/crates/tokmd/src/context_pack.rs
+++ b/crates/tokmd/src/context_pack.rs
@@ -3,6 +3,7 @@
 mod budget;
 mod manifest;
 mod output;
+mod receipt;
 mod render;
 mod select;
 

--- a/crates/tokmd/src/context_pack/manifest.rs
+++ b/crates/tokmd/src/context_pack/manifest.rs
@@ -1,20 +1,25 @@
 //! Context bundle directory receipt and manifest writing.
 
+use anyhow::{Context, Result, bail};
+use blake3::Hasher;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use anyhow::{Context, Result, bail};
-use blake3::Hasher;
 use tokmd_types::{
-    ArtifactEntry, ArtifactHash, CONTEXT_BUNDLE_SCHEMA_VERSION, CONTEXT_SCHEMA_VERSION,
-    ContextBundleManifest, ContextExcludedPath, ContextFileRow, ContextReceipt, ToolInfo,
+    ArtifactEntry, ArtifactHash, CONTEXT_BUNDLE_SCHEMA_VERSION, ContextBundleManifest,
+    ContextExcludedPath, ContextFileRow, ToolInfo,
 };
 
 use crate::cli;
 
-use super::{CountingWriter, SelectResult, write_bundle_output};
+use super::{
+    CountingWriter, SelectResult,
+    receipt::{
+        ContextReceiptParams, build_context_receipt, generated_at_ms, lower_debug,
+        rank_by_effective, token_estimation, total_file_bytes,
+    },
+    write_bundle_output,
+};
 
 /// Write bundle to a directory with manifest.
 ///
@@ -50,39 +55,21 @@ pub(crate) fn write_bundle_directory(
             .with_context(|| format!("Failed to create bundle directory: {}", dir.display()))?;
     }
 
-    let now_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-
-    // Compute token estimation from selected file bytes.
-    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
-    let token_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
+    let now_ms = generated_at_ms();
+    let total_file_bytes = total_file_bytes(selected);
 
     // Write receipt.json.
     let receipt_path = dir.join("receipt.json");
-    let receipt = ContextReceipt {
-        schema_version: CONTEXT_SCHEMA_VERSION,
-        generated_at_ms: now_ms,
-        tool: ToolInfo::current(),
-        mode: "context".to_string(),
-        budget_tokens: budget,
+    let receipt = build_context_receipt(ContextReceiptParams {
+        args,
+        selected,
+        budget,
         used_tokens,
-        utilization_pct: utilization,
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
-        file_count: selected.len(),
-        files: selected.to_vec(),
-        rank_by_effective: if select_result.fallback_reason.is_some() {
-            Some(select_result.rank_by_effective.clone())
-        } else {
-            None
-        },
-        fallback_reason: select_result.fallback_reason.clone(),
-        excluded_by_policy: select_result.excluded_by_policy.clone(),
-        token_estimation: Some(token_estimation),
+        utilization,
+        select_result,
+        generated_at_ms: now_ms,
         bundle_audit: None,
-    };
+    });
     // Write initial receipt.json (bundle_audit populated after bundle is written).
     let initial_receipt_json = serde_json::to_string_pretty(&receipt)?;
     fs::write(&receipt_path, &initial_receipt_json)
@@ -137,8 +124,7 @@ pub(crate) fn write_bundle_directory(
 
     // Write manifest.json (authoritative index).
     let manifest_path = dir.join("manifest.json");
-    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
-    let bundle_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
+    let bundle_estimation = token_estimation(selected);
     let bundle_audit =
         tokmd_types::TokenAudit::from_output(bundle_bytes as u64, total_file_bytes as u64);
     let manifest = ContextBundleManifest {
@@ -149,19 +135,15 @@ pub(crate) fn write_bundle_directory(
         budget_tokens: budget,
         used_tokens,
         utilization_pct: utilization,
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
+        strategy: lower_debug(&args.strategy),
+        rank_by: lower_debug(&args.rank_by),
         file_count: selected.len(),
         bundle_bytes,
         artifacts,
         included_files: selected.to_vec(),
         excluded_paths: excluded_paths.to_vec(),
         excluded_patterns: excluded_patterns.to_vec(),
-        rank_by_effective: if select_result.fallback_reason.is_some() {
-            Some(select_result.rank_by_effective.clone())
-        } else {
-            None
-        },
+        rank_by_effective: rank_by_effective(select_result),
         fallback_reason: select_result.fallback_reason.clone(),
         excluded_by_policy: select_result.excluded_by_policy.clone(),
         token_estimation: Some(bundle_estimation),

--- a/crates/tokmd/src/context_pack/output.rs
+++ b/crates/tokmd/src/context_pack/output.rs
@@ -1,19 +1,18 @@
 //! Context command output destination and log writing helpers.
 
+use anyhow::{Context, Result};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use anyhow::{Context, Result};
-use tokmd_types::{
-    CONTEXT_SCHEMA_VERSION, ContextFileRow, ContextLogRecord, ContextReceipt, SCHEMA_VERSION,
-    ToolInfo,
-};
+use tokmd_types::{ContextFileRow, ContextLogRecord, SCHEMA_VERSION, ToolInfo};
 
 use crate::cli;
 
-use super::{CountingWriter, SelectResult, format_list_output, write_bundle_output};
+use super::{
+    CountingWriter, SelectResult, format_list_output,
+    receipt::{ContextReceiptParams, build_context_receipt, generated_at_ms, lower_debug},
+    write_bundle_output,
+};
 
 /// Determine the output destination string for context logging.
 pub(crate) fn determine_output_destination(args: &cli::CliContextArgs) -> String {
@@ -82,16 +81,13 @@ pub(crate) fn append_context_log_record(
 ) -> Result<()> {
     let log_record = ContextLogRecord {
         schema_version: SCHEMA_VERSION,
-        generated_at_ms: SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis(),
+        generated_at_ms: generated_at_ms(),
         tool: ToolInfo::current(),
         budget_tokens: budget,
         used_tokens,
         utilization_pct: utilization,
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
+        strategy: lower_debug(&args.strategy),
+        rank_by: lower_debug(&args.rank_by),
         file_count,
         total_bytes,
         output_destination,
@@ -151,33 +147,16 @@ fn format_json_output(
     args: &cli::CliContextArgs,
     select_result: &SelectResult,
 ) -> Result<String> {
-    let total_file_bytes: usize = selected.iter().map(|f| f.bytes).sum();
-    let token_estimation = tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes, 4.0);
-    let receipt = ContextReceipt {
-        schema_version: CONTEXT_SCHEMA_VERSION,
-        generated_at_ms: SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis(),
-        tool: ToolInfo::current(),
-        mode: "context".to_string(),
-        budget_tokens: budget,
+    let receipt = build_context_receipt(ContextReceiptParams {
+        args,
+        selected,
+        budget,
         used_tokens,
-        utilization_pct: utilization,
-        strategy: format!("{:?}", args.strategy).to_lowercase(),
-        rank_by: format!("{:?}", args.rank_by).to_lowercase(),
-        file_count: selected.len(),
-        files: selected.to_vec(),
-        rank_by_effective: if select_result.fallback_reason.is_some() {
-            Some(select_result.rank_by_effective.clone())
-        } else {
-            None
-        },
-        fallback_reason: select_result.fallback_reason.clone(),
-        excluded_by_policy: select_result.excluded_by_policy.clone(),
-        token_estimation: Some(token_estimation),
+        utilization,
+        select_result,
+        generated_at_ms: generated_at_ms(),
         bundle_audit: None,
-    };
+    });
     let json = serde_json::to_string_pretty(&receipt)?;
     Ok(format!("{json}\n"))
 }

--- a/crates/tokmd/src/context_pack/receipt.rs
+++ b/crates/tokmd/src/context_pack/receipt.rs
@@ -1,0 +1,68 @@
+//! Shared context receipt construction helpers.
+
+use std::fmt::Debug;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokmd_types::{CONTEXT_SCHEMA_VERSION, ContextFileRow, ContextReceipt, TokenAudit, ToolInfo};
+
+use crate::cli;
+
+use super::SelectResult;
+
+pub(crate) struct ContextReceiptParams<'a> {
+    pub(crate) args: &'a cli::CliContextArgs,
+    pub(crate) selected: &'a [ContextFileRow],
+    pub(crate) budget: usize,
+    pub(crate) used_tokens: usize,
+    pub(crate) utilization: f64,
+    pub(crate) select_result: &'a SelectResult,
+    pub(crate) generated_at_ms: u128,
+    pub(crate) bundle_audit: Option<TokenAudit>,
+}
+
+pub(crate) fn generated_at_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+pub(crate) fn lower_debug(value: &impl Debug) -> String {
+    format!("{value:?}").to_lowercase()
+}
+
+pub(crate) fn total_file_bytes(selected: &[ContextFileRow]) -> usize {
+    selected.iter().map(|file| file.bytes).sum()
+}
+
+pub(crate) fn rank_by_effective(select_result: &SelectResult) -> Option<String> {
+    select_result
+        .fallback_reason
+        .as_ref()
+        .map(|_| select_result.rank_by_effective.clone())
+}
+
+pub(crate) fn token_estimation(selected: &[ContextFileRow]) -> tokmd_types::TokenEstimationMeta {
+    tokmd_types::TokenEstimationMeta::from_bytes(total_file_bytes(selected), 4.0)
+}
+
+pub(crate) fn build_context_receipt(params: ContextReceiptParams<'_>) -> ContextReceipt {
+    ContextReceipt {
+        schema_version: CONTEXT_SCHEMA_VERSION,
+        generated_at_ms: params.generated_at_ms,
+        tool: ToolInfo::current(),
+        mode: "context".to_string(),
+        budget_tokens: params.budget,
+        used_tokens: params.used_tokens,
+        utilization_pct: params.utilization,
+        strategy: lower_debug(&params.args.strategy),
+        rank_by: lower_debug(&params.args.rank_by),
+        file_count: params.selected.len(),
+        files: params.selected.to_vec(),
+        rank_by_effective: rank_by_effective(params.select_result),
+        fallback_reason: params.select_result.fallback_reason.clone(),
+        excluded_by_policy: params.select_result.excluded_by_policy.clone(),
+        token_estimation: Some(token_estimation(params.selected)),
+        bundle_audit: params.bundle_audit,
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated receipt construction logic across the context pack code by centralizing timestamp, debug-name normalization, token estimation, and fallback/rank handling.

### Description
- Add `crates/tokmd/src/context_pack/receipt.rs` with helpers: `generated_at_ms`, `lower_debug`, `total_file_bytes`, `rank_by_effective`, `token_estimation`, `ContextReceiptParams`, and `build_context_receipt` to assemble `ContextReceipt` objects.
- Wire the new module into the context pack (`mod receipt;` and `pub(crate) use ...`) and import the helpers where receipts were previously constructed inline.
- Update `output.rs` to use the shared helpers for JSON output and JSONL log records, replacing inline timestamp/name/token logic.
- Update `manifest.rs` to reuse the shared receipt, token-estimation, byte-count, and rank handling helpers when writing `receipt.json` and `manifest.json`.

### Testing
- Ran `cargo fmt-fix` / `cargo fmt-check` and formatting checks passed.
- Ran unit/integration tests for the context pack with `cargo test -p tokmd context_pack --verbose` and all relevant tests passed (107 passed).
- Ran `cargo clippy -p tokmd -- -D warnings` and the linter finished with no new warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b87e3a3c833380e425afac39eed9)