### PR TITLE
merge(swarm): import tokmd-swarm agent graph preflight

### DIFF
--- a/docs/agent-workflows/source-of-truth.md
+++ b/docs/agent-workflows/source-of-truth.md
@@ -15,12 +15,26 @@ controller.
 ## Before Starting
 
 1. Check the open PR queue.
-2. Read `docs/NEXT.md` for the current operating mode.
-3. Read `.tokmd-spec/index.toml`, then the accepted plan, linked spec, ADR,
+2. Fetch `tokmd-swarm` and `tokmd` refs, then verify the dual-repo graph before
+   starting ordinary swarm work:
+
+   ```bash
+   cargo xtask repo-graph \
+     --publication public/main \
+     --swarm origin/main \
+     --expect aligned \
+     --json target/repo-graph/agent-start.json
+   ```
+
+   If the graph is not aligned, do not start unrelated feature work. Follow the
+   publication-import, fast-forward, hotfix, or emergency-repair path in
+   `docs/ci/swarm-routing.md` first.
+3. Read `docs/NEXT.md` for the current operating mode.
+4. Read `.tokmd-spec/index.toml`, then the accepted plan, linked spec, ADR,
    proposal, or policy file named by current repo guidance or PR context.
-4. Review `.jules/goals/active.toml` as Jules-local context when it is relevant,
+5. Review `.jules/goals/active.toml` as Jules-local context when it is relevant,
    not as Codex's primary lane selector.
-5. Confirm `docs/NEXT.md`, accepted docs/plans/specs/ADRs, and the PR context do
+6. Confirm `docs/NEXT.md`, accepted docs/plans/specs/ADRs, and the PR context do
    not contradict each other.
 
 If those artifacts disagree, stop and fix the routing artifact that owns the


### PR DESCRIPTION
## Summary
Import the latest `tokmd-swarm/main` docs-only workbench commit into the publication repo by merge commit.

Swarm-Head: 142030d429ea1ee6aa56a621f67bb7e6f49a7ee7
Swarm-Range: c07b9e7451d2557b11872f05d107bd3c374fd497..142030d429ea1ee6aa56a621f67bb7e6f49a7ee7

Imported swarm PR:
- EffortlessMetrics/tokmd-swarm#69 — docs(agent): add graph preflight to source-of-truth workflow

## Proof Before Import
- `cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-agent-graph-preflight.json`
- Swarm PR #69 `Tokmd Rust Small Result`: success
- Swarm PR #69 `CI (Required)`: success
- Droid Auto Review on #69: no issues found

## Claim Boundary
Publication import only. This does not create release tags, publish packages, move `v1`, sign artifacts, push Docker images, promote proof, change Codecov defaults, or move Nix-full into the swarm workbench gate.

## After Merge
Fast-forward `EffortlessMetrics/tokmd-swarm:main` to the publication merge commit and verify `repo-graph --expect aligned`.