### PR TITLE
merge(swarm): import spec index operating-mode link

### DIFF
--- a/.tokmd-spec/index.toml
+++ b/.tokmd-spec/index.toml
@@ -40,6 +40,12 @@ path = "docs/agent-workflows/source-of-truth.md"
 status = "active"
 
 [[artifact]]
+id = "next-program"
+kind = "operating-mode"
+path = "docs/NEXT.md"
+status = "active"
+
+[[artifact]]
 id = "doc-artifacts-spec"
 kind = "spec"
 path = "docs/specs/doc-artifacts.md"


### PR DESCRIPTION
Summary: import tokmd-swarm through 474fd62b, carrying swarm PR #85. This adds docs/NEXT.md to .tokmd-spec/index.toml as the active operating-mode artifact. Swarm-Head: 474fd62b. Swarm proof: PR #85 checks passed, including Tokmd Rust Small Result, Docs Check, PR Cockpit Report, and CI Required. Local validation before swarm PR: cargo xtask doc-artifacts --check; cargo xtask docs --check; cargo xtask check-file-policy; cargo xtask proof-policy --check; cargo xtask affected/proof plan; cargo test -p xtask doc_artifacts --verbose; git diff --check. Boundary: docs/source-of-truth indexing only; no product behavior, schema, proof-promotion, Codecov, AST, release, publish, signing, or graph-policy changes.