### PR TITLE
merge(swarm): import tokmd-swarm repo graph no-divergence tests

### DIFF
--- a/xtask/tests/repo_graph_w99.rs
+++ b/xtask/tests/repo_graph_w99.rs
@@ -201,6 +201,74 @@ fn repo_graph_reports_publication_ahead_in_real_git_repo() {
 }
 
 #[test]
+fn repo_graph_no_divergence_accepts_swarm_ahead_in_real_git_repo() {
+    let temp = init_repo();
+    let repo = temp.path();
+
+    git(repo, &["switch", "swarm"]);
+    write_file(repo, "file.txt", "base\nswarm\n");
+    commit(repo, "swarm");
+
+    let (stdout, stderr, success) = run_xtask_in_dir(
+        &[
+            "repo-graph",
+            "--publication",
+            "publication",
+            "--swarm",
+            "swarm",
+            "--expect",
+            "no-divergence",
+        ],
+        repo,
+    );
+
+    assert!(
+        success,
+        "repo-graph no-divergence swarm-ahead failed. stderr: {stderr}"
+    );
+    assert!(stdout.contains("SwarmAhead"), "stdout: {stdout}");
+    assert!(stdout.contains("ok=true"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("open a tokmd publication PR"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn repo_graph_no_divergence_accepts_publication_ahead_in_real_git_repo() {
+    let temp = init_repo();
+    let repo = temp.path();
+
+    git(repo, &["switch", "publication"]);
+    write_file(repo, "file.txt", "base\npublication\n");
+    commit(repo, "publication");
+
+    let (stdout, stderr, success) = run_xtask_in_dir(
+        &[
+            "repo-graph",
+            "--publication",
+            "publication",
+            "--swarm",
+            "swarm",
+            "--expect",
+            "no-divergence",
+        ],
+        repo,
+    );
+
+    assert!(
+        success,
+        "repo-graph no-divergence publication-ahead failed. stderr: {stderr}"
+    );
+    assert!(stdout.contains("PublicationAhead"), "stdout: {stdout}");
+    assert!(stdout.contains("ok=true"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("fast-forward tokmd-swarm/main"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
 fn repo_graph_rejects_swarm_ahead_when_publication_must_descend_from_swarm() {
     let temp = init_repo();
     let repo = temp.path();


### PR DESCRIPTION
## Summary

Imports the latest tokmd-swarm workbench commit into the publication repo by merge commit.

Swarm-Head: 3ec973d8fedad589b8c72e40e771641ee7dd9450
Swarm-Range: 9f6fb87ea7d2cc9d6e891853b009c1bc71f1651b..3ec973d8fedad589b8c72e40e771641ee7dd9450

Included swarm PR:
- EffortlessMetrics/tokmd-swarm#40 test: cover repo graph no-divergence ancestors

## Checks

Swarm PR #40:
- Tokmd Rust Small Result: success, run 26277371878
- CI Required: success, run 26277371815
- PR Plan advisory override: success, run 26277497491
- Droid review: approved with no findings, run 26277371751

Local publication precheck:
- cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-descends-publication --json target/repo-graph/pre-publication-repo-graph-no-divergence.json

## Merge Policy

Merge this PR with a merge commit, not squash. This preserves the swarm squash commit as second-parent history and keeps the shared tokmd/tokmd-swarm graph meaningful.

## Claim Boundary

This is a publication import only. It does not publish packages, move tags, create releases, change signing, push Docker images, or move the v1 alias.

## Rollback

Revert the publication merge commit if this import needs to be backed out. After merge, fast-forward tokmd-swarm/main to the publication merge commit.