### PR TITLE
docs(release): prepare 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-05-19
+
+### Fixed
+
+- `tokmd diff` now reports missing file-like inputs as missing or invalid paths
+  before falling through to git-reference resolution, including outside a git
+  repository.
+- Nix release validation now includes review-packet schema files in the checked
+  source tree and keeps receipt-status tests independent of repository-history
+  availability when Nix check sources intentionally omit `.git`.
+
 ## [1.11.0] - 2026-05-18
 
 1.11 makes tokmd's evidence surfaces easier to consume: cockpit review

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "blake3",
  "proptest",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "proptest",
  "serde",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2688,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "proptest",
  "serde",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3548,7 +3548,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.11.0"
+version = "1.11.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -194,22 +194,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.11.0" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.11.0" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.11.0" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.11.0" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.11.0" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.11.0" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.11.0" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.11.0" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.11.0" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.11.0" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.11.0" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.11.0" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.11.0" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.11.0" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.11.0" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.11.0" }
+tokmd = { path = "crates/tokmd", version = "1.11.1" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.11.1" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.11.1" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.11.1" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.11.1" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.11.1" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.11.1" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.11.1" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.11.1" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.11.1" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.11.1" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.11.1" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.11.1" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.11.1" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.11.1" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.11.1" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.11.0"
+        "version": "1.11.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.11.0"
+        "version": "1.11.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.11.0"
+        "version": "1.11.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.11.0"
+        "version": "1.11.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.11.0"
+        "version": "1.11.1"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.11.0",
-    "@tokmd/core-darwin-x64": "1.11.0",
-    "@tokmd/core-linux-arm64-gnu": "1.11.0",
-    "@tokmd/core-linux-x64-gnu": "1.11.0",
-    "@tokmd/core-win32-x64-msvc": "1.11.0"
+    "@tokmd/core-darwin-arm64": "1.11.1",
+    "@tokmd/core-darwin-x64": "1.11.1",
+    "@tokmd/core-linux-arm64-gnu": "1.11.1",
+    "@tokmd/core-linux-x64-gnu": "1.11.1",
+    "@tokmd/core-win32-x64-msvc": "1.11.1"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.0.0-alpha.66"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.11.0",
-    "@tokmd/core-darwin-x64": "1.11.0",
-    "@tokmd/core-darwin-arm64": "1.11.0",
-    "@tokmd/core-linux-x64-gnu": "1.11.0",
-    "@tokmd/core-linux-x64-musl": "1.11.0",
-    "@tokmd/core-linux-arm64-gnu": "1.11.0",
-    "@tokmd/core-linux-arm64-musl": "1.11.0",
-    "@tokmd/core-win32-arm64-msvc": "1.11.0"
+    "@tokmd/core-win32-x64-msvc": "1.11.1",
+    "@tokmd/core-darwin-x64": "1.11.1",
+    "@tokmd/core-darwin-arm64": "1.11.1",
+    "@tokmd/core-linux-x64-gnu": "1.11.1",
+    "@tokmd/core-linux-x64-musl": "1.11.1",
+    "@tokmd/core-linux-arm64-gnu": "1.11.1",
+    "@tokmd/core-linux-arm64-musl": "1.11.1",
+    "@tokmd/core-win32-arm64-msvc": "1.11.1"
   }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 walkdir = "2"
 tokmd-core = { workspace = true, features = ["analysis"] }
-tokmd-analysis = { path = "../crates/tokmd-analysis", version = "1.11.0", default-features = false, features = ["ast"] }
+tokmd-analysis = { path = "../crates/tokmd-analysis", version = "1.11.1", default-features = false, features = ["ast"] }
 tokmd-analysis-types.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Summary:
- Bumps workspace Cargo metadata, Cargo.lock, xtask internal pin, and Node package manifests to 1.11.1.
- Adds the 1.11.1 changelog entry for the diff missing-path repair and Nix release-validation source repair.
- Keeps this as release metadata only; no dependency bump or workflow behavior change.

Validation:
- cargo xtask version-consistency
- cargo xtask publish-surface --json --verify-publish
- cargo xtask doc-artifacts --check
- cargo xtask docs --check
- cargo xtask proof-policy --check
- cargo fmt-check
- git diff --check
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-1-11-1.json: 6 changed files, 6 scopes, 0 unknown files
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-1-11-1.json --evidence-json target/proof/proof-evidence-release-1-11-1.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution --plan-json target/proof/proof-plan-release-1-11-1.json --proof-run-summary target/proof/proof-run-summary-release-1-11-1.json: 22 required commands executed, 22 passed

Release notes:
- v1.11.1 does not exist yet; gh release view v1.11.1 returned release not found.
- The moving v1 tag was not locally clobbered during fetch; remote v1 currently resolves via ls-remote.