### PR TITLE
merge(swarm): import tokmd-swarm source-truth routing

### DIFF
--- a/.github/workflows/em-routed-rust-small.yml
+++ b/.github/workflows/em-routed-rust-small.yml
@@ -250,7 +250,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ci-disk-guard /mnt/ci-scratch 100
+          ci-disk-guard /mnt/ci-scratch 95
           ci-disk-guard /mnt/docker 20
           ci-disk-guard /mnt/ci-cache 20
 

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1209,12 +1209,16 @@ coverage = false
 name = "doc_artifacts_policy"
 kind = "non_rust"
 paths = [
+  ".tokmd-spec/**",
   ".jules/goals/**",
   "docs/adr/**",
   "docs/agent-workflows/**",
+  "docs/ci/swarm-routing.md",
+  "docs/contributing/spec-rails.md",
   "docs/plans/**",
   "docs/proposals/**",
   "docs/source-of-truth.md",
+  "docs/spec-style.md",
   "docs/specs/**",
   "docs/templates/**",
   "policy/doc-artifacts.toml",

--- a/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
+++ b/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
@@ -68,6 +68,8 @@ pub(crate) fn source_of_truth_path(path: &str) -> bool {
         || path == "docs/source-of-truth.md"
         || path == "docs/review-packet.md"
         || path == "docs/cockpit-proof-evidence.md"
+        || path == "docs/agent-workflows/source-of-truth.md"
+        || path == "docs/ci/swarm-routing.md"
         || path == "docs/contributing/spec-rails.md"
         || path == "docs/spec-style.md"
         || path == "policy/doc-artifacts.toml"
@@ -127,6 +129,10 @@ mod tests {
         assert!(source_of_truth_path("docs/source-of-truth.md"));
         assert!(source_of_truth_path("docs/review-packet.md"));
         assert!(source_of_truth_path("docs/cockpit-proof-evidence.md"));
+        assert!(source_of_truth_path(
+            "docs/agent-workflows/source-of-truth.md"
+        ));
+        assert!(source_of_truth_path("docs/ci/swarm-routing.md"));
         assert!(source_of_truth_path("docs/contributing/spec-rails.md"));
         assert!(source_of_truth_path("docs/spec-style.md"));
         assert!(source_of_truth_path("docs/specs/doc-artifacts.md"));

--- a/crates/tokmd-cockpit/src/review_plan.rs
+++ b/crates/tokmd-cockpit/src/review_plan.rs
@@ -203,7 +203,7 @@ mod tests {
     fn test_review_plan_boosts_source_of_truth_contracts() {
         let stats = vec![
             make_stat("src/large.rs", 150, 100),
-            make_stat("docs/review-packet.md", 3, 2),
+            make_stat("docs/ci/swarm-routing.md", 3, 2),
             make_stat("docs/tutorial.md", 3, 2),
         ];
         let contracts = Contracts {
@@ -213,7 +213,7 @@ mod tests {
             breaking_indicators: 0,
         };
         let plan = generate_review_plan(&stats, &contracts);
-        assert_eq!(plan[0].path, "docs/review-packet.md");
+        assert_eq!(plan[0].path, "docs/ci/swarm-routing.md");
         assert_eq!(plan[0].priority, 1);
         assert_eq!(
             plan[0].reason,

--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -129,7 +129,10 @@ CPX42 -> CX43 -> CX53 -> GitHub-hosted
 
 CPX42 uses the pinned Rust 1.95 toolchain directly on the host, with
 `/mnt/ci-scratch` `TMPDIR` prepared before the toolchain action runs. CX43 and
-CX53 keep their existing local `em-ci-rust:1.95` Docker execution path.
+CX53 keep their existing local `em-ci-rust:1.95` Docker execution path. CX43
+uses a 95GB scratch-space guard to avoid false negatives from host-reserved
+space while preserving a high floor for the isolated Cargo target directory;
+CX53 keeps the 100GB scratch-space guard.
 
 Merge commits may remain available for exceptional sync or admin flows, but
 normal feature work should be squash-only.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -40,9 +40,10 @@ Open the packet in this order:
 4. `.tokmd/review/manifest.json` for packet-local artifact paths and hashes.
 5. `target/tokmd/review-packet-check.json` for the verifier receipt.
 
-If the PR changes `.tokmd-spec/**`, source-of-truth docs, plans, ADRs,
-templates, `.jules/goals/**`, or doc-artifact policy, generate and import the
-documentation-control receipt first:
+If the PR changes `.tokmd-spec/**`, source-of-truth docs, the swarm routing
+topology, agent workflow rails, plans, ADRs, templates, `.jules/goals/**`, or
+doc-artifact policy, generate and import the documentation-control receipt
+first:
 
 ```bash
 cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
@@ -190,7 +191,8 @@ packet, see [tokmd and evidencebus integration](evidencebus-integration.md).
 ## Documentation Artifact Evidence
 
 Source-of-truth changes are review evidence too. When a PR changes
-`.tokmd-spec/**`, docs, plans, specs, ADRs, templates, `.jules/goals/**`, or
+`.tokmd-spec/**`, source-of-truth docs, the swarm routing topology, agent
+workflow rails, plans, specs, ADRs, templates, `.jules/goals/**`, or
 doc-artifact policy, cockpit packets can import the docs checker receipt:
 
 ```text

--- a/docs/specs/doc-artifacts.md
+++ b/docs/specs/doc-artifacts.md
@@ -27,6 +27,7 @@ The documentation artifact checker reads these repo paths:
 
 - `.tokmd-spec/README.md`
 - `.tokmd-spec/index.toml`
+- paths indexed by `.tokmd-spec/index.toml`
 - `docs/source-of-truth.md`
 - `docs/proposals/**/*.md`
 - `docs/specs/**/*.md`


### PR DESCRIPTION
﻿Imports the current tokmd-swarm main into the publication repo by merge commit.

Swarm-Head: c73f0e4049dd1af87d12f4bb2ebf4ad616639726
Swarm-Range: 81198607732291b63b3488eba7b6994612d81443..c73f0e4049dd1af87d12f4bb2ebf4ad616639726

Included swarm PR:
- EffortlessMetrics/tokmd-swarm#30: route source-of-truth docs through cockpit/proof policy and relax the CX43 routed Rust Small scratch guard from 100GB to 95GB.

Checks from swarm PR #30:
- Tokmd Rust Small Result: run 26257647747, passed
- CI / CI (Required): run 26257647754, passed
- PR Plan: run 26257647757, passed with ci-budget-override

Publication intent:
- Merge this PR with a merge commit, not squash.
- After merge, fast-forward tokmd-swarm/main to the resulting publication merge commit.
