### PR TITLE
release: prepare tokmd v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-06-11
+
+1.13.1 is a correction release for the syntax-aware evidence packet surface
+introduced in 1.13.0. The 1.13.0 crate and release assets were published, but a
+default `cargo install tokmd --version 1.13.0` binary did not include the
+feature-gated `tokmd syntax` command that the release notes and packet workflow
+documented. This patch release makes the documented packet flow installable from
+the default published artifact and tightens bounded complexity evidence status.
+
+### Fixed
+
+- Default `tokmd` installs now include the `ast` feature so `tokmd syntax` and
+  syntax-aware evidence packet workflows are available from the published crate
+  without custom feature flags.
+- File-backed complexity scans that are bounded by the default
+  `max_file_bytes` content window now emit explicit `complexity scan bounded`
+  warnings and mark the analysis receipt `partial` instead of looking complete
+  with silently clipped input.
+- The `tokmd analyze --max-file-bytes` help and generated CLI reference now
+  state the default file-backed scan cap.
+
+### Tests
+
+- Added an installed-binary smoke during release prep proving `tokmd syntax
+  --help` and `tokmd evidence-packet --help` are available from the default
+  install surface.
+- Added a capped-complexity integration regression proving a large scoped Rust
+  file reports `status=partial` with bounded-evidence warnings.
+- Re-ran affected proof for analysis complexity, analysis orchestration, CLI,
+  and workspace dependency graph scopes before publication import.
+
 ## [1.13.0] - 2026-06-11
 
 1.13 is the syntax-aware evidence packet release. It turns the Bun UB evidence

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "blake3",
  "proptest",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "proptest",
  "serde",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "proptest",
  "serde",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3570,7 +3570,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.13.0"
+version = "1.13.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -194,22 +194,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.13.0" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.13.0" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.13.0" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.13.0" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.13.0" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.13.0" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.13.0" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.13.0" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.13.0" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.13.0" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.13.0" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.13.0" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.13.0" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.13.0" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.13.0" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.13.0" }
+tokmd = { path = "crates/tokmd", version = "1.13.1" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.13.1" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.13.1" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.13.1" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.13.1" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.13.1" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.13.1" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.13.1" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.13.1" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.13.1" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.13.1" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.13.1" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.13.1" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.13.1" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.13.1" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.13.1" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.13.0"
+        "version": "1.13.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.13.0"
+        "version": "1.13.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.13.0"
+        "version": "1.13.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.13.0"
+        "version": "1.13.1"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.13.0"
+        "version": "1.13.1"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.13.0",
-    "@tokmd/core-darwin-x64": "1.13.0",
-    "@tokmd/core-linux-arm64-gnu": "1.13.0",
-    "@tokmd/core-linux-x64-gnu": "1.13.0",
-    "@tokmd/core-win32-x64-msvc": "1.13.0"
+    "@tokmd/core-darwin-arm64": "1.13.1",
+    "@tokmd/core-darwin-x64": "1.13.1",
+    "@tokmd/core-linux-arm64-gnu": "1.13.1",
+    "@tokmd/core-linux-x64-gnu": "1.13.1",
+    "@tokmd/core-win32-x64-msvc": "1.13.1"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.13.0",
-    "@tokmd/core-darwin-x64": "1.13.0",
-    "@tokmd/core-darwin-arm64": "1.13.0",
-    "@tokmd/core-linux-x64-gnu": "1.13.0",
-    "@tokmd/core-linux-x64-musl": "1.13.0",
-    "@tokmd/core-linux-arm64-gnu": "1.13.0",
-    "@tokmd/core-linux-arm64-musl": "1.13.0",
-    "@tokmd/core-win32-arm64-msvc": "1.13.0"
+    "@tokmd/core-win32-x64-msvc": "1.13.1",
+    "@tokmd/core-darwin-x64": "1.13.1",
+    "@tokmd/core-darwin-arm64": "1.13.1",
+    "@tokmd/core-linux-x64-gnu": "1.13.1",
+    "@tokmd/core-linux-x64-musl": "1.13.1",
+    "@tokmd/core-linux-arm64-gnu": "1.13.1",
+    "@tokmd/core-linux-arm64-musl": "1.13.1",
+    "@tokmd/core-win32-arm64-msvc": "1.13.1"
   }
 }

--- a/docs/evidence-packet.md
+++ b/docs/evidence-packet.md
@@ -88,7 +88,7 @@ readiness.
 ```json
 {
   "schema": "tokmd.evidence-packet/v1",
-  "tokmd_version": "1.13.0",
+  "tokmd_version": "1.13.1",
   "preset": "bun-ub",
   "base": "origin/main",
   "head": "HEAD",

--- a/docs/releases/1.13-ledger.md
+++ b/docs/releases/1.13-ledger.md
@@ -14,12 +14,41 @@ graph, default AST behavior, or release mutation from `tokmd-swarm`.
 
 - Previous stable release: `v1.12.0`
 - Candidate release version: `1.13.0`
+- Patch correction version: `1.13.1`
 - Primary release-note companion: [1.13 release notes](1.13.md)
 - Dogfood evidence: [1.13 syntax evidence dogfood](1.13-dogfood.md)
 - Release readiness report: [1.13 readiness](1.13-readiness.md)
+- Patch correction readiness report: [1.13.1 readiness](1.13.1-readiness.md)
 - Pre-release checks: [release readiness](../release-readiness.md)
-- Workbench import: pending release-prep import from `tokmd-swarm` into
-  `tokmd` by merge commit.
+- Workbench import: imported from `tokmd-swarm` into `tokmd` by merge commit
+  before tagging.
+
+## 1.13.1 Correction Record
+
+`v1.13.0` was published and installable, but the default crate install did not
+include the `ast` feature. That made the documented `tokmd syntax` command
+unavailable from `cargo install tokmd --version 1.13.0`, even though the syntax
+command was present in all-feature development and CI builds. The `v1.13.1`
+correction makes `ast` part of the default `tokmd` feature set so the installed
+binary matches the documented syntax-aware evidence packet workflow.
+
+The same correction also closes the remaining capped-scan trust gap for
+complexity evidence. File-backed complexity analysis has a default per-file
+content window; when eligible source exceeds that window, the analysis receipt
+now carries `complexity scan bounded` warnings and `partial` status. This keeps
+review packets from treating clipped complexity input as complete evidence.
+
+Correction proof included:
+
+- local default install smoke from the release-correction branch;
+- `tokmd syntax --help` and `tokmd evidence-packet --help` from the installed
+  binary;
+- a capped Rust complexity smoke producing `status=partial` and bounded
+  warnings;
+- focused CLI and analysis regressions;
+- affected proof over analysis complexity, analysis orchestration, CLI, and
+  workspace dependency graph scopes;
+- green `tokmd-swarm` PR #235 and publication import PR #2564.
 
 Representative PRs are examples, not an exhaustive list. The release work lands
 as narrow swarm PRs, then moves into the publication repository by merge commit

--- a/docs/releases/1.13.1-readiness.md
+++ b/docs/releases/1.13.1-readiness.md
@@ -1,0 +1,87 @@
+# tokmd 1.13.1 Release Readiness Report
+
+Date: 2026-06-11
+
+## Purpose
+
+`v1.13.1` is a correction release for the 1.13 syntax-aware evidence packet
+surface. `v1.13.0` was published, but a default crate install did not expose
+`tokmd syntax`. This report records the correction proof before tagging
+`v1.13.1`.
+
+## Correction Scope
+
+Included:
+
+- default `tokmd` installs include the `ast` feature, making `tokmd syntax`
+  available from the published crate without custom feature flags;
+- bounded/default-capped file-backed complexity scans emit explicit
+  `complexity scan bounded` warnings;
+- bounded complexity scans mark the analysis receipt `partial`;
+- CLI help and generated reference docs state the default file-backed scan cap.
+
+Not included:
+
+- no new syntax analyzer;
+- no schema change to evidence packet manifests;
+- no UB detection, reachability proof, safety proof, or merge-readiness claim;
+- no release mutation from `tokmd-swarm`.
+
+## Publication Flow
+
+- `tokmd-swarm` PR #235 landed the correction and passed hosted CI after
+  rerunning one canceled CPX42 routed job.
+- `EffortlessMetrics/tokmd` PR #2564 imported that swarm state by merge commit.
+- `tokmd-swarm/main` was fast-forwarded back to the publication merge commit.
+- This release-prep branch is metadata-only after the publication import.
+
+## Validation Evidence
+
+Local correction proof before the swarm PR:
+
+```text
+cargo +1.95.0 fmt -p tokmd -p tokmd-analysis -- --check
+cargo +1.95.0 test -p tokmd --test cli_syntax_integration --verbose
+cargo +1.95.0 test -p tokmd --test analyze_integration analyze_marks_default_capped_complexity_as_partial --verbose
+cargo +1.95.0 test -p tokmd-analysis --all-features bounded_complexity_warnings_report_default_file_cap --verbose
+cargo +1.95.0 xtask docs --check
+cargo +1.95.0 clippy -p tokmd -p tokmd-analysis --all-targets --all-features -- -D warnings
+cargo +1.95.0 xtask affected --base origin/main --head HEAD --json-output target/proof/affected-v1.13.1-corrections.json
+cargo +1.95.0 xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-v1.13.1-corrections.json --evidence-json target/proof/proof-evidence-v1.13.1-corrections.json
+RUSTUP_TOOLCHAIN=1.95.0 cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution
+```
+
+Installed correction smoke from the local branch:
+
+```text
+cargo +1.95.0 install --path crates/tokmd --locked --root target/install-smoke/tokmd-v1.13.1-local --force
+tokmd --version
+tokmd syntax --help
+tokmd evidence-packet --help
+tokmd analyze src/large.rs --preset receipt --format json --no-git
+```
+
+Observed installed-smoke behavior:
+
+```text
+tokmd syntax --help: available
+tokmd evidence-packet --help: available
+capped complexity smoke status: partial
+capped complexity smoke warning: complexity scan bounded
+```
+
+Hosted proof:
+
+- `tokmd-swarm` PR #235: CI required aggregate passed; Tokmd Rust Small Result
+  passed after rerunning a canceled CPX42 job; docs, publish surface, cargo
+  deny, quality gate, Linux build/test, and advisory proof jobs passed.
+- `tokmd` PR #2564: publication CI required aggregate passed; docs, publish
+  surface, version consistency, cargo deny, quality gate, Linux build/test, Nix
+  package gate, and advisory proof jobs passed.
+
+## Release Decision
+
+Ready for `v1.13.1` release-prep PR: yes.
+
+Ready to tag/publish: pending merge of the metadata-only release-prep PR and
+post-merge release validation from `EffortlessMetrics/tokmd`.

--- a/docs/releases/1.13.md
+++ b/docs/releases/1.13.md
@@ -9,11 +9,26 @@ Use this page as the user-facing release note. For the lane-by-lane maintainer
 record, see the [1.13 release ledger](1.13-ledger.md). For dogfood evidence,
 see the [1.13 syntax evidence dogfood note](1.13-dogfood.md). For the
 command-backed pre-release check, see the
-[1.13 readiness report](1.13-readiness.md).
+[1.13 readiness report](1.13-readiness.md). For the patch correction proof, see
+the [1.13.1 readiness report](1.13.1-readiness.md).
 
 This release does not make tokmd a verifier. Syntax receipts and review
 priority are advisory parser evidence. They do not prove reachability, undefined
 behavior, safety, correctness, CI proof, or merge readiness.
+
+## 1.13.1 Correction
+
+Use `v1.13.1` for the installed syntax-aware packet workflow. `v1.13.0` was
+published, but the default crate install did not include the `ast` feature, so
+`tokmd syntax` was not available from a plain `cargo install tokmd --version
+1.13.0`. `v1.13.1` corrects that install surface and keeps the 1.13 packet
+contract unchanged.
+
+The patch release also makes bounded file-backed complexity scans visibly
+partial: when an eligible source file exceeds the default complexity content
+window, `tokmd analyze` now emits `complexity scan bounded` warnings and reports
+the receipt as `partial` instead of silently presenting clipped complexity input
+as complete evidence.
 
 ## Review Bot Artifacts
 
@@ -161,7 +176,7 @@ confidence model, category diversity, and non-claims.
 
 ## Release Preflight
 
-Before tagging `v1.13.0`, run the release-readiness checks in
+Before tagging `v1.13.x`, run the release-readiness checks in
 `docs/release-readiness.md`, verify the changelog and this release note, import
 `tokmd-swarm` into the publication repository by merge commit, and confirm that
 the publication repository is the only release mutation surface.


### PR DESCRIPTION
## Summary

- bump workspace, lockfile, and Node package metadata to 1.13.1
- add a 1.13.1 changelog correction entry
- document the install-surface correction in the 1.13 release notes and ledger
- add docs/releases/1.13.1-readiness.md

## Why 1.13.1

1.13.0 was published, but the default crate install did not expose 	okmd syntax. The swarm correction imported by #2564 makes st part of the default 	okmd feature set and marks bounded complexity scans as partial evidence. This PR is metadata-only release prep for that correction.

## Proof

- cargo +1.95.0 xtask version-consistency
- cargo +1.95.0 xtask docs --check
- cargo +1.95.0 xtask doc-artifacts --check
- cargo +1.95.0 xtask proof-policy --check
- cargo +1.95.0 xtask ci-lane-whitelist --strict
- cargo +1.95.0 xtask publish-surface --json --verify-publish
- cargo +1.95.0 xtask affected --base origin/main --head HEAD --json-output target/proof/affected-v1.13.1-release-prep.json
- cargo +1.95.0 xtask proof --profile affected --base origin/main --head HEAD --plan --plan-json target/proof/proof-plan-v1.13.1-release-prep.json --evidence-json target/proof/proof-evidence-v1.13.1-release-prep.json
- RUSTUP_TOOLCHAIN=1.95.0 cargo xtask proof --profile affected --base origin/main --head HEAD --run-required --allow-local-required-execution
- cargo +1.95.0 install --path crates/tokmd --locked --root target/install-smoke/tokmd-v1.13.1-release-prep --force
- installed smoke: 	okmd --version => 	okmd 1.13.1
- installed smoke: 	okmd syntax --help available
- installed smoke: 	okmd evidence-packet --help available

## Known validation gap

- cargo +1.95.0 fmt --all -- --check was not usable in this Windows workspace: it failed with The filename or extension is too long. (os error 206). This PR has no Rust source edits; git diff --check passed.

## Claim boundary

This PR only prepares publication metadata for 1.13.1. It does not add product behavior beyond the already imported swarm correction.