### PR TITLE
merge(swarm): import tokmd-swarm nix side-validation docs

### DIFF
--- a/docs/ci/cache-and-cancellation.md
+++ b/docs/ci/cache-and-cancellation.md
@@ -30,6 +30,13 @@ gate. Treat an in-progress Nix full run as a release-readiness caveat, not as a
 reason to block a green `tokmd-swarm` PR, a merge-commit publication import, or
 the follow-up fast-forward back to swarm.
 
+When checking current publication state, key Nix full runs by `headSha`, not
+just by workflow name. Multiple in-progress `Nix Full Validation` runs can be
+valid at the same time when they cover different publication commits. Report the
+run for the current `tokmd/main` head separately from older commit-scoped runs,
+and avoid treating an older in-progress run as evidence about the current
+publication merge.
+
 ## Cache save policy
 
 Every `Swatinem/rust-cache@v2` use sets:


### PR DESCRIPTION
## Summary
- Imports tokmd-swarm PR #53 into the publication repo with a merge commit.
- Carries the docs-only clarification for commit-scoped Nix Full Validation interpretation.
- Preserves the publication/workbench graph: swarm PR squashed in 	okmd-swarm, then imported here by merge commit.

## Swarm Import
- Swarm head: 2e1f0efad022e55d2c5b93a069cae9bdad768dea
- Swarm range: 42b839287879637107a7d06dba07d73561f15b3b..2e1f0efad022e55d2c5b93a069cae9bdad768dea
- Source swarm PR: EffortlessMetrics/tokmd-swarm#53

## Verification
- Swarm PR #53 passed Tokmd Rust Small Result.
- Swarm PR #53 passed CI (Required).
- Pre-publication graph check passed:
  cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-nix-side-validation-interpretation.json

## Merge Policy
Merge this PR with a merge commit, not squash, so the squashed swarm commit remains preserved as second-parent history.

## Claim Boundary
Publication import only. This does not publish crates, create tags, create GitHub releases, push Docker images, sign artifacts, move the v1 alias, or change Nix workflow behavior.

## Rollback
Revert the publication merge commit if the imported docs change must be backed out. After merge, fast-forward 	okmd-swarm/main to the publication merge commit to restore aligned graph state.