### PR TITLE
docs(release): expand 1.11 changelog and notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,113 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.11.0] - 2026-05-08
+## [1.11.0] - 2026-05-18
+
+1.11 makes tokmd's evidence surfaces easier to consume: cockpit review
+packets, coding-agent handoffs, proof receipts, browser/native guidance, and
+release evidence now compose into practical workflows without promoting
+advisory checks or changing public AST behavior.
+
+### Added
+
+- Cockpit review packets now surface clearer review-first ordering, source of
+  truth and proof evidence, missing/stale/degraded states, packet verification,
+  and reproduction commands for review evidence.
+- Review-map Markdown now explains priority reasons so reviewers can start from
+  the packet instead of inferring meaning from CI job names or pull request
+  prose.
+- Handoff bundles now include actionable `work-order.md` guidance for coding
+  agents, including changed surfaces, linked review evidence, proof
+  expectations, missing evidence, and stop conditions.
+- Handoff inputs can link review packets, review-packet verifier receipts,
+  affected-proof receipts, and proof plans as external evidence handles.
+- Proof observation, proof workflow status, proof artifact check, and CI
+  risk-pack receipts make required/advisory proof easier to inspect without
+  turning advisory evidence into gates.
+- Rust-owned `xtask` helpers now emit or verify more proof-control artifacts,
+  including affected proof plans, proof policy JSON, no-panic family JSON,
+  proof observation status, proof workflow status, mutation scope, mutation
+  summaries, and RIPR annotations.
+- User-path docs now map inspect, PR review, agent handoff, CI evidence,
+  browser trial, and publishing/release evidence to commands, primary
+  artifacts, open-first files, meanings, non-meanings, and next actions.
+- Sample artifact trees, copy-ready workflows, install/try guidance, GitHub
+  Action quickstarts, browser-to-native guidance, and release-readiness docs
+  provide adoption paths for maintainers, reviewers, CI owners, and agent
+  operators.
+- Publishing and release evidence docs now describe package-surface,
+  version-consistency, affected-proof, and proof-plan checks before any release
+  mutation.
+- Current-facing WASM/browser release artifact examples now point at the
+  `v1.11.0` artifact shape, and release-prep metadata is aligned with the
+  `1.11.0` workspace version.
+- Developer-facing AST shadow tooling can compare heuristic Rust landmarks
+  with Tree-sitter-backed Rust landmarks, write deterministic shadow artifacts,
+  verify them, summarize mismatch counts, and record function-boundary evidence.
+  AST remains shadow-only.
 
 ### Changed
+
 - Raised the minimum supported Rust version from 1.93 to 1.95.
 - Activated the Rust 1.94/1.95 lint policy ratchets staged in `policy/clippy-lints.toml`: `same_length_and_capacity` (deny), `manual_ilog2`, `decimal_bitwise_operands`, `needless_type_cast`, `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and `unnecessary_trailing_comma` (all warn).
+- README, tutorial, recipes, and Start Here docs now emphasize the shortest
+  user paths instead of requiring readers to learn the proof-control plane
+  first.
+- Browser docs now frame browser mode as a no-install trial lens with clear
+  native-only boundaries, not native parity.
+- Cockpit and handoff internals continued moving toward smaller SRP owner
+  modules while preserving public schema and CLI behavior.
+- Workflow-local shell and Python glue continued moving into Rust-owned
+  `xtask` helpers where the resulting artifact is consumed as review or proof
+  evidence.
+- Proof remains advisory unless a maintainer explicitly promotes a check, and
+  Codecov upload remains opt-in rather than a default release or CI behavior.
+
+### Fixed
+
+- Review-map reproduction commands now preserve the actual relative
+  `--review-packet-dir` instead of always showing `.tokmd/review` or leaking
+  absolute local paths.
+- UTF-8-sensitive analysis paths avoid byte/character index panics around
+  ternary `?` tokens after multibyte input.
+- Content tag counting now treats empty tags as zero matches and respects
+  Unicode identifier boundaries instead of matching inside non-ASCII words.
+- Context policy classification now normalizes Windows separators and matches
+  vendor, fixture, and generated directories by exact path segment instead of
+  broad substring matches.
+- Python/FFI JSON settings now reject `paths: null` consistently, keep other
+  nullable option fields on their defaults, and make PyO3 extension-module
+  behavior opt-in for the test harness.
+- Average-line rounding avoids integer overflow on very large code totals.
+- Complexity histogram Markdown handles narrow and zero-width rendering cases
+  without malformed ASCII bars.
+- Redacted safe-extension handling was tightened for compound and case-varied
+  extensions.
+- Browser token rejection and worker progress states now surface clearer
+  browser-runner feedback.
+- RIPR GitHub annotation rendering moved out of a Python helper into
+  `cargo xtask ripr-annotations`.
+- Generated coverage work was restacked into narrow keeper tests for cockpit
+  review maps, cockpit comments, derived Markdown rendering, core FFI parsing,
+  effort helpers, complexity spans, proof-evidence model strings, and git
+  fixture signing.
+
+### Internal
+
+- Added doc-artifact policy, receipt, CI upload, source-of-truth routing, and
+  cockpit import support so documentation-control evidence can appear in review
+  packets.
+- Added review-packet verifier receipts and tighter review-packet contract
+  documentation.
+- Added AST shadow fixture corpora, corpus manifests, comparison summaries,
+  timing receipts, verifier checks, and proof routing for the shadow lane.
+- Added proof observation decision artifacts, hosted proof workflow status
+  evidence, and verifier checks while preserving non-required/advisory behavior.
+- Added publishing-evidence and release-readiness plans, guides, glossary
+  entries, and closeouts without adding a release mutation command.
+- Added targeted tests and refactors across cockpit, handoff, analysis, format,
+  scan, gate, core, and types to lock behavior behind the new evidence
+  consumption paths.
 
 ## [1.10.0] - 2026-04-30
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1328,6 +1328,7 @@ kind = "non_rust"
 paths = [
   ".github/workflows/release.yml",
   "CHANGELOG.md",
+  "docs/releases/**",
 ]
 proof = [
   "cargo xtask version-consistency",

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ schemas, and verification policy for `tokmd`.
   surface, metadata, and CI ownership evidence before release mutation.
 - [release-readiness.md](release-readiness.md) — quickstart for pre-release
   evidence checks without publishing, tagging, or creating releases.
+- [releases/1.11.md](releases/1.11.md) — draft release notes for the 1.11
+  evidence-consumption release.
 - [reference-cli.md](reference-cli.md) — generated CLI flag reference.
 - [SCHEMA.md](SCHEMA.md) — receipt format documentation.
 - [architecture.md](architecture.md) — crate hierarchy and data flow.

--- a/docs/releases/1.11.md
+++ b/docs/releases/1.11.md
@@ -1,0 +1,112 @@
+# tokmd 1.11
+
+tokmd 1.11 is an evidence-consumption release. It makes the existing code
+intelligence surfaces easier to use for PR review, coding-agent handoff, CI
+evidence, browser trials, and release preparation.
+
+The release does not add a `tokmd review` command, promote proof gates, enable
+Codecov upload by default, make AST-backed output public by default, or perform
+release mutation outside the explicit release workflow.
+
+## Highlights
+
+- Review packets are more usable. `tokmd cockpit --review-packet-dir` now
+  produces clearer review-map priority reasons, evidence states, reproduction
+  commands, and verifier receipts.
+- Agent handoffs are more actionable. `.handoff/work-order.md` now tells a
+  coding agent what changed, what review/proof evidence is linked, what is
+  missing, and when to stop.
+- Proof evidence is easier to read. Proof observation, workflow status,
+  artifact check, mutation, and RIPR annotation artifacts are increasingly
+  Rust-owned and receipt-backed while remaining advisory unless explicitly
+  promoted.
+- The first-run path is shorter. Install/try, user-path, sample artifact tree,
+  GitHub Action, browser-to-native, and release-readiness docs now route users
+  from a job to a command, artifact, open-first file, meaning, non-meaning, and
+  next action.
+- Release-facing surfaces are aligned for 1.11. WASM/browser artifact examples,
+  package-surface checks, version-consistency checks, and release-readiness docs
+  now point at the staged `1.11.0` release shape.
+- AST work stays honest. The AST shadow lane now has developer-facing
+  comparison, verifier, summary, timing, and function-boundary evidence, but it
+  remains outside default analyze, cockpit, context, handoff, browser, and
+  public receipt behavior.
+- The minimum supported Rust version is now Rust 1.95, with the 1.94/1.95
+  clippy lint ratchets active in repo policy.
+- Correctness hardening landed in the release path for content tag boundaries,
+  context policy path classification, Python/FFI null-path handling, average
+  line rounding, and complexity histogram rendering.
+
+## For Maintainers And Reviewers
+
+Start PR review with a cockpit packet:
+
+```bash
+tokmd cockpit \
+  --base origin/main \
+  --head HEAD \
+  --review-packet-dir .tokmd/review
+
+cargo xtask review-packet-check \
+  --dir .tokmd/review \
+  --json target/tokmd/review-packet-check.json
+```
+
+Open `.tokmd/review/review-map.md` first, then `comment.md`, `evidence.json`,
+and the review-packet-check receipt. The packet is review evidence, not a merge
+verdict.
+
+## For Coding-Agent Operators
+
+Use `tokmd handoff` when you want a bounded source bundle plus review and proof
+expectations:
+
+```bash
+tokmd handoff \
+  --preset risk \
+  --budget 128k \
+  --strategy spread \
+  --review-packet-dir .tokmd/review \
+  --review-packet-check target/tokmd/review-packet-check.json \
+  --affected target/proof/affected.json \
+  --proof-plan target/proof/proof-plan.json \
+  --out-dir .handoff
+```
+
+Give the agent `.handoff/work-order.md` first, then `.handoff/code.txt` and the
+linked evidence files. Missing, stale, degraded, skipped, or unavailable
+evidence is not passing proof.
+
+## For CI And Release Owners
+
+The GitHub Action quickstart now covers simple receipt artifacts and review
+packet artifacts. It keeps artifacts and optional comments separate from
+repository tests, proof promotion, Codecov upload, and merge decisions.
+
+For release preparation, collect evidence before mutation:
+
+```bash
+cargo xtask publish-surface --json --verify-publish
+cargo xtask version-consistency
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release.json --evidence-json target/proof/proof-evidence-release.json
+```
+
+These checks do not publish crates, create tags, create GitHub releases, move
+release aliases, or push images.
+
+## What Did Not Change
+
+- No new public `tokmd review` command.
+- No default Codecov upload.
+- No proof promotion or required gate expansion.
+- No default AST-backed analyze, cockpit, context, handoff, or browser output.
+- No evidencebus runtime integration inside tokmd.
+- No release mutation without an explicit maintainer decision.
+
+## Release Preflight
+
+Before tagging `v1.11.0`, run the release-readiness checks in
+`docs/release-readiness.md`, verify the changelog and this release note, and
+confirm hosted release workflows are ready for the selected stable or
+prerelease tag.


### PR DESCRIPTION
## Summary
- expands the 1.11.0 changelog into user-facing release/adoption readiness notes
- adds docs/releases/1.11.md as a concise release-notes draft and links it from docs/README.md
- routes docs/releases/** through release_metadata proof scope

## Validation
- cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-changelog.json (4 files, 3 scopes, 0 unknown)
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-changelog.json --evidence-json target/proof/proof-evidence-changelog.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --plan-json target/proof/proof-plan-changelog.json
- cargo fmt-check