### PR TITLE
merge(swarm): import tokmd-swarm doc artifact policy validation

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -153,6 +153,7 @@ paths = [
   "xtask/src/tasks/proof_run_pr_policy.rs",
   "xtask/src/tasks/proof_workflow_status.rs",
   "xtask/src/tasks/repo_graph.rs",
+  "xtask/src/tasks/workspace.rs",
   "xtask/tests/affected_w91.rs",
   "xtask/tests/ci_actuals_w96.rs",
   "xtask/tests/coverage_receipt_w95.rs",

--- a/xtask/src/tasks/doc_artifacts.rs
+++ b/xtask/src/tasks/doc_artifacts.rs
@@ -23,6 +23,8 @@ struct Policy {
     #[serde(default)]
     required_doc: Vec<RequiredDoc>,
     #[serde(default)]
+    policy_file: Vec<PolicyFile>,
+    #[serde(default)]
     family: Vec<ArtifactFamily>,
 }
 
@@ -61,6 +63,14 @@ struct RequiredDoc {
     path: String,
     #[serde(default)]
     required_sections: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyFile {
+    path: String,
+    owner: String,
+    #[serde(default)]
+    covered_by: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -195,6 +205,10 @@ fn check(root: &Path, policy_path: &Path) -> Result<CheckReport> {
     if let Some(active_goal) = &policy.active_goal {
         report.active_goals += 1;
         validate_active_goal(root, active_goal, &mut report.errors);
+    }
+
+    for policy_file in &policy.policy_file {
+        validate_policy_file(root, policy_file, &mut report.errors);
     }
 
     for family in &policy.family {
@@ -437,6 +451,45 @@ fn validate_spec_index_path(
         errors.push(format!(
             "{index_path}: {entry}.path points at missing path {value:?}"
         ));
+    }
+}
+
+fn validate_policy_file(root: &Path, policy_file: &PolicyFile, errors: &mut Vec<String>) {
+    validate_non_empty_policy_field(&policy_file.path, "path", errors);
+    validate_non_empty_policy_field(&policy_file.owner, "owner", errors);
+    if policy_file.covered_by.is_empty() {
+        errors.push(format!(
+            "policy_file {:?}: covered_by must list at least one verifier command",
+            policy_file.path
+        ));
+    }
+
+    let path = Path::new(&policy_file.path);
+    if path.is_absolute() {
+        errors.push(format!(
+            "policy_file {:?}: path must be repo-relative",
+            policy_file.path
+        ));
+        return;
+    }
+    if policy_file.path.contains("..") {
+        errors.push(format!(
+            "policy_file {:?}: path must not traverse parents",
+            policy_file.path
+        ));
+        return;
+    }
+    if !root.join(path).is_file() {
+        errors.push(format!(
+            "policy_file {:?}: points at missing path",
+            policy_file.path
+        ));
+    }
+}
+
+fn validate_non_empty_policy_field(value: &str, field: &str, errors: &mut Vec<String>) {
+    if value.trim().is_empty() {
+        errors.push(format!("policy_file must have non-empty {field}"));
     }
 }
 
@@ -867,6 +920,51 @@ mod tests {
     }
 
     #[test]
+    fn missing_policy_file_reference_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        write_valid_fixture(temp.path());
+        let policy = fs::read_to_string(temp.path().join("policy/doc-artifacts.toml"))
+            .unwrap()
+            .replace("path = \"ci/proof.toml\"", "path = \"ci/missing.toml\"");
+        fs::write(temp.path().join("policy/doc-artifacts.toml"), policy).unwrap();
+
+        let report = check(temp.path(), Path::new("policy/doc-artifacts.toml")).unwrap();
+
+        assert!(
+            report.errors.iter().any(|error| {
+                error.contains("policy_file \"ci/missing.toml\"")
+                    && error.contains("points at missing path")
+            }),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn policy_file_reference_requires_verifier_command() {
+        let temp = tempfile::tempdir().unwrap();
+        write_valid_fixture(temp.path());
+        let policy = fs::read_to_string(temp.path().join("policy/doc-artifacts.toml"))
+            .unwrap()
+            .replace(
+                "covered_by = [\"cargo xtask proof-policy --check\"]",
+                "covered_by = []",
+            );
+        fs::write(temp.path().join("policy/doc-artifacts.toml"), policy).unwrap();
+
+        let report = check(temp.path(), Path::new("policy/doc-artifacts.toml")).unwrap();
+
+        assert!(
+            report.errors.iter().any(|error| {
+                error.contains("policy_file \"ci/proof.toml\"")
+                    && error.contains("covered_by must list")
+            }),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
     fn missing_required_section_fails() {
         let temp = tempfile::tempdir().unwrap();
         write_valid_fixture(temp.path());
@@ -938,13 +1036,14 @@ mod tests {
             "docs/specs",
             "docs/adr",
             "docs/plans",
+            "ci",
             ".tokmd-spec",
             ".jules/goals",
             "policy",
         ] {
             fs::create_dir_all(root.join(dir)).unwrap();
         }
-        fs::write(root.join("ci-proof-placeholder"), "").unwrap();
+        fs::write(root.join("ci/proof.toml"), "").unwrap();
         fs::write(
             root.join("policy/doc-artifacts.toml"),
             include_str!("../../../policy/doc-artifacts.toml"),

--- a/xtask/src/tasks/workspace.rs
+++ b/xtask/src/tasks/workspace.rs
@@ -27,7 +27,7 @@ pub fn run_workspace_fmt(check: bool) -> Result<()> {
         let mut command = Command::new("cargo");
         command.arg("fmt").arg("--all");
         if check {
-            command.arg("--check");
+            command.arg("--").arg("--check");
         }
 
         let status = command.status().context("failed to run cargo fmt")?;
@@ -42,7 +42,7 @@ pub fn run_workspace_fmt(check: bool) -> Result<()> {
         let mut command = Command::new("cargo");
         command.arg("fmt").arg("-p").arg(&package);
         if check {
-            command.arg("--check");
+            command.arg("--").arg("--check");
         }
 
         let status = command

--- a/xtask/tests/proof_policy_w90.rs
+++ b/xtask/tests/proof_policy_w90.rs
@@ -168,6 +168,7 @@ fn proof_policy_includes_current_product_scopes() {
     assert!(proof_control_paths.contains(".github/workflows/mutants.yml"));
     assert!(proof_control_paths.contains(".github/workflows/nix-full.yml"));
     assert!(proof_control_paths.contains(".github/workflows/nix-macos.yml"));
+    assert!(proof_control_paths.contains("xtask/src/tasks/workspace.rs"));
     assert!(proof_control_proof.contains("cargo xtask ci-lane-whitelist"));
 
     let project_truth_docs = scopes


### PR DESCRIPTION
## Summary
- import tokmd-swarm PR #37 as a publication checkpoint
- brings over the doc-artifacts checker policy-file validation slice
- preserves the swarm squash commit as second-parent history via merge commit

## Swarm Import
- Swarm-Head: 2217c838e602f247b6065efb348fabf107b4d5e8
- Swarm-Range: a77080f802a4a96675c6804f63ba506c61bac8c6..2217c838e602f247b6065efb348fabf107b4d5e8
- Swarm PR: EffortlessMetrics/tokmd-swarm#37

## Proof
Swarm PR #37 passed required hosted checks before merge:
- Tokmd Rust Small Result: success
- CI (Required): success
- droid-review: success
- CI Policy / No-panic / Docs Check / Affected Proof Plan: success

Local publication graph proof before import:
- cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-descends-publication --json target/repo-graph/swarm-descends-publication-doc-artifacts-policy-files.json

## Claim Boundary
Publication import only. This does not create tags, releases, crates.io publishes, Docker pushes, signing changes, v1 alias movement, proof promotion, Codecov default upload, or release mutation.

## Merge Policy
Merge this PR with a merge commit, not squash, so tokmd records the swarm import edge.