### PR TITLE
docs(agent): clarify release-prep PR lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,9 +278,18 @@ cargo +nightly fuzz list  # List all targets
   - the change is not worth merging in the current phase
 
 ### Release-prep queue discipline
-- During prep or RC hardening, every open PR must either be a real blocker/improvement worth finishing now or remain explicitly parked for later.
-- “Not for prep” does not automatically mean “close now”.
-- If a PR may still be worth keeping, leave it open or restack it; do not churn the queue without a concrete reason.
+- Never close a PR merely because a release is near.
+- During prep or RC hardening, classify each open PR by substance: release
+  blocker, safe aligned change, useful non-blocking work, duplicate of a
+  merged keeper, invalid/incorrect work, stale branch needing restack, or
+  explicitly declined work.
+- Merge release blockers and safe aligned PRs after validation. Leave useful
+  non-blocking PRs open, parked, labeled, or restacked for later.
+- Close a PR only for an intrinsic reason: it is invalid, duplicated or
+  superseded by a merged keeper, stale beyond practical restack, conflicts with
+  accepted direction, or was explicitly declined.
+- Queue cleanliness is not a release criterion. Release readiness is proven by
+  preflight, release-record accuracy, and clean release-surface evidence.
 
 ## Codex Commit / Push Policy
 

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -53,6 +53,24 @@ Ask before committing, pushing, or merging only when:
 - the diff is broad or ambiguous relative to the requested lane;
 - the worktree contains unrelated user changes that cannot be isolated safely.
 
+## Release-Prep PR Lifecycle
+
+Never close a PR merely because a release is near.
+
+During prep or RC hardening, classify each open PR by substance: release
+blocker, safe aligned change, useful non-blocking work, duplicate of a merged
+keeper, invalid or incorrect work, stale branch needing restack, or explicitly
+declined work.
+
+Merge release blockers and safe aligned PRs after validation. Leave useful
+non-blocking PRs open, parked, labeled, or restacked for later. Close a PR only
+when it is intrinsically invalid, duplicated or superseded by a merged keeper,
+stale beyond practical restack, conflicts with accepted direction, or was
+explicitly declined.
+
+Queue cleanliness is not a release criterion. Release readiness is proven by
+preflight, release-record accuracy, and clean release-surface evidence.
+
 ## Architecture
 
 The codebase follows a tiered crate-and-module architecture:

--- a/docs/releases/1.11-ledger.md
+++ b/docs/releases/1.11-ledger.md
@@ -50,7 +50,7 @@ and `docs/release-readiness.md` for command-backed preflight.
 | AST shadow evidence | AST work produces developer-facing comparison and timing evidence while staying out of default output. | #1780, #1781, #2241, #2242, #2251, #2254, #2255, #2265, #2266, #2273 | Maintainers can evaluate AST-backed analysis without changing public receipts. |
 | Correctness hardening | Release-path correctness fixes landed for FFI, Unicode, path classification, rounding, rendering, and review reproduction. | #2352, #2377, #2378, #2379, #2380, #2382 | The public evidence surfaces are less brittle under edge cases. |
 | Test coverage keepers | Generated coverage work was reduced to narrow keeper tests. | #2316, #2317, #2318, #2319, #2321, #2337, #2338, #2339, #2340, #2341, #2344, #2345, #2386, #2387 | The release keeps useful coverage without absorbing broad generated churn. |
-| Generated PR disposition | Generated and duplicate PRs were mined for keeper slices, merged narrowly, or closed with superseded/deferred rationale. | #2377, #2378, #2380, #2382, #2386, #2387 | The release narrative stays product-driven rather than queue-driven. |
+| Generated PR disposition | Generated and duplicate PRs were mined for keeper slices; PRs were merged, parked, restacked, or closed only for substantive reasons. | #2377, #2378, #2380, #2382, #2386, #2387 | The release narrative stays product-driven rather than queue-driven. |
 | Agent governance | Codex and Jules responsibilities were separated; PR-bound Codex work no longer stops for redundant commit/push permission. | #2395, #2396 | Agents can keep release work moving while preserving release and destructive-operation guardrails. |
 
 ## User-Facing Adoption Surfaces
@@ -387,32 +387,37 @@ contract were closed, parked, or superseded.
 ### What Landed
 
 Generated PRs were treated as scouts. Narrow correctness, test, and
-release-surface keepers were merged; duplicates and broad refactors were closed
-or deferred with concrete rationale.
+release-surface keepers were merged. Other generated PRs were parked, restacked,
+or closed only when the PR itself was duplicated, superseded, invalid, stale
+beyond practical restack, or explicitly declined on substance.
 
 ### Why It Matters
 
-The release stayed coherent. It did not become a queue cleanup release, and it
-did not let generated churn replace the release story.
+The release stayed coherent without making queue cleanliness a release
+criterion. Release prep classified work by substance and kept generated churn
+from replacing the release story.
 
 ### Representative PRs
 
 - #2377, #2378, #2380, #2382, #2386, and #2387 are examples of keeper slices.
 - #2401, #2402, and #2404 are representative public badge refreshes.
-- Duplicate and superseded generated PRs were closed rather than merged by
-  momentum.
+- Duplicate and superseded generated PRs were closed only when the duplicate or
+  superseded state was intrinsic to the PR.
 
 ### Validation Pattern
 
 - One semantic change per keeper PR.
 - Affected/proof-plan before merge.
 - Focused local tests plus hosted checks.
-- Explicit close/defer rationale for non-keepers.
+- Explicit classification for non-keepers: park, restack, label, or close for a
+  substantive reason.
 
 ### Deferred
 
-Broad refactors, stale generated branches, and non-release blockers remain out
-of 1.11.
+Broad refactors and useful non-blocking generated branches may remain open,
+parked, labeled, or restacked across the release. They stay out of 1.11 unless a
+concrete user path proves they are needed, but release proximity alone is not a
+reason to close them.
 
 ## Agent Governance / Codex Vs Jules
 

--- a/docs/templates/active-goal.toml
+++ b/docs/templates/active-goal.toml
@@ -18,7 +18,7 @@ codecov_default_upload = "do_not_enable_without_maintainer_decision"
 product_behavior = "docs_only_lane"
 
 [stop_conditions]
-open_pr_queue = "must_be_empty_before_starting_new_lane"
+open_pr_queue = "must_be_reviewed_and_classified_before_starting_new_lane"
 docs_check = "cargo xtask docs --check"
 proof_policy = "cargo xtask proof-policy --check"
 affected_plan = "cargo xtask affected --base origin/main --head HEAD --json"


### PR DESCRIPTION
## Summary
- clarifies that release proximity alone is not a reason to close PRs
- updates shared agent guidance and the 1.11 ledger to classify, park, restack, or close PRs by substance
- changes the active-goal template queue stop condition from empty to reviewed/classified

## Validation
- cargo xtask docs --check
- cargo xtask doc-artifacts --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-pr-lifecycle.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-pr-lifecycle.json --evidence-json target/proof/proof-evidence-pr-lifecycle.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --plan-json target/proof/proof-plan-pr-lifecycle.json --proof-run-summary target/proof/proof-run-summary-pr-lifecycle.json (31/31 passed)
- git diff --check