### PR TITLE
docs(agent): allow PR-bound Codex commit and push flow

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,27 @@
+# .codex/
+
+This directory is reserved for Codex-local tracked execution state and operator
+notes when a Codex workflow needs durable in-repo context.
+
+## Commit And Push Policy
+
+For PR-bound work, Codex may create scoped branches, commit scoped changes, push
+branches, open PRs, update PR branches, and merge aligned PRs after validation
+without asking for additional user confirmation.
+
+PR-bound work includes requests to implement, review, improve, merge, drain PRs,
+prepare release docs, update changelogs, fix tests, or otherwise carry a repo
+task through completion.
+
+Do not ask for extra permission merely because a commit, push, PR update, or
+aligned merge is needed to finish that task.
+
+Ask before committing, pushing, or merging only when:
+
+- the user explicitly requested read-only or local-only work;
+- the task is exploratory and no implementation was requested;
+- the mutation would publish crates, create tags, create GitHub releases, move
+  release aliases, push images, rotate secrets, or change external-service
+  ownership;
+- the diff is broad or ambiguous relative to the requested lane;
+- the worktree contains unrelated user changes that cannot be isolated safely.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,3 +273,26 @@ cargo +nightly fuzz list  # List all targets
 - During prep or RC hardening, every open PR must either be a real blocker/improvement worth finishing now or remain explicitly parked for later.
 - “Not for prep” does not automatically mean “close now”.
 - If a PR may still be worth keeping, leave it open or restack it; do not churn the queue without a concrete reason.
+
+## Codex Commit / Push Policy
+
+For PR-bound work, Codex may create scoped branches, commit scoped changes, push
+branches, open PRs, update PR branches, and merge aligned PRs after validation
+without asking for additional user confirmation.
+
+PR-bound work includes requests to implement, review, improve, merge, drain PRs,
+prepare release docs, update changelogs, fix tests, or otherwise carry a repo
+task through completion.
+
+Do not ask for extra permission merely because a commit, push, PR update, or
+aligned merge is needed to finish that task.
+
+Ask before committing, pushing, or merging only when:
+
+- the user explicitly requested read-only or local-only work;
+- the task is exploratory and no implementation was requested;
+- the mutation would publish crates, create tags, create GitHub releases, move
+  release aliases, push images, rotate secrets, or change external-service
+  ownership;
+- the diff is broad or ambiguous relative to the requested lane;
+- the worktree contains unrelated user changes that cannot be isolated safely.

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -30,6 +30,29 @@ Optional git hooks:
 git config core.hooksPath .githooks
 ```
 
+## Codex Commit / Push Policy
+
+For PR-bound work, Codex may create scoped branches, commit scoped changes, push
+branches, open PRs, update PR branches, and merge aligned PRs after validation
+without asking for additional user confirmation.
+
+PR-bound work includes requests to implement, review, improve, merge, drain PRs,
+prepare release docs, update changelogs, fix tests, or otherwise carry a repo
+task through completion.
+
+Do not ask for extra permission merely because a commit, push, PR update, or
+aligned merge is needed to finish that task.
+
+Ask before committing, pushing, or merging only when:
+
+- the user explicitly requested read-only or local-only work;
+- the task is exploratory and no implementation was requested;
+- the mutation would publish crates, create tags, create GitHub releases, move
+  release aliases, push images, rotate secrets, or change external-service
+  ownership;
+- the diff is broad or ambiguous relative to the requested lane;
+- the worktree contains unrelated user changes that cannot be isolated safely.
+
 ## Architecture
 
 The codebase follows a tiered crate-and-module architecture:

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1084,6 +1084,15 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "codex_workspace"
+kind = "non_rust"
+paths = [".codex/**"]
+proof = ["cargo xtask proof-policy --check"]
+reason = "Codex-local tracked execution state and operator notes are intentional repo knowledge artifacts when checked in."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "project_readme"
 kind = "non_rust"
 paths = ["README.md"]


### PR DESCRIPTION
## Summary
- Add explicit Codex PR-bound commit/push/PR/merge policy to `AGENTS.md` and `agents/shared/repo.md`.
- Create `.codex/README.md` with the same repo-local Codex workflow policy.
- Add a `codex_workspace` proof scope so checked-in `.codex/**` state is routed instead of reported as unknown.

## Validation
- `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json` - passed
- `cargo xtask docs --check` - passed
- `cargo xtask proof-policy --check` - passed
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json` - passed, 0 unknown files
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --summary-md target/proof/proof-plan.md` - passed, plan generated
- `cargo fmt-check` - passed
- `git diff --check HEAD~1..HEAD` - passed

## Notes
- The affected proof plan lists broader proof-control commands; this PR generated the plan and ran the requested local docs/proof/fmt/diff checks.