### PR TITLE
merge(swarm): import tokmd-swarm PR evidence template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,10 @@
 <!-- AI-FILL:SUMMARY -->
 <!-- Brief description of what this PR does -->
 
+## Why
+
+<!-- What concrete reviewer, agent, user, proof, or workflow ambiguity does this remove? -->
+
 ## Type of Change
 
 <!-- Check the relevant option(s) -->
@@ -65,6 +69,11 @@
 
 ## Verification
 
+<!-- Summarize the actual proof run for this PR. Keep planned proof distinct
+     from executed proof. -->
+
+- **Proof summary:** <!-- commands run + result, hosted check IDs/URLs if useful -->
+
 - [ ] `cargo build` compiles
 - [ ] `cargo test` passes
 - [ ] `cargo clippy` clean
@@ -90,6 +99,17 @@
   Post-publication fast-forward: cargo xtask repo-graph --publication public/main --swarm origin/main --expect aligned
 -->
 
+## Claim Boundary
+
+<!-- State what this PR proves and what it does not prove. Call out unchanged
+     release, publish, signing, Docker, v1 alias, proof-promotion, Codecov,
+     AST, evidencebus, or public CLI behavior when relevant. -->
+
+## Rollback
+
+<!-- How to revert or park this change without breaking the swarm/publication
+     graph or losing needed evidence. -->
+
 ---
 
 ## CI economics
@@ -101,7 +121,7 @@
 - **Branch protection impact:** <!-- none / adds required job / removes required job -->
 - **Failure mode caught:** <!-- one sentence on what proof this PR buys -->
 - **Cheaper signal considered:** <!-- what was rejected and why -->
-- **Rollback path:** <!-- how to revert without losing the receipt model -->
+- **CI rollback path:** <!-- how to revert CI changes without losing the receipt model -->
 
 ---
 

--- a/docs/agent-workflows/source-of-truth.md
+++ b/docs/agent-workflows/source-of-truth.md
@@ -76,10 +76,17 @@ When a change touches source-of-truth artifacts:
 
 For non-trivial source-of-truth changes, the PR body should include:
 
+- what changed and why the change removes a concrete reviewer, agent, user,
+  proof, or workflow ambiguity;
 - linked source-of-truth artifact or active goal;
 - changed layer, such as proposal, spec, ADR, plan, active goal, policy, or
   proof scope;
 - validation commands and result summary;
+- repo-graph evidence for the current swarm or publication step;
+- claim boundary that names behavior, schemas, release mutation, proof
+  promotion, Codecov defaults, AST behavior, evidencebus runtime, or public CLI
+  surfaces that are intentionally unchanged;
+- rollback or parking path that preserves the swarm/publication graph;
 - stop condition or parking rationale if the work is intentionally incomplete;
 - explicit note when product behavior, schemas, proof promotion, Codecov
   defaults, or publish surface are not changed.


### PR DESCRIPTION
## Summary
Import tokmd-swarm PR #78 by merge commit.

Swarm-Head: daf4f8c3fece2fe2d61a2df20b29a6f47caac6ea
Swarm-Range: 0eb8c97754bf90f9f59f339d561cb1f2aaada886..daf4f8c3fece2fe2d61a2df20b29a6f47caac6ea
Swarm PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/78

## Why
Keeps the publication repo on the same graph as the active workbench after the PR evidence-boundary template slice landed in swarm.

## Verification
- Swarm PR #78 hosted checks passed 26/0, including Tokmd Rust Small Result and CI Required.
- Nix PR Package Gate skipped in tokmd-swarm.
- rtk cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-pr-evidence-boundary-template.json: passed, swarm_ahead=1.

## Repo Boundary
- Publication import PR targeting EffortlessMetrics/tokmd.
- Merge with a merge commit, not squash.
- After merge, fast-forward EffortlessMetrics/tokmd-swarm/main to the publication merge commit and rerun repo-graph --expect aligned.

## Claim Boundary
Imports docs/template-only work. This does not release, publish, sign, tag, move Docker/v1 aliases, promote proof, change Codecov defaults, change AST behavior, change evidencebus runtime, or change public CLI behavior.

## Rollback
Close this PR before merge, or revert the publication merge commit after merge and fast-forward/sync swarm only after inspecting the graph.