### PR TITLE
merge(swarm): import tokmd-swarm nix gate guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,13 +582,17 @@ jobs:
   nix-pr:
     name: Nix PR Package Gate
     needs: detect
+    # Nix package validation is publication-owned. Keep it out of the
+    # tokmd-swarm workbench so swarm push/PR checks do not depend on
+    # publication repo Nix state.
     if: >-
-      github.event_name == 'push' ||
+      github.repository == 'EffortlessMetrics/tokmd' &&
+      (github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'nix') ||
       contains(github.event.pull_request.labels.*.name, 'release-check') ||
       contains(github.event.pull_request.labels.*.name, 'full-ci') ||
       needs.detect.outputs.nix == 'true' ||
-      needs.detect.outputs.release == 'true'
+      needs.detect.outputs.release == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Summary
Import the tokmd-swarm CI guard repair by merge commit.

Swarm-Head: d71a8d6c3d170ba8202f9185e769d6dee39e94b2
Swarm-Range: 3089ac068f4282c73171d56eec7bbf4f20509fcd..d71a8d6c3d170ba8202f9185e769d6dee39e94b2
Swarm PR: EffortlessMetrics/tokmd-swarm#76

## Why
Post-fast-forward tokmd-swarm main run 26332201089 showed Nix PR Package Gate running in tokmd-swarm and failing. PR #76 guards that package gate to EffortlessMetrics/tokmd only; hosted swarm PR checks show Nix PR Package Gate skipped and CI Required passed.

## Proof
- tokmd-swarm PR #76: 26 passed, 0 failed after advisory checkout/auth reruns
- Tokmd Rust Small Result: success
- CI Required: success
- Nix PR Package Gate in tokmd-swarm: skipped
- cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-nix-pr-gate-guard.json

## Merge Policy
Merge this PR with a merge commit, not squash, to preserve the swarm squashed commit as second-parent history.