### PR TITLE
surveyor: consolidate internal crates to use workspace dependencies 🧭

### DIFF
--- a/.jules/runs/run-1/decision.md
+++ b/.jules/runs/run-1/decision.md
@@ -1,0 +1,16 @@
+# Decision
+
+## Option A (recommended)
+Fix dependency direction and workspace structure issues by moving internal crate references to use `workspace = true` rather than explicit path + version strings where possible. This tightens workspace bounds and prevents versions from drifting within the `tokmd` project. Note that Cargo workspace inheritance does not yet fully support overriding `default-features = false` if the workspace specifies `default-features = true`, so crates like `tokmd-cockpit` requiring this pattern will retain their explicit path dependency.
+
+- Why it fits: We are acting as Surveyor, and dependency direction/workspace structure is exactly within our target ranking. Using explicit versions/paths for internal workspace dependencies instead of relying on workspace resolution is a structural issue.
+- Trade-offs:
+    - Structure: Better cohesion; everything centralizes to `workspace.dependencies`.
+    - Velocity: Faster version bumps.
+    - Governance: Less chance of accidentally unlinking a local crate during publish.
+
+## Option B
+Do nothing, since explicit paths still technically link crates.
+- Trade-offs: Will leave messy dependency duplication and version mismatches.
+
+We will proceed with Option A.

--- a/.jules/runs/run-1/envelope.json
+++ b/.jules/runs/run-1/envelope.json
@@ -1,0 +1,9 @@
+{
+  "prompt_id": "surveyor_workspace",
+  "persona": "Surveyor",
+  "style": "Explorer",
+  "primary_shard": "workspace-wide",
+  "allowed_paths": ["**"],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/run-1/pr_body.md
+++ b/.jules/runs/run-1/pr_body.md
@@ -1,0 +1,54 @@
+## 💡 Summary
+Consolidated explicit path and version declarations for internal crates to rely on workspace dependency resolution. This aligns crates like `tokmd-types`, and `tokmd-wasm` with the rest of the workspace.
+
+## 🎯 Why
+Several `dev-dependencies` and `dependencies` blocks across internal crates were manually specifying `path` and `version` blocks instead of utilizing `{ workspace = true }`. This causes internal drift and increases maintenance overhead when making version bumps or structural refactors across the project.
+
+## 🔎 Evidence
+- `crates/tokmd-types/Cargo.toml` manually specified `path = "../tokmd-scan", version = ">=1.9, <2"`.
+- Workspace resolution (`cargo tree`) succeeds and confirms proper linking after the change.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Use `{ workspace = true }` for all internal crates already defined in the root `Cargo.toml` under `[workspace.dependencies]` where possible.
+- Fits this repo and shard as it directly improves workspace structure and dependency hygiene.
+- Trade-offs: Requires a targeted refactor of `Cargo.toml` files, but increases Structural cohesion and Velocity for future version bumps.
+
+### Option B
+- Keep the hardcoded paths.
+- Trade-offs: Preserves current state, but allows dependency graphs to fragment and requires redundant version updates across the codebase.
+
+## ✅ Decision
+Proceed with Option A. The workspace structure is cleaner and less prone to publish errors when centralized in the root `Cargo.toml`. `tokmd-cockpit` was left as-is because Cargo workspace dependencies cannot override default-features yet, so the explicit path is maintained.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-analysis-types/Cargo.toml`: Migrated `tokmd-scan` to workspace.
+- `crates/tokmd-envelope/Cargo.toml`: Migrated `tokmd-core` to workspace.
+- `crates/tokmd-scan/Cargo.toml`: Migrated `tokmd-model` to workspace.
+- `crates/tokmd-types/Cargo.toml`: Migrated `tokmd-scan`, `tokmd-format`, and `tokmd-model` to workspace.
+- `crates/tokmd-wasm/Cargo.toml`: Migrated `tokmd-types` to workspace.
+
+## 🧪 Verification receipts
+```text
+cargo build --verbose
+CI=true cargo test --verbose -p tokmd-cockpit -p tokmd-analysis-types -p tokmd-envelope -p tokmd-scan -p tokmd-types -p tokmd-wasm
+cargo fmt -- --check
+cargo clippy -- -D warnings
+```
+
+## 🧭 Telemetry
+- Change shape: Structural refactor.
+- Blast radius: Internal API / build resolution. No runtime impact.
+- Risk class: Low. Cargo verifies workspace validity at build time.
+- Rollback: Revert `Cargo.toml` changes.
+- Gates run: `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-1/envelope.json`
+- `.jules/runs/run-1/decision.md`
+- `.jules/runs/run-1/receipts.jsonl`
+- `.jules/runs/run-1/result.json`
+- `.jules/runs/run-1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-1/receipts.jsonl
+++ b/.jules/runs/run-1/receipts.jsonl
@@ -1,0 +1,12 @@
+{"command": "grep -r 'path = \"\\.\\./tokmd' crates/*/Cargo.toml", "outcome": "Found several crates hardcoding paths and versions instead of using workspace."}
+{"command": "sed -i 's/tokmd-scan = { path = \"\\.\\.\\/tokmd-scan\", version = \">=1.9, <2\" }/tokmd-scan = { workspace = true }/g' crates/tokmd-analysis-types/Cargo.toml", "outcome": "Success"}
+{"command": "sed -i 's/tokmd-core = { path = \"\\.\\.\\/tokmd-core\", version = \">=1.9, <2\" }/tokmd-core = { workspace = true }/g' crates/tokmd-envelope/Cargo.toml", "outcome": "Success"}
+{"command": "sed -i 's/tokmd-model = { path = \"\\.\\.\\/tokmd-model\", version = \">=1.9, <2\" }/tokmd-model = { workspace = true }/g' crates/tokmd-scan/Cargo.toml", "outcome": "Success"}
+{"command": "sed -i 's/tokmd-scan = { path = \"\\.\\.\\/tokmd-scan\", version = \">=1.9, <2\" }/tokmd-scan = { workspace = true }/g' crates/tokmd-types/Cargo.toml", "outcome": "Success"}
+{"command": "sed -i 's/tokmd-format = { path = \"\\.\\.\\/tokmd-format\", version = \">=1.9, <2\" }/tokmd-format = { workspace = true }/g' crates/tokmd-types/Cargo.toml", "outcome": "Success"}
+{"command": "sed -i 's/tokmd-model = { path = \"\\.\\.\\/tokmd-model\", version = \">=1.9, <2\" }/tokmd-model = { workspace = true }/g' crates/tokmd-types/Cargo.toml", "outcome": "Success"}
+{"command": "sed -i 's/tokmd-types = { path = \"\\.\\.\\/tokmd-types\", version = \">=1.9, <2\" }/tokmd-types = { workspace = true }/g' crates/tokmd-wasm/Cargo.toml", "outcome": "Success"}
+{"command": "cargo build --verbose", "outcome": "Success"}
+{"command": "CI=true cargo test --verbose -p tokmd-cockpit -p tokmd-analysis-types -p tokmd-envelope -p tokmd-scan -p tokmd-types -p tokmd-wasm", "outcome": "Success"}
+{"command": "cargo fmt -- --check", "outcome": "Success"}
+{"command": "cargo clippy -- -D warnings", "outcome": "Success"}

--- a/.jules/runs/run-1/result.json
+++ b/.jules/runs/run-1/result.json
@@ -1,0 +1,5 @@
+{
+  "outcome": "PR-ready patch",
+  "learning_pr": false,
+  "summary": "Consolidated workspace dependency definitions."
+}

--- a/crates/tokmd-analysis-types/Cargo.toml
+++ b/crates/tokmd-analysis-types/Cargo.toml
@@ -23,4 +23,4 @@ js-sys = "0.3.91"
 [dev-dependencies]
 chrono = "0.4.44"
 proptest.workspace = true
-tokmd-scan = { path = "../tokmd-scan", version = ">=1.9, <2" }
+tokmd-scan = { workspace = true }

--- a/crates/tokmd-envelope/Cargo.toml
+++ b/crates/tokmd-envelope/Cargo.toml
@@ -18,4 +18,4 @@ serde_json.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-tokmd-core = { path = "../tokmd-core", version = ">=1.9, <2" }
+tokmd-core = { workspace = true }

--- a/crates/tokmd-scan/Cargo.toml
+++ b/crates/tokmd-scan/Cargo.toml
@@ -22,4 +22,4 @@ tokmd-types.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-tokmd-model = { path = "../tokmd-model", version = ">=1.9, <2" }
+tokmd-model = { workspace = true }

--- a/crates/tokmd-types/Cargo.toml
+++ b/crates/tokmd-types/Cargo.toml
@@ -18,6 +18,6 @@ serde.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
 insta = { workspace = true }
-tokmd-scan = { path = "../tokmd-scan", version = ">=1.9, <2" }
-tokmd-format = { path = "../tokmd-format", version = ">=1.9, <2" }
-tokmd-model = { path = "../tokmd-model", version = ">=1.9, <2" }
+tokmd-scan = { workspace = true }
+tokmd-format = { workspace = true }
+tokmd-model = { workspace = true }

--- a/crates/tokmd-wasm/Cargo.toml
+++ b/crates/tokmd-wasm/Cargo.toml
@@ -26,7 +26,7 @@ tokmd-envelope.workspace = true
 wasm-bindgen = "0.2.114"
 
 [dev-dependencies]
-tokmd-types = { path = "../tokmd-types", version = ">=1.9, <2" }
+tokmd-types = { workspace = true }
 wasm-bindgen-test = "0.3.72"
 
 [package.metadata.wasm-pack.profile.release]


### PR DESCRIPTION
## 💡 Summary 
Consolidated explicit path and version declarations for internal crates to rely on workspace dependency resolution. This aligns crates like `tokmd-types`, and `tokmd-wasm` with the rest of the workspace.

## 🎯 Why 
Several `dev-dependencies` and `dependencies` blocks across internal crates were manually specifying `path` and `version` blocks instead of utilizing `{ workspace = true }`. This causes internal drift and increases maintenance overhead when making version bumps or structural refactors across the project.

## 🔎 Evidence 
- `crates/tokmd-types/Cargo.toml` manually specified `path = "../tokmd-scan", version = ">=1.9, <2"`.
- Workspace resolution (`cargo tree`) succeeds and confirms proper linking after the change.

## 🧭 Options considered 
### Option A (recommended) 
- Use `{ workspace = true }` for all internal crates already defined in the root `Cargo.toml` under `[workspace.dependencies]` where possible.
- Fits this repo and shard as it directly improves workspace structure and dependency hygiene.
- Trade-offs: Requires a targeted refactor of `Cargo.toml` files, but increases Structural cohesion and Velocity for future version bumps.

### Option B 
- Keep the hardcoded paths.
- Trade-offs: Preserves current state, but allows dependency graphs to fragment and requires redundant version updates across the codebase.

## ✅ Decision 
Proceed with Option A. The workspace structure is cleaner and less prone to publish errors when centralized in the root `Cargo.toml`. `tokmd-cockpit` was left as-is because Cargo workspace dependencies cannot override default-features yet, so the explicit path is maintained.

## 🧱 Changes made (SRP) 
- `crates/tokmd-analysis-types/Cargo.toml`: Migrated `tokmd-scan` to workspace.
- `crates/tokmd-envelope/Cargo.toml`: Migrated `tokmd-core` to workspace.
- `crates/tokmd-scan/Cargo.toml`: Migrated `tokmd-model` to workspace.
- `crates/tokmd-types/Cargo.toml`: Migrated `tokmd-scan`, `tokmd-format`, and `tokmd-model` to workspace.
- `crates/tokmd-wasm/Cargo.toml`: Migrated `tokmd-types` to workspace.

## 🧪 Verification receipts 
```text
cargo build --verbose
CI=true cargo test --verbose -p tokmd-cockpit -p tokmd-analysis-types -p tokmd-envelope -p tokmd-scan -p tokmd-types -p tokmd-wasm
cargo fmt -- --check
cargo clippy -- -D warnings
```

## 🧭 Telemetry 
- Change shape: Structural refactor.
- Blast radius: Internal API / build resolution. No runtime impact.
- Risk class: Low. Cargo verifies workspace validity at build time.
- Rollback: Revert `Cargo.toml` changes.
- Gates run: `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`.

## 🗂️ .jules artifacts 
- `.jules/runs/run-1/envelope.json`
- `.jules/runs/run-1/decision.md`
- `.jules/runs/run-1/receipts.jsonl`
- `.jules/runs/run-1/result.json`
- `.jules/runs/run-1/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [13406895226036194576](https://jules.google.com/task/13406895226036194576) started by @EffortlessSteven*