### PR TITLE
merge(swarm): import tokmd-swarm repo boundary template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -84,7 +84,11 @@
       `tokmd-swarm` head, and must merge with a merge commit, not squash.
 - [ ] Other: explain why this PR is outside the normal swarm/publication loop.
 
-- **Repo-graph evidence:** <!-- e.g. cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-descends-publication -->
+- **Repo-graph evidence:** <!-- Replace with the matching command and result.
+  Normal swarm PR: cargo xtask repo-graph --publication public/main --swarm HEAD --expect swarm-descends-publication
+  Publication import PR: cargo xtask repo-graph --publication origin/main --swarm HEAD --expect swarm-descends-publication
+  Post-publication fast-forward: cargo xtask repo-graph --publication public/main --swarm origin/main --expect aligned
+-->
 
 ---
 


### PR DESCRIPTION
## Summary
Import tokmd-swarm PR #44 into the publication repository.

Swarm-Head: 85361e7a5e1efe5b7a6274cbe0dbdd516071dde4
Swarm-Range: 84bab5a3ec1d96a08d2b5b7d532ae0b83cc95f14..85361e7a5e1efe5b7a6274cbe0dbdd516071dde4

## Imported Work
- EffortlessMetrics/tokmd-swarm#44: docs: clarify repo boundary graph evidence

## Validation
- Swarm PR #44 hosted checks passed, including Tokmd Rust Small Result, CI (Required), Docs Check, and PR Plan after ci-budget-override for the known 150 LEM static overcount.
- cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-descends-publication --json target/repo-graph/pre-publication-template.json: pass; swarm_ahead=1, publication_ahead=0.

## Merge Policy
This is a publication import PR. Merge with a merge commit, not squash.

## Claim Boundary
Publication import only. No release, publish, signing, Docker, tag, or v1 alias mutation.

## Rollback
Revert the publication merge commit if the imported docs/template change needs to be backed out, then fast-forward or sync tokmd-swarm according to docs/ci/swarm-routing.md.