### PR TITLE
test(core): cover nested FFI argument objects

### DIFF
--- a/crates/tokmd-core/src/ffi/parse.rs
+++ b/crates/tokmd-core/src/ffi/parse.rs
@@ -8,8 +8,16 @@ use serde_json::Value;
 use crate::error::TokmdError;
 use crate::settings::{ChildIncludeMode, ChildrenMode, ConfigMode, ExportFormat, RedactMode};
 
-pub(super) fn scan_arg_object(args: &Value) -> &Value {
-    args.get("scan").unwrap_or(args)
+pub(super) fn scan_arg_object(args: &Value) -> Result<&Value, TokmdError> {
+    nested_arg_object(args, "scan")
+}
+
+pub(super) fn nested_arg_object<'a>(args: &'a Value, field: &str) -> Result<&'a Value, TokmdError> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(args),
+        Some(value @ Value::Object(_)) => Ok(value),
+        Some(_) => Err(TokmdError::invalid_field(field, "an object")),
+    }
 }
 
 /// Parse a boolean field strictly: missing/null -> default, non-bool -> error.

--- a/crates/tokmd-core/src/ffi/settings_parse.rs
+++ b/crates/tokmd-core/src/ffi/settings_parse.rs
@@ -6,9 +6,9 @@
 use serde_json::Value;
 
 use super::parse::{
-    parse_analyze_preset, parse_bool, parse_child_include_mode, parse_children_mode,
-    parse_config_mode, parse_effort_layer, parse_effort_model, parse_export_format,
-    parse_import_granularity, parse_optional_bool, parse_optional_redact_mode,
+    nested_arg_object, parse_analyze_preset, parse_bool, parse_child_include_mode,
+    parse_children_mode, parse_config_mode, parse_effort_layer, parse_effort_model,
+    parse_export_format, parse_import_granularity, parse_optional_bool, parse_optional_redact_mode,
     parse_optional_string, parse_optional_u64, parse_optional_usize, parse_redact_mode,
     parse_required_string, parse_string, parse_string_array, parse_usize, scan_arg_object,
 };
@@ -19,7 +19,7 @@ use crate::settings::{
 };
 
 pub(super) fn parse_scan_settings(args: &Value) -> Result<ScanSettings, TokmdError> {
-    let obj = scan_arg_object(args);
+    let obj = scan_arg_object(args)?;
 
     Ok(ScanSettings {
         paths: parse_string_array(obj, "paths", vec![".".to_string()])?,
@@ -37,7 +37,7 @@ pub(super) fn parse_scan_settings(args: &Value) -> Result<ScanSettings, TokmdErr
 }
 
 pub(super) fn parse_lang_settings(args: &Value) -> Result<LangSettings, TokmdError> {
-    let obj = args.get("lang").unwrap_or(args);
+    let obj = nested_arg_object(args, "lang")?;
 
     Ok(LangSettings {
         top: parse_usize(obj, "top", 0)?,
@@ -48,7 +48,7 @@ pub(super) fn parse_lang_settings(args: &Value) -> Result<LangSettings, TokmdErr
 }
 
 pub(super) fn parse_module_settings(args: &Value) -> Result<ModuleSettings, TokmdError> {
-    let obj = args.get("module").unwrap_or(args);
+    let obj = nested_arg_object(args, "module")?;
 
     Ok(ModuleSettings {
         top: parse_usize(obj, "top", 0)?,
@@ -64,7 +64,7 @@ pub(super) fn parse_module_settings(args: &Value) -> Result<ModuleSettings, Tokm
 }
 
 pub(super) fn parse_export_settings(args: &Value) -> Result<ExportSettings, TokmdError> {
-    let obj = args.get("export").unwrap_or(args);
+    let obj = nested_arg_object(args, "export")?;
 
     Ok(ExportSettings {
         format: parse_export_format(obj, ExportFormat::Jsonl)?,
@@ -85,7 +85,7 @@ pub(super) fn parse_export_settings(args: &Value) -> Result<ExportSettings, Tokm
 
 #[allow(dead_code)]
 pub(super) fn parse_analyze_settings(args: &Value) -> Result<AnalyzeSettings, TokmdError> {
-    let obj = args.get("analyze").unwrap_or(args);
+    let obj = nested_arg_object(args, "analyze")?;
 
     let effort_base_ref = parse_optional_string(obj, "effort_base_ref")?;
     let effort_head_ref = parse_optional_string(obj, "effort_head_ref")?;
@@ -130,7 +130,7 @@ pub(super) fn parse_analyze_settings(args: &Value) -> Result<AnalyzeSettings, To
 pub(super) fn parse_cockpit_settings(
     args: &Value,
 ) -> Result<crate::settings::CockpitSettings, TokmdError> {
-    let obj = args.get("cockpit").unwrap_or(args);
+    let obj = nested_arg_object(args, "cockpit")?;
 
     Ok(crate::settings::CockpitSettings {
         base: parse_string(obj, "base", "main")?,
@@ -141,7 +141,7 @@ pub(super) fn parse_cockpit_settings(
 }
 
 pub(super) fn parse_diff_settings(args: &Value) -> Result<DiffSettings, TokmdError> {
-    let obj = args.get("diff").unwrap_or(args);
+    let obj = nested_arg_object(args, "diff")?;
 
     let from = parse_required_string(obj, "from")?;
     let to = parse_required_string(obj, "to")?;

--- a/crates/tokmd-core/src/ffi/tests.rs
+++ b/crates/tokmd-core/src/ffi/tests.rs
@@ -291,6 +291,48 @@ fn nested_lang_object_invalid_top_returns_error() -> Result<(), Box<dyn std::err
     Ok(())
 }
 
+#[test]
+fn nested_lang_object_valid_values_override_top_level_defaults()
+-> Result<(), Box<dyn std::error::Error>> {
+    let args: Value = serde_json::json!({"lang": {"top": 7, "files": true}});
+    let settings = parse_lang_settings(&args)?;
+    assert_eq!(settings.top, 7);
+    assert!(settings.files);
+    Ok(())
+}
+
+#[test]
+fn nested_mode_object_must_be_an_object() -> Result<(), Box<dyn std::error::Error>> {
+    let result = run_json("lang", r#"{"lang": "not-an-object"}"#);
+    let parsed: Value = serde_json::from_str(&result)?;
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "invalid_settings");
+    assert_eq!(parsed["error"]["details"], "lang");
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .ok_or_else(|| std::io::Error::other("not a string"))?
+            .contains("object")
+    );
+    Ok(())
+}
+
+#[test]
+fn nested_scan_object_must_be_an_object() -> Result<(), Box<dyn std::error::Error>> {
+    let result = run_json("lang", r#"{"scan": []}"#);
+    let parsed: Value = serde_json::from_str(&result)?;
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "invalid_settings");
+    assert_eq!(parsed["error"]["details"], "scan");
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .ok_or_else(|| std::io::Error::other("not a string"))?
+            .contains("object")
+    );
+    Ok(())
+}
+
 // ========================================================================
 // Null handling tests
 // ========================================================================


### PR DESCRIPTION
### Motivation
- Ensure nested FFI argument sections (e.g. `scan`, `lang`, `module`, `export`, `analyze`, `cockpit`, `diff`) are validated as JSON objects when present instead of silently falling back to top-level defaults.
- Make parsing stricter and fail-fast on malformed nested payloads so calling bindings (Python/Node) receive clear `invalid_settings` envelopes.
- Add unit coverage for the new behavior to prevent regressions.

### Description
- Add `nested_arg_object` helper and make `scan_arg_object` return `Result<&Value, TokmdError>` to enforce that nested sections are objects; implemented in `crates/tokmd-core/src/ffi/parse.rs`.
- Update mode-specific parsers to use `nested_arg_object` and propagate errors, replacing previous `unwrap_or(args)` behavior in `crates/tokmd-core/src/ffi/settings_parse.rs`.
- Add unit tests exercising the new validation and behavior in `crates/tokmd-core/src/ffi/tests.rs`, including a positive test where nested `lang` overrides top-level defaults and regression tests for non-object `lang`/`scan` payloads.

### Testing
- Ran `cargo test -p tokmd-core nested_` which executed the newly added/related tests and succeeded.
- Ran full crate tests with `cargo test -p tokmd-core` and all tests passed.
- Ran formatting and lints with `cargo fmt-check` and `cargo clippy -p tokmd-core -- -D warnings`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1bbd4ac83338025031c694b5a04)