### PR TITLE
Avoid overflow in average line rounding

### DIFF
--- a/crates/tokmd-model/src/lib.rs
+++ b/crates/tokmd-model/src/lib.rs
@@ -54,8 +54,14 @@ pub fn avg(lines: usize, files: usize) -> usize {
     if files == 0 {
         return 0;
     }
-    // Round to nearest integer.
-    (lines + (files / 2)) / files
+    // Round to nearest integer without adding to `lines`, which can overflow for
+    // very large repositories. The fractional part rounds up once the remainder
+    // reaches half the divisor, using an overflow-safe comparison.
+    let whole = lines / files;
+    let remainder = lines % files;
+    let rounds_up = remainder >= files - (files / 2);
+
+    whole + usize::from(rounds_up)
 }
 
 /// Normalize a path for portable output.
@@ -286,5 +292,12 @@ mod tests {
         assert_eq!(avg(9, 3), 3);
         assert_eq!(avg(10, 3), 3);
         assert_eq!(avg(11, 3), 4);
+    }
+
+    #[test]
+    fn avg_handles_large_values_without_overflow() {
+        assert_eq!(avg(usize::MAX, usize::MAX), 1);
+        assert_eq!(avg(usize::MAX, 2), (usize::MAX / 2) + 1);
+        assert_eq!(avg(usize::MAX - 1, 2), usize::MAX / 2);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent `usize` overflow when computing rounded average lines-per-file for extremely large counts (e.g., `usize::MAX`) by avoiding arithmetic that adds to `lines`.

### Description
- Replace the previous `(lines + (files / 2)) / files` rounding with quotient/remainder logic that decides rounding up without mutating/adding to `lines`, and add an edge-case unit test `avg_handles_large_values_without_overflow` in `crates/tokmd-model/src/lib.rs`.

### Testing
- Ran `cargo test -p tokmd-model avg_handles_large_values_without_overflow --verbose` (the test reproduced the overflow on the original implementation and passed after the fix), ran `cargo fmt-check`, and ran `cargo test -p tokmd-model --verbose`; all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1f4502483338a302eb782cbd384)