### PR TITLE
Fix tokmd-python test linkage and path validation

### DIFF
--- a/crates/tokmd-python/Cargo.toml
+++ b/crates/tokmd-python/Cargo.toml
@@ -24,7 +24,7 @@ tokmd-core = { workspace = true, features = ["analysis", "cockpit"] }
 tokmd-envelope.workspace = true
 
 [features]
-default = ["extension-module"]
+default = []
 extension-module = ["pyo3/extension-module"]
 
 

--- a/crates/tokmd-python/build.rs
+++ b/crates/tokmd-python/build.rs
@@ -1,0 +1,29 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
+    let output = Command::new(python)
+        .args([
+            "-c",
+            "import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')",
+        ])
+        .output();
+
+    let Ok(output) = output else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+
+    let libdir = String::from_utf8_lossy(&output.stdout);
+    let libdir = libdir.trim();
+    if libdir.is_empty() {
+        return;
+    }
+
+    if env::var_os("CARGO_FEATURE_EXTENSION_MODULE").is_none() {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{libdir}");
+    }
+}

--- a/crates/tokmd-python/pyproject.toml
+++ b/crates/tokmd-python/pyproject.toml
@@ -37,7 +37,7 @@ Repository = "https://github.com/EffortlessMetrics/tokmd"
 Changelog = "https://github.com/EffortlessMetrics/tokmd/blob/main/CHANGELOG.md"
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["extension-module"]
 python-source = "python"
 module-name = "tokmd._tokmd"
 strip = true

--- a/crates/tokmd-python/src/runtime.rs
+++ b/crates/tokmd-python/src/runtime.rs
@@ -165,6 +165,13 @@ pub(crate) fn run_with_json_module(
     // (e.g., circular reference), it propagates immediately as a Python
     // exception without panicking the Rust code.
     let json_module = json_module?;
+    if let Some(paths) = args.get_item("paths")?
+        && paths.is_none()
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "paths must be a list of strings, not None",
+        ));
+    }
     let args_json: String = json_module.call_method1("dumps", (args,))?.extract()?;
 
     // Run the operation (releasing GIL)

--- a/crates/tokmd-python/src/tests.rs
+++ b/crates/tokmd-python/src/tests.rs
@@ -782,8 +782,8 @@ fn red_test_python_ffi_schema_version_returns_valid_number() {
 #[test]
 fn red_test_python_ffi_all_wrappers_return_pyresult() {
     with_py(|py| {
-        let temp_dir = std::env::temp_dir();
-        let temp_path = temp_dir.to_string_lossy().to_string();
+        let repo = make_repo("fn all_wrappers_return_pyresult() {}\n");
+        let temp_path = repo.path().to_string_lossy().to_string();
 
         // lang() - should return PyResult
         let _ = lang(
@@ -851,8 +851,8 @@ fn red_test_python_ffi_all_wrappers_return_pyresult() {
         // diff() - should return PyResult
         let _ = diff(py, Some(&temp_path), Some(&temp_path));
 
-        // cockpit() - should return PyResult
-        let _ = cockpit(py, None, None, None, None);
+        // cockpit() - should return PyResult without scanning the ambient repository.
+        let _ = cockpit(py, Some("__tokmd_missing_base__"), Some("HEAD"), None, None);
     });
 }
 


### PR DESCRIPTION
### Motivation
- Rust unit tests for `tokmd-python` failed to run reliably because test binaries could not find the Python runtime library, and the high-level Python runtime silently accepted `paths=None` instead of returning a clear error. 
- Tests also exercised the ambient repository in a couple of wrapper-contract checks which made them brittle and slow. 

### Description
- Disable the `extension-module` feature by default in `crates/tokmd-python/Cargo.toml` so test builds link as an embedded Python consumer (`default = []`) while keeping an `extension-module` feature for maturin packaging. 
- Update `crates/tokmd-python/pyproject.toml` to map maturin to the crate `extension-module` feature so packaging still uses the extension build. 
- Add `crates/tokmd-python/build.rs` that discovers Python's `LIBDIR` and emits an rpath for non-extension-module builds to ensure test binaries can load `libpython` at runtime. 
- Add input validation in the high-level runtime (`run_with_json_module`) to reject `paths=None` with a `PyValueError` before JSON serialization, and tighten wrapper tests to use a small temporary repo and avoid ambient cockpit scans. 

### Testing
- Ran `cargo test -p tokmd-python --all-targets` (unit tests + property tests) and the tokmd-python test suite passed. 
- Ran `cargo fmt --check` and `cargo clippy -p tokmd-python --all-targets -- -D warnings` for the package and they completed successfully. 
- Workspace-wide `cargo test --workspace` was attempted but a full workspace run exceeded the time budget and was not completed, so only focused `tokmd-python` verification was used for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0843459d108333858ce517cd60fee9)