### PR TITLE
merge(swarm): import GHCR support status docs

### DIFF
--- a/docs/packet-workflows.md
+++ b/docs/packet-workflows.md
@@ -197,7 +197,16 @@ required in a later contract.
 
 ## GHCR Runtime
 
-Container runtime should be optional:
+GHCR is the intended secondary Linux/container runtime, not the primary user
+experience. The primary PR path should be a GitHub Action that downloads a
+prebuilt binary. Cargo install remains the local/dev fallback.
+
+Current support status: GHCR is pending public visibility verification. Do not
+document it as a supported install path or default runtime until anonymous
+manifest inspection, pull, `--version`, and mounted-repository packet smokes all
+pass for the published tag.
+
+Target Action shape after verification:
 
 ```yaml
 with:
@@ -223,6 +232,11 @@ consumer visibility. A release gate should verify:
 - anonymous pull works;
 - the container reports the expected `tokmd --version`;
 - the container can generate a packet against a mounted repository.
+
+If any public-pull check returns `denied`, keep GHCR marked pending and do not
+rewrite tags, rerun release mutation, or advertise container runtime support as
+available. Fix package visibility or linkage first, then rerun the verification
+checklist.
 
 ## Non-Claims
 

--- a/docs/publishing-evidence.md
+++ b/docs/publishing-evidence.md
@@ -133,19 +133,50 @@ configured build and push. It does not, by itself, prove that unauthenticated or
 intended downstream consumers can pull the published GHCR tags.
 
 After an intentional stable release that should publish Docker images, verify
-the expected semver tags separately:
+the expected semver tags separately from an unauthenticated Docker client. Use a
+temporary Docker config so the check does not accidentally reuse a local GHCR
+login:
 
 ```bash
-VERSION=1.11.1
+VERSION=1.13.1
+IMAGE=ghcr.io/effortlessmetrics/tokmd
+DOCKER_CONFIG="$(mktemp -d)"
 
-docker manifest inspect ghcr.io/effortlessmetrics/tokmd:${VERSION}
-docker manifest inspect ghcr.io/effortlessmetrics/tokmd:${VERSION%.*}
-docker manifest inspect ghcr.io/effortlessmetrics/tokmd:1
+docker --config "${DOCKER_CONFIG}" manifest inspect "${IMAGE}:${VERSION}"
+docker --config "${DOCKER_CONFIG}" manifest inspect "${IMAGE}:${VERSION%.*}"
+docker --config "${DOCKER_CONFIG}" manifest inspect "${IMAGE}:1"
+docker --config "${DOCKER_CONFIG}" pull "${IMAGE}:${VERSION}"
+docker --config "${DOCKER_CONFIG}" run --rm "${IMAGE}:${VERSION}" --version
+```
+
+Keep the temporary `DOCKER_CONFIG` for the packet smoke below if you are
+verifying container runtime support; otherwise remove it after the visibility
+checks.
+
+For releases where GHCR is advertised as a supported secondary runtime, also run
+a mounted-repository packet smoke before calling the container path verified:
+
+```bash
+mkdir -p sensors/tokmd
+
+docker --config "${DOCKER_CONFIG}" run --rm \
+  -v "$PWD:/repo:ro" \
+  -w /repo \
+  "${IMAGE}:${VERSION}" \
+  evidence-packet \
+  --preset bun-ub \
+  --base HEAD \
+  --head HEAD \
+  src \
+  > sensors/tokmd/manifest.json
+
+rm -rf "${DOCKER_CONFIG}"
 ```
 
 If direct registry inspection returns `denied`, do not rewrite the release tag
-or rerun release mutation by default. First check package visibility with a
-maintainer token that has GHCR package access:
+or rerun release mutation by default, and do not advertise GHCR as a supported
+runtime for that tag. First check package visibility with a maintainer token
+that has GHCR package access:
 
 ```bash
 gh api /orgs/EffortlessMetrics/packages/container/tokmd/versions


### PR DESCRIPTION
Repo graph sync only; not a release PR.\n\nImports tokmd-swarm PR #256, which marks GHCR as an intended secondary runtime but pending public visibility verification until anonymous manifest/pull/version and mounted packet smokes pass.\n\nThis must merge with a merge commit, not squash, so the shared swarm/publication graph remains aligned. No version metadata, changelog release section, tags, crates.io, GitHub release, GHCR publish, or v1 alias changes are included.\n\nSwarm validation from PR #256:\n- Tokmd Rust Small Result passed\n- CI (Required) passed\n- docs check passed\n- typos passed\n- PR Cockpit passed\n\nLive GHCR evidence from the docs lane:\n- anonymous manifest inspect for ghcr.io/effortlessmetrics/tokmd:1.13.1 returned denied\n- package API returned 403 without read:packages\n- local docker pull/run could not complete because the Docker daemon was unavailable