### PR TITLE
merge(swarm): import tokmd-swarm CI concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # Only cancel on synchronize (new commits). Label add/remove must not
-  # cancel an in-flight run: it triggers a fresh run with the new label
+  # Cancel superseded push runs and PR synchronize runs. Label add/remove must
+  # not cancel an in-flight PR run: it triggers a fresh run with the new label
   # set without throwing away work.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+  cancel-in-progress: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action == 'synchronize') }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Summary:
- Import tokmd-swarm commit 4d4061f10c450f6be4155a24f2e9c48fc4b95328.
- Includes PR #20: CI push runs now cancel superseded main push CI while PR label-event behavior is preserved.

Swarm proof:
- tokmd-swarm PR #20 merged by squash after hosted checks passed.
- Tokmd Rust Small Result: success.
- CI (Required): success.
- CI Lane Whitelist: success.
- PR Plan (advisory): rerun success with ci-budget-override after expected 150 LEM budget gate.
- Local required affected proof: 23 passed / 0 failed.

Publication boundary:
- Merge this PR with a merge commit, not squash.
- No release, publish, signing, Docker, v1 alias, or tag mutation included.

Rollback:
- Revert the publication merge commit, then fast-forward or sync tokmd-swarm from tokmd before further swarm work.