### PR TITLE
bolt: swap BTreeMap for FxHashMap in near_dup pairs ⚡

### DIFF
--- a/.jules/runs/bolt_analysis_stack_builder/decision.md
+++ b/.jules/runs/bolt_analysis_stack_builder/decision.md
@@ -1,12 +1,24 @@
-## Options Considered
+# Decision
 
-### Option A: Remove String allocations in duplicate analysis hot loop
-- **What it is:** Change `BTreeMap<String, ...>` to `BTreeMap<&str, ...>` in `build_duplicate_report` (inside `tokmd-analysis/src/content/mod.rs`). Replace redundant `get_mut` / `insert` blocks with `entry(module).or_default()`.
-- **Trade-offs:** Clean win. Reduces repeated hashing/lookups and removes string copying completely during the hot loop of counting duplicate and wasted files by module. Very aligned with Bolt's "hot-path work reduction" and "unnecessary string building".
+## Option A (recommended)
+**Change BTreeMap to FxHashMap in near-duplicate pair building**
 
-### Option B: Partial sorting in `build_top_offenders`
-- **What it is:** Use `select_nth_unstable` in `tokmd-analysis/src/derived/files.rs` to avoid full `O(N log N)` sorting on large file trees.
-- **Trade-offs:** `select_nth_unstable` requires mutable, owned vectors, so we'd still have to allocate vectors. And while it saves sorting time, the duplicate report string building happens per duplicate file group, which can be significant.
+- **What it is**: Update `inverted_index` and `shared_fingerprint_counts` in `crates/tokmd-analysis/src/near_dup/pairs.rs` to use `rustc_hash::FxHashMap` instead of `std::collections::BTreeMap`.
+- **Why it fits this repo and shard**: The benchmark shows that for both building the inverted index and counting the shared fingerprints, `FxHashMap` is significantly faster than `BTreeMap`. Specifically:
+  - `inverted_index`: BTreeMap takes ~650µs, FxHashMap takes ~255µs (2.5x speedup)
+  - `shared_counts`: BTreeMap takes ~3.25ms, FxHashMap takes ~340µs (9.5x speedup)
+  This fits within the `analysis-stack` primary shard where `tokmd-analysis` resides, optimizing a core part of the `near_dup` analysis flow.
+- **Trade-offs**:
+  - Structure: We lose the ordered keys of `BTreeMap`, but since we only use these maps for grouping and looking up values, and not for ordered iteration, order doesn't matter for these two specific internal maps. The output of `build_pairs` still gets correctly sorted using `sort_pairs(&mut pairs)`.
+  - Velocity: Simple internal change, no public API adjustments needed.
+  - Governance: Uses `rustc_hash::FxHashMap` which is already a dependency in `tokmd-analysis` (used in `near_dup/fingerprint.rs`).
+
+## Option B
+**Change the pair loop nested loops**
+
+- **What it is**: Pre-compute pair keys differently or avoid the `(usize, usize)` pair structure entirely.
+- **When to choose it instead**: If replacing `BTreeMap` isn't fast enough.
+- **Trade-offs**: More complex algorithmic changes might break determinism or alter the results slightly without immense speedups. The data structure swap is much safer and easier to prove correct.
 
 ## ✅ Decision
-We will proceed with Option A because `tokmd-analysis/src/content/mod.rs` does repetitive `to_string()` allocations and double map lookups in a hot loop (iterating every duplicate file). By binding the module strings to the lifetime of the input `ExportData` and using the `Entry` API natively, we remove the string allocations and halve the map lookups.
+We choose **Option A**. The transition from `BTreeMap` to `FxHashMap` provides a substantial performance speedup to the pairing phase in `near-dup` analysis. The benchmark data clearly backs up this optimization and no deterministic output changes are expected because the final pair list is always explicitly sorted at the end.

--- a/.jules/runs/bolt_analysis_stack_builder/envelope.json
+++ b/.jules/runs/bolt_analysis_stack_builder/envelope.json
@@ -1,13 +1,1 @@
-{
-  "prompt_id": "bolt_analysis_stack_builder",
-  "persona": "Bolt ⚡",
-  "style": "Builder",
-  "primary_shard": "analysis-stack",
-  "allowed_paths": [
-    "crates/tokmd-analysis*/**",
-    "crates/tokmd-fun/**",
-    "crates/tokmd-gate/**"
-  ],
-  "gate_profile": "perf-proof",
-  "allowed_outcomes": ["patch", "proof_patch", "learning_pr"]
-}
+{"run_id": "bolt_analysis_stack_builder", "prompt_id": "bolt_analysis_stack_builder", "persona": "bolt", "style": "builder", "primary_shard": "analysis-stack", "allowed_paths": ["crates/tokmd-analysis*/**", "crates/tokmd-fun/**", "crates/tokmd-gate/**"], "gate_profile": "perf-proof", "allowed_outcomes": ["pr-ready patch", "learning PR"]}

--- a/.jules/runs/bolt_analysis_stack_builder/pr_body.md
+++ b/.jules/runs/bolt_analysis_stack_builder/pr_body.md
@@ -1,48 +1,53 @@
 ## 💡 Summary
-Reduced repeated string allocations and BTreeMap lookups inside the hot-path duplicate file analysis loop by utilizing the `Entry` API with `&str` keys instead of `String`.
+Replaced `BTreeMap` with `FxHashMap` in `crates/tokmd-analysis/src/near_dup/pairs.rs` to improve the performance of near-duplicate analysis.
 
 ## 🎯 Why
-In `build_duplicate_report`, every duplicate file iteration was performing redundant `BTreeMap::get_mut` followed by `BTreeMap::insert` allocations for `module.to_string()`. This caused unnecessary string building and double lookups.
+The `near_dup` module's pairing phase builds an inverted index of fingerprints and computes shared fingerprint counts. This phase was using `BTreeMap`, which incurs unnecessary allocation and balancing overhead since ordering is not required for these internal structures. `FxHashMap` provides much faster hashing and lookups.
 
 ## 🔎 Evidence
-- File: `crates/tokmd-analysis/src/content/mod.rs`
-- Finding: Redundant `String` copies in the hot loop counting duplicates by module.
-- Receipt: Cargo tests passed successfully without allocations.
+- **File**: `crates/tokmd-analysis/src/near_dup/pairs.rs`
+- **Observed behavior**: Benchmarking the inverted index and shared counts operations.
+- **Receipts**:
+  - `inverted_index`: BTreeMap takes ~650µs, FxHashMap takes ~255µs (2.5x speedup)
+  - `shared_counts`: BTreeMap takes ~3.25ms, FxHashMap takes ~340µs (9.5x speedup)
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- What it is: Use `&str` bound to the `ExportData` row lifetime and the `Entry` API.
-- Why it fits: Aligns perfectly with Bolt's focus on hot-path work reduction and removing unnecessary allocations inside analysis loops.
-- Trade-offs: Structure is cleaner; no velocity or governance impact.
+- Replace internal `BTreeMap` usages with `FxHashMap` in `build_pairs` functions.
+- Fits the repo as `rustc-hash` is already an available dependency and this is a hot path for near-duplicate scaling.
+- **Trade-offs**: None functionally. Internal order is lost, but the output `pairs` list is sorted explicitly at the end anyway, preserving determinism.
 
 ### Option B
-- What it is: Sort vectors partially in `build_top_offenders`.
-- When to choose it instead: When memory footprints in the top offenders map dwarf duplicated metrics building.
-- Trade-offs: Harder to prove performance improvements and limits dataset size optimizations.
+- Modify the near-dup similarity algorithm fundamentally.
+- Too much complexity and risk to determinism without guaranteed wins. The simple data structure swap works best.
 
 ## ✅ Decision
-Chose Option A to cleanly eliminate repetitive string building and duplicate map lookups in a hot loop.
+Option A was chosen. It's a proven optimization that cuts down overhead on a hot path in `tokmd-analysis`.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd-analysis/src/content/mod.rs`
+- `crates/tokmd-analysis/src/near_dup/pairs.rs`
 
 ## 🧪 Verification receipts
-cargo test -p tokmd-analysis --verbose
+```text
+cargo build --verbose
+CI=true cargo test --verbose -p tokmd-analysis --all-features
+cargo clippy -- -D warnings
 cargo fmt -- --check
+```
 
 ## 🧭 Telemetry
-- Change shape: Performance optimization
-- Blast radius: None
-- Risk class: Low
-- Rollback: `git checkout crates/tokmd-analysis/src/content/mod.rs`
-- Gates run: perf-proof, core-rust
+- Change shape: Implementation detail swap
+- Blast radius: `near_dup` module only, purely internal implementation.
+- Risk class: Low, tests prove that determinism holds.
+- Rollback: Revert to BTreeMap.
+- Gates run: `cargo build`, `cargo test`, `cargo clippy`, `cargo fmt`
 
 ## 🗂️ .jules artifacts
-- `envelope.json`
-- `decision.md`
-- `receipts.jsonl`
-- `result.json`
-- `pr_body.md`
+- `.jules/runs/bolt_analysis_stack_builder/envelope.json`
+- `.jules/runs/bolt_analysis_stack_builder/decision.md`
+- `.jules/runs/bolt_analysis_stack_builder/receipts.jsonl`
+- `.jules/runs/bolt_analysis_stack_builder/result.json`
+- `.jules/runs/bolt_analysis_stack_builder/pr_body.md`
 
 ## 🔜 Follow-ups
 None

--- a/.jules/runs/bolt_analysis_stack_builder/receipts.jsonl
+++ b/.jules/runs/bolt_analysis_stack_builder/receipts.jsonl
@@ -1,3 +1,5 @@
 {"ts_utc": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")", "phase": "setup", "cwd": "$(pwd)", "cmd": "mkdir -p .jules/runs/bolt_analysis_stack_builder", "status": 0, "summary": "Created run artifacts directory"}
 {"ts_utc": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")", "phase": "patch", "cwd": "$(pwd)", "cmd": "cargo test -p tokmd-analysis --verbose", "status": 0, "summary": "Tests passed"}
 {"ts_utc": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")", "phase": "patch", "cwd": "$(pwd)", "cmd": "cargo fmt -- --check", "status": 0, "summary": "Fmt passed"}
+{"command": "cargo bench -p tokmd-analysis --bench near_dup_bench", "output": "near_dup/inverted_index_btreemap time: [649.52 \u00b5s 650.43 \u00b5s 651.44 \u00b5s]\nnear_dup/inverted_index_fxhashmap time: [255.97 \u00b5s 257.46 \u00b5s 259.66 \u00b5s]\nnear_dup/shared_counts_btreemap time: [3.2305 ms 3.2404 ms 3.2520 ms]\nnear_dup/shared_counts_fxhashmap time: [340.33 \u00b5s 342.76 \u00b5s 345.86 \u00b5s]"}
+{"command": "replace_with_git_merge_diff", "output": "Edit applied successfully"}

--- a/.jules/runs/bolt_analysis_stack_builder/result.json
+++ b/.jules/runs/bolt_analysis_stack_builder/result.json
@@ -1,1 +1,6 @@
-{ "outcome": "patch", "title": "bolt: reduce hot path string allocation in duplicate analysis \u26a1", "summary": "Reduced allocations by replacing BTreeMap<String, T> with BTreeMap<&str, T> and utilizing Entry API.", "target_paths": ["crates/tokmd-analysis/src/content/mod.rs"], "proof_summary": "Replaced repetitive get_mut and insert logic with zero-allocation Entry API in hot loops.", "gates_run": ["cargo test -p tokmd-analysis --verbose"], "friction_items_created": [], "persona_notes_created": [], "rollback": "git checkout crates/tokmd-analysis/src/content/mod.rs", "follow_ups": [] }
+{
+  "summary": "Swapped BTreeMap for FxHashMap in near-duplicate pairing",
+  "reason": "Improves performance of near-duplicate inverted index building and pair matching.",
+  "status": "success",
+  "evidence": "Benchmark tests show ~2.5x speedup for inverted_index and ~9.5x speedup for shared_counts operations."
+}

--- a/crates/tokmd-analysis/src/near_dup/pairs.rs
+++ b/crates/tokmd-analysis/src/near_dup/pairs.rs
@@ -1,6 +1,6 @@
 //! Pair scoring for near-duplicate detection.
 
-use std::collections::BTreeMap;
+use rustc_hash::FxHashMap;
 
 use tokmd_analysis_types::NearDupPairRow;
 use tokmd_types::FileRow;
@@ -61,8 +61,8 @@ pub(super) fn build_pairs(
     }
 }
 
-fn inverted_index(file_fingerprints: &[(usize, Vec<u64>)]) -> BTreeMap<u64, Vec<usize>> {
-    let mut inverted: BTreeMap<u64, Vec<usize>> = BTreeMap::new();
+fn inverted_index(file_fingerprints: &[(usize, Vec<u64>)]) -> FxHashMap<u64, Vec<usize>> {
+    let mut inverted: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
     for (local_idx, (_, fps)) in file_fingerprints.iter().enumerate() {
         for &fp in fps {
             inverted.entry(fp).or_default().push(local_idx);
@@ -72,9 +72,9 @@ fn inverted_index(file_fingerprints: &[(usize, Vec<u64>)]) -> BTreeMap<u64, Vec<
 }
 
 fn shared_fingerprint_counts(
-    inverted: &BTreeMap<u64, Vec<usize>>,
-) -> BTreeMap<(usize, usize), usize> {
-    let mut pair_shared: BTreeMap<(usize, usize), usize> = BTreeMap::new();
+    inverted: &FxHashMap<u64, Vec<usize>>,
+) -> FxHashMap<(usize, usize), usize> {
+    let mut pair_shared: FxHashMap<(usize, usize), usize> = FxHashMap::default();
     for posting_list in inverted.values() {
         if posting_list.len() > MAX_POSTINGS {
             continue;
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn self_pair_guard_skips_same_index() {
-        let mut inverted = BTreeMap::new();
+        let mut inverted = FxHashMap::default();
         inverted.insert(1, vec![0, 0, 1]);
 
         let pair_shared = shared_fingerprint_counts(&inverted);


### PR DESCRIPTION
Replaced `BTreeMap` with `FxHashMap` in `crates/tokmd-analysis/src/near_dup/pairs.rs` to improve the performance of near-duplicate analysis.

The `near_dup` module's pairing phase builds an inverted index of fingerprints and computes shared fingerprint counts. This phase was using `BTreeMap`, which incurs unnecessary allocation and balancing overhead since ordering is not required for these internal structures. `FxHashMap` provides much faster hashing and lookups, demonstrating a 2.5x and 9.5x speedup in operations respectively without breaking determinism.

---
*PR created automatically by Jules for task [15319246790362112298](https://jules.google.com/task/15319246790362112298) started by @EffortlessSteven*