### PR TITLE
specsmith: add bdd scenarios for gate and cockpit 🧪

### DIFF
--- a/.jules/runs/run-specsmith-interfaces/decision.md
+++ b/.jules/runs/run-specsmith-interfaces/decision.md
@@ -1,0 +1,21 @@
+# Specsmith Decision
+
+## Target Selection
+We need to improve scenario coverage, regression coverage, and edge-case polish in the `interfaces` shard (Config, core facade, and CLI interfaces). The target ranking is:
+1) missing BDD/integration coverage for an important path
+2) edge-case regression not locked in by tests
+3) confusing scenario setup that hides real behavior
+4) scenario-driven sharp-edge polish
+
+Checking the test suite, we have BDD coverage for almost all major commands (`lang`, `module`, `export`, `analyze`, `diff`, `global/config` behavior), except for two newer commands: `gate` and `cockpit`.
+
+*   **Option A**: Add BDD scenario tests for `gate` (`bdd_gate_scenarios_w50.rs`).
+    *   **Pros**: `gate` is a crucial CI policy enforcement tool. Providing a clear Given/When/Then scenario suite documents the exact behaviour of `tokmd gate` and ensures regressions are caught in user-facing workflows (e.g. ratchet failures, policy parsing).
+    *   **Cons**: Relies on existing test harnesses, might overlap slightly with `gate_integration.rs` (which tests the mechanics but less the user-facing BDD contract).
+*   **Option B**: Add BDD scenario tests for `cockpit` (`bdd_cockpit_scenarios_w50.rs`).
+    *   **Pros**: `cockpit` is a complex command aggregating Git data and analysis. BDD tests document exactly what PR diffs produce what outputs.
+    *   **Cons**: `cockpit_cli_w71.rs` already contains very deep structural checks on the output JSON/MD, acting much like integration tests. Re-writing them as BDD might be redundant or lower ROI compared to `gate` which has nuanced ratchet logic.
+*   **Option C**: Fix an edge-case configuration scenario where `toml` settings interact with CLI args for commands like `sensor` or `export`. The `config_resolution.rs` is very unit-test focused.
+
+I choose **Option A (Add BDD tests for `gate`)**.
+The `tokmd gate` command represents the CI-blocking surface of the tool. User stories describing "Given a ratchet config with a 10% tolerance, When a change exceeds 10%, Then the gate fails" is the ideal candidate for BDD-style documentation tests. We have `feature_gates_w71.rs` (testing CLI flags/features) and `gate_integration.rs` (testing the mechanics), but no `bdd_gate_scenarios_w50.rs`.

--- a/.jules/runs/run-specsmith-interfaces/envelope.json
+++ b/.jules/runs/run-specsmith-interfaces/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "specsmith_interfaces",
+  "persona": "Specsmith",
+  "style": "Explorer",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/run-specsmith-interfaces/plan.md
+++ b/.jules/runs/run-specsmith-interfaces/plan.md
@@ -1,0 +1,10 @@
+1. **Verify Implementation State**
+   - Check that `crates/tokmd/tests/bdd_gate_scenarios_w50.rs` and `crates/tokmd/tests/bdd_cockpit_scenarios_w50.rs` exist using `ls`.
+   - Check that the required `.jules` artifacts exist using `cat` on `.jules/runs/run-specsmith-interfaces/pr_body.md`.
+2. **Execute Validation Gate Expectations**
+   - Run the fallback validations for the `core-rust` gate profile scoped to the affected crates.
+   - I will run `cargo build --verbose -p tokmd`, `CI=true cargo test --verbose -p tokmd --test bdd_gate_scenarios_w50 --test bdd_cockpit_scenarios_w50`, `cargo fmt -- --check`, and `cargo clippy -- -D warnings`.
+3. **Pre-commit Step**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+4. **Final Submission**
+   - Commit and submit the code changes.

--- a/.jules/runs/run-specsmith-interfaces/pr_body.md
+++ b/.jules/runs/run-specsmith-interfaces/pr_body.md
@@ -1,0 +1,60 @@
+## 💡 Summary
+Added BDD-style documentation tests for `tokmd gate` and `tokmd cockpit` commands. This locks in the Given/When/Then behaviour for Ratchet CI failure boundaries and the Cockpit PR diff analysis output.
+
+## 🎯 Why
+While both the `gate` and `cockpit` commands had unit and integration coverage, they were missing the `bdd_*_scenarios_w50.rs` structural coverage that the other commands (`lang`, `export`, `diff`, `analyze`) possessed. This gap made the exact user-facing contract around CI ratchet failures and PR Markdown generation harder to reason about and vulnerable to regression drift.
+
+## 🔎 Evidence
+- `crates/tokmd/tests/bdd_gate_scenarios_w50.rs` (created)
+- `crates/tokmd/tests/bdd_cockpit_scenarios_w50.rs` (created)
+- `cargo test -p tokmd --test bdd_gate_scenarios_w50` passes
+- `cargo test -p tokmd --test bdd_cockpit_scenarios_w50` passes
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add BDD tests for the `gate` and `cockpit` CLI commands.
+- Why it fits: The primary shard is `interfaces`, and the persona is Specsmith. This is a targeted improvement to the integration test boundary (which is an allowed path).
+- Trade-offs: Increases CI runtime slightly but adds strong structural regression protection.
+
+### Option B
+- Refactor the existing CLI integration tests (`gate_integration.rs` and `cockpit_cli_w71.rs`) to be pure BDD files.
+- When to choose it instead: If the existing test files were already 90% BDD.
+- Trade-offs: Carries a high risk of losing non-scenario mechanical coverage hidden deep within the existing files. Additive BDD testing is safer.
+
+## ✅ Decision
+Chose Option A to create additive Given/When/Then proofs for the highest-value edge cases (Ratchet behaviour and PR Diff generation) to satisfy the Specsmith goal.
+
+## 🧱 Changes made (SRP)
+- Added `crates/tokmd/tests/bdd_gate_scenarios_w50.rs`
+- Added `crates/tokmd/tests/bdd_cockpit_scenarios_w50.rs`
+
+## 🧪 Verification receipts
+```text
+running 3 tests
+test given_missing_baseline_when_gate_evaluated_then_it_errors ... ok
+test given_degraded_metrics_when_gate_evaluated_then_gate_fails ... ok
+test given_improved_metrics_when_gate_evaluated_then_gate_passes ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+running 2 tests
+test given_git_branch_with_changes_when_cockpit_md_then_sections_generated ... ok
+test given_git_branch_with_changes_when_cockpit_json_then_valid_schema ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
+```
+
+## 🧭 Telemetry
+- Change shape: proof-improvement patch
+- Blast radius: Testing only. No IO/API changes.
+- Risk class: Low - additive integration tests.
+- Rollback: Revert the added test files.
+- Gates run: `core-rust` (cargo build, test, fmt, clippy).
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-specsmith-interfaces/envelope.json`
+- `.jules/runs/run-specsmith-interfaces/decision.md`
+- `.jules/runs/run-specsmith-interfaces/receipts.jsonl`
+- `.jules/runs/run-specsmith-interfaces/result.json`
+- `.jules/runs/run-specsmith-interfaces/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-specsmith-interfaces/receipts.jsonl
+++ b/.jules/runs/run-specsmith-interfaces/receipts.jsonl
@@ -1,0 +1,2 @@
+{"cmd": "cargo test -p tokmd --test bdd_gate_scenarios_w50", "status": "ok. 3 passed; 0 failed"}
+{"cmd": "cargo test -p tokmd --test bdd_cockpit_scenarios_w50", "status": "ok. 2 passed; 0 failed"}

--- a/.jules/runs/run-specsmith-interfaces/result.json
+++ b/.jules/runs/run-specsmith-interfaces/result.json
@@ -1,0 +1,5 @@
+{
+  "outcome": "proof-improvement patch",
+  "reason": "Found missing BDD/scenario test coverage for `gate` and `cockpit` interfaces. I created Given/When/Then scenarios to lock in edge-case behaviour without touching the implementation.",
+  "diff_summary": "Added crates/tokmd/tests/bdd_gate_scenarios_w50.rs and bdd_cockpit_scenarios_w50.rs"
+}

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1064,6 +1064,7 @@ paths = [
   "crates/tokmd/src/commands/gate.rs",
   "crates/tokmd/src/commands/gate/**",
   "crates/tokmd/tests/gate_integration.rs",
+  "crates/tokmd/tests/bdd_gate_scenarios_w50.rs",
 ]
 packages = ["tokmd-gate", "tokmd"]
 proof = [
@@ -1089,6 +1090,7 @@ paths = [
   "crates/tokmd/schemas/review-packet-evidence.schema.json",
   "crates/tokmd/schemas/review-packet-manifest.schema.json",
   "crates/tokmd/tests/cockpit_*.rs",
+  "crates/tokmd/tests/bdd_cockpit_scenarios_w50.rs",
   "docs/cockpit-proof-evidence.md",
   "docs/review-packet.md",
   "docs/review-map.schema.json",

--- a/crates/tokmd/tests/bdd_cockpit_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_cockpit_scenarios_w50.rs
@@ -1,0 +1,114 @@
+#![cfg(feature = "git")]
+
+//! BDD-style scenario tests for the `cockpit` command.
+//!
+//! Each test follows the Given/When/Then pattern to verify key user-facing
+//! workflows of the cockpit PR summarization command.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+fn tokmd_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tokmd"))
+}
+
+/// Scaffold a two-branch git repo: main (initial commit) -> feature (with changes).
+fn scaffold_git_repo(
+    base_files: &[(&str, &str)],
+    feature_files: &[(&str, &str)],
+) -> tempfile::TempDir {
+    let dir = tempdir().unwrap();
+
+    if !common::git_available() || !common::init_git_repo(dir.path()) {
+        panic!("git not available or init failed");
+    }
+
+    for (name, content) in base_files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, content).unwrap();
+    }
+    assert!(common::git_add_commit(dir.path(), "Initial commit"));
+
+    let _ = std::process::Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(dir.path())
+        .status();
+
+    for (name, content) in feature_files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, content).unwrap();
+    }
+    assert!(common::git_add_commit(dir.path(), "Feature commit"));
+
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Cockpit Markdown generation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_git_branch_with_changes_when_cockpit_md_then_sections_generated() {
+    if !common::git_available() {
+        return;
+    }
+
+    // Given: A git repository with a feature branch containing changes
+    let dir = scaffold_git_repo(
+        &[("src/main.rs", "fn main() {}\n")],
+        &[("src/main.rs", "fn main() { println!(\"hello\"); }\n")],
+    );
+
+    // When: I run the cockpit command with markdown format
+    tokmd_cmd()
+        .current_dir(dir.path())
+        .args(["cockpit", "--base", "main", "--format", "md"])
+        .assert()
+        // Then: The markdown output contains expected Review Plan and Change Surface headers
+        .success()
+        .stdout(predicate::str::contains("## Glass Cockpit"))
+        .stdout(predicate::str::contains("### Change Surface"))
+        .stdout(predicate::str::contains("### Review Plan"));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Cockpit JSON structure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_git_branch_with_changes_when_cockpit_json_then_valid_schema() {
+    if !common::git_available() {
+        return;
+    }
+
+    // Given: A git repository with a feature branch containing changes
+    let dir = scaffold_git_repo(
+        &[("src/lib.rs", "fn main() {}\n")],
+        &[("src/lib.rs", "fn main() { println!(\"hi\"); }\n")],
+    );
+
+    // When: I run the cockpit command with json format
+    let output = tokmd_cmd()
+        .current_dir(dir.path())
+        .args(["cockpit", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // Then: The JSON output matches the expected envelope schema
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["mode"], "cockpit");
+    assert!(json["schema_version"].is_number());
+    assert!(json["change_surface"].is_object());
+    assert!(json["review_plan"].is_array());
+}

--- a/crates/tokmd/tests/bdd_gate_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_gate_scenarios_w50.rs
@@ -1,0 +1,154 @@
+#![cfg(feature = "analysis")]
+
+//! BDD-style scenario tests for the `gate` command.
+//!
+//! Each test follows the Given/When/Then pattern to verify key user-facing
+//! workflows of the CI gate command, specifically around policies and ratchets.
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::{TempDir, tempdir};
+
+fn tokmd_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tokmd"))
+}
+
+// Helper: create a baseline receipt
+fn create_baseline(dir: &TempDir) -> std::path::PathBuf {
+    let receipt = serde_json::json!({
+        "schema_version": 4,
+        "complexity": {
+            "avg_cyclomatic": 5.0,
+            "max_cyclomatic": 20
+        }
+    });
+    let path = dir.path().join("baseline.json");
+    fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
+    path
+}
+
+// Helper: create a current receipt with higher complexity
+fn create_current_high(dir: &TempDir) -> std::path::PathBuf {
+    let receipt = serde_json::json!({
+        "schema_version": 4,
+        "complexity": {
+            "avg_cyclomatic": 7.0, // > 10% increase from 5.0
+            "max_cyclomatic": 25
+        }
+    });
+    let path = dir.path().join("current.json");
+    fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
+    path
+}
+
+// Helper: create a current receipt with lower complexity
+fn create_current_low(dir: &TempDir) -> std::path::PathBuf {
+    let receipt = serde_json::json!({
+        "schema_version": 4,
+        "complexity": {
+            "avg_cyclomatic": 4.5,
+            "max_cyclomatic": 18
+        }
+    });
+    let path = dir.path().join("current.json");
+    fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
+    path
+}
+
+// Helper: create a strict ratchet config
+fn create_ratchet(dir: &TempDir) -> std::path::PathBuf {
+    let config = r#"
+[[rules]]
+pointer = "/complexity/avg_cyclomatic"
+max_increase_pct = 10.0
+level = "error"
+"#;
+    let path = dir.path().join("ratchet.toml");
+    fs::write(&path, config).unwrap();
+    path
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Ratchet passing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_improved_metrics_when_gate_evaluated_then_gate_passes() {
+    // Given: A baseline receipt and a new receipt with improved (lower) complexity
+    let dir = tempdir().unwrap();
+    let baseline = create_baseline(&dir);
+    let current = create_current_low(&dir);
+    let ratchet = create_ratchet(&dir);
+
+    // When: I run the gate command with a 10% tolerance ratchet
+    tokmd_cmd()
+        .args([
+            "gate",
+            current.to_str().unwrap(),
+            "--baseline",
+            baseline.to_str().unwrap(),
+            "--ratchet-config",
+            ratchet.to_str().unwrap(),
+        ])
+        .assert()
+        // Then: The gate succeeds and outputs PASSED
+        .success()
+        .stdout(predicate::str::contains("PASSED"));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Ratchet failing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_degraded_metrics_when_gate_evaluated_then_gate_fails() {
+    // Given: A baseline receipt and a new receipt with degraded complexity exceeding the 10% threshold
+    let dir = tempdir().unwrap();
+    let baseline = create_baseline(&dir);
+    let current = create_current_high(&dir);
+    let ratchet = create_ratchet(&dir);
+
+    // When: I run the gate command
+    tokmd_cmd()
+        .args([
+            "gate",
+            current.to_str().unwrap(),
+            "--baseline",
+            baseline.to_str().unwrap(),
+            "--ratchet-config",
+            ratchet.to_str().unwrap(),
+        ])
+        .assert()
+        // Then: The gate fails with a non-zero exit code and outputs FAILED
+        .failure()
+        .stdout(predicate::str::contains("FAILED"))
+        .stdout(predicate::str::contains("exceeds maximum allowed increase"));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Missing baseline with fail_fast=false
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_missing_baseline_when_gate_evaluated_then_it_errors() {
+    // Given: A current receipt and a ratchet config, but NO baseline
+    let dir = tempdir().unwrap();
+    let current = create_current_low(&dir);
+    let ratchet = create_ratchet(&dir);
+
+    // When: I run the gate command without providing a baseline
+    tokmd_cmd()
+        .args([
+            "gate",
+            current.to_str().unwrap(),
+            "--ratchet-config",
+            ratchet.to_str().unwrap(),
+        ])
+        .assert()
+        // Then: It fails gracefully explaining that ratchet rules require a baseline
+        .failure()
+        .stderr(predicate::str::contains("No policy or ratchet rules"));
+}


### PR DESCRIPTION
Added BDD-style documentation tests (`bdd_gate_scenarios_w50.rs` and `bdd_cockpit_scenarios_w50.rs`) to formally document and verify the Given/When/Then user-facing contracts around CI ratchet failures and PR Markdown generation. This increases regression protection for the CLI interfaces.

---
*PR created automatically by Jules for task [1016234727876789539](https://jules.google.com/task/1016234727876789539) started by @EffortlessSteven*