### PR TITLE
mutant: close mutation gaps in path redaction 🧬

### DIFF
--- a/.jules/runs/run-1/decision.md
+++ b/.jules/runs/run-1/decision.md
@@ -1,0 +1,15 @@
+## Option A (recommended)
+Add targeted unit tests in `crates/tokmd-format/src/redact/mod.rs` to close the `cargo mutants` gaps around path redaction logic. Specifically:
+- Add a test for trailing dot normalization in `clean_path` to catch `-` vs `+` mutations.
+- Add tests for hidden file extensions (e.g. `.env`, `.rs`, `.tar.gz`) to catch logical operator mutations (`==` vs `!=`) in `redact_path`.
+
+This fits the `mutation` gate profile by strengthening behavioral assertions around meaningful code paths (path redaction boundary).
+Trade-offs: Increases test code slightly, but proves correctness of edge cases without changing production code.
+
+## Option B
+Refactor `clean_path` and `redact_path` to use a simpler path manipulation crate like `std::path::Path`.
+While this might reduce the need for custom string manipulation, it risks cross-platform determinism (e.g., Windows vs Linux path separators) and introduces complexity to a sensitive tier-0 function. It also doesn't directly address the missing mutation coverage without rewriting the logic.
+Trade-offs: Higher risk of determinism regressions.
+
+## Decision
+Choosing Option A because it provides direct, evidence-backed coverage of the exact gaps identified by `cargo mutants` without changing the proven deterministic production code.

--- a/.jules/runs/run-1/envelope.json
+++ b/.jules/runs/run-1/envelope.json
@@ -1,0 +1,14 @@
+{
+  "prompt_id": "mutant_high_value",
+  "persona": "Mutant",
+  "style": "Prover",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**"
+  ],
+  "gate_profile": "mutation",
+  "allowed_outcomes": ["proof-improvement patch", "learning PR"]
+}

--- a/.jules/runs/run-1/pr_body.md
+++ b/.jules/runs/run-1/pr_body.md
@@ -1,0 +1,61 @@
+## 💡 Summary
+Added targeted unit tests in `tokmd-format` to close path redaction mutation gaps. This is a proof-improvement patch that strengthens the test suite's ability to catch regressions in the `clean_path` and `redact_path` functions.
+
+## 🎯 Why
+Running `cargo mutants` on `crates/tokmd-format/src/redact/mod.rs` revealed three missed mutants:
+- `replace - with + in clean_path`
+- `replace - with / in clean_path`
+- `replace == with != in redact_path`
+
+These logic branches (trailing dot removal and hidden file extension processing) lacked specific coverage, which could allow path normalization or redaction leaks to slip through unnoticed.
+
+## 🔎 Evidence
+- `crates/tokmd-format/src/redact/mod.rs`
+- Observed missing mutation coverage initially:
+```
+MISSED   crates/tokmd-format/src/redact/mod.rs:48:46: replace - with + in clean_path
+MISSED   crates/tokmd-format/src/redact/mod.rs:48:46: replace - with / in clean_path
+MISSED   crates/tokmd-format/src/redact/mod.rs:140:41: replace == with != in redact_path
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add targeted unit tests for `clean_path` trailing dot handling and `redact_path` hidden file extension parsing.
+- Fits the `mutation` gate profile by strengthening assertions around real code paths.
+- Trade-offs: Structure is maintained; Velocity is high; Governance is safe as it doesn't change production logic.
+
+### Option B
+- Refactor `clean_path` and `redact_path` to use standard library path operations.
+- Choose when the logic becomes too complex to maintain manually.
+- Trade-offs: High risk of cross-platform determinism regressions (e.g., Windows `\` vs Linux `/`).
+
+## ✅ Decision
+Chose Option A to directly close the test gaps without risking determinism regressions in production path handling.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-format/src/redact/mod.rs`: Added `test_clean_path_trailing_dot`, `test_redact_path_empty_filename_part`, `test_redact_path_only_extension`, and `test_redact_path_hidden_compound_extension`.
+
+## 🧪 Verification receipts
+```text
+cargo mutants --file crates/tokmd-format/src/redact/mod.rs -p tokmd-format --no-shuffle
+Found 17 mutants to test
+ok       Unmutated baseline in 48s build + 6s test
+17 mutants tested in 4m: 17 caught
+```
+
+## 🧭 Telemetry
+- Change shape: Tests added
+- Blast radius: `crates/tokmd-format/src/redact/mod.rs`
+- Risk class: Low (test-only change)
+- Rollback: Revert the test additions
+- Gates run: `cargo mutants --file crates/tokmd-format/src/redact/mod.rs -p tokmd-format`, `cargo test -p tokmd-format`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-1/envelope.json`
+- `.jules/runs/run-1/decision.md`
+- `.jules/runs/run-1/receipts.jsonl`
+- `.jules/runs/run-1/result.json`
+- `.jules/runs/run-1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-1/receipts.jsonl
+++ b/.jules/runs/run-1/receipts.jsonl
@@ -1,0 +1,4 @@
+{"timestamp": "2026-06-05T06:09:30Z", "command": "mkdir -p .jules/runs/run-1", "output": ""}
+{"timestamp": "2026-06-05T06:10:15Z", "command": "cargo mutants --file crates/tokmd-format/src/redact/mod.rs -p tokmd-format --no-shuffle", "output": "MISSED   crates/tokmd-format/src/redact/mod.rs:48:46: replace - with + in clean_path\nMISSED   crates/tokmd-format/src/redact/mod.rs:48:46: replace - with / in clean_path\nMISSED   crates/tokmd-format/src/redact/mod.rs:140:41: replace == with != in redact_path"}
+{"timestamp": "2026-06-05T06:15:20Z", "command": "cargo test -p tokmd-format", "output": "test result: ok. 154 passed; 0 failed"}
+{"timestamp": "2026-06-05T06:18:40Z", "command": "cargo mutants --file crates/tokmd-format/src/redact/mod.rs -p tokmd-format --no-shuffle", "output": "17 mutants tested in 4m: 17 caught"}

--- a/.jules/runs/run-1/result.json
+++ b/.jules/runs/run-1/result.json
@@ -1,0 +1,6 @@
+{
+  "outcome": "proof-improvement patch",
+  "receipts_count": 4,
+  "options_considered": ["Option A", "Option B"],
+  "decision": "Option A"
+}

--- a/crates/tokmd-format/src/redact/mod.rs
+++ b/crates/tokmd-format/src/redact/mod.rs
@@ -294,4 +294,30 @@ mod tests {
     fn test_redact_path_normalizes_dot_prefix() {
         assert_eq!(redact_path("src/main.rs"), redact_path("./src/main.rs"));
     }
+
+    #[test]
+    fn test_clean_path_trailing_dot() {
+        assert_eq!(clean_path("src/lib/."), "src/lib");
+    }
+
+    #[test]
+    fn test_redact_path_empty_filename_part() {
+        let redacted = redact_path(".env");
+        assert_eq!(redacted.len(), 16);
+        assert!(!redacted.contains('.'));
+    }
+
+    #[test]
+    fn test_redact_path_only_extension() {
+        let redacted = redact_path(".rs");
+        assert_eq!(redacted.len(), 16);
+        assert!(!redacted.contains('.'));
+    }
+
+    #[test]
+    fn test_redact_path_hidden_compound_extension() {
+        let redacted = redact_path(".tar.gz");
+        assert!(redacted.ends_with(".gz"));
+        assert_eq!(redacted.len(), 16 + 3);
+    }
 }


### PR DESCRIPTION
## 💡 Summary 
Added targeted unit tests in `tokmd-format` to close path redaction mutation gaps. This is a proof-improvement patch that strengthens the test suite's ability to catch regressions in the `clean_path` and `redact_path` functions.

## 🎯 Why 
Running `cargo mutants` on `crates/tokmd-format/src/redact/mod.rs` revealed three missed mutants:
- `replace - with + in clean_path`
- `replace - with / in clean_path`
- `replace == with != in redact_path`

These logic branches (trailing dot removal and hidden file extension processing) lacked specific coverage, which could allow path normalization or redaction leaks to slip through unnoticed.

## 🔎 Evidence 
- `crates/tokmd-format/src/redact/mod.rs`
- Observed missing mutation coverage initially:
```
MISSED   crates/tokmd-format/src/redact/mod.rs:48:46: replace - with + in clean_path
MISSED   crates/tokmd-format/src/redact/mod.rs:48:46: replace - with / in clean_path
MISSED   crates/tokmd-format/src/redact/mod.rs:140:41: replace == with != in redact_path
```

## 🧭 Options considered 
### Option A (recommended) 
- Add targeted unit tests for `clean_path` trailing dot handling and `redact_path` hidden file extension parsing.
- Fits the `mutation` gate profile by strengthening assertions around real code paths.
- Trade-offs: Structure is maintained; Velocity is high; Governance is safe as it doesn't change production logic.

### Option B 
- Refactor `clean_path` and `redact_path` to use standard library path operations.
- Choose when the logic becomes too complex to maintain manually.
- Trade-offs: High risk of cross-platform determinism regressions (e.g., Windows `\` vs Linux `/`).

## ✅ Decision 
Chose Option A to directly close the test gaps without risking determinism regressions in production path handling.

## 🧱 Changes made (SRP) 
- `crates/tokmd-format/src/redact/mod.rs`: Added `test_clean_path_trailing_dot`, `test_redact_path_empty_filename_part`, `test_redact_path_only_extension`, and `test_redact_path_hidden_compound_extension`.

## 🧪 Verification receipts 
```text
cargo mutants --file crates/tokmd-format/src/redact/mod.rs -p tokmd-format --no-shuffle
Found 17 mutants to test
ok       Unmutated baseline in 48s build + 6s test
17 mutants tested in 4m: 17 caught
```

## 🧭 Telemetry 
- Change shape: Tests added
- Blast radius: `crates/tokmd-format/src/redact/mod.rs`
- Risk class: Low (test-only change)
- Rollback: Revert the test additions
- Gates run: `cargo mutants --file crates/tokmd-format/src/redact/mod.rs -p tokmd-format`, `cargo test -p tokmd-format`

## 🗂️ .jules artifacts 
- `.jules/runs/run-1/envelope.json`
- `.jules/runs/run-1/decision.md`
- `.jules/runs/run-1/receipts.jsonl`
- `.jules/runs/run-1/result.json`
- `.jules/runs/run-1/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [10940445227256719064](https://jules.google.com/task/10940445227256719064) started by @EffortlessSteven*