### PR TITLE
merge(swarm): import tokmd-swarm spec gap index

### DIFF
--- a/.tokmd-spec/index.toml
+++ b/.tokmd-spec/index.toml
@@ -52,6 +52,12 @@ path = "docs/specs/ast-shadow.md"
 status = "draft"
 
 [[artifact]]
+id = "spec-contract-gap-audit"
+kind = "spec-audit"
+path = "docs/specs/SPEC_GAPS.md"
+status = "draft"
+
+[[artifact]]
 id = "doc-artifacts-policy"
 kind = "policy"
 path = "policy/doc-artifacts.toml"


### PR DESCRIPTION
## Summary
- import the latest `tokmd-swarm/main` docs-only squash commit into publication history
- carries PR #72: `docs(specs): index contract gap audit`
- keeps the shared-history loop intact by using this PR as a publication merge-commit import

## Swarm Head
- Swarm-Head: `2169b9130db55be341898ed6981acfa174172cb1`
- Swarm-Range: `579d5fbd1f654b7b1c64fc8a009705e462856d4b..2169b9130db55be341898ed6981acfa174172cb1`

## Pre-Publication Graph Check
- `cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-spec-gap-index.json`
- Result: `SwarmAhead publication_ahead=0 swarm_ahead=1 expectation=swarm-ahead ok=true`

## Swarm Proof
- Swarm PR: EffortlessMetrics/tokmd-swarm#72
- PR checks: 26 passed, 0 failed
- Local proof recorded in the swarm PR body:
  - `cargo xtask doc-artifacts --check --json target/docs/doc-artifacts-check-spec-gap-index.json`
  - `cargo xtask docs --check`
  - `cargo xtask proof-policy --check`
  - `cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-spec-gap-index.json`
  - `cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-spec-gap-index.json --evidence-json target/proof/proof-evidence-spec-gap-index.json`
  - `cargo test -p xtask doc_artifacts --verbose`
  - `cargo xtask check-file-policy`
  - `git diff --check origin/main..HEAD`

## Publication Nix Full Boundary
Publication Nix Full Validation is release-boundary evidence, not the swarm fast-forward gate. Current publication-only Nix Full runs may still be in progress; no release, publish, signing, tag, Docker, `v1` alias, or full-Nix claim is made by this docs import.

## Merge Method
Merge this PR with a merge commit, not squash. After it lands, fast-forward `tokmd-swarm/main` to the resulting `tokmd/main` merge commit.

## Claim Boundary
Publication import only. This carries docs/index-only source-of-truth linkage and does not change workflow YAML, branch protection, product behavior, schemas, proof promotion, Codecov defaults, AST behavior, release/publish/signing/tag/Docker/v1 behavior, or Nix policy.