### PR TITLE
cartographer: align roadmap with shipped reality 🗺️

### DIFF
--- a/.jules/friction/open/FRIC-20260611-001.md
+++ b/.jules/friction/open/FRIC-20260611-001.md
@@ -1,0 +1,4 @@
+# Missing schema version constants in xtask bump command
+
+In `xtask/src/tasks/bump.rs`, the `SCHEMA_LOCATIONS` array is missing several schema constants, including `BASELINE_VERSION` from `crates/tokmd-analysis-types/src/baseline.rs` and `SENSOR_REPORT_SCHEMA` from `crates/tokmd-envelope/src/lib.rs`.
+This means `cargo xtask bump --schema` will fail to update these versions or warn on drift.

--- a/.jules/runs/cartographer_roadmap_design/decision.md
+++ b/.jules/runs/cartographer_roadmap_design/decision.md
@@ -1,25 +1,20 @@
 # Cartographer Decision
 
 ## Target identification
-The shard is `tooling-governance` with allowed paths including `ROADMAP.md`, `docs/**`, `Cargo.toml`.
-Currently `Cargo.toml` is at version `1.11.0` and the last two releases (1.10.0 and 1.11.0) have been marked complete in `ROADMAP.md` and `CHANGELOG.md`.
+Through exploring the codebase, I see the following drift targets:
+1. `ROADMAP.md` is out of date. It tracks up to `v1.11.0` and marks `v2.0.0` as planned. However, the current package version is `1.13.1`. The roadmap completely misses `1.12.0` (Bun UB evidence readiness and `tokmd-swarm` workbench) and `1.13.0` (Syntax-aware evidence packet release). It also lists "v1.12.x — Selection-First Product and Evidence Work" under a future section.
+2. `ROADMAP.md` still refers to AST as "Shadow-only", but `1.13.0` shipped `tokmd syntax` behind the `ast` feature, and `1.13.1` made `ast` included by default in the published `tokmd` crate.
 
-In `docs/architecture.md`, the `## WASM & Browser Runner` section refers to `v1.9.0` as the current state in its non-goals section: `Non-goals for v1.9.0: No browser-side git-history churn/hotspot metrics or other heavy host tooling. No browser zipball ingestion as the primary supported path while tree+contents is the stable browser-safe acquisition strategy.`
-However, we just completed `v1.11.0` which focuses on "Browser Runtime Polish". The architecture doc's references to `v1.9.0` constraints and non-goals are outdated and misleading.
+## Options considered
+### Option A (recommended)
+- what it is: Update `ROADMAP.md` to record `v1.12` and `v1.13` as shipped reality. Add them to the "Status Summary" table and "Completed Milestones". Remove the stale "v1.12.x" section and update the AST status.
+- why it fits this repo and shard: Fixes factual drift between shipped reality and roadmap/design docs, aligning perfectly with Cartographer's mission.
+- trade-offs: Structure: Keeps the document chronologically accurate. Velocity: Helps reviewers understand what is actually shipped vs planned. Governance: Accurate historical tracking.
 
-In `docs/NOW.md`, the `LATER (roadmap)` section says: `- **Browser runner**: zipball ingestion remains later; in-browser receipt generation shipped in \`1.9.0\`.`. Since we are at v1.11.0, this is historically accurate but phrased as if it just shipped, and we can just frame it generically or reflect that we are much further along. Better to just say "in-browser analysis has shipped".
-
-## Options Considered
-
-### Option A: Update `docs/architecture.md` and `docs/NOW.md` to reflect `v1.11.0` state and current non-goals
-- **What it is**: Update references to `v1.9.0` non-goals in `docs/architecture.md` to reflect the current ongoing state, and update `docs/NOW.md` to remove stale "shipped in 1.9.0" context, orienting instead to the active v1.12.0 architecture consolidation focus.
-- **Why it fits**: The architecture document describes the current shape of the WASM/Browser Runner. Keeping non-goals scoped to `v1.9.0` when the repo is at `1.11.0` (with 1.11.0 having shipped browser polish) makes the architecture doc read as outdated. `docs/NOW.md` also references the v1.9.0 browser runner instead of the v1.12.0 active work.
-- **Trade-offs**: Corrects drift without being overly broad. Velocity is fast. Structure is improved.
-
-### Option B: Rewrite the entire `docs/architecture.md`
-- **What it is**: Redo the entire WASM section to focus solely on architecture, removing any milestone/versioning mentions.
-- **Why it fits**: Avoids future version drift.
-- **Trade-offs**: Higher risk of removing important historical context or current-state context.
+### Option B
+- what it is: Fix missing schema constants in `xtask/src/tasks/bump.rs` like `BASELINE_VERSION` and `SENSOR_REPORT_SCHEMA`.
+- when to choose it instead: If playing Gatekeeper/Steward to fix release tooling.
+- trade-offs: Not the primary mission of Cartographer, and `cargo xtask version-consistency` currently passes. I will create a friction item for it instead.
 
 ## Decision
-**Option A**. It's precise, targets actual drift where docs lag behind the completed `v1.11.0` and active `v1.12.0` roadmap states, and fixes misleading references to older versions in structural/architecture files.
+I will proceed with Option A and create a friction item for Option B.

--- a/.jules/runs/cartographer_roadmap_design/envelope.json
+++ b/.jules/runs/cartographer_roadmap_design/envelope.json
@@ -10,13 +10,8 @@
     "ROADMAP.md",
     "CHANGELOG.md",
     "Cargo.toml",
-    "Cargo.lock",
-    "crates/**/Cargo.toml",
-    ".cargo/**"
+    "Cargo.lock"
   ],
   "gate_profile": "governance-release",
-  "allowed_outcomes": [
-    "PR-ready patch",
-    "learning PR"
-  ]
+  "allowed_outcomes": ["patch", "learning_pr"]
 }

--- a/.jules/runs/cartographer_roadmap_design/pr_body.md
+++ b/.jules/runs/cartographer_roadmap_design/pr_body.md
@@ -1,46 +1,47 @@
 ## 💡 Summary
-Updated `docs/NOW.md` and `docs/architecture.md` to reflect the shipped state of the v1.11.0 browser runner polish. Stale references to `v1.9.0` non-goals were removed or updated to correctly represent current constraints without version drift.
+Updated `ROADMAP.md` to reflect that `v1.12.0` (Evidence Workbench) and `v1.13.0` (Syntax-Aware Evidence Packets) have shipped.
 
 ## 🎯 Why
-With the completion of v1.11.0 ("Browser Runtime Polish") and active focus on v1.12.0 ("Cockpit & Architecture Consolidation"), the `architecture.md` references to "Non-goals for v1.9.0" read as outdated history rather than the current truth of the system's browser boundaries. `NOW.md` also incorrectly framed in-browser capabilities using historical `1.9.0` phrasing.
+There is significant factual drift between the shipped reality (currently at v1.13.1) and `ROADMAP.md` which tracked status only up to `v1.11.0`. The roadmap still described `v1.12.x` as planned and AST parsing as "shadow-only", missing the actual features delivered.
 
 ## 🔎 Evidence
-- `docs/architecture.md` explicitly listed `### Non-goals for v1.9.0`.
-- `docs/NOW.md` stated `in-browser receipt generation shipped in 1.9.0` while actively in the `LATER` section, which creates confusing version timelines.
+- `ROADMAP.md` missing v1.12.0 and v1.13.0
+- `CHANGELOG.md` shows `v1.12.0` and `v1.13.0` features actually released
+- `Cargo.toml` shows `version = "1.13.1"`
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- Update references to `v1.9.0` non-goals in `docs/architecture.md` to reflect the current ongoing state, and update `docs/NOW.md` to remove stale "shipped in 1.9.0" context, orienting instead to the active v1.12.0 architecture consolidation focus.
-- Why it fits: The architecture document describes the current shape of the WASM/Browser Runner. Keeping non-goals scoped to `v1.9.0` when the repo is at `1.11.0` makes the architecture doc read as outdated. `docs/NOW.md` also referenced the v1.9.0 browser runner instead of the broader completed state.
-- Trade-offs: Corrects drift without being overly broad. Velocity is fast. Structure is improved.
+- Update `ROADMAP.md` with factual status of v1.12 and v1.13 based on CHANGELOG.md
+- Fits repo and shard by fixing documentation drift
+- Structure: Keeps the document chronologically accurate.
+- Velocity: Helps reviewers understand what is actually shipped vs planned.
+- Governance: Accurate historical tracking.
 
 ### Option B
-- Redo the entire WASM section to focus solely on architecture, removing any milestone/versioning mentions entirely.
-- When to choose: If the entire browser runner strategy changed dramatically.
-- Trade-offs: Higher risk of removing important historical or structural context.
+- Fix missing schema constants in `xtask/src/tasks/bump.rs`
+- Better suited for a Gatekeeper or Steward persona fixing release tooling, so recorded as friction instead.
 
 ## ✅ Decision
-Option A. It's precise, targets actual drift where docs lag behind the completed `v1.11.0` and active `v1.12.0` roadmap states, and fixes misleading references to older versions in structural/architecture files.
+Proceeded with Option A to accurately map the current repository state and recorded Option B as friction.
 
 ## 🧱 Changes made (SRP)
-- `docs/architecture.md`: Renamed `### Non-goals for v1.9.0` to `### Current browser non-goals`.
-- `docs/NOW.md`: Updated roadmap reference from `shipped in 1.9.0` to `has shipped`.
+- `ROADMAP.md`: Added v1.12.0 and v1.13.0 to Status Summary and Completed Milestones, and updated Current Roadmap Status to remove stale items.
 
 ## 🧪 Verification receipts
 ```text
-$ cargo xtask docs --check
-Documentation is up to date.
-
-$ cargo fmt -- --check && cargo clippy -- -D warnings
-Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.34s
+cargo xtask publish --plan --verbose
+cargo xtask version-consistency
+cargo xtask docs --check
+cargo fmt -- --check
+cargo clippy -- -D warnings
 ```
 
 ## 🧭 Telemetry
 - Change shape: Docs update
 - Blast radius: Docs only
-- Risk class: Zero risk.
-- Rollback: git revert
-- Gates run: `cargo xtask docs --check`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`
+- Risk class: Low, no runtime impact
+- Rollback: Revert PR
+- Gates run: `governance-release` profile checks
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/cartographer_roadmap_design/envelope.json`
@@ -48,6 +49,7 @@ Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.34s
 - `.jules/runs/cartographer_roadmap_design/receipts.jsonl`
 - `.jules/runs/cartographer_roadmap_design/result.json`
 - `.jules/runs/cartographer_roadmap_design/pr_body.md`
+- `.jules/friction/open/FRIC-20260611-001.md`
 
 ## 🔜 Follow-ups
-None.
+- FRIC-20260611-001: Missing schema version constants in xtask bump command

--- a/.jules/runs/cartographer_roadmap_design/receipts.jsonl
+++ b/.jules/runs/cartographer_roadmap_design/receipts.jsonl
@@ -1,4 +1,9 @@
-{"timestamp": "2024-05-11T12:05:00.000000Z", "command": "sed -n '255,265p' docs/architecture.md", "output": "- Broaden browser analysis only where the preset can stay rootless and capability-honest.\n\n### Current browser non-goals\n\n- No browser-side git-history churn/hotspot metrics or other heavy host tooling.\n- No browser zipball ingestion as the primary supported path while tree+contents is the stable browser-safe acquisition strategy."}
-{"timestamp": "2024-05-11T12:05:10.000000Z", "command": "cargo xtask docs --check", "output": "Documentation is up to date.\n     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.29s\n     Running `target/debug/xtask docs --check`"}
-{"timestamp": "2024-05-11T12:05:20.000000Z", "command": "cargo fmt -- --check", "output": ""}
-{"timestamp": "2024-05-11T12:05:30.000000Z", "command": "cargo clippy -- -D warnings", "output": "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.34s"}
+{"command": "head -n 50 ROADMAP.md", "exit_code": 0}
+{"command": "grep -rn \"v1.11.0\" ROADMAP.md -A 5", "exit_code": 0}
+{"command": "grep -rn \"v1.12.0\" ROADMAP.md -A 5", "exit_code": 1}
+{"command": "grep -rn \"v1.13.0\" ROADMAP.md -A 5", "exit_code": 1}
+{"command": "cargo xtask publish --plan --verbose", "exit_code": 0}
+{"command": "cargo xtask version-consistency", "exit_code": 0}
+{"command": "cargo xtask docs --check", "exit_code": 0}
+{"command": "cargo fmt -- --check", "exit_code": 0}
+{"command": "cargo clippy -- -D warnings", "exit_code": 0}

--- a/.jules/runs/cartographer_roadmap_design/result.json
+++ b/.jules/runs/cartographer_roadmap_design/result.json
@@ -1,9 +1,5 @@
 {
-  "outcome": "PR-ready patch",
-  "title": "cartographer: align browser runner non-goals with v1.11 reality 🗺️",
-  "summary": "Updated docs/architecture.md and docs/NOW.md to reflect current browser constraints rather than outdated v1.9.0 non-goals.",
-  "target_paths": [
-    "docs/architecture.md",
-    "docs/NOW.md"
-  ]
+  "status": "success",
+  "outcome": "patch",
+  "message": "Updated ROADMAP.md to document shipped v1.12.0 and v1.13.0 milestones."
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,8 @@ context for humans, machines, CI, and agents.
 | **v1.10.0-rc.1** | ✅ Complete | Release-candidate proof for CI control plane, bounded trust hardening, WASM truth, and proof stability. |
 | **v1.10.0** | ✅ Complete | Stable CI control plane, trust hardening, WASM truth, Action release, and proof stability. |
 | **v1.11.0** | ✅ Complete | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
+| **v1.12.0** | ✅ Complete | Bun UB evidence-readiness and `tokmd-swarm` workbench. |
+| **v1.13.0** | ✅ Complete | Syntax-aware evidence packets, `tokmd syntax` command, and bounding complexity analysis. |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
 | **v3.0.0** | 🚧 Active (Shadow) | Tree-sitter AST foundation in-tree behind feature flag. |
 
@@ -50,10 +52,10 @@ The historical roadmap remains useful as a record of shipped milestones and
 longer-term horizons. The active planning state is now selection-first:
 
 - v1.11 browser runtime polish is complete.
+- v1.12 Bun UB evidence-readiness and `tokmd-swarm` workbench is complete.
+- v1.13 Syntax-aware evidence packets are complete. The `ast` feature is now included by default in the `tokmd` crate, enabling `tokmd syntax`.
 - Cockpit/review evidence is stable as the current PR-review surface.
 - Proof observation remains advisory, not promoted to required gates.
-- AST remains shadow-only until broader comparison evidence justifies public
-  schema or behavior changes.
 - There is no selected implementation lane by default.
 
 New work should start from one of:
@@ -80,6 +82,32 @@ rules.
 ---
 
 ## Completed Milestones
+
+### ✅ v1.13.0 — Syntax-Aware Evidence Packets
+
+**Goal:** Provide a manifest-first evidence packet that can include scoped analysis, context, optional syntax receipts, and artifact references in one bot-readable contract.
+
+- [x] Feature-gated `tokmd syntax` command (now included by default in `1.13.1`).
+- [x] History-preserving swarm import for the syntax/evidence lane.
+- [x] Packet manifest wiring and cockpit/handoff artifact references.
+- [x] File-backed complexity scan bounds with `partial` status and explicit warnings.
+
+### ✅ v1.12.0 — Evidence Workbench
+
+**Goal:** Deliver the Bun UB evidence-readiness and `tokmd-swarm` workbench release.
+
+- [x] `tokmd analyze --preset bun-ub` as a thin on-diff review preset.
+- [x] Routed-proof/CI actuals feedback loop.
+- [x] Publication-graph tooling for shared swarm development history.
+
+### ✅ v1.11.0 — Browser Runtime Polish
+
+**Goal:** Deliver explicit cache semantics, visible progress, resilient fetch UX, and safe authenticated-fetch boundaries.
+
+- [x] Browser cache key/invalidation semantics.
+- [x] Browser worker and repo-load progress visibility.
+- [x] Retry and rate-limit UX with retry-after guidance.
+- [x] Auth-safe fetch/cache boundaries with session-only token state.
 
 ### ✅ v1.0.0 — Stability Release
 
@@ -592,30 +620,10 @@ back into single-responsibility owner modules.
 - [x] Determinism and proof coverage for analyze snapshots, run/diff receipts, effort serde, and core CLI behavior.
 - [x] CLI reference docs generated through checked HELP markers.
 
-## v1.11.0 — Browser Runtime Polish
 
-**Goal:** Deliver the browser runtime polish deferred from the v1.10 release fence: explicit cache semantics, visible progress, resilient fetch UX, and safe authenticated-fetch boundaries.
-
-### What shipped for v1.11.0
-
-- [x] Browser cache key/invalidation semantics.
-- [x] Browser worker and repo-load progress visibility.
-- [x] Retry and rate-limit UX with retry-after guidance.
-- [x] Auth-safe fetch/cache boundaries with session-only token state.
 
 ## Future Horizons
 
-### v1.12.x — Selection-First Product and Evidence Work
-
-_Goal: Choose the next implementation lane deliberately from release, adoption, review-evidence, workflow, browser, performance, or AST-shadow evidence gaps._
-
-Potential lanes:
-
-- Release/distribution verification.
-- CLI and adoption UX.
-- Review evidence consumption.
-- Measured performance and CI feedback.
-- Browser/WASM rootless capability expansion.
 - AST shadow evidence expansion.
 
 Architecture consolidation is paused unless fresh product or proof evidence


### PR DESCRIPTION
## 💡 Summary 
Updated `ROADMAP.md` to reflect that `v1.12.0` (Evidence Workbench) and `v1.13.0` (Syntax-Aware Evidence Packets) have shipped.

## 🎯 Why 
There is significant factual drift between the shipped reality (currently at v1.13.1) and `ROADMAP.md` which tracked status only up to `v1.11.0`. The roadmap still described `v1.12.x` as planned and AST parsing as "shadow-only", missing the actual features delivered.

## 🔎 Evidence 
- `ROADMAP.md` missing v1.12.0 and v1.13.0
- `CHANGELOG.md` shows `v1.12.0` and `v1.13.0` features actually released
- `Cargo.toml` shows `version = "1.13.1"`

## 🧭 Options considered 
### Option A (recommended) 
- Update `ROADMAP.md` with factual status of v1.12 and v1.13 based on CHANGELOG.md
- Fits repo and shard by fixing documentation drift
- Structure: Keeps the document chronologically accurate.
- Velocity: Helps reviewers understand what is actually shipped vs planned.
- Governance: Accurate historical tracking.

### Option B 
- Fix missing schema constants in `xtask/src/tasks/bump.rs`
- Better suited for a Gatekeeper or Steward persona fixing release tooling, so recorded as friction instead.

## ✅ Decision 
Proceeded with Option A to accurately map the current repository state and recorded Option B as friction.

## 🧱 Changes made (SRP) 
- `ROADMAP.md`: Added v1.12.0 and v1.13.0 to Status Summary and Completed Milestones, and updated Current Roadmap Status to remove stale items.

## 🧪 Verification receipts 
```text
cargo xtask publish --plan --verbose
cargo xtask version-consistency
cargo xtask docs --check
cargo fmt -- --check
cargo clippy -- -D warnings
```

## 🧭 Telemetry 
- Change shape: Docs update
- Blast radius: Docs only
- Risk class: Low, no runtime impact
- Rollback: Revert PR
- Gates run: `governance-release` profile checks

## 🗂️ .jules artifacts 
- `.jules/runs/cartographer_roadmap_design/envelope.json`
- `.jules/runs/cartographer_roadmap_design/decision.md`
- `.jules/runs/cartographer_roadmap_design/receipts.jsonl`
- `.jules/runs/cartographer_roadmap_design/result.json`
- `.jules/runs/cartographer_roadmap_design/pr_body.md`
- `.jules/friction/open/FRIC-20260611-001.md`

## 🔜 Follow-ups 
- FRIC-20260611-001: Missing schema version constants in xtask bump command

---
*PR created automatically by Jules for task [4957905447945079255](https://jules.google.com/task/4957905447945079255) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and internal Jules metadata only; no runtime, API, or release-tooling behavior changes.
> 
> **Overview**
> **`ROADMAP.md`** is brought in line with the current **v1.13.1** release: **v1.12.0** (evidence workbench / Bun UB) and **v1.13.0** (syntax-aware evidence packets) are marked complete in the status table, current-status bullets, and new **Completed Milestones** sections (with checklist items pulled from shipped work).
> 
> Stale planning text is removed—the future **v1.12.x** lane and duplicate mid-doc **v1.11.0** narrative—and **Current Roadmap Status** no longer says AST is shadow-only; it notes **`tokmd syntax`** and default **`ast`** on the published crate.
> 
> The PR also refreshes **`.jules/runs/cartographer_roadmap_design/*`** to document that decision and adds **`.jules/friction/open/FRIC-20260611-001.md`** as a follow-up on missing **`SCHEMA_LOCATIONS`** entries in **`xtask` bump** (not fixed here).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a39af7789dc3498e078f9b1fc65b8047057148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->