### PR TITLE
merge(swarm): import analysis README examples

### DIFF
--- a/crates/tokmd-analysis-types/README.md
+++ b/crates/tokmd-analysis-types/README.md
@@ -10,6 +10,18 @@ You need a stable analysis schema without pulling in orchestration or rendering 
 - `AnalysisReceipt`, `AnalysisSource`, `AnalysisArgsMeta`
 - Shared report and finding structs used by the analysis presets
 
+## Example
+
+```rust
+use tokmd_analysis_types::{AnalysisReceipt, ANALYSIS_SCHEMA_VERSION};
+
+fn summarize(receipt: AnalysisReceipt) -> Option<usize> {
+    assert_eq!(receipt.schema_version, ANALYSIS_SCHEMA_VERSION);
+
+    receipt.derived.map(|derived| derived.totals.code)
+}
+```
+
 ## Integration notes
 - Pure data and serialization, with deterministic ordering at the type boundary.
 - `ANALYSIS_SCHEMA_VERSION = 9`.

--- a/crates/tokmd-analysis/README.md
+++ b/crates/tokmd-analysis/README.md
@@ -7,9 +7,41 @@ You need one analysis entrypoint that can assemble receipt enrichments without w
 
 ## What it gives you
 - `analyze`
+- `derive_report`, `build_tree`
 - `AnalysisContext`, `AnalysisRequest`, `AnalysisPreset`
 - `ImportGranularity`
 - Re-exports of `AnalysisLimits`, `NearDupScope`, and `normalize_root`
+
+## Example
+
+```rust
+use tokmd_analysis::derive_report;
+use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
+
+let export = ExportData {
+    rows: vec![FileRow {
+        path: "src/lib.rs".into(),
+        module: "src".into(),
+        lang: "Rust".into(),
+        kind: FileKind::Parent,
+        code: 120,
+        comments: 20,
+        blanks: 10,
+        lines: 150,
+        bytes: 4_096,
+        tokens: 900,
+    }],
+    module_roots: vec![],
+    module_depth: 1,
+    children: ChildIncludeMode::Separate,
+};
+
+let report = derive_report(&export, Some(128_000));
+
+assert_eq!(report.totals.files, 1);
+assert_eq!(report.totals.code, 120);
+assert!(report.context_window.as_ref().is_some_and(|window| window.fits));
+```
 
 ## Integration notes
 - Default features: `fun`, `topics`, `archetype`, `effort`.


### PR DESCRIPTION
Summary:
- Import the tokmd-swarm docs-only slice that adds current-layout examples for tokmd-analysis and tokmd-analysis-types.
- Keep EffortlessMetrics/tokmd#991 scoped to the consolidated analysis crates rather than restoring removed leaf crates.

Swarm-Head: cf843d6027d3391497c66507d7239618e7768922
Swarm-Range: af7849fe9be4c1d2c534be0734170221b5096702..cf843d6027d3391497c66507d7239618e7768922
Checks:
- Tokmd Rust Small Result: https://github.com/EffortlessMetrics/tokmd-swarm/actions/runs/26346799952
- Publication CI: pending on this PR

Closes #991