### PR TITLE
merge(swarm): import tokmd-swarm repo-graph ahead expectations

### DIFF
--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -142,14 +142,15 @@ cargo xtask repo-graph \
 ```
 
 Before a publication import, a green swarm PR may intentionally leave
-`tokmd-swarm/main` ahead of `tokmd/main`. In that state, verify the graph is
-still a single ancestor line rather than a divergence:
+`tokmd-swarm/main` ahead of `tokmd/main`. In that state, use the exact
+`swarm-ahead` expectation when proving a pending publication import; use
+`swarm-descends-publication` only when aligned or swarm-ahead are both acceptable:
 
 ```bash
 cargo xtask repo-graph \
   --publication public/main \
   --swarm origin/main \
-  --expect swarm-descends-publication \
+  --expect swarm-ahead \
   --json target/repo-graph/pre-publication.json
 ```
 
@@ -381,9 +382,12 @@ Verify that direction before the fast-forward:
 cargo xtask repo-graph \
   --publication public/main \
   --swarm origin/main \
-  --expect publication-descends-swarm \
+  --expect publication-ahead \
   --json target/repo-graph/publication-hotfix.json
 ```
+
+Use `publication-descends-swarm` instead when aligned and publication-ahead are
+both acceptable for the calling workflow.
 
 If publication is not a descendant of swarm, sync publication into swarm with an
 explicit merge commit:

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -663,6 +663,10 @@ impl Default for RepoGraphArgs {
 pub enum RepoGraphExpectation {
     /// Refs point at the same commit.
     Aligned,
+    /// Swarm is ahead of publication and publication is an ancestor of swarm.
+    SwarmAhead,
+    /// Publication is ahead of swarm and swarm is an ancestor of publication.
+    PublicationAhead,
     /// Publication is an ancestor of swarm; aligned and swarm-ahead are accepted.
     SwarmDescendsPublication,
     /// Swarm is an ancestor of publication; aligned and publication-ahead are accepted.

--- a/xtask/src/tasks/repo_graph.rs
+++ b/xtask/src/tasks/repo_graph.rs
@@ -190,6 +190,8 @@ pub(crate) fn expectation_matches(
 ) -> bool {
     match expectation {
         RepoGraphExpectation::Aligned => relation == GraphRelation::Aligned,
+        RepoGraphExpectation::SwarmAhead => relation == GraphRelation::SwarmAhead,
+        RepoGraphExpectation::PublicationAhead => relation == GraphRelation::PublicationAhead,
         RepoGraphExpectation::SwarmDescendsPublication => {
             matches!(relation, GraphRelation::Aligned | GraphRelation::SwarmAhead)
         }
@@ -209,6 +211,8 @@ pub(crate) fn expectation_matches(
 fn expectation_name(expectation: RepoGraphExpectation) -> &'static str {
     match expectation {
         RepoGraphExpectation::Aligned => "aligned",
+        RepoGraphExpectation::SwarmAhead => "swarm-ahead",
+        RepoGraphExpectation::PublicationAhead => "publication-ahead",
         RepoGraphExpectation::SwarmDescendsPublication => "swarm-descends-publication",
         RepoGraphExpectation::PublicationDescendsSwarm => "publication-descends-swarm",
         RepoGraphExpectation::NoDivergence => "no-divergence",
@@ -225,23 +229,29 @@ fn graph_next_action(expectation: &str, relation: GraphRelation) -> &'static str
             "graph is aligned; no publication or swarm fast-forward action is needed"
         }
         ("swarm-descends-publication", GraphRelation::Aligned)
+        | ("swarm-ahead", GraphRelation::Aligned)
+        | ("publication-ahead", GraphRelation::Aligned)
         | ("publication-descends-swarm", GraphRelation::Aligned)
         | ("no-divergence", GraphRelation::Aligned) => {
             "graph is aligned; continue with the operating step that requested this check"
         }
-        ("swarm-descends-publication", GraphRelation::SwarmAhead)
+        ("swarm-ahead", GraphRelation::SwarmAhead)
+        | ("swarm-descends-publication", GraphRelation::SwarmAhead)
         | ("no-divergence", GraphRelation::SwarmAhead) => {
             "swarm descends from publication; open a tokmd publication PR and merge it with a merge commit before fast-forwarding swarm"
         }
-        ("publication-descends-swarm", GraphRelation::PublicationAhead)
+        ("publication-ahead", GraphRelation::PublicationAhead)
+        | ("publication-descends-swarm", GraphRelation::PublicationAhead)
         | ("no-divergence", GraphRelation::PublicationAhead) => {
             "publication descends from swarm; fast-forward tokmd-swarm/main to the publication commit before routine swarm work continues"
         }
         ("aligned", GraphRelation::SwarmAhead)
+        | ("publication-ahead", GraphRelation::SwarmAhead)
         | ("publication-descends-swarm", GraphRelation::SwarmAhead) => {
             "publication has not imported the swarm head; create a tokmd publication PR and merge it with a merge commit before fast-forwarding swarm"
         }
         ("aligned", GraphRelation::PublicationAhead)
+        | ("swarm-ahead", GraphRelation::PublicationAhead)
         | ("swarm-descends-publication", GraphRelation::PublicationAhead) => {
             "swarm is behind publication; fast-forward tokmd-swarm/main to the publication commit before routine swarm work continues"
         }
@@ -352,6 +362,34 @@ mod tests {
         ));
         assert!(!expectation_matches(
             RepoGraphExpectation::Aligned,
+            GraphRelation::SwarmAhead
+        ));
+    }
+
+    #[test]
+    fn ahead_expectations_require_exact_ahead_side() {
+        assert!(expectation_matches(
+            RepoGraphExpectation::SwarmAhead,
+            GraphRelation::SwarmAhead
+        ));
+        assert!(!expectation_matches(
+            RepoGraphExpectation::SwarmAhead,
+            GraphRelation::Aligned
+        ));
+        assert!(!expectation_matches(
+            RepoGraphExpectation::SwarmAhead,
+            GraphRelation::PublicationAhead
+        ));
+        assert!(expectation_matches(
+            RepoGraphExpectation::PublicationAhead,
+            GraphRelation::PublicationAhead
+        ));
+        assert!(!expectation_matches(
+            RepoGraphExpectation::PublicationAhead,
+            GraphRelation::Aligned
+        ));
+        assert!(!expectation_matches(
+            RepoGraphExpectation::PublicationAhead,
             GraphRelation::SwarmAhead
         ));
     }

--- a/xtask/tests/repo_graph_w99.rs
+++ b/xtask/tests/repo_graph_w99.rs
@@ -96,6 +96,8 @@ fn repo_graph_help_mentions_refs_expectation_and_json() {
     assert!(stdout.contains("--swarm"), "stdout: {stdout}");
     assert!(stdout.contains("--expect"), "stdout: {stdout}");
     assert!(stdout.contains("--json"), "stdout: {stdout}");
+    assert!(stdout.contains("swarm-ahead"), "stdout: {stdout}");
+    assert!(stdout.contains("publication-ahead"), "stdout: {stdout}");
 }
 
 #[test]
@@ -158,7 +160,7 @@ fn repo_graph_reports_swarm_ahead_in_real_git_repo() {
             "--swarm",
             "swarm",
             "--expect",
-            "swarm-descends-publication",
+            "swarm-ahead",
         ],
         repo,
     );
@@ -186,7 +188,7 @@ fn repo_graph_reports_publication_ahead_in_real_git_repo() {
             "--swarm",
             "swarm",
             "--expect",
-            "publication-descends-swarm",
+            "publication-ahead",
         ],
         repo,
     );


### PR DESCRIPTION
Swarm-Head: 7a6ed94a466c3b75e38733db3c1232048f04cd52
Swarm-Range: 866b9253e5466474e1157161c426daa897641c15..7a6ed94a466c3b75e38733db3c1232048f04cd52

Import
- xtask: add exact repo graph ahead expectations

Checks
- tokmd-swarm PR #51 Tokmd Rust Small Result: success
- tokmd-swarm PR #51 CI (Required): success
- Local repo-graph expectation: swarm-ahead passed before import

Publication rule
- Merge this PR with a merge commit, not squash.

After merge
- Fast-forward tokmd-swarm/main to the publication merge commit.