### PR TITLE
merge(swarm): import cockpit proof run metadata

### DIFF
--- a/crates/tokmd-cockpit/src/proof_evidence/model.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/model.rs
@@ -91,6 +91,8 @@ pub(crate) struct NormalizedProofEvidence {
     pub execution_status: ProofExecutionStatus,
     pub availability: ProofEvidenceAvailability,
     pub commit_match: CommitMatch,
+    pub run_id: Option<String>,
+    pub run_attempt: Option<String>,
     pub artifact_refs: Vec<String>,
 }
 

--- a/crates/tokmd-cockpit/src/proof_evidence/normalize.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/normalize.rs
@@ -66,6 +66,8 @@ pub(crate) fn normalize_proof_evidence(
                     execution_status,
                     availability,
                     commit_match,
+                    run_id: None,
+                    run_attempt: None,
                     artifact_refs: vec![format!("{source_ref}#/entries/{idx}")],
                 }
             })
@@ -90,6 +92,8 @@ pub(crate) fn normalize_proof_evidence(
                     execution_status,
                     availability,
                     commit_match,
+                    run_id: None,
+                    run_attempt: None,
                     artifact_refs: vec![format!("{source_ref}#/scopes/{idx}")],
                 }
             })
@@ -113,6 +117,8 @@ pub(crate) fn normalize_proof_evidence(
                     execution_status,
                     availability,
                     commit_match,
+                    run_id: None,
+                    run_attempt: None,
                     artifact_refs: vec![format!("{source_ref}#/scopes/{idx}")],
                 }
             })
@@ -144,6 +150,8 @@ pub(crate) fn normalize_proof_evidence(
                 execution_status,
                 availability,
                 commit_match,
+                run_id: non_empty_string(receipt.github.run_id.as_deref()),
+                run_attempt: non_empty_string(receipt.github.run_attempt.as_deref()),
                 artifact_refs,
             }]
         }
@@ -189,6 +197,10 @@ fn non_empty(value: Option<&str>) -> Option<&str> {
         let trimmed = value.trim();
         (!trimmed.is_empty()).then_some(trimmed)
     })
+}
+
+fn non_empty_string(value: Option<&str>) -> Option<String> {
+    non_empty(value).map(ToOwned::to_owned)
 }
 
 fn normalize_path_for_ref(path: &Path) -> String {
@@ -300,6 +312,8 @@ mod tests {
             evidence.artifact_refs,
             vec!["proof/coverage-receipt.json#/artifacts/0"]
         );
+        assert_eq!(evidence.run_id.as_deref(), Some("12345"));
+        assert_eq!(evidence.run_attempt.as_deref(), Some("1"));
     }
 
     #[test]

--- a/crates/tokmd-cockpit/src/render/evidence.rs
+++ b/crates/tokmd-cockpit/src/render/evidence.rs
@@ -93,7 +93,9 @@ fn review_packet_proof_evidence(
     )
     .into_iter()
     .map(|item| {
-        json!({
+        let run_id = item.run_id;
+        let run_attempt = item.run_attempt;
+        let mut evidence = json!({
             "kind": item.kind.as_str(),
             "source": normalize_path_for_output(&item.source_path),
             "source_schema": item.source_schema,
@@ -106,7 +108,16 @@ fn review_packet_proof_evidence(
             "availability": item.availability.as_str(),
             "commit_match": item.commit_match,
             "refs": item.artifact_refs,
-        })
+        });
+
+        if let Some(run_id) = run_id {
+            evidence["run_id"] = json!(run_id);
+        }
+        if let Some(run_attempt) = run_attempt {
+            evidence["run_attempt"] = json!(run_attempt);
+        }
+
+        evidence
     })
     .collect()
 }

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1589,6 +1589,14 @@ fn scenario_review_map_md_includes_packet_level_proof_overview() {
     tokmd_cockpit::render::write_review_packet_with_proof_evidence(&out, &receipt, &[proof])
         .unwrap();
 
+    let evidence: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("evidence.json")).unwrap()).unwrap();
+    let proof = evidence["proof"].as_array().expect("proof evidence array");
+    assert_eq!(proof.len(), 1);
+    assert_eq!(proof[0]["kind"], "coverage_receipt");
+    assert_eq!(proof[0]["run_id"], "12345");
+    assert_eq!(proof[0]["run_attempt"], "1");
+
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("Proof evidence overview:"));
     assert!(review_map_md.contains("- Required proof: 0 passed, 0 failed, 0 missing"));

--- a/crates/tokmd/schemas/review-packet-evidence.schema.json
+++ b/crates/tokmd/schemas/review-packet-evidence.schema.json
@@ -94,6 +94,8 @@
         },
         "source": { "type": "string", "minLength": 1 },
         "source_schema": { "type": "string", "minLength": 1 },
+        "run_id": { "type": "string", "minLength": 1 },
+        "run_attempt": { "type": "string", "minLength": 1 },
         "profile": {
           "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
         },

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -117,7 +117,12 @@ const COVERAGE_RECEIPT_JSON: &str = r#"{
   "flag": "tokmd_cockpit",
   "workflow": "Coverage",
   "sha": "abc123",
-  "github": {},
+  "github": {
+    "run_id": "12345",
+    "run_attempt": "1",
+    "event_name": "pull_request",
+    "ref_name": "feature"
+  },
   "artifacts": [],
   "status": { "ok": true, "missing": [], "empty": [] }
 }"#;
@@ -349,6 +354,44 @@ fn test_cockpit_review_packet_includes_imported_proof_evidence() {
     assert!(comment_md.contains("Required proof: 1 passed, 0 failed, 0 missing"));
     assert!(comment_md.contains("Advisory proof: 0 available, 0 missing"));
     assert!(comment_md.contains("Proof freshness: 1 exact, 0 partial, 0 stale, 0 unknown"));
+}
+
+#[test]
+fn test_cockpit_review_packet_preserves_coverage_run_metadata() {
+    let Some(dir) = basic_cockpit_repo() else {
+        return;
+    };
+    let coverage_json = COVERAGE_RECEIPT_JSON.replace("\"sha\": \"abc123\"", "\"sha\": \"HEAD\"");
+    std::fs::write(dir.path().join("coverage-receipt.json"), coverage_json).unwrap();
+    let packet_dir = dir.path().join(".tokmd").join("review");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir.path())
+        .arg("cockpit")
+        .arg("--base")
+        .arg("main")
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--coverage-receipt")
+        .arg("coverage-receipt.json")
+        .arg("--review-packet-dir")
+        .arg(&packet_dir)
+        .assert()
+        .success();
+
+    let evidence: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packet_dir.join("evidence.json")).unwrap())
+            .expect("valid evidence JSON");
+    assert_validates_against_schema(
+        REVIEW_PACKET_EVIDENCE_SCHEMA_JSON,
+        &evidence,
+        "review packet evidence with coverage run metadata",
+    );
+    let proof = evidence["proof"].as_array().expect("proof evidence array");
+    assert_eq!(proof.len(), 1);
+    assert_eq!(proof[0]["kind"], "coverage_receipt");
+    assert_eq!(proof[0]["run_id"], "12345");
+    assert_eq!(proof[0]["run_attempt"], "1");
 }
 
 #[test]

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -124,7 +124,8 @@ Each imported evidence item should preserve:
 
 - packet-local source artifact path;
 - source schema;
-- source run or workflow URL when available;
+- source run metadata, such as GitHub run ID and attempt, or workflow URL when
+  available;
 - base ref or commit when available;
 - head ref or commit when available;
 - proof profile, such as `fast`, `affected`, `release`, or `deep`;
@@ -135,6 +136,11 @@ Each imported evidence item should preserve:
 - required/advisory classification;
 - artifact references, such as LCOV paths;
 - generated timestamp when available.
+
+Coverage receipts that include GitHub run metadata preserve non-empty
+`run_id` and `run_attempt` values on their normalized `evidence.json` proof
+entry. That lets packet consumers distinguish reruns while keeping the copied
+`proof/coverage-receipt.json` artifact as the full source payload.
 
 Packet renderers should refer back to packet-local source artifacts using
 stable refs rather than copying large proof payloads into every packet file.

--- a/docs/review-packet-evidence.schema.json
+++ b/docs/review-packet-evidence.schema.json
@@ -94,6 +94,8 @@
         },
         "source": { "type": "string", "minLength": 1 },
         "source_schema": { "type": "string", "minLength": 1 },
+        "run_id": { "type": "string", "minLength": 1 },
+        "run_attempt": { "type": "string", "minLength": 1 },
         "profile": {
           "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
         },

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -179,8 +179,10 @@ Cockpit proof imports should follow
 are supplied with `--review-packet-dir`, cockpit validates them, copies them
 into canonical packet-local `proof/*.json` paths, and records normalized proof
 items in `evidence.json`. Packet imports preserve required/advisory
-classification and commit freshness, and must not promote advisory proof into
-blocking evidence.
+classification and commit freshness. Coverage proof entries also preserve
+non-empty GitHub `run_id` and `run_attempt` values when the source receipt
+includes them. Packet imports must not promote advisory proof into blocking
+evidence.
 
 For a complete local workflow that plans proof, optionally executes guarded
 required proof, imports proof artifacts, and verifies the packet, see the


### PR DESCRIPTION
Summary
- Import tokmd-swarm through fbd139b3b7f6b60bd5f82677f95d7107725273f3.
- Swarm-Range: 7427b0a78a72fd4130f2843eabb83ceab4a5dd11..fbd139b3b7f6b60bd5f82677f95d7107725273f3.
- Includes PR #82 from tokmd-swarm, preserving coverage proof run metadata in cockpit review packet evidence.

Checks
- Tokmd Rust Small Result: passed on tokmd-swarm PR #82.
- Local affected proof required commands passed before swarm merge.

Merge policy
- This publication import must be merged with a merge commit, not squash.