### PR TITLE
merge(swarm): import tokmd-swarm repo topology spec

### DIFF
--- a/.tokmd-spec/index.toml
+++ b/.tokmd-spec/index.toml
@@ -70,6 +70,12 @@ path = "docs/ci/swarm-routing.md"
 status = "active"
 
 [[artifact]]
+id = "dual-repo-topology-spec"
+kind = "spec"
+path = "docs/specs/repo-topology.md"
+status = "active"
+
+[[artifact]]
 id = "spec-rails-contributor-guide"
 kind = "contributor-guide"
 path = "docs/contributing/spec-rails.md"

--- a/docs/source-of-truth.md
+++ b/docs/source-of-truth.md
@@ -78,7 +78,8 @@ changing a lane, see `docs/agent-workflows/source-of-truth.md`.
 | `docs/specs/` | Testable behavior contracts, artifact shapes, compatibility rules, proof requirements, and accepted semantics. | Historical decision rationale or PR-by-PR sequencing. |
 | `docs/adr/` | Durable architecture, packaging, boundary, or governance decisions and their consequences. | Detailed behavior matrices that should be tested as specs. |
 | `docs/plans/` | PR sequencing, implementation packets, validation commands, dependencies, and stop conditions. | Product contracts or architecture decisions. |
-| `docs/ci/swarm-routing.md` | Repository topology, publication/swarm roles, import and fast-forward rules, and repo-conditional workflow boundaries. | Product behavior contracts, release evidence, or workflow implementation details. |
+| `docs/specs/repo-topology.md` | Testable dual-repo topology contract, allowed graph relations, and proof requirements for publication/workbench alignment. | Operational runbooks, release evidence, or workflow implementation details. |
+| `docs/ci/swarm-routing.md` | Repository topology runbook, publication/swarm roles, import and fast-forward procedures, and repo-conditional workflow boundaries. | Product behavior contracts, release evidence, or workflow implementation details. |
 | `.jules/goals/active.toml` | Jules-local machine-readable state, suggestions, and linked context for Jules runs. | Codex primary lane selection, accepted product decisions, raw terminal logs, complete run history, or policy. |
 | `.jules/runs/` | Per-run Jules packets, receipts, decisions, and PR bodies. | Codex primary lane selection, shared active state, or edited truth ledgers. |
 | `.jules/friction/` | Structured future-work and friction items found by Jules runs. | Codex primary lane selection, current implementation plans, or accepted decisions. |

--- a/docs/specs/SPEC_GAPS.md
+++ b/docs/specs/SPEC_GAPS.md
@@ -58,6 +58,7 @@ require deleting or rewriting user-facing docs in the same change.
 | Non-Rust allowlist/file-policy semantics | `docs/specs/file-policy.md`, `policy/non-rust-allowlist.toml`, xtask checks, `docs/FILE_POLICY.md` | specified | keep checker, allowlist, proof routing, and guide aligned with the spec |
 | PR disposition lifecycle rules near release | `docs/adr/0011-pr-disposition-lifecycle.md`, `docs/specs/pr-disposition.md`, `AGENTS.md`, `docs/source-of-truth.md` | specified | keep agent guidance, PR bodies, release ledgers, and disposition rationale aligned |
 | Dependency maintenance classification and validation | `docs/specs/dependency-maintenance.md`, `deny.toml`, CI/proof scopes | specified | keep advisory exceptions and dependency proof aligned with the spec |
+| Dual-repo publication/workbench topology | `docs/specs/repo-topology.md`, `docs/ci/swarm-routing.md`, `cargo xtask repo-graph` | specified | keep graph verifier semantics, workflow guards, merge policy, and import/fast-forward runbook aligned |
 
 ## Classification Vocabulary
 

--- a/docs/specs/repo-topology.md
+++ b/docs/specs/repo-topology.md
@@ -1,0 +1,139 @@
+# Spec: Dual-Repo Repository Topology
+
+- Status: active
+- Schema family, if any: `tokmd.repo_graph.v1`
+- Related ADRs: n/a
+- Related proof scopes: `project_truth_docs`, `proof_control_plane`
+
+## Contract
+
+`EffortlessMetrics/tokmd-swarm` and `EffortlessMetrics/tokmd` must operate as
+one Git commit graph with two repository roles.
+
+`tokmd-swarm` is the active development workbench. Normal feature, docs, test,
+and maintenance changes branch from `tokmd-swarm/main`, open PRs against
+`tokmd-swarm/main`, and land by squash merge after local proof and hosted
+workbench checks.
+
+`tokmd` is the publication repository. It owns release, publish, signing, tag,
+Docker, `v1` alias, and release-record mutation. Routine swarm work is imported
+into `tokmd` by a deliberate merge-commit PR, not by squash merge or orphan
+content sync.
+
+After each publication import, `tokmd-swarm/main` must fast-forward to the exact
+publication merge commit. This keeps GitHub ahead/behind counts meaningful and
+preserves the squashed swarm commits as second-parent history behind each
+publication merge.
+
+## Inputs
+
+The topology contract is evaluated from these inputs:
+
+- the current `EffortlessMetrics/tokmd:main` commit;
+- the current `EffortlessMetrics/tokmd-swarm:main` commit;
+- the merge base between those two refs;
+- publication PR merge method;
+- swarm PR merge method;
+- repository-guarded workflow behavior.
+
+The operational runbook for these inputs is `docs/ci/swarm-routing.md`.
+
+## Outputs
+
+The primary machine-readable topology receipt is produced by:
+
+```bash
+cargo xtask repo-graph \
+  --publication public/main \
+  --swarm origin/main \
+  --expect aligned \
+  --json target/repo-graph/alignment.json
+```
+
+The receipt uses schema `tokmd.repo_graph.v1` and must report the relation,
+publication head, swarm head, merge base, ahead counts, and recommended next
+action for the requested expectation.
+
+The steady-state aligned output means:
+
+```text
+relation = aligned
+publication_ahead = 0
+swarm_ahead = 0
+```
+
+During normal operation, temporary non-aligned relations are allowed only when
+they match the current step:
+
+- `swarm-ahead` before a deliberate publication import;
+- `publication-ahead` after a publication import and before swarm fast-forward;
+- aligned after the publication merge commit has been pushed back to swarm.
+
+## Compatibility
+
+This contract replaces orphan-import content sync as the normal operating
+model. Orphan content sync may be used only as an explicit emergency repair and
+must not become the routine publication path.
+
+Swarm-aware files may live in shared history when their behavior is guarded by
+repository conditions. Publication-only workflows must not run release, publish,
+signing, tag, Docker, alias, or full-publication validation behavior in
+`tokmd-swarm`. Swarm-routed workbench workflows must not become required
+publication release gates unless a future ADR and policy update explicitly move
+that boundary.
+
+This spec does not change product receipts, public CLI behavior, release
+workflow behavior, proof promotion, Codecov defaults, AST behavior, or
+evidencebus runtime behavior.
+
+## Proof Requirements
+
+For a routine swarm PR, the proof is:
+
+```bash
+cargo xtask repo-graph \
+  --publication public/main \
+  --swarm origin/main \
+  --expect aligned \
+  --json target/repo-graph/agent-start.json
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan
+git diff --check
+```
+
+For a publication import, prove the sequence with:
+
+```bash
+cargo xtask repo-graph \
+  --publication public/main \
+  --swarm origin/main \
+  --expect swarm-ahead \
+  --json target/repo-graph/pre-publication.json
+```
+
+Then merge the publication PR in `tokmd` with a merge commit, fast-forward
+`tokmd-swarm/main` to the publication merge commit, and prove:
+
+```bash
+cargo xtask repo-graph \
+  --publication public/main \
+  --swarm origin/main \
+  --expect aligned \
+  --json target/repo-graph/post-fast-forward.json
+```
+
+For changes to this spec or the topology runbook, also run:
+
+```bash
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+```
+
+## Open Questions
+
+- Whether future publication-import automation should write a dedicated
+  closeout receipt that bundles the pre-publication, merge-commit, and
+  post-fast-forward `repo-graph` receipts.
+- Whether branch-protection settings should be mirrored into a checked policy
+  file once GitHub settings drift becomes a recurring source of topology risk.


### PR DESCRIPTION
## Summary
- Imports tokmd-swarm PR #74 into the publication repository with the required merge-commit path.
- Adds the focused dual-repo topology spec and its source-of-truth/index links.

## Swarm import
Swarm-Head: c4c1a71860834b565df9f72150ac99c5d4ce91a1
Swarm-Range: 9201b75dd77c790d209f4ace4ad4a1bfa666a0ab..c4c1a71860834b565df9f72150ac99c5d4ce91a1
Swarm PR: EffortlessMetrics/tokmd-swarm#74

## Proof
- Swarm PR checks passed, including Tokmd Rust Small Result and CI (Required).
- Local pre-publication graph: cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-repo-topology-spec.json
- Local docs/proof checks passed on the swarm branch before merge.

## Merge policy
Merge this PR with a merge commit, not squash. After it lands, fast-forward tokmd-swarm/main to the publication merge commit and verify repo-graph aligned.

## Claim boundary
Publication import only. No release, publish, signing, tag, Docker, v1 alias, Codecov default, proof promotion, public CLI behavior, AST behavior, or evidencebus runtime mutation.