### PR TITLE
fix(handoff): remove work-order self-reference

### DIFF
--- a/crates/tokmd/src/commands/handoff/output.rs
+++ b/crates/tokmd/src/commands/handoff/output.rs
@@ -239,7 +239,6 @@ fn push_start_here_section(out: &mut String, links: &HandoffLinkInputs<'_>) {
     out.push_str("## Start Here\n\n");
     let mut steps = vec![
         "Read `manifest.json` for the authoritative artifact index, token budget, included files, and exclusions.",
-        "Read `work-order.md` for the agent task map and guardrails.",
         "Read `code.txt` for the bounded source bundle.",
         "Use `map.jsonl` for full file inventory and path lookup.",
         "Use `intelligence.json` for repository shape, hotspots, complexity, and derived signals.",

--- a/crates/tokmd/tests/handoff_integration.rs
+++ b/crates/tokmd/tests/handoff_integration.rs
@@ -210,6 +210,7 @@ fn test_handoff_links_review_and_proof_artifacts() {
     let work_order = fs::read_to_string(out_dir.join("work-order.md")).unwrap();
     assert!(work_order.contains("review-links.json"));
     assert!(work_order.contains("proof-links.json"));
+    assert!(!work_order.contains("Read `work-order.md`"));
     assert!(
         work_order.contains("Treat linked review and proof receipts as external evidence handles")
     );


### PR DESCRIPTION
## Summary
- remove the generated work-order instruction that tells readers to read work-order.md from inside work-order.md
- add regression coverage so generated handoff work orders keep that self-reference out

## Validation
- cargo test -p tokmd --test handoff_integration --verbose
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-handoff-start-here.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-handoff-start-here.json --evidence-json target/proof/proof-evidence-handoff-start-here.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --plan-json target/proof/proof-plan-handoff-start-here.json --proof-run-summary target/proof/proof-run-summary-handoff-start-here.json
- cargo fmt-check
- git diff --check origin/main...HEAD

## Adoption smoke source
Found during the 1.11 pre-release adoption smoke after generating a cockpit packet, verifying it, producing affected/proof artifacts, and generating .handoff/work-order.md from the linked evidence.