### PR TITLE
merge(swarm): import scan missing-path test fix

### DIFF
--- a/crates/tokmd-scan/tests/edge_cases_w50.rs
+++ b/crates/tokmd-scan/tests/edge_cases_w50.rs
@@ -24,8 +24,10 @@ fn default_opts() -> ScanOptions {
 
 #[test]
 fn scan_nonexistent_path_errors_not_panics() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("missing-child");
     let opts = default_opts();
-    let result = scan(&[PathBuf::from("/this/path/does/not/exist")], &opts);
+    let result = scan(&[missing], &opts);
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(msg.contains("Path not found"), "unexpected error: {msg}");


### PR DESCRIPTION
## Summary
- Import tokmd-swarm PR #201 into the publication repo.
- Keeps the release dry-run test fix for Windows-safe missing-path assertions in the shared graph.

## Imported swarm commit
- EffortlessMetrics/tokmd-swarm@93dab7e686230cf2a3254df903cd890c4642809e `test(scan): use temp missing path (#201)`

## Proof
- Swarm PR #201 merged with required CI green, including `Tokmd Rust Small Result` and `CI (Required)`.
- Local focused proof on the source branch:
  - `cargo test -p tokmd-scan --test edge_cases_w50 scan_nonexistent_path_errors_not_panics -- --nocapture` -> 1 passed
  - `cargo test -p tokmd-scan --test edge_cases_w50 -- --nocapture` -> 6 passed
  - `cargo fmt -p tokmd-scan -- --check`
  - `git diff --check`

## Boundary
Merge this PR with a merge commit to preserve the swarm/publication graph. This is not a release tag or publish action.