### PR TITLE
merge(swarm): import routed CI healthy-route proof

### DIFF
--- a/.github/workflows/em-routed-rust-small.yml
+++ b/.github/workflows/em-routed-rust-small.yml
@@ -97,13 +97,16 @@ jobs:
           import os
 
           data = json.loads(os.environ["RUNNERS_JSON"])
-          required = {"self-hosted", "linux", "x64", "em-ci", "trusted-pr"}
+          required = {"self-hosted", "linux", "x64", "em-ci", "trusted-pr", "rust-small"}
           eligible = []
           idle = []
           busy = 0
 
           for runner in data.get("runners", []):
-              labels = {label.get("name") for label in runner.get("labels", [])}
+              labels = {
+                  str(label.get("name", "")).lower()
+                  for label in runner.get("labels", [])
+              }
               if runner.get("status") != "online" or not required.issubset(labels):
                   continue
               eligible.append(runner)
@@ -302,10 +305,10 @@ jobs:
       needs.route-rust-small.outputs.target == 'self-hosted'
     runs-on:
       group: em-ci-small
-      labels: [self-hosted, linux, x64, em-ci, trusted-pr]
+      labels: [self-hosted, linux, x64, em-ci, trusted-pr, rust-small]
     timeout-minutes: 120
     env:
-      CARGO_HOME: /mnt/ci-cache/cargo-home
+      CARGO_HOME: /mnt/ci-scratch/cargo-home/${{ github.run_id }}-${{ github.run_attempt }}
       CARGO_INCREMENTAL: "0"
       CARGO_BUILD_JOBS: "6"
       TMPDIR: /mnt/ci-scratch/tmp/${{ github.run_id }}-${{ github.run_attempt }}
@@ -316,7 +319,6 @@ jobs:
         run: |
           set -euo pipefail
           ci-disk-guard /mnt/ci-scratch 45
-          ci-disk-guard /mnt/ci-cache 10
           mkdir -p "$TMPDIR" "$CARGO_TARGET_DIR" "$CARGO_HOME"
 
       - name: Checkout
@@ -335,7 +337,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          df -h /mnt/ci-scratch /mnt/ci-cache || true
+          df -h /mnt/ci-scratch || true
           rustc --version
           cargo --version
           if command -v python3 >/dev/null 2>&1; then python3 --version; elif command -v python >/dev/null 2>&1; then python --version; fi
@@ -353,7 +355,8 @@ jobs:
           set +e
           rm -rf "$TMPDIR"
           rm -rf "$CARGO_TARGET_DIR"
-          df -h /mnt/ci-scratch /mnt/ci-cache || true
+          rm -rf "$CARGO_HOME"
+          df -h /mnt/ci-scratch || true
 
   rust-small-github:
     name: Tokmd Rust Small on GitHub Hosted
@@ -418,7 +421,7 @@ jobs:
           case "${TARGET}" in
             self-hosted)
               selected_name="Tokmd Rust Small on Self Hosted"
-              cache_note="self-hosted cargo cache with scratch target cleanup"
+              cache_note="self-hosted run-scoped Cargo home with scratch target cleanup"
               ;;
             github-hosted)
               selected_name="Tokmd Rust Small on GitHub Hosted"

--- a/_typos.toml
+++ b/_typos.toml
@@ -46,6 +46,8 @@ jsonl = "jsonl"
 # Common abbreviations
 loc = "loc"
 sloc = "sloc"
+hel = "hel"
+hel2 = "hel2"
 
 # Mathematical abbreviations (numerator/denominator)
 numer = "numer"

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -134,6 +134,7 @@ paths = [
   "docs/agent-context/review-invariants.md",
   "docs/agent-context/droid-smoke-tests.md",
   "agents/shared/**",
+  "_typos.toml",
   "xtask/src/cli.rs",
   "xtask/src/main.rs",
   "xtask/src/proof/**",

--- a/docs/ci/routed-ci-policy.md
+++ b/docs/ci/routed-ci-policy.md
@@ -117,7 +117,7 @@ for Rust Small rather than occupying a self-hosted queue blindly.
 Target-state runner labels should describe a pool, for example:
 
 ```text
-self-hosted, linux, x64, em-ci-small
+self-hosted, linux, x64, em-ci, trusted-pr, rust-small
 ```
 
 Machine-specific labels can remain implementation details while the fleet is
@@ -251,7 +251,10 @@ Example:
 
 The route receipt must not contain secrets. It explains the target, reason,
 trust decision, runner counts, health state, fallback allowance, and selected
-runner label/name when a self-hosted runner is chosen. When a runner health
+runner label/name when a self-hosted runner is chosen. For label/group based
+self-hosted dispatch, the route receipt's selected runner name is a
+pre-dispatch idle-runner candidate, not a pin. The normalized result receipt
+owns the actual runner name reported by GitHub Actions after dispatch. When a runner health
 receipt is available, it also records health age plus disk and scratch guard
 inputs. It is diagnostic routing evidence; the branch-protection contract is
 still the normalized result check.

--- a/docs/ci/routed-rust-small-dogfood.md
+++ b/docs/ci/routed-rust-small-dogfood.md
@@ -1,6 +1,6 @@
 # Routed Rust Small dogfood
 
-Status: first live dogfood note for the routed Rust Small front door.
+Status: live dogfood note for the routed Rust Small front door.
 
 Date: 2026-06-12
 
@@ -125,15 +125,103 @@ seconds of queue time in these observations.
 
 ## Cases not yet observed live
 
-These cases remain `Unknown` from live hosted evidence in this dogfood note:
-
-| Case | Status | Next proof |
-| --- | --- | --- |
-| Same-repo PR with idle healthy self-hosted capacity | Unknown | Observe a real PR or manual run when an eligible runner is idle and healthy. |
+No routed Rust Small route class remains intentionally unobserved in this
+dogfood note. The fallback proof modes above cover hosted fallback behavior;
+the healthy self-hosted proof below covers the trusted idle-capacity path.
 
 The workflow-contract tests cover the proof-mode wiring, and the route helper
 tests cover the decision table. Those tests are not substitutes for live fleet
 observations.
+
+## Healthy self-hosted proof
+
+PR:
+
+```text
+https://github.com/EffortlessMetrics/tokmd-swarm/pull/254
+```
+
+Routed Rust Small workflow:
+
+```text
+https://github.com/EffortlessMetrics/tokmd-swarm/actions/runs/27432612954
+```
+
+The live PR route selected self-hosted execution before dispatching an
+implementation job:
+
+| Field | Observed value |
+| --- | --- |
+| Event | `pull_request` |
+| Target | `self-hosted` |
+| Reason | `trusted_capacity_available` |
+| Eligible runners | `7` |
+| Busy runners | `2` |
+| Healthy runners | `7` |
+| Selected runner label | `em-ci-small` |
+| Route-selected runner candidate | `em-ci-hel2-cpx42-rust-01` |
+| Actual execution runner | `em-ci-hel2-cx53-rust-01` |
+| Router job | passed |
+| Self-hosted implementation | passed |
+| GitHub-hosted implementation | skipped |
+| Normalized result | passed |
+
+Downloaded `target/ci/route-rust-small.json` from run `27432612954` showed:
+
+```json
+{
+  "target": "self-hosted",
+  "reason": "trusted_capacity_available",
+  "eligible_runners": 7,
+  "busy_runners": 2,
+  "healthy_runners": 7,
+  "selected_runner_label": "em-ci-small",
+  "selected_runner": "em-ci-hel2-cpx42-rust-01",
+  "warnings": [],
+  "errors": []
+}
+```
+
+Downloaded `target/ci/routed-rust-small-result.json` from the same run showed:
+
+```json
+{
+  "router": {
+    "target": "self-hosted",
+    "reason": "trusted_capacity_available"
+  },
+  "selected": {
+    "job": "rust-small-self-hosted",
+    "result": "success"
+  },
+  "jobs": {
+    "self_hosted": "success",
+    "github": "skipped"
+  },
+  "telemetry": {
+    "runner_name": "em-ci-hel2-cx53-rust-01",
+    "runner_group": "em-ci-small",
+    "runner_labels": ["self-hosted", "linux", "x64", "em-ci", "trusted-pr", "rust-small"],
+    "duration_seconds": 497.0,
+    "queue_seconds": 2.0,
+    "cache_note": "self-hosted run-scoped Cargo home with scratch target cleanup"
+  }
+}
+```
+
+The route receipt's `selected_runner` is a pre-dispatch idle-runner candidate
+from the runner API. GitHub still owns final self-hosted assignment for the
+label/group match. The actual execution runner is recorded in
+`routed-rust-small-result.json` telemetry for the selected implementation job.
+
+This proves the healthy-capacity invariant for the observed case:
+
+```text
+trusted same-repo PR + healthy idle Rust Small runner
+  -> self-hosted implementation runs
+  -> GitHub-hosted implementation skips
+  -> Tokmd Rust Small Result normalizes the selected implementation result
+```
 
 ## Confusing points
 
@@ -145,11 +233,14 @@ observations.
   after required checks are green.
 - GitHub emitted a Node.js 20 deprecation annotation for `oven-sh/setup-bun`.
   That warning is unrelated to routed Rust Small behavior.
+- Before PR #254, the runner API adapter compared labels case-sensitively
+  against `linux` and `x64`, while GitHub returned built-in labels as `Linux`
+  and `X64`. It also did not require the `rust-small` lane label. PR #254
+  normalized API labels and aligned the route predicate with the self-hosted
+  dispatch labels.
 
 ## Follow-ups
 
-- Capture one self-hosted-selected run when an eligible runner is idle and
-  health is fresh.
 - Keep branch protection pinned to `Tokmd Rust Small Result`; do not require
   the route or conditional implementation jobs directly.
 - Watch router-job duration. If it becomes noisy, consider a narrower route
@@ -161,7 +252,7 @@ observations.
 This dogfood note does not prove:
 
 - every future PR will select GitHub-hosted under capacity pressure;
-- self-hosted selection works under a fresh idle runner;
+- every future trusted PR will select self-hosted when a runner appears idle;
 - all manual simulation modes have been executed live;
 - route telemetry is a CI actuals source of truth;
 - routed Rust Small behavior generalizes to release, publish, signing, full

--- a/docs/ci/runner-health-runbook.md
+++ b/docs/ci/runner-health-runbook.md
@@ -43,7 +43,9 @@ cargo +1.95.0 xtask ci-runner-health \
   --label self-hosted \
   --label linux \
   --label x64 \
-  --label em-ci-small \
+  --label em-ci \
+  --label trusted-pr \
+  --label rust-small \
   --disk-free-bytes "$DISK_FREE_BYTES" \
   --scratch-free-bytes "$SCRATCH_FREE_BYTES" \
   --min-free-bytes 8589934592
@@ -77,7 +79,9 @@ cargo +1.95.0 xtask ci-runner-health \
   --label self-hosted \
   --label linux \
   --label x64 \
-  --label em-ci-small \
+  --label em-ci \
+  --label trusted-pr \
+  --label rust-small \
   --status quarantined \
   --reason manual_quarantine
 ```
@@ -98,25 +102,24 @@ The self-hosted implementation uses run-scoped scratch paths:
 ```text
 /mnt/ci-scratch/tmp/<run-id>-<attempt>
 /mnt/ci-scratch/target/<run-id>-<attempt>
+/mnt/ci-scratch/cargo-home/<run-id>-<attempt>
 ```
 
-The shared Cargo home is under:
+Clean run-scoped `tmp`, `target`, and `cargo-home` directories first. The
+routed Rust Small workflow does not depend on a shared Cargo home; a previous
+shared-cache attempt made selected self-hosted jobs vulnerable to cross-run
+cache ownership drift. If a future lane reintroduces a shared Cargo cache,
+preserve that cache unless the runner is already degraded for cache pressure or
+a maintainer explicitly assigns cache cleanup.
 
-```text
-/mnt/ci-cache/cargo-home
-```
-
-Clean run-scoped `tmp` and `target` directories first. Preserve shared Cargo
-cache unless the runner is already degraded for cache pressure or a maintainer
-explicitly assigns cache cleanup. If scratch or cache cleanup is needed to make
-the runner usable, mark the runner degraded or quarantined before cleanup work
-starts so new PR runs fall back to GitHub-hosted.
+If scratch cleanup is needed to make the runner usable, mark the runner
+degraded or quarantined before cleanup work starts so new PR runs fall back to
+GitHub-hosted.
 
 The workflow preflight guards currently check:
 
 ```text
 ci-disk-guard /mnt/ci-scratch 45
-ci-disk-guard /mnt/ci-cache 10
 ```
 
 Treat those failures as runner health failures, not code failures.

--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -421,6 +421,11 @@ rerun count for rerun-storm accounting. The receipt is run evidence for the
 normalized routed check; it does not replace the selected implementation job
 log.
 
+For self-hosted routes, the route receipt may name an idle-runner candidate
+from the pre-dispatch runner API. GitHub owns the final label/group assignment;
+use `telemetry.runner_name` in `routed-rust-small-result.json` for the actual
+runner that executed the selected implementation job.
+
 Open the receipt before reading runner logs:
 
 ```text

--- a/xtask/tests/proof_plan_w92.rs
+++ b/xtask/tests/proof_plan_w92.rs
@@ -759,6 +759,28 @@ fn routed_rust_small_workflow_exposes_fallback_proof_modes() {
 }
 
 #[test]
+fn routed_rust_small_runner_api_labels_are_case_normalized() {
+    let workflow =
+        fs::read_to_string(workspace_root().join(".github/workflows/em-routed-rust-small.yml"))
+            .expect("routed Rust Small workflow should be readable");
+
+    assert!(
+        workflow.contains("str(label.get(\"name\", \"\")).lower()"),
+        "GitHub runner API labels should be normalized before matching linux/x64 requirements"
+    );
+    assert!(
+        workflow.contains(
+            "required = {\"self-hosted\", \"linux\", \"x64\", \"em-ci\", \"trusted-pr\", \"rust-small\"}"
+        ),
+        "runner requirements should stay lowercase and match the Rust Small pool"
+    );
+    assert!(
+        workflow.contains("labels: [self-hosted, linux, x64, em-ci, trusted-pr, rust-small]"),
+        "self-hosted dispatch labels should match the Rust Small route predicate"
+    );
+}
+
+#[test]
 fn routed_rust_small_concurrency_is_pr_scoped() {
     let workflow =
         fs::read_to_string(workspace_root().join(".github/workflows/em-routed-rust-small.yml"))


### PR DESCRIPTION
Imports the tokmd-swarm routed Rust Small front-door closeout commit. This must merge with a merge commit, not squash, so the shared swarm/publication graph remains aligned.\n\nIncluded:\n- fixes Rust Small self-hosted label matching and dispatch labels\n- records the live healthy self-hosted route proof\n- keeps Cargo home run-scoped on self-hosted Rust Small\n- includes the proof allowlist and spelling updates needed by the route proof\n\nValidation from swarm PR #254:\n- Tokmd Rust Small Result passed on self-hosted run 27433317634\n- CI (Required), Affected Proof Plan, CI Lane Whitelist, Proof Policy, Docs Check, Doc Artifacts, Typos all passed\n- local ci-lane-whitelist --strict passed after merge