### PR TITLE
steward: polish publish plan exclusion output 🚢

### DIFF
--- a/.jules/runs/steward_release/decision.md
+++ b/.jules/runs/steward_release/decision.md
@@ -1,0 +1,18 @@
+# Decision
+
+## Option A (recommended)
+Implement `std::fmt::Display` for `ExclusionReason` in `xtask/src/tasks/publish.rs` and update `print_plan` to use `Display` instead of `Debug` for exclusion reasons. Currently, `cargo xtask publish --plan --verbose` outputs raw Debug formatting (e.g. `NotPublishable`), which looks like an unpolished internal detail for release governance tooling.
+
+* Fits repo and shard: Directly targets the `xtask` workspace tooling for release metadata presentation (a stated primary path and focus).
+* Trade-offs:
+  * Structure: Marginally increases boilerplate by adding a standard `Display` impl.
+  * Velocity: Negligible cost.
+  * Governance: Improves the polish and clarity of the publish plan drift output (a top-priority target) without altering behavioral semantics.
+
+## Option B
+Find another release/governance issue, perhaps in `CHANGELOG.md` or `.github/workflows/release.yml`.
+* When to choose: If the current `publish --plan` output format isn't considered "drift" or "RC-hardening" enough.
+* Trade-offs: Might require larger, riskier changes, potentially missing the "low-risk, high-confidence" requirement.
+
+## Decision
+Choose Option A. It's a low-risk, zero-behavior-change improvement to the governance release tooling output surface, perfectly aligning with the "Stabilizer" style and the specific request to focus on `publish-plan` presentation drift.

--- a/.jules/runs/steward_release/envelope.json
+++ b/.jules/runs/steward_release/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "steward_release",
+  "persona": "Steward",
+  "style": "Stabilizer",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/**/Cargo.toml",
+    ".cargo/**"
+  ],
+  "gate_profile": "governance-release",
+  "allowed_outcomes": ["patch", "learning_pr"]
+}

--- a/.jules/runs/steward_release/pr_body.md
+++ b/.jules/runs/steward_release/pr_body.md
@@ -1,0 +1,53 @@
+## 💡 Summary
+Implemented `std::fmt::Display` for `ExclusionReason` in `xtask` publish command and updated formatting. This improves the readability of the release publish plan drift output by providing clear, human-readable reasons instead of internal Debug enum variants.
+
+## 🎯 Why
+Running `cargo xtask publish --plan --verbose` previously exposed internal Rust `Debug` enum formatting (e.g., `NotPublishable`) for excluded crates. This was an unpolished presentation detail for a release governance surface.
+
+## 🔎 Evidence
+- `xtask/src/tasks/publish.rs`
+- Observed behavior: `Excluded crates:\n  - tokmd-fuzz: NotPublishable`
+- Command: `cargo run -p xtask -- publish --plan --verbose`
+
+## 🧭 Options considered
+### Option A (recommended)
+- Implement `Display` for `ExclusionReason` to map variants to clear descriptions (e.g., "publish = false in manifest") and use `{}` instead of `{:?}` in `print_plan`.
+- Fits repo and shard: Directly improves the presentation of the release publish plan, a stated priority in the governance shard.
+- Trade-offs: Structure: Adds a standard boilerplate trait impl. Velocity: Fast. Governance: Polishes a core release artifact.
+
+### Option B
+- Look for drift in `.github/workflows/` or `CHANGELOG.md` instead.
+- When to choose: If the presentation of the publish plan is deemed insufficiently impactful.
+- Trade-offs: Misses an easy win to fulfill the core prompt directive of low-risk, high-confidence release-surface fixes.
+
+## ✅ Decision
+Chose Option A to cleanly polish the release publish plan without changing behavioral semantics.
+
+## 🧱 Changes made (SRP)
+- `xtask/src/tasks/publish.rs`: Added `Display` implementation for `ExclusionReason` and updated the format string in `print_plan`.
+
+## 🧪 Verification receipts
+```text
+=== Publish Plan ===
+...
+Excluded crates:
+  - tokmd-fuzz: publish = false in manifest
+...
+```
+
+## 🧭 Telemetry
+- Change shape: Presentation improvement
+- Blast radius: Internal release tooling output only
+- Risk class: Very Low - No behavioral changes
+- Rollback: Revert the PR
+- Gates run: `cargo xtask publish --plan --verbose`, `cargo xtask version-consistency`, `cargo xtask docs --check`, `cargo build/test`, `cargo fmt/clippy`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/steward_release/envelope.json`
+- `.jules/runs/steward_release/decision.md`
+- `.jules/runs/steward_release/receipts.jsonl`
+- `.jules/runs/steward_release/result.json`
+- `.jules/runs/steward_release/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/steward_release/receipts.jsonl
+++ b/.jules/runs/steward_release/receipts.jsonl
@@ -1,0 +1,1 @@
+{"command": "cargo run -p xtask -- publish --plan --verbose", "output_snippet": "Excluded crates:\\n  - tokmd-fuzz: NotPublishable\\n  - tokmd-node: NotPublishable"}

--- a/.jules/runs/steward_release/result.json
+++ b/.jules/runs/steward_release/result.json
@@ -1,0 +1,17 @@
+{
+  "outcome": "patch",
+  "primary_shard": "tooling-governance",
+  "gate_profile": "governance-release",
+  "files_modified": [
+    "xtask/src/tasks/publish.rs"
+  ],
+  "verification_commands_run": [
+    "cargo run -p xtask -- publish --plan --verbose",
+    "cargo run -p xtask -- version-consistency",
+    "cargo run -p xtask -- docs --check",
+    "cargo build -p xtask --verbose",
+    "cargo test -p xtask --verbose",
+    "cargo fmt -- --check",
+    "cargo clippy -- -D warnings"
+  ]
+}

--- a/xtask/src/tasks/publish.rs
+++ b/xtask/src/tasks/publish.rs
@@ -55,6 +55,18 @@ pub enum ExclusionReason {
     NotRequested,
 }
 
+impl std::fmt::Display for ExclusionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExclusionReason::NotPublishable => write!(f, "publish = false in manifest"),
+            ExclusionReason::IsXtask => write!(f, "internal xtask tool"),
+            ExclusionReason::IsFuzz => write!(f, "internal fuzz tool"),
+            ExclusionReason::ExplicitExclude => write!(f, "explicitly excluded"),
+            ExclusionReason::NotRequested => write!(f, "not in requested set"),
+        }
+    }
+}
+
 /// The resolved publish plan.
 #[derive(Debug)]
 pub struct PublishPlan {
@@ -326,7 +338,7 @@ fn print_plan(plan: &PublishPlan, args: &PublishArgs) {
     if !plan.exclusion_reasons.is_empty() && args.verbose {
         println!("\nExcluded crates:");
         for (name, reason) in &plan.exclusion_reasons {
-            println!("  - {}: {:?}", name, reason);
+            println!("  - {}: {}", name, reason);
         }
     }
 


### PR DESCRIPTION
## 💡 Summary 
Implemented `std::fmt::Display` for `ExclusionReason` in `xtask` publish command and updated formatting. This improves the readability of the release publish plan drift output by providing clear, human-readable reasons instead of internal Debug enum variants.

## 🎯 Why 
Running `cargo xtask publish --plan --verbose` previously exposed internal Rust `Debug` enum formatting (e.g., `NotPublishable`) for excluded crates. This was an unpolished presentation detail for a release governance surface.

## 🔎 Evidence 
- `xtask/src/tasks/publish.rs`
- Observed behavior: `Excluded crates:\n  - tokmd-fuzz: NotPublishable`
- Command: `cargo run -p xtask -- publish --plan --verbose`

## 🧭 Options considered 
### Option A (recommended) 
- Implement `Display` for `ExclusionReason` to map variants to clear descriptions (e.g., "publish = false in manifest") and use `{}` instead of `{:?}` in `print_plan`.
- Fits repo and shard: Directly improves the presentation of the release publish plan, a stated priority in the governance shard.
- Trade-offs: Structure: Adds a standard boilerplate trait impl. Velocity: Fast. Governance: Polishes a core release artifact.

### Option B 
- Look for drift in `.github/workflows/` or `CHANGELOG.md` instead.
- When to choose: If the presentation of the publish plan is deemed insufficiently impactful.
- Trade-offs: Misses an easy win to fulfill the core prompt directive of low-risk, high-confidence release-surface fixes.

## ✅ Decision 
Chose Option A to cleanly polish the release publish plan without changing behavioral semantics.

## 🧱 Changes made (SRP) 
- `xtask/src/tasks/publish.rs`: Added `Display` implementation for `ExclusionReason` and updated the format string in `print_plan`.

## 🧪 Verification receipts 
```text
=== Publish Plan ===
...
Excluded crates:
  - tokmd-fuzz: publish = false in manifest
...
```

## 🧭 Telemetry 
- Change shape: Presentation improvement
- Blast radius: Internal release tooling output only
- Risk class: Very Low - No behavioral changes
- Rollback: Revert the PR
- Gates run: `cargo xtask publish --plan --verbose`, `cargo xtask version-consistency`, `cargo xtask docs --check`, `cargo build/test`, `cargo fmt/clippy`

## 🗂️ .jules artifacts 
- `.jules/runs/steward_release/envelope.json`
- `.jules/runs/steward_release/decision.md`
- `.jules/runs/steward_release/receipts.jsonl`
- `.jules/runs/steward_release/result.json`
- `.jules/runs/steward_release/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [17634640264838156837](https://jules.google.com/task/17634640264838156837) started by @EffortlessSteven*