### PR TITLE
archivist: update jules index rollup 🗃️

### DIFF
--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -10,13 +10,12 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `36cec87d-2836-42ed-9ae1-33dbf2702319` | Librarian | Explorer | docs | completed | 3 | live |
 | `37581ca1` | Sentinel | Stabilizer | core-pipeline | in-progress | 0 | live |
 | `archivist_jules` | Archivist | Builder | workspace-wide | in-progress | 1 | live |
-| `auditor_bindings_manifests` | Unknown | Unknown | Unknown | in-progress | 0 | live |
+| `archivist_jules_run_1` | Archivist | Builder | workspace-wide | success | 0 | live |
 | `bolt-run-001` | Bolt | Refactorer | core-pipeline | in-progress | 0 | live |
 | `bolt_analysis_stack_builder` | Bolt ⚡ | Builder | analysis-stack | in-progress | 1 | live |
 | `carto-roadmap-design-1` | Cartographer | Builder | tooling-governance | in-progress | 0 | live |
 | `cartographer_roadmap_design` | Cartographer | Builder | tooling-governance | in-progress | 0 | live |
 | `cartographer_roadmap_design_1` | cartographer | builder | tooling-governance | in-progress | 0 | live |
-| `compat_interfaces_matrix_01` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `d657338a-caa9-4ccf-93a1-4733ada7154c` | Gatekeeper | Unknown | quality | completed | 0 | live |
 | `fuzzer_input_hardening_1` | Fuzzer 🌪️ | Prover | interfaces | in-progress | 1 | live |
 | `gatekeeper_contracts` | Gatekeeper | Builder | tooling-governance | in-progress | 6 | live |

--- a/.jules/runs/archivist_jules_run_1/decision.md
+++ b/.jules/runs/archivist_jules_run_1/decision.md
@@ -1,0 +1,17 @@
+## Option A (recommended)
+- Run `cargo xtask jules-index` to regenerate the indexes based on the latest runs and friction items.
+- Check the output of `cargo xtask jules-index --check`.
+- This ensures generated Jules indexes are up-to-date and serves the mission of consolidating per-run packets.
+- Trade-offs:
+  - Structure: Better, keeps repo indices updated.
+  - Velocity: High, it's just one command.
+  - Governance: Ensures adherence to generated docs requirements.
+
+## Option B
+- Add more documentation to `xtask` around how indexing works.
+- Trade-offs:
+  - We already regenerated indexes with `--check`, Option A is a direct fulfillment of the primary target ranking.
+  - Changing tool code violates anti-drift rules unless necessary for indices.
+
+## Decision
+Option A. Running `cargo xtask jules-index` directly answers Target #2: "summarize per-run packets into generated indexes/rollups".

--- a/.jules/runs/archivist_jules_run_1/envelope.json
+++ b/.jules/runs/archivist_jules_run_1/envelope.json
@@ -1,0 +1,9 @@
+{
+  "prompt_id": "archivist_jules",
+  "persona": "Archivist",
+  "style": "Builder",
+  "primary_shard": "workspace-wide",
+  "allowed_paths": ["**"],
+  "gate_profile": "governance-release",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/archivist_jules_run_1/pr_body.md
+++ b/.jules/runs/archivist_jules_run_1/pr_body.md
@@ -1,0 +1,54 @@
+## 💡 Summary
+Regenerated Jules indices by running `cargo xtask jules-index`. This rolls up metadata from all run packets into `.jules/index/generated/RUNS_ROLLUP.md` to reflect current state accurately.
+
+## 🎯 Why
+The auto-generated index (`RUNS_ROLLUP.md`) was out of sync with the actual contents of `.jules/runs/`. Keeping this index updated is critical for the Archivist persona's goal to consolidate run learnings and scaffolding.
+
+## 🔎 Evidence
+- `.jules/index/generated/RUNS_ROLLUP.md` drift detected.
+- `cargo xtask jules-index` applied changes to `.jules/index/generated/RUNS_ROLLUP.md`.
+- `cargo xtask jules-index --check` passed after generation.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Run `cargo xtask jules-index` to regenerate the indexes based on the latest runs and friction items.
+- Check the output of `cargo xtask jules-index --check`.
+- This ensures generated Jules indexes are up-to-date and serves the mission of consolidating per-run packets.
+- Trade-offs: Structure / Velocity / Governance - Better structure by keeping repo indices updated, high velocity, and ensures adherence to generated docs requirements.
+
+### Option B
+- Add more documentation to `xtask` around how indexing works.
+- when to choose it instead: If the index generator itself was unclear or breaking.
+- trade-offs: Changing tool code without a clear bug violates anti-drift rules unless necessary for indices.
+
+## ✅ Decision
+Option A. Running `cargo xtask jules-index` directly answers Target #2: "summarize per-run packets into generated indexes/rollups".
+
+## 🧱 Changes made (SRP)
+- `.jules/index/generated/RUNS_ROLLUP.md` (Updated based on `cargo xtask jules-index`)
+
+## 🧪 Verification receipts
+```text
+cargo xtask jules-index
+Jules indexes written under /app/.jules/index/generated
+
+cargo xtask jules-index --check
+Jules indexes are up to date.
+```
+
+## 🧭 Telemetry
+- Change shape: Regenerated documentation/index.
+- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): docs
+- Risk class + why: Low, only documentation indexes updated.
+- Rollback: Revert the commit.
+- Gates run: `cargo xtask jules-index --check`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/archivist_jules_run_1/envelope.json`
+- `.jules/runs/archivist_jules_run_1/decision.md`
+- `.jules/runs/archivist_jules_run_1/receipts.jsonl`
+- `.jules/runs/archivist_jules_run_1/result.json`
+- `.jules/runs/archivist_jules_run_1/pr_body.md`
+
+## 🔜 Follow-ups
+None at this time.

--- a/.jules/runs/archivist_jules_run_1/receipts.jsonl
+++ b/.jules/runs/archivist_jules_run_1/receipts.jsonl
@@ -1,0 +1,4 @@
+{"command": "mkdir -p .jules/runs/archivist_jules_run_1", "status": "success"}
+{"command": "write envelope.json", "status": "success"}
+{"command": "cargo xtask jules-index", "status": "success"}
+{"command": "cargo xtask jules-index --check", "status": "success"}

--- a/.jules/runs/archivist_jules_run_1/result.json
+++ b/.jules/runs/archivist_jules_run_1/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "chosen_option": "A",
+  "notes": "Regenerated RUNS_ROLLUP.md and verified it is up to date."
+}


### PR DESCRIPTION
## 💡 Summary 
Regenerated Jules indices by running `cargo xtask jules-index`. This rolls up metadata from all run packets into `.jules/index/generated/RUNS_ROLLUP.md` to reflect current state accurately.
 
## 🎯 Why 
The auto-generated index (`RUNS_ROLLUP.md`) was out of sync with the actual contents of `.jules/runs/`. Keeping this index updated is critical for the Archivist persona's goal to consolidate run learnings and scaffolding.
 
## 🔎 Evidence 
- `.jules/index/generated/RUNS_ROLLUP.md` drift detected.
- `cargo xtask jules-index` applied changes to `.jules/index/generated/RUNS_ROLLUP.md`.
- `cargo xtask jules-index --check` passed after generation.
 
## 🧭 Options considered 
### Option A (recommended) 
- Run `cargo xtask jules-index` to regenerate the indexes based on the latest runs and friction items.
- Check the output of `cargo xtask jules-index --check`.
- This ensures generated Jules indexes are up-to-date and serves the mission of consolidating per-run packets.
- Trade-offs: Structure / Velocity / Governance - Better structure by keeping repo indices updated, high velocity, and ensures adherence to generated docs requirements.
 
### Option B 
- Add more documentation to `xtask` around how indexing works.
- when to choose it instead: If the index generator itself was unclear or breaking.
- trade-offs: Changing tool code without a clear bug violates anti-drift rules unless necessary for indices.
 
## ✅ Decision 
Option A. Running `cargo xtask jules-index` directly answers Target #2: "summarize per-run packets into generated indexes/rollups".
 
## 🧱 Changes made (SRP) 
- `.jules/index/generated/RUNS_ROLLUP.md` (Updated based on `cargo xtask jules-index`)
 
## 🧪 Verification receipts 
```text
cargo xtask jules-index
Jules indexes written under /app/.jules/index/generated

cargo xtask jules-index --check
Jules indexes are up to date.
```
 
## 🧭 Telemetry 
- Change shape: Regenerated documentation/index.
- Blast radius (API / IO / docs / schema / concurrency / compatibility / dependencies): docs
- Risk class + why: Low, only documentation indexes updated.
- Rollback: Revert the commit.
- Gates run: `cargo xtask jules-index --check`
 
## 🗂️ .jules artifacts 
- `.jules/runs/archivist_jules_run_1/envelope.json`
- `.jules/runs/archivist_jules_run_1/decision.md`
- `.jules/runs/archivist_jules_run_1/receipts.jsonl`
- `.jules/runs/archivist_jules_run_1/result.json`
- `.jules/runs/archivist_jules_run_1/pr_body.md`
 
## 🔜 Follow-ups 
None at this time.

---
*PR created automatically by Jules for task [11880155880249132717](https://jules.google.com/task/11880155880249132717) started by @EffortlessSteven*