### PR TITLE
mutant: fix path redaction extension case leak 🧬

### DIFF
--- a/.jules/runs/run-mutant-12345/decision.md
+++ b/.jules/runs/run-mutant-12345/decision.md
@@ -1,0 +1,18 @@
+# Decision
+
+## Option A (recommended)
+- Modify `redact_path` in `crates/tokmd-format/src/redact/mod.rs` to normalize the safe extensions to lowercase before hashing the path.
+- This ensures that trust boundary data leaks related to original file casing are prevented, as paths differing only by case in their extension will yield the same hash/redaction.
+- Why it fits this repo and shard: It closes a concrete missed-mutant-style gap regarding path case-normalization for redaction output, strictly within the `tokmd-format` core pipeline, directly preventing information leakage via extension casing.
+- Trade-offs:
+  - Structure: Requires a slight modification in path string manipulation inside `redact_path`.
+  - Velocity: Simple logic addition.
+  - Governance: Adds strict, test-backed proof against case leakage.
+
+## Option B
+- Modify the `safe_path_extension_suffix` helper in `crates/tokmd-format/src/redact/extensions.rs` to return an explicit list of the lower-cased extensions, and build the hash from that.
+- When to choose it instead: If the responsibility of normalizing extension cases should lie entirely on the extension registry rather than the path string logic.
+- Trade-offs: Still requires modification of `clean_path` or the hashed string, which operates on the raw path before `safe_path_extension_suffix` is mapped. Doing the logic purely in `redact_path` before hashing is simpler and directly addresses the hash-input problem.
+
+## ✅ Decision
+Option A is selected because it tackles the hash-input problem exactly where the string is being prepared for hashing within `redact_path`. We will adjust the path to have a lowercased extension before passing it to `short_hash`.

--- a/.jules/runs/run-mutant-12345/envelope.json
+++ b/.jules/runs/run-mutant-12345/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "mutant_high_value",
+  "persona": "Mutant",
+  "style": "Prover",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "mutation",
+  "allowed_outcomes": ["proof-improvement patch", "learning PR"]
+}

--- a/.jules/runs/run-mutant-12345/pr_body.md
+++ b/.jules/runs/run-mutant-12345/pr_body.md
@@ -1,0 +1,50 @@
+## 💡 Summary
+Fixed a path redaction case-normalization issue in `tokmd-format`. Added test to verify identical paths with different extension cases yield the exact same redact/hash output.
+
+## 🎯 Why
+Redaction outputs were producing entirely different hash strings when file extensions only differed by casing (e.g., `src/lib.rs` vs `src/lib.RS`), leaking original file casing across the trust boundary.
+
+## 🔎 Evidence
+- `crates/tokmd-format/src/redact/mod.rs`
+- `test redaction_must_normalize_case_for_safe_extensions_hash ... FAILED`
+
+## 🧭 Options considered
+### Option A (recommended)
+- Normalize the safe extensions to lowercase before hashing the path.
+- Fits this repo and shard: Closes a concrete missed-mutant-style gap strictly within the `tokmd-format` core pipeline, directly preventing information leakage via extension casing.
+- Trade-offs: Simple logic addition, adds strict test-backed proof against case leakage.
+
+### Option B
+- Modify the `safe_path_extension_suffix` helper to return lower-cased extensions.
+- When to choose: If extension normalization responsibility lies in the registry.
+- Trade-offs: Requires modification of `clean_path` or the hashed string; doing it purely in `redact_path` before hashing is simpler.
+
+## ✅ Decision
+Option A is selected because it directly tackles the hash-input problem exactly where the string is being prepared for hashing within `redact_path`.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-format/src/redact/mod.rs`
+- `crates/tokmd-format/tests/test_redaction_case_leak.rs`
+
+## 🧪 Verification receipts
+```text
+cargo test -p tokmd-format --test test_redaction_case_leak
+test redaction_must_normalize_case_for_safe_extensions_hash ... ok
+```
+
+## 🧭 Telemetry
+- Change shape: Core bugfix / test coverage
+- Blast radius: Output redaction layer only
+- Risk class + why: Low risk, deterministic formatting output check fix.
+- Rollback: Revert `crates/tokmd-format/src/redact/mod.rs` and the new test file.
+- Gates run: `cargo test`, `cargo build`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-mutant-12345/envelope.json`
+- `.jules/runs/run-mutant-12345/decision.md`
+- `.jules/runs/run-mutant-12345/receipts.jsonl`
+- `.jules/runs/run-mutant-12345/result.json`
+- `.jules/runs/run-mutant-12345/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-mutant-12345/receipts.jsonl
+++ b/.jules/runs/run-mutant-12345/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "cargo test -p tokmd-format --test test_redaction_case_leak", "output": "test redaction_must_normalize_case_for_safe_extensions_hash ... FAILED"}
+{"command": "cargo test -p tokmd-format --test test_redaction_case_leak", "output": "test redaction_must_normalize_case_for_safe_extensions_hash ... ok"}

--- a/.jules/runs/run-mutant-12345/result.json
+++ b/.jules/runs/run-mutant-12345/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "run_id": "run-mutant-12345",
+  "outcome": "proof-improvement patch"
+}

--- a/crates/tokmd-format/src/redact/mod.rs
+++ b/crates/tokmd-format/src/redact/mod.rs
@@ -131,7 +131,30 @@ pub fn short_hash(s: &str) -> String {
 /// assert!(gz.ends_with(".tar.gz"));
 /// ```
 pub fn redact_path(path: &str) -> String {
-    let cleaned = clean_path(path);
+    let mut cleaned = clean_path(path);
+    let filename = cleaned.split('/').next_back().unwrap_or(&cleaned);
+    let parts: Vec<&str> = filename.split('.').collect();
+
+    let mut ext_len = 0;
+    if parts.len() > 1 && !(parts.len() == 2 && parts[0].is_empty()) {
+        let extension_parts = if parts[0].is_empty() {
+            &parts[2..]
+        } else {
+            &parts[1..]
+        };
+
+        if let Some(suffix) = extensions::safe_path_extension_suffix(extension_parts) {
+            ext_len = suffix.iter().map(|ext| ext.len() + 1).sum();
+        }
+    }
+
+    if ext_len > 0 {
+        let len_without_ext = cleaned.len() - ext_len;
+        let ext = &cleaned[len_without_ext..];
+        let lower_ext = ext.to_ascii_lowercase();
+        cleaned.replace_range(len_without_ext.., &lower_ext);
+    }
+
     let mut out = short_hash(&cleaned);
 
     let filename = cleaned.split('/').next_back().unwrap_or(&cleaned);

--- a/crates/tokmd-format/tests/test_redaction_case_leak.rs
+++ b/crates/tokmd-format/tests/test_redaction_case_leak.rs
@@ -1,0 +1,15 @@
+use tokmd_format::redact_path;
+
+#[test]
+fn redaction_must_normalize_case_for_safe_extensions_hash() {
+    let lower = redact_path("src/lib.rs");
+    let upper = redact_path("src/lib.RS");
+    let mixed = redact_path("src/lib.Rs");
+
+    assert_eq!(lower, upper, "Upper-case extension produced a different hash/redaction: {} != {}", lower, upper);
+    assert_eq!(lower, mixed, "Mixed-case extension produced a different hash/redaction: {} != {}", lower, mixed);
+
+    assert!(lower.ends_with(".rs"));
+    assert!(upper.ends_with(".rs"));
+    assert!(mixed.ends_with(".rs"));
+}

--- a/crates/tokmd-format/tests/test_redaction_case_leak.rs
+++ b/crates/tokmd-format/tests/test_redaction_case_leak.rs
@@ -6,8 +6,16 @@ fn redaction_must_normalize_case_for_safe_extensions_hash() {
     let upper = redact_path("src/lib.RS");
     let mixed = redact_path("src/lib.Rs");
 
-    assert_eq!(lower, upper, "Upper-case extension produced a different hash/redaction: {} != {}", lower, upper);
-    assert_eq!(lower, mixed, "Mixed-case extension produced a different hash/redaction: {} != {}", lower, mixed);
+    assert_eq!(
+        lower, upper,
+        "Upper-case extension produced a different hash/redaction: {} != {}",
+        lower, upper
+    );
+    assert_eq!(
+        lower, mixed,
+        "Mixed-case extension produced a different hash/redaction: {} != {}",
+        lower, mixed
+    );
 
     assert!(lower.ends_with(".rs"));
     assert!(upper.ends_with(".rs"));


### PR DESCRIPTION
## 💡 Summary 
Fixed a path redaction case-normalization issue in `tokmd-format`. Added test to verify identical paths with different extension cases yield the exact same redact/hash output.

## 🎯 Why 
Redaction outputs were producing entirely different hash strings when file extensions only differed by casing (e.g., `src/lib.rs` vs `src/lib.RS`), leaking original file casing across the trust boundary.

## 🔎 Evidence 
- `crates/tokmd-format/src/redact/mod.rs`
- `test redaction_must_normalize_case_for_safe_extensions_hash ... FAILED`

## 🧭 Options considered 
### Option A (recommended) 
- Normalize the safe extensions to lowercase before hashing the path.
- Fits this repo and shard: Closes a concrete missed-mutant-style gap strictly within the `tokmd-format` core pipeline, directly preventing information leakage via extension casing.
- Trade-offs: Simple logic addition, adds strict test-backed proof against case leakage.

### Option B 
- Modify the `safe_path_extension_suffix` helper to return lower-cased extensions.
- When to choose: If extension normalization responsibility lies in the registry.
- Trade-offs: Requires modification of `clean_path` or the hashed string; doing it purely in `redact_path` before hashing is simpler.

## ✅ Decision 
Option A is selected because it directly tackles the hash-input problem exactly where the string is being prepared for hashing within `redact_path`.

## 🧱 Changes made (SRP) 
- `crates/tokmd-format/src/redact/mod.rs`
- `crates/tokmd-format/tests/test_redaction_case_leak.rs`

## 🧪 Verification receipts 
```text
cargo test -p tokmd-format --test test_redaction_case_leak
test redaction_must_normalize_case_for_safe_extensions_hash ... ok
```

## 🧭 Telemetry 
- Change shape: Core bugfix / test coverage
- Blast radius: Output redaction layer only
- Risk class + why: Low risk, deterministic formatting output check fix.
- Rollback: Revert `crates/tokmd-format/src/redact/mod.rs` and the new test file.
- Gates run: `cargo test`, `cargo build`

## 🗂️ .jules artifacts 
- `.jules/runs/run-mutant-12345/envelope.json`
- `.jules/runs/run-mutant-12345/decision.md`
- `.jules/runs/run-mutant-12345/receipts.jsonl`
- `.jules/runs/run-mutant-12345/result.json`
- `.jules/runs/run-mutant-12345/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [13018973534541070095](https://jules.google.com/task/13018973534541070095) started by @EffortlessSteven*