### PR TITLE
docs: define source-of-truth stack

### DIFF
--- a/.tokmd/goals/README.md
+++ b/.tokmd/goals/README.md
@@ -1,0 +1,35 @@
+# tokmd goals
+
+Status: reserved
+Owner: docs/control-plane
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: docs/specs/doc-artifacts.md
+Linked ADRs: docs/adr/0000-adr-process.md
+Linked plan: docs/plans/doc-artifacts-check.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation routing only; no product support claim changes
+Policy impact: no policy exception changes
+
+This directory is reserved for tokmd-native active-goal manifests in the linked
+source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+The current checked active-goal surface for this repository remains
+`.jules/goals/active.toml`. Do not add `.tokmd/goals/active.toml` or migrate the
+active lane here unless a proposal, plan, and checker update explicitly select
+that migration.
+
+When activated, files in this directory should stay small and machine-readable:
+
+- `active.toml` for the current lane;
+- `archive/YYYY-MM-DD-<lane>.toml` for completed or superseded checkpoints with
+  durable value;
+- links to proposals, specs, ADRs, plans, status docs, and proof commands.
+
+Do not store raw run logs, chat transcripts, generated metrics, or long prose in
+active-goal manifests. Link to the owning artifact instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,29 @@
 Canonical shared repo guidance is mirrored in `agents/shared/repo.md`.
 This file provides guidance to AI agents (Claude, Factory Droid, etc.) when working with code in this repository.
 
+## Repo Source-of-Truth Stack
+
+tokmd uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Before changing source-of-truth artifacts or selecting implementation work, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `docs/source-of-truth.md`
+3. `.jules/goals/active.toml`
+4. the linked implementation plan
+5. the linked spec for the selected work item
+6. linked ADRs
+
+Work on one semantic artifact or one implementation work item per PR unless the
+selected plan item says otherwise. Do not broaden support claims without proof,
+do not hand-edit generated status unless the plan names that as the required
+change, and stop instead of guessing when linked artifacts are missing or a
+request conflicts with an ADR.
+
 ## Droid Auto Review
 
 **tokmd** uses Factory Droid for automated code review. Droid runs on all pull requests using the safe action configuration with MiniMax BYOK, and can be invoked manually with `@droid review` or `@droid security` comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,23 @@ Canonical repo guidance lives in `agents/shared/repo.md`.
 
 This file is the Claude adapter wrapper for runtime-specific notes.
 
+## First Read Source-of-Truth Stack
+
+Before changing source-of-truth artifacts or selecting implementation work, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `docs/source-of-truth.md`
+3. `.jules/goals/active.toml`
+4. the linked implementation plan
+5. the linked spec for the selected work item
+6. linked ADRs
+
+Work on exactly one semantic artifact or one implementation work item per PR
+unless the selected plan item says otherwise. Stop instead of guessing when the
+active goal is missing or stale, linked artifacts are missing, proof commands
+cannot run, generated status is dirty without a named generator, or the request
+conflicts with an ADR.
+
 ## Claude Runtime Surface
 
 - Settings: `.claude/settings.json`

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -2,6 +2,20 @@
 
 This file is the canonical shared repo context for checked-in agent adapters in this repository.
 
+## Repo Source-of-Truth Stack
+
+tokmd uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Before changing source-of-truth artifacts or selecting implementation work, read
+`docs/reference/SPEC_SYSTEM.md`, `docs/source-of-truth.md`,
+`.jules/goals/active.toml`, the linked plan, the linked spec for the selected
+work item, and linked ADRs. Work on one semantic artifact or one implementation
+work item per PR unless the selected plan item says otherwise.
+
 ## Project Overview
 
 **tokmd** is a Rust CLI tool and library that generates deterministic inventory receipts and derived analytics for code repositories. It produces human-readable summaries and machine-friendly artifacts for AI-native workflows, LLM context generation, code analysis, and review pipelines.

--- a/docs/agent-workflows/source-of-truth.md
+++ b/docs/agent-workflows/source-of-truth.md
@@ -9,13 +9,15 @@ in `docs/source-of-truth.md`, `docs/specs/`, `docs/adr/`, `docs/plans/`,
 
 ## Before Starting
 
-1. Check the open PR queue.
-2. Read `docs/NEXT.md` for the current operating mode.
-3. Read `.jules/goals/active.toml` for the active program, lane, linked
+1. Read `docs/reference/SPEC_SYSTEM.md` for the first-read contract and stop
+   conditions.
+2. Check the open PR queue.
+3. Read `docs/NEXT.md` for the current operating mode.
+4. Read `.jules/goals/active.toml` for the active program, lane, linked
    artifacts, rules, and stop conditions.
-4. Read the linked plan first, then any linked spec, ADR, proposal, or policy
+5. Read the linked plan first, then any linked spec, ADR, proposal, or policy
    file named by the active goal.
-5. Confirm `docs/NEXT.md` does not contradict `.jules/goals/active.toml` or the
+6. Confirm `docs/NEXT.md` does not contradict `.jules/goals/active.toml` or the
    linked plan.
 
 If those artifacts disagree, stop and fix the routing artifact that owns the

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,209 @@
+# Repo source-of-truth system
+
+Status: active
+Owner: docs/control-plane
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: docs/specs/doc-artifacts.md
+Linked ADRs: docs/adr/0000-adr-process.md
+Linked plan: docs/plans/doc-artifacts-check.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation routing only; no product support claim changes
+Policy impact: documents existing source-of-truth policy; no policy exception changes
+
+This repo uses a linked source-of-truth stack for humans and agents. The rule is
+simple: do not make every document do every job. Separate why, what, durable
+decision, implementation order, current agent state, and proof.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR where needed
+        -> Implementation plan
+          -> Active goal
+            -> PR / issue
+              -> Proof commands
+              -> CI receipts
+              -> support-tier updates
+              -> policy ledger updates
+```
+
+Small changes may skip layers that do not add clarity, but they must not put one
+kind of truth in the wrong artifact. If the repo already has a durable artifact
+for the question being answered, update or cite that artifact instead of relying
+on chat history.
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, and high-level product strategy. | Detailed PR order, live status, proof receipts, or generated metrics. |
+| Proposal | Why a lane exists, user pain, alternatives, risks, non-goals, affected surfaces, success criteria, and which specs or ADRs are needed. | Exact PR sequence, implementation details, generated status, or test receipt state. |
+| Spec | Required behavior, acceptance examples, proof requirements, test mapping, implementation mapping, CI proof, and claim boundaries. | Product rationale, PR order, active queue state, or durable architecture rationale. |
+| ADR | Durable architecture, packaging, governance, or operating decisions and their consequences. | Current task lists, live metric state, or detailed behavior matrices that belong in specs. |
+| Implementation plan | PR sequence, work items, dependencies, proof commands, rollback, and handoff status. | Product motivation, durable decisions, or generated status truth. |
+| Active goal | Current machine-readable lane state, selected work items, proof commands, status pointers, and claim boundaries. | Long prose, generated metrics, durable decisions, or run logs. |
+| Support tiers | Public claim proof, stable/advisory/experimental/blocked classification, known limitations, and promotion requirements. | Feature design, PR sequencing, or architecture decisions. |
+| Policy ledgers | Machine-checkable exceptions, CI lane intent, owners, reasons, coverage, review dates, and expiry. | Broad architecture rationale or informal notes. |
+| PR bodies | Review-local summary, durable links, evidence, claim boundary, and rollback notes. | Sole long-term source of truth when a repo artifact should exist. |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the selected plan item says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record durable decisions.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier proof or an equivalent proof pointer.
+8. Policy exceptions require owner, reason, coverage, and review date.
+9. Proof commands must be run before claiming success, or explicitly recorded as unavailable with the reason and merge impact.
+
+## Required routing fields
+
+New proposals, specs, ADRs, plans, and active goals should carry enough metadata
+to make their links auditable. Use `n/a` when a field does not apply.
+
+- `Status`
+- `Owner`
+- `Created` or `Date`
+- `Linked proposal`
+- `Linked specs`
+- `Linked ADRs`
+- `Linked plan`
+- `Linked issues`
+- `Linked PRs`
+- `Support-tier impact`
+- `Policy impact`
+
+Existing tokmd artifacts may use older house style while they are migrated. Do
+not rewrite unrelated accepted artifacts just to normalize headings.
+
+## Agent workflow
+
+Agents must begin with repo instructions, then use the linked stack to bound the
+work:
+
+1. Read `AGENTS.md`, `CLAUDE.md`, or the runtime-specific repo instructions.
+2. Read this file and `docs/source-of-truth.md`.
+3. Read the active goal (`.jules/goals/active.toml` today; `.tokmd/goals/active.toml` when a tokmd-native active-goal lane is activated).
+4. Read the linked implementation plan.
+5. Read the linked proposal only for why.
+6. Read the linked spec for acceptance.
+7. Read linked ADRs for constraints.
+8. Inspect git status and avoid unrelated staged or untracked work.
+9. Pick exactly one ready work item.
+10. Implement only that work item.
+11. Run the listed proof commands and `git diff --check`.
+12. Update status, receipts, support tiers, or policy only when the work item requires it.
+13. Open or update one focused PR.
+
+If no ready work item exists, stop and report instead of inventing one.
+
+## Stop conditions
+
+Stop instead of guessing when:
+
+- the active goal is missing or stale;
+- linked files do not exist;
+- the linked spec or plan is missing;
+- the requested change contradicts an ADR;
+- generated status is dirty and no generator/checker is named;
+- proof commands cannot run and no unavailable-proof note is acceptable;
+- unrelated staged files exist;
+- a public claim lacks support-tier proof;
+- a policy exception lacks owner, reason, coverage, and review date.
+
+## Active goal lifecycle
+
+The active goal is the small machine-readable pointer to current work. It should
+link out to human-readable artifacts instead of carrying long prose.
+
+```text
+.<repo>/goals/active.toml
+```
+
+For this repository, `.jules/goals/active.toml` is the current checked active-goal
+surface. `.tokmd/goals/` is reserved for tokmd-native control-plane manifests and
+must not silently replace `.jules/goals/active.toml` until a plan and checker say
+so.
+
+Use `status = "active"` only for a selected lane with ready work. Use
+`status = "paused"` when no implementation lane is selected. Archive completed or
+superseded goals under `.<repo>/goals/archive/YYYY-MM-DD-<lane>.toml` only when
+the checkpoint has durable value.
+
+## Closeout format
+
+At the end of a lane, write or update the closeout named by the plan. A closeout
+should summarize:
+
+- what shipped;
+- proof commands and receipts;
+- PRs and CI runs;
+- generated status, support-tier, and policy updates;
+- deferred work;
+- claim boundary;
+- next lane recommendation.
+
+Closeout prevents the next human or agent from rediscovering old work.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to the implementation plan. Keep the spec focused on behavior,
+examples, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move why and alternatives to the proposal. Keep the plan focused on work items,
+proof commands, rollback, dependencies, and stop conditions.
+
+### Active goal becomes prose
+
+Keep active goals as small TOML manifests. Link to docs instead of embedding long
+tables or run logs.
+
+### Agent hand-edits generated status
+
+Add or use the named generator/checker. If no generator exists, stop or create a
+plan item for the checker before changing generated status by hand.
+
+### Support claims drift
+
+Require support-tier impact on source-of-truth artifacts and proof pointers for
+public claims.
+
+### Policy exceptions become silent debt
+
+Every exception must have an owner, reason, coverage, review date, and optional
+expiry.
+
+### Mega PR
+
+Split by semantic artifact or by one implementation work item. Do not mix
+proposal, spec, ADR, plan, active-goal, runtime, support-tier, and policy changes
+unless the selected plan item explicitly requires it.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.

--- a/docs/source-of-truth.md
+++ b/docs/source-of-truth.md
@@ -14,13 +14,14 @@ kind of truth in the artifact that can best carry it.
 The intended flow is:
 
 ```text
-idea or problem
+roadmap or problem
   -> proposal
   -> spec
   -> ADR when a durable architecture decision is needed
   -> implementation plan
-  -> policy/checks
-  -> receipts and PR evidence
+  -> active goal
+  -> PR / issue
+  -> proof commands, receipts, support tiers, and policy ledgers
 ```
 
 Skipping a step is fine for small changes, but mixing these roles in one
@@ -63,8 +64,10 @@ Templates under `docs/templates/` are starting points for new artifacts. They
 are not source-of-truth documents until copied into the owning directory and
 filled with repo-specific content.
 
-For an operational checklist that coding agents can follow before starting or
-changing a lane, see `docs/agent-workflows/source-of-truth.md`.
+For the canonical first-read contract and source-of-truth stack, see
+`docs/reference/SPEC_SYSTEM.md`. For an operational checklist that coding agents
+can follow before starting or changing a lane, see
+`docs/agent-workflows/source-of-truth.md`.
 
 ## Artifact Roles
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,33 @@
+# Top-level plans
+
+Status: active
+Owner: docs/control-plane
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: docs/specs/doc-artifacts.md
+Linked ADRs: docs/adr/0000-adr-process.md
+Linked plan: docs/plans/doc-artifacts-check.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation routing only; no product support claim changes
+Policy impact: no policy exception changes
+
+This directory contains older or cross-cutting planning notes that predate the
+current source-of-truth layout. New source-of-truth implementation plans should
+prefer `docs/plans/`, which is covered by the documentation artifact checker and
+indexed by the active goal manifest.
+
+Use top-level `plans/` only when a repo owner explicitly asks for a scratch,
+migration, or analysis plan that should not yet be promoted into the checked
+`docs/plans/` family.
+
+## Routing rules
+
+- Product rationale belongs in `docs/proposals/`.
+- Behavior contracts belong in `docs/specs/`.
+- Durable decisions belong in `docs/adr/`.
+- Current implementation sequencing belongs in `docs/plans/`.
+- Machine-readable active work belongs in the active goal manifest.
+- Proof claims belong in proof receipts, CI output, support tiers, or policy ledgers.
+
+See `docs/reference/SPEC_SYSTEM.md` for the full source-of-truth stack.


### PR DESCRIPTION
### Motivation

- Provide a single, machine-friendly canonical description of the repository "source-of-truth" stack so agents and maintainers know where each kind of truth should live. 
- Prevent agents from drifting by making the first-read contract explicit and directing them to the small machine-readable active-goal manifest before implementation. 
- Reserve a tokmd-native active-goal location while keeping the currently-checked `.jules/goals/active.toml` as authoritative until a plan and checker explicitly migrate it.

### Description

- Added `docs/reference/SPEC_SYSTEM.md` as the canonical "first-read" reference describing the linked source-of-truth stack, artifact roles, routing fields, agent workflow, stop conditions, active-goal lifecycle, and failure modes. 
- Added `plans/README.md` and `.tokmd/goals/README.md` to document top-level plans usage and reserve tokmd-native active-goal manifests respectively. 
- Updated agent-facing guidance in `AGENTS.md`, `CLAUDE.md`, and `agents/shared/repo.md` to include the new first-read sequence (`docs/reference/SPEC_SYSTEM.md`, `docs/source-of-truth.md`, `.jules/goals/active.toml`, plan, spec, ADR) and the one-work-item-per-PR rule. 
- Aligned and adjusted existing docs `docs/source-of-truth.md` and `docs/agent-workflows/source-of-truth.md` to reference the new `docs/reference/SPEC_SYSTEM.md` and to incorporate active-goal / PR / proof ledger sequencing.

### Testing

- Ran `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json` and the doc-artifacts checker completed with a successful report. 
- Ran `cargo xtask docs --check` and the docs validation completed with "Documentation is up to date." 
- Ran `git diff --check` to verify diff hygiene and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a17acb63c8333a7a6a94447ed79e6)