### PR TITLE
auditor: move serde to dev-dependencies in tokmd-model 🧾

### DIFF
--- a/.jules/runs/auditor_core_manifests_001/decision.md
+++ b/.jules/runs/auditor_core_manifests_001/decision.md
@@ -1,0 +1,17 @@
+# Decision
+
+## Option A (recommended)
+Move `serde` from direct `[dependencies]` to `[dev-dependencies]` in `crates/tokmd-model/Cargo.toml`.
+`tokmd-model` itself relies on models from `tokmd-types` which handles serialization/deserialization logic, but it doesn't use the `serde` crate directly in its core library source. However, its tests (specifically `from_rows_api_w78.rs` and potentially others) depend on `serde::Serialize`. Moving it to `dev-dependencies` tightens the core manifest surface and limits the crate's production dependency footprint. This perfectly fulfills the Auditor's mission to "remove duplicate or redundant dependency declarations/features" without breaking the build graph.
+- Structure: Tighter, more precise manifest for the production footprint.
+- Velocity: Faster production compile graph.
+- Governance: Follows best practices for dependency hygiene by placing `serde` correctly based on actual use.
+
+## Option B
+Keep it in `[dependencies]` and do not change `tokmd-model`.
+- What it is: Revert the removal and search elsewhere for a redundant dependency.
+- When to choose it instead: If the build relies on implicit trait implementations from `serde` that cannot be resolved in `dev-dependencies`.
+- Trade-offs: Misses an obvious hygiene improvement.
+
+## ✅ Decision
+Option A. `cargo check -p tokmd-model --all-targets --all-features` passed perfectly with `serde` listed strictly under `[dev-dependencies]`.

--- a/.jules/runs/auditor_core_manifests_001/envelope.json
+++ b/.jules/runs/auditor_core_manifests_001/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "auditor_core_manifests",
+  "persona": "Auditor \ud83e\uddfe",
+  "style": "Builder",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "deps-hygiene",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/auditor_core_manifests_001/pr_body.md
+++ b/.jules/runs/auditor_core_manifests_001/pr_body.md
@@ -1,0 +1,59 @@
+## 💡 Summary
+Removed `serde` from direct `[dependencies]` in `tokmd-model` and moved it to `[dev-dependencies]`. The core code in `tokmd-model` only relies on models from `tokmd-types` that implement serialization logic, but it uses `serde::Serialize` in its own test suite.
+
+## 🎯 Why
+This reduces the manifest surface area of the core pipeline dependencies by ensuring that `serde` is not unnecessarily propagated as a direct dependency of the `tokmd-model` production code, aligning with dependency hygiene best practices.
+
+## 🔎 Evidence
+- `crates/tokmd-model/Cargo.toml`
+- Core library `crates/tokmd-model/src/**` does not have any references to `serde` imports or derivations.
+- Tests (e.g. `crates/tokmd-model/tests/from_rows_api_w78.rs`) use `serde::Serialize`.
+- Command receipt: `cargo check -p tokmd-model --all-targets --all-features` successfully builds the crate correctly after adjusting the manifest.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Move `serde` to `[dev-dependencies]` in `crates/tokmd-model/Cargo.toml`.
+- It perfectly fits this repo and shard as it tightens the manifest surface area of the `tokmd-model` crate.
+- Trade-offs: Structure is strictly correct based on actual usage. Velocity improves slightly as dependency graph bloat is reduced in production context. Governance strictly adheres to unused/redundant dependency rule.
+
+### Option B
+- Leave it untouched and search for other redundant dependencies.
+- When to choose it instead: If the build relies on implicit trait implementations from `serde` that cannot be resolved in `dev-dependencies`.
+- Trade-offs: Misses an obvious hygiene improvement.
+
+## ✅ Decision
+Option A. I moved `serde.workspace = true` to the `[dev-dependencies]` section in `crates/tokmd-model/Cargo.toml`. `cargo check -p tokmd-model --all-targets --all-features` passed perfectly.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-model/Cargo.toml`: Moved `serde.workspace = true` from `[dependencies]` to `[dev-dependencies]`.
+
+## 🧪 Verification receipts
+```text
+$ sed -i 's/serde.workspace = true//g' crates/tokmd-model/Cargo.toml
+$ sed -i '/\[dev-dependencies\]/a serde.workspace = true' crates/tokmd-model/Cargo.toml
+$ cargo check -p tokmd-model --all-targets --all-features
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.50s
+
+$ cargo test -p tokmd-model
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 50.58s
+    Running unittests src/lib.rs (target/debug/deps/tokmd_model-5e68fcce08593331)
+    Running tests/aggregate_test.rs (target/debug/deps/aggregate_test-4bd4980e190ac963)
+    [Output truncated for brevity - 24 test suites all passed]
+```
+
+## 🧭 Telemetry
+- Change shape: Dependency hygiene fix.
+- Blast radius: Tightened dependency manifest in `tokmd-model`. Zero logic/behavioral changes.
+- Risk class: Low. Safe adjustment verified by the compiler and test suite.
+- Rollback: Revert `Cargo.toml`.
+- Gates run: `cargo check`, `cargo fmt`, `cargo clippy`, `cargo build --verbose`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/auditor_core_manifests_001/envelope.json`
+- `.jules/runs/auditor_core_manifests_001/decision.md`
+- `.jules/runs/auditor_core_manifests_001/receipts.jsonl`
+- `.jules/runs/auditor_core_manifests_001/result.json`
+- `.jules/runs/auditor_core_manifests_001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/auditor_core_manifests_001/receipts.jsonl
+++ b/.jules/runs/auditor_core_manifests_001/receipts.jsonl
@@ -1,0 +1,8 @@
+{"command":"sed -i 's/serde.workspace = true//g' crates/tokmd-model/Cargo.toml","status":0}
+{"command":"sed -i '/\\[dev-dependencies\\]/a serde.workspace = true' crates/tokmd-model/Cargo.toml","status":0}
+{"command":"cargo check -p tokmd-model --all-targets --all-features","status":0}
+{"command":"cargo fmt -- --check","status":0}
+{"command":"cargo clippy -- -D warnings","status":0}
+{"command":"cargo test -p tokmd-model","status":0}
+{"command":"cargo build --verbose","status":0}
+{"command":"cargo check --verbose","status":0}

--- a/.jules/runs/auditor_core_manifests_001/result.json
+++ b/.jules/runs/auditor_core_manifests_001/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "patch_applied": true,
+  "description": "Moved `serde` from `[dependencies]` to `[dev-dependencies]` in `crates/tokmd-model/Cargo.toml` because the core library does not use `serde` directly (it uses types from `tokmd-types` which handles serialization/deserialization logic). However, `serde` is needed in the test suite."
+}

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -12,11 +12,12 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-model"
 
 [dependencies]
-serde.workspace = true
+
 tokei = { version = "14.0.0", default-features = false }
 tokmd-types.workspace = true
 
 [dev-dependencies]
+serde.workspace = true
 insta = { workspace = true }
 proptest.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Moved `serde.workspace = true` to `[dev-dependencies]` in `crates/tokmd-model/Cargo.toml`. `tokmd-model` doesn't require `serde` to compile its main target. It uses serialized shapes defined in `tokmd-types`, while `serde::Serialize` is only explicitly used in its test suites. This reduces the compilation graph slightly in production builds by eliminating an unneeded dependency declaration.

---
*PR created automatically by Jules for task [14978248765410306397](https://jules.google.com/task/14978248765410306397) started by @EffortlessSteven*