### PR TITLE
Refactor diff markdown rendering into SRP submodules

### DIFF
--- a/crates/tokmd-format/src/diff/render.rs
+++ b/crates/tokmd-format/src/diff/render.rs
@@ -1,78 +1,24 @@
 //! Markdown rendering for diff receipts.
 //!
-//! This module owns human diff table rendering and color formatting. The parent
-//! diff module owns row/totals computation and JSON receipt construction.
+//! This module owns high-level diff Markdown composition. SRP submodules own
+//! color/style formatting, numeric helpers, language movement classification,
+//! and individual Markdown table writers.
 
 use std::fmt::Write as FmtWrite;
 
 use tokmd_types::{DiffRow, DiffTotals};
 
-fn format_delta(delta: i64) -> String {
-    if delta > 0 {
-        format!("+{}", delta)
-    } else {
-        delta.to_string()
-    }
-}
+mod math;
+mod movement;
+mod style;
+mod tables;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DiffColorMode {
-    Off,
-    Ansi,
-}
+pub use style::{DiffColorMode, DiffRenderOptions};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DiffRenderOptions {
-    pub compact: bool,
-    pub color: DiffColorMode,
-}
-
-impl Default for DiffRenderOptions {
-    fn default() -> Self {
-        Self {
-            compact: false,
-            color: DiffColorMode::Off,
-        }
-    }
-}
-
-fn format_delta_colored(delta: i64, mode: DiffColorMode) -> String {
-    let raw = format_delta(delta);
-    if mode == DiffColorMode::Off {
-        return raw;
-    }
-    if delta > 0 {
-        format!("\x1b[32m{}\x1b[0m", raw)
-    } else if delta < 0 {
-        format!("\x1b[31m{}\x1b[0m", raw)
-    } else {
-        format!("\x1b[33m{}\x1b[0m", raw)
-    }
-}
-
-fn format_pct_delta_colored(delta_pct: f64, mode: DiffColorMode) -> String {
-    let raw = format!("{:+.1}%", delta_pct);
-    if mode == DiffColorMode::Off {
-        return raw;
-    }
-    if delta_pct > 0.0 {
-        format!("\x1b[32m{}\x1b[0m", raw)
-    } else if delta_pct < 0.0 {
-        format!("\x1b[31m{}\x1b[0m", raw)
-    } else {
-        format!("\x1b[33m{}\x1b[0m", raw)
-    }
-}
-
-fn percent_change(old: usize, new: usize) -> f64 {
-    if old > 0 {
-        ((new as f64 - old as f64) / old as f64) * 100.0
-    } else if new > 0 {
-        100.0
-    } else {
-        0.0
-    }
-}
+use movement::LanguageMovement;
+use tables::{
+    write_compact_summary, write_language_breakdown, write_movement_table, write_summary_table,
+};
 
 /// Render diff as Markdown table with optional compact/color behavior.
 pub fn render_diff_md_with_options(
@@ -88,158 +34,16 @@ pub fn render_diff_md_with_options(
     let _ = writeln!(s, "## Diff: {} → {}", from_source, to_source);
     s.push('\n');
 
-    let languages_added = rows
-        .iter()
-        .filter(|r| r.old_code == 0 && r.new_code > 0)
-        .count();
-    let languages_removed = rows
-        .iter()
-        .filter(|r| r.old_code > 0 && r.new_code == 0)
-        .count();
-    let languages_modified = rows
-        .len()
-        .saturating_sub(languages_added + languages_removed);
+    let movement = LanguageMovement::from_rows(rows);
 
     if options.compact {
-        s.push_str("### Summary\n\n");
-        s.push_str("|Metric|Value|\n");
-        s.push_str("|---|---:|\n");
-        let _ = writeln!(s, "|From LOC|{}|", totals.old_code);
-        let _ = writeln!(s, "|To LOC|{}|", totals.new_code);
-        let _ = writeln!(
-            s,
-            "|Delta LOC|{}|",
-            format_delta_colored(totals.delta_code, options.color)
-        );
-        let _ = writeln!(
-            s,
-            "|LOC Change|{}|",
-            format_pct_delta_colored(
-                percent_change(totals.old_code, totals.new_code),
-                options.color
-            )
-        );
-        let _ = writeln!(
-            s,
-            "|Delta Lines|{}|",
-            format_delta_colored(totals.delta_lines, options.color)
-        );
-        let _ = writeln!(
-            s,
-            "|Delta Files|{}|",
-            format_delta_colored(totals.delta_files, options.color)
-        );
-        let _ = writeln!(
-            s,
-            "|Delta Bytes|{}|",
-            format_delta_colored(totals.delta_bytes, options.color)
-        );
-        let _ = writeln!(
-            s,
-            "|Delta Tokens|{}|",
-            format_delta_colored(totals.delta_tokens, options.color)
-        );
-        let _ = writeln!(s, "|Languages changed|{}|", rows.len());
-        let _ = writeln!(s, "|Languages added|{}|", languages_added);
-        let _ = writeln!(s, "|Languages removed|{}|", languages_removed);
-        let _ = writeln!(s, "|Languages modified|{}|", languages_modified);
+        write_compact_summary(&mut s, totals, movement, options);
         return s;
     }
 
-    // Summary comparison table
-    s.push_str("### Summary\n\n");
-    s.push_str("|Metric|From|To|Delta|Change|\n");
-    s.push_str("|---|---:|---:|---:|---:|\n");
-
-    let _ = writeln!(
-        s,
-        "|LOC|{}|{}|{}|{}|",
-        totals.old_code,
-        totals.new_code,
-        format_delta_colored(totals.delta_code, options.color),
-        format_pct_delta_colored(
-            percent_change(totals.old_code, totals.new_code),
-            options.color
-        )
-    );
-    let _ = writeln!(
-        s,
-        "|Lines|{}|{}|{}|{}|",
-        totals.old_lines,
-        totals.new_lines,
-        format_delta_colored(totals.delta_lines, options.color),
-        format_pct_delta_colored(
-            percent_change(totals.old_lines, totals.new_lines),
-            options.color
-        )
-    );
-    let _ = writeln!(
-        s,
-        "|Files|{}|{}|{}|{}|",
-        totals.old_files,
-        totals.new_files,
-        format_delta_colored(totals.delta_files, options.color),
-        format_pct_delta_colored(
-            percent_change(totals.old_files, totals.new_files),
-            options.color
-        )
-    );
-    let _ = writeln!(
-        s,
-        "|Bytes|{}|{}|{}|{}|",
-        totals.old_bytes,
-        totals.new_bytes,
-        format_delta_colored(totals.delta_bytes, options.color),
-        format_pct_delta_colored(
-            percent_change(totals.old_bytes, totals.new_bytes),
-            options.color
-        )
-    );
-    let _ = writeln!(
-        s,
-        "|Tokens|{}|{}|{}|{}|",
-        totals.old_tokens,
-        totals.new_tokens,
-        format_delta_colored(totals.delta_tokens, options.color),
-        format_pct_delta_colored(
-            percent_change(totals.old_tokens, totals.new_tokens),
-            options.color
-        )
-    );
-    s.push('\n');
-
-    s.push_str("### Language Movement\n\n");
-    s.push_str("|Type|Count|\n");
-    s.push_str("|---|---:|\n");
-    let _ = writeln!(s, "|Changed|{}|", rows.len());
-    let _ = writeln!(s, "|Added|{}|", languages_added);
-    let _ = writeln!(s, "|Removed|{}|", languages_removed);
-    let _ = writeln!(s, "|Modified|{}|", languages_modified);
-    s.push('\n');
-
-    // Detailed language breakdown
-    s.push_str("### Language Breakdown\n\n");
-    s.push_str("|Language|Old LOC|New LOC|Delta|\n");
-    s.push_str("|---|---:|---:|---:|\n");
-
-    for row in rows {
-        let _ = writeln!(
-            s,
-            "|{}|{}|{}|{}|",
-            row.lang,
-            row.old_code,
-            row.new_code,
-            format_delta_colored(row.delta_code, options.color)
-        );
-    }
-
-    let _ = writeln!(
-        s,
-        "|**Total**|{}|{}|{}|",
-        totals.old_code,
-        totals.new_code,
-        format_delta_colored(totals.delta_code, options.color)
-    );
+    write_summary_table(&mut s, totals, options);
+    write_movement_table(&mut s, movement);
+    write_language_breakdown(&mut s, rows, totals, options);
 
     s
 }
@@ -258,17 +62,4 @@ pub fn render_diff_md(
         totals,
         DiffRenderOptions::default(),
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::format_delta;
-
-    #[test]
-    fn test_format_delta() {
-        // Kills mutants in format_delta function
-        assert_eq!(format_delta(5), "+5");
-        assert_eq!(format_delta(0), "0");
-        assert_eq!(format_delta(-3), "-3");
-    }
 }

--- a/crates/tokmd-format/src/diff/render/math.rs
+++ b/crates/tokmd-format/src/diff/render/math.rs
@@ -1,0 +1,11 @@
+//! Numeric helpers for diff Markdown rendering.
+
+pub(super) fn percent_change(old: usize, new: usize) -> f64 {
+    if old > 0 {
+        ((new as f64 - old as f64) / old as f64) * 100.0
+    } else if new > 0 {
+        100.0
+    } else {
+        0.0
+    }
+}

--- a/crates/tokmd-format/src/diff/render/movement.rs
+++ b/crates/tokmd-format/src/diff/render/movement.rs
@@ -1,0 +1,32 @@
+//! Language movement classification for diff Markdown rendering.
+
+use tokmd_types::DiffRow;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct LanguageMovement {
+    pub changed: usize,
+    pub added: usize,
+    pub removed: usize,
+    pub modified: usize,
+}
+
+impl LanguageMovement {
+    pub fn from_rows(rows: &[DiffRow]) -> Self {
+        let added = rows
+            .iter()
+            .filter(|r| r.old_code == 0 && r.new_code > 0)
+            .count();
+        let removed = rows
+            .iter()
+            .filter(|r| r.old_code > 0 && r.new_code == 0)
+            .count();
+        let modified = rows.len().saturating_sub(added + removed);
+
+        Self {
+            changed: rows.len(),
+            added,
+            removed,
+            modified,
+        }
+    }
+}

--- a/crates/tokmd-format/src/diff/render/style.rs
+++ b/crates/tokmd-format/src/diff/render/style.rs
@@ -1,0 +1,71 @@
+//! Delta formatting and optional ANSI coloring for diff Markdown.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffColorMode {
+    Off,
+    Ansi,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiffRenderOptions {
+    pub compact: bool,
+    pub color: DiffColorMode,
+}
+
+impl Default for DiffRenderOptions {
+    fn default() -> Self {
+        Self {
+            compact: false,
+            color: DiffColorMode::Off,
+        }
+    }
+}
+
+pub(super) fn format_delta(delta: i64) -> String {
+    if delta > 0 {
+        format!("+{}", delta)
+    } else {
+        delta.to_string()
+    }
+}
+
+pub(super) fn format_delta_colored(delta: i64, mode: DiffColorMode) -> String {
+    let raw = format_delta(delta);
+    if mode == DiffColorMode::Off {
+        return raw;
+    }
+    if delta > 0 {
+        format!("\x1b[32m{}\x1b[0m", raw)
+    } else if delta < 0 {
+        format!("\x1b[31m{}\x1b[0m", raw)
+    } else {
+        format!("\x1b[33m{}\x1b[0m", raw)
+    }
+}
+
+pub(super) fn format_pct_delta_colored(delta_pct: f64, mode: DiffColorMode) -> String {
+    let raw = format!("{:+.1}%", delta_pct);
+    if mode == DiffColorMode::Off {
+        return raw;
+    }
+    if delta_pct > 0.0 {
+        format!("\x1b[32m{}\x1b[0m", raw)
+    } else if delta_pct < 0.0 {
+        format!("\x1b[31m{}\x1b[0m", raw)
+    } else {
+        format!("\x1b[33m{}\x1b[0m", raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_delta;
+
+    #[test]
+    fn test_format_delta() {
+        // Kills mutants in format_delta function
+        assert_eq!(format_delta(5), "+5");
+        assert_eq!(format_delta(0), "0");
+        assert_eq!(format_delta(-3), "-3");
+    }
+}

--- a/crates/tokmd-format/src/diff/render/tables.rs
+++ b/crates/tokmd-format/src/diff/render/tables.rs
@@ -1,0 +1,163 @@
+//! Markdown table writers for diff receipts.
+
+use std::fmt::Write as FmtWrite;
+
+use tokmd_types::{DiffRow, DiffTotals};
+
+use super::math::percent_change;
+use super::movement::LanguageMovement;
+use super::style::{DiffRenderOptions, format_delta_colored, format_pct_delta_colored};
+
+pub(super) fn write_compact_summary(
+    s: &mut String,
+    totals: &DiffTotals,
+    movement: LanguageMovement,
+    options: DiffRenderOptions,
+) {
+    s.push_str("### Summary\n\n");
+    s.push_str("|Metric|Value|\n");
+    s.push_str("|---|---:|\n");
+    let _ = writeln!(s, "|From LOC|{}|", totals.old_code);
+    let _ = writeln!(s, "|To LOC|{}|", totals.new_code);
+    let _ = writeln!(
+        s,
+        "|Delta LOC|{}|",
+        format_delta_colored(totals.delta_code, options.color)
+    );
+    let _ = writeln!(
+        s,
+        "|LOC Change|{}|",
+        format_pct_delta_colored(
+            percent_change(totals.old_code, totals.new_code),
+            options.color
+        )
+    );
+    let _ = writeln!(
+        s,
+        "|Delta Lines|{}|",
+        format_delta_colored(totals.delta_lines, options.color)
+    );
+    let _ = writeln!(
+        s,
+        "|Delta Files|{}|",
+        format_delta_colored(totals.delta_files, options.color)
+    );
+    let _ = writeln!(
+        s,
+        "|Delta Bytes|{}|",
+        format_delta_colored(totals.delta_bytes, options.color)
+    );
+    let _ = writeln!(
+        s,
+        "|Delta Tokens|{}|",
+        format_delta_colored(totals.delta_tokens, options.color)
+    );
+    let _ = writeln!(s, "|Languages changed|{}|", movement.changed);
+    let _ = writeln!(s, "|Languages added|{}|", movement.added);
+    let _ = writeln!(s, "|Languages removed|{}|", movement.removed);
+    let _ = writeln!(s, "|Languages modified|{}|", movement.modified);
+}
+
+pub(super) fn write_summary_table(s: &mut String, totals: &DiffTotals, options: DiffRenderOptions) {
+    s.push_str("### Summary\n\n");
+    s.push_str("|Metric|From|To|Delta|Change|\n");
+    s.push_str("|---|---:|---:|---:|---:|\n");
+
+    let _ = writeln!(
+        s,
+        "|LOC|{}|{}|{}|{}|",
+        totals.old_code,
+        totals.new_code,
+        format_delta_colored(totals.delta_code, options.color),
+        format_pct_delta_colored(
+            percent_change(totals.old_code, totals.new_code),
+            options.color
+        )
+    );
+    let _ = writeln!(
+        s,
+        "|Lines|{}|{}|{}|{}|",
+        totals.old_lines,
+        totals.new_lines,
+        format_delta_colored(totals.delta_lines, options.color),
+        format_pct_delta_colored(
+            percent_change(totals.old_lines, totals.new_lines),
+            options.color
+        )
+    );
+    let _ = writeln!(
+        s,
+        "|Files|{}|{}|{}|{}|",
+        totals.old_files,
+        totals.new_files,
+        format_delta_colored(totals.delta_files, options.color),
+        format_pct_delta_colored(
+            percent_change(totals.old_files, totals.new_files),
+            options.color
+        )
+    );
+    let _ = writeln!(
+        s,
+        "|Bytes|{}|{}|{}|{}|",
+        totals.old_bytes,
+        totals.new_bytes,
+        format_delta_colored(totals.delta_bytes, options.color),
+        format_pct_delta_colored(
+            percent_change(totals.old_bytes, totals.new_bytes),
+            options.color
+        )
+    );
+    let _ = writeln!(
+        s,
+        "|Tokens|{}|{}|{}|{}|",
+        totals.old_tokens,
+        totals.new_tokens,
+        format_delta_colored(totals.delta_tokens, options.color),
+        format_pct_delta_colored(
+            percent_change(totals.old_tokens, totals.new_tokens),
+            options.color
+        )
+    );
+    s.push('\n');
+}
+
+pub(super) fn write_movement_table(s: &mut String, movement: LanguageMovement) {
+    s.push_str("### Language Movement\n\n");
+    s.push_str("|Type|Count|\n");
+    s.push_str("|---|---:|\n");
+    let _ = writeln!(s, "|Changed|{}|", movement.changed);
+    let _ = writeln!(s, "|Added|{}|", movement.added);
+    let _ = writeln!(s, "|Removed|{}|", movement.removed);
+    let _ = writeln!(s, "|Modified|{}|", movement.modified);
+    s.push('\n');
+}
+
+pub(super) fn write_language_breakdown(
+    s: &mut String,
+    rows: &[DiffRow],
+    totals: &DiffTotals,
+    options: DiffRenderOptions,
+) {
+    s.push_str("### Language Breakdown\n\n");
+    s.push_str("|Language|Old LOC|New LOC|Delta|\n");
+    s.push_str("|---|---:|---:|---:|\n");
+
+    for row in rows {
+        let _ = writeln!(
+            s,
+            "|{}|{}|{}|{}|",
+            row.lang,
+            row.old_code,
+            row.new_code,
+            format_delta_colored(row.delta_code, options.color)
+        );
+    }
+
+    let _ = writeln!(
+        s,
+        "|**Total**|{}|{}|{}|",
+        totals.old_code,
+        totals.new_code,
+        format_delta_colored(totals.delta_code, options.color)
+    );
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity in `crates/tokmd-format/src/diff/render.rs` by separating responsibilities for style, numeric helpers, language movement classification, and table writing. 
- Improve maintainability and testability by giving each responsibility a small, single-responsibility (SRP) module. 
- Preserve the public diff render API while making internals easier to reason about and extend.

### Description
- Introduced four SRP submodules under `crates/tokmd-format/src/diff/render/`: `style.rs`, `math.rs`, `movement.rs`, and `tables.rs` to own coloring/formatting, numeric helpers, movement classification, and markdown table writers respectively. 
- Simplified `render.rs` so it only orchestrates rendering, calls the submodule helpers, and re-exports `DiffRenderOptions` and `DiffColorMode` from the new `style` module via `pub use style::{...}`. 
- Moved internal helper functions into their respective modules: `format_delta*` and `DiffRenderOptions`/`DiffColorMode` → `style.rs`; `percent_change` → `math.rs`; language movement logic → `movement.rs`; summary/movement/breakdown table writers → `tables.rs`. 
- Kept the external `render_diff_md_with_options` / `render_diff_md` behavior and signatures unchanged so callers are unaffected.

### Testing
- Ran `cargo fmt-check` and formatting verification passed. 
- Ran `cargo test -p tokmd-format --test diff_deep` and all tests passed (`27` tests in that suite). 
- Ran `cargo test -p tokmd-format diff::render` and unit tests for the diff render helpers passed. 
- Ran `cargo clippy -p tokmd-format -- -D warnings` and the lint check completed without warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e743aea883339b2e267440ac99fc)