### PR TITLE
librarian: add doctests for core settings structures 📚

### DIFF
--- a/.jules/runs/run-librarian-docs-1/decision.md
+++ b/.jules/runs/run-librarian-docs-1/decision.md
@@ -1,0 +1,12 @@
+# Decision
+
+## Option A
+Add doctests to the `tokmd-settings` crate's key public structures (`TomlConfig`, `ScanConfig`, `UserConfig`).
+This fits the `Librarian` persona and `interfaces` shard by providing executable examples of how configuration is parsed and structured, ensuring the configuration schema remains stable and aligned with the actual implementation.
+
+## Option B
+Add comprehensive mock testing scripts in the `tests/` directory of `tokmd`.
+While useful, this focuses more on integration testing and less on immediately visible, executable documentation on the public APIs themselves, which is the Librarian's primary goal.
+
+## Decision
+Proceeding with **Option A**. Adding doctests directly to the configuration structs in `tokmd-settings` provides high-signal proof of parsing behavior that acts as both documentation and tests.

--- a/.jules/runs/run-librarian-docs-1/envelope.json
+++ b/.jules/runs/run-librarian-docs-1/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "librarian_api_doctests",
+  "persona": "Librarian \ud83d\udcda",
+  "style": "Prover",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-settings/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": [
+    "proof_patch",
+    "learning_pr"
+  ]
+}

--- a/.jules/runs/run-librarian-docs-1/pr_body.md
+++ b/.jules/runs/run-librarian-docs-1/pr_body.md
@@ -1,0 +1,57 @@
+## 💡 Summary
+Added executable doctests for core configuration structures in `tokmd-settings`. This proves configuration parsing behavior and keeps the interface documentation perfectly aligned with the schema.
+
+## 🎯 Why
+The `interfaces` shard requires high confidence in the public API contract, especially for configuration. Adding executable examples ensures that the `tokmd.toml` and legacy `config.json` parsing behavior remains factual and verifiable over time, preventing silent drift.
+
+## 🔎 Evidence
+- `crates/tokmd-settings/src/config.rs`
+- `crates/tokmd-settings/src/profile.rs`
+- Missing explicit executable coverage for top-level config struct parsing.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add explicit `/// # Example` doctests to the core structs (`TomlConfig`, `ScanConfig`, `UserConfig`, `Profile`) demonstrating how they deserialize from configuration string literals.
+- Why it fits: Aligns perfectly with the `Librarian` persona's goal of improving executable docs, reducing ambiguity around valid shapes.
+- Trade-offs: Structure: High (locks in expectations). Velocity: Neutral. Governance: Low.
+
+### Option B
+- Build broad integration tests for config parsing.
+- When to choose it: If edge cases or cross-cutting configuration behavior were the primary gap.
+- Trade-offs: Less visible as documentation on the types themselves.
+
+## ✅ Decision
+Option A was selected to directly improve the executable examples on the public types, acting simultaneously as proof and documentation.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-settings/src/config.rs`
+- `crates/tokmd-settings/src/profile.rs`
+
+## 🧪 Verification receipts
+```text
+running 5 tests
+test crates/tokmd-settings/src/config.rs - config::ModuleConfig (line 98) ... ok
+test crates/tokmd-settings/src/config.rs - config::ScanConfig (line 54) ... ok
+test crates/tokmd-settings/src/config.rs - config::TomlConfig (line 11) ... ok
+test crates/tokmd-settings/src/profile.rs - profile::Profile (line 41) ... ok
+test crates/tokmd-settings/src/profile.rs - profile::UserConfig (line 16) ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+## 🧭 Telemetry
+- Change shape: Documentation and Proof improvements
+- Blast radius: Only docs/tests; no production behavior changes.
+- Risk class: Safe; strictly additive test coverage.
+- Rollback: `git checkout crates/tokmd-settings/src/config.rs crates/tokmd-settings/src/profile.rs`
+- Gates run: `cargo test -p tokmd-settings --doc`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-librarian-docs-1/envelope.json`
+- `.jules/runs/run-librarian-docs-1/decision.md`
+- `.jules/runs/run-librarian-docs-1/receipts.jsonl`
+- `.jules/runs/run-librarian-docs-1/result.json`
+- `.jules/runs/run-librarian-docs-1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-librarian-docs-1/receipts.jsonl
+++ b/.jules/runs/run-librarian-docs-1/receipts.jsonl
@@ -1,0 +1,7 @@
+{"cmd": "mkdir -p .jules/runs/run-librarian-docs-1", "status": 0, "summary": "Create run dir"}
+{"cmd": "cargo tree --depth 1", "status": 0, "summary": "Inspect crates"}
+{"cmd": "cargo test -p tokmd-settings --doc", "status": 0, "summary": "Run doctests on tokmd-settings"}
+{"cmd": "cargo test -p tokmd-core --doc", "status": 0, "summary": "Run doctests on tokmd-core"}
+{"cmd": "cargo test -p tokmd --doc", "status": 0, "summary": "Run doctests on tokmd"}
+{"cmd": "echo decision.md written", "status": 0, "summary": "Wrote decision.md"}
+{"cmd": "git diff", "status": 0, "summary": "Verify added doctests"}

--- a/.jules/runs/run-librarian-docs-1/result.json
+++ b/.jules/runs/run-librarian-docs-1/result.json
@@ -1,0 +1,12 @@
+{
+  "outcome": "proof_patch",
+  "title": "librarian: add doctests for core settings structures \ud83d\udcda",
+  "summary": "Added executable doctests for `TomlConfig`, `ScanConfig`, `ModuleConfig`, `UserConfig`, and `Profile` to ensure configuration parsing is correct and verifiable.",
+  "target_paths": ["crates/tokmd-settings/src/config.rs", "crates/tokmd-settings/src/profile.rs"],
+  "proof_summary": "Doctests assert successful parsing and verify data layout.",
+  "gates_run": ["cargo test -p tokmd-settings --doc"],
+  "friction_items_created": [],
+  "persona_notes_created": [],
+  "rollback": "git checkout crates/tokmd-settings/src/config.rs crates/tokmd-settings/src/profile.rs",
+  "follow_ups": []
+}

--- a/crates/tokmd-settings/src/config.rs
+++ b/crates/tokmd-settings/src/config.rs
@@ -6,6 +6,19 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 /// Root TOML configuration structure.
+///
+/// # Example
+/// ```rust
+/// use tokmd_settings::TomlConfig;
+///
+/// let toml_str = r#"
+/// [scan]
+/// paths = ["src"]
+/// exclude = ["tests"]
+/// "#;
+/// let config: TomlConfig = toml::from_str(toml_str).unwrap();
+/// assert_eq!(config.scan.paths, Some(vec!["src".to_string()]));
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TomlConfig {
@@ -36,6 +49,18 @@ pub struct TomlConfig {
 }
 
 /// Scan settings shared by all commands.
+///
+/// # Example
+/// ```rust
+/// use tokmd_settings::ScanConfig;
+///
+/// let toml_str = r#"
+/// paths = ["crates"]
+/// exclude = ["target"]
+/// "#;
+/// let scan: ScanConfig = toml::from_str(toml_str).unwrap();
+/// assert_eq!(scan.paths, Some(vec!["crates".to_string()]));
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ScanConfig {
@@ -68,6 +93,20 @@ pub struct ScanConfig {
 }
 
 /// Module command settings.
+///
+/// # Example
+/// ```rust
+/// use tokmd_settings::ModuleConfig;
+///
+/// let toml_str = r#"
+/// roots = ["crates"]
+/// depth = 2
+/// children = "collapse"
+/// "#;
+/// let module: ModuleConfig = toml::from_str(toml_str).unwrap();
+/// assert_eq!(module.depth, Some(2));
+/// assert_eq!(module.children.as_deref(), Some("collapse"));
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ModuleConfig {

--- a/crates/tokmd-settings/src/profile.rs
+++ b/crates/tokmd-settings/src/profile.rs
@@ -11,6 +11,24 @@ use tokmd_types::RedactMode;
 // profile contract is available without CLI parsing dependencies.
 
 /// Legacy profile map used by historical `config.json` files.
+///
+/// # Example
+/// ```rust
+/// use tokmd_settings::UserConfig;
+///
+/// let json_str = r#"
+/// {
+///   "profiles": {
+///     "default": {
+///       "format": "json"
+///     }
+///   },
+///   "repos": {}
+/// }
+/// "#;
+/// let config: UserConfig = serde_json::from_str(json_str).unwrap();
+/// assert_eq!(config.profiles["default"].format.as_deref(), Some("json"));
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UserConfig {
     pub profiles: BTreeMap<String, Profile>,
@@ -18,6 +36,23 @@ pub struct UserConfig {
 }
 
 /// Legacy profile options shared by configuration consumers.
+///
+/// # Example
+/// ```rust
+/// use tokmd_settings::Profile;
+///
+/// let json_str = r#"
+/// {
+///   "format": "json",
+///   "top": 5,
+///   "files": true
+/// }
+/// "#;
+/// let profile: Profile = serde_json::from_str(json_str).unwrap();
+/// assert_eq!(profile.format.as_deref(), Some("json"));
+/// assert_eq!(profile.top, Some(5));
+/// assert_eq!(profile.files, Some(true));
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Profile {
     // Shared


### PR DESCRIPTION
## 💡 Summary
Added executable doctests for core configuration structures in `tokmd-settings`. This proves configuration parsing behavior and keeps the interface documentation perfectly aligned with the schema.

## 🎯 Why
The `interfaces` shard requires high confidence in the public API contract, especially for configuration. Adding executable examples ensures that the `tokmd.toml` and legacy `config.json` parsing behavior remains factual and verifiable over time, preventing silent drift.

## 🔎 Evidence
- `crates/tokmd-settings/src/config.rs`
- `crates/tokmd-settings/src/profile.rs`
- Missing explicit executable coverage for top-level config struct parsing.

## 🧭 Options considered
### Option A (recommended)
- Add explicit `/// # Example` doctests to the core structs (`TomlConfig`, `ScanConfig`, `UserConfig`, `Profile`) demonstrating how they deserialize from configuration string literals.
- Why it fits: Aligns perfectly with the `Librarian` persona's goal of improving executable docs, reducing ambiguity around valid shapes.
- Trade-offs: Structure: High (locks in expectations). Velocity: Neutral. Governance: Low.

### Option B
- Build broad integration tests for config parsing.
- When to choose it: If edge cases or cross-cutting configuration behavior were the primary gap.
- Trade-offs: Less visible as documentation on the types themselves.

## ✅ Decision
Option A was selected to directly improve the executable examples on the public types, acting simultaneously as proof and documentation.

## 🧱 Changes made (SRP)
- `crates/tokmd-settings/src/config.rs`
- `crates/tokmd-settings/src/profile.rs`

## 🧪 Verification receipts
```text
running 5 tests
test crates/tokmd-settings/src/config.rs - config::ModuleConfig (line 98) ... ok
test crates/tokmd-settings/src/config.rs - config::ScanConfig (line 54) ... ok
test crates/tokmd-settings/src/config.rs - config::TomlConfig (line 11) ... ok
test crates/tokmd-settings/src/profile.rs - profile::Profile (line 41) ... ok
test crates/tokmd-settings/src/profile.rs - profile::UserConfig (line 16) ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## 🧭 Telemetry
- Change shape: Documentation and Proof improvements
- Blast radius: Only docs/tests; no production behavior changes.
- Risk class: Safe; strictly additive test coverage.
- Rollback: `git checkout crates/tokmd-settings/src/config.rs crates/tokmd-settings/src/profile.rs`
- Gates run: `cargo test -p tokmd-settings --doc`

## 🗂️ .jules artifacts
- `.jules/runs/run-librarian-docs-1/envelope.json`
- `.jules/runs/run-librarian-docs-1/decision.md`
- `.jules/runs/run-librarian-docs-1/receipts.jsonl`
- `.jules/runs/run-librarian-docs-1/result.json`
- `.jules/runs/run-librarian-docs-1/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [9168769385660659734](https://jules.google.com/task/9168769385660659734) started by @EffortlessSteven*