### PR TITLE
ci: fix label color string

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -69,7 +69,7 @@
   description: Good for newcomers
 
 - name: help wanted
-  color: 008672
+  color: "008672"
   description: Extra attention is needed
 
 # Priority


### PR DESCRIPTION
## Summary
- quote the numeric-looking help wanted label color so the label-sync action treats it as a string
- fixes the main-branch sync-labels failure from run 26211086289 after the dual-repo workflow guard merge

## Validation
- cargo xtask check-file-policy
- cargo xtask docs --check
- cargo xtask affected --base public/main --head HEAD --json-output target\\proof\\affected-label-color.json
- git diff --check