### PR TITLE
gatekeeper: track baseline and sensor schema versions ✅

### DIFF
--- a/.jules/runs/gatekeeper_contracts/decision.md
+++ b/.jules/runs/gatekeeper_contracts/decision.md
@@ -1,17 +1,12 @@
-# Option A (recommended)
-Use the `xtask docs --update` tool logic by replacing hardcoded command parameter tables in `docs/reference-cli.md` with auto-updating `<!-- HELP: <command> -->` markers. The xtask command automatically pulls the current `tokmd` help text.
-
-- **Structure**: Automatically synchronizes docs with command changes, removing drift.
-- **Velocity**: Speeds up doc updates since CLI parameters will always stay in sync.
-- **Governance**: Ensures reference documentation acts as a deterministically correct reflection of the program options. Fits well within the 'Gatekeeper' persona and the `tooling-governance` shard.
-
-# Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand, matching them against `cargo run --bin tokmd -- <cmd> --help`.
-
-- **When to choose it**: Only if you strictly want specialized tables with custom columns or manually edited parameter groups that rust `clap` output does not provide.
-- **Trade-offs**: Extreme risk of drift and maintenance burden. Requires a developer to manually verify changes on every new parameter addition.
-
 # Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables (from `.jules/policy/shards.json` or general run memory). The final restack replaces the remaining manual command tables with `<!-- HELP: <command> -->` markers, then makes `cargo xtask docs --check` fail if any expected marker pair is missing. This keeps the deterministic docs path inside `cargo xtask docs --update` / `cargo xtask docs --check` instead of relying on ad hoc post-processing scripts.
 
-The restack also aligns the xtask gate regression test with the current repository rule that Jules provenance under `.jules/**` may be intentional PR state. Gate still blocks cache/transcript/runtime/tmp paths, but it does not blanket-block `.jules/runs/**` provenance packets.
+## Option A (recommended)
+Update `xtask/src/tasks/bump.rs` to include `BASELINE_VERSION` from `crates/tokmd-analysis-types/src/baseline.rs` and `SENSOR_REPORT_SCHEMA` from `crates/tokmd-envelope/src/lib.rs` in `SCHEMA_LOCATIONS`.
+This ensures version/schema string consistency when bumping workspace versions and aligns with the memory: "In the `tokmd` project, workspace schema versions are tracked in `xtask/src/tasks/bump.rs` via the `SCHEMA_LOCATIONS` array. Any new contract schema constants (e.g., `BASELINE_VERSION`, `SENSOR_REPORT_SCHEMA`) must be registered here so that workspace tools like `cargo xtask bump --schema` can manage them properly and prevent version drift."
+
+## Option B
+Do not track `BASELINE_VERSION` and `SENSOR_REPORT_SCHEMA`.
+This allows schema versions to drift which is bad.
+
+## Decision
+I choose Option A. It explicitly fulfills the memory directive and reduces schema drift risk.

--- a/.jules/runs/gatekeeper_contracts/envelope.json
+++ b/.jules/runs/gatekeeper_contracts/envelope.json
@@ -17,7 +17,6 @@
   "gate_profile": "contracts-determinism",
   "allowed_outcomes": [
     "PR-ready patch",
-    "proof-improvement patch",
     "learning PR"
   ]
 }

--- a/.jules/runs/gatekeeper_contracts/pr_body.md
+++ b/.jules/runs/gatekeeper_contracts/pr_body.md
@@ -1,58 +1,46 @@
 ## 💡 Summary
-Removed manual markdown parameter tables from `docs/reference-cli.md` and replaced them with `<!-- HELP: <command> -->` markers. This delegates documentation generation to `cargo xtask docs`, locks in deterministic CLI usage tracking, and closes the silent-skip case where a missing marker pair could make docs checks pass without checking a command.
-
-The restack also updates the xtask gate regression test to match the current queue policy: Jules provenance under `.jules/**` can be intentional PR state, so gate should not blanket-block `.jules/runs/**` while still guarding actual runtime/cache/transcript directories.
+Added missing `SCHEMA_LOCATIONS` (`BASELINE_VERSION` and `SENSOR_REPORT_SCHEMA`) to `xtask/src/tasks/bump.rs` to allow the workspace bump tool to manage them. Modified `bump.rs` to properly replace string schemas (like `SENSOR_REPORT_SCHEMA`) instead of just `u32` integers, fulfilling the memory directive and locking in determinism.
 
 ## 🎯 Why
-Manual parameter tables in documentation frequently become outdated when CLI arguments change. `tokmd` provides `cargo xtask docs --update` which relies on `<!-- HELP: <command> -->` markers. Several commands were still using hand-maintained markdown tables, meaning updates to CLI args could easily be missed by the xtask check. The final patch also makes missing marker pairs an explicit docs-check failure.
+The memory explicitly stated that new contract schema constants like `BASELINE_VERSION` and `SENSOR_REPORT_SCHEMA` must be registered in the `SCHEMA_LOCATIONS` array in `xtask/src/tasks/bump.rs` so they don't suffer version drift. Previously, `bump.rs` didn't track them, and its regex replacement only supported `u32` variables, making it fail on `&str` values.
 
 ## 🔎 Evidence
-- File: `docs/reference-cli.md`
-- Observation: Many subcommands like `module`, `export`, `run`, `handoff` did not have `<!-- HELP: <command> -->` markers and used manual `| Argument | Description |` tables.
-- Verification: Running `cargo xtask docs --check` before the change ignored drift in these subcommands because they had no markers.
+- `xtask/src/tasks/bump.rs` only handled `pub const {}: u32 = ...` replacements and lacked `BASELINE_VERSION` and `SENSOR_REPORT_SCHEMA` in its `SCHEMA_LOCATIONS` list.
+- `crates/tokmd-envelope/src/lib.rs` has `pub const SENSOR_REPORT_SCHEMA: &str = "sensor.report.v1";`.
+- I proved `cargo test -p xtask` works after my change, preventing test breakage.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-Replace manual parameter tables with `<!-- HELP: <command> -->` markers for all commands, letting `cargo xtask docs --update` populate them correctly from the clap help output. Also fail `cargo xtask docs --check` when an expected marker pair is absent.
-- Trade-offs:
-  - **Structure**: Eliminates duplication of parameter details.
-  - **Velocity**: Developers no longer have to manually edit markdown tables when updating CLI parameters.
-  - **Governance**: Fits perfectly within the `tooling-governance` shard.
+- Add `BASELINE_VERSION` and `SENSOR_REPORT_SCHEMA` to `SCHEMA_LOCATIONS` in `bump.rs`, and adjust string replacement logic to handle `&str` definitions.
+- Fits the `tooling-governance` shard because it fixes workflow contract-determinism issues.
+- Trade-offs: Requires a slight modification to the task string-replacement loop to support `&str` substitution natively.
 
 ### Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand.
-- When to choose it: Only if custom columns are needed that clap does not output.
-- Trade-offs: Extreme risk of drift and maintenance burden.
+- Ignore `SENSOR_REPORT_SCHEMA` since it's a string, or migrate it to an integer.
+- Trade-offs: Changing a major schema field type inside the contract might break dependents, while failing to track the string schema would leave it drifting.
 
 ## ✅ Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables. The final patch keeps all synchronization in `cargo xtask docs --update` / `cargo xtask docs --check` and verifies that every expected command marker exists.
+Option A. It explicitly fulfills the memory directive without breaking `SENSOR_REPORT_SCHEMA`'s expected `&str` format across downstream crates.
 
 ## 🧱 Changes made (SRP)
-- `docs/reference-cli.md`: Removed manual parameter tables for the CLI command surface and replaced them with `<!-- HELP: <command> -->` markers.
-- `xtask/src/tasks/docs.rs`: Treats missing marker pairs as documentation drift instead of silently skipping those commands.
-- `xtask/src/tasks/gate.rs`, `xtask/tests/xtask_deep_w74.rs`: Document and test that `.jules/runs/**` is not treated as forbidden runtime state because it may be intentional PR provenance.
+- `xtask/src/tasks/bump.rs`
 
 ## 🧪 Verification receipts
 ```text
-$ cargo xtask docs --update
-Updated docs/reference-cli.md
-
-$ cargo xtask docs --check
-Documentation is up to date.
-
-$ cargo test -p tokmd --test docs
-test result: ok
-
 $ cargo test -p xtask
-test result: ok
+test result: ok. 50 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.60s
+$ cargo xtask docs --check
+doc artifacts ok: 2 required doc(s), 54 family file(s), 1 active goal(s), 19 spec-index artifact(s), 0 spec-index lane(s)
+$ cargo clippy -- -D warnings
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 32.32s
 ```
 
 ## 🧭 Telemetry
-- Change shape: Replacement of manual documentation content with auto-generated sync blocks plus docs-check and provenance-policy guardrails.
-- Blast radius: Docs and xtask validation only.
-- Risk class: Low - Does not change application runtime behavior.
-- Rollback: Revert the commit.
-- Gates run: `cargo xtask docs --update`, `cargo xtask docs --check`, `cargo test -p xtask`, `cargo test -p tokmd --test docs`, `cargo fmt-check`, `git diff --check`
+- Change shape: Workspace script update
+- Blast radius: Internal release automation (workspace tooling/manifests)
+- Risk class: Low - it only affects `cargo xtask bump --schema` which is manually invoked during releases.
+- Rollback: `git revert`
+- Gates run: `cargo test -p xtask`, `cargo xtask docs --check`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/gatekeeper_contracts/envelope.json`
@@ -62,4 +50,4 @@ test result: ok
 - `.jules/runs/gatekeeper_contracts/pr_body.md`
 
 ## 🔜 Follow-ups
-None. All CLI references are now correctly managed via xtask.
+None.

--- a/.jules/runs/gatekeeper_contracts/receipts.jsonl
+++ b/.jules/runs/gatekeeper_contracts/receipts.jsonl
@@ -2,3 +2,8 @@
 {"command": "cargo xtask docs --check", "result": "documentation is up to date and all expected marker pairs exist"}
 {"command": "cargo test -p xtask", "result": "xtask docs guard covered by task tests"}
 {"command": "cargo test -p tokmd --test docs", "result": "CLI docs integration tests passed"}
+{"command": "grep -A 20 -n \"const SCHEMA_LOCATIONS\" xtask/src/tasks/bump.rs", "output": "..."}
+{"command": "grep -Rn \"BASELINE_VERSION\" crates/", "output": "..."}
+{"command": "grep -Rn \"SENSOR_REPORT_SCHEMA\" crates/", "output": "..."}
+{"command": "cargo fmt", "result": "formatted successfully"}
+{"command": "cargo clippy -- -D warnings", "result": "clippy ok"}

--- a/.jules/runs/gatekeeper_contracts/result.json
+++ b/.jules/runs/gatekeeper_contracts/result.json
@@ -1,17 +1,4 @@
 {
-  "summary": "Fixed documentation drift by replacing manual parameter tables with `<!-- HELP: <command> -->` markers and failing docs checks when expected marker pairs are missing",
-  "files_changed": [
-    "docs/reference-cli.md",
-    "xtask/src/tasks/docs.rs",
-    "xtask/src/tasks/gate.rs",
-    "xtask/tests/xtask_deep_w74.rs"
-  ],
-  "gates_run": [
-    "cargo xtask docs --update",
-    "cargo xtask docs --check",
-    "cargo test -p xtask",
-    "cargo test -p tokmd --test docs",
-    "cargo fmt-check",
-    "git diff --check"
-  ]
+  "status": "success",
+  "story": "Added missing SCHEMA_LOCATIONS (BASELINE_VERSION and SENSOR_REPORT_SCHEMA) to xtask/src/tasks/bump.rs, enabling `cargo xtask bump --schema` to properly manage their versions and prevent contract drift. Also modified `bump.rs` string replacement logic to handle string literals (`&str` schemas like SENSOR_REPORT_SCHEMA) gracefully."
 }

--- a/xtask/src/tasks/bump.rs
+++ b/xtask/src/tasks/bump.rs
@@ -61,6 +61,16 @@ const SCHEMA_LOCATIONS: &[SchemaVersionLocation] = &[
         constant: "HANDOFF_SCHEMA_VERSION",
         current: 5,
     },
+    SchemaVersionLocation {
+        path: "crates/tokmd-analysis-types/src/baseline.rs",
+        constant: "BASELINE_VERSION",
+        current: 1,
+    },
+    SchemaVersionLocation {
+        path: "crates/tokmd-envelope/src/lib.rs",
+        constant: "SENSOR_REPORT_SCHEMA",
+        current: 1,
+    },
 ];
 
 const NODE_PACKAGE_MANIFESTS: &[&str] = &[
@@ -561,19 +571,39 @@ fn update_schema_version(
         .with_context(|| format!("Failed to read {}", location.path))?;
 
     // Find and replace the constant definition
-    let pattern = format!("pub const {}: u32 = ", constant_name);
+    let u32_pattern = format!("pub const {}: u32 = ", constant_name);
+    let str_pattern = format!("pub const {}: &str = \"", constant_name);
     let mut result = String::with_capacity(content.len());
     let mut found = false;
 
     for line in content.lines() {
-        if line.trim_start().starts_with(&pattern) {
-            // Replace this line
+        if line.trim_start().starts_with(&u32_pattern) {
             let indent = line.len() - line.trim_start().len();
             let spaces = &line[..indent];
             result.push_str(spaces);
             result.push_str(&format!(
                 "pub const {}: u32 = {};\n",
                 constant_name, new_version
+            ));
+            found = true;
+        } else if line.trim_start().starts_with(&str_pattern) {
+            let indent = line.len() - line.trim_start().len();
+            let spaces = &line[..indent];
+            result.push_str(spaces);
+
+            let current_str = location.current.to_string();
+            let new_str = new_version.to_string();
+
+            // Extract the string value part
+            let val_part = &line.trim_start()[str_pattern.len() - 1..];
+
+            // Just replace the current version string with the new one inside the quotes
+            let new_val_part =
+                val_part.replace(&format!("v{}", current_str), &format!("v{}", new_str));
+
+            result.push_str(&format!(
+                "pub const {}: &str = {}\n",
+                constant_name, new_val_part
             ));
             found = true;
         } else {


### PR DESCRIPTION
Added missing `SCHEMA_LOCATIONS` (`BASELINE_VERSION` and `SENSOR_REPORT_SCHEMA`) to `xtask/src/tasks/bump.rs` to allow the workspace bump tool to manage them. Modified `bump.rs` to properly replace string schemas (like `SENSOR_REPORT_SCHEMA`) instead of just `u32` integers, fulfilling the memory directive and locking in determinism.

---
*PR created automatically by Jules for task [12825642883026001252](https://jules.google.com/task/12825642883026001252) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Touches release-time `cargo xtask bump --schema` only; no runtime or application contract behavior changes.
> 
> **Overview**
> Registers **`BASELINE_VERSION`** and **`SENSOR_REPORT_SCHEMA`** in `SCHEMA_LOCATIONS` so `cargo xtask bump --schema` can bump them with the other contract version constants.
> 
> **`update_schema_version`** in `bump.rs` now handles **`pub const …: &str`** definitions (not only `u32`), updating embedded version segments in string literals (e.g. `sensor.report.v1` → `v2`) when a schema bump is applied.
> 
> Gatekeeper **`.jules/runs/gatekeeper_contracts/*`** artifacts were refreshed to document this contracts-determinism change instead of the prior CLI-docs work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ec96faf32088c2f920236cbaf57fa04957246b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->