### PR TITLE
Refactor context policy into SRP modules

### DIFF
--- a/crates/tokmd-core/src/context_policy/cap.rs
+++ b/crates/tokmd-core/src/context_policy/cap.rs
@@ -1,0 +1,15 @@
+//! Per-file token cap calculations for context policy.
+
+use super::DEFAULT_MAX_FILE_TOKENS;
+
+/// Compute the maximum tokens a single file may consume.
+#[must_use]
+pub fn compute_file_cap(budget: usize, max_file_pct: f64, max_file_tokens: Option<usize>) -> usize {
+    if budget == usize::MAX {
+        return usize::MAX;
+    }
+
+    let pct_cap = (budget as f64 * max_file_pct) as usize;
+    let hard_cap = max_file_tokens.unwrap_or(DEFAULT_MAX_FILE_TOKENS);
+    pct_cap.min(hard_cap)
+}

--- a/crates/tokmd-core/src/context_policy/classify.rs
+++ b/crates/tokmd-core/src/context_policy/classify.rs
@@ -1,0 +1,77 @@
+//! File hygiene classification for context policy.
+
+use tokmd_scan::normalize_slashes as normalize_path;
+use tokmd_types::FileClassification;
+
+use super::patterns::{FIXTURE_DIRS, GENERATED_PATTERNS, LOCKFILES, VENDORED_DIRS, basename};
+
+/// Classify a file for context/handoff hygiene policy evaluation.
+#[must_use]
+pub fn classify_file(
+    path: &str,
+    tokens: usize,
+    lines: usize,
+    dense_threshold: f64,
+) -> Vec<FileClassification> {
+    let mut classes = Vec::new();
+    let normalized = normalize_path(path);
+    let basename = basename(&normalized);
+
+    classify_basename(basename, &mut classes);
+    classify_path(&normalized, &mut classes);
+    classify_density(tokens, lines, dense_threshold, &mut classes);
+
+    classes.sort();
+    classes.dedup();
+    classes
+}
+
+fn classify_basename(basename: &str, classes: &mut Vec<FileClassification>) {
+    if LOCKFILES.contains(&basename) {
+        classes.push(FileClassification::Lockfile);
+    }
+
+    if basename.ends_with(".min.js") || basename.ends_with(".min.css") {
+        classes.push(FileClassification::Minified);
+    }
+
+    if basename.ends_with(".js.map") || basename.ends_with(".css.map") {
+        classes.push(FileClassification::Sourcemap);
+    }
+
+    if GENERATED_PATTERNS
+        .iter()
+        .any(|pat| basename == *pat || basename.contains(pat))
+    {
+        classes.push(FileClassification::Generated);
+    }
+}
+
+fn classify_path(normalized: &str, classes: &mut Vec<FileClassification>) {
+    if VENDORED_DIRS
+        .iter()
+        .any(|dir| normalized.contains(dir) || normalized.starts_with(dir.trim_end_matches('/')))
+    {
+        classes.push(FileClassification::Vendored);
+    }
+
+    if FIXTURE_DIRS
+        .iter()
+        .any(|dir| normalized.contains(dir) || normalized.starts_with(dir.trim_end_matches('/')))
+    {
+        classes.push(FileClassification::Fixture);
+    }
+}
+
+fn classify_density(
+    tokens: usize,
+    lines: usize,
+    dense_threshold: f64,
+    classes: &mut Vec<FileClassification>,
+) {
+    let effective_lines = lines.max(1);
+    let tokens_per_line = tokens as f64 / effective_lines as f64;
+    if tokens_per_line > dense_threshold {
+        classes.push(FileClassification::DataBlob);
+    }
+}

--- a/crates/tokmd-core/src/context_policy/mod.rs
+++ b/crates/tokmd-core/src/context_policy/mod.rs
@@ -2,8 +2,15 @@
 
 #![forbid(unsafe_code)]
 
-use tokmd_scan::normalize_slashes as normalize_path;
-use tokmd_types::{FileClassification, InclusionPolicy};
+mod cap;
+mod classify;
+mod patterns;
+mod policy;
+
+pub use cap::compute_file_cap;
+pub use classify::classify_file;
+pub use patterns::{is_spine_file, smart_exclude_reason};
+pub use policy::assign_policy;
 
 /// Default maximum fraction of budget a single file may consume.
 pub const DEFAULT_MAX_FILE_PCT: f64 = 0.15;
@@ -12,228 +19,11 @@ pub const DEFAULT_MAX_FILE_TOKENS: usize = 16_000;
 /// Default tokens-per-line threshold for dense blob detection.
 pub const DEFAULT_DENSE_THRESHOLD: f64 = 50.0;
 
-const LOCKFILES: &[&str] = &[
-    "Cargo.lock",
-    "package-lock.json",
-    "pnpm-lock.yaml",
-    "yarn.lock",
-    "poetry.lock",
-    "Pipfile.lock",
-    "go.sum",
-    "composer.lock",
-    "Gemfile.lock",
-];
-
-const SMART_EXCLUDE_SUFFIXES: &[(&str, &str)] = &[
-    (".min.js", "minified"),
-    (".min.css", "minified"),
-    (".js.map", "sourcemap"),
-    (".css.map", "sourcemap"),
-];
-
-const SPINE_PATTERNS: &[&str] = &[
-    "README.md",
-    "README",
-    "README.rst",
-    "README.txt",
-    "ROADMAP.md",
-    "docs/ROADMAP.md",
-    "CONTRIBUTING.md",
-    "Cargo.toml",
-    "package.json",
-    "pyproject.toml",
-    "go.mod",
-    "docs/architecture.md",
-    "docs/design.md",
-    "tokmd.toml",
-    "cockpit.toml",
-];
-
-const GENERATED_PATTERNS: &[&str] = &[
-    "node-types.json",
-    "grammar.json",
-    ".generated.",
-    ".pb.go",
-    ".pb.rs",
-    "_pb2.py",
-    ".g.dart",
-    ".freezed.dart",
-];
-
-const VENDORED_DIRS: &[&str] = &["vendor/", "third_party/", "third-party/", "node_modules/"];
-const FIXTURE_DIRS: &[&str] = &[
-    "fixtures/",
-    "testdata/",
-    "test_data/",
-    "__snapshots__/",
-    "golden/",
-];
-
-/// Returns the smart-exclude reason for a path, if any.
-///
-/// Reasons:
-/// - `lockfile`
-/// - `minified`
-/// - `sourcemap`
-#[must_use]
-pub fn smart_exclude_reason(path: &str) -> Option<&'static str> {
-    let basename = path.rsplit('/').next().unwrap_or(path);
-
-    if LOCKFILES.contains(&basename) {
-        return Some("lockfile");
-    }
-
-    for &(suffix, reason) in SMART_EXCLUDE_SUFFIXES {
-        if basename.ends_with(suffix) {
-            return Some(reason);
-        }
-    }
-
-    None
-}
-
-/// Returns `true` when a path matches a "spine" file that should be prioritized.
-#[must_use]
-pub fn is_spine_file(path: &str) -> bool {
-    let normalized = normalize_path(path);
-    let basename = normalized.rsplit('/').next().unwrap_or(&normalized);
-
-    for &pattern in SPINE_PATTERNS {
-        if pattern.contains('/') {
-            if normalized == pattern || normalized.ends_with(&format!("/{pattern}")) {
-                return true;
-            }
-        } else if basename == pattern {
-            return true;
-        }
-    }
-
-    false
-}
-
-/// Classify a file for context/handoff hygiene policy evaluation.
-#[must_use]
-pub fn classify_file(
-    path: &str,
-    tokens: usize,
-    lines: usize,
-    dense_threshold: f64,
-) -> Vec<FileClassification> {
-    let mut classes = Vec::new();
-    let normalized = normalize_path(path);
-    let basename = normalized.rsplit('/').next().unwrap_or(&normalized);
-
-    if LOCKFILES.contains(&basename) {
-        classes.push(FileClassification::Lockfile);
-    }
-
-    if basename.ends_with(".min.js") || basename.ends_with(".min.css") {
-        classes.push(FileClassification::Minified);
-    }
-
-    if basename.ends_with(".js.map") || basename.ends_with(".css.map") {
-        classes.push(FileClassification::Sourcemap);
-    }
-
-    if GENERATED_PATTERNS
-        .iter()
-        .any(|pat| basename == *pat || basename.contains(pat))
-    {
-        classes.push(FileClassification::Generated);
-    }
-
-    if VENDORED_DIRS
-        .iter()
-        .any(|dir| normalized.contains(dir) || normalized.starts_with(dir.trim_end_matches('/')))
-    {
-        classes.push(FileClassification::Vendored);
-    }
-
-    if FIXTURE_DIRS
-        .iter()
-        .any(|dir| normalized.contains(dir) || normalized.starts_with(dir.trim_end_matches('/')))
-    {
-        classes.push(FileClassification::Fixture);
-    }
-
-    let effective_lines = lines.max(1);
-    let tokens_per_line = tokens as f64 / effective_lines as f64;
-    if tokens_per_line > dense_threshold {
-        classes.push(FileClassification::DataBlob);
-    }
-
-    classes.sort();
-    classes.dedup();
-    classes
-}
-
-/// Compute the maximum tokens a single file may consume.
-#[must_use]
-pub fn compute_file_cap(budget: usize, max_file_pct: f64, max_file_tokens: Option<usize>) -> usize {
-    if budget == usize::MAX {
-        return usize::MAX;
-    }
-
-    let pct_cap = (budget as f64 * max_file_pct) as usize;
-    let hard_cap = max_file_tokens.unwrap_or(DEFAULT_MAX_FILE_TOKENS);
-    pct_cap.min(hard_cap)
-}
-
-/// Assign an inclusion policy based on size and file classifications.
-#[must_use]
-pub fn assign_policy(
-    tokens: usize,
-    file_cap: usize,
-    classifications: &[FileClassification],
-) -> (InclusionPolicy, Option<String>) {
-    if tokens <= file_cap {
-        return (InclusionPolicy::Full, None);
-    }
-
-    let skip_classes = [
-        FileClassification::Generated,
-        FileClassification::DataBlob,
-        FileClassification::Vendored,
-    ];
-
-    if classifications.iter().any(|c| skip_classes.contains(c)) {
-        let class_names: Vec<&str> = classifications.iter().map(classification_name).collect();
-        return (
-            InclusionPolicy::Skip,
-            Some(format!(
-                "{} file exceeds cap ({} > {} tokens)",
-                class_names.join("+"),
-                tokens,
-                file_cap
-            )),
-        );
-    }
-
-    (
-        InclusionPolicy::HeadTail,
-        Some(format!(
-            "file exceeds cap ({} > {} tokens); head+tail included",
-            tokens, file_cap
-        )),
-    )
-}
-
-fn classification_name(classification: &FileClassification) -> &'static str {
-    match classification {
-        FileClassification::Generated => "generated",
-        FileClassification::Fixture => "fixture",
-        FileClassification::Vendored => "vendored",
-        FileClassification::Lockfile => "lockfile",
-        FileClassification::Minified => "minified",
-        FileClassification::DataBlob => "data_blob",
-        FileClassification::Sourcemap => "sourcemap",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use tokmd_types::{FileClassification, InclusionPolicy};
 
     #[test]
     fn smart_exclude_reason_detects_lockfiles_and_sourcemaps() {

--- a/crates/tokmd-core/src/context_policy/patterns.rs
+++ b/crates/tokmd-core/src/context_policy/patterns.rs
@@ -1,0 +1,108 @@
+//! Path pattern tables and path-focused predicates for context policy.
+
+use tokmd_scan::normalize_slashes as normalize_path;
+
+pub(crate) const LOCKFILES: &[&str] = &[
+    "Cargo.lock",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "poetry.lock",
+    "Pipfile.lock",
+    "go.sum",
+    "composer.lock",
+    "Gemfile.lock",
+];
+
+pub(crate) const GENERATED_PATTERNS: &[&str] = &[
+    "node-types.json",
+    "grammar.json",
+    ".generated.",
+    ".pb.go",
+    ".pb.rs",
+    "_pb2.py",
+    ".g.dart",
+    ".freezed.dart",
+];
+
+pub(crate) const VENDORED_DIRS: &[&str] =
+    &["vendor/", "third_party/", "third-party/", "node_modules/"];
+pub(crate) const FIXTURE_DIRS: &[&str] = &[
+    "fixtures/",
+    "testdata/",
+    "test_data/",
+    "__snapshots__/",
+    "golden/",
+];
+
+const SMART_EXCLUDE_SUFFIXES: &[(&str, &str)] = &[
+    (".min.js", "minified"),
+    (".min.css", "minified"),
+    (".js.map", "sourcemap"),
+    (".css.map", "sourcemap"),
+];
+
+const SPINE_PATTERNS: &[&str] = &[
+    "README.md",
+    "README",
+    "README.rst",
+    "README.txt",
+    "ROADMAP.md",
+    "docs/ROADMAP.md",
+    "CONTRIBUTING.md",
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    "go.mod",
+    "docs/architecture.md",
+    "docs/design.md",
+    "tokmd.toml",
+    "cockpit.toml",
+];
+
+/// Returns the smart-exclude reason for a path, if any.
+///
+/// Reasons:
+/// - `lockfile`
+/// - `minified`
+/// - `sourcemap`
+#[must_use]
+pub fn smart_exclude_reason(path: &str) -> Option<&'static str> {
+    let basename = basename(path);
+
+    if LOCKFILES.contains(&basename) {
+        return Some("lockfile");
+    }
+
+    for &(suffix, reason) in SMART_EXCLUDE_SUFFIXES {
+        if basename.ends_with(suffix) {
+            return Some(reason);
+        }
+    }
+
+    None
+}
+
+/// Returns `true` when a path matches a "spine" file that should be prioritized.
+#[must_use]
+pub fn is_spine_file(path: &str) -> bool {
+    let normalized = normalize_path(path);
+    let basename = basename(&normalized);
+
+    for &pattern in SPINE_PATTERNS {
+        if pattern.contains('/') {
+            if normalized == pattern || normalized.ends_with(&format!("/{pattern}")) {
+                return true;
+            }
+        } else if basename == pattern {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[must_use]
+pub(crate) fn basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}

--- a/crates/tokmd-core/src/context_policy/policy.rs
+++ b/crates/tokmd-core/src/context_policy/policy.rs
@@ -1,0 +1,54 @@
+//! Inclusion policy assignment for classified context files.
+
+use tokmd_types::{FileClassification, InclusionPolicy};
+
+/// Assign an inclusion policy based on size and file classifications.
+#[must_use]
+pub fn assign_policy(
+    tokens: usize,
+    file_cap: usize,
+    classifications: &[FileClassification],
+) -> (InclusionPolicy, Option<String>) {
+    if tokens <= file_cap {
+        return (InclusionPolicy::Full, None);
+    }
+
+    let skip_classes = [
+        FileClassification::Generated,
+        FileClassification::DataBlob,
+        FileClassification::Vendored,
+    ];
+
+    if classifications.iter().any(|c| skip_classes.contains(c)) {
+        let class_names: Vec<&str> = classifications.iter().map(classification_name).collect();
+        return (
+            InclusionPolicy::Skip,
+            Some(format!(
+                "{} file exceeds cap ({} > {} tokens)",
+                class_names.join("+"),
+                tokens,
+                file_cap
+            )),
+        );
+    }
+
+    (
+        InclusionPolicy::HeadTail,
+        Some(format!(
+            "file exceeds cap ({} > {} tokens); head+tail included",
+            tokens, file_cap
+        )),
+    )
+}
+
+fn classification_name(classification: &FileClassification) -> &'static str {
+    match classification {
+        FileClassification::Generated => "generated",
+        FileClassification::Fixture => "fixture",
+        FileClassification::Vendored => "vendored",
+        FileClassification::Lockfile => "lockfile",
+        FileClassification::Minified => "minified",
+        FileClassification::DataBlob => "data_blob",
+        FileClassification::Sourcemap => "sourcemap",
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve maintainability and testability by splitting the large `context_policy` module into single-responsibility submodules.  
- Make intent clearer by separating path/pattern tables, classification logic, cap calculations, and policy assignment so future changes are localized.  

### Description
- Added `crates/tokmd-core/src/context_policy/patterns.rs` to hold path pattern tables and predicates (`smart_exclude_reason`, `is_spine_file`, and `basename`).  
- Added `crates/tokmd-core/src/context_policy/classify.rs` to encapsulate file classification (basename, path, density) and expose `classify_file`.  
- Added `crates/tokmd-core/src/context_policy/cap.rs` to contain the per-file cap calculation `compute_file_cap`.  
- Added `crates/tokmd-core/src/context_policy/policy.rs` to implement inclusion policy assignment `assign_policy` and the classification name helper.  
- Converted `crates/tokmd-core/src/context_policy/mod.rs` into a thin facade that defines `DEFAULT_*` constants and re-exports the public API (`compute_file_cap`, `classify_file`, `is_spine_file`, `smart_exclude_reason`, `assign_policy`) so callers remain unchanged, and kept the existing tests in place.  

### Testing
- Ran `cargo test -p tokmd-core context_policy`, and the context-policy unit/property tests passed (all tests OK).  
- Ran `cargo fmt-check` to verify formatting, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ddf5a61c83339096bf16374457c8)