### PR TITLE
jules: record gatekeeper learning on baseline schema drift ✅

### DIFF
--- a/.jules/friction/open/FRIC-20240615-001.md
+++ b/.jules/friction/open/FRIC-20240615-001.md
@@ -1,0 +1,27 @@
+# Friction Item
+
+id: FRIC-20240615-001
+persona: Gatekeeper
+style: Prover
+shard: core-pipeline
+status: open
+
+## Problem
+The `BASELINE_VERSION` constant was added to `crates/tokmd-analysis-types/src/baseline.rs` and documented in `docs/SCHEMA.md`, but it was omitted from the centralized `SCHEMA_LOCATIONS` array in `xtask/src/tasks/bump.rs`. This creates a risk of version drift where running `cargo xtask bump --schema` would fail to update or validate this contract.
+
+Because `xtask/src/tasks/bump.rs` is outside the `core-pipeline` shard, I am unable to make this fix directly.
+
+## Evidence
+- `xtask/src/tasks/bump.rs`
+- `crates/tokmd-analysis-types/src/baseline.rs`
+- Command receipt:
+```text
+$ grep -rn "BASELINE_VERSION" crates/tokmd-analysis-types/src/baseline.rs
+20:pub const BASELINE_VERSION: u32 = 1;
+```
+
+## Why it matters
+This leaves a gap in the automated tooling, creating a risk of human error during future schema updates and violating the deterministic behavior of the repository's schema management tool.
+
+## Done when
+- [ ] `BASELINE_VERSION` is added to `SCHEMA_LOCATIONS` in `xtask/src/tasks/bump.rs`.

--- a/.jules/runs/gatekeeper_determinism/decision.md
+++ b/.jules/runs/gatekeeper_determinism/decision.md
@@ -1,0 +1,10 @@
+# Decision
+
+## Option A (recommended)
+Record a friction item describing the schema drift and file a learning PR. The `BASELINE_VERSION` constant was added to `crates/tokmd-analysis-types/src/baseline.rs` and documented in `docs/SCHEMA.md`, but it was omitted from the centralized `SCHEMA_LOCATIONS` array in `xtask/src/tasks/bump.rs`. This creates a risk of version drift where running `cargo xtask bump --schema` would fail to update or validate this contract. Because `xtask/src/tasks/bump.rs` is outside the `core-pipeline` shard, making the fix directly would violate shard discipline. The correct procedure is to surface the drift as friction and exit gracefully as a learning PR.
+
+## Option B
+Modify `xtask/src/tasks/bump.rs` directly. This directly fixes the schema version drift. However, it violates prompt constraints and risks corrupting tools outside the assigned domain.
+
+## Decision
+**Option A**. Sticking to the assigned shard is a hard constraint. The friction item properly documents the gap so a future run assigned to `xtask` can safely apply the fix.

--- a/.jules/runs/gatekeeper_determinism/envelope.json
+++ b/.jules/runs/gatekeeper_determinism/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "gatekeeper_determinism",
+  "persona": "Gatekeeper",
+  "style": "Prover",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "contracts-determinism",
+  "allowed_outcomes": ["proof-improvement patch", "learning PR"]
+}

--- a/.jules/runs/gatekeeper_determinism/pr_body.md
+++ b/.jules/runs/gatekeeper_determinism/pr_body.md
@@ -1,0 +1,58 @@
+## 💡 Summary
+This is a learning PR. I explored the codebase looking for schema version drift to fix within the `core-pipeline` shard. I discovered that `BASELINE_VERSION` is missing from the workspace schema bump task (`xtask/src/tasks/bump.rs`), but since `xtask` is outside my allowed paths, I have recorded this as a friction item instead of chasing the fix out-of-bounds.
+
+## 🎯 Why
+The assignment was to protect contract-bearing surfaces. The strongest target found was schema drift in the workspace bump script. Because `xtask` is strictly outside the `core-pipeline` shard boundaries, making the fix directly would violate shard discipline. The correct procedure is to surface the drift as friction and exit gracefully as a learning PR.
+
+## 🔎 Evidence
+- **File**: `crates/tokmd-analysis-types/src/baseline.rs`
+- **Finding**: The constant `BASELINE_VERSION` is defined here but missing from `SCHEMA_LOCATIONS` in `xtask/src/tasks/bump.rs`.
+- **Receipt**:
+```text
+$ grep -rn "BASELINE_VERSION" crates/tokmd-analysis-types/src/baseline.rs
+20:pub const BASELINE_VERSION: u32 = 1;
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Record a friction item describing the schema drift and file a learning PR.
+- **Why it fits**: Obeys strict shard discipline. Acknowledges the problem without violating architectural boundaries.
+- **Trade-offs**: Structure (high) / Velocity (medium) / Governance (high).
+
+### Option B
+- Modify `xtask/src/tasks/bump.rs` directly.
+- **When to choose**: When the `xtask` directory is explicitly added to the allowed shard paths.
+- **Trade-offs**: Violates prompt constraints and risks corrupting tools outside the assigned domain.
+
+## ✅ Decision
+**Option A**. Sticking to the assigned shard is a hard constraint. The friction item properly documents the gap so a future run assigned to `xtask` can safely apply the fix.
+
+## 🧱 Changes made (SRP)
+- Created `.jules/friction/open/FRIC-20240615-001.md`.
+- No production files were changed.
+
+## 🧪 Verification receipts
+```text
+$ grep -rn "BASELINE_VERSION" crates/tokmd-analysis-types/src/baseline.rs
+20:pub const BASELINE_VERSION: u32 = 1;
+$ grep -rn "SCHEMA_LOCATIONS" xtask/src/tasks/bump.rs
+30:const SCHEMA_LOCATIONS: &[SchemaVersionLocation] = &[
+```
+
+## 🧭 Telemetry
+- **Change shape**: Learning PR.
+- **Blast radius**: None.
+- **Risk class**: Trivial. Only per-run artifacts and friction items.
+- **Rollback**: None.
+- **Gates run**: None.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/gatekeeper_determinism/envelope.json`
+- `.jules/runs/gatekeeper_determinism/decision.md`
+- `.jules/runs/gatekeeper_determinism/receipts.jsonl`
+- `.jules/runs/gatekeeper_determinism/result.json`
+- `.jules/runs/gatekeeper_determinism/pr_body.md`
+- `.jules/friction/open/FRIC-20240615-001.md`
+
+## 🔜 Follow-ups
+- A future run assigned to the workspace tooling shard should address `FRIC-20240615-001`.

--- a/.jules/runs/gatekeeper_determinism/receipts.jsonl
+++ b/.jules/runs/gatekeeper_determinism/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "grep -rn \"BASELINE_VERSION\" crates/tokmd-analysis-types/src/baseline.rs", "output": "20:pub const BASELINE_VERSION: u32 = 1;"}
+{"command": "grep -rn \"SCHEMA_LOCATIONS\" xtask/src/tasks/bump.rs", "output": "const SCHEMA_LOCATIONS: &[SchemaVersionLocation] = &["}

--- a/.jules/runs/gatekeeper_determinism/result.json
+++ b/.jules/runs/gatekeeper_determinism/result.json
@@ -1,0 +1,18 @@
+{
+  "outcome": "learning_pr",
+  "title": "jules: record gatekeeper learning on baseline schema drift ✅",
+  "summary": "This is a learning PR. Recorded a friction item identifying schema version drift for `BASELINE_VERSION` missing from the workspace schema bump task.",
+  "target_paths": [
+    ".jules/friction/open/FRIC-20240615-001.md"
+  ],
+  "proof_summary": "Identified schema version drift between `crates/tokmd-analysis-types/src/baseline.rs` and `xtask/src/tasks/bump.rs`. Created friction item because `xtask` is outside the allowed shard.",
+  "gates_run": [],
+  "friction_items_created": [
+    ".jules/friction/open/FRIC-20240615-001.md"
+  ],
+  "persona_notes_created": [],
+  "rollback": "none",
+  "follow_ups": [
+    "Address FRIC-20240615-001"
+  ]
+}


### PR DESCRIPTION
## 💡 Summary
This is a learning PR. I explored the codebase looking for schema version drift to fix within the `core-pipeline` shard. I discovered that `BASELINE_VERSION` is missing from the workspace schema bump task (`xtask/src/tasks/bump.rs`), but since `xtask` is outside my allowed paths, I have recorded this as a friction item instead of chasing the fix out-of-bounds.

## 🎯 Why
The assignment was to protect contract-bearing surfaces. The strongest target found was schema drift in the workspace bump script. Because `xtask` is strictly outside the `core-pipeline` shard boundaries, making the fix directly would violate shard discipline. The correct procedure is to surface the drift as friction and exit gracefully as a learning PR.

## 🔎 Evidence
- **File**: `crates/tokmd-analysis-types/src/baseline.rs`
- **Finding**: The constant `BASELINE_VERSION` is defined here but missing from `SCHEMA_LOCATIONS` in `xtask/src/tasks/bump.rs`.
- **Receipt**:
```text
$ grep -rn "BASELINE_VERSION" crates/tokmd-analysis-types/src/baseline.rs
20:pub const BASELINE_VERSION: u32 = 1;
```

## 🧭 Options considered
### Option A (recommended)
- Record a friction item describing the schema drift and file a learning PR.
- **Why it fits**: Obeys strict shard discipline. Acknowledges the problem without violating architectural boundaries.
- **Trade-offs**: Structure (high) / Velocity (medium) / Governance (high).

### Option B
- Modify `xtask/src/tasks/bump.rs` directly.
- **When to choose**: When the `xtask` directory is explicitly added to the allowed shard paths.
- **Trade-offs**: Violates prompt constraints and risks corrupting tools outside the assigned domain.

## ✅ Decision
**Option A**. Sticking to the assigned shard is a hard constraint. The friction item properly documents the gap so a future run assigned to `xtask` can safely apply the fix.

## 🧱 Changes made (SRP)
- Created `.jules/friction/open/FRIC-20240615-001.md`.
- No production files were changed.

## 🧪 Verification receipts
```text
$ grep -rn "BASELINE_VERSION" crates/tokmd-analysis-types/src/baseline.rs
20:pub const BASELINE_VERSION: u32 = 1;
$ grep -rn "SCHEMA_LOCATIONS" xtask/src/tasks/bump.rs
30:const SCHEMA_LOCATIONS: &[SchemaVersionLocation] = &[
```

## 🧭 Telemetry
- **Change shape**: Learning PR.
- **Blast radius**: None.
- **Risk class**: Trivial. Only per-run artifacts and friction items.
- **Rollback**: None.
- **Gates run**: None.

## 🗂️ .jules artifacts
- `.jules/runs/gatekeeper_determinism/envelope.json`
- `.jules/runs/gatekeeper_determinism/decision.md`
- `.jules/runs/gatekeeper_determinism/receipts.jsonl`
- `.jules/runs/gatekeeper_determinism/result.json`
- `.jules/runs/gatekeeper_determinism/pr_body.md`
- `.jules/friction/open/FRIC-20240615-001.md`

## 🔜 Follow-ups
- A future run assigned to the workspace tooling shard should address `FRIC-20240615-001`.

---
*PR created automatically by Jules for task [8160881558511042499](https://jules.google.com/task/8160881558511042499) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.jules` documentation and friction tracking; no runtime, schema, or bump-script behavior changes.
> 
> **Overview**
> This is a **learning PR** with no production or tooling code changes. It adds Jules run artifacts under `.jules/runs/gatekeeper_determinism/` (envelope, decision, receipts, result, PR body) and opens friction item **FRIC-20240615-001** documenting that `BASELINE_VERSION` in `crates/tokmd-analysis-types/src/baseline.rs` is not listed in `SCHEMA_LOCATIONS` in `xtask/src/tasks/bump.rs`, so `cargo xtask bump --schema` may not update or validate that contract.
> 
> The Gatekeeper run stayed within the `core-pipeline` shard and did not edit `xtask`; the follow-up is for a workspace-tooling run to add `BASELINE_VERSION` to `SCHEMA_LOCATIONS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f11ef8d5ed913bf81b51dfce99f79b05715635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->