### PR TITLE
fix(diff): handle missing file paths outside git

### DIFF
--- a/crates/tokmd/src/commands/diff.rs
+++ b/crates/tokmd/src/commands/diff.rs
@@ -104,8 +104,20 @@ fn resolve_lang_report(input: &str, global: &cli::GlobalArgs) -> Result<LangRepo
     if path.exists() {
         return load_lang_report_from_path(&path);
     }
+    if looks_like_missing_path(input, &path) {
+        bail!("invalid reference or path '{}': path does not exist", input);
+    }
 
     lang_report_from_git_ref(input, global)
+}
+
+fn looks_like_missing_path(input: &str, path: &Path) -> bool {
+    path.is_absolute()
+        || path.extension().is_some()
+        || input.starts_with("./")
+        || input.starts_with("../")
+        || input.starts_with(".\\")
+        || input.starts_with("..\\")
 }
 
 fn load_lang_report_from_path(path: &Path) -> Result<LangReport> {

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -10,6 +10,7 @@ mod common;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use tempfile::tempdir;
 
 fn tokmd_cmd() -> Command {
     Command::new(env!("CARGO_BIN_EXE_tokmd"))
@@ -165,6 +166,28 @@ fn diff_nonexistent_before_after_fails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid reference"));
+}
+
+#[test]
+fn diff_nonexistent_before_after_does_not_require_git_repo() {
+    let cwd = tempdir().unwrap();
+    let p = nonexistent_path();
+    let a = p.join("a.json");
+    let b = p.join("b.json");
+    let mut cmd = tokmd_cmd();
+
+    cmd.current_dir(cwd.path())
+        .arg("diff")
+        .arg("--from")
+        .arg(a.as_os_str())
+        .arg("--to")
+        .arg(b.as_os_str())
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("invalid reference")
+                .and(predicate::str::contains("not inside a git repository").not()),
+        );
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- treats missing absolute/file-like diff inputs as missing paths before trying git-ref resolution
- keeps ordinary git ref resolution available for non-path inputs
- adds a regression test that runs the missing-file diff from a non-git temp directory

## Release repair context
- 1.11.0 tag check Nix Full Validation failed in cargo test -p tokmd --test cli_error_paths_w51
- failing test: diff_nonexistent_before_after_fails
- observed error: missing diff files were reported as 
ot inside a git repository under Nix instead of the expected invalid-reference/missing-path failure

## Validation
- cargo test -p tokmd --test cli_error_paths_w51 diff_nonexistent_before_after --verbose
- cargo test -p tokmd --test cli_error_paths_w51 --verbose
- cargo test -p tokmd --test cli_errors_w66 diff_with_nonexistent_files_produces_error --verbose
- cargo fmt-check
- git diff --check
- cargo xtask proof-policy --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-nix-diff-error.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-nix-diff-error.json --evidence-json target/proof/proof-evidence-nix-diff-error.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --plan-json target/proof/proof-plan-nix-diff-error.json --proof-run-summary target/proof/proof-run-summary-nix-diff-error.json (4/4 required passed; advisory coverage/mutation skipped)

Nix was not available locally; hosted Nix should be the final reproduction check.