### PR TITLE
merge(swarm): import tokmd-swarm Nix attempt docs

### DIFF
--- a/docs/ci/cache-and-cancellation.md
+++ b/docs/ci/cache-and-cancellation.md
@@ -35,7 +35,10 @@ just by workflow name. Multiple in-progress `Nix Full Validation` runs can be
 valid at the same time when they cover different publication commits. Report the
 run for the current `tokmd/main` head separately from older commit-scoped runs,
 and avoid treating an older in-progress run as evidence about the current
-publication merge.
+publication merge. When a failed Nix full run is rerun, also record the run
+`attempt`, current `status`, and `conclusion`; GitHub keeps the rerun under the
+same run ID, so an in-progress later attempt is different evidence from the
+earlier failed attempt.
 
 ## Cache save policy
 

--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -109,10 +109,20 @@ When the publication-only Nix lane is still running after an otherwise complete
 import, record:
 
 - repository, run ID or URL, and head SHA;
+- run attempt, status, and conclusion;
 - current job or step, if the GitHub API exposes it;
 - whether any earlier attempt failed before repository code executed;
 - the boundary that no release, publish, signing, tag, Docker, `v1` alias, or
   full-Nix claim is proven until the run reaches a terminal success.
+
+Use an attempt-aware status check so reruns are not confused with the original
+failed attempt:
+
+```bash
+gh run view <run-id> \
+  --repo EffortlessMetrics/tokmd \
+  --json attempt,status,conclusion,headSha,jobs,url
+```
 
 Routine swarm PR work may continue while that side workflow runs only when the
 publication PR's required checks passed, the publication merge commit was pushed


### PR DESCRIPTION
## Summary
Import tokmd-swarm PR #79 by merge commit.

Swarm-Head: b4a47109053130a4f685da5c4fb8385f94c673a6
Swarm-Range: c651c21879408813ca6d93a917c4945c98704929..b4a47109053130a4f685da5c4fb8385f94c673a6
Swarm PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/79

## Why
Keeps publication current with the swarm docs slice that makes Nix Full Validation rerun evidence attempt-aware.

## Verification
- Swarm PR #79 hosted checks passed 26/0, including Tokmd Rust Small Result and CI Required.
- Nix PR Package Gate skipped in tokmd-swarm.
- rtk cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-nix-full-attempt-followup.json: passed, swarm_ahead=1.
- Current publication-only Nix Full Validation run 26335426251 for c651c218 is attempt=2, status=in_progress in Check flake (full); no full-Nix or release-boundary claim is made here.

## Repo Boundary
- Publication import PR targeting EffortlessMetrics/tokmd.
- Merge with a merge commit, not squash.
- After merge, fast-forward EffortlessMetrics/tokmd-swarm/main to the publication merge commit and rerun repo-graph --expect aligned.

## Claim Boundary
Imports docs-only work. This does not release, publish, sign, tag, move Docker/v1 aliases, promote proof, change Codecov defaults, change AST behavior, change evidencebus runtime, change public CLI behavior, or change Nix workflow behavior.

## Rollback
Close this PR before merge, or revert the publication merge commit after merge and fast-forward/sync swarm only after inspecting the graph.