### PR TITLE
merge(swarm): import v1.13.1 release corrections

### DIFF
--- a/crates/tokmd-analysis/src/analysis/enrichers/code_quality.rs
+++ b/crates/tokmd-analysis/src/analysis/enrichers/code_quality.rs
@@ -93,7 +93,19 @@ fn run_complexity(
                 input.limits,
                 input.detail_functions,
             ) {
-                Ok(report) => outputs.complexity = Some(report),
+                Ok(report) => {
+                    outputs.complexity = Some(report);
+                    for warning in crate::complexity::bounded_complexity_warnings(
+                        input.root,
+                        list,
+                        input.export,
+                        input.limits,
+                    ) {
+                        if warnings.iter().all(|existing| existing != &warning) {
+                            warnings.push(warning);
+                        }
+                    }
+                }
                 Err(err) => warnings.push(format!("complexity scan failed: {}", err)),
             }
         }

--- a/crates/tokmd-analysis/src/complexity/mod.rs
+++ b/crates/tokmd-analysis/src/complexity/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::maintainability::compute_maintainability_index;
@@ -179,4 +180,69 @@ pub(crate) fn build_complexity_report(
         technical_debt,
         files: file_complexities,
     })
+}
+
+pub(crate) fn bounded_complexity_warnings(
+    root: &Path,
+    files: &[PathBuf],
+    export: &ExportData,
+    limits: &AnalysisLimits,
+) -> Vec<String> {
+    let mut row_map: BTreeMap<String, &FileRow> = BTreeMap::new();
+    for row in export.rows.iter().filter(|r| r.kind == FileKind::Parent) {
+        row_map.insert(normalize_path(&row.path, root), row);
+    }
+
+    let scoped_files: BTreeSet<String> = files
+        .iter()
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .collect();
+    let per_file_limit = limits.max_file_bytes.unwrap_or(DEFAULT_MAX_FILE_BYTES);
+    let limit_label = if limits.max_file_bytes.is_some() {
+        format!("max_file_bytes={per_file_limit}")
+    } else {
+        format!("default max_file_bytes={per_file_limit}")
+    };
+
+    let mut eligible_files = 0usize;
+    let mut clipped_files = 0usize;
+    let mut bounded_bytes = 0u64;
+    let mut total_estimated_read_bytes = 0u64;
+
+    for (path, row) in row_map {
+        if !scoped_files.contains(&path) || !is_complexity_lang(&row.lang) {
+            continue;
+        }
+
+        eligible_files += 1;
+        let row_bytes = row.bytes as u64;
+        let read_bytes = row_bytes.min(per_file_limit);
+        total_estimated_read_bytes = total_estimated_read_bytes.saturating_add(read_bytes);
+
+        if row_bytes > per_file_limit {
+            clipped_files += 1;
+            bounded_bytes = bounded_bytes.saturating_add(row_bytes.saturating_sub(per_file_limit));
+        }
+    }
+
+    let mut warnings = Vec::new();
+    if clipped_files > 0 {
+        warnings.push(format!(
+            "complexity scan bounded: {clipped_files} of {eligible_files} eligible file(s) exceed {limit_label}; complexity metrics are partial"
+        ));
+    }
+    if let Some(max_bytes) = limits.max_bytes
+        && total_estimated_read_bytes > max_bytes
+    {
+        warnings.push(format!(
+            "complexity scan bounded: max_bytes={max_bytes} stops before all eligible complexity files are scanned; complexity metrics are partial"
+        ));
+    }
+    if bounded_bytes > 0 {
+        warnings.push(format!(
+            "complexity scan bounded: at least {bounded_bytes} byte(s) of eligible source were outside the scanned content window"
+        ));
+    }
+
+    warnings
 }

--- a/crates/tokmd-analysis/src/complexity/tests/unit.rs
+++ b/crates/tokmd-analysis/src/complexity/tests/unit.rs
@@ -356,6 +356,46 @@ fn test_compute_technical_debt_ratio_none_for_zero_code() {
 }
 
 #[test]
+fn bounded_complexity_warnings_report_default_file_cap() {
+    let export = ExportData {
+        rows: vec![FileRow {
+            path: "src/lib.rs".to_string(),
+            module: "src".to_string(),
+            lang: "Rust".to_string(),
+            kind: FileKind::Parent,
+            code: 40_000,
+            comments: 0,
+            blanks: 0,
+            lines: 40_000,
+            bytes: DEFAULT_MAX_FILE_BYTES as usize + 4096,
+            tokens: 10_000,
+        }],
+        module_roots: vec![],
+        module_depth: 1,
+        children: tokmd_types::ChildIncludeMode::Separate,
+    };
+    let warnings = bounded_complexity_warnings(
+        Path::new("."),
+        &[PathBuf::from("src/lib.rs")],
+        &export,
+        &AnalysisLimits::default(),
+    );
+
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("default max_file_bytes=131072")),
+        "{warnings:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("complexity metrics are partial")),
+        "{warnings:?}"
+    );
+}
+
+#[test]
 fn test_detect_fn_python_decorators_extended() {
     let code = r#"
 @app.route("/")

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [features]
-default = ["git", "walk", "content", "ui", "fun", "topics", "archetype", "analysis"]
+default = ["git", "walk", "content", "ui", "fun", "topics", "archetype", "analysis", "ast"]
 alias-tok = []
 analysis = ["tokmd-core/analysis"]
 git = [

--- a/crates/tokmd/src/cli/parser/analysis.rs
+++ b/crates/tokmd/src/cli/parser/analysis.rs
@@ -46,7 +46,7 @@ pub struct CliAnalyzeArgs {
     #[arg(long)]
     pub max_bytes: Option<u64>,
 
-    /// Limit bytes per file during content scans.
+    /// Limit bytes per file during content scans [default for file-backed scans: 131072].
     #[arg(long)]
     pub max_file_bytes: Option<u64>,
 

--- a/crates/tokmd/tests/analyze_integration.rs
+++ b/crates/tokmd/tests/analyze_integration.rs
@@ -64,6 +64,51 @@ fn analyze_help_lists_bun_ub_preset() {
 }
 
 #[test]
+fn analyze_marks_default_capped_complexity_as_partial() {
+    let dir = tempdir().expect("should create temp dir");
+    let src_dir = dir.path().join("src");
+    std::fs::create_dir_all(&src_dir).expect("create src dir");
+    std::fs::create_dir_all(dir.path().join(".git")).expect("create .git marker");
+
+    let mut source =
+        String::from("pub fn early_branch(x: i32) -> i32 { if x > 0 { x } else { 0 } }\n");
+    source
+        .push_str(&"// filler keeps the file over the default complexity byte cap\n".repeat(3000));
+    std::fs::write(src_dir.join("large.rs"), source).expect("write large Rust source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(dir.path())
+        .arg("--no-progress")
+        .arg("analyze")
+        .arg("src/large.rs")
+        .arg("--preset")
+        .arg("receipt")
+        .arg("--format")
+        .arg("json")
+        .arg("--no-git")
+        .output()
+        .expect("failed to execute tokmd analyze");
+
+    assert!(
+        output.status.success(),
+        "tokmd analyze failed: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert_eq!(json["status"], "partial");
+    let warnings = json["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings.iter().any(|warning| {
+            warning
+                .as_str()
+                .is_some_and(|text| text.contains("complexity scan bounded"))
+        }),
+        "{warnings:?}"
+    );
+}
+
+#[test]
 fn analyze_health_scoped_directory_does_not_scan_unrelated_todos() {
     let dir = tempdir().expect("should create temp dir");
     let src_dir = dir.path().join("src");

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -394,7 +394,7 @@ Options:
           Limit total bytes read during content scans
 
       --max-file-bytes <MAX_FILE_BYTES>
-          Limit bytes per file during content scans
+          Limit bytes per file during content scans [default for file-backed scans: 131072]
 
       --max-commits <MAX_COMMITS>
           Limit how many commits are scanned for git metrics


### PR DESCRIPTION
## Summary

Import tokmd-swarm through PR #235:

- default tokmd installs now include 	okmd syntax
- bounded/default-capped complexity scans now emit partial-evidence warnings
- CLI reference reflects the default file-backed scan cap

## Merge method

This PR must be merged with a merge commit, not squash, to preserve the swarm/publication graph.

## Proof

Swarm PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/235

- local focused tests, docs check, clippy, affected required proof, and installed CLI smoke passed
- hosted Tokmd Rust Small Result passed after rerunning a canceled CPX42 job
- CI required aggregate and release-facing checks were green on the swarm PR

## Claim boundary

This is a publication import only. Release metadata for 1.13.1 should land in a separate release-prep PR after this import merges.