### PR TITLE
merge(swarm): import publication template evidence fields

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -102,6 +102,10 @@
   Publication import PR: cargo xtask repo-graph --publication origin/main --swarm HEAD --expect swarm-ahead
   Post-publication fast-forward: cargo xtask repo-graph --publication public/main --swarm origin/main --expect aligned
 -->
+- **Publication import fields:** <!-- For publication import PRs only. Record
+  Swarm-Head, Swarm-Range, imported swarm PRs or commits, required swarm checks,
+  publication checks, and the post-merge fast-forward command/result. State
+  explicitly that the PR must merge with a merge commit, not squash. -->
 - **Post-fast-forward branch health:** <!-- If branch CI starts after the graph
   is aligned, record repo/run IDs, shared headSha, active jobs, and the boundary
   that in_progress jobs are not passing proof. -->


### PR DESCRIPTION
Summary: Import tokmd-swarm/main 7f3fe5a075fc9796985987f9ac077b0f966da0fc into the publication repo. Swarm-Head: 7f3fe5a075fc9796985987f9ac077b0f966da0fc. Swarm-Range: 85cff34f416e5466dff6cb0262cff3235d6d1f06..7f3fe5a075fc9796985987f9ac077b0f966da0fc. Imported swarm PR: EffortlessMetrics/tokmd-swarm#103. Swarm checks: Tokmd Rust Small Result run 26354270523 succeeded; CI Required run 26354270533 succeeded. Pre-publication graph: repo-graph --publication public/main --swarm origin/main --expect swarm-ahead passed with merge base 85cff34f416e5466dff6cb0262cff3235d6d1f06. Merge method: merge commit only, not squash. Claim boundary: docs/template-only import; no release, publish, signing, Docker, tag, v1 alias, proof-promotion, Codecov, AST, evidencebus, or workflow behavior changes. Post-merge action: fast-forward tokmd-swarm/main to the publication merge commit and prove repo-graph aligned.