### PR TITLE
merge(swarm): import tokmd-swarm repo-graph hotfix proof

### DIFF
--- a/.github/workflows/em-routed-rust-small.yml
+++ b/.github/workflows/em-routed-rust-small.yml
@@ -250,7 +250,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ci-disk-guard /mnt/ci-scratch 95
+          ci-disk-guard /mnt/ci-scratch 90
           ci-disk-guard /mnt/docker 20
           ci-disk-guard /mnt/ci-cache 20
 

--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -193,7 +193,7 @@ CPX42 -> CX43 -> CX53 -> GitHub-hosted
 CPX42 uses the pinned Rust 1.95 toolchain directly on the host, with
 `/mnt/ci-scratch` `TMPDIR` prepared before the toolchain action runs. CX43 and
 CX53 keep their existing local `em-ci-rust:1.95` Docker execution path. CX43
-uses a 95GB scratch-space guard to avoid false negatives from host-reserved
+uses a 90GB scratch-space guard to avoid false negatives from host-reserved
 space while preserving a high floor for the isolated Cargo target directory;
 CX53 keeps the 100GB scratch-space guard.
 
@@ -337,6 +337,16 @@ Release and hotfix work remains in `tokmd`.
 
 If a release or hotfix lands directly in publication and `tokmd/main` is a
 descendant of `tokmd-swarm/main`, fast-forward swarm immediately.
+
+Verify that direction before the fast-forward:
+
+```bash
+cargo xtask repo-graph \
+  --publication public/main \
+  --swarm origin/main \
+  --expect publication-descends-swarm \
+  --json target/repo-graph/publication-hotfix.json
+```
 
 If publication is not a descendant of swarm, sync publication into swarm with an
 explicit merge commit:

--- a/xtask/src/tasks/repo_graph.rs
+++ b/xtask/src/tasks/repo_graph.rs
@@ -323,6 +323,22 @@ mod tests {
     }
 
     #[test]
+    fn publication_descends_swarm_accepts_aligned_or_publication_ahead() {
+        assert!(expectation_matches(
+            RepoGraphExpectation::PublicationDescendsSwarm,
+            GraphRelation::Aligned
+        ));
+        assert!(expectation_matches(
+            RepoGraphExpectation::PublicationDescendsSwarm,
+            GraphRelation::PublicationAhead
+        ));
+        assert!(!expectation_matches(
+            RepoGraphExpectation::PublicationDescendsSwarm,
+            GraphRelation::SwarmAhead
+        ));
+    }
+
+    #[test]
     fn no_divergence_rejects_diverged_and_unrelated_refs() {
         assert!(expectation_matches(
             RepoGraphExpectation::NoDivergence,

--- a/xtask/tests/repo_graph_w99.rs
+++ b/xtask/tests/repo_graph_w99.rs
@@ -194,6 +194,39 @@ fn repo_graph_reports_publication_ahead_in_real_git_repo() {
 }
 
 #[test]
+fn repo_graph_rejects_swarm_ahead_when_publication_must_descend_from_swarm() {
+    let temp = init_repo();
+    let repo = temp.path();
+
+    git(repo, &["switch", "swarm"]);
+    write_file(repo, "file.txt", "base\nswarm\n");
+    commit(repo, "swarm");
+
+    let (stdout, stderr, success) = run_xtask_in_dir(
+        &[
+            "repo-graph",
+            "--publication",
+            "publication",
+            "--swarm",
+            "swarm",
+            "--expect",
+            "publication-descends-swarm",
+        ],
+        repo,
+    );
+
+    assert!(
+        !success,
+        "swarm-ahead refs should fail publication-descends-swarm"
+    );
+    assert!(stdout.contains("SwarmAhead"), "stdout: {stdout}");
+    assert!(
+        stderr.contains("repo graph expectation publication-descends-swarm was not met"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn repo_graph_rejects_diverged_refs_in_real_git_repo() {
     let temp = init_repo();
     let repo = temp.path();


### PR DESCRIPTION
Summary:
- import the latest tokmd-swarm squash commit into the publication repo
- preserve the swarm commit as second-parent history through a merge-commit publication PR

Swarm-Head: a7e8287c7b1fe879f9d8de8aa6062f6f65f79cbc
Swarm-Range: 7c819ab15f9e2eb3271518868c44c9972124bd63..a7e8287c7b1fe879f9d8de8aa6062f6f65f79cbc
Checks:
- Tokmd Rust Small Result: actions run 26266385720, success
- CI (Required): actions run 26266385813, success
- repo-graph pre-publication: swarm-descends-publication, success

Merge policy:
- merge this PR with a merge commit, not squash
- fast-forward tokmd-swarm/main to tokmd/main after publication merge