### PR TITLE
compat: restore wasm32 compatibility by removing ast from default features 🧷

### DIFF
--- a/.jules/runs/compat_interfaces_matrix/decision.md
+++ b/.jules/runs/compat_interfaces_matrix/decision.md
@@ -1,0 +1,19 @@
+# Decision
+
+## 🧭 Options considered
+
+### Option A (recommended)
+- **What it is:** Remove `ast` from the `default` features of the `tokmd` crate.
+- **Why it fits this repo and shard:** The memory explicitly states "In the `tokmd` project, the `ast` feature (which pulls in `tree-sitter` and its parsers) requires a C standard library (`stdlib.h`) and breaks standard `wasm32-unknown-unknown` builds. It should not be included in `default` features for crates intended to be WASM compatible." By removing it from `default` in `crates/tokmd/Cargo.toml`, we fix `wasm32-unknown-unknown` compatibility for the main crate under `--all-features` without breaking `x86_64` standard builds. We'll still keep the feature available to explicitly opt-in if someone has the C stdlib on WASM or is compiling for a native target, but it shouldn't be default.
+- **Trade-offs:**
+  - *Structure:* Better alignment with standard WASM compilation expectations.
+  - *Velocity:* High velocity, as it's a simple feature adjustment.
+  - *Governance:* Reduces friction for downstream consumers using standard wasm targets.
+
+### Option B
+- **What it is:** Provide a proxy WASM shim for `stdlib.h` so that `ast` can compile.
+- **When to choose it instead:** If `ast` was deeply essential for all wasm runs and we couldn't just gate it behind a non-default feature.
+- **Trade-offs:** Significant complexity, requires maintaining C stubs which is beyond the scope of a simple config fix.
+
+## ✅ Decision
+Option A. The `ast` feature explicitly prevents out-of-the-box WASM builds due to `tree-sitter`'s reliance on `stdlib.h`. Removing it from the `default` features list in `tokmd` restores default WASM compatibility.

--- a/.jules/runs/compat_interfaces_matrix/envelope.json
+++ b/.jules/runs/compat_interfaces_matrix/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "compat_interfaces_matrix",
+  "persona": "Compat",
+  "style": "Builder",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "compat-matrix",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/compat_interfaces_matrix/pr_body.md
+++ b/.jules/runs/compat_interfaces_matrix/pr_body.md
@@ -1,0 +1,59 @@
+## 💡 Summary
+Removed `ast` from the `default` features of the `tokmd` crate to restore `wasm32-unknown-unknown` compatibility. The `ast` feature relies on `tree-sitter`, which strictly requires a C standard library (`stdlib.h`) and breaks compilation for targets without it.
+
+## 🎯 Why
+WASM compatibility is a hard requirement for parts of the `tokmd` CLI facade that run in restricted environments. Because `ast` was added to `default`, standard invocations like `cargo build` on WASM fail with `stdlib.h not found`. This drift breaks the `compat-matrix` gates. By moving `ast` to an opt-in feature, we keep the capability for environments that support C-stdlib but restore the baseline matrix.
+
+## 🔎 Evidence
+- `crates/tokmd/Cargo.toml`
+- **Observed behavior**:
+  ```text
+  warning: tree-sitter-rust@0.24.2: src/tree_sitter/parser.h:10:10: fatal error: 'stdlib.h' file not found
+  ```
+- **Receipts**: Removing `ast` from `default` makes `cargo check -p tokmd --target wasm32-unknown-unknown` succeed without `--no-default-features`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- **What it is**: Remove `ast` from `tokmd`'s `default` features.
+- **Why it fits this repo and shard**: Directly addresses the compatibility breakdown while retaining functionality via explicit `--features ast`. Aligns with memory guidelines that standard WASM should not pull in `ast` by default.
+- **Trade-offs**:
+  - *Structure*: Corrects dependency boundary.
+  - *Velocity*: Fast to land.
+  - *Governance*: Requires consumers needing AST parsing to explicitly opt in.
+
+### Option B
+- **What it is**: Add conditional `cfg` flags around `tree-sitter` in `tokmd-analysis` to disable it only on WASM, even when the `ast` feature is enabled.
+- **When to choose it instead**: If the `ast` feature had other significant capabilities that *did* work on WASM.
+- **Trade-offs**: More complex `Cargo.toml` configuration and potential confusion where enabling a feature doesn't actually enable it on certain targets. Option A is cleaner.
+
+## ✅ Decision
+Option A. It's the simplest, most structurally sound way to fix the matrix without complicating feature flags. `ast` is explicitly designed as opt-in infrastructure for now.
+
+## 🧱 Changes made (SRP)
+- Modified `crates/tokmd/Cargo.toml` to remove `"ast"` from the `default` feature list.
+
+## 🧪 Verification receipts
+```text
+$ cargo check -p tokmd --target wasm32-unknown-unknown
+    Checking tokmd-cockpit v1.13.1 (/app/crates/tokmd-cockpit)
+    Checking tokmd-core v1.13.1 (/app/crates/tokmd-core)
+    Checking tokmd v1.13.1 (/app/crates/tokmd)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.07s
+```
+
+## 🧭 Telemetry
+- Change shape: Feature flag reduction
+- Blast radius: API (consumers relying on default `ast` features will need to opt-in)
+- Risk class: Low (matrix repair)
+- Rollback: Revert `Cargo.toml` change
+- Gates run: `cargo check -p tokmd --target wasm32-unknown-unknown`, `cargo check -p tokmd --no-default-features`, `cargo build --verbose`, `cargo test -p tokmd --verbose`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/compat_interfaces_matrix/envelope.json`
+- `.jules/runs/compat_interfaces_matrix/decision.md`
+- `.jules/runs/compat_interfaces_matrix/receipts.jsonl`
+- `.jules/runs/compat_interfaces_matrix/result.json`
+- `.jules/runs/compat_interfaces_matrix/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/compat_interfaces_matrix/receipts.jsonl
+++ b/.jules/runs/compat_interfaces_matrix/receipts.jsonl
@@ -1,0 +1,1 @@
+{"command": "cargo check -p tokmd --target wasm32-unknown-unknown", "status": "success"}

--- a/.jules/runs/compat_interfaces_matrix/result.json
+++ b/.jules/runs/compat_interfaces_matrix/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "summary": "Removed `ast` feature from `tokmd` default features to restore WASM compatibility.",
+  "outcome": "PR-ready patch"
+}

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [features]
-default = ["git", "walk", "content", "ui", "fun", "topics", "archetype", "analysis", "ast"]
+default = ["git", "walk", "content", "ui", "fun", "topics", "archetype", "analysis"]
 alias-tok = []
 analysis = ["tokmd-core/analysis"]
 git = [


### PR DESCRIPTION
Removed `ast` from the `default` features of the `tokmd` crate to restore `wasm32-unknown-unknown` compatibility. The `ast` feature relies on `tree-sitter`, which strictly requires a C standard library (`stdlib.h`) and breaks compilation for targets without it.

## 🎯 Why 
WASM compatibility is a hard requirement for parts of the `tokmd` CLI facade that run in restricted environments. Because `ast` was added to `default`, standard invocations like `cargo build` on WASM fail with `stdlib.h not found`. This drift breaks the `compat-matrix` gates. By moving `ast` to an opt-in feature, we keep the capability for environments that support C-stdlib but restore the baseline matrix.

## 🔎 Evidence 
- `crates/tokmd/Cargo.toml`
- **Observed behavior**: 
  ```text
  warning: tree-sitter-rust@0.24.2: src/tree_sitter/parser.h:10:10: fatal error: 'stdlib.h' file not found
  ```
- **Receipts**: Removing `ast` from `default` makes `cargo check -p tokmd --target wasm32-unknown-unknown` succeed without `--no-default-features`.

## 🧭 Options considered
### Option A (recommended)
- **What it is**: Remove `ast` from `tokmd`'s `default` features.
- **Why it fits this repo and shard**: Directly addresses the compatibility breakdown while retaining functionality via explicit `--features ast`. Aligns with memory guidelines that standard WASM should not pull in `ast` by default.
- **Trade-offs**: 
  - *Structure*: Corrects dependency boundary.
  - *Velocity*: Fast to land.
  - *Governance*: Requires consumers needing AST parsing to explicitly opt in.

### Option B
- **What it is**: Add conditional `cfg` flags around `tree-sitter` in `tokmd-analysis` to disable it only on WASM, even when the `ast` feature is enabled.
- **When to choose it instead**: If the `ast` feature had other significant capabilities that *did* work on WASM.
- **Trade-offs**: More complex `Cargo.toml` configuration and potential confusion where enabling a feature doesn't actually enable it on certain targets. Option A is cleaner.

## ✅ Decision
Option A. It's the simplest, most structurally sound way to fix the matrix without complicating feature flags. `ast` is explicitly designed as opt-in infrastructure for now.

## 🧱 Changes made (SRP) 
- Modified `crates/tokmd/Cargo.toml` to remove `"ast"` from the `default` feature list.

## 🧪 Verification receipts 
```text
$ cargo check -p tokmd --target wasm32-unknown-unknown
    Checking tokmd-cockpit v1.13.1 (/app/crates/tokmd-cockpit)
    Checking tokmd-core v1.13.1 (/app/crates/tokmd-core)
    Checking tokmd v1.13.1 (/app/crates/tokmd)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.07s
```

## 🧭 Telemetry 
- Change shape: Feature flag reduction
- Blast radius: API (consumers relying on default `ast` features will need to opt-in)
- Risk class: Low (matrix repair)
- Rollback: Revert `Cargo.toml` change
- Gates run: `cargo check -p tokmd --target wasm32-unknown-unknown`, `cargo check -p tokmd --no-default-features`, `cargo build --verbose`, `cargo test -p tokmd --verbose`

## 🗂️ .jules artifacts 
- `.jules/runs/compat_interfaces_matrix/envelope.json`
- `.jules/runs/compat_interfaces_matrix/decision.md`
- `.jules/runs/compat_interfaces_matrix/receipts.jsonl`
- `.jules/runs/compat_interfaces_matrix/result.json`
- `.jules/runs/compat_interfaces_matrix/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [10608394726175028943](https://jules.google.com/task/10608394726175028943) started by @EffortlessSteven*