### PR TITLE
merge(swarm): import tokmd-swarm RIPR badge pin

### DIFF
--- a/.github/workflows/badge-endpoints.yml
+++ b/.github/workflows/badge-endpoints.yml
@@ -10,6 +10,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  RIPR_VERSION: "0.7.0"
+
 concurrency:
   group: badge-endpoints-${{ github.ref }}
   cancel-in-progress: true
@@ -27,7 +30,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install ripr
-        run: cargo install ripr --locked
+        run: cargo install ripr --version "$RIPR_VERSION" --locked
 
       - name: Refresh badge endpoints
         run: cargo xtask badges

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: -C debuginfo=0
+  RIPR_VERSION: "0.7.0"
 
 jobs:
   ripr:
@@ -35,7 +36,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install ripr
-        run: cargo install ripr --locked
+        run: cargo install ripr --version "$RIPR_VERSION" --locked
 
       - name: Fetch base branch
         if: github.base_ref != ''

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr",
-  "message": "13607",
+  "message": "238",
   "color": "orange"
 }

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -39,6 +39,13 @@ Regenerate public badge endpoints:
 cargo xtask badges
 ```
 
+Badge generation uses `ripr 0.7.0`. If local regeneration reports a version
+drift, install the pinned version or set `RIPR_BIN` to a matching binary:
+
+```bash
+cargo install ripr --version 0.7.0 --locked --force
+```
+
 Check committed endpoint drift:
 
 ```bash

--- a/xtask/src/tasks/badges.rs
+++ b/xtask/src/tasks/badges.rs
@@ -14,6 +14,7 @@ use crate::cli::BadgesArgs;
 
 const BADGE_ENDPOINT_DIR: &str = "badges";
 const BADGE_ENDPOINT_TARGET_DIR: &str = "target/xtask/badges";
+const EXPECTED_RIPR_VERSION: &str = "0.7.0";
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub(crate) struct ShieldsEndpointBadge {
@@ -59,6 +60,7 @@ pub fn run(args: BadgesArgs) -> Result<()> {
 
 fn ripr_badge(workspace_root: &Path) -> Result<ShieldsEndpointBadge> {
     let ripr_bin = std::env::var("RIPR_BIN").unwrap_or_else(|_| "ripr".to_string());
+    validate_ripr_version(&ripr_bin)?;
 
     let output = Command::new(&ripr_bin)
         .arg("check")
@@ -79,6 +81,39 @@ fn ripr_badge(workspace_root: &Path) -> Result<ShieldsEndpointBadge> {
 
     serde_json::from_slice(&output.stdout)
         .with_context(|| format!("{ripr_bin} emitted invalid Shields endpoint JSON"))
+}
+
+fn validate_ripr_version(ripr_bin: &str) -> Result<()> {
+    let output = Command::new(ripr_bin)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("run {ripr_bin} --version"))?;
+
+    if !output.status.success() {
+        bail!(
+            "{ripr_bin} --version failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let actual = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let expected = expected_ripr_version();
+
+    if !is_expected_ripr_version(&actual) {
+        bail!(
+            "ripr version drift: expected `{expected}`, got `{actual}`; install with `cargo install ripr --version {EXPECTED_RIPR_VERSION} --locked --force` or set RIPR_BIN to a matching binary"
+        );
+    }
+
+    Ok(())
+}
+
+fn expected_ripr_version() -> String {
+    format!("ripr {EXPECTED_RIPR_VERSION}")
+}
+
+fn is_expected_ripr_version(actual: &str) -> bool {
+    actual.trim() == expected_ripr_version()
 }
 
 pub(crate) fn validate_shields_badge(
@@ -165,5 +200,12 @@ mod tests {
         };
 
         assert!(validate_shields_badge(&badge, Some("ripr+")).is_err());
+    }
+
+    #[test]
+    fn ripr_version_match_is_exact() {
+        assert!(is_expected_ripr_version("ripr 0.7.0\n"));
+        assert!(!is_expected_ripr_version("ripr 0.5.0"));
+        assert!(!is_expected_ripr_version("ripr 0.7.0-dev"));
     }
 }


### PR DESCRIPTION
## Summary
- Import tokmd-swarm/main after #19.
- Carries the pinned ripr 0.7.0 badge/advisory workflow fix and generated ripr badge endpoint.
- This PR must be merged with a merge commit, not squash, to preserve the swarm commit as imported history.

## Evidence
- Swarm head: 3404b47b215700c73b58823b4ce410ce508ee997
- Swarm range: 7533792095fbdadbd89a46ef2fa9c41be54a5022..3404b47b215700c73b58823b4ce410ce508ee997
- Swarm PR: EffortlessMetrics/tokmd-swarm#19
- Hosted swarm proof included Tokmd Rust Small Result success, CI Required success, ripr advisory success, CI Lane Whitelist success, Proof Policy success, Affected Proof Plan success, Docs Check success, and Build & Test Linux success.

## Boundary
- No release, publish, signing, Docker push, tag, or v1 alias movement is part of this import.
- This closes the public endpoint-only bot symptom by importing the workflow pin, not by accepting generated drift alone.