### PR TITLE
merge(swarm): import tokmd-swarm handoff work-order spec

### DIFF
--- a/docs/specs/SPEC_GAPS.md
+++ b/docs/specs/SPEC_GAPS.md
@@ -52,7 +52,7 @@ require deleting or rewriting user-facing docs in the same change.
 | Diff input classification (path-like before git refs) | implementation/tests, issue #2411 notes | needs ADR/spec split | add `docs/specs/diff-input-classification.md` |
 | Nix/release source-closure invariants for schemas/fixtures/docs | `flake.nix`, tests, issue #2415 notes | policy-only | add `docs/specs/release-validation-source-closure.md` |
 | Cockpit review packet contract (required files, evidence states, verifier semantics) | `docs/review-packet.md`, schemas, tests | documented but not specced | add `docs/specs/review-packet.md` |
-| Handoff work-order required sections and semantics | `docs/handoff.md`, schema/tests | documented but not specced | add `docs/specs/handoff-work-order.md` |
+| Handoff work-order required sections and semantics | `docs/specs/handoff-work-order.md`, `docs/handoff.md`, schema/tests | specified | keep renderer and tests aligned with spec |
 | Coverage/Codecov evidence claim boundary | `docs/ci/coverage.md` | documented but not specced | add `docs/specs/coverage-evidence.md` |
 | No-panic allowlist checker semantics | `policy/no-panic-allowlist.toml`, xtask checks | policy-only | add `docs/specs/no-panic-policy.md` |
 | Non-Rust allowlist/file-policy semantics | `policy/non-rust-allowlist.toml`, xtask checks, `docs/FILE_POLICY.md` | policy-only | add `docs/specs/file-policy.md` |

--- a/docs/specs/handoff-work-order.md
+++ b/docs/specs/handoff-work-order.md
@@ -1,0 +1,113 @@
+# Spec: Handoff Work Order
+
+- Status: active
+- Schema family, if any: handoff manifest schema version 5; no separate
+  `work-order.md` JSON schema
+- Related ADRs:
+- Related proof scopes: `tokmd_context_handoff`, `project_truth_docs`,
+  `doc_artifacts_policy`
+
+## Contract
+
+`.handoff/work-order.md` is the agent-readable task map inside a
+`tokmd handoff` bundle. It turns the bundle manifest, selected files, optional
+review links, and optional proof links into a consumption guide for coding-agent
+work.
+
+The work order is not the authoritative bundle index. `manifest.json` remains
+the authoritative artifact inventory, schema-versioned handoff receipt, and
+hash source for packet-local artifacts.
+
+The work order is not a proof verifier, merge verdict, release approval, or
+policy promotion surface. It may summarize adjacent review and proof receipts
+for triage, but the linked review-packet verifier, affected-proof receipt, and
+proof-plan receipt remain the evidence sources to inspect before claiming proof.
+
+## Inputs
+
+The work order is generated from explicit handoff inputs:
+
+- the handoff manifest and selected bundle metadata;
+- included files, excluded paths, smart exclusions, and token-budget state;
+- optional `--review-packet-dir` and `--review-packet-check` inputs;
+- optional `--affected` and `--proof-plan` inputs;
+- best-effort readable summaries of linked review/proof receipts when supplied.
+
+Input paths recorded in the handoff bundle must be repo-relative or
+operator-supplied paths represented as link handles. The work order must not
+discover hidden proof state, call GitHub APIs, fetch CI artifacts, execute proof
+commands, or mutate external review/proof receipts while rendering.
+
+## Outputs
+
+The work order is a Markdown artifact listed in `manifest.json` as
+`work-order.md`. It should give agents a stable reading order and enough
+guardrails to avoid treating context as proof.
+
+The generated work order should include these semantic sections or equivalent
+content:
+
+- a short statement that the handoff is a deterministic source/context bundle;
+- selected-file and bundle-scope summary;
+- changed-surface or relevant-source summary when available;
+- review evidence handles when review packet links are supplied;
+- proof expectations when affected/proof-plan links are supplied;
+- missing, stale, degraded, skipped, or unavailable evidence as work to resolve;
+- agent stop conditions and boundaries;
+- pointers back to packet-local link artifacts when they exist.
+
+The work order may summarize readable linked receipts, but it must keep those
+summaries compact. It should point to source artifacts instead of copying raw
+receipt bodies or command output.
+
+## Compatibility
+
+This spec does not change the public `tokmd handoff` CLI, handoff manifest
+schema version, work-order filename, link-artifact filenames, review-packet
+behavior, proof-plan behavior, Codecov defaults, AST defaults, release
+surfaces, or branch-protection gates.
+
+Existing consumers can continue to read:
+
+- `.handoff/manifest.json` as the authoritative artifact index;
+- `.handoff/work-order.md` as the human agent brief;
+- `.handoff/review-links.json` for review packet handles;
+- `.handoff/proof-links.json` for affected/proof-plan handles;
+- linked review and proof receipts as their own evidence sources.
+
+Future changes that alter required work-order sections, link-artifact
+semantics, or manifest artifact requirements should update this spec and the
+handoff tests in the same PR.
+
+## Proof Requirements
+
+For spec-only changes:
+
+```bash
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-handoff-work-order-spec.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-handoff-work-order-spec.json --evidence-json target/proof/proof-evidence-handoff-work-order-spec.json
+git diff --check
+```
+
+Implementation changes to the work-order renderer should also run focused
+handoff tests that prove:
+
+- `work-order.md` is listed in `manifest.json`;
+- packet-local hashes remain valid after work-order rendering;
+- plain handoffs include the reading order and guardrails;
+- linked review/proof handoffs include link handles without copying external
+  receipts;
+- missing linked receipts are rendered as missing work, not passing proof;
+- advisory proof, Codecov upload, review verdicts, release mutation, and AST
+  defaults remain unchanged.
+
+## Open Questions
+
+- Whether a future downstream tool needs a separate structured
+  `agent-work-order.json` artifact, or whether the current manifest plus
+  Markdown work order is enough.
+- Whether work-order section headings should become machine-checked once a
+  second independent consumer depends on exact headings.


### PR DESCRIPTION
Imports the completed tokmd-swarm proof slice from the active workbench.

Swarm-PR: EffortlessMetrics/tokmd-swarm#54
Swarm-Head: 2d63a7919e665577a2cda463b3d67021515e0861
Swarm-Range: a5ad2e1eb283d3a64759a2083463ae7a39eade47..2d63a7919e665577a2cda463b3d67021515e0861

Checks:
- tokmd-swarm PR #54 Tokmd Rust Small Result: passed
- tokmd-swarm PR #54 CI (Required): passed
- repo-graph pre-publication: passed with swarm-ahead

Merge policy:
- Merge this PR with a merge commit, not squash.
- After merge, fast-forward tokmd-swarm/main to the publication merge commit.

Scope boundary:
- Docs/spec source-of-truth only.
- No release, publish, signing, Docker, v1 alias, CLI, receipt schema, or runtime behavior changes.

Rollback:
- Revert the publication merge commit, then fast-forward tokmd-swarm/main to the corrected publication commit.