### PR TITLE
merge(swarm): import tokmd-swarm doc artifacts evidence counts

### DIFF
--- a/.github/workflows/em-routed-rust-small.yml
+++ b/.github/workflows/em-routed-rust-small.yml
@@ -250,7 +250,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ci-disk-guard /mnt/ci-scratch 90
+          ci-disk-guard /mnt/ci-scratch 80
           ci-disk-guard /mnt/docker 20
           ci-disk-guard /mnt/ci-cache 20
 

--- a/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
+++ b/crates/tokmd-cockpit/src/doc_artifacts_evidence.rs
@@ -23,6 +23,10 @@ pub struct DocArtifactsCheckedCounts {
     pub required_docs: usize,
     pub family_files: usize,
     pub active_goals: usize,
+    #[serde(default)]
+    pub spec_index_artifacts: usize,
+    #[serde(default)]
+    pub spec_index_lanes: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,6 +95,19 @@ mod tests {
   "checked": {
     "required_docs": 1,
     "family_files": 11,
+    "active_goals": 1,
+    "spec_index_artifacts": 9,
+    "spec_index_lanes": 2
+  },
+  "errors": []
+}"#;
+
+    const LEGACY_RECEIPT: &str = r#"{
+  "schema": "tokmd.doc_artifacts_check.v1",
+  "ok": true,
+  "checked": {
+    "required_docs": 1,
+    "family_files": 11,
     "active_goals": 1
   },
   "errors": []
@@ -105,7 +122,21 @@ mod tests {
         assert_eq!(input.receipt.checked.required_docs, 1);
         assert_eq!(input.receipt.checked.family_files, 11);
         assert_eq!(input.receipt.checked.active_goals, 1);
+        assert_eq!(input.receipt.checked.spec_index_artifacts, 9);
+        assert_eq!(input.receipt.checked.spec_index_lanes, 2);
         assert_eq!(input.availability(), "available");
+    }
+
+    #[test]
+    fn parses_legacy_doc_artifacts_check_receipt_without_spec_index_counts() {
+        let input = parse_doc_artifacts_evidence_input(LEGACY_RECEIPT, "target/docs/check.json")
+            .expect("legacy doc artifacts receipt");
+
+        assert_eq!(input.receipt.checked.required_docs, 1);
+        assert_eq!(input.receipt.checked.family_files, 11);
+        assert_eq!(input.receipt.checked.active_goals, 1);
+        assert_eq!(input.receipt.checked.spec_index_artifacts, 0);
+        assert_eq!(input.receipt.checked.spec_index_lanes, 0);
     }
 
     #[test]

--- a/crates/tokmd-cockpit/src/render/comment.rs
+++ b/crates/tokmd-cockpit/src/render/comment.rs
@@ -188,10 +188,12 @@ fn write_doc_artifacts_summary(
         Some(input) if input.receipt.ok => {
             let _ = writeln!(
                 s,
-                "**Doc artifacts**: verified ({} required docs, {} family files, {} active goals).",
+                "**Doc artifacts**: verified ({} required docs, {} family files, {} active goals, {} spec-index artifacts, {} spec-index lanes).",
                 input.receipt.checked.required_docs,
                 input.receipt.checked.family_files,
                 input.receipt.checked.active_goals,
+                input.receipt.checked.spec_index_artifacts,
+                input.receipt.checked.spec_index_lanes,
             );
             let _ = writeln!(s);
         }

--- a/crates/tokmd-cockpit/src/render/evidence.rs
+++ b/crates/tokmd-cockpit/src/render/evidence.rs
@@ -52,6 +52,8 @@ pub(super) fn review_packet_doc_artifacts_evidence(
                 "required_docs": input.receipt.checked.required_docs,
                 "family_files": input.receipt.checked.family_files,
                 "active_goals": input.receipt.checked.active_goals,
+                "spec_index_artifacts": input.receipt.checked.spec_index_artifacts,
+                "spec_index_lanes": input.receipt.checked.spec_index_lanes,
             },
             "errors": input.receipt.errors,
             "refs": [format!("{DOC_ARTIFACTS_PACKET_PATH}")],

--- a/crates/tokmd-cockpit/src/render/review_map.rs
+++ b/crates/tokmd-cockpit/src/render/review_map.rs
@@ -468,7 +468,7 @@ fn write_doc_artifacts_overview(
         Some(input) => {
             let _ = writeln!(
                 s,
-                "Doc artifacts: {} ({} required docs, {} family files, {} active goals).",
+                "Doc artifacts: {} ({} required docs, {} family files, {} active goals, {} spec-index artifacts, {} spec-index lanes).",
                 if input.receipt.ok {
                     "verified"
                 } else {
@@ -477,6 +477,8 @@ fn write_doc_artifacts_overview(
                 input.receipt.checked.required_docs,
                 input.receipt.checked.family_files,
                 input.receipt.checked.active_goals,
+                input.receipt.checked.spec_index_artifacts,
+                input.receipt.checked.spec_index_lanes,
             );
             if !input.receipt.errors.is_empty() {
                 let _ = writeln!(s, "- Errors: {}", input.receipt.errors.len());

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1368,7 +1368,9 @@ fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
   "checked": {
     "required_docs": 1,
     "family_files": 11,
-    "active_goals": 1
+    "active_goals": 1,
+    "spec_index_artifacts": 9,
+    "spec_index_lanes": 2
   },
   "errors": []
 }"#,
@@ -1399,6 +1401,11 @@ fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
     assert_eq!(evidence["doc_artifacts"]["checked"]["required_docs"], 1);
     assert_eq!(evidence["doc_artifacts"]["checked"]["family_files"], 11);
     assert_eq!(evidence["doc_artifacts"]["checked"]["active_goals"], 1);
+    assert_eq!(
+        evidence["doc_artifacts"]["checked"]["spec_index_artifacts"],
+        9
+    );
+    assert_eq!(evidence["doc_artifacts"]["checked"]["spec_index_lanes"], 2);
     assert_eq!(
         evidence["doc_artifacts"]["refs"][0],
         "docs/doc-artifacts-check.json"
@@ -1487,7 +1494,9 @@ fn scenario_write_review_packet_includes_imported_doc_artifacts_evidence() {
 
     let comment_md = std::fs::read_to_string(out.join("comment.md")).unwrap();
     assert!(comment_md.contains("Doc artifacts"));
-    assert!(comment_md.contains("verified (1 required docs, 11 family files, 1 active goals)"));
+    assert!(comment_md.contains(
+        "verified (1 required docs, 11 family files, 1 active goals, 9 spec-index artifacts, 2 spec-index lanes)"
+    ));
 }
 
 #[test]

--- a/crates/tokmd/schemas/review-packet-evidence.schema.json
+++ b/crates/tokmd/schemas/review-packet-evidence.schema.json
@@ -171,7 +171,9 @@
       "properties": {
         "required_docs": { "type": "integer", "minimum": 0 },
         "family_files": { "type": "integer", "minimum": 0 },
-        "active_goals": { "type": "integer", "minimum": 0 }
+        "active_goals": { "type": "integer", "minimum": 0 },
+        "spec_index_artifacts": { "type": "integer", "minimum": 0 },
+        "spec_index_lanes": { "type": "integer", "minimum": 0 }
       }
     },
     "scopeCoverage": {

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -128,7 +128,9 @@ const DOC_ARTIFACTS_CHECK_JSON: &str = r#"{
   "checked": {
     "required_docs": 1,
     "family_files": 11,
-    "active_goals": 1
+    "active_goals": 1,
+    "spec_index_artifacts": 9,
+    "spec_index_lanes": 2
   },
   "errors": []
 }"#;
@@ -396,6 +398,11 @@ fn test_cockpit_review_packet_includes_imported_doc_artifacts_evidence() {
     assert_eq!(evidence["doc_artifacts"]["checked"]["required_docs"], 1);
     assert_eq!(evidence["doc_artifacts"]["checked"]["family_files"], 11);
     assert_eq!(evidence["doc_artifacts"]["checked"]["active_goals"], 1);
+    assert_eq!(
+        evidence["doc_artifacts"]["checked"]["spec_index_artifacts"],
+        9
+    );
+    assert_eq!(evidence["doc_artifacts"]["checked"]["spec_index_lanes"], 2);
 
     let copied_doc_artifacts_path = packet_dir.join("docs").join("doc-artifacts-check.json");
     assert!(

--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -194,9 +194,10 @@ CPX42 -> CX43 -> CX53 -> GitHub-hosted
 CPX42 uses the pinned Rust 1.95 toolchain directly on the host, with
 `/mnt/ci-scratch` `TMPDIR` prepared before the toolchain action runs. CX43 and
 CX53 keep their existing local `em-ci-rust:1.95` Docker execution path. CX43
-uses a 90GB scratch-space guard to avoid false negatives from host-reserved
-space while preserving a high floor for the isolated Cargo target directory;
-CX53 keeps the 100GB scratch-space guard.
+uses an 80GB scratch-space guard after a PR-event false negative showed 86GB
+free on the 150GB host filesystem; that still preserves a high floor for the
+isolated Cargo target directory while avoiding known host-reserved-space
+failures. CX53 keeps the 100GB scratch-space guard.
 
 Merge commits may remain available for exceptional sync or admin flows, but
 normal feature work should be squash-only.

--- a/docs/review-packet-evidence.schema.json
+++ b/docs/review-packet-evidence.schema.json
@@ -171,7 +171,9 @@
       "properties": {
         "required_docs": { "type": "integer", "minimum": 0 },
         "family_files": { "type": "integer", "minimum": 0 },
-        "active_goals": { "type": "integer", "minimum": 0 }
+        "active_goals": { "type": "integer", "minimum": 0 },
+        "spec_index_artifacts": { "type": "integer", "minimum": 0 },
+        "spec_index_lanes": { "type": "integer", "minimum": 0 }
       }
     },
     "scopeCoverage": {

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -207,8 +207,9 @@ cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check.json
 
 The review packet should treat this as documentation-control evidence, not as a
 merge verdict. A successful receipt means the source-of-truth artifact shape,
-links, active-goal state, and policy routing checked by the doc-artifacts
-contract were valid at verification time. It does not prove the prose is
+links, `.tokmd-spec` index entries, active-goal state, and policy routing
+checked by the doc-artifacts contract were valid at verification time. It does
+not prove the prose is
 correct or that a PR should merge.
 
 Packet treatment:

--- a/docs/specs/doc-artifacts.md
+++ b/docs/specs/doc-artifacts.md
@@ -171,7 +171,9 @@ The JSON receipt uses schema `tokmd.doc_artifacts_check.v1`:
   "checked": {
     "required_docs": 1,
     "family_files": 11,
-    "active_goals": 1
+    "active_goals": 1,
+    "spec_index_artifacts": 9,
+    "spec_index_lanes": 2
   },
   "errors": []
 }

--- a/xtask/src/tasks/doc_artifacts.rs
+++ b/xtask/src/tasks/doc_artifacts.rs
@@ -153,6 +153,8 @@ struct CheckReport {
     required_docs: usize,
     family_files: usize,
     active_goals: usize,
+    spec_index_artifacts: usize,
+    spec_index_lanes: usize,
     errors: Vec<String>,
 }
 
@@ -169,6 +171,8 @@ struct CheckedCounts {
     required_docs: usize,
     family_files: usize,
     active_goals: usize,
+    spec_index_artifacts: usize,
+    spec_index_lanes: usize,
 }
 
 impl From<&CheckReport> for CheckReceipt {
@@ -180,6 +184,8 @@ impl From<&CheckReport> for CheckReceipt {
                 required_docs: report.required_docs,
                 family_files: report.family_files,
                 active_goals: report.active_goals,
+                spec_index_artifacts: report.spec_index_artifacts,
+                spec_index_lanes: report.spec_index_lanes,
             },
             errors: report.errors.clone(),
         }
@@ -199,7 +205,7 @@ fn check(root: &Path, policy_path: &Path) -> Result<CheckReport> {
     }
 
     if let Some(spec_index) = &policy.spec_index {
-        validate_spec_index(root, spec_index, &mut report.errors);
+        validate_spec_index(root, spec_index, &mut report);
     }
 
     if let Some(active_goal) = &policy.active_goal {
@@ -230,8 +236,12 @@ fn report_result(report: CheckReport) -> Result<String> {
     }
 
     Ok(format!(
-        "doc artifacts ok: {} required doc(s), {} family file(s), {} active goal(s)",
-        report.required_docs, report.family_files, report.active_goals
+        "doc artifacts ok: {} required doc(s), {} family file(s), {} active goal(s), {} spec-index artifact(s), {} spec-index lane(s)",
+        report.required_docs,
+        report.family_files,
+        report.active_goals,
+        report.spec_index_artifacts,
+        report.spec_index_lanes
     ))
 }
 
@@ -294,22 +304,30 @@ fn validate_required_doc(root: &Path, required_doc: &RequiredDoc, errors: &mut V
     }
 }
 
-fn validate_spec_index(root: &Path, policy: &SpecIndexPolicy, errors: &mut Vec<String>) {
+fn validate_spec_index(root: &Path, policy: &SpecIndexPolicy, report: &mut CheckReport) {
     let path = root.join(&policy.path);
     let content = match fs::read_to_string(&path) {
         Ok(content) => content,
         Err(err) => {
-            errors.push(format!("{} is unreadable: {err}", policy.path));
+            report
+                .errors
+                .push(format!("{} is unreadable: {err}", policy.path));
             return;
         }
     };
     let index: SpecIndex = match toml::from_str(&content) {
         Ok(index) => index,
         Err(err) => {
-            errors.push(format!("{} is invalid TOML: {err}", policy.path));
+            report
+                .errors
+                .push(format!("{} is invalid TOML: {err}", policy.path));
             return;
         }
     };
+    report.spec_index_artifacts += index.artifact.len();
+    report.spec_index_lanes += index.lane.len();
+
+    let errors = &mut report.errors;
 
     if index.schema_version != policy.schema_version {
         errors.push(format!(
@@ -759,6 +777,8 @@ mod tests {
         assert_eq!(report.active_goals, 1);
         assert_eq!(report.required_docs, 2);
         assert_eq!(report.family_files, 4);
+        assert_eq!(report.spec_index_artifacts, 1);
+        assert_eq!(report.spec_index_lanes, 0);
     }
 
     #[test]
@@ -776,6 +796,8 @@ mod tests {
         assert_eq!(receipt["checked"]["required_docs"], 2);
         assert_eq!(receipt["checked"]["family_files"], 4);
         assert_eq!(receipt["checked"]["active_goals"], 1);
+        assert_eq!(receipt["checked"]["spec_index_artifacts"], 1);
+        assert_eq!(receipt["checked"]["spec_index_lanes"], 0);
         assert_eq!(receipt["errors"].as_array().expect("errors array").len(), 0);
     }
 


### PR DESCRIPTION
## Summary
- Import tokmd-swarm main after PR #42.
- Carries doc-artifacts spec-index receipt counts through cockpit/review-packet evidence.
- Carries the narrow CX43 routed Rust Small scratch-guard reliability fix from 90GB to 80GB.
- Keeps the shared graph model intact: publication import by merge commit, then swarm fast-forward after merge.

## Import
- Swarm PR: EffortlessMetrics/tokmd-swarm#42
- Swarm-Head: 6af749153e1bd838111e9221cabe98982fb30b60
- Swarm-Range: 207a68f6468df2b9e3cd258b7ee48c676e7d8f1f..6af749153e1bd838111e9221cabe98982fb30b60

## Swarm Proof
- Tokmd Rust Small Result: success on PR #42
- CI (Required): success on PR #42
- PR Plan (advisory): success with explicit ci-budget-override
- Droid review: approved
- Local required affected proof: 38 executed, 38 passed, 0 failed
- Proof-run artifact verifier: passed

## Merge Instruction
Merge this PR with a merge commit. Do not squash this publication import.