### PR TITLE
merge(swarm): import tokmd-swarm repo graph import test

### DIFF
--- a/xtask/tests/repo_graph_w99.rs
+++ b/xtask/tests/repo_graph_w99.rs
@@ -201,6 +201,52 @@ fn repo_graph_reports_publication_ahead_in_real_git_repo() {
 }
 
 #[test]
+fn repo_graph_accepts_publication_merge_commit_import() {
+    let temp = init_repo();
+    let repo = temp.path();
+
+    git(repo, &["switch", "swarm"]);
+    write_file(repo, "file.txt", "base\nswarm\n");
+    commit(repo, "swarm");
+    git(repo, &["switch", "publication"]);
+    git(
+        repo,
+        &[
+            "merge",
+            "--no-ff",
+            "swarm",
+            "-m",
+            "merge(swarm): import proof slice",
+        ],
+    );
+
+    let (stdout, stderr, success) = run_xtask_in_dir(
+        &[
+            "repo-graph",
+            "--publication",
+            "publication",
+            "--swarm",
+            "swarm",
+            "--expect",
+            "publication-descends-swarm",
+        ],
+        repo,
+    );
+
+    assert!(
+        success,
+        "repo-graph publication import failed. stderr: {stderr}"
+    );
+    assert!(stdout.contains("PublicationAhead"), "stdout: {stdout}");
+    assert!(stdout.contains("publication_ahead=1"), "stdout: {stdout}");
+    assert!(stdout.contains("swarm_ahead=0"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("fast-forward tokmd-swarm/main"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
 fn repo_graph_no_divergence_accepts_swarm_ahead_in_real_git_repo() {
     let temp = init_repo();
     let repo = temp.path();


### PR DESCRIPTION
## Summary
- Import tokmd-swarm PR #46 into the publication repo with a merge-commit PR.
- Carries the repo-graph test that proves publication merge-commit imports are accepted and produce the expected fast-forward hint for swarm.

## Swarm import
- Swarm-Head: 617855b57afad3d7395529661662d4e737782f44
- Swarm-Range: bbf57aeb0f8f86138c95725e40c83f360ede029c..617855b57afad3d7395529661662d4e737782f44
- Imported PR: EffortlessMetrics/tokmd-swarm#46

## Validation
- Swarm PR #46 checks: Tokmd Rust Small Result, CI (Required), Docs Check, Affected Proof Plan, Quality Gate, Build & Test (Linux), droid-review all passed.
- Local: cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-descends-publication --json target/repo-graph/pre-publication-repo-graph-import-merge.json

## Merge policy
Merge this PR with a merge commit, not squash. This is a publication import from tokmd-swarm.

## Claim boundary
This imports one swarm proof slice. It does not move release tags, publish crates, update v1 aliases, or change release artifacts.