### PR TITLE
surveyor: Remove ast feature from tokmd crate default features 🧭

### DIFF
--- a/.jules/runs/surveyor_workspace/decision.md
+++ b/.jules/runs/surveyor_workspace/decision.md
@@ -1,0 +1,17 @@
+## Options Considered
+
+### Option A: Remove `ast` from default features in `tokmd` crate
+**What it is:** In `crates/tokmd/Cargo.toml`, remove the `ast` feature from the `default` list.
+**Why it fits this repo and shard:** The memory mentions: "In the `tokmd` project, the `ast` feature (which pulls in `tree-sitter` and its parsers) requires a C standard library (`stdlib.h`) and breaks standard `wasm32-unknown-unknown` builds. It should not be included in `default` features for crates intended to be WASM compatible." The `tokmd` crate is intended to be a CLI tool, but also serves as the top-level aggregation, and including `ast` by default breaks compiling the crate (or workspace tools that depend on it) when testing WASM compatibility via targets. Removing it from `default` ensures `ast` is strictly opt-in for users needing syntax parsing while ensuring compatibility across environments, aligning with the Surveyor persona's mandate on "feature-boundary hygiene" and "dependency direction / workspace structure problems."
+**Trade-offs:**
+- *Structure*: Improves feature hygiene and target compatibility.
+- *Velocity*: `wasm32` builds succeed out of the box without requiring `--no-default-features`.
+- *Governance*: Prevents accidental dependencies on C libs in the default path.
+
+### Option B: Keep `ast` in default features, create a learning PR
+**What it is:** Acknowledge the WASM build failure caused by `tree-sitter` in the `tokmd` crate but leave it. Record it as friction.
+**When to choose it instead:** If removing `ast` from `default` breaks too many user workflows. However, `ast` appears to be a heavy, niche feature (syntax analysis using tree-sitter) that shouldn't be pulled in by every default install, especially when memory strictly states it "should not be included in `default` features for crates intended to be WASM compatible."
+**Trade-offs:** Avoids breaking current users expecting `ast` by default, but fails to fix a known compatibility issue.
+
+## Decision
+**Option A**. Removing `ast` from the `default` features of the `tokmd` crate fixes a concrete target compatibility issue (WASM builds fail with missing `stdlib.h`), directly addressing the memory requirement and the "feature-boundary hygiene" mandate of the Surveyor persona.

--- a/.jules/runs/surveyor_workspace/envelope.json
+++ b/.jules/runs/surveyor_workspace/envelope.json
@@ -1,0 +1,9 @@
+{
+  "prompt_id": "surveyor_workspace",
+  "persona": "Surveyor",
+  "style": "Explorer",
+  "primary_shard": "workspace-wide",
+  "allowed_paths": ["**"],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/surveyor_workspace/pr_body.md
+++ b/.jules/runs/surveyor_workspace/pr_body.md
@@ -1,0 +1,63 @@
+## 💡 Summary
+Remove `ast` from the `default` features of the `tokmd` crate to fix standard `wasm32-unknown-unknown` builds.
+
+## 🎯 Why
+The memory explicitly notes: "In the `tokmd` project, the `ast` feature (which pulls in `tree-sitter` and its parsers) requires a C standard library (`stdlib.h`) and breaks standard `wasm32-unknown-unknown` builds. It should not be included in `default` features for crates intended to be WASM compatible." By including it in `default`, compiling the `tokmd` crate or testing it across targets inherently fails on environments missing C standard libraries, causing friction and feature-boundary hygiene issues.
+
+## 🔎 Evidence
+```text
+$ cargo check -p tokmd --target wasm32-unknown-unknown
+warning: tree-sitter-python@0.25.0: src/tree_sitter/parser.h:10:10: fatal error: 'stdlib.h' file not found
+warning: tree-sitter-typescript@0.23.2: ./typescript/src/tree_sitter/parser.h:10:10: fatal error: 'stdlib.h' file not found
+error: failed to run custom build command for `tree-sitter-python v0.25.0`
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Remove `ast` from `default` features in `crates/tokmd/Cargo.toml`.
+- Why it fits: Aligns precisely with the prompt's `core-rust` constraints and the Surveyor mandate to fix feature-boundary hygiene.
+- Trade-offs: `ast` must now be explicitly requested using `--features ast`, which slightly increases friction for niche users but guarantees compatibility for the rest of the ecosystem.
+
+### Option B
+- Keep `ast` in default features, create a learning PR documenting the build failure as friction.
+- When to choose it: If removing `ast` would break too many downstream dependencies that expect syntax analysis out of the box.
+- Trade-offs: Avoids breaking backwards compatibility but leaves the codebase structurally flawed for cross-platform builds.
+
+## ✅ Decision
+Option A was chosen to fix the concrete boundary issue and guarantee successful `wasm32-unknown-unknown` builds by default, adhering to memory constraints and the Surveyor persona's mandate.
+
+## 🧱 Changes made (SRP)
+- Modified `crates/tokmd/Cargo.toml` to remove `"ast"` from the `default` feature list.
+
+## 🧪 Verification receipts
+```text
+$ cargo check -p tokmd --target wasm32-unknown-unknown
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.47s
+
+$ CI=true cargo test --verbose -p tokmd
+    Finished `test` profile [unoptimized + debuginfo] target(s)
+     Running `/app/target/debug/deps/tok_integration-0dd92f42ba1f312f`
+     Running `/app/target/debug/deps/tools_integration-dca1d6635dab696b`
+   Doc-tests tokmd
+test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+$ cargo clippy -- -D warnings -p tokmd
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.42s
+```
+
+## 🧭 Telemetry
+- Change shape: Removal of a single feature string from an array.
+- Blast radius: Compilation flags, CLI defaults for feature usage, compatibility.
+- Risk class: Low - `ast` parsing logic is fully preserved, just no longer enabled implicitly by default for CLI users.
+- Rollback: Revert the commit.
+- Gates run: `cargo build --verbose`, `CI=true cargo test --verbose`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/surveyor_workspace/envelope.json`
+- `.jules/runs/surveyor_workspace/decision.md`
+- `.jules/runs/surveyor_workspace/receipts.jsonl`
+- `.jules/runs/surveyor_workspace/result.json`
+- `.jules/runs/surveyor_workspace/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/surveyor_workspace/receipts.jsonl
+++ b/.jules/runs/surveyor_workspace/receipts.jsonl
@@ -1,0 +1,8 @@
+{"command": "cargo build --target wasm32-unknown-unknown -p tokmd --no-default-features", "status": "success", "stdout": "Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 08s"}
+{"command": "cargo check -p tokmd --target wasm32-unknown-unknown", "status": "failure", "stdout": "error: failed to run custom build command for `tree-sitter-python v0.25.0`\nfatal error: 'stdlib.h' file not found"}
+{"command": "sed -i 's/\"analysis\", \"ast\"/\"analysis\"/' crates/tokmd/Cargo.toml", "status": "success"}
+{"command": "cargo check -p tokmd --target wasm32-unknown-unknown", "status": "success", "stdout": "Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.47s"}
+{"command": "cargo build --verbose", "status": "success"}
+{"command": "CI=true cargo test --verbose -p tokmd", "status": "success", "stdout": "test result: ok. 12 passed; 0 failed"}
+{"command": "cargo fmt -- --check", "status": "success"}
+{"command": "cargo clippy -- -D warnings -p tokmd", "status": "success"}

--- a/.jules/runs/surveyor_workspace/result.json
+++ b/.jules/runs/surveyor_workspace/result.json
@@ -1,0 +1,6 @@
+{
+  "outcome": "success",
+  "decision": "Option A",
+  "patch_type": "code",
+  "files_changed": ["crates/tokmd/Cargo.toml"]
+}

--- a/crates/tokmd/Cargo.toml
+++ b/crates/tokmd/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [features]
-default = ["git", "walk", "content", "ui", "fun", "topics", "archetype", "analysis", "ast"]
+default = ["git", "walk", "content", "ui", "fun", "topics", "archetype", "analysis"]
 alias-tok = []
 analysis = ["tokmd-core/analysis"]
 git = [


### PR DESCRIPTION
Remove `ast` from the `default` features of the `tokmd` crate to fix standard `wasm32-unknown-unknown` builds.

The `ast` feature pulls in `tree-sitter` and its parsers, which require a C standard library (`stdlib.h`) and break standard `wasm32-unknown-unknown` builds. By including it in `default`, compiling the `tokmd` crate inherently fails on environments missing C standard libraries, causing friction and feature-boundary hygiene issues.

This change requires users who need syntax parsing to explicitly opt-in with `--features ast`, aligning with the library's goal to support cross-target builds by default.

---
*PR created automatically by Jules for task [6726347314325631218](https://jules.google.com/task/6726347314325631218) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Cargo feature default change with an explicit opt-in path; main user-facing risk is anyone who relied on AST tooling without passing `--features ast`.
> 
> **Overview**
> Removes **`ast`** from the **`default`** feature set in `crates/tokmd/Cargo.toml` so default `tokmd` builds no longer pull in **tree-sitter** (and C/stdlib) via that feature path.
> 
> **Syntax / AST parsing stays available** behind `--features ast`; only the implicit default enablement changes. The goal is **`wasm32-unknown-unknown`** (and similar) **`cargo check -p tokmd`** succeeding without `--no-default-features`.
> 
> The PR also adds **`.jules/runs/surveyor_workspace/`** artifacts (decision notes, receipts, PR body template) recording the change and verification commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271790c8133e818cfee4f8c03cc16fb36e6251a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->