### PR TITLE
docs(release): polish 1.11 release record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ packets, coding-agent handoffs, proof receipts, browser/native guidance, and
 release evidence now compose into practical workflows without promoting
 advisory checks or changing public AST behavior.
 
+This changelog is the concise release index. For the maintainer audit trail,
+see `docs/releases/1.11-ledger.md`.
+
 ### Added
 
 - Review packets and cockpit evidence: cockpit packets now surface

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ schemas, and verification policy for `tokmd`.
   surface, metadata, and CI ownership evidence before release mutation.
 - [release-readiness.md](release-readiness.md) — quickstart for pre-release
   evidence checks without publishing, tagging, or creating releases.
-- [releases/1.11.md](releases/1.11.md) — draft release notes for the 1.11
+- [releases/1.11.md](releases/1.11.md) — user-facing release notes for the 1.11
   evidence-consumption release.
 - [releases/1.11-ledger.md](releases/1.11-ledger.md) — lane-by-lane maintainer
   ledger for the 1.11 evidence-consumption release.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -8,16 +8,24 @@ release.
 
 ## Run First
 
+Check version alignment:
+
+```bash
+cargo xtask version-consistency
+```
+
 Check the package surface:
 
 ```bash
 cargo xtask publish-surface --json --verify-publish
 ```
 
-Check version alignment:
+Check docs and proof policy control surfaces:
 
 ```bash
-cargo xtask version-consistency
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
 ```
 
 If release metadata, workflow files, package manifests, `CHANGELOG.md`, or
@@ -40,12 +48,13 @@ cargo xtask proof \
 
 ## Open First
 
-1. `publish-surface --json --verify-publish` output.
-2. `version-consistency` output.
-3. `target/proof/affected-release.json`, when release-facing files changed.
-4. `target/proof/proof-plan-release.json`, when you need the required and
+1. `version-consistency` output.
+2. `publish-surface --json --verify-publish` output.
+3. `doc-artifacts --check`, `docs --check`, and `proof-policy --check` output.
+4. `target/proof/affected-release.json`, when release-facing files changed.
+5. `target/proof/proof-plan-release.json`, when you need the required and
    advisory proof command list.
-5. `target/proof/proof-evidence-release.json`, when you need the planned
+6. `target/proof/proof-evidence-release.json`, when you need the planned
    evidence receipt.
 
 If a CI job or maintainer script saves the first two outputs, use:
@@ -59,8 +68,11 @@ target/publishing/version-consistency.txt
 
 | Check | Means | Does not mean |
 | --- | --- | --- |
-| `publish-surface --json --verify-publish` | Package taxonomy, non-dev publish closure, and package-list checks are valid for the checked workspace state. | Crates were published, crates.io has the version, or release mutation is approved. |
 | `version-consistency` | Workspace, package, binding, and release metadata versions are aligned. | Package closure is valid or artifacts were uploaded. |
+| `publish-surface --json --verify-publish` | Package taxonomy, non-dev publish closure, and package-list checks are valid for the checked workspace state. | Crates were published, crates.io has the version, or release mutation is approved. |
+| `doc-artifacts --check` | Required documentation-control artifacts are present and wired into policy. | The docs are complete, current, or release-approved. |
+| `docs --check` | Generated or checked documentation surfaces are current for this workspace state. | The release note is sufficient or user adoption has been proven. |
+| `proof-policy --check` | Proof policy parses and preserves its configured gate/upload behavior. | Proof was promoted or Codecov upload is enabled. |
 | `affected` | Changed files route to proof scopes, and unknown files are explicit. | Proof commands ran. |
 | `proof --profile affected --plan` | Required and advisory proof commands selected for the changed surface. | Planned proof passed. |
 
@@ -70,6 +82,7 @@ Stop before release mutation when:
 
 - `publish-surface` reports any violation;
 - `version-consistency` fails;
+- `doc-artifacts`, `docs`, or `proof-policy` checks fail;
 - affected planning reports unknown release or publishing files;
 - required proof selected by the affected plan has not run or is failing;
 - release approval, tag creation, GitHub release creation, crates.io publish,
@@ -80,8 +93,9 @@ Stop before release mutation when:
 For an ordinary PR:
 
 1. Keep package-surface and version checks green.
-2. Confirm release-facing files route to known proof scopes.
-3. Do not change release workflow behavior unless the PR is explicitly about
+2. Keep docs and proof-policy checks green.
+3. Confirm release-facing files route to known proof scopes.
+4. Do not change release workflow behavior unless the PR is explicitly about
    release automation.
 
 For release preparation:
@@ -94,6 +108,8 @@ For release preparation:
 
 Related:
 
+- [1.11 release notes](releases/1.11.md)
+- [1.11 release ledger](releases/1.11-ledger.md)
 - [Publishing evidence](publishing-evidence.md)
 - [Publish surface policy](publish-surface.md)
 - [Publishing evidence tree](examples/publishing-evidence-tree.md)

--- a/docs/releases/1.11-ledger.md
+++ b/docs/releases/1.11-ledger.md
@@ -22,13 +22,20 @@ they matter, representative PRs, validation patterns, and explicit boundaries.
 
 - Previous stable release: `v1.10.0`
 - Candidate release version: `1.11.0`
-- Candidate release head at final preflight: `aaa0cd0e`
+- Ledger introduced by: `#2406` at `3690fcc5`
+- Release-surface inventory snapshot used to build the ledger: `aaa0cd0e`
 - Primary release-note companion: [1.11 release notes](1.11.md)
 - Pre-release checks: [release readiness](../release-readiness.md)
 
 Representative PRs are examples, not an exhaustive list. Generated badge
 refreshes and duplicate scout PRs are summarized by lane rather than listed one
 by one.
+
+## How To Read This Ledger
+
+Use `CHANGELOG.md` for the concise release index, `1.11.md` for the
+user-facing release note, this ledger for the lane-by-lane maintainer record,
+and `docs/release-readiness.md` for command-backed preflight.
 
 ## Lane Summary
 

--- a/docs/releases/1.11.md
+++ b/docs/releases/1.11.md
@@ -4,8 +4,9 @@ tokmd 1.11 is an evidence-consumption release. It makes the existing code
 intelligence surfaces easier to use for PR review, coding-agent handoff, CI
 evidence, browser trials, and release preparation.
 
-For a lane-by-lane maintainer record, see the
-[1.11 release ledger](1.11-ledger.md).
+Use this page as the user-facing release note. For a lane-by-lane maintainer
+record, see the [1.11 release ledger](1.11-ledger.md). For the command-first
+preflight path, see [release readiness](../release-readiness.md).
 
 The release does not add a `tokmd review` command, promote proof gates, enable
 Codecov upload by default, make AST-backed output public by default, or perform


### PR DESCRIPTION
## Summary
- clarify that CHANGELOG.md is the concise 1.11 release index and the ledger is the maintainer audit trail
- correct the 1.11 ledger source-range wording so it records the ledger-introduction PR and inventory snapshot without becoming stale on later docs edits
- align release-readiness docs with the actual 1.11 preflight checks: version consistency, publish-surface, doc-artifacts, docs, proof-policy, affected planning, and required proof

## Scope
Docs/changelog only. No release workflow behavior change, release mutation, proof promotion, default Codecov upload, AST default behavior, evidencebus runtime, release-readiness wrapper receipt, or public tokmd review command.

## Validation
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-doc-polish.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-doc-polish.json --evidence-json target/proof/proof-evidence-doc-polish.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --plan-json target/proof/proof-plan-doc-polish.json --proof-run-summary target/proof/proof-run-summary-doc-polish.json

Required affected proof summary: 5 planned, 5 executed, 5 passed, 0 failed, 0 unknown files.