### PR TITLE
merge(swarm): import tokmd-swarm Nix full handoff docs

### DIFF
--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -94,6 +94,35 @@ fast-forward complete. If it fails, triage it before release or publication
 claims that rely on full Nix proof; do not move the Nix-full lane into routine
 swarm development to make the workbench loop look cleaner.
 
+## Publication-Only Nix Full Handoff
+
+`Nix Full Validation` may still be queued or running after the publication PR's
+required checks pass, the merge-commit import lands, and `tokmd-swarm/main`
+fast-forwards to the publication merge commit. That is a release-boundary
+follow-up, not evidence that the shared-history graph is unaligned.
+
+When the publication-only Nix lane is still running after an otherwise complete
+import, record:
+
+- repository, run ID or URL, and head SHA;
+- current job or step, if the GitHub API exposes it;
+- whether any earlier attempt failed before repository code executed;
+- the boundary that no release, publish, signing, tag, Docker, `v1` alias, or
+  full-Nix claim is proven until the run reaches a terminal success.
+
+Routine swarm PR work may continue while that side workflow runs only when the
+publication PR's required checks passed, the publication merge commit was pushed
+back to `tokmd-swarm/main` as a fast-forward, and `repo-graph` reports
+`aligned`. Do not cite an in-progress Nix run as passing proof.
+
+If an earlier Nix attempt failed while fetching a flake input from GitHub, for
+example with `HTTP error 401` / `Bad credentials`, and a rerun gets past
+checkout, Nix installation, and cache setup into `nix flake check`, treat the
+first failure as an infrastructure/auth transient. Keep watching the rerun. If
+the rerun reaches repository validation and fails in `nix flake check`,
+`nix build .#tokmd`, or `nix build .#tokmd-with-alias`, triage it as a
+publication validation failure before making release-boundary claims.
+
 ## Publication Import CI Triage
 
 Publication imports should be treated as normal CI until evidence says


### PR DESCRIPTION
## Summary
- import the latest `tokmd-swarm/main` docs-only squash commit into publication history
- carries PR #71: `docs(ci): clarify Nix full import handoff`
- keeps the shared-history loop intact by using this PR as a publication merge-commit import

## Swarm Head
- Swarm-Head: `9f8d20007d756cd98c5fdfd9a0933df7f6276031`
- Swarm-Range: `f9a69dfe6b73969f2b0b5b4ba5ee48001b69f17a..9f8d20007d756cd98c5fdfd9a0933df7f6276031`

## Pre-Publication Graph Check
- `cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-ci-nix-full-import-handoff.json`
- Result: `SwarmAhead publication_ahead=0 swarm_ahead=1 expectation=swarm-ahead ok=true`

## Swarm Proof
- Swarm PR: EffortlessMetrics/tokmd-swarm#71
- PR checks: 26 passed, 0 failed
- Local proof recorded in the swarm PR body:
  - `cargo xtask docs --check`
  - `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check-ci-nix-full-import-handoff.json`
  - `cargo xtask proof-policy --check`
  - `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-ci-nix-full-import-handoff.json`
  - `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-ci-nix-full-import-handoff.json --evidence-json target/proof/proof-evidence-ci-nix-full-import-handoff.json`
  - `cargo test -p xtask doc_artifacts --verbose`
  - `git diff --check origin/main..HEAD`

## Publication Nix Full Boundary
Publication Nix Full Validation is release-boundary evidence, not the swarm fast-forward gate. Existing publication Nix Full run `26327638444` for the previous import is still in progress on `f9a69dfe`; no release, publish, signing, tag, Docker, `v1` alias, or full-Nix claim is made by this docs import.

## Merge Method
Merge this PR with a merge commit, not squash. After it lands, fast-forward `tokmd-swarm/main` to the resulting `tokmd/main` merge commit.

## Claim Boundary
Publication import only. This carries docs-only CI interpretation guidance and does not change workflow YAML, branch protection, product behavior, schemas, proof promotion, Codecov defaults, release/publish/signing/tag/Docker/v1 behavior, or Nix policy.