### PR TITLE
merge(swarm): import tokmd-swarm spec index validation

### DIFF
--- a/.tokmd-spec/index.toml
+++ b/.tokmd-spec/index.toml
@@ -15,5 +15,56 @@ speckit = ".spec"
 claude = ".claude"
 jules = ".jules"
 
-# Add [[artifact]] and [[lane]] entries as durable artifacts are created.
-# Paths in [[artifact]] entries must not point into .codex/.spec/.claude/.jules.
+[[artifact]]
+id = "tokmd-spec-namespace"
+kind = "namespace"
+path = ".tokmd-spec/README.md"
+status = "active"
+
+[[artifact]]
+id = "tokmd-spec-index"
+kind = "index"
+path = ".tokmd-spec/index.toml"
+status = "active"
+
+[[artifact]]
+id = "source-of-truth-model"
+kind = "routing-guide"
+path = "docs/source-of-truth.md"
+status = "active"
+
+[[artifact]]
+id = "agent-source-of-truth-workflow"
+kind = "agent-workflow"
+path = "docs/agent-workflows/source-of-truth.md"
+status = "active"
+
+[[artifact]]
+id = "doc-artifacts-spec"
+kind = "spec"
+path = "docs/specs/doc-artifacts.md"
+status = "draft"
+
+[[artifact]]
+id = "doc-artifacts-policy"
+kind = "policy"
+path = "policy/doc-artifacts.toml"
+status = "draft"
+
+[[artifact]]
+id = "swarm-routing"
+kind = "topology"
+path = "docs/ci/swarm-routing.md"
+status = "active"
+
+[[artifact]]
+id = "spec-rails-contributor-guide"
+kind = "contributor-guide"
+path = "docs/contributing/spec-rails.md"
+status = "active"
+
+[[artifact]]
+id = "spec-rails-style-guide"
+kind = "style-guide"
+path = "docs/spec-style.md"
+status = "active"

--- a/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
+++ b/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
@@ -64,9 +64,12 @@ pub fn parse_doc_artifacts_evidence_input(
 }
 
 pub(crate) fn source_of_truth_path(path: &str) -> bool {
-    path == "docs/source-of-truth.md"
+    path.starts_with(".tokmd-spec/")
+        || path == "docs/source-of-truth.md"
         || path == "docs/review-packet.md"
         || path == "docs/cockpit-proof-evidence.md"
+        || path == "docs/contributing/spec-rails.md"
+        || path == "docs/spec-style.md"
         || path == "policy/doc-artifacts.toml"
         || path.starts_with("docs/proposals/")
         || path.starts_with("docs/specs/")
@@ -119,9 +122,13 @@ mod tests {
 
     #[test]
     fn recognizes_source_of_truth_paths() {
+        assert!(source_of_truth_path(".tokmd-spec/README.md"));
+        assert!(source_of_truth_path(".tokmd-spec/index.toml"));
         assert!(source_of_truth_path("docs/source-of-truth.md"));
         assert!(source_of_truth_path("docs/review-packet.md"));
         assert!(source_of_truth_path("docs/cockpit-proof-evidence.md"));
+        assert!(source_of_truth_path("docs/contributing/spec-rails.md"));
+        assert!(source_of_truth_path("docs/spec-style.md"));
         assert!(source_of_truth_path("docs/specs/doc-artifacts.md"));
         assert!(source_of_truth_path(".jules/goals/active.toml"));
         assert!(source_of_truth_path("policy/doc-artifacts.toml"));

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -29,7 +29,7 @@ each section.
 | Understand CI evidence | `target/proof/affected.json`, then `target/proof/proof-plan.json` | Shows changed files, matched proof scopes, and selected proof commands. |
 | Check executed required proof | `target/proof-run/proof-run-summary.json` | Shows which required proof commands actually ran and passed or failed. |
 | Prepare an agent | `.handoff/work-order.md`, then `.handoff/manifest.json` | Gives the agent task map, linked evidence summary, bundle index, and guardrails. |
-| Audit docs/source-of-truth changes | `target/docs/doc-artifacts-check.json` | Shows source-of-truth artifact shape, links, active-goal state, and policy checks. |
+| Audit source-of-truth changes | `target/docs/doc-artifacts-check.json` | Shows source-of-truth artifact shape, `.tokmd-spec` index paths, links, active-goal state, and policy checks. |
 
 ## Core Repo And Change Receipts
 
@@ -81,7 +81,7 @@ each section.
 | `proof-observation-decision.json` | `target/proof-observations/proof-observation-decision.json` | `cargo xtask proof-observation-status --json <path>` | Advisory aggregate over supplied proof artifacts: policy state, required/advisory proof counts, freshness, thresholds, criteria met/missing, and reproduction commands. | It does not execute proof, upload coverage, promote gates, or replace source-artifact verifiers. | Check the listed `source_artifacts`, `criteria_missing`, and `reproduce` commands before making a promotion decision. |
 | `proof-observation-decision-check.json` | `target/proof-observations/proof-observation-decision-check.json` | `cargo xtask proof-observation-status-check --decision <path> --json <path>` | Verifier receipt for the advisory decision packet: schema/mode, source artifact references, count consistency, policy guardrails, criteria shape, and reproduction commands. | It does not verify the original source receipts or make advisory proof required. | Run after generating `proof-observation-decision.json`; still verify source artifacts with their own checkers. |
 | `coverage-receipt.json` | `target/coverage/coverage-receipt.json` | `cargo xtask coverage-receipt` | Inventory and byte-count receipt for coverage artifacts such as JSON, text, and LCOV files. | It does not say coverage is required, sufficient, or uploaded to Codecov. | Inspect artifact paths and byte counts; pair with coverage workflow logs if needed. |
-| `doc-artifacts-check.json` | `target/docs/doc-artifacts-check.json` | `cargo xtask doc-artifacts --check --json <path>` | Source-of-truth docs/control-plane checker receipt: required docs, artifact family shape, active-goal links, status vocabulary, and errors. | It does not judge prose quality or merge readiness. | Re-run `cargo xtask doc-artifacts --check` or `cargo xtask docs --check`. |
+| `doc-artifacts-check.json` | `target/docs/doc-artifacts-check.json` | `cargo xtask doc-artifacts --check --json <path>` | Source-of-truth docs/control-plane checker receipt: required docs, `.tokmd-spec` index paths, artifact family shape, active-goal links, status vocabulary, and errors. | It does not judge prose quality or merge readiness. | Re-run `cargo xtask doc-artifacts --check` or `cargo xtask docs --check`. |
 
 ## Publishing And Release Evidence
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -441,8 +441,9 @@ cargo xtask review-packet-check --dir .tokmd/review
 - optional `target/tokmd/review-packet-check.json`: verifier receipt when
   `--json` is passed to `review-packet-check`
 
-If the PR changes source-of-truth docs, plans, ADRs, templates,
-`.jules/goals/**`, or doc-artifact policy, include the doc-artifacts receipt:
+If the PR changes `.tokmd-spec/**`, source-of-truth docs, plans, ADRs,
+templates, `.jules/goals/**`, or doc-artifact policy, include the
+doc-artifacts receipt:
 
 ```bash
 cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -40,8 +40,8 @@ Open the packet in this order:
 4. `.tokmd/review/manifest.json` for packet-local artifact paths and hashes.
 5. `target/tokmd/review-packet-check.json` for the verifier receipt.
 
-If the PR changes source-of-truth docs, plans, ADRs, templates,
-`.jules/goals/**`, or doc-artifact policy, generate and import the
+If the PR changes `.tokmd-spec/**`, source-of-truth docs, plans, ADRs,
+templates, `.jules/goals/**`, or doc-artifact policy, generate and import the
 documentation-control receipt first:
 
 ```bash
@@ -189,9 +189,9 @@ packet, see [tokmd and evidencebus integration](evidencebus-integration.md).
 
 ## Documentation Artifact Evidence
 
-Source-of-truth changes are review evidence too. When a PR changes docs,
-plans, specs, ADRs, templates, `.jules/goals/**`, or doc-artifact policy,
-cockpit packets can import the docs checker receipt:
+Source-of-truth changes are review evidence too. When a PR changes
+`.tokmd-spec/**`, docs, plans, specs, ADRs, templates, `.jules/goals/**`, or
+doc-artifact policy, cockpit packets can import the docs checker receipt:
 
 ```text
 target/docs/doc-artifacts-check.json

--- a/docs/specs/doc-artifacts.md
+++ b/docs/specs/doc-artifacts.md
@@ -26,6 +26,7 @@ proof gates should be promoted.
 The documentation artifact checker reads these repo paths:
 
 - `.tokmd-spec/README.md`
+- `.tokmd-spec/index.toml`
 - `docs/source-of-truth.md`
 - `docs/proposals/**/*.md`
 - `docs/specs/**/*.md`
@@ -130,8 +131,21 @@ The checker should require:
 - `## Source-of-truth chain`.
 
 `.tokmd-spec/index.toml` is the index for durable artifacts in or linked from
-the namespace. Index schema enforcement is intentionally separate from this
-first routing check until the indexed artifact shape is promoted.
+the namespace.
+
+The checker should require:
+
+- `schema_version = "1.0"`;
+- `repo = "tokmd"`;
+- `namespace = ".tokmd-spec"`;
+- each `[[artifact]]` entry to have non-empty `id`, `kind`, `path`, and
+  `status`;
+- each `[[lane]]` entry to have non-empty `id`, `path`, and `status` when lane
+  entries are present;
+- indexed paths to be repo-relative, existing paths;
+- indexed paths to avoid tool-local namespaces such as `.codex/`, `.spec/`,
+  `.claude/`, and `.jules/`;
+- duplicate indexed IDs to fail the check.
 
 ## Outputs
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -92,9 +92,9 @@ Open these files in order:
 4. `.tokmd/review/manifest.json`
 5. `target/tokmd/review-packet-check.json`
 
-If the PR changes source-of-truth docs, plans, ADRs, templates,
-`.jules/goals/**`, or doc-artifact policy, generate the documentation-control
-receipt first and import it:
+If the PR changes `.tokmd-spec/**`, source-of-truth docs, plans, ADRs,
+templates, `.jules/goals/**`, or doc-artifact policy, generate the
+documentation-control receipt first and import it:
 
 ```bash
 cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json

--- a/docs/tokmd-in-cockpit.md
+++ b/docs/tokmd-in-cockpit.md
@@ -47,9 +47,9 @@ Open the packet in this order:
 4. `.tokmd/review/manifest.json` for packet-local artifact paths and hashes.
 5. `target/tokmd/review-packet-check.json` for the verifier receipt.
 
-When the PR changes source-of-truth docs, plans, ADRs, templates,
-`.jules/goals/**`, or doc-artifact policy, generate the documentation-control
-receipt first and import it:
+When the PR changes `.tokmd-spec/**`, source-of-truth docs, plans, ADRs,
+templates, `.jules/goals/**`, or doc-artifact policy, generate the
+documentation-control receipt first and import it:
 
 ```bash
 cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
@@ -78,7 +78,7 @@ Start with the smallest packet that can answer the review question:
 | PR shape | Add these inputs | What the packet can say |
 | --- | --- | --- |
 | Code-only change | `--review-packet-dir` | What changed, what to review first, and which cockpit evidence is available, missing, stale, degraded, skipped, or unavailable. |
-| Source-of-truth docs, plans, ADRs, templates, `.jules/goals/**`, or doc-artifact policy changed | `--doc-artifacts-check target/docs/doc-artifacts-check.json` | Whether the documentation-control checker receipt is present and whether source-of-truth artifact shape, links, active goal state, and policy routing passed. |
+| `.tokmd-spec/**`, source-of-truth docs, plans, ADRs, templates, `.jules/goals/**`, or doc-artifact policy changed | `--doc-artifacts-check target/docs/doc-artifacts-check.json` | Whether the documentation-control checker receipt is present and whether source-of-truth artifact shape, links, active goal state, spec-index paths, and policy routing passed. |
 | Required proof was planned or run | `--proof-run-summary`, `--proof-observation` | Which required proof applied to the reviewed change, whether it passed, and whether imported proof freshness matches the cockpit head. |
 | Advisory proof or coverage exists | `--executor-observation`, `--coverage-receipt` | Which advisory evidence exists, which evidence is missing, and which evidence must not be treated as a required gate. |
 

--- a/policy/doc-artifacts.toml
+++ b/policy/doc-artifacts.toml
@@ -17,6 +17,19 @@ proof_promotion = false
 codecov_default_upload = false
 json_receipt = "tokmd.doc_artifacts_check.v1"
 
+[spec_index]
+path = ".tokmd-spec/index.toml"
+schema_version = "1.0"
+repo = "tokmd"
+namespace = ".tokmd-spec"
+require_existing_paths = true
+forbidden_path_prefixes = [
+  ".codex/",
+  ".spec/",
+  ".claude/",
+  ".jules/",
+]
+
 [active_goal]
 path = ".jules/goals/active.toml"
 schema = "tokmd.jules.active_goal.v1"

--- a/xtask/src/tasks/doc_artifacts.rs
+++ b/xtask/src/tasks/doc_artifacts.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -16,11 +17,25 @@ struct Policy {
     schema_version: String,
     policy: String,
     #[serde(default)]
+    spec_index: Option<SpecIndexPolicy>,
+    #[serde(default)]
     active_goal: Option<ActiveGoalPolicy>,
     #[serde(default)]
     required_doc: Vec<RequiredDoc>,
     #[serde(default)]
     family: Vec<ArtifactFamily>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpecIndexPolicy {
+    path: String,
+    schema_version: String,
+    repo: String,
+    namespace: String,
+    #[serde(default)]
+    require_existing_paths: bool,
+    #[serde(default)]
+    forbidden_path_prefixes: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -63,6 +78,32 @@ struct ArtifactFamily {
     required_sections: Vec<String>,
     #[serde(default)]
     draft_may_omit_sections: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpecIndex {
+    schema_version: String,
+    repo: String,
+    namespace: String,
+    #[serde(default)]
+    artifact: Vec<SpecIndexArtifact>,
+    #[serde(default)]
+    lane: Vec<SpecIndexLane>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpecIndexArtifact {
+    id: String,
+    kind: String,
+    path: String,
+    status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpecIndexLane {
+    id: String,
+    path: String,
+    status: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -145,6 +186,10 @@ fn check(root: &Path, policy_path: &Path) -> Result<CheckReport> {
     for required_doc in &policy.required_doc {
         report.required_docs += 1;
         validate_required_doc(root, required_doc, &mut report.errors);
+    }
+
+    if let Some(spec_index) = &policy.spec_index {
+        validate_spec_index(root, spec_index, &mut report.errors);
     }
 
     if let Some(active_goal) = &policy.active_goal {
@@ -232,6 +277,166 @@ fn validate_required_doc(root: &Path, required_doc: &RequiredDoc, errors: &mut V
     validate_top_heading(&required_doc.path, &content, errors);
     for section in &required_doc.required_sections {
         validate_section(&required_doc.path, &content, section, errors);
+    }
+}
+
+fn validate_spec_index(root: &Path, policy: &SpecIndexPolicy, errors: &mut Vec<String>) {
+    let path = root.join(&policy.path);
+    let content = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) => {
+            errors.push(format!("{} is unreadable: {err}", policy.path));
+            return;
+        }
+    };
+    let index: SpecIndex = match toml::from_str(&content) {
+        Ok(index) => index,
+        Err(err) => {
+            errors.push(format!("{} is invalid TOML: {err}", policy.path));
+            return;
+        }
+    };
+
+    if index.schema_version != policy.schema_version {
+        errors.push(format!(
+            "{}: unsupported schema_version {:?}; expected {:?}",
+            policy.path, index.schema_version, policy.schema_version
+        ));
+    }
+    if index.repo != policy.repo {
+        errors.push(format!(
+            "{}: repo {:?} does not match expected {:?}",
+            policy.path, index.repo, policy.repo
+        ));
+    }
+    if index.namespace != policy.namespace {
+        errors.push(format!(
+            "{}: namespace {:?} does not match expected {:?}",
+            policy.path, index.namespace, policy.namespace
+        ));
+    }
+    if index.artifact.is_empty() && index.lane.is_empty() {
+        errors.push(format!(
+            "{}: expected at least one [[artifact]] or [[lane]] entry",
+            policy.path
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    for artifact in &index.artifact {
+        validate_non_empty_index_field(&policy.path, "artifact", &artifact.id, "id", errors);
+        validate_non_empty_index_field(
+            &policy.path,
+            &format!("artifact {}", artifact.id),
+            &artifact.kind,
+            "kind",
+            errors,
+        );
+        validate_non_empty_index_field(
+            &policy.path,
+            &format!("artifact {}", artifact.id),
+            &artifact.status,
+            "status",
+            errors,
+        );
+        validate_unique_index_id(&policy.path, "artifact", &artifact.id, &mut ids, errors);
+        validate_spec_index_path(
+            root,
+            &policy.path,
+            &format!("artifact {}", artifact.id),
+            &artifact.path,
+            policy,
+            errors,
+        );
+    }
+    for lane in &index.lane {
+        validate_non_empty_index_field(&policy.path, "lane", &lane.id, "id", errors);
+        validate_non_empty_index_field(
+            &policy.path,
+            &format!("lane {}", lane.id),
+            &lane.status,
+            "status",
+            errors,
+        );
+        validate_unique_index_id(&policy.path, "lane", &lane.id, &mut ids, errors);
+        validate_spec_index_path(
+            root,
+            &policy.path,
+            &format!("lane {}", lane.id),
+            &lane.path,
+            policy,
+            errors,
+        );
+    }
+}
+
+fn validate_non_empty_index_field(
+    index_path: &str,
+    entry: &str,
+    value: &str,
+    field: &str,
+    errors: &mut Vec<String>,
+) {
+    if value.trim().is_empty() {
+        errors.push(format!("{index_path}: {entry} must have non-empty {field}"));
+    }
+}
+
+fn validate_unique_index_id(
+    index_path: &str,
+    kind: &str,
+    id: &str,
+    ids: &mut BTreeSet<String>,
+    errors: &mut Vec<String>,
+) {
+    if id.trim().is_empty() {
+        return;
+    }
+    if !ids.insert(id.to_string()) {
+        errors.push(format!(
+            "{index_path}: duplicate indexed id {id:?} in {kind}"
+        ));
+    }
+}
+
+fn validate_spec_index_path(
+    root: &Path,
+    index_path: &str,
+    entry: &str,
+    value: &str,
+    policy: &SpecIndexPolicy,
+    errors: &mut Vec<String>,
+) {
+    let link_path = Path::new(value);
+    if link_path.is_absolute() {
+        errors.push(format!(
+            "{index_path}: {entry}.path must be repo-relative, found {value:?}"
+        ));
+        return;
+    }
+    if value.contains("..") {
+        errors.push(format!(
+            "{index_path}: {entry}.path must not traverse parents, found {value:?}"
+        ));
+        return;
+    }
+
+    let normalized = normalize_path(link_path);
+    for prefix in &policy.forbidden_path_prefixes {
+        let prefix = prefix.replace('\\', "/");
+        let prefix_without_slash = prefix.trim_end_matches('/');
+        if normalized == prefix_without_slash || normalized.starts_with(&prefix) {
+            errors.push(format!(
+                "{index_path}: {entry}.path must not point into forbidden prefix {prefix_without_slash:?}, found {value:?}"
+            ));
+            return;
+        }
+    }
+
+    if policy.require_existing_paths && !root.join(link_path).exists() {
+        errors.push(format!(
+            "{index_path}: {entry}.path points at missing path {value:?}"
+        ));
     }
 }
 
@@ -596,6 +801,72 @@ mod tests {
     }
 
     #[test]
+    fn spec_index_rejects_tool_local_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        write_valid_fixture(temp.path());
+        fs::write(
+            temp.path().join(".tokmd-spec/index.toml"),
+            spec_index(".jules/goals/active.toml"),
+        )
+        .unwrap();
+
+        let report = check(temp.path(), Path::new("policy/doc-artifacts.toml")).unwrap();
+
+        assert!(
+            report.errors.iter().any(|error| {
+                error.contains("forbidden prefix \".jules\"")
+                    && error.contains(".jules/goals/active.toml")
+            }),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn spec_index_rejects_missing_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        write_valid_fixture(temp.path());
+        fs::write(
+            temp.path().join(".tokmd-spec/index.toml"),
+            spec_index("docs/missing.md"),
+        )
+        .unwrap();
+
+        let report = check(temp.path(), Path::new("policy/doc-artifacts.toml")).unwrap();
+
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|error| error.contains("points at missing path \"docs/missing.md\"")),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn spec_index_rejects_duplicate_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        write_valid_fixture(temp.path());
+        let index = spec_index("docs/source-of-truth.md").replace(
+            "[[artifact]]\nid = \"source-of-truth-model\"",
+            "[[artifact]]\nid = \"source-of-truth-model\"\nkind = \"spec\"\npath = \"docs/specs/doc-artifacts.md\"\nstatus = \"draft\"\n\n[[artifact]]\nid = \"source-of-truth-model\"",
+        );
+        fs::write(temp.path().join(".tokmd-spec/index.toml"), index).unwrap();
+
+        let report = check(temp.path(), Path::new("policy/doc-artifacts.toml")).unwrap();
+
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|error| error.contains("duplicate indexed id \"source-of-truth-model\"")),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
     fn missing_required_section_fails() {
         let temp = tempfile::tempdir().unwrap();
         write_valid_fixture(temp.path());
@@ -685,6 +956,11 @@ mod tests {
         )
         .unwrap();
         fs::write(
+            root.join(".tokmd-spec/index.toml"),
+            spec_index("docs/source-of-truth.md"),
+        )
+        .unwrap();
+        fs::write(
             root.join("docs/source-of-truth.md"),
             "# Source of Truth Model\n\n## Goal\n\n## Artifact Roles\n\n## Conflict Resolution\n\n## Lifecycle\n\n## Review Expectations\n",
         )
@@ -741,6 +1017,34 @@ proof_promotion = "do_not_promote"
 
 [stop_conditions]
 docs_check = "cargo xtask docs --check"
+"#
+        )
+    }
+
+    fn spec_index(artifact_path: &str) -> String {
+        format!(
+            r#"schema_version = "1.0"
+
+repo = "tokmd"
+namespace = ".tokmd-spec"
+
+[conventions]
+proposal_prefix = "TOKMD-PROP"
+spec_prefix = "TOKMD-SPEC"
+adr_prefix = "TOKMD-ADR"
+lane_prefix = "TOKMD-LANE"
+
+[external_namespaces]
+codex = ".codex"
+speckit = ".spec"
+claude = ".claude"
+jules = ".jules"
+
+[[artifact]]
+id = "source-of-truth-model"
+kind = "routing-guide"
+path = "{artifact_path}"
+status = "active"
 "#
         )
     }


### PR DESCRIPTION
## Summary
- Import tokmd-swarm spec-index validation slice by merge commit.
- Swarm PR: EffortlessMetrics/tokmd-swarm#29
- Swarm-Head: 96d7ef02d9a38bf88f328dad61e497254bd9e73e
- Swarm-Range: bd106b2435966139e7cbc32837e1dce355b4f3b8..96d7ef02d9a38bf88f328dad61e497254bd9e73e

## Proof
Swarm PR #29 passed hosted CI Required and Tokmd Rust Small Result. Local proof in the swarm PR included doc-artifacts, docs, proof-policy, file policy, fmt, affected/proof-plan, ci-lane-whitelist, xtask focused tests, and tokmd-cockpit tests.

## Claim boundary
Publication import only. No release, publish, tag, signing, Docker, v1 alias, proof promotion, or Codecov-default mutation.

## Merge rule
Merge this PR with a merge commit, not squash, to preserve the swarm squashed commit as second-parent history.