### PR TITLE
invariant: add determinism and input bounding properties to entropy analysis 🔬

### DIFF
--- a/.jules/runs/run-invariant-001/decision.md
+++ b/.jules/runs/run-invariant-001/decision.md
@@ -1,0 +1,20 @@
+# Invariant Run Decision
+
+## Problem
+The entropy analysis report (`build_entropy_report`) lacked property-based tests verifying:
+1. **Determinism:** The same input files should yield exactly the same `EntropyReport`.
+2. **Input Path Bounding:** All paths present in the suspects list must correspond to one of the requested input paths.
+
+## Options Considered
+
+### Option A: Add missing properties to `entropy/tests/properties.rs` (Recommended)
+Add `deterministic_entropy_report` and `suspect_paths_must_be_in_inputs` property tests.
+- **Why it fits:** Reduces uncertainty around core invariant expectations for the entropy analysis engine, directly aligning with the `Prover` and `Invariant` persona goals.
+- **Trade-offs:** Minimal structural impact, high return on verification confidence.
+
+### Option B: Perform broad fuzz testing
+Attempt to use `cargo fuzz` or similar to hit untested input spaces.
+- **Why reject:** This requires setting up custom fuzz targets rather than leaning on the existing property-based test framework. The property-based tests are cleaner to insert for deterministic bounding.
+
+## Decision
+Chose Option A: Added two missing property tests to `crates/tokmd-analysis/src/entropy/tests/properties.rs`.

--- a/.jules/runs/run-invariant-001/envelope.json
+++ b/.jules/runs/run-invariant-001/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "invariant_model_analysis",
+  "persona": "Invariant \ud83d\udd2c",
+  "style": "Prover",
+  "primary_shard": "analysis-stack",
+  "allowed_paths": [
+    "crates/tokmd-analysis*/**",
+    "crates/tokmd-fun/**",
+    "crates/tokmd-gate/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/tests/**",
+    "docs/**"
+  ],
+  "gate_profile": "property",
+  "allowed_outcomes": ["proof-improvement patch", "learning PR"]
+}

--- a/.jules/runs/run-invariant-001/pr_body.md
+++ b/.jules/runs/run-invariant-001/pr_body.md
@@ -1,0 +1,52 @@
+## 💡 Summary
+Added two missing property-based invariants to the `tokmd-analysis` entropy module. This tightens verification around entropy scan determinism and ensures suspect paths are strictly bounded by input lists.
+
+## 🎯 Why
+The `build_entropy_report` function returns suspects based on computed entropy, but there were no invariant checks guaranteeing deterministic behavior or strict adherence to the input file list. Adding these reduces edge-case risk.
+
+## 🔎 Evidence
+Added tests in `crates/tokmd-analysis/src/entropy/tests/properties.rs`:
+- `deterministic_entropy_report`
+- `suspect_paths_must_be_in_inputs`
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add missing properties to `entropy/tests/properties.rs`.
+- Why it fits: Directly aligns with the `property` gate expectations and `Prover` style by adding clear deterministic proof constraints.
+- Trade-offs: Increases test execution time marginally, but adds significant confidence.
+
+### Option B
+- Refactor the entropy engine to structurally prevent non-determinism.
+- When to choose: If the engine is fundamentally unstable. Currently, adding tests is sufficient to prove stability.
+- Trade-offs: Unnecessary risk and churn.
+
+## ✅ Decision
+Implemented Option A.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-analysis/src/entropy/tests/properties.rs`
+
+## 🧪 Verification receipts
+```text
+cargo test --verbose
+cargo build --verbose
+cargo fmt -- --check
+cargo clippy -- -D warnings
+```
+
+## 🧭 Telemetry
+- Change shape: Additions to property tests.
+- Blast radius: Test-only impact.
+- Risk class: Low
+- Rollback: git checkout crates/tokmd-analysis/src/entropy/tests/properties.rs
+- Gates run: `cargo build --verbose`, `CI=true cargo test --verbose`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-invariant-001/envelope.json`
+- `.jules/runs/run-invariant-001/decision.md`
+- `.jules/runs/run-invariant-001/receipts.jsonl`
+- `.jules/runs/run-invariant-001/result.json`
+- `.jules/runs/run-invariant-001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-invariant-001/receipts.jsonl
+++ b/.jules/runs/run-invariant-001/receipts.jsonl
@@ -1,0 +1,5 @@
+{"command": "cargo build --verbose", "outcome": "success"}
+{"command": "CI=true cargo test --verbose", "outcome": "success"}
+{"command": "cargo fmt -- --check", "outcome": "success"}
+{"command": "cargo clippy -- -D warnings", "outcome": "success"}
+{"command": "CI=true cargo test -p tokmd-analysis properties --all-features", "outcome": "success"}

--- a/.jules/runs/run-invariant-001/result.json
+++ b/.jules/runs/run-invariant-001/result.json
@@ -1,0 +1,4 @@
+{
+  "outcome": "success",
+  "patch_type": "proof-improvement"
+}

--- a/crates/tokmd-analysis/src/entropy/tests/properties.rs
+++ b/crates/tokmd-analysis/src/entropy/tests/properties.rs
@@ -198,4 +198,54 @@ proptest! {
             );
         }
     }
+
+    #[test]
+    fn deterministic_entropy_report(data in arb_file_content()) {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("test.bin");
+        fs::write(&f, &data).unwrap();
+
+        let export = export_for_paths(&["test.bin"]);
+        let files = vec![PathBuf::from("test.bin")];
+
+        let report1 = build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+        let report2 = build_entropy_report(dir.path(), &files, &export, &AnalysisLimits::default()).unwrap();
+
+        prop_assert_eq!(report1.suspects.len(), report2.suspects.len(), "suspects length must be deterministic");
+        for (s1, s2) in report1.suspects.iter().zip(report2.suspects.iter()) {
+            prop_assert_eq!(&s1.path, &s2.path);
+            prop_assert_eq!(&s1.module, &s2.module);
+            prop_assert_eq!(s1.entropy_bits_per_byte, s2.entropy_bits_per_byte);
+            prop_assert_eq!(s1.sample_bytes, s2.sample_bytes);
+            prop_assert_eq!(&s1.class, &s2.class);
+        }
+    }
+
+    #[test]
+    fn suspect_paths_must_be_in_inputs(data in prop::collection::vec(arb_file_content(), 1..=5)) {
+        let dir = tempdir().unwrap();
+        let mut paths = Vec::new();
+        let mut path_strs = Vec::new();
+
+        for (i, content) in data.iter().enumerate() {
+            let name = format!("f{i}.bin");
+            let f = dir.path().join(&name);
+            fs::write(&f, content).unwrap();
+            paths.push(PathBuf::from(&name));
+            path_strs.push(name);
+        }
+
+        let str_refs: Vec<&str> = path_strs.iter().map(|s| s.as_str()).collect();
+        let export = export_for_paths(&str_refs);
+        let report =
+            build_entropy_report(dir.path(), &paths, &export, &AnalysisLimits::default()).unwrap();
+
+        for finding in &report.suspects {
+            prop_assert!(
+                str_refs.contains(&finding.path.as_str()),
+                "suspect path {} must be in the input list",
+                finding.path
+            );
+        }
+    }
 }


### PR DESCRIPTION
## 💡 Summary 
Added two missing property-based invariants to the `tokmd-analysis` entropy module. This tightens verification around entropy scan determinism and ensures suspect paths are strictly bounded by input lists.

## 🎯 Why 
The `build_entropy_report` function returns suspects based on computed entropy, but there were no invariant checks guaranteeing deterministic behavior or strict adherence to the input file list. Adding these reduces edge-case risk.

## 🔎 Evidence 
Added tests in `crates/tokmd-analysis/src/entropy/tests/properties.rs`:
- `deterministic_entropy_report`
- `suspect_paths_must_be_in_inputs`

## 🧭 Options considered 
### Option A (recommended) 
- Add missing properties to `entropy/tests/properties.rs`.
- Why it fits: Directly aligns with the `property` gate expectations and `Prover` style by adding clear deterministic proof constraints.
- Trade-offs: Increases test execution time marginally, but adds significant confidence.

### Option B 
- Refactor the entropy engine to structurally prevent non-determinism.
- When to choose: If the engine is fundamentally unstable. Currently, adding tests is sufficient to prove stability.
- Trade-offs: Unnecessary risk and churn.

## ✅ Decision 
Implemented Option A.

## 🧱 Changes made (SRP) 
- `crates/tokmd-analysis/src/entropy/tests/properties.rs`

## 🧪 Verification receipts 
```text
cargo test --verbose
cargo build --verbose
cargo fmt -- --check
cargo clippy -- -D warnings
```

## 🧭 Telemetry 
- Change shape: Additions to property tests.
- Blast radius: Test-only impact.
- Risk class: Low
- Rollback: git checkout crates/tokmd-analysis/src/entropy/tests/properties.rs
- Gates run: `cargo build --verbose`, `CI=true cargo test --verbose`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`

## 🗂️ .jules artifacts 
- `.jules/runs/run-invariant-001/envelope.json`
- `.jules/runs/run-invariant-001/decision.md`
- `.jules/runs/run-invariant-001/receipts.jsonl`
- `.jules/runs/run-invariant-001/result.json`
- `.jules/runs/run-invariant-001/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [5485351239367888899](https://jules.google.com/task/5485351239367888899) started by @EffortlessSteven*