### PR TITLE
librarian: register missing syntax and evidence-packet commands in docs generator 📚

### DIFF
--- a/.jules/runs/librarian-run-001/decision.md
+++ b/.jules/runs/librarian-run-001/decision.md
@@ -1,0 +1,26 @@
+# Decision: Add missing syntax and evidence-packet commands to reference-cli.md generation
+
+## Context
+The `cargo xtask docs --check` command passes, meaning the existing registered markers in `docs/reference-cli.md` are up-to-date with their `tokmd <command> --help` outputs.
+
+However, the `tokmd` CLI has two commands: `syntax` and `evidence-packet` that are present in the output of `tokmd --help`, and they have markers in `docs/reference-cli.md`:
+`<!-- HELP: syntax -->`
+`<!-- HELP: evidence-packet -->`
+but these markers are NOT in the `markers` array in `xtask/src/tasks/docs.rs`. This means that if the CLI output for `syntax` or `evidence-packet` changes, `docs/reference-cli.md` will *silently drift* because `xtask docs` will not check or update these sections.
+
+This perfectly matches the target ranking for the Librarian persona:
+4) docs/schema/help text mismatch
+and the anti-drift rules (we are fixing factual drift / missing executable coverage of a tool).
+
+### Option A
+Add `("syntax", "syntax")` and `("evidence-packet", "evidence-packet")` to the `markers` array in `xtask/src/tasks/docs.rs`.
+- Fits the repo/shard by directly addressing the tooling governance mechanism that generates reference docs.
+- Trade-offs: Structure/Governance - ensures CLI and reference-cli.md stay in sync for these commands, preventing silent drift. Velocity - low effort, high impact.
+
+### Option B
+Wait for someone else to notice the drift when those commands change.
+- When to choose: If we were outside the `tooling-governance` shard.
+- Trade-offs: Fails the mission.
+
+## Decision
+Option A. It ensures that the `syntax` and `evidence-packet` commands are checked for drift by `cargo xtask docs --check` and automatically updated by `cargo xtask docs --update`, matching the rest of the CLI.

--- a/.jules/runs/librarian-run-001/envelope.json
+++ b/.jules/runs/librarian-run-001/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "librarian_docs_examples",
+  "persona": "Librarian",
+  "style": "Builder",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": ["patch", "learning_pr"]
+}

--- a/.jules/runs/librarian-run-001/pr_body.md
+++ b/.jules/runs/librarian-run-001/pr_body.md
@@ -1,0 +1,53 @@
+## 💡 Summary
+Fixed silent documentation drift in `docs/reference-cli.md` by explicitly registering the missing `syntax` and `evidence-packet` command help markers.
+
+## 🎯 Why
+The `tokmd` CLI currently includes `syntax` and `evidence-packet` commands, and their help markers exist in `docs/reference-cli.md`. However, they were not registered in the `markers` array in `xtask/src/tasks/docs.rs`. This omission caused `cargo xtask docs --check` to ignore them, leading to silent reference documentation drift when those CLI contracts changed.
+
+## 🔎 Evidence
+- `docs/reference-cli.md` contains `<!-- HELP: syntax -->` and `<!-- HELP: evidence-packet -->` markers.
+- `tokmd --help` exposes both `syntax` and `evidence-packet` commands.
+- `xtask/src/tasks/docs.rs` was missing these commands in the `markers` array.
+- Running `cargo xtask docs --check` before the fix falsely passed without validating these sections.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add `("syntax", "syntax")` and `("evidence-packet", "evidence-packet")` to the `markers` array in `xtask/src/tasks/docs.rs`.
+- Fits the repo and shard by directly addressing the tooling governance mechanism that generates reference docs.
+- Trade-offs: Structure/Governance - ensures CLI and reference-cli.md stay in sync for these commands, preventing silent drift. Velocity - low effort, high impact.
+
+### Option B
+- Wait for someone else to notice the drift when those commands change.
+- When to choose: If we were outside the `tooling-governance` shard.
+- Trade-offs: Fails the mission.
+
+## ✅ Decision
+Option A. It ensures that the `syntax` and `evidence-packet` commands are checked for drift by `cargo xtask docs --check` and automatically updated by `cargo xtask docs --update`, matching the rest of the CLI.
+
+## 🧱 Changes made (SRP)
+- `xtask/src/tasks/docs.rs`: Registered `syntax` and `evidence-packet` in the `markers` array.
+- `docs/reference-cli.md`: Updated via `cargo xtask docs --update`.
+
+## 🧪 Verification receipts
+```text
+cargo xtask docs --update
+cargo xtask docs --check
+cargo test --doc
+```
+
+## 🧭 Telemetry
+- Change shape: Pure tooling fix
+- Blast radius: `docs` and `xtask` tooling surfaces only. No runtime API impact.
+- Risk class + why: Low risk. Fixes a documentation generation omission.
+- Rollback: Revert the PR.
+- Gates run: `docs-executable`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/librarian-run-001/envelope.json`
+- `.jules/runs/librarian-run-001/decision.md`
+- `.jules/runs/librarian-run-001/receipts.jsonl`
+- `.jules/runs/librarian-run-001/result.json`
+- `.jules/runs/librarian-run-001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/librarian-run-001/receipts.jsonl
+++ b/.jules/runs/librarian-run-001/receipts.jsonl
@@ -1,0 +1,12 @@
+{"cmd": "ls -la"}
+{"cmd": "mkdir -p .jules/runs/librarian-run-001"}
+{"cmd": "cat << EOF > .jules/runs/librarian-run-001/decision.md"}
+{"cmd": "git diff xtask/src/tasks/docs.rs"}
+{"cmd": "cargo xtask docs --update"}
+{"cmd": "git diff docs/reference-cli.md"}
+{"cmd": "cat << EOF > .jules/runs/librarian-run-001/result.json"}
+{"cmd": "cat << EOF > .jules/runs/librarian-run-001/pr_body.md"}
+{"cmd": "cargo xtask docs --check"}
+{"cmd": "cargo fmt -- --check"}
+{"cmd": "cargo clippy -- -D warnings"}
+{"cmd": "cargo test --doc"}

--- a/.jules/runs/librarian-run-001/result.json
+++ b/.jules/runs/librarian-run-001/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "outcome": "patch",
+  "description": "Fixed silent documentation drift by adding missing syntax and evidence-packet commands to reference-cli.md marker list in xtask/src/tasks/docs.rs."
+}

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -1541,14 +1541,14 @@ Arguments:
 Options:
       --exclude <PATTERN>
           Exclude pattern(s) using gitignore syntax. Repeatable.
-          
+
           Examples: --exclude target --exclude "**/*.min.js"
-          
+
           [aliases: --ignore]
 
       --max-bytes <MAX_BYTES>
           Maximum bytes per file before syntax parsing is skipped
-          
+
           [default: 1048576]
 
       --include-generated-vendor
@@ -1559,7 +1559,7 @@ Options:
 
       --profile <PROFILE>
           Configuration profile to use (e.g., "llm_safe", "ci")
-          
+
           [aliases: --view]
 
   -h, --help

--- a/xtask/src/tasks/docs.rs
+++ b/xtask/src/tasks/docs.rs
@@ -34,6 +34,8 @@ pub fn run(args: DocsArgs) -> Result<()> {
         ("tools", "tools"),
         ("cockpit", "cockpit"),
         ("sensor", "sensor"),
+        ("syntax", "syntax"),
+        ("evidence-packet", "evidence-packet"),
         ("gate", "gate"),
         ("completions", "completions"),
     ];


### PR DESCRIPTION
## 💡 Summary
Fixed silent documentation drift in `docs/reference-cli.md` by explicitly registering the missing `syntax` and `evidence-packet` command help markers.

## 🎯 Why
The `tokmd` CLI currently includes `syntax` and `evidence-packet` commands, and their help markers exist in `docs/reference-cli.md`. However, they were not registered in the `markers` array in `xtask/src/tasks/docs.rs`. This omission caused `cargo xtask docs --check` to ignore them, leading to silent reference documentation drift when those CLI contracts changed.

## 🔎 Evidence
- `docs/reference-cli.md` contains `<!-- HELP: syntax -->` and `<!-- HELP: evidence-packet -->` markers.
- `tokmd --help` exposes both `syntax` and `evidence-packet` commands.
- `xtask/src/tasks/docs.rs` was missing these commands in the `markers` array.
- Running `cargo xtask docs --check` before the fix falsely passed without validating these sections.

## 🧭 Options considered
### Option A (recommended)
- Add `("syntax", "syntax")` and `("evidence-packet", "evidence-packet")` to the `markers` array in `xtask/src/tasks/docs.rs`.
- Fits the repo and shard by directly addressing the tooling governance mechanism that generates reference docs.
- Trade-offs: Structure/Governance - ensures CLI and reference-cli.md stay in sync for these commands, preventing silent drift. Velocity - low effort, high impact.

### Option B
- Wait for someone else to notice the drift when those commands change.
- When to choose: If we were outside the `tooling-governance` shard.
- Trade-offs: Fails the mission.

## ✅ Decision
Option A. It ensures that the `syntax` and `evidence-packet` commands are checked for drift by `cargo xtask docs --check` and automatically updated by `cargo xtask docs --update`, matching the rest of the CLI.

## 🧱 Changes made (SRP)
- `xtask/src/tasks/docs.rs`: Registered `syntax` and `evidence-packet` in the `markers` array.
- `docs/reference-cli.md`: Updated via `cargo xtask docs --update`.

## 🧪 Verification receipts
```text
cargo xtask docs --update
cargo xtask docs --check
cargo test --doc
```

## 🧭 Telemetry
- Change shape: Pure tooling fix
- Blast radius: `docs` and `xtask` tooling surfaces only. No runtime API impact.
- Risk class + why: Low risk. Fixes a documentation generation omission.
- Rollback: Revert the PR.
- Gates run: `docs-executable`

## 🗂️ .jules artifacts
- `.jules/runs/librarian-run-001/envelope.json`
- `.jules/runs/librarian-run-001/decision.md`
- `.jules/runs/librarian-run-001/receipts.jsonl`
- `.jules/runs/librarian-run-001/result.json`
- `.jules/runs/librarian-run-001/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [15410355272616806989](https://jules.google.com/task/15410355272616806989) started by @EffortlessSteven*