### PR TITLE
merge(swarm): import tokmd-swarm repo-graph diagnostics

### DIFF
--- a/xtask/src/tasks/repo_graph.rs
+++ b/xtask/src/tasks/repo_graph.rs
@@ -53,12 +53,14 @@ pub fn run(args: RepoGraphArgs) -> Result<()> {
     if report.ok {
         Ok(())
     } else {
+        let hint = expectation_failure_hint(&report);
         bail!(
-            "repo graph expectation {} was not met: relation {:?}, publication_ahead={}, swarm_ahead={}",
+            "repo graph expectation {} was not met: relation {:?}, publication_ahead={}, swarm_ahead={}. next: {}",
             report.expectation,
             report.relation,
             report.ahead_behind.publication_ahead,
-            report.ahead_behind.swarm_ahead
+            report.ahead_behind.swarm_ahead,
+            hint
         )
     }
 }
@@ -209,6 +211,26 @@ fn expectation_name(expectation: RepoGraphExpectation) -> &'static str {
     }
 }
 
+fn expectation_failure_hint(report: &RepoGraphReport) -> &'static str {
+    match (report.expectation.as_str(), report.relation) {
+        ("aligned", GraphRelation::SwarmAhead)
+        | ("publication-descends-swarm", GraphRelation::SwarmAhead) => {
+            "publication has not imported the swarm head; create a tokmd publication PR and merge it with a merge commit before fast-forwarding swarm"
+        }
+        ("aligned", GraphRelation::PublicationAhead)
+        | ("swarm-descends-publication", GraphRelation::PublicationAhead) => {
+            "swarm is behind publication; fast-forward tokmd-swarm/main to the publication commit before routine swarm work continues"
+        }
+        (_, GraphRelation::Diverged) => {
+            "publication and swarm both have unique commits; inspect the graph and use an explicit sync merge rather than a squash/content sync"
+        }
+        (_, GraphRelation::Unrelated) => {
+            "the refs share no merge base; stop normal work and run an admin realignment instead of merging unrelated histories"
+        }
+        _ => "inspect the requested expectation and refs before changing either main branch",
+    }
+}
+
 fn write_json(path: &Path, report: &RepoGraphReport) -> Result<()> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -244,7 +266,10 @@ fn print_human_report(report: &RepoGraphReport) {
 
 #[cfg(test)]
 mod tests {
-    use super::{AheadBehind, GraphRelation, classify_relation, expectation_matches};
+    use super::{
+        AheadBehind, GraphRelation, RefReport, RepoGraphReport, classify_relation,
+        expectation_failure_hint, expectation_matches,
+    };
     use crate::cli::RepoGraphExpectation;
 
     fn counts(publication_ahead: u64, swarm_ahead: u64) -> AheadBehind {
@@ -352,5 +377,64 @@ mod tests {
             RepoGraphExpectation::NoDivergence,
             GraphRelation::Unrelated
         ));
+    }
+
+    fn report(expectation: &str, relation: GraphRelation) -> RepoGraphReport {
+        let ahead_behind = match relation {
+            GraphRelation::Aligned => counts(0, 0),
+            GraphRelation::SwarmAhead => counts(0, 1),
+            GraphRelation::PublicationAhead => counts(1, 0),
+            GraphRelation::Diverged | GraphRelation::Unrelated => counts(1, 1),
+        };
+
+        RepoGraphReport {
+            schema: super::SCHEMA,
+            ok: false,
+            expectation: expectation.to_string(),
+            relation,
+            publication: RefReport {
+                name: "publication/main".to_string(),
+                sha: "publication-sha".to_string(),
+            },
+            swarm: RefReport {
+                name: "origin/main".to_string(),
+                sha: "swarm-sha".to_string(),
+            },
+            merge_base: Some("base-sha".to_string()),
+            ahead_behind,
+        }
+    }
+
+    #[test]
+    fn failure_hint_names_publication_import_for_swarm_ahead() {
+        let report = report("publication-descends-swarm", GraphRelation::SwarmAhead);
+
+        let hint = expectation_failure_hint(&report);
+
+        assert!(hint.contains("publication has not imported the swarm head"));
+        assert!(hint.contains("merge commit"));
+    }
+
+    #[test]
+    fn failure_hint_names_swarm_fast_forward_for_publication_ahead() {
+        let report = report(
+            "swarm-descends-publication",
+            GraphRelation::PublicationAhead,
+        );
+
+        let hint = expectation_failure_hint(&report);
+
+        assert!(hint.contains("swarm is behind publication"));
+        assert!(hint.contains("fast-forward tokmd-swarm/main"));
+    }
+
+    #[test]
+    fn failure_hint_names_admin_realignment_for_unrelated_refs() {
+        let report = report("no-divergence", GraphRelation::Unrelated);
+
+        let hint = expectation_failure_hint(&report);
+
+        assert!(hint.contains("share no merge base"));
+        assert!(hint.contains("admin realignment"));
     }
 }

--- a/xtask/tests/repo_graph_w99.rs
+++ b/xtask/tests/repo_graph_w99.rs
@@ -224,6 +224,11 @@ fn repo_graph_rejects_swarm_ahead_when_publication_must_descend_from_swarm() {
         stderr.contains("repo graph expectation publication-descends-swarm was not met"),
         "stderr: {stderr}"
     );
+    assert!(
+        stderr.contains("publication has not imported the swarm head"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("merge commit"), "stderr: {stderr}");
 }
 
 #[test]
@@ -257,6 +262,7 @@ fn repo_graph_rejects_diverged_refs_in_real_git_repo() {
         stderr.contains("repo graph expectation no-divergence was not met"),
         "stderr: {stderr}"
     );
+    assert!(stderr.contains("explicit sync merge"), "stderr: {stderr}");
 }
 
 #[test]
@@ -288,6 +294,7 @@ fn repo_graph_rejects_unrelated_refs_in_real_git_repo() {
         stderr.contains("repo graph expectation no-divergence was not met"),
         "stderr: {stderr}"
     );
+    assert!(stderr.contains("admin realignment"), "stderr: {stderr}");
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- import the latest tokmd-swarm squash commit into the publication repo
- preserve the swarm commit as second-parent history through a merge-commit publication PR

Swarm-Head: 71b357deec3b6a3ba96409aeb89cd7111daca021
Swarm-Range: d1470d2e7d2a5b1f6e4de886b848a81ba12621d8..71b357deec3b6a3ba96409aeb89cd7111daca021
Checks:
- Tokmd Rust Small Result: actions run 26267474422, success
- CI Required: actions run 26267474421, success
- droid-review: actions run 26267474419, success
- repo-graph pre-publication: swarm-descends-publication, success

Merge policy:
- merge this PR with a merge commit, not squash
- fast-forward tokmd-swarm/main to tokmd/main after publication merge