### PR TITLE
merge(swarm): import tokmd-swarm agent boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,21 @@ cargo +nightly fuzz list  # List all targets
 - `CHANGELOG.md`: Version history
 - `CONTRIBUTING.md`: Development setup, testing, and publishing guide
 
+## Dual-Repo Workbench Boundary
+
+Normal tokmd development starts from `EffortlessMetrics/tokmd-swarm:main`.
+Create narrow PRs there, wait for `Tokmd Rust Small Result`, and squash-merge
+aligned work into the swarm repo.
+
+`EffortlessMetrics/tokmd` is the publication repository. Do not push feature
+work, release tags, GitHub releases, crates.io publishes, Docker pushes,
+signing changes, or `v1` alias moves from swarm. Publication imports are
+explicit merge-commit PRs in `tokmd`, followed by fast-forwarding
+`tokmd-swarm/main` to the publication merge commit.
+
+See `docs/ci/swarm-routing.md` for the shared-history topology and routing
+rules.
+
 ## PR Triage Rules
 
 ### Codex and Jules state boundaries

--- a/agents/shared/repo.md
+++ b/agents/shared/repo.md
@@ -30,6 +30,21 @@ Optional git hooks:
 git config core.hooksPath .githooks
 ```
 
+## Dual-Repo Workbench Boundary
+
+Normal tokmd development starts from `EffortlessMetrics/tokmd-swarm:main`.
+Create narrow PRs there, wait for `Tokmd Rust Small Result`, and squash-merge
+aligned work into the swarm repo.
+
+`EffortlessMetrics/tokmd` is the publication repository. Do not push feature
+work, release tags, GitHub releases, crates.io publishes, Docker pushes,
+signing changes, or `v1` alias moves from swarm. Publication imports are
+explicit merge-commit PRs in `tokmd`, followed by fast-forwarding
+`tokmd-swarm/main` to the publication merge commit.
+
+See `docs/ci/swarm-routing.md` for the shared-history topology and routing
+rules.
+
 ## Codex Commit / Push Policy
 
 For PR-bound work, Codex may create scoped branches, commit scoped changes, push


### PR DESCRIPTION
Summary:
- Import tokmd-swarm workbench commit 7524e746 into the publication repository.
- Carries the shared AGENTS.md and agents/shared/repo.md dual-repo workbench boundary into tokmd.

Swarm-Head: 7524e74682b0bf6c9c229dddf20d81663b66dadf
Swarm-Range: 2d9be9ddf5ee8ed4f6f5220bcbfdf2591d6129b2..7524e74682b0bf6c9c229dddf20d81663b66dadf

Checks:
- tokmd-swarm PR #23 Tokmd Rust Small Result: success
- tokmd-swarm PR #23 CI (Required): success
- tokmd-swarm PR #23 PR Plan (advisory): success with ci-budget-override after 150 LEM override-required plan