### PR TITLE
docs: define source-of-truth stack and add active-goals scaffold

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,35 @@
 <!-- AI-FILL:SUMMARY -->
 <!-- Brief description of what this PR does -->
 
+
+## Source-of-Truth Links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+What this PR explicitly does not do:
+
+## Claim Boundary
+
+What may be claimed after this PR, and what must not be claimed yet:
+
 ## Type of Change
 
 <!-- Check the relevant option(s) -->

--- a/.tokmd/goals/README.md
+++ b/.tokmd/goals/README.md
@@ -1,0 +1,60 @@
+# tokmd active goals
+
+Status: scaffolded
+Owner: docs/control-plane
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: `docs/specs/doc-artifacts.md`
+Linked ADRs: `docs/adr/0000-adr-process.md`
+Linked plan: `docs/plans/doc-artifacts-check.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation-control guidance only; no product support claim changes
+Policy impact: no policy exception added
+
+This directory is the repo-native home for machine-readable active goal manifests:
+
+```text
+.tokmd/goals/active.toml
+.tokmd/goals/archive/YYYY-MM-DD-lane.toml
+```
+
+An active goal owns only current execution state: selected lane, objective,
+linked source-of-truth artifacts, work items, proof commands, status pointers,
+and claim boundaries. It must not become a prose plan, generated status table,
+run log, or architecture decision record.
+
+## Current migration note
+
+Tokmd currently has legacy Jules active-agent state in `.jules/goals/active.toml`
+and durable Jules provenance under `.jules/**`. That provenance is intentional
+repo state. Until a future goal-activation PR creates `.tokmd/goals/active.toml`,
+agents should treat `.jules/goals/active.toml` as the current active-agent state
+and this directory as the target repo-native scaffold.
+
+## Active manifest shape
+
+Use `docs/templates/active-goal.toml` as the starting point. A repo-native active
+goal should remain small and link out to the proposal, spec, ADR, plan, status
+docs, and proof commands.
+
+Required intent:
+
+- exactly one active or paused goal;
+- all linked files are repo-relative and exist;
+- every work item has an ID, status, plan pointer, claim boundary, and proof
+  commands;
+- completed work items point to a receipt, PR, or closeout note;
+- archived goals are historical checkpoints and do not compete with
+  `active.toml`.
+
+## Stop conditions
+
+Stop rather than guessing when:
+
+- `active.toml` is missing after the repo has migrated to `.tokmd/goals/`;
+- linked proposal/spec/ADR/plan files are missing;
+- a work item has no proof commands;
+- the requested work contradicts a linked ADR;
+- unrelated staged changes exist;
+- proof cannot run and no substitute evidence is defined.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,30 @@
 Canonical shared repo guidance is mirrored in `agents/shared/repo.md`.
 This file provides guidance to AI agents (Claude, Factory Droid, etc.) when working with code in this repository.
 
+
+## Repo Source-of-Truth Stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. the active goal manifest when present (`.tokmd/goals/active.toml`; until that migration lands, `.jules/goals/active.toml`)
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. any linked ADRs
+
+Work on exactly one work item per PR. Do not mix proposal/spec/ADR/plan/runtime
+changes unless the selected work item says to. Run the proof commands listed by
+the plan item, and record any unavailable proof honestly instead of claiming
+success. Do not hand-edit generated status; run the named generator or checker.
+If you add a policy exception, update the relevant `policy/*.toml` ledger with
+owner, reason, coverage, creation date, and review date.
+
 ## Droid Auto Review
 
 **tokmd** uses Factory Droid for automated code review. Droid runs on all pull requests using the safe action configuration with MiniMax BYOK, and can be invoked manually with `@droid review` or `@droid security` comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,25 @@ Canonical repo guidance lives in `agents/shared/repo.md`.
 
 This file is the Claude adapter wrapper for runtime-specific notes.
 
+
+## Source-of-Truth First Read
+
+Before making changes, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.tokmd/goals/active.toml` when present; until that migration lands, `.jules/goals/active.toml`
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. any linked ADRs
+
+Work on exactly one work item at a time. Do not create a new lane, mix semantic
+doc layers with runtime changes, broaden docs-only PRs into behavior, hand-edit
+generated status, or claim success without proof commands unless the selected
+plan item explicitly allows it. Stop and report if the active goal is missing or
+stale, linked specs are missing, proof cannot run, generated status is dirty,
+the request conflicts with an ADR, or the branch contains unrelated staged
+changes.
+
 ## Claude Runtime Surface
 
 - Settings: `.claude/settings.json`

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,8 @@
 This directory contains user guides, product contracts, architecture notes,
 schemas, and verification policy for `tokmd`.
 
+- [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md) — source-of-truth stack, artifact roles, agent workflow, and stop conditions.
+
 ## Key references
 
 - [start-here.md](start-here.md) — choose the shortest path for repo

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,247 @@
+# Repo source-of-truth system
+
+Status: active
+Owner: docs/control-plane
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: `docs/specs/doc-artifacts.md`
+Linked ADRs: `docs/adr/0000-adr-process.md`
+Linked plan: `docs/plans/doc-artifacts-check.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation-control guidance only; no public support-tier claim changes
+Policy impact: documents policy-ledger expectations; no policy exception added
+
+This repo uses a linked source-of-truth stack. The rule is simple: do not make
+every document do every job. Separate why, what, durable decisions, sequencing,
+active work, and proof.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal / PRD
+    -> Spec
+      -> ADR where needed
+        -> Implementation plan
+          -> Active goal
+            -> Issue / PR
+              -> Proof command
+              -> CI receipt
+              -> support-tier update
+              -> policy-ledger update
+```
+
+The stack is a control plane for humans and agents. It lets a cold reader answer
+what the repo is doing, why, what must be true, what constrains the work, what
+lands next, what proves it, what may be claimed, and what must not be claimed.
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, product strategy, and the lanes that exist. | Detailed PR order, live status, generated metrics, proof receipts. |
+| Proposal / PRD | Why the work exists, user pain, affected surfaces, success criteria, alternatives, risks, non-goals, needed specs or ADRs. | Exact PR sequence, implementation details, generated status, test receipt state. |
+| Spec | Required behavior, non-goals, acceptance examples, proof requirements, test mapping, implementation mapping, CI proof, support-tier impact. | Why the lane exists, PR order, active queue, durable architecture decision unless unavoidable. |
+| ADR | Durable architecture or operating decisions, context, consequences, rejected alternatives, follow-up specs or plans. | PR task lists, current metric state, implementation queue. |
+| Implementation plan | PR sequence, work items, dependencies, proof commands, rollback, status handoff. | Product motivation, durable architecture, generated status truth. |
+| Active goal | Current lane, machine-readable objective, active work items, proof commands, status pointers, claim boundaries. | Long prose, generated metrics, durable decisions. |
+| Support tiers | Public claims, stable/advisory/experimental/blocked classification, proof commands, known limitations, next promotion requirement. | Feature design or architecture rationale. |
+| Policy ledgers | Exceptions, CI lane intent, cost, owner, proof, expiry and review dates. | Broad architecture or unowned allowlists. |
+
+## Canonical locations
+
+Tokmd already has durable source-of-truth artifacts. Prefer these locations for
+new work:
+
+| Question | Source of truth |
+| --- | --- |
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What durable architecture decision did we make? | `docs/adr/` |
+| What PR lands next? | `docs/plans/` or a lane under `plans/` when explicitly selected |
+| What is the agent actively executing? | `.tokmd/goals/active.toml` when activated; `.jules/goals/active.toml` remains the current legacy active-agent state until that migration lands |
+| What proves the claim? | support/status docs, receipts, CI, and proof commands named by the plan |
+| What exceptions exist? | `policy/*.toml` and `ci/proof.toml` |
+
+Existing Jules provenance under `.jules/**` is intentional repository state. Do
+not delete, split, or reject it merely because it is provenance.
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the selected plan item says otherwise.
+3. Proposals explain why; specs define behavior; ADRs record durable decisions.
+4. Plans define sequencing and proof; active goals tell agents what to do now.
+5. Runtime/code PRs must link to the spec and plan item they implement.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier proof or an equivalent proof pointer.
+8. Policy exceptions require owner, reason, coverage, and review date.
+9. Do not broaden behavior from a docs-only PR.
+10. Do not claim success without running proof commands or recording why a proof
+    command is unavailable.
+
+## Required metadata
+
+New proposals, specs, ADRs, and implementation plans should include enough
+metadata to route the artifact without chat history. Use `n/a` when a field does
+not apply.
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+Existing older artifacts may use their historical house style until they are
+revised for substantive reasons.
+
+## Agent workflow
+
+Agents must:
+
+1. Read `AGENTS.md` or `CLAUDE.md`.
+2. Read this file.
+3. Read the active goal manifest when one exists.
+4. Read the linked implementation plan.
+5. Read the linked proposal only for why.
+6. Read the linked spec for acceptance.
+7. Read linked ADRs for constraints.
+8. Inspect current git status and avoid unrelated staged or untracked work.
+9. Pick exactly one ready work item.
+10. Implement only that work item.
+11. Run the listed proof commands.
+12. Update plan/status/receipts only if the work item requires it.
+13. Open or update one focused PR.
+
+If no ready work item exists, do not invent one. Write a handoff or ask for lane
+selection.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- active goal state is missing, stale, or contradictory;
+- linked files do not exist;
+- linked specs are missing for behavior changes;
+- proof commands cannot run and no substitute evidence is defined;
+- generated status differs from committed status;
+- unrelated staged changes exist;
+- requested work conflicts with an ADR;
+- a public claim lacks support-tier proof;
+- a policy exception lacks owner, reason, coverage, or review date.
+
+## Artifact templates
+
+Use the templates in `docs/templates/` as the starting point for new proposals,
+specs, ADRs, plans, and active-goal manifests. Keep names boring and stable so
+humans, reviewers, and automation can link artifacts reliably.
+
+## Active goal lifecycle
+
+The repo-native target path for active goals is `.tokmd/goals/active.toml`.
+During migration, `.jules/goals/active.toml` remains valid legacy active-agent
+state and `.jules/**` remains intentional provenance.
+
+Activate one goal at a time:
+
+```toml
+id = "tokmd-lane-id"
+title = "Human readable lane title"
+status = "active"
+owner = "codex-claude"
+created = "2026-05-17"
+proposal = "docs/proposals/TOKMD-PROP-0001-lane.md"
+plan = "docs/plans/lane.md"
+specs = ["docs/specs/TOKMD-SPEC-0001-contract.md"]
+adrs = []
+```
+
+Pause explicitly when no implementation lane is selected:
+
+```toml
+status = "paused"
+reason = "No selected implementation lane."
+```
+
+Archive superseded goals under `.tokmd/goals/archive/YYYY-MM-DD-lane.toml` only
+when the machine-readable checkpoint has durable value.
+
+## Closeout format
+
+At the end of a lane, write a closeout in the lane plan or a dedicated
+`closeout.md` with:
+
+- what shipped;
+- proof commands and receipts;
+- PRs and CI runs;
+- generated status, support-tier, and policy updates;
+- what did not ship;
+- deferred work;
+- claim boundary;
+- next lane recommendation.
+
+Closeout prevents the next agent from rediscovering old work.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to the implementation plan. Keep the spec focused on behavior,
+examples, and proof.
+
+### Plan becomes product rationale
+
+Move why and alternatives to the proposal. Keep the plan focused on work items,
+proof, rollback, dependencies, and status handoff.
+
+### Active goal becomes prose
+
+Keep active goals small, TOML-shaped, and link-rich. Put long rationale in the
+proposal, plan, or handoff.
+
+### Agent hand-edits generated status
+
+Use the named generator or checker instead. If no generator exists, update the
+plan before relying on manual status edits.
+
+### Support claims drift
+
+Require support-tier impact metadata and proof pointers before broadening README
+or public support claims.
+
+### Policy exceptions become silent debt
+
+Each exception must have owner, reason, `covered_by`, `created`, and
+`review_after`; temporary exceptions should also have an expiry.
+
+### Mega PR
+
+Split by semantic artifact or by one implementation work item unless the plan
+explicitly says the work must land together.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.

--- a/docs/source-of-truth.md
+++ b/docs/source-of-truth.md
@@ -6,6 +6,9 @@ This document defines where durable tokmd intent, behavior, decisions, plans,
 agent state, and machine-checkable policy belong. It is a routing guide for
 maintainers and agents, not a new product feature.
 
+The compact reference and agent stop-condition contract lives in
+[`docs/reference/SPEC_SYSTEM.md`](reference/SPEC_SYSTEM.md).
+
 ## Goal
 
 Keep tokmd's repository knowledge reviewable and enforceable by putting each

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,80 @@
+# Plans
+
+Status: active routing guide
+Owner: docs/control-plane
+Created: 2026-05-17
+Linked proposal: n/a
+Linked specs: `docs/specs/doc-artifacts.md`
+Linked ADRs: `docs/adr/0000-adr-process.md`
+Linked plan: `docs/plans/doc-artifacts-check.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: documentation-control guidance only; no product support claim changes
+Policy impact: no policy exception added
+
+Plans own sequencing: PR order, dependencies, proof commands, rollback notes,
+and status handoff. They do not own product motivation, durable architecture, or
+generated status truth.
+
+Tokmd currently keeps durable checked implementation plans in `docs/plans/`.
+This top-level directory is retained for compatibility with older planning notes
+and for future lane directories when a proposal or active goal explicitly chooses
+`plans/<lane>/implementation-plan.md`.
+
+## Use this directory for
+
+- lane directories selected by an active goal or proposal;
+- migration/staging plans that need to live outside `docs/plans/` temporarily;
+- compatibility notes for older top-level planning artifacts.
+
+## Prefer `docs/plans/` for
+
+- new source-of-truth implementation plans checked by `cargo xtask doc-artifacts
+  --check`;
+- plans linked from `.jules/goals/active.toml` during the current legacy active
+  goal period;
+- plans that should follow the existing tokmd doc-artifact policy.
+
+## Plan shape
+
+A source-of-truth implementation plan should include:
+
+```md
+# Lane implementation plan
+
+Status: active
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Active goal:
+
+## Current state
+
+## Work item: short-id
+
+Status: ready | active | blocked | completed | superseded
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+### Goal
+
+### Production delta
+
+### Non-goals
+
+### Acceptance
+
+### Proof commands
+
+### Rollback
+
+### Notes
+```
+
+If a plan starts explaining why the lane exists, move that text to a proposal.
+If it records a durable architecture choice, move that choice to an ADR.


### PR DESCRIPTION
### Motivation

- Provide a compact, machine-and-agent-friendly reference for the repo's linked source-of-truth stack so maintainers and automation know where each kind of truth lives. 
- Reduce agent drift by prescribing a first-read order, one-item work rule, proof rule, and explicit stop conditions for coding agents. 
- Install a repo-native scaffold for machine-readable active goals while preserving existing Jules provenance during migration. 

### Description

- Add `docs/reference/SPEC_SYSTEM.md` containing the concise source-of-truth stack, artifact roles, canonical locations, agent workflow, stop conditions, active-goal lifecycle, templates, and common failure modes. 
- Add repo-native active-goal scaffold at `.tokmd/goals/README.md` and an archive placeholder to host future `.tokmd/goals/active.toml` manifests while documenting the current `.jules` migration boundary. 
- Add `plans/README.md` explaining plan ownership, preferred location for lane plans, and a plan shape template. 
- Update agent guidance files `AGENTS.md` and `CLAUDE.md` to include a source-of-truth first-read and one-item work rules, and update `docs/README.md` and `docs/source-of-truth.md` to point to the new compact reference. 
- Extend the PR template `.github/pull_request_template.md` with Source-of-Truth Links, Scope, Non-goals, and Claim Boundary sections to standardize PR routing and proof expectations. 

### Testing

- Ran `git diff --check` and it produced no hygiene errors. 
- Ran `cargo xtask doc-artifacts --check`, which validated the doc-artifact shapes and links and returned an OK result for required docs, family files, and active goal counts. 
- Ran `cargo xtask docs --check`, which invoked the docs checks and completed without errors. 
- All automated checks listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a17acb63c8333a7a6a94447ed79e6)