### PR TITLE
merge(swarm): import tokmd-swarm PR plan routed budget docs

### DIFF
--- a/docs/ci/default-pr-gate.md
+++ b/docs/ci/default-pr-gate.md
@@ -65,6 +65,16 @@ That remains below the hard override ceiling, but it is intentionally reported
 as high-cost while the advisory proof executor and proof-run observation lanes
 collect real timing evidence.
 
+`tokmd-swarm` workbench PRs also run the routed Rust Small frontdoor. The
+router and aggregate result are cheap, but the lane catalogue also includes the
+conditional implementation jobs for CPX42, CX43, CX53, and GitHub-hosted
+fallback. Only one implementation job should run for a given route; the others
+skip. Static PR Plan estimates may therefore look higher than the runtime cost
+until route-aware or learned estimates are wired in. When an override label is
+used for that case, review the latest successful PR Plan run for the current
+head SHA and the actual `Tokmd Rust Small Result` check rather than an older
+pre-label failure.
+
 ## Anti-patterns
 
 - Don't use `full-ci` to dodge a real failure; the deep lanes catch

--- a/docs/ci/pr-plan.md
+++ b/docs/ci/pr-plan.md
@@ -76,6 +76,26 @@ fails until the PR is split or an explicit override label is present.
   actuals with `--actuals-dir`, but the workflow must wire that directory in
   before hosted PRs use learned estimates.
 
+## Routed Rust Small Interpretation
+
+`tokmd-swarm` has an additional routed Rust Small frontdoor. The lane catalogue
+lists the router, the aggregate `Tokmd Rust Small Result`, and each conditional
+implementation job so reviewers can see the whole route surface.
+
+Those implementation jobs are mutually exclusive at runtime. A trusted
+same-repo swarm PR normally selects one self-hosted target and skips the other
+implementation jobs. A publication-repo PR skips the routed workflow entirely
+because it is guarded to `github.repository == 'EffortlessMetrics/tokmd-swarm'`.
+
+Until hosted PR Plan uses route-aware or learned estimates, its static lane
+catalogue can overstate the cost of small proof-control or topology PRs by
+counting conditional routed implementation lanes that will not all run. In that
+case, reviewers should treat the latest successful PR Plan run for the current
+head SHA, the explicit `ci-budget-override` label, and the actual hosted check
+rollup as the actionable budget evidence. Do not treat an older failed PR Plan
+attempt for the same head as a code failure after the label-triggered rerun has
+passed.
+
 ## Override handling
 
 Use `ci-budget-override` when a high-LEM PR is intentionally broad enough to


### PR DESCRIPTION
## Summary
- Import tokmd-swarm main after PR #41.
- Carries the docs-only clarification for routed Rust Small PR Plan budget signals.
- Keeps the shared graph model intact: publication import by merge commit, then swarm fast-forward after merge.

## Import
- Swarm PR: EffortlessMetrics/tokmd-swarm#41
- Swarm-Head: c626ea1f156de38ec5e3c3fcf817e958a6473b37
- Swarm-Range: 9e84a360512b0ffe9872321b6acb1ac854dbfb28..c626ea1f156de38ec5e3c3fcf817e958a6473b37

## Swarm Proof
- Tokmd Rust Small Result: success on PR #41
- CI (Required): success on PR #41
- PR Plan (advisory): success after ci-budget-override label; older pre-label advisory failure is superseded
- Droid review: complete, no findings
- Local proof before PR: docs check, doc artifacts check, affected proof plan, affected required proof run, proof run artifacts check

## Merge Instruction
Merge this PR with a merge commit. Do not squash this publication import.