### PR TITLE
Refactor export metadata helpers

### DIFF
--- a/crates/tokmd-format/src/export.rs
+++ b/crates/tokmd-format/src/export.rs
@@ -14,6 +14,7 @@ mod csv;
 mod cyclonedx;
 mod json;
 mod jsonl;
+mod meta;
 mod redact;
 
 use csv::write_export_csv;

--- a/crates/tokmd-format/src/export/json.rs
+++ b/crates/tokmd-format/src/export/json.rs
@@ -9,13 +9,11 @@ use std::io::Write;
 use anyhow::Result;
 
 use tokmd_settings::ScanOptions;
-use tokmd_types::{
-    ExportArgs, ExportArgsMeta, ExportData, ExportReceipt, RedactMode, ScanStatus, ToolInfo,
-};
+use tokmd_types::{ExportArgs, ExportData, ExportReceipt, ScanStatus, ToolInfo};
 
-use crate::{now_ms, redact_module_roots, redact_path, scan_args};
+use crate::{now_ms, scan_args};
 
-use super::redact_rows;
+use super::meta::{args_meta_from_export, redacted_export_data, redacted_rows_for_json};
 
 pub(super) fn write_export_json<W: Write>(
     out: &mut W,
@@ -23,12 +21,7 @@ pub(super) fn write_export_json<W: Write>(
     global: &ScanOptions,
     args: &ExportArgs,
 ) -> Result<()> {
-    let module_roots = redact_module_roots(&export.module_roots, args.redact);
-
     if args.meta {
-        let should_redact = args.redact == RedactMode::Paths || args.redact == RedactMode::All;
-        let strip_prefix_redacted = should_redact && args.strip_prefix.is_some();
-
         let receipt = ExportReceipt {
             schema_version: tokmd_types::SCHEMA_VERSION,
             generated_at_ms: now_ms(),
@@ -37,40 +30,15 @@ pub(super) fn write_export_json<W: Write>(
             status: ScanStatus::Complete,
             warnings: vec![],
             scan: scan_args(&args.paths, global, Some(args.redact)),
-            args: ExportArgsMeta {
-                format: args.format,
-                module_roots: module_roots.clone(),
-                module_depth: export.module_depth,
-                children: export.children,
-                min_code: args.min_code,
-                max_rows: args.max_rows,
-                redact: args.redact,
-                strip_prefix: if should_redact {
-                    args.strip_prefix
-                        .as_ref()
-                        .map(|p| redact_path(&p.display().to_string().replace('\\', "/")))
-                } else {
-                    args.strip_prefix
-                        .as_ref()
-                        .map(|p| p.display().to_string().replace('\\', "/"))
-                },
-                strip_prefix_redacted,
-            },
-            data: ExportData {
-                rows: redact_rows(&export.rows, args.redact)
-                    .map(|c| c.into_owned())
-                    .collect(),
-                module_roots: module_roots.clone(),
-                module_depth: export.module_depth,
-                children: export.children,
-            },
+            args: args_meta_from_export(export, args),
+            data: redacted_export_data(export, args.redact),
         };
         writeln!(out, "{}", serde_json::to_string(&receipt)?)?;
     } else {
         writeln!(
             out,
             "{}",
-            serde_json::to_string(&redact_rows(&export.rows, args.redact).collect::<Vec<_>>())?
+            serde_json::to_string(&redacted_rows_for_json(export, args.redact))?
         )?;
     }
     Ok(())

--- a/crates/tokmd-format/src/export/jsonl.rs
+++ b/crates/tokmd-format/src/export/jsonl.rs
@@ -16,9 +16,12 @@ use tokmd_types::{
     ExportArgs, ExportArgsMeta, ExportData, FileRow, RedactMode, ScanArgs, ScanStatus, ToolInfo,
 };
 
-use crate::{now_ms, redact_module_roots, redact_path, scan_args};
+use crate::{now_ms, scan_args};
 
-use super::redact_rows;
+use super::{
+    meta::{args_meta_from_export, redacted_args_meta},
+    redact_rows,
+};
 
 #[derive(Debug, Clone, Serialize)]
 struct ExportMeta {
@@ -32,6 +35,22 @@ struct ExportMeta {
     warnings: Vec<String>,
     scan: ScanArgs,
     args: ExportArgsMeta,
+}
+
+impl ExportMeta {
+    fn complete(scan: ScanArgs, args: ExportArgsMeta) -> Self {
+        Self {
+            ty: "meta",
+            schema_version: tokmd_types::SCHEMA_VERSION,
+            generated_at_ms: now_ms(),
+            tool: ToolInfo::current(),
+            mode: "export".to_string(),
+            status: ScanStatus::Complete,
+            warnings: vec![],
+            scan,
+            args,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -48,41 +67,11 @@ pub(super) fn write_export_jsonl<W: Write>(
     global: &ScanOptions,
     args: &ExportArgs,
 ) -> Result<()> {
-    let module_roots = redact_module_roots(&export.module_roots, args.redact);
-
     if args.meta {
-        let should_redact = args.redact == RedactMode::Paths || args.redact == RedactMode::All;
-        let strip_prefix_redacted = should_redact && args.strip_prefix.is_some();
-
-        let meta = ExportMeta {
-            ty: "meta",
-            schema_version: tokmd_types::SCHEMA_VERSION,
-            generated_at_ms: now_ms(),
-            tool: ToolInfo::current(),
-            mode: "export".to_string(),
-            status: ScanStatus::Complete,
-            warnings: vec![],
-            scan: scan_args(&args.paths, global, Some(args.redact)),
-            args: ExportArgsMeta {
-                format: args.format,
-                module_roots: module_roots.clone(),
-                module_depth: export.module_depth,
-                children: export.children,
-                min_code: args.min_code,
-                max_rows: args.max_rows,
-                redact: args.redact,
-                strip_prefix: if should_redact {
-                    args.strip_prefix
-                        .as_ref()
-                        .map(|p| redact_path(&p.display().to_string().replace('\\', "/")))
-                } else {
-                    args.strip_prefix
-                        .as_ref()
-                        .map(|p| p.display().to_string().replace('\\', "/"))
-                },
-                strip_prefix_redacted,
-            },
-        };
+        let meta = ExportMeta::complete(
+            scan_args(&args.paths, global, Some(args.redact)),
+            args_meta_from_export(export, args),
+        );
         writeln!(out, "{}", serde_json::to_string(&meta)?)?;
     }
 
@@ -103,20 +92,7 @@ pub fn write_export_jsonl_to_file(
     let file = File::create(path)?;
     let mut out = BufWriter::new(file);
 
-    let mut final_args = args_meta.clone();
-    final_args.module_roots = redact_module_roots(&final_args.module_roots, args_meta.redact);
-
-    let meta = ExportMeta {
-        ty: "meta",
-        schema_version: tokmd_types::SCHEMA_VERSION,
-        generated_at_ms: now_ms(),
-        tool: ToolInfo::current(),
-        mode: "export".to_string(),
-        status: ScanStatus::Complete,
-        warnings: vec![],
-        scan: scan.clone(),
-        args: final_args,
-    };
+    let meta = ExportMeta::complete(scan.clone(), redacted_args_meta(args_meta));
     writeln!(out, "{}", serde_json::to_string(&meta)?)?;
 
     write_rows(&mut out, export, args_meta.redact)?;

--- a/crates/tokmd-format/src/export/meta.rs
+++ b/crates/tokmd-format/src/export/meta.rs
@@ -1,0 +1,70 @@
+//! Shared helpers for export receipt metadata and redacted payloads.
+//!
+//! JSON and JSONL exports both need the same envelope fields and redaction
+//! decisions. Keeping that logic here prevents the two wire formats from
+//! drifting apart.
+
+use std::{borrow::Cow, path::Path};
+
+use tokmd_types::{ExportArgs, ExportArgsMeta, ExportData, FileRow, RedactMode};
+
+use crate::{redact_module_roots, redact_path};
+
+use super::redact_rows;
+
+pub(super) fn args_meta_from_export(export: &ExportData, args: &ExportArgs) -> ExportArgsMeta {
+    let should_redact = redact_paths(args.redact);
+
+    ExportArgsMeta {
+        format: args.format,
+        module_roots: redact_module_roots(&export.module_roots, args.redact),
+        module_depth: export.module_depth,
+        children: export.children,
+        min_code: args.min_code,
+        max_rows: args.max_rows,
+        redact: args.redact,
+        strip_prefix: args
+            .strip_prefix
+            .as_deref()
+            .map(|path| normalized_strip_prefix(path, should_redact)),
+        strip_prefix_redacted: should_redact && args.strip_prefix.is_some(),
+    }
+}
+
+pub(super) fn redacted_args_meta(args_meta: &ExportArgsMeta) -> ExportArgsMeta {
+    let mut final_args = args_meta.clone();
+    final_args.module_roots = redact_module_roots(&final_args.module_roots, args_meta.redact);
+    final_args
+}
+
+pub(super) fn redacted_export_data(export: &ExportData, redact: RedactMode) -> ExportData {
+    ExportData {
+        rows: redacted_rows_for_json(export, redact)
+            .into_iter()
+            .map(|row| row.into_owned())
+            .collect(),
+        module_roots: redact_module_roots(&export.module_roots, redact),
+        module_depth: export.module_depth,
+        children: export.children,
+    }
+}
+
+pub(super) fn redacted_rows_for_json(
+    export: &ExportData,
+    redact: RedactMode,
+) -> Vec<Cow<'_, FileRow>> {
+    redact_rows(&export.rows, redact).collect()
+}
+
+fn normalized_strip_prefix(path: &Path, should_redact: bool) -> String {
+    let normalized = path.display().to_string().replace('\\', "/");
+    if should_redact {
+        redact_path(&normalized)
+    } else {
+        normalized
+    }
+}
+
+fn redact_paths(redact: RedactMode) -> bool {
+    redact == RedactMode::Paths || redact == RedactMode::All
+}


### PR DESCRIPTION
### Motivation
- Prevent duplicated construction and redaction logic for export receipts across JSON and JSONL renderers by centralizing envelope/args decisions. 

### Description
- Add a shared helper module `crates/tokmd-format/src/export/meta.rs` that centralizes export metadata and redaction logic including `args_meta_from_export`, `redacted_args_meta`, `redacted_export_data`, and `redacted_rows_for_json`.
- Update JSON export (`crates/tokmd-format/src/export/json.rs`) to reuse `args_meta_from_export`, `redacted_export_data`, and `redacted_rows_for_json` instead of duplicating envelope and row-redaction code.
- Update JSONL export (`crates/tokmd-format/src/export/jsonl.rs`) to reuse `args_meta_from_export` / `redacted_args_meta` and introduce a compact `ExportMeta::complete` constructor to consolidate meta envelope creation.
- Register the new `meta` module in the export dispatcher (`crates/tokmd-format/src/export.rs`) so both JSON and JSONL use the shared helpers.

### Testing
- Ran `cargo fmt-check` which passed. 
- Ran `cargo test -p tokmd-format` which completed with all tests passing for the crate. 
- Ran `cargo clippy -p tokmd-format -- -D warnings` which finished without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b87e3a3c833380e425afac39eed9)