### PR TITLE
merge(swarm): import CI docs evidence guard

### DIFF
--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -464,6 +464,29 @@ fn affected_plan_ci_blocks_on_planner_generation_failures() {
 }
 
 #[test]
+fn ci_workflow_keeps_pr_docs_evidence_routable() {
+    let ci = fs::read_to_string(workspace_root().join(".github/workflows/ci.yml"))
+        .expect("ci workflow should be readable");
+
+    assert!(
+        ci.contains("pull_request:"),
+        "CI workflow should continue to run for PRs so affected proof can classify changes"
+    );
+    assert!(
+        !ci.contains("paths-ignore:"),
+        "do not skip the whole CI workflow by path; docs-only PRs still need Docs Check and Affected Proof Plan evidence"
+    );
+    assert!(
+        ci.contains("docs-check:"),
+        "CI workflow should keep the docs check job available to PRs"
+    );
+    assert!(
+        ci.contains("affected-plan:"),
+        "CI workflow should keep affected proof planning available to PRs"
+    );
+}
+
+#[test]
 fn proof_plan_json_writes_plan_report_artifact() {
     let root = workspace_root();
     let path = root


### PR DESCRIPTION
﻿## Summary
- Import tokmd-swarm PR #95: test(ci): guard PR CI docs evidence.
- Brings the regression guard that prevents workflow-level PR path ignores from dropping Docs Check and Affected Proof Plan coverage for docs/source-of-truth PRs.

Swarm-Head: e4ffa14f55d6d4e725a05ae08a0f52d350f0f706
Swarm-Range: 8a50229f180b86079b6ea6fe5bd88effde3eda09..e4ffa14f55d6d4e725a05ae08a0f52d350f0f706

## Swarm proof
- PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/95
- Tokmd Rust Small Result: success on run 26350014916
- CI (Required): success on run 26350014933
- CI Lane Whitelist, Proof Policy, Affected Proof Plan, Docs Check, and targeted local xtask tests passed.

## Local validation before swarm merge
- cargo test -p xtask ci_workflow_keeps_pr_docs_evidence_routable --verbose
- cargo xtask proof-policy --check
- cargo xtask ci-lane-whitelist
- cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-pr-ci-docs-evidence.json
- cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-pr-ci-docs-evidence.json --evidence-json target/proof/proof-evidence-pr-ci-docs-evidence.json
- cargo test -p xtask proof_plan --verbose
- cargo test -p xtask affected --verbose
- git diff --check origin/main..HEAD

## Merge mode
Merge this PR with a merge commit, not squash, so tokmd preserves the swarm commit as second-parent history.

## Boundaries
- Test-only CI guard.
- Does not optimize CI runtime yet.
- Does not promote proof gates, enable default Codecov upload, move Nix-full into swarm, publish, tag, sign, move v1, or change release authority.
