### PR TITLE
merge(swarm): import Nix source closure fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,8 @@
           || (baseName == "README.md" && pkgs.lib.hasInfix "/crates/" p)
           # Keep test directories and their contents
           || (pkgs.lib.hasInfix "/tests/" p)
+          # Keep top-level integration fixtures used by compile-time include_str! tests
+          || (pkgs.lib.hasInfix "/fixtures/" p)
           # Keep contract fixtures validated by schema tests
           || (pkgs.lib.hasInfix "/contracts/" p)
           # Keep snapshot files

--- a/xtask/tests/release_source_closure_w101.rs
+++ b/xtask/tests/release_source_closure_w101.rs
@@ -1,0 +1,43 @@
+//! W101 - Release validation source-closure guards.
+//!
+//! These tests protect files that hosted Nix validation needs inside filtered
+//! check sources. They are intentionally text-level because `flake.nix` owns the
+//! actual filter and hosted Nix remains the authoritative sandbox proof.
+
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn flake_nix() -> String {
+    std::fs::read_to_string(workspace_root().join("flake.nix")).expect("flake.nix must exist")
+}
+
+#[test]
+fn nix_check_source_keeps_top_level_fixtures() {
+    let flake = flake_nix();
+
+    assert!(
+        flake.contains(r#"pkgs.lib.hasInfix "/fixtures/" p"#),
+        "mkCheckSrc must keep top-level fixtures used by compile-time include_str! tests"
+    );
+}
+
+#[test]
+fn syntax_native_boundary_fixture_exists_for_nix_checks() {
+    let fixture = workspace_root()
+        .join("fixtures")
+        .join("syntax")
+        .join("typescript")
+        .join("native_boundary.ts");
+
+    assert!(
+        fixture.is_file(),
+        "{} must exist for cli_syntax_integration include_str! and Nix checks",
+        fixture.display()
+    );
+}


### PR DESCRIPTION
## Summary
- Import tokmd-swarm PR #253 by preserving the shared commit graph.
- Keeps top-level fixtures/ in the Nix check source so hosted flake checks can compile include_str! syntax integration fixtures.

## Validation in tokmd-swarm
- PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/253
- Tokmd Rust Small Result: passed
- CI (Required): passed
- cargo +1.95.0 test -p xtask --test release_source_closure_w101 --verbose
- cargo +1.95.0 test -p tokmd --test cli_syntax_integration --features ast --verbose
- affected proof required commands: 2 planned, 2 executed, 2 passed

## Merge discipline
Merge this PR with a merge commit. Do not squash; this is a publication import from tokmd-swarm.