### PR TITLE
Refactor derived Markdown rendering into SRP modules

### DIFF
--- a/crates/tokmd-format/src/analysis/markdown/derived.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived.rs
@@ -1,226 +1,33 @@
 //! Derived analysis Markdown rendering.
 //!
-//! This module owns totals, ratios, distribution, top-offender tables, density,
-//! context-window, legacy COCOMO fallback, and integrity sections.
+//! This module coordinates single-responsibility renderers for totals, ratios,
+//! distributions, top-offender tables, density, context-window, legacy COCOMO
+//! fallback, and integrity sections.
 
-use std::fmt::Write;
+use super::effort;
+use tokmd_analysis_types::{DerivedReport, EffortEstimateReport};
 
-use super::{effort, fmt_f64, fmt_pct};
-use tokmd_analysis_types::{DerivedReport, EffortEstimateReport, FileStatRow};
+mod context;
+mod density;
+mod distribution;
+mod integrity;
+mod ratios;
+mod structure;
+mod top;
+mod totals;
 
 pub(super) fn render_derived_report(
     out: &mut String,
     derived: &DerivedReport,
     effort_report: Option<&EffortEstimateReport>,
 ) {
-    out.push_str("## Totals\n\n");
-    out.push_str("|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|\n");
-    out.push_str("|---:|---:|---:|---:|---:|---:|---:|\n");
-    let _ = writeln!(
-        out,
-        "|{}|{}|{}|{}|{}|{}|{}|\n",
-        derived.totals.files,
-        derived.totals.code,
-        derived.totals.comments,
-        derived.totals.blanks,
-        derived.totals.lines,
-        derived.totals.bytes,
-        derived.totals.tokens
-    );
-
-    out.push_str("## Ratios\n\n");
-    out.push_str("|Metric|Value|\n");
-    out.push_str("|---|---:|\n");
-    let _ = writeln!(
-        out,
-        "|Doc density|{}|",
-        fmt_pct(derived.doc_density.total.ratio)
-    );
-    let _ = writeln!(
-        out,
-        "|Whitespace ratio|{}|",
-        fmt_pct(derived.whitespace.total.ratio)
-    );
-    let _ = writeln!(
-        out,
-        "|Bytes per line|{}|\n",
-        fmt_f64(derived.verbosity.total.rate, 2)
-    );
-
-    out.push_str("### Doc density by language\n\n");
-    out.push_str("|Lang|Doc%|Comments|Code|\n");
-    out.push_str("|---|---:|---:|---:|\n");
-    for row in derived.doc_density.by_lang.iter().take(10) {
-        let _ = writeln!(
-            out,
-            "|{}|{}|{}|{}|",
-            row.key,
-            fmt_pct(row.ratio),
-            row.numerator,
-            row.denominator.saturating_sub(row.numerator)
-        );
-    }
-    out.push('\n');
-
-    out.push_str("### Whitespace ratio by language\n\n");
-    out.push_str("|Lang|Blank%|Blanks|Code+Comments|\n");
-    out.push_str("|---|---:|---:|---:|\n");
-    for row in derived.whitespace.by_lang.iter().take(10) {
-        let _ = writeln!(
-            out,
-            "|{}|{}|{}|{}|",
-            row.key,
-            fmt_pct(row.ratio),
-            row.numerator,
-            row.denominator
-        );
-    }
-    out.push('\n');
-
-    out.push_str("### Verbosity by language\n\n");
-    out.push_str("|Lang|Bytes/Line|Bytes|Lines|\n");
-    out.push_str("|---|---:|---:|---:|\n");
-    for row in derived.verbosity.by_lang.iter().take(10) {
-        let _ = writeln!(
-            out,
-            "|{}|{}|{}|{}|",
-            row.key,
-            fmt_f64(row.rate, 2),
-            row.numerator,
-            row.denominator
-        );
-    }
-    out.push('\n');
-
-    out.push_str("## Distribution\n\n");
-    out.push_str("|Count|Min|Max|Mean|Median|P90|P99|Gini|\n");
-    out.push_str("|---:|---:|---:|---:|---:|---:|---:|---:|\n");
-    let _ = writeln!(
-        out,
-        "|{}|{}|{}|{}|{}|{}|{}|{}|\n",
-        derived.distribution.count,
-        derived.distribution.min,
-        derived.distribution.max,
-        fmt_f64(derived.distribution.mean, 2),
-        fmt_f64(derived.distribution.median, 2),
-        fmt_f64(derived.distribution.p90, 2),
-        fmt_f64(derived.distribution.p99, 2),
-        fmt_f64(derived.distribution.gini, 4)
-    );
-
-    out.push_str("## File size histogram\n\n");
-    out.push_str("|Bucket|Min|Max|Files|Pct|\n");
-    out.push_str("|---|---:|---:|---:|---:|\n");
-    for bucket in &derived.histogram {
-        let max = bucket
-            .max
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "∞".to_string());
-        let _ = writeln!(
-            out,
-            "|{}|{}|{}|{}|{}|",
-            bucket.label,
-            bucket.min,
-            max,
-            bucket.files,
-            fmt_pct(bucket.pct)
-        );
-    }
-    out.push('\n');
-
-    out.push_str("## Top offenders\n\n");
-
-    out.push_str("### Largest files by lines\n\n");
-    out.push_str(&render_file_table(&derived.top.largest_lines));
-    out.push('\n');
-
-    out.push_str("### Largest files by tokens\n\n");
-    out.push_str(&render_file_table(&derived.top.largest_tokens));
-    out.push('\n');
-
-    out.push_str("### Largest files by bytes\n\n");
-    out.push_str(&render_file_table(&derived.top.largest_bytes));
-    out.push('\n');
-
-    out.push_str("### Least documented (min LOC)\n\n");
-    out.push_str(&render_file_table(&derived.top.least_documented));
-    out.push('\n');
-
-    out.push_str("### Most dense (bytes/line)\n\n");
-    out.push_str(&render_file_table(&derived.top.most_dense));
-    out.push('\n');
-
-    out.push_str("## Structure\n\n");
-    let _ = writeln!(
-        out,
-        "- Max depth: `{}`\n- Avg depth: `{}`\n",
-        derived.nesting.max,
-        fmt_f64(derived.nesting.avg, 2)
-    );
-
-    out.push_str("## Test density\n\n");
-    let _ = writeln!(
-        out,
-        "- Test lines: `{}`\n- Prod lines: `{}`\n- Test ratio: `{}`\n",
-        derived.test_density.test_lines,
-        derived.test_density.prod_lines,
-        fmt_pct(derived.test_density.ratio)
-    );
-
-    if let Some(todo) = &derived.todo {
-        out.push_str("## TODOs\n\n");
-        let _ = writeln!(
-            out,
-            "- Total: `{}`\n- Density (per KLOC): `{}`\n",
-            todo.total,
-            fmt_f64(todo.density_per_kloc, 2)
-        );
-        out.push_str("|Tag|Count|\n");
-        out.push_str("|---|---:|\n");
-        for tag in &todo.tags {
-            let _ = writeln!(out, "|{}|{}|", tag.tag, tag.count);
-        }
-        out.push('\n');
-    }
-
-    out.push_str("## Boilerplate ratio\n\n");
-    let _ = writeln!(
-        out,
-        "- Infra lines: `{}`\n- Logic lines: `{}`\n- Infra ratio: `{}`\n",
-        derived.boilerplate.infra_lines,
-        derived.boilerplate.logic_lines,
-        fmt_pct(derived.boilerplate.ratio)
-    );
-
-    out.push_str("## Polyglot\n\n");
-    let _ = writeln!(
-        out,
-        "- Languages: `{}`\n- Dominant: `{}` ({})\n- Entropy: `{}`\n",
-        derived.polyglot.lang_count,
-        derived.polyglot.dominant_lang,
-        fmt_pct(derived.polyglot.dominant_pct),
-        fmt_f64(derived.polyglot.entropy, 4)
-    );
-
-    out.push_str("## Reading time\n\n");
-    let _ = writeln!(
-        out,
-        "- Minutes: `{}` ({} lines/min)\n",
-        fmt_f64(derived.reading_time.minutes, 2),
-        derived.reading_time.lines_per_minute
-    );
-
-    if let Some(context) = &derived.context_window {
-        out.push_str("## Context window\n\n");
-        let _ = writeln!(
-            out,
-            "- Window tokens: `{}`\n- Total tokens: `{}`\n- Utilization: `{}`\n- Fits: `{}`\n",
-            context.window_tokens,
-            context.total_tokens,
-            fmt_pct(context.pct),
-            context.fits
-        );
-    }
+    totals::render_totals(out, derived);
+    ratios::render_ratios(out, derived);
+    distribution::render_distribution(out, derived);
+    top::render_top_offenders(out, derived);
+    structure::render_structure(out, derived);
+    density::render_density_sections(out, derived);
+    context::render_context_sections(out, derived);
 
     // Prefer the richer top-level effort contract when present; fall back to
     // legacy derived COCOMO output for older receipts.
@@ -230,33 +37,5 @@ pub(super) fn render_derived_report(
         effort::render_legacy_cocomo_report(out, derived, cocomo);
     }
 
-    out.push_str("## Integrity\n\n");
-    let _ = writeln!(
-        out,
-        "- Hash: `{}` (`{}`)\n- Entries: `{}`\n",
-        derived.integrity.hash, derived.integrity.algo, derived.integrity.entries
-    );
-}
-
-fn render_file_table(rows: &[FileStatRow]) -> String {
-    let mut out = String::with_capacity((rows.len() + 3) * 80);
-    out.push_str("|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|\n");
-    out.push_str("|---|---|---:|---:|---:|---:|---:|---:|\n");
-    for row in rows {
-        let _ = writeln!(
-            out,
-            "|{}|{}|{}|{}|{}|{}|{}|{}|",
-            row.path,
-            row.lang,
-            row.lines,
-            row.code,
-            row.bytes,
-            row.tokens,
-            row.doc_pct.map(fmt_pct).unwrap_or_else(|| "-".to_string()),
-            row.bytes_per_line
-                .map(|v| fmt_f64(v, 2))
-                .unwrap_or_else(|| "-".to_string())
-        );
-    }
-    out
+    integrity::render_integrity(out, derived);
 }

--- a/crates/tokmd-format/src/analysis/markdown/derived/context.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/context.rs
@@ -1,0 +1,21 @@
+//! Context-window rendering for derived analysis reports.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DerivedReport;
+
+use crate::analysis::markdown::fmt_pct;
+
+pub(super) fn render_context_sections(out: &mut String, derived: &DerivedReport) {
+    if let Some(context) = &derived.context_window {
+        out.push_str("## Context window\n\n");
+        let _ = writeln!(
+            out,
+            "- Window tokens: `{}`\n- Total tokens: `{}`\n- Utilization: `{}`\n- Fits: `{}`\n",
+            context.window_tokens,
+            context.total_tokens,
+            fmt_pct(context.pct),
+            context.fits
+        );
+    }
+}

--- a/crates/tokmd-format/src/analysis/markdown/derived/density.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/density.rs
@@ -1,0 +1,77 @@
+//! Test, TODO, boilerplate, polyglot, and reading-time sections.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DerivedReport;
+
+use crate::analysis::markdown::{fmt_f64, fmt_pct};
+
+pub(super) fn render_density_sections(out: &mut String, derived: &DerivedReport) {
+    render_test_density(out, derived);
+    render_todos(out, derived);
+    render_boilerplate_ratio(out, derived);
+    render_polyglot(out, derived);
+    render_reading_time(out, derived);
+}
+
+fn render_test_density(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Test density\n\n");
+    let _ = writeln!(
+        out,
+        "- Test lines: `{}`\n- Prod lines: `{}`\n- Test ratio: `{}`\n",
+        derived.test_density.test_lines,
+        derived.test_density.prod_lines,
+        fmt_pct(derived.test_density.ratio)
+    );
+}
+
+fn render_todos(out: &mut String, derived: &DerivedReport) {
+    if let Some(todo) = &derived.todo {
+        out.push_str("## TODOs\n\n");
+        let _ = writeln!(
+            out,
+            "- Total: `{}`\n- Density (per KLOC): `{}`\n",
+            todo.total,
+            fmt_f64(todo.density_per_kloc, 2)
+        );
+        out.push_str("|Tag|Count|\n");
+        out.push_str("|---|---:|\n");
+        for tag in &todo.tags {
+            let _ = writeln!(out, "|{}|{}|", tag.tag, tag.count);
+        }
+        out.push('\n');
+    }
+}
+
+fn render_boilerplate_ratio(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Boilerplate ratio\n\n");
+    let _ = writeln!(
+        out,
+        "- Infra lines: `{}`\n- Logic lines: `{}`\n- Infra ratio: `{}`\n",
+        derived.boilerplate.infra_lines,
+        derived.boilerplate.logic_lines,
+        fmt_pct(derived.boilerplate.ratio)
+    );
+}
+
+fn render_polyglot(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Polyglot\n\n");
+    let _ = writeln!(
+        out,
+        "- Languages: `{}`\n- Dominant: `{}` ({})\n- Entropy: `{}`\n",
+        derived.polyglot.lang_count,
+        derived.polyglot.dominant_lang,
+        fmt_pct(derived.polyglot.dominant_pct),
+        fmt_f64(derived.polyglot.entropy, 4)
+    );
+}
+
+fn render_reading_time(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Reading time\n\n");
+    let _ = writeln!(
+        out,
+        "- Minutes: `{}` ({} lines/min)\n",
+        fmt_f64(derived.reading_time.minutes, 2),
+        derived.reading_time.lines_per_minute
+    );
+}

--- a/crates/tokmd-format/src/analysis/markdown/derived/distribution.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/distribution.rs
@@ -1,0 +1,49 @@
+//! Distribution and histogram rendering for derived analysis reports.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DerivedReport;
+
+use crate::analysis::markdown::{fmt_f64, fmt_pct};
+
+pub(super) fn render_distribution(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Distribution\n\n");
+    out.push_str("|Count|Min|Max|Mean|Median|P90|P99|Gini|\n");
+    out.push_str("|---:|---:|---:|---:|---:|---:|---:|---:|\n");
+    let _ = writeln!(
+        out,
+        "|{}|{}|{}|{}|{}|{}|{}|{}|\n",
+        derived.distribution.count,
+        derived.distribution.min,
+        derived.distribution.max,
+        fmt_f64(derived.distribution.mean, 2),
+        fmt_f64(derived.distribution.median, 2),
+        fmt_f64(derived.distribution.p90, 2),
+        fmt_f64(derived.distribution.p99, 2),
+        fmt_f64(derived.distribution.gini, 4)
+    );
+
+    render_file_size_histogram(out, derived);
+}
+
+fn render_file_size_histogram(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## File size histogram\n\n");
+    out.push_str("|Bucket|Min|Max|Files|Pct|\n");
+    out.push_str("|---|---:|---:|---:|---:|\n");
+    for bucket in &derived.histogram {
+        let max = bucket
+            .max
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "∞".to_string());
+        let _ = writeln!(
+            out,
+            "|{}|{}|{}|{}|{}|",
+            bucket.label,
+            bucket.min,
+            max,
+            bucket.files,
+            fmt_pct(bucket.pct)
+        );
+    }
+    out.push('\n');
+}

--- a/crates/tokmd-format/src/analysis/markdown/derived/integrity.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/integrity.rs
@@ -1,0 +1,14 @@
+//! Integrity section rendering for derived analysis reports.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DerivedReport;
+
+pub(super) fn render_integrity(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Integrity\n\n");
+    let _ = writeln!(
+        out,
+        "- Hash: `{}` (`{}`)\n- Entries: `{}`\n",
+        derived.integrity.hash, derived.integrity.algo, derived.integrity.entries
+    );
+}

--- a/crates/tokmd-format/src/analysis/markdown/derived/ratios.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/ratios.rs
@@ -1,0 +1,83 @@
+//! Ratio table rendering for derived analysis reports.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DerivedReport;
+
+use crate::analysis::markdown::{fmt_f64, fmt_pct};
+
+pub(super) fn render_ratios(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Ratios\n\n");
+    out.push_str("|Metric|Value|\n");
+    out.push_str("|---|---:|\n");
+    let _ = writeln!(
+        out,
+        "|Doc density|{}|",
+        fmt_pct(derived.doc_density.total.ratio)
+    );
+    let _ = writeln!(
+        out,
+        "|Whitespace ratio|{}|",
+        fmt_pct(derived.whitespace.total.ratio)
+    );
+    let _ = writeln!(
+        out,
+        "|Bytes per line|{}|\n",
+        fmt_f64(derived.verbosity.total.rate, 2)
+    );
+
+    render_doc_density_by_language(out, derived);
+    render_whitespace_by_language(out, derived);
+    render_verbosity_by_language(out, derived);
+}
+
+fn render_doc_density_by_language(out: &mut String, derived: &DerivedReport) {
+    out.push_str("### Doc density by language\n\n");
+    out.push_str("|Lang|Doc%|Comments|Code|\n");
+    out.push_str("|---|---:|---:|---:|\n");
+    for row in derived.doc_density.by_lang.iter().take(10) {
+        let _ = writeln!(
+            out,
+            "|{}|{}|{}|{}|",
+            row.key,
+            fmt_pct(row.ratio),
+            row.numerator,
+            row.denominator.saturating_sub(row.numerator)
+        );
+    }
+    out.push('\n');
+}
+
+fn render_whitespace_by_language(out: &mut String, derived: &DerivedReport) {
+    out.push_str("### Whitespace ratio by language\n\n");
+    out.push_str("|Lang|Blank%|Blanks|Code+Comments|\n");
+    out.push_str("|---|---:|---:|---:|\n");
+    for row in derived.whitespace.by_lang.iter().take(10) {
+        let _ = writeln!(
+            out,
+            "|{}|{}|{}|{}|",
+            row.key,
+            fmt_pct(row.ratio),
+            row.numerator,
+            row.denominator
+        );
+    }
+    out.push('\n');
+}
+
+fn render_verbosity_by_language(out: &mut String, derived: &DerivedReport) {
+    out.push_str("### Verbosity by language\n\n");
+    out.push_str("|Lang|Bytes/Line|Bytes|Lines|\n");
+    out.push_str("|---|---:|---:|---:|\n");
+    for row in derived.verbosity.by_lang.iter().take(10) {
+        let _ = writeln!(
+            out,
+            "|{}|{}|{}|{}|",
+            row.key,
+            fmt_f64(row.rate, 2),
+            row.numerator,
+            row.denominator
+        );
+    }
+    out.push('\n');
+}

--- a/crates/tokmd-format/src/analysis/markdown/derived/structure.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/structure.rs
@@ -1,0 +1,17 @@
+//! Structural metric rendering for derived analysis reports.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DerivedReport;
+
+use crate::analysis::markdown::fmt_f64;
+
+pub(super) fn render_structure(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Structure\n\n");
+    let _ = writeln!(
+        out,
+        "- Max depth: `{}`\n- Avg depth: `{}`\n",
+        derived.nesting.max,
+        fmt_f64(derived.nesting.avg, 2)
+    );
+}

--- a/crates/tokmd-format/src/analysis/markdown/derived/top.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/top.rs
@@ -1,0 +1,50 @@
+//! Top-offender table rendering for derived analysis reports.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::{DerivedReport, FileStatRow};
+
+use crate::analysis::markdown::{fmt_f64, fmt_pct};
+
+pub(super) fn render_top_offenders(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Top offenders\n\n");
+
+    render_top_table(out, "Largest files by lines", &derived.top.largest_lines);
+    render_top_table(out, "Largest files by tokens", &derived.top.largest_tokens);
+    render_top_table(out, "Largest files by bytes", &derived.top.largest_bytes);
+    render_top_table(
+        out,
+        "Least documented (min LOC)",
+        &derived.top.least_documented,
+    );
+    render_top_table(out, "Most dense (bytes/line)", &derived.top.most_dense);
+}
+
+fn render_top_table(out: &mut String, title: &str, rows: &[FileStatRow]) {
+    let _ = writeln!(out, "### {title}\n");
+    out.push_str(&render_file_table(rows));
+    out.push('\n');
+}
+
+fn render_file_table(rows: &[FileStatRow]) -> String {
+    let mut out = String::with_capacity((rows.len() + 3) * 80);
+    out.push_str("|Path|Lang|Lines|Code|Bytes|Tokens|Doc%|B/Line|\n");
+    out.push_str("|---|---|---:|---:|---:|---:|---:|---:|\n");
+    for row in rows {
+        let _ = writeln!(
+            out,
+            "|{}|{}|{}|{}|{}|{}|{}|{}|",
+            row.path,
+            row.lang,
+            row.lines,
+            row.code,
+            row.bytes,
+            row.tokens,
+            row.doc_pct.map(fmt_pct).unwrap_or_else(|| "-".to_string()),
+            row.bytes_per_line
+                .map(|v| fmt_f64(v, 2))
+                .unwrap_or_else(|| "-".to_string())
+        );
+    }
+    out
+}

--- a/crates/tokmd-format/src/analysis/markdown/derived/totals.rs
+++ b/crates/tokmd-format/src/analysis/markdown/derived/totals.rs
@@ -1,0 +1,22 @@
+//! Totals table rendering for derived analysis reports.
+
+use std::fmt::Write;
+
+use tokmd_analysis_types::DerivedReport;
+
+pub(super) fn render_totals(out: &mut String, derived: &DerivedReport) {
+    out.push_str("## Totals\n\n");
+    out.push_str("|Files|Code|Comments|Blanks|Lines|Bytes|Tokens|\n");
+    out.push_str("|---:|---:|---:|---:|---:|---:|---:|\n");
+    let _ = writeln!(
+        out,
+        "|{}|{}|{}|{}|{}|{}|{}|\n",
+        derived.totals.files,
+        derived.totals.code,
+        derived.totals.comments,
+        derived.totals.blanks,
+        derived.totals.lines,
+        derived.totals.bytes,
+        derived.totals.tokens
+    );
+}


### PR DESCRIPTION
### Motivation
- The previous `derived.rs` contained a large monolithic Markdown renderer mixing many concerns, making it hard to read and maintain.
- Break the renderer into single-responsibility submodules to improve readability, testability, and future extension without changing the rendered output or behavior.

### Description
- Split the derived analysis Markdown rendering into focused submodules under `crates/tokmd-format/src/analysis/markdown/derived/`: `totals.rs`, `ratios.rs`, `distribution.rs`, `top.rs`, `structure.rs`, `density.rs`, `context.rs`, and `integrity.rs`.
- Reduced `crates/tokmd-format/src/analysis/markdown/derived.rs` to an orchestration coordinator that delegates to the new submodules and preserves the existing effort-report fallback logic (`effort::render_effort_report` and legacy COCOMO fallback).
- Moved table- and section-specific rendering logic (including the former `render_file_table` and per-section formatting) into the corresponding new modules so each file now implements a single rendering responsibility.
- Kept public API and Markdown output shape unchanged so callers of `render_derived_report` see no behavior change.

### Testing
- Ran formatting checks with `cargo fmt-fix` and `cargo fmt-check` and the formatter passed.
- Ran unit and integration tests for the formatter with `cargo test -p tokmd-format` and all tests passed.
- Ran lints with `cargo clippy -p tokmd-format -- -D warnings` and the crate passed with no remaining warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e743aea883339b2e267440ac99fc)