### PR TITLE
release: prepare tokmd v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,139 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-06-11
+
+1.13 is the syntax-aware evidence packet release. It turns the Bun UB evidence
+path from 1.12 into a manifest-first packet that can include scoped analysis,
+context, optional syntax receipts, review-priority rows, artifact references,
+reproduction commands, warnings, errors, and non-claims in one bot-readable
+contract.
+
+The release range after `v1.12.0` includes the history-preserving swarm import
+for the syntax/evidence lane, the feature-gated syntax receipt command, packet
+manifest wiring, cockpit/handoff artifact references, complexity metric trust
+repairs, real dogfood runs, and a command-backed readiness report. The release
+does not make syntax evidence a verifier and does not claim UB detection,
+public reachability, type resolution, or merge readiness.
+
+For the user-facing release note, see `docs/releases/1.13.md`. For the
+maintainer release record, see `docs/releases/1.13-ledger.md`. For dogfood and
+pre-release proof, see `docs/releases/1.13-dogfood.md` and
+`docs/releases/1.13-readiness.md`.
+
+### Added
+
+- `tokmd evidence-packet` now emits `sensors/tokmd/manifest.json`, a versioned
+  `tokmd.evidence-packet/v1` manifest over `analyze.md`, `analyze.json`,
+  `context.md`, and optional `syntax.json` artifacts.
+- Evidence packet manifests now record packet status, artifact paths,
+  warnings, errors, non-claims, reproduction commands, and advisory
+  `review_priority` rows.
+- Feature-gated `tokmd syntax` command for parser-backed
+  `tokmd.syntax_receipts.v1` receipts when the binary is built with the `ast`
+  feature.
+- Syntax parser registry and capability model for Rust, TypeScript, TSX, and
+  Python, with unsupported or skipped syntax evidence represented explicitly
+  instead of silently disappearing.
+- Rust syntax extraction for function and call facts, panic-like seams,
+  indexing/capacity risk seams, native/FFI hints, and advisory review signals.
+- TypeScript and TSX syntax extraction for imports, exports, dynamic imports,
+  call sites, native-boundary hints, and review signals.
+- Python syntax extraction for imports, from-imports, call sites, dynamic
+  execution, subprocess/file I/O seams, native/FFI hints, exception seams, and
+  review signals.
+- Cross-language syntax fact and review-signal normalization so packet
+  consumers can read common categories across Rust, TypeScript, TSX, and
+  Python without scraping language-specific prose.
+- Optional `--syntax-json` support in `tokmd evidence-packet`, including refs
+  from manifest `review_priority` entries back into `syntax.json` JSON
+  pointers.
+- Syntax-derived advisory review priority that ranks parser-backed risk seams
+  and exposes category, severity, score, reason, evidence, path, and refs.
+- Cockpit references to Bun UB packet artifacts, including manifest,
+  analysis, context, optional syntax evidence, and regeneration commands.
+- Handoff output references to evidence packet artifacts and review-priority
+  context so agents can start from the manifest rather than rediscovering the
+  packet layout.
+- JSON schemas and docs for the evidence packet manifest, including generated
+  schema copies under both CLI and docs schema locations.
+- Syntax receipt specification in `docs/specs/syntax-receipts.md`, covering
+  status, parser capability, facts, review signals, warnings, errors, and
+  non-claims.
+- Release documentation for 1.13: user release notes, maintainer ledger,
+  dogfood report, and command-backed readiness report.
+- Syntax fixtures for Rust panic seams, TypeScript native boundaries, TSX
+  components, and Python native/dynamic-boundary examples.
+
+### Changed
+
+- `docs/analyze/bun-ub.md`, `docs/integrations/ub-review.md`, and artifact
+  docs now describe the full packet family:
+  `manifest.json`, `analyze.md`, `analyze.json`, `context.md`, and optional
+  `syntax.json`.
+- `docs/reference-cli.md` and CLI snapshots now include the evidence-packet
+  command and the feature-gated syntax command/help surface.
+- Handoff examples and handoff schema docs now show linked packet evidence and
+  packet-backed reading order.
+- WASM capability metadata was refreshed to preserve native-only boundaries
+  while the new syntax command remains native/feature-gated.
+- Proof policy now routes syntax receipt specs and 1.13 release metadata
+  through named proof scopes instead of unknown-file handling.
+- The evidence packet docs now make `manifest.json` the first file a reviewer,
+  bot, or agent should open.
+- Release readiness docs now link directly to the 1.13 command-backed
+  readiness report.
+
+### Fixed
+
+- Cockpit `avg_cyclomatic` now divides total function cyclomatic complexity by
+  detected function count instead of reporting a per-file total as an average.
+- Analysis aggregate `avg_cyclomatic` now uses detected functions as the
+  denominator and excludes functionless rows from the function average.
+- Complexity schema and metric explanation text now describe
+  `avg_cyclomatic` as an average across detected functions, preventing
+  avg-vs-max unit contradictions in review packets.
+- Evidence packets now degrade optional malformed, failed, or explicitly
+  missing syntax artifacts to named warnings/status instead of silently
+  treating syntax evidence as valid.
+- Syntax artifact status is surfaced in packet manifests so partial parser
+  evidence remains visible to bots and reviewers.
+- The Rust ref recipe documentation test now runs in a git fixture, avoiding
+  environment-dependent failures outside a repository.
+
+### Tests
+
+- Added syntax CLI integration coverage for scoped parser receipts, feature
+  gating, parser status, and fixture-backed syntax output.
+- Added evidence packet integration tests for complete packets, missing
+  required artifacts, optional syntax artifacts, malformed syntax JSON, failed
+  syntax receipts, explicit missing syntax artifacts, review-priority ordering,
+  and schema validation.
+- Added language-specific syntax tests for Rust, TypeScript/TSX, and Python
+  fact extraction and review-signal normalization.
+- Added cockpit integration coverage for Bun UB packet artifact references.
+- Added handoff integration coverage for packet artifact links and linked
+  evidence output.
+- Added schema validation for evidence packet JSON schema copies.
+- Added complexity average-unit regressions for cockpit and analysis receipts.
+- Added dogfood packet runs over real tokmd Rust parser source plus
+  representative Rust, TypeScript, and Python syntax fixtures.
+- Added release-readiness evidence covering fmt, clippy, workspace tests,
+  docs/doc-artifacts, proof policy, lane whitelist, publish surface, affected
+  routing, packet smoke, and bad-ref negative smoke.
+
+### Boundaries
+
+- Syntax receipts are advisory parser evidence, not a verifier.
+- 1.13 does not prove public reachability, UB presence or absence, safety,
+  correctness, CI proof, or merge readiness.
+- `tokmd syntax` remains feature-gated behind `ast`; default installs do not
+  imply default AST-backed behavior.
+- Full public-reachable panic-seam receipts remain post-1.13 work.
+- 1.13 does not add a semantic call graph, type resolution, public
+  `tokmd review` command, evidencebus runtime, proof promotion, default
+  Codecov upload, or release mutation from `tokmd-swarm`.
+
 ## [1.12.0] - 2026-06-04
 
 1.12 is the Bun UB evidence-readiness and `tokmd-swarm` workbench release. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3570,7 +3570,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.12.0"
+version = "1.13.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -194,22 +194,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.12.0" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.12.0" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.12.0" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.12.0" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.12.0" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.12.0" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.12.0" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.12.0" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.12.0" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.12.0" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.12.0" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.12.0" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.12.0" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.12.0" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.12.0" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.12.0" }
+tokmd = { path = "crates/tokmd", version = "1.13.0" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.13.0" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.13.0" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.13.0" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.13.0" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.13.0" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.13.0" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.13.0" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.13.0" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.13.0" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.13.0" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.13.0" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.13.0" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.13.0" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.13.0" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.13.0" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.12.0"
+        "version": "1.13.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.12.0"
+        "version": "1.13.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.12.0"
+        "version": "1.13.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.12.0"
+        "version": "1.13.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.12.0"
+        "version": "1.13.0"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.12.0",
-    "@tokmd/core-darwin-x64": "1.12.0",
-    "@tokmd/core-linux-arm64-gnu": "1.12.0",
-    "@tokmd/core-linux-x64-gnu": "1.12.0",
-    "@tokmd/core-win32-x64-msvc": "1.12.0"
+    "@tokmd/core-darwin-arm64": "1.13.0",
+    "@tokmd/core-darwin-x64": "1.13.0",
+    "@tokmd/core-linux-arm64-gnu": "1.13.0",
+    "@tokmd/core-linux-x64-gnu": "1.13.0",
+    "@tokmd/core-win32-x64-msvc": "1.13.0"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.12.0",
-    "@tokmd/core-darwin-x64": "1.12.0",
-    "@tokmd/core-darwin-arm64": "1.12.0",
-    "@tokmd/core-linux-x64-gnu": "1.12.0",
-    "@tokmd/core-linux-x64-musl": "1.12.0",
-    "@tokmd/core-linux-arm64-gnu": "1.12.0",
-    "@tokmd/core-linux-arm64-musl": "1.12.0",
-    "@tokmd/core-win32-arm64-msvc": "1.12.0"
+    "@tokmd/core-win32-x64-msvc": "1.13.0",
+    "@tokmd/core-darwin-x64": "1.13.0",
+    "@tokmd/core-darwin-arm64": "1.13.0",
+    "@tokmd/core-linux-x64-gnu": "1.13.0",
+    "@tokmd/core-linux-x64-musl": "1.13.0",
+    "@tokmd/core-linux-arm64-gnu": "1.13.0",
+    "@tokmd/core-linux-arm64-musl": "1.13.0",
+    "@tokmd/core-win32-arm64-msvc": "1.13.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bump the workspace and Node package metadata to 1.13.0.
- Add a full CHANGELOG.md entry for the syntax-aware evidence packet release, covering the imported swarm range after 1.12.0.
- Keep Cargo.lock scoped to workspace package version changes only; no registry dependency churn is included.
- Refresh CycloneDX golden snapshots so generated tool metadata reports 1.13.0.

## Release Boundary

This is metadata-only release prep after the history-preserving swarm import. It does not add new syntax/evidence behavior, does not tag or publish, and does not broaden the v1.13 claims beyond advisory syntax-backed evidence packets.

## Local Validation

Passed on head eb429de8:

- rtk cargo +1.95.0 xtask version-consistency
- rtk cargo +1.95.0 xtask publish-surface --json --verify-publish
- rtk cargo +1.95.0 xtask docs --check
- rtk cargo +1.95.0 xtask doc-artifacts --check
- rtk cargo +1.95.0 xtask proof-policy --check
- rtk cargo +1.95.0 xtask ci-lane-whitelist --strict
- rtk cargo +1.95.0 xtask affected --base origin/main --head HEAD --json-output target/proof/affected-v1.13.0-release-prep-r3.json
- rtk cargo +1.95.0 xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-v1.13.0-release-prep-r3.json --evidence-json target/proof/proof-evidence-v1.13.0-release-prep-r3.json
- RUSTUP_TOOLCHAIN=1.95.0 rtk cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution
- rtk cargo +1.95.0 test -p tokmd-format --all-features --verbose
- package-scoped rtk cargo +1.95.0 fmt -p <workspace package> -- --check for all 20 workspace packages

Hosted validation on head eb429de8:

- PR checks: 25 passed, 0 failed.
- CI Required, Linux Build & Test, Quality Gate, Docs Check, Publish Surface, Version consistency, Nix PR Package Gate, Cargo Deny, Proof Policy, and Affected Proof Plan all passed.

Known local limitations:

- rtk cargo +1.95.0 fmt --all -- --check still fails on this Windows checkout with The filename or extension is too long. (os error 206); package-scoped fmt passed.
- rtk cargo +1.95.0 test --workspace --all-features -j 1 --no-fail-fast hit the 30-minute local timeout during this release-prep branch. The prior v1.13 readiness sweep already recorded a passing single-threaded workspace test from the imported release candidate, and this PR only changes release metadata/version files plus release-version snapshots.