### PR TITLE
merge(swarm): import cockpit proof source metadata

### DIFF
--- a/crates/tokmd-cockpit/src/proof_evidence/model.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/model.rs
@@ -93,6 +93,10 @@ pub(crate) struct NormalizedProofEvidence {
     pub commit_match: CommitMatch,
     pub run_id: Option<String>,
     pub run_attempt: Option<String>,
+    pub run_url: Option<String>,
+    pub workflow: Option<String>,
+    pub event_name: Option<String>,
+    pub ref_name: Option<String>,
     pub artifact_refs: Vec<String>,
 }
 

--- a/crates/tokmd-cockpit/src/proof_evidence/normalize.rs
+++ b/crates/tokmd-cockpit/src/proof_evidence/normalize.rs
@@ -68,6 +68,10 @@ pub(crate) fn normalize_proof_evidence(
                     commit_match,
                     run_id: None,
                     run_attempt: None,
+                    run_url: None,
+                    workflow: None,
+                    event_name: None,
+                    ref_name: None,
                     artifact_refs: vec![format!("{source_ref}#/entries/{idx}")],
                 }
             })
@@ -94,6 +98,10 @@ pub(crate) fn normalize_proof_evidence(
                     commit_match,
                     run_id: None,
                     run_attempt: None,
+                    run_url: None,
+                    workflow: None,
+                    event_name: None,
+                    ref_name: None,
                     artifact_refs: vec![format!("{source_ref}#/scopes/{idx}")],
                 }
             })
@@ -119,6 +127,10 @@ pub(crate) fn normalize_proof_evidence(
                     commit_match,
                     run_id: None,
                     run_attempt: None,
+                    run_url: None,
+                    workflow: None,
+                    event_name: None,
+                    ref_name: None,
                     artifact_refs: vec![format!("{source_ref}#/scopes/{idx}")],
                 }
             })
@@ -152,6 +164,10 @@ pub(crate) fn normalize_proof_evidence(
                 commit_match,
                 run_id: non_empty_string(receipt.github.run_id.as_deref()),
                 run_attempt: non_empty_string(receipt.github.run_attempt.as_deref()),
+                run_url: github_run_url(&receipt.repo, receipt.github.run_id.as_deref()),
+                workflow: non_empty_string(Some(&receipt.workflow)),
+                event_name: non_empty_string(receipt.github.event_name.as_deref()),
+                ref_name: non_empty_string(receipt.github.ref_name.as_deref()),
                 artifact_refs,
             }]
         }
@@ -201,6 +217,36 @@ fn non_empty(value: Option<&str>) -> Option<&str> {
 
 fn non_empty_string(value: Option<&str>) -> Option<String> {
     non_empty(value).map(ToOwned::to_owned)
+}
+
+fn github_run_url(repo: &str, run_id: Option<&str>) -> Option<String> {
+    let repo = non_empty(Some(repo))?;
+    let run_id = non_empty(run_id)?;
+
+    if !valid_github_repo(repo) || !run_id.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(format!("https://github.com/{repo}/actions/runs/{run_id}"))
+}
+
+fn valid_github_repo(repo: &str) -> bool {
+    let mut parts = repo.split('/');
+    let Some(owner) = parts.next() else {
+        return false;
+    };
+    let Some(name) = parts.next() else {
+        return false;
+    };
+
+    parts.next().is_none() && valid_github_segment(owner) && valid_github_segment(name)
+}
+
+fn valid_github_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
 }
 
 fn normalize_path_for_ref(path: &Path) -> String {
@@ -314,6 +360,13 @@ mod tests {
         );
         assert_eq!(evidence.run_id.as_deref(), Some("12345"));
         assert_eq!(evidence.run_attempt.as_deref(), Some("1"));
+        assert_eq!(
+            evidence.run_url.as_deref(),
+            Some("https://github.com/EffortlessMetrics/tokmd/actions/runs/12345")
+        );
+        assert_eq!(evidence.workflow.as_deref(), Some("Coverage"));
+        assert_eq!(evidence.event_name.as_deref(), Some("pull_request"));
+        assert_eq!(evidence.ref_name.as_deref(), Some("feature"));
     }
 
     #[test]
@@ -339,5 +392,22 @@ mod tests {
 
         assert_eq!(evidence.commit_match, CommitMatch::Unknown);
         assert_eq!(evidence.availability, ProofEvidenceAvailability::Degraded);
+    }
+
+    #[test]
+    fn github_run_url_requires_safe_repo_and_numeric_run_id() {
+        assert_eq!(
+            github_run_url("EffortlessMetrics/tokmd", Some("12345")).as_deref(),
+            Some("https://github.com/EffortlessMetrics/tokmd/actions/runs/12345")
+        );
+        assert_eq!(github_run_url("EffortlessMetrics", Some("12345")), None);
+        assert_eq!(
+            github_run_url("EffortlessMetrics/tokmd", Some("run-12345")),
+            None
+        );
+        assert_eq!(
+            github_run_url("EffortlessMetrics/tokmd?x=1", Some("12345")),
+            None
+        );
     }
 }

--- a/crates/tokmd-cockpit/src/render/evidence.rs
+++ b/crates/tokmd-cockpit/src/render/evidence.rs
@@ -95,6 +95,10 @@ fn review_packet_proof_evidence(
     .map(|item| {
         let run_id = item.run_id;
         let run_attempt = item.run_attempt;
+        let run_url = item.run_url;
+        let workflow = item.workflow;
+        let event_name = item.event_name;
+        let ref_name = item.ref_name;
         let mut evidence = json!({
             "kind": item.kind.as_str(),
             "source": normalize_path_for_output(&item.source_path),
@@ -115,6 +119,18 @@ fn review_packet_proof_evidence(
         }
         if let Some(run_attempt) = run_attempt {
             evidence["run_attempt"] = json!(run_attempt);
+        }
+        if let Some(run_url) = run_url {
+            evidence["run_url"] = json!(run_url);
+        }
+        if let Some(workflow) = workflow {
+            evidence["workflow"] = json!(workflow);
+        }
+        if let Some(event_name) = event_name {
+            evidence["event_name"] = json!(event_name);
+        }
+        if let Some(ref_name) = ref_name {
+            evidence["ref_name"] = json!(ref_name);
         }
 
         evidence

--- a/crates/tokmd-cockpit/tests/bdd.rs
+++ b/crates/tokmd-cockpit/tests/bdd.rs
@@ -1596,6 +1596,13 @@ fn scenario_review_map_md_includes_packet_level_proof_overview() {
     assert_eq!(proof[0]["kind"], "coverage_receipt");
     assert_eq!(proof[0]["run_id"], "12345");
     assert_eq!(proof[0]["run_attempt"], "1");
+    assert_eq!(
+        proof[0]["run_url"],
+        "https://github.com/EffortlessMetrics/tokmd/actions/runs/12345"
+    );
+    assert_eq!(proof[0]["workflow"], "Coverage");
+    assert_eq!(proof[0]["event_name"], "pull_request");
+    assert_eq!(proof[0]["ref_name"], "feature");
 
     let review_map_md = std::fs::read_to_string(out.join("review-map.md")).unwrap();
     assert!(review_map_md.contains("Proof evidence overview:"));

--- a/crates/tokmd/schemas/review-packet-evidence.schema.json
+++ b/crates/tokmd/schemas/review-packet-evidence.schema.json
@@ -96,6 +96,10 @@
         "source_schema": { "type": "string", "minLength": 1 },
         "run_id": { "type": "string", "minLength": 1 },
         "run_attempt": { "type": "string", "minLength": 1 },
+        "run_url": { "type": "string", "minLength": 1 },
+        "workflow": { "type": "string", "minLength": 1 },
+        "event_name": { "type": "string", "minLength": 1 },
+        "ref_name": { "type": "string", "minLength": 1 },
         "profile": {
           "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
         },

--- a/crates/tokmd/tests/cockpit_integration.rs
+++ b/crates/tokmd/tests/cockpit_integration.rs
@@ -392,6 +392,13 @@ fn test_cockpit_review_packet_preserves_coverage_run_metadata() {
     assert_eq!(proof[0]["kind"], "coverage_receipt");
     assert_eq!(proof[0]["run_id"], "12345");
     assert_eq!(proof[0]["run_attempt"], "1");
+    assert_eq!(
+        proof[0]["run_url"],
+        "https://github.com/EffortlessMetrics/tokmd/actions/runs/12345"
+    );
+    assert_eq!(proof[0]["workflow"], "Coverage");
+    assert_eq!(proof[0]["event_name"], "pull_request");
+    assert_eq!(proof[0]["ref_name"], "feature");
 }
 
 #[test]

--- a/docs/cockpit-proof-evidence.md
+++ b/docs/cockpit-proof-evidence.md
@@ -124,8 +124,8 @@ Each imported evidence item should preserve:
 
 - packet-local source artifact path;
 - source schema;
-- source run metadata, such as GitHub run ID and attempt, or workflow URL when
-  available;
+- source run metadata, such as GitHub run ID, attempt, run URL, workflow,
+  event name, and ref when available;
 - base ref or commit when available;
 - head ref or commit when available;
 - proof profile, such as `fast`, `affected`, `release`, or `deep`;
@@ -138,9 +138,12 @@ Each imported evidence item should preserve:
 - generated timestamp when available.
 
 Coverage receipts that include GitHub run metadata preserve non-empty
-`run_id` and `run_attempt` values on their normalized `evidence.json` proof
-entry. That lets packet consumers distinguish reruns while keeping the copied
-`proof/coverage-receipt.json` artifact as the full source payload.
+`run_id`, `run_attempt`, `workflow`, `event_name`, and `ref_name` values on
+their normalized `evidence.json` proof entry. When the receipt has a safe
+GitHub `owner/repo` value and numeric run ID, cockpit also derives `run_url`.
+That lets packet consumers distinguish reruns and open the source Action while
+keeping the copied `proof/coverage-receipt.json` artifact as the full source
+payload.
 
 Packet renderers should refer back to packet-local source artifacts using
 stable refs rather than copying large proof payloads into every packet file.

--- a/docs/review-packet-evidence.schema.json
+++ b/docs/review-packet-evidence.schema.json
@@ -96,6 +96,10 @@
         "source_schema": { "type": "string", "minLength": 1 },
         "run_id": { "type": "string", "minLength": 1 },
         "run_attempt": { "type": "string", "minLength": 1 },
+        "run_url": { "type": "string", "minLength": 1 },
+        "workflow": { "type": "string", "minLength": 1 },
+        "event_name": { "type": "string", "minLength": 1 },
+        "ref_name": { "type": "string", "minLength": 1 },
         "profile": {
           "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
         },

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -180,9 +180,10 @@ are supplied with `--review-packet-dir`, cockpit validates them, copies them
 into canonical packet-local `proof/*.json` paths, and records normalized proof
 items in `evidence.json`. Packet imports preserve required/advisory
 classification and commit freshness. Coverage proof entries also preserve
-non-empty GitHub `run_id` and `run_attempt` values when the source receipt
-includes them. Packet imports must not promote advisory proof into blocking
-evidence.
+non-empty GitHub `run_id`, `run_attempt`, `workflow`, `event_name`, and
+`ref_name` values when the source receipt includes them, plus a derived
+`run_url` for safe GitHub repository/run ID pairs. Packet imports must not
+promote advisory proof into blocking evidence.
 
 For a complete local workflow that plans proof, optionally executes guarded
 required proof, imports proof artifacts, and verifies the packet, see the


### PR DESCRIPTION
Summary
- Import tokmd-swarm through 7f6b1800c53127e4c0ea36de16568e035cb3f94a.
- Swarm-Range: f1feef7f34e6ee37e30d57752a0e9c8b1e1a17da..7f6b1800c53127e4c0ea36de16568e035cb3f94a.
- Includes tokmd-swarm PR #83, enriching cockpit review-packet proof evidence with optional coverage source metadata.

Checks
- Tokmd Rust Small Result: passed on tokmd-swarm PR #83.
- PR Cockpit Report: passed on rerun after transient GitHub Bad credentials when posting the PR comment.
- Local affected proof required commands passed before swarm merge.
- Publication main CI rerun for the prior import is now green.

Merge policy
- This publication import must be merged with a merge commit, not squash.