### PR TITLE
docs(release): add 1.11 release ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,104 +16,99 @@ advisory checks or changing public AST behavior.
 
 ### Added
 
-- Cockpit review packets now surface clearer review-first ordering, source of
-  truth and proof evidence, missing/stale/degraded states, packet verification,
-  and reproduction commands for review evidence.
-- Review-map Markdown now explains priority reasons so reviewers can start from
-  the packet instead of inferring meaning from CI job names or pull request
-  prose.
-- Handoff bundles now include actionable `work-order.md` guidance for coding
-  agents, including changed surfaces, linked review evidence, proof
-  expectations, missing evidence, and stop conditions.
-- Handoff inputs can link review packets, review-packet verifier receipts,
-  affected-proof receipts, and proof plans as external evidence handles.
-- Proof observation, proof workflow status, proof artifact check, and CI
-  risk-pack receipts make required/advisory proof easier to inspect without
-  turning advisory evidence into gates.
-- Rust-owned `xtask` helpers now emit or verify more proof-control artifacts,
-  including affected proof plans, proof policy JSON, no-panic family JSON,
-  proof observation status, proof workflow status, mutation scope, mutation
-  summaries, and RIPR annotations.
-- User-path docs now map inspect, PR review, agent handoff, CI evidence,
-  browser trial, and publishing/release evidence to commands, primary
-  artifacts, open-first files, meanings, non-meanings, and next actions.
-- Sample artifact trees, copy-ready workflows, install/try guidance, GitHub
-  Action quickstarts, browser-to-native guidance, and release-readiness docs
-  provide adoption paths for maintainers, reviewers, CI owners, and agent
-  operators.
-- Publishing and release evidence docs now describe package-surface,
-  version-consistency, affected-proof, and proof-plan checks before any release
-  mutation.
-- Current-facing WASM/browser release artifact examples now point at the
-  `v1.11.0` artifact shape, and release-prep metadata is aligned with the
-  `1.11.0` workspace version.
-- Developer-facing AST shadow tooling can compare heuristic Rust landmarks
-  with Tree-sitter-backed Rust landmarks, write deterministic shadow artifacts,
-  verify them, summarize mismatch counts, and record function-boundary evidence.
-  AST remains shadow-only.
+- Review packets and cockpit evidence: cockpit packets now surface
+  review-first ordering, priority reasons, source-of-truth evidence,
+  proof evidence, missing/stale/degraded/skipped/unavailable states, packet
+  verification, and reproduction commands.
+- Agent handoff/work-order: handoff bundles now include actionable
+  `work-order.md` guidance, linked review-packet evidence, linked affected and
+  proof-plan receipts, proof expectations, missing evidence, stop conditions,
+  and agent guardrails.
+- Proof and CI evidence receipts: proof observation, proof workflow status,
+  proof artifact checks, CI risk-pack receipts, mutation summaries, mutation
+  scope, no-panic family JSON, and RIPR annotations are easier to inspect as
+  evidence without turning advisory telemetry into gates.
+- User-path and adoption docs: install/try, Start Here, user paths, copy-ready
+  workflows, sample artifact trees, GitHub Action quickstarts, browser-to-native
+  guidance, and release-readiness docs now map jobs to commands, artifacts,
+  open-first files, meanings, non-meanings, and next actions.
+- Publishing and release evidence: release-facing docs now describe
+  package-surface checks, version consistency, affected-proof routing, and
+  proof-plan generation before any release mutation.
+- Browser/WASM adoption: current-facing WASM/browser examples point at the
+  staged `v1.11.0` artifact shape while browser mode is positioned as a
+  no-install trial lens.
+- AST shadow evidence: developer-facing AST tooling can compare heuristic Rust
+  landmarks with Tree-sitter-backed Rust landmarks, write deterministic shadow
+  artifacts, verify them, summarize mismatch counts, and record timing and
+  function-boundary evidence. AST remains shadow-only.
+- Release record: `docs/releases/1.11-ledger.md` now gives maintainers a
+  lane-by-lane release ledger without flattening hundreds of PRs into this
+  changelog.
 
 ### Changed
 
-- Raised the minimum supported Rust version from 1.93 to 1.95.
-- Activated the Rust 1.94/1.95 lint policy ratchets staged in `policy/clippy-lints.toml`: `same_length_and_capacity` (deny), `manual_ilog2`, `decimal_bitwise_operands`, `needless_type_cast`, `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and `unnecessary_trailing_comma` (all warn).
-- README, tutorial, recipes, and Start Here docs now emphasize the shortest
-  user paths instead of requiring readers to learn the proof-control plane
-  first.
-- Browser docs now frame browser mode as a no-install trial lens with clear
-  native-only boundaries, not native parity.
-- Cockpit and handoff internals continued moving toward smaller SRP owner
-  modules while preserving public schema and CLI behavior.
-- Workflow-local shell and Python glue continued moving into Rust-owned
-  `xtask` helpers where the resulting artifact is consumed as review or proof
-  evidence.
-- Proof remains advisory unless a maintainer explicitly promotes a check, and
-  Codecov upload remains opt-in rather than a default release or CI behavior.
+- MSRV and lint policy: the minimum supported Rust version moved from 1.93 to
+  1.95, and the Rust 1.94/1.95 lint ratchets staged in
+  `policy/clippy-lints.toml` are active.
+- CI/proof orchestration: workflow-local shell and Python glue continued moving
+  into Rust-owned `xtask` helpers where the result is consumed as review,
+  proof, mutation, or annotation evidence.
+- Browser/native positioning: browser docs now frame browser mode as a
+  no-install trial lens with clear native-only boundaries, not native parity.
+- First-run documentation: README, tutorial, recipes, Start Here, and user-path
+  docs emphasize the shortest job-oriented paths instead of requiring readers
+  to learn the proof-control plane first.
+- Owner-module cleanup: cockpit and handoff internals continued moving toward
+  smaller SRP owner modules while preserving public schema and CLI behavior.
+- Advisory evidence boundary: proof remains advisory unless a maintainer
+  explicitly promotes a check, and Codecov upload remains opt-in rather than a
+  default release or CI behavior.
 
 ### Fixed
 
-- Review-map reproduction commands now preserve the actual relative
-  `--review-packet-dir` instead of always showing `.tokmd/review` or leaking
-  absolute local paths.
-- UTF-8-sensitive analysis paths avoid byte/character index panics around
-  ternary `?` tokens after multibyte input.
-- Content tag counting now treats empty tags as zero matches and respects
-  Unicode identifier boundaries instead of matching inside non-ASCII words.
-- Context policy classification now normalizes Windows separators and matches
-  vendor, fixture, and generated directories by exact path segment instead of
-  broad substring matches.
-- Python/FFI JSON settings now reject `paths: null` consistently, keep other
-  nullable option fields on their defaults, and make PyO3 extension-module
+- Cockpit reproduction: review-map reproduction commands preserve the actual
+  relative `--review-packet-dir` instead of always showing `.tokmd/review` or
+  leaking absolute local paths.
+- FFI and Python settings: JSON settings reject `paths: null` consistently,
+  keep other nullable option fields on defaults, and make PyO3 extension-module
   behavior opt-in for the test harness.
-- Average-line rounding avoids integer overflow on very large code totals.
-- Complexity histogram Markdown handles narrow and zero-width rendering cases
-  without malformed ASCII bars.
-- Redacted safe-extension handling was tightened for compound and case-varied
-  extensions.
-- Browser token rejection and worker progress states now surface clearer
+- Unicode/content handling: UTF-8-sensitive analysis paths avoid
+  byte/character index panics, and content tag counting treats empty tags as
+  zero matches while respecting Unicode identifier boundaries.
+- Context policy paths: Windows separators are normalized, and vendor, fixture,
+  and generated directories match by exact path segment instead of broad
+  substring matches.
+- Numeric and rendering edges: average-line rounding avoids integer overflow,
+  and complexity histogram Markdown handles narrow and zero-width rendering
+  cases without malformed ASCII bars.
+- Browser feedback: token rejection and worker progress states surface clearer
   browser-runner feedback.
-- RIPR GitHub annotation rendering moved out of a Python helper into
-  `cargo xtask ripr-annotations`.
-- Generated coverage work was restacked into narrow keeper tests for cockpit
-  review maps, cockpit comments, derived Markdown rendering, core FFI parsing,
-  effort helpers, complexity spans, proof-evidence model strings, and git
-  fixture signing.
+- Test determinism: git fixture signing and generated coverage work were
+  restacked into narrow keeper tests for cockpit review maps, cockpit comments,
+  derived Markdown, core FFI parsing, effort helpers, complexity spans,
+  proof-evidence model strings, git behavior, and in-memory row collection.
+- Handoff smoke friction: generated `work-order.md` no longer tells readers to
+  read itself from inside the work order.
 
-### Internal
+### Internal / Governance
 
-- Added doc-artifact policy, receipt, CI upload, source-of-truth routing, and
-  cockpit import support so documentation-control evidence can appear in review
-  packets.
-- Added review-packet verifier receipts and tighter review-packet contract
-  documentation.
-- Added AST shadow fixture corpora, corpus manifests, comparison summaries,
-  timing receipts, verifier checks, and proof routing for the shadow lane.
-- Added proof observation decision artifacts, hosted proof workflow status
-  evidence, and verifier checks while preserving non-required/advisory behavior.
-- Added publishing-evidence and release-readiness plans, guides, glossary
-  entries, and closeouts without adding a release mutation command.
-- Added targeted tests and refactors across cockpit, handoff, analysis, format,
-  scan, gate, core, and types to lock behavior behind the new evidence
-  consumption paths.
+- Codex/Jules boundary: `.jules/**` remains Jules provenance and ambient
+  suggestion state, while Codex uses repo docs, accepted plans/specs/ADRs,
+  AGENTS.md, and `.codex` guidance as its operating surface.
+- PR-bound Codex policy: implementation, review, release-prep, PR-drain, and
+  changelog work authorize scoped commits, pushes, PR updates, and aligned
+  merges after validation without redundant permission prompts.
+- Generated PR triage: generated PRs were treated as scouts, with narrow
+  correctness/test/release-surface keepers merged and duplicate or broad
+  generated branches closed, parked, or superseded.
+- Source-of-truth and doc-artifact enforcement: doc-artifact policy, receipts,
+  CI upload, source-of-truth routing, and cockpit import support make
+  documentation-control evidence visible in review packets.
+- Known boundaries: 1.11 does not add `tokmd review`, proof promotion, default
+  Codecov upload, default AST-backed output, evidencebus runtime integration,
+  a release-readiness wrapper receipt, browser/native parity claims, or release
+  mutation without explicit maintainer action.
 
 ## [1.10.0] - 2026-04-30
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ schemas, and verification policy for `tokmd`.
   evidence checks without publishing, tagging, or creating releases.
 - [releases/1.11.md](releases/1.11.md) — draft release notes for the 1.11
   evidence-consumption release.
+- [releases/1.11-ledger.md](releases/1.11-ledger.md) — lane-by-lane maintainer
+  ledger for the 1.11 evidence-consumption release.
 - [reference-cli.md](reference-cli.md) — generated CLI flag reference.
 - [SCHEMA.md](SCHEMA.md) — receipt format documentation.
 - [architecture.md](architecture.md) — crate hierarchy and data flow.

--- a/docs/releases/1.11-ledger.md
+++ b/docs/releases/1.11-ledger.md
@@ -1,0 +1,470 @@
+# tokmd 1.11 Release Ledger
+
+## Purpose
+
+tokmd 1.11 is the evidence-consumption release. It turns the existing code
+intelligence pieces into a clearer set of user jobs:
+
+- inspect a repository;
+- review a PR with a cockpit packet;
+- hand a bounded work order to a coding agent;
+- read CI and proof evidence without treating advisory telemetry as a gate;
+- try browser mode as a no-install lens before moving to native evidence;
+- verify publishing and release readiness before any release mutation.
+
+This ledger is a lane-by-lane release record. It is intentionally not a flat PR
+index. The 1.11 cycle covers hundreds of merged PRs, including generated scout
+PRs, badge refreshes, follow-up tests, release-surface cleanup, and narrow
+correctness fixes. The entries below identify the durable release lanes, why
+they matter, representative PRs, validation patterns, and explicit boundaries.
+
+## Source Range
+
+- Previous stable release: `v1.10.0`
+- Candidate release version: `1.11.0`
+- Candidate release head at final preflight: `aaa0cd0e`
+- Primary release-note companion: [1.11 release notes](1.11.md)
+- Pre-release checks: [release readiness](../release-readiness.md)
+
+Representative PRs are examples, not an exhaustive list. Generated badge
+refreshes and duplicate scout PRs are summarized by lane rather than listed one
+by one.
+
+## Lane Summary
+
+| Lane | Outcome | Representative PRs | User impact |
+| --- | --- | --- | --- |
+| Cockpit review packets | Review packets became a review-first evidence surface with priority reasons, reproduction commands, and verifier receipts. | #2335, #2343, #2352 | Reviewers can open `review-map.md` first and know what to inspect. |
+| Agent handoff | Handoff bundles gained actionable work orders and linked evidence handles. | #2330, #2346, #2364, #2365, #2405 | Coding agents start from bounded context and proof expectations. |
+| Proof and CI receipts | Proof planning, proof status, mutation scope, and RIPR annotations moved toward Rust-owned receipts. | #2294, #2307, #2310, #2311, #2312, #2313, #2314, #2350 | CI owners can distinguish required proof, advisory proof, and missing evidence. |
+| User-path docs | First-run docs now route by job instead of internal subsystem. | #2323, #2324, #2336, #2342, #2361, #2363, #2369 | New maintainers can install, inspect, review, hand off, and read evidence without repo lore. |
+| Publishing and release evidence | Release-facing docs and checks align around package surface, version consistency, affected proof, and proof-plan evidence. | #2360, #2367, #2368, #2370, #2371, #2403 | Release maintainers can verify readiness before tagging or publishing. |
+| Browser and WASM adoption | Browser mode is framed as a no-install trial lens with explicit native-only boundaries. | #2366, #2355 | Users can try tokmd in browser without assuming native parity. |
+| AST shadow evidence | AST work produces developer-facing comparison and timing evidence while staying out of default output. | #1780, #1781, #2241, #2242, #2251, #2254, #2255, #2265, #2266, #2273 | Maintainers can evaluate AST-backed analysis without changing public receipts. |
+| Correctness hardening | Release-path correctness fixes landed for FFI, Unicode, path classification, rounding, rendering, and review reproduction. | #2352, #2377, #2378, #2379, #2380, #2382 | The public evidence surfaces are less brittle under edge cases. |
+| Test coverage keepers | Generated coverage work was reduced to narrow keeper tests. | #2316, #2317, #2318, #2319, #2321, #2337, #2338, #2339, #2340, #2341, #2344, #2345, #2386, #2387 | The release keeps useful coverage without absorbing broad generated churn. |
+| Generated PR disposition | Generated and duplicate PRs were mined for keeper slices, merged narrowly, or closed with superseded/deferred rationale. | #2377, #2378, #2380, #2382, #2386, #2387 | The release narrative stays product-driven rather than queue-driven. |
+| Agent governance | Codex and Jules responsibilities were separated; PR-bound Codex work no longer stops for redundant commit/push permission. | #2395, #2396 | Agents can keep release work moving while preserving release and destructive-operation guardrails. |
+
+## User-Facing Adoption Surfaces
+
+### What Landed
+
+The documentation now starts from jobs: inspect a repository, review a PR,
+prepare a handoff, read CI/proof evidence, run browser mode, and collect
+release evidence. The main adoption path is spread across `start-here.md`,
+`install-and-try.md`, `user-paths.md`, `workflows.md`, sample artifact trees,
+the GitHub Action quickstart, browser docs, and release-readiness docs.
+
+### Why It Matters
+
+1.11 is the first release where a new maintainer can start from an intended job
+instead of learning the internal receipt graph first.
+
+### Representative PRs
+
+- #2323 defined the user-path evidence-consumption lane.
+- #2324 added sample artifact walkthroughs.
+- #2336 added copy-ready user workflows.
+- #2342 closed the user-path evidence lane.
+- #2361 added install-and-try guidance.
+- #2362 added the GitHub Action quickstart.
+- #2363 recorded a user-path smoke run.
+- #2369 compressed the README first-run path.
+
+### Validation Pattern
+
+- `cargo xtask docs --check`
+- `cargo xtask doc-artifacts --check`
+- user-path smoke: install or local path install, inspect output, cockpit
+  packet, review-packet check, affected proof, proof plan, required proof, and
+  handoff bundle generation.
+
+### Deferred
+
+This lane does not claim that every browser or Action path is equivalent to
+native local execution. Browser mode remains a trial lens.
+
+## Cockpit / Review Packet
+
+### What Landed
+
+Cockpit review packets became the PR-review evidence surface. Review maps now
+explain priority reasons, expose evidence states, preserve reproduction
+commands, and are paired with verifier receipts.
+
+### Why It Matters
+
+Reviewers can open `.tokmd/review/review-map.md` first and see what changed,
+what to review first, why it is first, what evidence exists, and what evidence
+is missing, stale, degraded, skipped, or unavailable.
+
+### Representative PRs
+
+- #2335 explained review-map priority reasons.
+- #2343 covered review-map predicates and ordering.
+- #2352 fixed review-map reproduction commands to preserve the actual
+  `--review-packet-dir`.
+- #2403 aligned the release note around review packets as a user-facing surface.
+
+### Validation Pattern
+
+- `tokmd cockpit --base origin/main --head HEAD --review-packet-dir .tokmd/review`
+- `cargo xtask review-packet-check --dir .tokmd/review --json target/tokmd/review-packet-check.json`
+- focused cockpit tests for review-map rendering, comments, proof-evidence
+  strings, and artifact verdicts.
+
+### Deferred
+
+The packet is review evidence, not a merge verdict. 1.11 does not add a public
+`tokmd review` command.
+
+## Handoff / Agent Work Order
+
+### What Landed
+
+`tokmd handoff` now emits a work-order-centered agent bundle. The work order
+names changed surfaces, linked review evidence, linked proof evidence, proof
+expectations, missing evidence, stop conditions, and guardrails. Optional
+`review-links.json` and `proof-links.json` connect handoff bundles to cockpit
+packets and affected/proof-plan artifacts.
+
+### Why It Matters
+
+Coding agents can start from `.handoff/work-order.md` and `.handoff/code.txt`
+without expanding scope or claiming proof from a plan that has not executed.
+
+### Representative PRs
+
+- #2330 made handoff work orders actionable.
+- #2346 split linked-evidence rendering into owner modules.
+- #2364 added the handoff prompt template.
+- #2365 covered the work-order contract.
+- #2405 removed a real adoption-smoke self-reference in `work-order.md`.
+
+### Validation Pattern
+
+- `tokmd handoff --preset risk --budget 128k --strategy spread --review-packet-dir .tokmd/review --review-packet-check target/tokmd/review-packet-check.json --affected target/proof/affected.json --proof-plan target/proof/proof-plan.json --out-dir .handoff`
+- `cargo test -p tokmd --test handoff_integration --verbose`
+- affected proof and required proof for changed handoff surfaces.
+
+### Deferred
+
+Handoff output does not verify linked review or proof receipts by itself. It
+names handles and expectations; operators still run required proof before
+claiming completion.
+
+## Proof Orchestration And Receipts
+
+### What Landed
+
+Proof planning, proof-run observation, workflow status, mutation scope, and
+RIPR annotation outputs moved toward Rust-owned `xtask` receipts. The proof
+policy now makes default PR proof behavior readable without turning advisory
+telemetry into a gate.
+
+### Why It Matters
+
+CI owners can inspect required proof, advisory proof, missing evidence, stale
+evidence, coverage telemetry, mutation telemetry, and promotion criteria as
+evidence. The output explains what was planned, what ran, and what remains
+advisory.
+
+### Representative PRs
+
+- #2294 summarized mutation results in Rust.
+- #2307 routed mutation scope through `xtask`.
+- #2309 defined the proof workflow status contract.
+- #2310 emitted proof workflow status packets.
+- #2311 and #2312 wired hosted proof workflow status packets.
+- #2313 recorded hosted proof workflow status evidence.
+- #2314 closed the proof workflow status lane.
+- #2350 implemented `ripr-annotations` in `xtask`.
+
+### Validation Pattern
+
+- `cargo xtask proof-policy --check`
+- `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json`
+- `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan.json --evidence-json target/proof/proof-evidence.json`
+- required affected proof when selected.
+
+### Deferred
+
+Proof remains advisory unless a maintainer explicitly promotes a check. Codecov
+upload remains opt-in and disabled by default.
+
+## Publishing / Release Evidence
+
+### What Landed
+
+Release-facing docs now describe pre-release evidence rather than release
+approval. The 1.11 release path centers on package-surface classification,
+version consistency, affected-proof routing, proof-plan generation, and
+release-readiness checks.
+
+### Why It Matters
+
+Release maintainers can verify readiness before any tag, GitHub release,
+crates.io publish, major Action alias movement, or image publication.
+
+### Representative PRs
+
+- #2360 planned release distribution readiness.
+- #2367 added release evidence quickstart material.
+- #2368 decided against a release-readiness wrapper receipt.
+- #2370 closed the release distribution readiness lane.
+- #2371 cleaned up `1.11.0` release surfaces.
+- #2403 expanded the 1.11 changelog and release note.
+
+### Validation Pattern
+
+- `cargo xtask version-consistency`
+- `cargo xtask publish-surface --json --verify-publish`
+- `cargo xtask doc-artifacts --check`
+- `cargo xtask docs --check`
+- `cargo xtask proof-policy --check`
+- affected/proof-plan receipts for release-facing changes.
+
+### Deferred
+
+1.11 release evidence does not publish crates, create tags, create GitHub
+releases, move `v1`, or push images. Those are separate explicit maintainer
+decisions.
+
+## Browser / WASM
+
+### What Landed
+
+Browser docs and current-facing WASM artifact references were aligned around
+the staged `v1.11.0` artifact shape. Browser mode is described as a no-install
+trial lens with a documented path to native review packets, handoff bundles,
+and CI evidence.
+
+### Why It Matters
+
+Users can try tokmd without installing native tooling and still understand when
+they need native commands for git history, review packets, handoffs, and proof.
+
+### Representative PRs
+
+- #2355 clarified compatibility wasm-pack test arguments.
+- #2366 added the browser-to-native adoption path.
+- #2371 aligned release-facing browser/WASM surfaces.
+- #2403 carried the browser/native boundary into release notes.
+
+### Validation Pattern
+
+- `npm --prefix web/runner test`
+- `npm --prefix web/runner run check`
+- WASM/browser release docs and artifact examples in release-facing docs.
+
+### Deferred
+
+Browser mode does not claim native parity and does not make native-only
+enrichers available in the browser.
+
+## AST Shadow Evidence
+
+### What Landed
+
+The AST lane added developer-facing fixture corpora, corpus manifests,
+comparison summaries, timing receipts, verifier checks, and proof routing for
+Tree-sitter-backed Rust landmark comparison.
+
+### Why It Matters
+
+Maintainers can evaluate AST-backed analysis with concrete shadow evidence
+without changing public analyze, cockpit, context, handoff, browser, or receipt
+behavior.
+
+### Representative PRs
+
+- #1780 scaffolded AST shadow analysis.
+- #1781 parsed Rust AST shadow landmarks.
+- #2241 defined the AST shadow artifact contract.
+- #2242 built AST shadow artifacts.
+- #2251 added the AST shadow comparison runner.
+- #2254 verified AST shadow artifacts.
+- #2255 summarized AST shadow comparisons.
+- #2265 added the AST shadow corpus manifest.
+- #2266 compared AST shadow corpus manifests.
+- #2273 timed AST shadow corpus comparisons.
+- #2403 carried the AST boundary into the release note.
+
+### Validation Pattern
+
+- AST shadow verifier checks.
+- AST shadow fixture and summary receipts.
+- Proof routing for the shadow lane.
+
+### Deferred
+
+AST remains shadow-only. There is no default AST-backed output in 1.11.
+
+## Correctness Hardening
+
+### What Landed
+
+The release path includes narrow correctness fixes for user-visible evidence
+surfaces and edge cases.
+
+### Why It Matters
+
+The evidence surfaces are only useful if they do not break on realistic inputs,
+Windows paths, generated directories, large values, or narrow rendering widths.
+
+### Representative PRs
+
+- #2352 preserved actual review-packet reproduction directories.
+- #2377 hardened content tag counting around empty tags and Unicode boundaries.
+- #2378 fixed average-line rounding overflow.
+- #2379 hardened context policy path classification.
+- #2380 rejected null Python/FFI `paths` consistently.
+- #2382 hardened complexity histogram ASCII rendering.
+- #2405 removed the handoff work-order self-reference found by adoption smoke.
+
+### Validation Pattern
+
+- Focused regression tests for each fix.
+- Affected/proof-plan receipts for changed surfaces.
+- Required affected proof when selected.
+
+### Deferred
+
+Correctness fixes are scoped to observed release-path friction and edge cases.
+They do not reopen broad architecture cleanup.
+
+## Test Coverage Keepers
+
+### What Landed
+
+Generated coverage suggestions were restacked into narrow keeper tests where
+they protected actual contracts or edge cases.
+
+### Why It Matters
+
+The release absorbed useful coverage without letting generated PRs dictate the
+roadmap or inflate the queue.
+
+### Representative PRs
+
+- #2316 hardened cockpit workflow doctests.
+- #2317 covered `tokmd-gate` policy modules.
+- #2318 covered scan path validation.
+- #2319 covered cockpit diff coverage and change surface.
+- #2321 added `tokmd-types` serde roundtrip and invariant tests.
+- #2337 covered effort helper boundaries.
+- #2338 covered complexity span dispatch.
+- #2339 covered effort Markdown rendering.
+- #2340 covered proof-evidence model strings.
+- #2341 disabled signing in git fixture repos.
+- #2343 covered review-map predicates and ordering.
+- #2344 covered derived Markdown rendering.
+- #2345 covered core FFI parse helpers.
+- #2386 covered in-memory row collection.
+- #2387 strengthened `tokmd-git` unit coverage.
+
+### Validation Pattern
+
+- Focused crate and integration tests.
+- Affected/proof-plan routing.
+- Hosted CI on merged keeper PRs.
+
+### Deferred
+
+Coverage-only PRs that did not restack cleanly or protect a release-relevant
+contract were closed, parked, or superseded.
+
+## Generated PR Queue Disposition
+
+### What Landed
+
+Generated PRs were treated as scouts. Narrow correctness, test, and
+release-surface keepers were merged; duplicates and broad refactors were closed
+or deferred with concrete rationale.
+
+### Why It Matters
+
+The release stayed coherent. It did not become a queue cleanup release, and it
+did not let generated churn replace the release story.
+
+### Representative PRs
+
+- #2377, #2378, #2380, #2382, #2386, and #2387 are examples of keeper slices.
+- #2401, #2402, and #2404 are representative public badge refreshes.
+- Duplicate and superseded generated PRs were closed rather than merged by
+  momentum.
+
+### Validation Pattern
+
+- One semantic change per keeper PR.
+- Affected/proof-plan before merge.
+- Focused local tests plus hosted checks.
+- Explicit close/defer rationale for non-keepers.
+
+### Deferred
+
+Broad refactors, stale generated branches, and non-release blockers remain out
+of 1.11.
+
+## Agent Governance / Codex Vs Jules
+
+### What Landed
+
+Agent guidance now separates Codex operating state from Jules provenance and
+allows PR-bound Codex work to commit, push, open/update PRs, and merge aligned
+PRs after validation without redundant permission prompts.
+
+### Why It Matters
+
+Release work can continue PR by PR while still preserving guardrails around
+read-only requests, destructive operations, release mutation, secrets, broad
+ambiguous diffs, and unrelated user changes.
+
+### Representative PRs
+
+- #2395 allowed PR-bound Codex commit and push flow.
+- #2396 separated Codex control from Jules provenance.
+
+### Validation Pattern
+
+- Docs/doc-artifacts/proof-policy checks.
+- Affected/proof-plan routing for guidance changes.
+- Hosted checks before merge.
+
+### Deferred
+
+Jules suggestions remain useful candidate evidence. They are not Codex's
+primary active-lane controller.
+
+## Known Boundaries
+
+1.11 deliberately does not ship:
+
+- a public `tokmd review` command;
+- proof promotion or required-gate expansion;
+- default Codecov upload;
+- default AST-backed analyze, cockpit, context, handoff, browser, or receipt
+  output;
+- evidencebus runtime integration inside tokmd;
+- a release-readiness wrapper receipt;
+- browser/native parity claims;
+- release mutation without explicit maintainer action.
+
+## Pre-Release Evidence Checklist
+
+Before tagging, verify:
+
+```bash
+cargo xtask version-consistency
+cargo xtask publish-surface --json --verify-publish
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-1-11.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-1-11.json --evidence-json target/proof/proof-evidence-release-1-11.json
+```
+
+If required affected proof is selected, run it before claiming release
+readiness. These commands are evidence. They do not tag, publish, create a
+GitHub release, move aliases, or push images.

--- a/docs/releases/1.11.md
+++ b/docs/releases/1.11.md
@@ -4,6 +4,9 @@ tokmd 1.11 is an evidence-consumption release. It makes the existing code
 intelligence surfaces easier to use for PR review, coding-agent handoff, CI
 evidence, browser trials, and release preparation.
 
+For a lane-by-lane maintainer record, see the
+[1.11 release ledger](1.11-ledger.md).
+
 The release does not add a `tokmd review` command, promote proof gates, enable
 Codecov upload by default, make AST-backed output public by default, or perform
 release mutation outside the explicit release workflow.


### PR DESCRIPTION
## Summary
- add docs/releases/1.11-ledger.md as a lane-by-lane maintainer release record
- expand CHANGELOG.md's 1.11.0 entry by release lane instead of flat PR listing
- link the release note and docs index to the ledger

## Scope
Docs/release-record only. No release workflow changes, no release mutation, no proof promotion, no Codecov default, no AST default behavior, no tokmd review command, and no evidencebus runtime.

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask proof-policy --check
- cargo xtask docs --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-ledger.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-ledger.json --evidence-json target/proof/proof-evidence-release-ledger.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --plan-json target/proof/proof-plan-release-ledger.json --proof-run-summary target/proof/proof-run-summary-release-ledger.json
- git diff --check origin/main...HEAD

## Source range
- Previous stable release: v1.10.0
- Candidate release head while drafting: aaa0cd0e
- Representative PRs were gathered from merged PR history after v1.10.0 and existing 1.11 release docs.