### PR TITLE
merge(swarm): import tokmd-swarm ci budget guidance

### DIFF
--- a/docs/ci/budget-guard.md
+++ b/docs/ci/budget-guard.md
@@ -38,7 +38,11 @@ changes.
 - `ci-budget-ack` — apply when the PR is intentionally elevated and the
   reviewer has confirmed the spend is worth it.
 - `ci-budget-override` — bypass the hard ceiling for one PR. Use
-  sparingly.
+  sparingly. This is appropriate when the PR is intentionally broad, or when a
+  narrow PR has a known static-estimator overcount such as mutually exclusive
+  routed Rust Small implementation lanes. In the overcount case, cite the
+  affected proof plan, latest passing PR Plan run for the current head SHA, and
+  hosted check rollup.
 - `full-ci` — also acts as override; the deep lanes will run anyway.
 
 If a label is added after an `override-required` failure, use the latest PR Plan

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -22,6 +22,11 @@ Labels select expensive lanes that ordinary PRs skip. The PR Plan job (PR
 | `ci-budget-ack` | Acknowledge an estimate above the elevated band. Suppresses warning, does not bypass hard ceiling. |
 | `ci-budget-override` | Bypass the >125 LEM hard ceiling. Use sparingly. |
 
+Use `ci-budget-override` for a narrow PR only when the PR body or review
+comment cites why the estimate is an overcount. The common case is the routed
+Rust Small catalogue: PR Plan may count mutually exclusive implementation lanes
+that the hosted check rollup proves did not all run.
+
 ## Advisory labels
 
 | Label | Effect |
@@ -34,5 +39,7 @@ Labels select expensive lanes that ordinary PRs skip. The PR Plan job (PR
   things the default lane is *intentionally* skipping.
 - Don't apply `ci-budget-override` to ship a PR that's broad because it
   bundles unrelated work. Split the PR instead.
+- Don't treat an older failed PR Plan attempt as current after a label-triggered
+  rerun has passed for the same head SHA.
 - Labels do not retroactively change branch protection. The required
   summary job still has to pass.


### PR DESCRIPTION
## Summary
Import tokmd-swarm PR #45 into the publication repository.

Swarm-Head: 880f02557bd39c81286c06125ea34a834dc6e4ca
Swarm-Range: 538368fde1d71a1432dbafef0831551b92738baa..880f02557bd39c81286c06125ea34a834dc6e4ca

## Imported Work
- EffortlessMetrics/tokmd-swarm#45: docs: clarify ci budget override overcounts

## Validation
- Swarm PR #45 hosted checks passed, including Tokmd Rust Small Result, CI (Required), Docs Check, and PR Plan after ci-budget-override for the documented 150 LEM static overcount.
- cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-descends-publication --json target/repo-graph/pre-publication-ci-budget-overcount.json: pass; swarm_ahead=1, publication_ahead=0.

## Merge Policy
This is a publication import PR. Merge with a merge commit, not squash.

## Claim Boundary
Publication import only. No release, publish, signing, Docker, tag, or v1 alias mutation.

## Rollback
Revert the publication merge commit if the imported docs change needs to be backed out, then fast-forward or sync tokmd-swarm according to docs/ci/swarm-routing.md.