### PR TITLE
merge(swarm): import tokmd-swarm nix boundary docs

### DIFF
--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -91,10 +91,12 @@ The swarm PR proved the same-repo workbench gate with
 merge commit and publication CI. Post-merge main CI passed in both repositories.
 
 `Nix Full Validation` remains a publication-only side workflow in `tokmd`.
-It is release-boundary evidence, not a condition for considering the swarm
-fast-forward complete. If it fails, triage it before release or publication
-claims that rely on full Nix proof; do not move the Nix-full lane into routine
-swarm development to make the workbench loop look cleaner.
+The CI `Nix PR Package Gate` is also publication-owned and must be guarded to
+`EffortlessMetrics/tokmd`. These Nix lanes are release-boundary evidence, not
+conditions for considering the swarm fast-forward complete. If they fail, triage
+them before release or publication claims that rely on Nix proof; do not move
+Nix package validation into routine swarm development to make the workbench loop
+look cleaner.
 
 ## Publication-Only Nix Full Handoff
 
@@ -274,8 +276,8 @@ for swarm-only routed CI jobs, and:
 if: github.repository == 'EffortlessMetrics/tokmd'
 ```
 
-for publication-only release, publish, signing, tag, alias, or full-matrix
-surfaces.
+for publication-only release, publish, signing, tag, alias, Nix package, or
+full-matrix surfaces.
 
 Shared files may include the routed Rust Small workflow and this routing
 document, as long as the jobs that must not run in one repository are guarded by

--- a/docs/specs/repo-topology.md
+++ b/docs/specs/repo-topology.md
@@ -77,10 +77,11 @@ must not become the routine publication path.
 
 Swarm-aware files may live in shared history when their behavior is guarded by
 repository conditions. Publication-only workflows must not run release, publish,
-signing, tag, Docker, alias, or full-publication validation behavior in
-`tokmd-swarm`. Swarm-routed workbench workflows must not become required
-publication release gates unless a future ADR and policy update explicitly move
-that boundary.
+signing, tag, Docker, alias, Nix package, or full-publication validation
+behavior in `tokmd-swarm`. This includes CI package gates such as
+`Nix PR Package Gate`, not only separate Nix full-validation workflows.
+Swarm-routed workbench workflows must not become required publication release
+gates unless a future ADR and policy update explicitly move that boundary.
 
 This spec does not change product receipts, public CLI behavior, release
 workflow behavior, proof promotion, Codecov defaults, AST behavior, or


### PR DESCRIPTION
## Summary
Import the tokmd-swarm docs/spec boundary update by merge commit.

Swarm-Head: 6c98eb6ddeb40940da8573d265cce3b5764b9db1
Swarm-Range: 9b17948c7676175371ead5e404fafda112bd3377..6c98eb6ddeb40940da8573d265cce3b5764b9db1
Swarm PR: EffortlessMetrics/tokmd-swarm#77

## Why
The shared code already guards CI's Nix PR Package Gate to EffortlessMetrics/tokmd. This import brings the runbook and topology spec into alignment so future swarm work does not treat Nix package validation as routine tokmd-swarm workbench proof.

## Proof
- tokmd-swarm PR #77: 26 passed, 0 failed
- Tokmd Rust Small Result: success
- CI Required: success
- Nix PR Package Gate in tokmd-swarm: skipped
- cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-nix-boundary-docs.json

## Merge Policy
Merge this PR with a merge commit, not squash, to preserve the swarm squashed commit as second-parent history.