### PR TITLE
docs: add compact source-of-truth reference and wire it into agent workflows

### DIFF
--- a/.jules/goals/active.toml
+++ b/.jules/goals/active.toml
@@ -5,6 +5,7 @@ lane = "no_selected_implementation_lane"
 outcome = "paused_after_release_distribution_readiness_closeout"
 
 [links]
+spec_system = "docs/reference/SPEC_SYSTEM.md"
 source_of_truth = "docs/source-of-truth.md"
 doc_artifacts_spec = "docs/specs/doc-artifacts.md"
 doc_artifacts_plan = "docs/plans/doc-artifacts-check.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,27 @@
 Canonical shared repo guidance is mirrored in `agents/shared/repo.md`.
 This file provides guidance to AI agents (Claude, Factory Droid, etc.) when working with code in this repository.
 
+
+## Repo Source-of-Truth Stack
+
+This repo uses a linked source-of-truth stack:
+
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.jules/goals/active.toml`
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. linked ADRs and policy files when named by the active goal or plan
+
+Work on exactly one ready work item per PR. If the active goal is paused,
+missing, stale, or contradicts linked artifacts, stop and report instead of
+inventing a lane. Runtime/code PRs must link to the spec and plan item they
+implement, run the proof commands listed there, and respect support/status and
+policy ledgers before broadening public claims.
+
 ## Droid Auto Review
 
 **tokmd** uses Factory Droid for automated code review. Droid runs on all pull requests using the safe action configuration with MiniMax BYOK, and can be invoked manually with `@droid review` or `@droid security` comments.

--- a/docs/agent-workflows/source-of-truth.md
+++ b/docs/agent-workflows/source-of-truth.md
@@ -3,19 +3,21 @@
 Status: active workflow guide.
 
 Use this guide when starting, continuing, or handing off a tokmd lane. It is
-operational guidance for humans and agents; the durable ownership rules remain
+operational guidance for humans and agents; the quick reference is
+`docs/reference/SPEC_SYSTEM.md`, and the durable ownership rules remain
 in `docs/source-of-truth.md`, `docs/specs/`, `docs/adr/`, `docs/plans/`,
 `.jules/goals/active.toml`, `ci/proof.toml`, and `policy/*.toml`.
 
 ## Before Starting
 
 1. Check the open PR queue.
-2. Read `docs/NEXT.md` for the current operating mode.
-3. Read `.jules/goals/active.toml` for the active program, lane, linked
+2. Read `docs/reference/SPEC_SYSTEM.md` for the source-of-truth stack.
+3. Read `docs/NEXT.md` for the current operating mode.
+4. Read `.jules/goals/active.toml` for the active program, lane, linked
    artifacts, rules, and stop conditions.
-4. Read the linked plan first, then any linked spec, ADR, proposal, or policy
+5. Read the linked plan first, then any linked spec, ADR, proposal, or policy
    file named by the active goal.
-5. Confirm `docs/NEXT.md` does not contradict `.jules/goals/active.toml` or the
+6. Confirm `docs/NEXT.md` does not contradict `.jules/goals/active.toml` or the
    linked plan.
 
 If those artifacts disagree, stop and fix the routing artifact that owns the

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,183 @@
+# Repo source-of-truth system
+
+Status: active reference
+Owner: docs
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: docs/specs/doc-artifacts.md
+Linked ADRs: docs/adr/0000-adr-process.md
+Linked plan: docs/plans/doc-artifacts-check.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation routing only; no product support-tier change
+Policy impact: documents existing `ci/proof.toml` and `policy/*.toml` ownership
+
+This repo uses a linked source-of-truth stack. The rule is simple: do not make
+every document do every job. Keep why, what, decisions, sequencing, active work,
+and proof in separate linked artifacts.
+
+For the full narrative model, see [`docs/source-of-truth.md`](../source-of-truth.md).
+For the agent operating checklist, see
+[`docs/agent-workflows/source-of-truth.md`](../agent-workflows/source-of-truth.md).
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR, when durable decisions are needed
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+|---|---|---|
+| Roadmap | Release direction, milestones, lane framing. | Detailed PR queue or proof receipts. |
+| Proposal | Why, users, alternatives, risks, and success criteria. | Accepted behavior contracts or PR order. |
+| Spec | Behavior, acceptance examples, compatibility, and proof requirements. | Product rationale or implementation sequencing. |
+| ADR | Durable architecture, packaging, governance, and product-boundary decisions. | Task lists or current metric state. |
+| Plan | PR order, work packets, proof commands, rollback, and stop conditions. | Product strategy or durable decisions. |
+| Active goal | Current machine-readable lane state, links, rules, and stop conditions. | Run logs, long prose, or generated status. |
+| Support/status docs | Public claims, current support posture, and proof pointers. | Feature design or architecture rationale. |
+| Policy ledgers | Machine-checkable exceptions, CI intent, owners, coverage, and review dates. | Broad narrative policy or product design. |
+
+## tokmd locations
+
+| Question | Source of truth |
+|---|---|
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` and schema/reference docs named by the spec. |
+| What durable decision constrains the work? | `docs/adr/` |
+| What lands next? | `docs/plans/` for active implementation lanes; root `plans/` for legacy or exploratory design notes. |
+| What is the agent actively executing? | `.jules/goals/active.toml` |
+| What proves the claim? | Proof commands, `ci/proof.toml`, status docs, receipts, and CI artifacts. |
+| What exceptions exist? | `policy/*.toml` and checked policy files such as `ci/proof.toml`. |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the selected plan item says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record decisions.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support/status proof or an equivalent receipt pointer.
+8. Policy exceptions require an owner, reason, coverage, and review date.
+
+## Required header expectations
+
+New proposals, specs, ADRs, and plans should include enough front matter or
+header fields for agents and validators to answer:
+
+- status;
+- owner;
+- creation or decision date;
+- linked proposal, specs, ADRs, and plan, using `n/a` when not applicable;
+- linked issues or PRs when known;
+- support/status impact;
+- policy impact.
+
+Existing historical documents may use older headings. When editing them for
+substantive source-of-truth changes, prefer moving them toward this reference
+rather than mixing roles.
+
+## Agent workflow
+
+Agents must:
+
+1. read repo instructions such as `AGENTS.md`;
+2. read this file;
+3. read `.jules/goals/active.toml`;
+4. read the linked implementation plan;
+5. read the linked proposal only for why;
+6. read the linked spec for acceptance and proof;
+7. read linked ADRs for constraints;
+8. choose exactly one ready work item;
+9. implement only that work item;
+10. run the listed proof commands and `git diff --check`;
+11. update status, receipts, or policy only when the work item requires it;
+12. stop instead of guessing when required artifacts are missing or contradictory.
+
+If `.jules/goals/active.toml` is paused or no ready work item is available,
+agents should report that state or create a handoff only when asked. They should
+not invent a new lane.
+
+## Stop conditions
+
+Stop before implementation when:
+
+- the active goal is missing, paused without an explicit request to choose a
+  lane, or contradicts the linked plan;
+- a linked proposal, spec, ADR, plan, policy file, or status document is missing;
+- a behavior or artifact-shape change has no owning spec;
+- an architecture or product-boundary change has no ADR when the decision should
+  remain durable;
+- proof commands cannot run and no substitute evidence is declared;
+- generated status would need hand editing;
+- unrelated staged changes exist;
+- a public claim lacks support/status proof or an equivalent receipt pointer;
+- a requested change contradicts an accepted ADR.
+
+## Validation commands
+
+Use the relevant subset for source-of-truth-only changes:
+
+```bash
+cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo fmt-check
+git diff --check
+```
+
+Use affected proof planning, package, schema, or publish-surface checks when the
+changed artifact touches those surfaces.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to an implementation plan and keep the spec focused on behavior,
+examples, compatibility, and proof.
+
+### Plan becomes product rationale
+
+Move why, users, alternatives, and success criteria to a proposal.
+
+### Active goal becomes prose
+
+Keep `.jules/goals/active.toml` machine-readable and short; link to human docs
+instead of embedding long tables or logs.
+
+### Generated status is hand-edited
+
+Run the named generator or checker. If no tool exists, make that limitation
+explicit instead of claiming generated proof.
+
+### Policy exceptions become silent debt
+
+Record each exception in the relevant policy ledger with an owner, reason,
+coverage, review date, and expiry when temporary.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.

--- a/docs/source-of-truth.md
+++ b/docs/source-of-truth.md
@@ -2,6 +2,9 @@
 
 Status: active documentation convention.
 
+For a compact agent-facing checklist, see
+[`docs/reference/SPEC_SYSTEM.md`](reference/SPEC_SYSTEM.md).
+
 This document defines where durable tokmd intent, behavior, decisions, plans,
 agent state, and machine-checkable policy belong. It is a routing guide for
 maintainers and agents, not a new product feature.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,37 @@
+# Root plans
+
+Status: active index
+Owner: docs
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: docs/specs/doc-artifacts.md
+Linked ADRs: docs/adr/0000-adr-process.md
+Linked plan: docs/plans/doc-artifacts-check.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation routing only; no product support-tier change
+Policy impact: none
+
+This directory contains historical or exploratory implementation notes that
+predate the current `docs/plans/` source-of-truth lane convention.
+
+For new tokmd implementation lanes, prefer `docs/plans/<lane>.md` unless a plan
+explicitly needs to live at the repository root. The source-of-truth stack is
+summarized in [`docs/reference/SPEC_SYSTEM.md`](../docs/reference/SPEC_SYSTEM.md)
+and described in detail in [`docs/source-of-truth.md`](../docs/source-of-truth.md).
+
+## Current files
+
+| Plan | Scope |
+|---|---|
+| [`microcrate-extraction-analysis.md`](microcrate-extraction-analysis.md) | Historical analysis of microcrate extraction opportunities. |
+| [`microcrate-extraction-refined.md`](microcrate-extraction-refined.md) | Refined microcrate extraction notes. |
+| [`xtask-publish-design.md`](xtask-publish-design.md) | Design notes for xtask publish workflows. |
+
+## Rules
+
+- Do not treat root plans as the active work queue unless the active goal links
+  to one explicitly.
+- Keep accepted implementation sequencing in `docs/plans/` when possible.
+- Keep behavior contracts in `docs/specs/`, durable decisions in `docs/adr/`,
+  and active machine-readable state in `.jules/goals/active.toml`.


### PR DESCRIPTION
### Motivation

- Provide a compact, agent-facing checklist describing the repo "source-of-truth" stack so agents and maintainers know where to find the single responsibility artifacts (proposal, spec, ADR, plan, active goal, proof). 
- Reduce agent drift by giving a short first-read contract that points to the owning artifacts and stop conditions. 
- Clarify that root-level `plans/` files are historical/exploratory and that active implementation lanes should prefer `docs/plans/`.

### Description

- Added a compact reference document at `docs/reference/SPEC_SYSTEM.md` describing the stack, artifact roles, agent workflow, stop conditions, validation commands, and common failure modes. 
- Updated `AGENTS.md` to include a concise first-read contract that points to `docs/reference/SPEC_SYSTEM.md`, `.jules/goals/active.toml`, the linked plan/spec/ADRs, and the one-work-item-per-PR rule. 
- Linked the new reference from `docs/agent-workflows/source-of-truth.md` and `docs/source-of-truth.md` to make the checklist discoverable from existing agent workflow docs. 
- Added `plans/README.md` to document the role of root-level plans and recommend `docs/plans/` for new active lanes. 
- Added a `spec_system` pointer in `.jules/goals/active.toml` so the active goal manifest links the machine-readable active state to the compact reference. 

### Testing

- Ran `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json` and it reported the doc artifacts OK. 
- Ran `cargo xtask docs --check` and it completed successfully. 
- Ran `cargo xtask proof-policy --check` and it reported proof policy OK. 
- Ran `cargo fmt-check` (via `xtask lint-fix --check`) and the formatting/lint steps passed. 
- Ran `git diff --check` and there were no diff-hygiene failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a17acb63c8333a7a6a94447ed79e6)