### PR TITLE
merge(swarm): import evidence packet contract

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1149,6 +1149,16 @@ mutation = false
 coverage = false
 
 [[scope]]
+name = "docs_recipe_tests"
+kind = "rust"
+paths = ["crates/tokmd/tests/docs.rs"]
+packages = ["tokmd"]
+proof = ["cargo test -p tokmd --test docs --verbose"]
+reason = "Docs-as-tests recipe coverage validates user-facing command examples and release recipes."
+mutation = false
+coverage = false
+
+[[scope]]
 name = "user_guides"
 kind = "non_rust"
 paths = [

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1157,6 +1157,7 @@ paths = [
   "docs/action-quickstart.md",
   "docs/browser.md",
   "docs/browser-to-native.md",
+  "docs/evidence-packet.md",
   "docs/examples/**",
   "docs/install-and-try.md",
   "docs/integrations/**",

--- a/crates/tokmd/tests/docs.rs
+++ b/crates/tokmd/tests/docs.rs
@@ -3,17 +3,61 @@
 use assert_cmd::Command;
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
-use std::path::PathBuf;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command as StdCommand,
+};
 
 /// "Docs as tests" - verify that the commands we recommend in README/Recipes actually work.
 /// These run against `tests/data` to ensure stability.
 fn tokmd() -> Command {
+    let fixtures = fixture_dir();
+    tokmd_in(&fixtures)
+}
+
+fn tokmd_in(cwd: &Path) -> Command {
     let mut cmd: Command = cargo_bin_cmd!("tokmd");
-    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("data");
-    cmd.current_dir(&fixtures);
+    cmd.current_dir(cwd);
     cmd
+}
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("data")
+}
+
+fn git_recipe_fixture() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("main.rs"), "fn main() {}\n").unwrap();
+
+    run_git(tmp.path(), &["init"]);
+    run_git(tmp.path(), &["add", "."]);
+    run_git(
+        tmp.path(),
+        &[
+            "-c",
+            "user.name=tokmd docs test",
+            "-c",
+            "user.email=tokmd@example.invalid",
+            "commit",
+            "-m",
+            "initial",
+        ],
+    );
+    tmp
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let status = StdCommand::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed with {status}");
 }
 
 #[test]
@@ -70,7 +114,8 @@ fn recipe_analyze_presets() {
         .success();
 
     // "tokmd analyze --preset estimate --effort-base-ref main --effort-head-ref HEAD --format md"
-    tokmd()
+    let git_fixture = git_recipe_fixture();
+    tokmd_in(git_fixture.path())
         .arg("analyze")
         .arg("--preset")
         .arg("estimate")

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,9 @@ schemas, and verification policy for `tokmd`.
   native review packets, handoff bundles, and CI evidence.
 - [analyze/bun-ub.md](analyze/bun-ub.md) — scoped `bun-ub` analysis artifacts
   for Bun undefined-behavior review bots, local reviewers, and agent handoff.
+- [evidence-packet.md](evidence-packet.md) - versioned
+  `sensors/tokmd/manifest.json` packet contract over `analyze.md`,
+  `analyze.json`, and `context.md`.
 - [integrations/ub-review.md](integrations/ub-review.md) - copy-ready
   `ub-review` sensor recipe for `sensors/tokmd/analyze.md`,
   `sensors/tokmd/analyze.json`, and `sensors/tokmd/context.md`.

--- a/docs/analyze/bun-ub.md
+++ b/docs/analyze/bun-ub.md
@@ -76,6 +76,13 @@ Open `sensors/tokmd/analyze.md` first for the human review summary. Use
 `sensors/tokmd/analyze.json` for bot ingestion, ledger storage, and exact field
 checks.
 
+When a workflow needs a single packet index, write
+`sensors/tokmd/manifest.json` using the [evidence packet contract](../evidence-packet.md).
+The manifest records the `tokmd` version, preset, refs, scoped paths, artifact
+paths, status, warnings, errors, non-claims, and reproduction commands. Current
+`tokmd` commands emit the underlying receipts; the manifest contract defines
+the producer and consumer shape for the packet wrapper.
+
 ## Required Refs
 
 For review-bot evidence, pass both refs explicitly:

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -42,6 +42,7 @@ each section.
 | `diff.json` | `tokmd diff --format json` output when redirected or saved | `tokmd diff` | Structured before/after change facts between receipts, runs, or refs. | It is not review prioritization by itself. | Re-run `tokmd diff <before> <after> --format json`. |
 | `gate.json` | `tokmd gate --format json` output when saved | `tokmd gate` | Policy evaluation result for a receipt and a TOML policy or baseline ratchet. | It does not replace the underlying test/build tools named by policy. | Re-run `tokmd gate ... --format json` with the same policy and receipt. |
 | `baseline.json` | `.tokmd/baseline.json` or user-selected baseline path | `tokmd baseline`, `tokmd gate` ratchet flows | Stored comparison point for ratchets and drift checks. | It is not a current scan; it can become stale. | Recreate from the intended reference state before relying on it. |
+| `manifest.json` | `sensors/tokmd/manifest.json` | Review-bot or sensor workflow using the [evidence packet contract](evidence-packet.md) | Packet index for scoped sensor artifacts, including preset, refs, requested paths, status, artifact paths, warnings, errors, non-claims, and reproduction commands. | It is not emitted by `tokmd analyze` in 1.12, does not verify itself, does not execute CI proof, and does not prove UB exists or is absent. | Check `status`, required artifact paths, `warnings`, `errors`, and `reproduce`; parse `analyze.json` before trusting machine evidence. |
 
 ## Cockpit Review Packet
 

--- a/docs/evidence-packet.md
+++ b/docs/evidence-packet.md
@@ -1,0 +1,177 @@
+# tokmd Evidence Packet Contract
+
+Status: specified. The first packet shape is intended for review bots,
+high-risk local review, and coding-agent handoff. Current `tokmd` commands emit
+the underlying receipts; a producer can assemble this manifest beside them until
+`tokmd` grows a first-class manifest emitter.
+
+## Purpose
+
+An evidence packet is the stable directory-level contract over a scoped review
+run. It lets a bot, reviewer, ledger, or agent consume one packet instead of
+scraping Markdown or guessing which receipt belongs to which command.
+
+The packet answers:
+
+- what diff window was requested;
+- which paths were in scope;
+- which artifacts were produced;
+- whether the packet is complete, partial, or failed;
+- what warnings, errors, and non-claims bound the evidence;
+- how to reproduce the packet.
+
+It is not a merge verdict, CI proof result, UB detector, safety proof, or
+release gate.
+
+## Default Layout
+
+For Bun UB review, the packet lives under `sensors/tokmd/`:
+
+```text
+sensors/tokmd/
+  manifest.json
+  analyze.md
+  analyze.json
+  context.md
+```
+
+The manifest is the packet index. The receipts remain the source evidence.
+
+## Manifest Schema
+
+Use this schema identifier for the first packet contract:
+
+```text
+tokmd.evidence-packet/v1
+```
+
+Required fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `schema` | string | Must be `tokmd.evidence-packet/v1`. |
+| `tokmd_version` | string | Version of the `tokmd` binary used for the receipts. |
+| `preset` | string | Analysis preset, for example `bun-ub`. |
+| `base` | string | Requested base ref. |
+| `head` | string | Requested head ref. |
+| `paths` | array of strings | Requested changed paths or review scope. |
+| `status` | string | Packet status: `complete`, `partial`, or `failed`. |
+| `artifacts` | object | Relative packet artifact paths. |
+| `warnings` | array | Non-fatal packet warnings. |
+| `errors` | array | Fatal packet or artifact errors. |
+| `non_claims` | array of strings | Claims this packet explicitly does not make. |
+| `reproduce` | array of strings | Commands to regenerate the artifacts. |
+
+Recommended artifact keys:
+
+| Key | Path | Meaning |
+| --- | --- | --- |
+| `analyze_md` | `sensors/tokmd/analyze.md` | Human-first scoped analysis summary. |
+| `analyze_json` | `sensors/tokmd/analyze.json` | Machine-readable analysis receipt. |
+| `context_md` | `sensors/tokmd/context.md` | Context budget audit for reviewer or agent handoff. |
+
+Producers may add fields when they do not change the meaning of required
+fields. Consumers should ignore unknown fields and fail closed when required
+fields are missing.
+
+## Example
+
+```json
+{
+  "schema": "tokmd.evidence-packet/v1",
+  "tokmd_version": "1.12.0",
+  "preset": "bun-ub",
+  "base": "origin/main",
+  "head": "HEAD",
+  "paths": ["src/runtime/api"],
+  "status": "complete",
+  "artifacts": {
+    "analyze_md": "sensors/tokmd/analyze.md",
+    "analyze_json": "sensors/tokmd/analyze.json",
+    "context_md": "sensors/tokmd/context.md"
+  },
+  "warnings": [],
+  "errors": [],
+  "non_claims": [
+    "bun-ub packages review evidence; it does not prove UB exists or is absent"
+  ],
+  "reproduce": [
+    "tokmd analyze --preset bun-ub --format md --effort-base-ref origin/main --effort-head-ref HEAD --no-progress src/runtime/api > sensors/tokmd/analyze.md",
+    "tokmd analyze --preset bun-ub --format json --effort-base-ref origin/main --effort-head-ref HEAD --no-progress src/runtime/api > sensors/tokmd/analyze.json",
+    "tokmd context --budget 64000 src/runtime/api > sensors/tokmd/context.md"
+  ]
+}
+```
+
+## Status Rules
+
+Use `complete` only when:
+
+- every required artifact listed in `artifacts` exists;
+- explicit base and head refs resolved before analysis;
+- `analyze.json` reports successful scoped analysis;
+- context generation completed for the requested paths;
+- `errors` is empty.
+
+Use `partial` when:
+
+- one or more non-fatal warnings bound the evidence;
+- optional artifacts are missing;
+- context was generated but a listed source path was skipped by policy;
+- analysis completed but some enrichment was unavailable.
+
+Use `failed` when:
+
+- explicit refs do not resolve;
+- a required artifact is missing;
+- `analyze.json` cannot be parsed;
+- the producer cannot determine whether the packet matches the requested paths.
+
+Do not attach a packet marked `complete` when the real state is `partial` or
+`failed`.
+
+## Producer Rules
+
+1. Generate `analyze.md`, `analyze.json`, and `context.md` from the same base,
+   head, and paths recorded in `manifest.json`.
+2. Write paths relative to the repository root or packet root, not absolute
+   machine-local paths.
+3. Record ref-resolution failures as `failed` packets, or do not attach a
+   packet at all.
+4. Preserve warnings from `analyze.json`; do not hide them in Markdown-only
+   output.
+5. Include non-claims that bound the preset. For `bun-ub`, the key non-claim is
+   that the packet packages review evidence and does not prove UB exists or is
+   absent.
+6. Keep reproduction commands copy-ready and scoped to the same paths.
+
+## Consumer Rules
+
+1. Open `manifest.json` first to identify the packet status and artifact list.
+2. Treat `status=failed` as invalid evidence.
+3. Treat `status=partial` as evidence with named limits, not a pass.
+4. Use `analyze.md` for first-read review context.
+5. Use `analyze.json` for bot, ledger, and agent ingestion.
+6. Use `context.md` to check which source files were included, truncated, or
+   skipped before handing the packet to an agent.
+7. Do not infer CI proof, safety, or whole-repo coverage from this packet.
+
+## Bun UB Non-Claims
+
+A `bun-ub` evidence packet does not:
+
+- detect undefined behavior;
+- prove memory safety;
+- prove that a change is safe to merge;
+- analyze the whole repository unless `.` was supplied as a path;
+- replace cockpit review packets;
+- execute CI proof;
+- promote coverage, mutation, fuzz, release, signing, or publish checks.
+
+## Related Docs
+
+- [Bun UB analysis preset](analyze/bun-ub.md)
+- [ub-review tokmd sensor recipe](integrations/ub-review.md)
+- [Artifact glossary](artifacts.md)
+- [Review packet contract](review-packet.md)
+- [Handoff bundles](handoff.md)

--- a/docs/integrations/ub-review.md
+++ b/docs/integrations/ub-review.md
@@ -67,9 +67,15 @@ Attach these artifacts:
 
 | Artifact | Consumer | Use |
 | --- | --- | --- |
+| `sensors/tokmd/manifest.json` | bot, ledger, agent | Packet index with refs, paths, status, artifact paths, warnings, errors, non-claims, and reproduction commands. |
 | `sensors/tokmd/analyze.md` | reviewer | First-read human summary of scoped risk evidence. |
 | `sensors/tokmd/analyze.json` | bot, ledger, agent | Machine-readable receipt with preset, refs, warnings, and signals. |
 | `sensors/tokmd/context.md` | reviewer, agent | Context budget audit showing included, truncated, and skipped files. |
+
+Use the [evidence packet contract](../evidence-packet.md) for
+`sensors/tokmd/manifest.json`. Until `tokmd` has a first-class manifest
+emitter, review-bot glue can write the manifest from the same `BASE`, `HEAD`,
+and changed paths used to generate the three receipts.
 
 ## Local Reviewer Recipe
 


### PR DESCRIPTION
﻿## Summary

Import the current 	okmd-swarm/main workbench state into the publication repo by preserving the shared commit graph.

Imported swarm commits:

- dc991dbb - docs(contract): define tokmd evidence packet
- cbb7e05 - 	est(docs): run ref recipe in git fixture

## Why

This keeps the evidence-packet contract and the release-validation docs-test fix on the publication line without squashing away the swarm history. The v1.12.0 tag remains on 442b42ac; these imports are post-1.12 publication-line work.

## Graph Evidence

- publication: origin/main = 442b42acffa8d86cad4edf7647c48f84e386ddcc
- swarm: swarm/main = cbb7e055eecca451fad8e4b9d86a100544052c4
- git rev-list --left-right --count origin/main...swarm/main =  2
- cargo xtask repo-graph --publication origin/main --swarm swarm/main --expect swarm-ahead --json target/proof/post-pr206-repo-graph.json passed

## Proof Notes

Swarm PR #206 passed required hosted checks after the formatting rerun, including CI (Required), Tokmd Rust Small Result, Quality Gate, Fast Proof Run (Advisory), Docs Check, Proof Policy, Affected Proof Plan, Build & Test (Linux), Publish Surface, and Version consistency.

Local release/user-path validation also confirmed published 	okmd 1.12.0 installs from crates.io, reports 	okmd 1.12.0, produces complete un-ub JSON with delta, and fails unresolved refs clearly.

## Merge Method

Merge commit only. Do not squash this publication import.
