### PR TITLE
merge(swarm): import post-fast-forward branch-health docs

### DIFF
--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -139,6 +139,32 @@ repository validation and fails in `nix flake check`,
 `nix build .#tokmd`, or `nix build .#tokmd-with-alias`, triage it as a
 publication validation failure before making release-boundary claims.
 
+## Post-Fast-Forward Branch Health
+
+After a publication import merges and `tokmd-swarm/main` fast-forwards to the
+publication merge commit, both repositories may start normal `main` branch CI for
+the same head SHA. Those runs are branch-health evidence, not additional graph
+alignment steps.
+
+When those post-merge runs are still active after the graph is aligned, record:
+
+- repository and workflow run ID or URL;
+- shared `headSha`;
+- run `status` and `conclusion`;
+- active job names and, when exposed, active step names;
+- the boundary that an `in_progress` run is not passing proof.
+
+Use `repo-graph` as the authority for topology state. Use the post-merge CI runs
+as branch-health evidence for the shared commit. Do not delay the
+fast-forward-back-to-swarm operation waiting for branch-health jobs that start
+only after the publication merge, but do not cite those jobs as successful until
+they reach a terminal success.
+
+If a post-fast-forward branch-health run fails in repository code, triage it as
+a current-main regression on the shared commit before relying on full CI, release
+readiness, or publication validation claims. The failure does not undo the Git
+graph alignment, but it does create a branch-health repair lane.
+
 ## Publication Import CI Triage
 
 Publication imports should be treated as normal CI until evidence says
@@ -384,6 +410,13 @@ The routed Rust Small implementation order is:
 ```text
 CPX42 -> CX43 -> CX53 -> GitHub-hosted
 ```
+
+Fallback labels such as `ci-budget-ack` are read by the routed workflow run.
+The routed workflow does not run on label-only PR events, so adding the label
+after a `no_idle_runner` result only authorizes fallback for the next route.
+Trigger a new route with a branch update or `workflow_dispatch` after applying
+the label. Do not treat the older failed aggregate as superseded until a newer
+`Tokmd Rust Small Result` succeeds for the same head.
 
 CPX42 uses the pinned Rust 1.95 toolchain directly on the host, with
 `/mnt/ci-scratch` `TMPDIR` prepared before the toolchain action runs. CX43 and


### PR DESCRIPTION
## Summary
Import the current 	okmd-swarm/main docs slice into the publication repo with a merge commit.

## Swarm import
- Swarm-Head: 500b78072db80675fa265ad0b671ca25fd5ca368
- Swarm-Range: 3331bcf9389c58ec083aa0f3f284079f05b5e9bd..500b78072db80675fa265ad0b671ca25fd5ca368
- Imported swarm commit: 500b7807 docs(ci): clarify post-fast-forward branch health (#101)

## Checks
- Pre-publication graph: cargo xtask repo-graph --publication public/main --swarm origin/main --expect swarm-ahead --json target/repo-graph/pre-publication-post-fast-forward-branch-health.json
- Swarm PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/101
- Tokmd Rust Small Result: run 26352873354, success
- Swarm CI Required: run 26352873334, success

## Claim boundary
- Docs-only import.
- Must merge with a merge commit, not squash.
- Does not release, publish, sign, tag, push Docker images, move the v1 alias, promote proof, or change workflow behavior.
- After this PR merges, 	okmd-swarm/main must fast-forward to the publication merge commit.

## Rollback
- Revert the publication merge commit if the imported docs clarification needs to be backed out.