### PR TITLE
docs(agent): separate Codex control from Jules provenance

### DIFF
--- a/.jules/README.md
+++ b/.jules/README.md
@@ -56,8 +56,8 @@ The primary truth for any run is the **per-run packet** under:
 - friction items under `.jules/friction/open/`
 - persona-local notes under `.jules/personas/<persona>/notes/`
   *(Use this directory only for **reusable learnings** that later runs can benefit from. Do not write per-run summaries here; per-run packets belong under `.jules/runs/<run-id>/`.)*
-- machine-readable active state under `.jules/goals/active.toml` when the
-  prompt explicitly changes the active lane or asks for a durable control
+- Jules-local machine-readable state under `.jules/goals/active.toml` when the
+  prompt explicitly changes Jules run state or asks for a durable Jules control
   surface update
 
 ### Agents must not write
@@ -73,7 +73,7 @@ The primary truth for any run is the **per-run packet** under:
 - `personas/` — persona-local notes and README files
 - `runs/` — per-run packets
 - `index/` — optional generated summaries
-- `goals/` — small machine-readable active-lane state
+- `goals/` — small Jules-local machine-readable state
 
 ## Persona instruction surface
 

--- a/.jules/goals/README.md
+++ b/.jules/goals/README.md
@@ -1,20 +1,21 @@
 # Jules Goals
 
-This directory stores machine-readable active-agent state for Jules and related
-automation.
+This directory stores machine-readable state for Jules and related automation.
+It is Jules-local. It does not define Codex's active lane and it does not define
+tokmd's accepted product decisions.
 
 The primary file is:
 
 - `active.toml`
 
-It should stay small and point to durable human-readable docs. It is not a run
-log, not a chat transcript, and not a replacement for proposals, specs, ADRs,
-plans, or policy files.
+It should stay small and point to durable human-readable docs when useful for
+Jules. It is not a run log, not a chat transcript, and not a replacement for
+proposals, specs, ADRs, plans, policy files, or Codex-local `.codex/` state.
 
 When a lane is complete, superseded, or paused with durable value, copy the
 active goal into `archive/YYYY-MM-DD-lane-slug.toml`, update its `status`, and
-leave `.jules/goals/active.toml` ready for the next current lane. The archive is
-historical context only; it is not a second active queue.
+leave `.jules/goals/active.toml` ready for the next Jules-local state. The
+archive is historical context only; it is not a second active queue.
 
 ## Allowed Content
 

--- a/.jules/goals/archive/README.md
+++ b/.jules/goals/archive/README.md
@@ -1,12 +1,13 @@
 # Archived Jules Goals
 
-Completed or superseded active-goal files may be copied here when a lane needs a
-durable machine-readable checkpoint after `active.toml` moves on.
+Completed or superseded Jules-local active-goal files may be copied here when a
+Jules lane needs a durable machine-readable checkpoint after `active.toml`
+moves on.
 
 Archive files are historical snapshots, not active execution state. The current
-lane always lives in `.jules/goals/active.toml`, and `cargo xtask
+Jules-local state always lives in `.jules/goals/active.toml`, and `cargo xtask
 doc-artifacts --check` validates only that active file in the first checker
-slice.
+slice. Codex-local state, when needed, belongs under `.codex/`.
 
 ## Naming
 
@@ -32,6 +33,7 @@ Examples:
 5. Keep raw logs and narrative run history in `.jules/runs/`, PR bodies, or
    linked plans instead.
 
-Do not let archived goals become a second active queue. If archived state and
-`active.toml` disagree, `active.toml` owns the current lane and the archive owns
-only historical context.
+Do not let archived goals become a second active queue. If archived Jules state
+and `active.toml` disagree, `active.toml` owns the current Jules-local state and
+the archive owns only historical context. Jules suggestions remain inputs for
+Codex to evaluate, not Codex's primary active-lane controller.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,14 @@ cargo +nightly fuzz list  # List all targets
 
 ## PR Triage Rules
 
+### Codex and Jules state boundaries
+- `.jules/**` is Jules provenance and ambient suggestion state. Treat it as
+  useful repo input, not Codex's primary active-lane controller.
+- Codex should use `AGENTS.md`, `docs/NEXT.md`, accepted docs/plans/specs/ADRs,
+  PR context, and `.codex/**` state where present for Codex lane selection.
+- Do not tell Jules to stop acting or remove Jules suggestions merely because
+  Codex is working. Evaluate Jules suggestions like any other repo input.
+
 ### Jules provenance is intentional repo state
 - Treat `.jules/**` logs, ledgers, envelopes, runbooks, and friction notes as intentional provenance unless a repo owner explicitly says otherwise.
 - Do not close, trim, or reject a PR merely because it includes `.jules/**` files.

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -148,6 +148,18 @@ cargo mutants --file crates/tokmd-format/src/redact/mod.rs
 cargo +nightly fuzz list
 ```
 
+## Agent State Boundaries
+
+`.jules/**` is Google Jules provenance and ambient suggestion state. Treat it as
+useful repo input, not Codex's primary active-lane controller.
+
+Codex should use `AGENTS.md`, `docs/NEXT.md`, accepted docs/plans/specs/ADRs, PR
+context, and `.codex/**` state where present for Codex lane selection.
+
+Do not tell Jules to stop acting or remove Jules suggestions merely because
+Codex is working. Jules suggestions remain inputs to evaluate with the rest of
+the repo evidence.
+
 ## Reference Docs
 
 - `docs/architecture.md`

--- a/docs/agent-workflows/source-of-truth.md
+++ b/docs/agent-workflows/source-of-truth.md
@@ -5,18 +5,23 @@ Status: active workflow guide.
 Use this guide when starting, continuing, or handing off a tokmd lane. It is
 operational guidance for humans and agents; the durable ownership rules remain
 in `docs/source-of-truth.md`, `docs/specs/`, `docs/adr/`, `docs/plans/`,
-`.jules/goals/active.toml`, `ci/proof.toml`, and `policy/*.toml`.
+`AGENTS.md`, `.codex/` state where present, `ci/proof.toml`, and
+`policy/*.toml`.
+
+For Codex work, `.jules/**` is Jules provenance and ambient suggestion state.
+Review it when relevant, but do not treat it as Codex's primary active-lane
+controller.
 
 ## Before Starting
 
 1. Check the open PR queue.
 2. Read `docs/NEXT.md` for the current operating mode.
-3. Read `.jules/goals/active.toml` for the active program, lane, linked
-   artifacts, rules, and stop conditions.
-4. Read the linked plan first, then any linked spec, ADR, proposal, or policy
-   file named by the active goal.
-5. Confirm `docs/NEXT.md` does not contradict `.jules/goals/active.toml` or the
-   linked plan.
+3. Read the accepted plan first, then any linked spec, ADR, proposal, or policy
+   file named by current repo guidance or PR context.
+4. Review `.jules/goals/active.toml` as Jules-local context when it is relevant,
+   not as Codex's primary lane selector.
+5. Confirm `docs/NEXT.md`, accepted docs/plans/specs/ADRs, and the PR context do
+   not contradict each other.
 
 If those artifacts disagree, stop and fix the routing artifact that owns the
 truth before opening an implementation branch.
@@ -30,7 +35,10 @@ truth before opening an implementation branch.
   decisions.
 - Use a plan for PR order, dependencies, validation commands, and stop
   conditions.
-- Use `.jules/goals/active.toml` only for small machine-readable active state.
+- Use `.jules/goals/active.toml` only for Jules-local machine-readable state and
+  suggestions.
+- Use `.codex/` for Codex-local tracked state when a Codex workflow needs a
+  durable in-repo packet.
 - Use `ci/proof.toml` and `policy/*.toml` for machine-checkable rules.
 - Use PR bodies for review-local evidence and links, not as the only durable
   source of truth when a repo artifact should exist.
@@ -42,11 +50,10 @@ When a change touches source-of-truth artifacts:
 1. Keep each artifact in its lane. Do not put implementation sequencing in a
    spec, or durable architecture rationale in an active-goal file.
 2. Update checked TOML policy when the claim should be enforced by tooling.
-3. Keep `.jules/goals/active.toml` short, current, and linked to human-readable
-   artifacts.
-4. Do not let `.jules/goals/active.toml` become a run log.
+3. Keep `.jules/goals/active.toml` short and Jules-local when it is changed.
+4. Do not let `.jules/goals/active.toml` become a Codex controller or run log.
 5. Archive a completed or superseded active goal under `.jules/goals/archive/`
-   only when the machine-readable checkpoint has durable value.
+   only when the Jules-local machine-readable checkpoint has durable value.
 6. Run the documentation artifact checker before opening the PR.
 
 ## PR Body Checklist
@@ -82,7 +89,7 @@ touch those surfaces.
 
 Stop before implementation when:
 
-- `docs/NEXT.md`, `.jules/goals/active.toml`, and the linked plan disagree;
+- `docs/NEXT.md`, accepted docs/plans/specs/ADRs, and the PR context disagree;
 - a behavior or artifact shape change has no owning spec;
 - an architecture boundary change has no ADR;
 - a machine-checkable claim has no policy owner;

--- a/docs/source-of-truth.md
+++ b/docs/source-of-truth.md
@@ -3,8 +3,8 @@
 Status: active documentation convention.
 
 This document defines where durable tokmd intent, behavior, decisions, plans,
-agent state, and machine-checkable policy belong. It is a routing guide for
-maintainers and agents, not a new product feature.
+agent-local state, and machine-checkable policy belong. It is a routing guide
+for maintainers and agents, not a new product feature.
 
 ## Goal
 
@@ -36,8 +36,8 @@ the owning artifact before relying on chat history.
 When planning a lane:
 
 1. Read `docs/NEXT.md` for the current operating mode.
-2. Read `.jules/goals/active.toml` for the active machine-readable lane and its
-   linked plan/spec/ADR/policy files.
+2. Read the accepted plan/spec/ADR/policy files linked by `docs/NEXT.md`, the
+   PR, or current repo guidance.
 3. Create or update a proposal only when the why, alternatives, or open
    questions need durable review.
 4. Create or update a spec when behavior, artifact shape, compatibility, or
@@ -50,7 +50,7 @@ When planning a lane:
 
 When executing a lane:
 
-- keep `.jules/goals/active.toml` small and current;
+- keep agent-local state small and clearly scoped to its agent;
 - follow the linked plan rather than inventing a parallel queue;
 - update specs before relying on new behavior contracts;
 - update ADRs before relying on new durable architecture decisions;
@@ -74,9 +74,10 @@ changing a lane, see `docs/agent-workflows/source-of-truth.md`.
 | `docs/specs/` | Testable behavior contracts, artifact shapes, compatibility rules, proof requirements, and accepted semantics. | Historical decision rationale or PR-by-PR sequencing. |
 | `docs/adr/` | Durable architecture, packaging, boundary, or governance decisions and their consequences. | Detailed behavior matrices that should be tested as specs. |
 | `docs/plans/` | PR sequencing, implementation packets, validation commands, dependencies, and stop conditions. | Product contracts or architecture decisions. |
-| `.jules/goals/active.toml` | Machine-readable active-agent state: current program, current lane, stop conditions, and where to find the human plan. | Raw terminal logs, complete run history, or policy. |
-| `.jules/runs/` | Per-run Jules packets, receipts, decisions, and PR bodies. | Shared active state or edited truth ledgers. |
-| `.jules/friction/` | Structured future-work and friction items found by agent runs. | Current implementation plans or accepted decisions. |
+| `.jules/goals/active.toml` | Jules-local machine-readable state, suggestions, and linked context for Jules runs. | Codex primary lane selection, accepted product decisions, raw terminal logs, complete run history, or policy. |
+| `.jules/runs/` | Per-run Jules packets, receipts, decisions, and PR bodies. | Codex primary lane selection, shared active state, or edited truth ledgers. |
+| `.jules/friction/` | Structured future-work and friction items found by Jules runs. | Codex primary lane selection, current implementation plans, or accepted decisions. |
+| `.codex/` | Codex-local tracked execution packets, operator notes, friction, or run provenance when present. | Jules run state, accepted product decisions, or shared truth ledgers. |
 | `ci/proof.toml` | Proof scope classification, affected-plan policy, executor defaults, allowlists, and dependency/fixture rules. | Narrative rationale or PR sequencing. |
 | `policy/*.toml` | Machine-checkable repo policies that are not proof-scope policy. | Human-only conventions. |
 | PR bodies and comments | Review-local summary, validation evidence, links to durable artifacts, and disposition rationale. | Primary long-term truth when a repo artifact should exist. |
@@ -90,8 +91,8 @@ When artifacts disagree:
 3. ADRs explain why durable decisions exist.
 4. Plans define the next implementation order, but never override specs or ADRs.
 5. Proposals explain unaccepted or exploratory direction.
-6. `.jules/goals/active.toml` points at the active lane, but it does not replace
-   the linked plan, spec, ADR, or policy.
+6. Agent-local state may point at a lane or suggestion, but it does not replace
+   the linked plan, spec, ADR, policy, or PR context.
 
 If a PR changes behavior, update the spec or schema that owns that behavior. If
 it changes architecture boundaries, add or update an ADR. If it changes the
@@ -124,14 +125,18 @@ future agent can pick the next PR without reopening the whole design discussion.
 
 ### Active agent state
 
-Use `.jules/goals/active.toml` to make the current program machine-readable. It
-should be small, current, and linked to durable human docs. It should not become
-a diary.
+Use `.jules/goals/active.toml` to make Jules-local state machine-readable. It
+should be small and linked to durable human docs when useful for Jules. It
+should not become a diary or Codex's primary active-lane controller.
 
 When a lane completes or is superseded, archive the old active goal under
 `.jules/goals/archive/YYYY-MM-DD-lane-slug.toml` only if the machine-readable
 checkpoint has durable value. Archived goals are historical context; they do not
 replace or compete with the current `active.toml`.
+
+Codex-local state may live under `.codex/` when a Codex workflow needs a durable
+in-repo packet. Jules suggestions remain useful inputs; they are not
+instructions to stop Jules or discard Jules provenance.
 
 ### Policy
 


### PR DESCRIPTION
## Summary
- Clarify that `.jules/**` is Jules provenance and ambient suggestion state, not Codex's primary active-lane controller.
- Point Codex routing to `AGENTS.md`, `docs/NEXT.md`, accepted plans/specs/ADRs, PR context, and `.codex/**` where present.
- Preserve Jules suggestions as inputs and update source-of-truth docs plus Jules goal docs to keep the boundary explicit.

## Validation
- `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json` - passed
- `cargo xtask docs --check` - passed
- `cargo xtask proof-policy --check` - passed
- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json` - passed, 0 unknown files
- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --summary-md target/proof/proof-plan.md` - passed, plan generated
- `cargo fmt-check` - passed
- `git diff --check HEAD~1..HEAD` - passed

## Notes
- The affected proof plan lists broader proof-control commands; this PR generated the plan and ran the requested local docs/proof/fmt/diff checks.