### PR TITLE
release: prepare tokmd v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-06-04
+
+1.12 makes `tokmd` a scoped evidence sensor for Bun undefined-behavior review
+and similar high-risk native-boundary work. A reviewer or review bot can now
+produce `sensors/tokmd/analyze.md`, `sensors/tokmd/analyze.json`, and
+`sensors/tokmd/context.md` from explicit refs and changed paths without turning
+the result into a UB detector or whole-repo health claim.
+
+For the user-facing release note, see `docs/releases/1.12.md`. For the
+maintainer release record, see `docs/releases/1.12-ledger.md`.
+
+### Added
+
+- `tokmd analyze --preset bun-ub` as a thin on-diff review preset combining
+  effort delta, git/churn, imports, complexity, API-surface, and duplication
+  signals while avoiding supply-chain, license, asset, dependency, novelty, and
+  whole-repo deep scans.
+- Bun UB review-bot documentation and the `ub-review` sensor recipe for
+  writing `sensors/tokmd/analyze.md`, `sensors/tokmd/analyze.json`, and
+  `sensors/tokmd/context.md`.
+- Bun-shaped smoke coverage proving scoped Markdown and JSON evidence with
+  valid base/head refs and unrelated dangling symlink fixtures.
+- Cockpit and handoff references for `bun-ub` sensor artifacts and regeneration
+  commands, so missing tokmd evidence is visible rather than treated as passing
+  proof.
+
+### Fixed
+
+- `tokmd analyze <file-or-dir>` now keeps file-backed enrichers inside the
+  requested input scope instead of walking the whole checkout by default.
+- Explicit bad `--effort-base-ref` or `--effort-head-ref` values now fail
+  clearly and name the unresolved ref instead of producing a generic baseline
+  gap.
+- Documentation density now uses `comments / (comments + code)`, so Markdown
+  and other code-zero rows cannot report density above 100%.
+- `tokmd context` list output now shows charged tokens, full-file tokens,
+  inclusion policy, and code lines so budget math reconciles row by row.
+- Dangling symlinks are skipped as file omissions during analysis collection
+  without poisoning unrelated scoped analysis.
+
+### Tests
+
+- Added focused regressions for doc-density math, context effective-token
+  rendering, scoped file-backed analysis, dangling symlink handling, unresolved
+  effort refs, the `bun-ub` preset contract, and Bun-shaped review evidence
+  smoke output.
+
+### Boundaries
+
+- `bun-ub` does not prove undefined behavior exists or is absent.
+- 1.12 does not add a public `tokmd review` command, proof promotion, default
+  Codecov upload, default AST-backed behavior, evidencebus runtime integration,
+  full-matrix migration, or release mutation from `tokmd-swarm`.
+
 ## [1.11.1] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2688,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3548,7 +3548,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.11.1"
+version = "1.12.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -194,22 +194,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.11.1" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.11.1" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.11.1" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.11.1" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.11.1" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.11.1" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.11.1" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.11.1" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.11.1" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.11.1" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.11.1" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.11.1" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.11.1" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.11.1" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.11.1" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.11.1" }
+tokmd = { path = "crates/tokmd", version = "1.12.0" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.12.0" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.12.0" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.12.0" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.12.0" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.12.0" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.12.0" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.12.0" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.12.0" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.12.0" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.12.0" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.12.0" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.12.0" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.12.0" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.12.0" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.12.0" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.11.1"
+        "version": "1.12.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.11.1"
+        "version": "1.12.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.11.1"
+        "version": "1.12.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.11.1"
+        "version": "1.12.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.11.1"
+        "version": "1.12.0"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.11.1",
-    "@tokmd/core-darwin-x64": "1.11.1",
-    "@tokmd/core-linux-arm64-gnu": "1.11.1",
-    "@tokmd/core-linux-x64-gnu": "1.11.1",
-    "@tokmd/core-win32-x64-msvc": "1.11.1"
+    "@tokmd/core-darwin-arm64": "1.12.0",
+    "@tokmd/core-darwin-x64": "1.12.0",
+    "@tokmd/core-linux-arm64-gnu": "1.12.0",
+    "@tokmd/core-linux-x64-gnu": "1.12.0",
+    "@tokmd/core-win32-x64-msvc": "1.12.0"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.11.1",
-    "@tokmd/core-darwin-x64": "1.11.1",
-    "@tokmd/core-darwin-arm64": "1.11.1",
-    "@tokmd/core-linux-x64-gnu": "1.11.1",
-    "@tokmd/core-linux-x64-musl": "1.11.1",
-    "@tokmd/core-linux-arm64-gnu": "1.11.1",
-    "@tokmd/core-linux-arm64-musl": "1.11.1",
-    "@tokmd/core-win32-arm64-msvc": "1.11.1"
+    "@tokmd/core-win32-x64-msvc": "1.12.0",
+    "@tokmd/core-darwin-x64": "1.12.0",
+    "@tokmd/core-darwin-arm64": "1.12.0",
+    "@tokmd/core-linux-x64-gnu": "1.12.0",
+    "@tokmd/core-linux-x64-musl": "1.12.0",
+    "@tokmd/core-linux-arm64-gnu": "1.12.0",
+    "@tokmd/core-linux-arm64-musl": "1.12.0",
+    "@tokmd/core-win32-arm64-msvc": "1.12.0"
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,10 @@ schemas, and verification policy for `tokmd`.
   surface, metadata, and CI ownership evidence before release mutation.
 - [release-readiness.md](release-readiness.md) — quickstart for pre-release
   evidence checks without publishing, tagging, or creating releases.
+- [releases/1.12.md](releases/1.12.md) — user-facing release notes for the 1.12
+  Bun UB evidence-readiness release.
+- [releases/1.12-ledger.md](releases/1.12-ledger.md) — maintainer release
+  record for the 1.12 Bun UB evidence-readiness release.
 - [releases/1.11.md](releases/1.11.md) — user-facing release notes for the 1.11
   evidence-consumption release.
 - [releases/1.11-ledger.md](releases/1.11-ledger.md) — lane-by-lane maintainer

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -108,6 +108,8 @@ For release preparation:
 
 Related:
 
+- [1.12 release notes](releases/1.12.md)
+- [1.12 release ledger](releases/1.12-ledger.md)
 - [1.11 release notes](releases/1.11.md)
 - [1.11 release ledger](releases/1.11-ledger.md)
 - [Publishing evidence](publishing-evidence.md)

--- a/docs/releases/1.12-ledger.md
+++ b/docs/releases/1.12-ledger.md
@@ -1,0 +1,102 @@
+# tokmd 1.12 Release Ledger
+
+## Purpose
+
+tokmd 1.12 is the Bun UB evidence-readiness release. It makes tokmd useful as a
+bounded evidence sensor for high-risk review workflows by producing scoped
+analysis and context artifacts for explicit refs and changed paths.
+
+This ledger is the maintainer release record. It is intentionally narrow: the
+1.12 cycle did not burn down old roadmap items, add a UB detector, or move
+release mutation into `tokmd-swarm`.
+
+## Source Range
+
+- Previous stable release: `v1.11.1`
+- Candidate release version: `1.12.0`
+- Primary release-note companion: [1.12 release notes](1.12.md)
+- Pre-release checks: [release readiness](../release-readiness.md)
+- Workbench import: `tokmd-swarm` was imported into `tokmd` by merge commit
+  before release preparation.
+
+Representative PRs are examples, not an exhaustive list. The release work
+landed as narrow swarm PRs, then moved into the publication repo by merge
+commit.
+
+## How To Read This Ledger
+
+Use `CHANGELOG.md` for the concise release index, `1.12.md` for the user-facing
+release note, this ledger for the maintainer record, and
+`docs/release-readiness.md` for command-backed preflight.
+
+## Lane Summary
+
+| Lane | Outcome | Representative PRs | User impact |
+| --- | --- | --- | --- |
+| Trust repairs | Fixed visible evidence defects before adding the preset: doc density math, context token reconciliation, path scope, symlink omissions, and bad ref handling. | tokmd-swarm #184, #185, #186, #188, #191 | Reviewers can trust the receipt basics before using `bun-ub`. |
+| Bun UB preset | Added `tokmd analyze --preset bun-ub` as a thin, scoped review evidence preset. | tokmd-swarm #192 | Review bots and local reviewers have a stable preset contract. |
+| Smoke coverage | Added Bun-shaped fixture coverage for scoped native/API paths, valid refs, and unrelated dangling symlinks. | tokmd-swarm #193 | The release proves the actual Bun UB user path, not just isolated helpers. |
+| Sensor documentation | Documented `bun-ub`, context handoff, and `ub-review` artifact recipes. | tokmd-swarm #194, #195, #198 | Operators can produce `sensors/tokmd/analyze.md`, `analyze.json`, and `context.md` without hand-editing. |
+| Cockpit and handoff linkage | Taught review/handoff surfaces to reference tokmd Bun UB artifacts and regeneration commands. | tokmd-swarm #196 | Missing evidence is explicit and reproducible rather than implied. |
+| Workbench substrate | Kept `tokmd-swarm` as the active workbench and imported the release work into `tokmd` by merge commit. | tokmd-swarm #197, tokmd #2511 | The shared graph remains clean while release ownership stays in `tokmd`. |
+| Queue hygiene | Merged or parked maintenance PRs by substance before release prep. | tokmd-swarm #187, #189, #190; tokmd #2506, #2509, #2510 | The release starts from an explainable queue. |
+
+## Evidence Contract
+
+The 1.12 evidence packet is:
+
+```text
+sensors/tokmd/analyze.md
+sensors/tokmd/analyze.json
+sensors/tokmd/context.md
+```
+
+The packet must be:
+
+- scoped to the changed paths passed to the command;
+- explicit about whether `BASE` and `HEAD` resolve;
+- readable enough for a human reviewer to inspect first;
+- stable enough for bot and ledger ingestion;
+- clear about included, truncated, skipped, missing, or partial evidence.
+
+## Validation Pattern
+
+The release lane used focused regressions first, then release-facing checks:
+
+- doc-density regression tests;
+- context effective-token rendering tests;
+- scoped analyze and dangling-symlink regressions;
+- unresolved effort-ref failure tests;
+- `bun-ub` preset CLI, serde, mapping, and help coverage;
+- Bun-shaped Markdown and JSON smoke tests;
+- docs, doc-artifacts, proof-policy, affected routing, and hosted PR checks for
+  the changed surfaces.
+
+Before tagging, run the release-readiness checks:
+
+```bash
+cargo xtask version-consistency
+cargo xtask publish-surface --json --verify-publish
+cargo xtask doc-artifacts --check
+cargo xtask docs --check
+cargo xtask proof-policy --check
+cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release.json
+cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release.json --evidence-json target/proof/proof-evidence-release.json
+```
+
+## Deferred
+
+1.12 does not add:
+
+- a UB detector;
+- public `tokmd review`;
+- evidencebus runtime integration;
+- proof promotion;
+- default Codecov upload;
+- default AST-backed public behavior;
+- full-matrix migration;
+- release, publish, signing, tag, crate, image, or alias mutation from
+  `tokmd-swarm`.
+
+Those remain separate maintainer decisions after the release evidence path has
+real usage.

--- a/docs/releases/1.12.md
+++ b/docs/releases/1.12.md
@@ -1,0 +1,111 @@
+# tokmd 1.12
+
+tokmd 1.12 is the Bun UB evidence-readiness release. It turns `tokmd analyze`
+and `tokmd context` into a scoped evidence packet for high-risk review work,
+starting with `EffortlessMetrics/ub-review`.
+
+Use this page as the user-facing release note. For the lane-by-lane maintainer
+record, see the [1.12 release ledger](1.12-ledger.md). For command-backed
+preflight before tagging or publishing, see [release readiness](../release-readiness.md).
+
+This release does not make tokmd an undefined-behavior detector. It packages
+bounded, reproducible evidence so a reviewer, review bot, or coding agent can
+inspect a risky diff with fewer false edges from the rest of the repository.
+
+## Review Bot Artifacts
+
+The intended review-bot shape is:
+
+```bash
+tokmd analyze \
+  --preset bun-ub \
+  --format md \
+  --effort-base-ref BASE \
+  --effort-head-ref HEAD \
+  --no-progress \
+  <changed paths> \
+  > sensors/tokmd/analyze.md
+
+tokmd analyze \
+  --preset bun-ub \
+  --format json \
+  --effort-base-ref BASE \
+  --effort-head-ref HEAD \
+  --no-progress \
+  <changed paths> \
+  > sensors/tokmd/analyze.json
+
+tokmd context \
+  --budget 64000 \
+  <changed paths> \
+  > sensors/tokmd/context.md
+```
+
+Open `sensors/tokmd/analyze.md` first for the human summary, use
+`sensors/tokmd/analyze.json` for bot and ledger ingestion, and use
+`sensors/tokmd/context.md` to see what source context was included, truncated,
+or skipped.
+
+## Highlights
+
+- `tokmd analyze --preset bun-ub` is now a stable preset contract for
+  unsafe/native-boundary review evidence.
+- Analysis is path-scoped: file-backed enrichers stay inside the positional
+  file or directory inputs unless `.` is explicitly supplied.
+- Explicit bad effort refs fail loudly and name the unresolved ref instead of
+  producing a healthy-looking receipt with a generic missing-baseline message.
+- Context list output reconciles charged tokens against full-file tokens and
+  shows the inclusion policy for each row.
+- Dangling symlinks are skipped as file omissions instead of degrading unrelated
+  scoped analysis.
+- Doc density cannot exceed 100% for Markdown or other code-zero rows.
+- Bun-shaped smoke tests lock the user path: scoped files, valid refs, unrelated
+  dangling symlinks, Markdown output, JSON output, and review-relevant sections.
+- `docs/analyze/bun-ub.md` and `docs/integrations/ub-review.md` give local
+  reviewers and review bots copy-ready commands and artifact paths.
+
+## For Bun UB Reviewers
+
+Run `bun-ub` with explicit refs and the changed paths under review:
+
+```bash
+tokmd analyze \
+  --preset bun-ub \
+  --format md \
+  --effort-base-ref origin/main \
+  --effort-head-ref HEAD \
+  --no-progress \
+  src/runtime/api
+```
+
+The preset requests effort delta, git/churn, imports, complexity, API-surface,
+and duplication signals. It intentionally avoids supply-chain, license, asset,
+dependency, novelty, and whole-repo deep scans.
+
+## For Bot Operators
+
+Use the `ub-review` recipe when attaching tokmd evidence:
+
+- [Bun UB preset contract](../analyze/bun-ub.md)
+- [ub-review sensor recipe](../integrations/ub-review.md)
+
+If `BASE` or `HEAD` cannot be resolved, the bot should treat the run as invalid
+evidence and avoid attaching a valid-looking artifact.
+
+## What Did Not Change
+
+- No UB-found or UB-absent claim.
+- No public `tokmd review` command.
+- No proof promotion.
+- No default Codecov upload.
+- No default AST-backed analyze, cockpit, context, handoff, or browser output.
+- No evidencebus runtime integration.
+- No full-matrix migration.
+- No release, publish, signing, tag, crate, image, or alias mutation from
+  `tokmd-swarm`.
+
+## Release Preflight
+
+Before tagging `v1.12.0`, run the release-readiness checks in
+`docs/release-readiness.md`, verify the changelog and this release note, and
+confirm the publication repo is the source of release mutation.


### PR DESCRIPTION
## Summary
- bump lockstep workspace and Node package metadata to 1.12.0
- add the 1.12 changelog entry, user-facing release note, and compact release ledger for Bun UB evidence readiness
- link the 1.12 release note and ledger from release-readiness/docs index

## Proof
- PASS: cargo xtask version-consistency
- PASS: cargo xtask doc-artifacts --check --json target/proof/release-1.12-doc-artifacts-check.json
- PASS: cargo xtask docs --check
- PASS: cargo xtask proof-policy --check
- PASS: cargo xtask affected --base origin/main --head HEAD --json-output target/proof/affected-release-1.12.json (9 files, 6 scopes, 0 unknown)
- PASS: cargo xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-release-1.12.json --evidence-json target/proof/proof-evidence-release-1.12.json
- PASS: cargo xtask publish-surface --json --verify-publish
- PASS: cargo xtask check-lint-policy
- PASS: cargo xtask check-clippy-exceptions
- PASS: cargo test -p xtask lint_policy --verbose
- PASS: cargo test -p xtask clippy_exceptions --verbose
- PASS: cargo clippy -p xtask --all-targets -- -D warnings
- PASS: cargo tree -i home --edges normal
- PASS: cargo test --manifest-path vendor/home-0.5.12/Cargo.toml --verbose
- PASS: cargo test -p tokmd-types manifest_stays_clap_free --verbose
- PASS: cargo xtask boundaries-check
- PASS: cargo xtask publish-surface --json
- PASS: cargo deny --all-features check (green with existing duplicate-crate warnings)
- PASS: cargo fmt-check
- PASS: cargo gate-check
- PASS: cargo xtask publish --plan

## Known gap
- cargo xtask publish --dry-run was attempted but did not complete within a 20-minute local timeout. The timed-out cargo/xtask child processes were stopped, and the worktree was left clean. No tag, publish, GitHub release, alias movement, or image mutation was performed.

## Boundaries
- This is release preparation only.
- No release mutation from tokmd-swarm.
- No tag, publish, signing, GHCR, crates.io, Docker, or v1 alias action is included.