### PR TITLE
specsmith: add bdd test for empty directory analysis edge case 🧪

### DIFF
--- a/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_analyze_scenarios_w50.rs
@@ -272,3 +272,36 @@ fn given_project_when_analyze_health_then_todo_and_complexity_present() {
         "should have derived.todo section"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 10: Empty directory gracefully produces valid receipt with zeroed metrics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_empty_dir_when_analyze_json_then_valid_empty_receipt() {
+    let dir = tempdir().expect("should create temp dir");
+
+    let output = tokmd_cmd()
+        .args(["analyze", ".", "--preset", "receipt", "--format", "json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to execute tokmd analyze");
+
+    assert!(output.status.success(), "analyze command failed");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(json["mode"], "analysis");
+    assert!(json.get("derived").is_some(), "missing derived");
+
+    let derived = &json["derived"];
+
+    assert_eq!(derived["totals"]["files"], 0, "should have 0 files");
+    assert_eq!(derived["totals"]["code"], 0, "should have 0 code");
+
+    let dist = &derived["distribution"];
+    assert_eq!(dist["count"], 0, "distribution count should be 0");
+    assert_eq!(dist["min"], 0, "distribution min should be 0");
+    assert_eq!(dist["max"], 0, "distribution max should be 0");
+    assert_eq!(dist["gini"], 0.0, "gini should gracefully be 0.0");
+}


### PR DESCRIPTION
This PR improves scenario coverage by explicitly testing `tokmd analyze` against an empty directory. It proves that the application correctly handles this edge case without panicking, outputting a valid JSON analysis receipt populated entirely with zeros for source totals, bounds, distributions, and limits.

---
*PR created automatically by Jules for task [4098274143555263060](https://jules.google.com/task/4098274143555263060) started by @EffortlessSteven*