### PR TITLE
palette: align check-ignore path not found error 🎨

### DIFF
--- a/.jules/runs/palette_runtime_dx/decision.md
+++ b/.jules/runs/palette_runtime_dx/decision.md
@@ -1,16 +1,14 @@
-## 💡 Options A and B
+# Decision
 
-### Option A: Improve error message formatting and guidance for Unrecognized subcommand
-- The current message is:
-  `Error: Unrecognized subcommand 'abc'`
-  `Hints:`
-  `- Verify the input path exists and is readable.`
-  `- Use an absolute path to avoid working-directory confusion.`
-- The hints are confusing because they refer to paths, not subcommands. The subcommand logic was added as a fallback to catch mis-parsed subcommands vs paths.
-- I will improve the hint to include listing available subcommands via `tokmd --help` instead of showing path hints when it is definitively interpreted as a subcommand.
+## Option A (recommended)
+Fix `tokmd check-ignore <nonexistent-path>` to report "Error: Path not found: <nonexistent-path>" instead of "Error: Path '<nonexistent-path>' does not exist". This aligns the error wording for `check-ignore` with all the other subcommands which report `Error: Path not found:` when a file doesn't exist. This also enables our general hint generator for "Path not found" to suggest to verify if the path exists, rather than just returning a plain error.
 
-### Option B: Fix enum value validation error messages
-- `error: invalid value 'xyz' for '--format <FORMAT>'` could provide better hints on how to list all options.
-- This is primarily handled by clap, so changing it might be more involved.
+- **Structure**: This requires updating `crates/tokmd/src/commands/check_ignore.rs` and the tests that verify the exact error text.
+- **Velocity**: This is a simple fix.
+- **Governance**: Low risk, improves CLI UX consistency.
 
-Decision: Option A.
+## Option B
+Do not fix `check-ignore` error messages and find another target.
+
+## ✅ Decision
+Option A. It's a small change but directly addresses the goal of improving "unclear or low-context error messages" by aligning the error output to a standard form that benefits from existing hint logic.

--- a/.jules/runs/palette_runtime_dx/envelope.json
+++ b/.jules/runs/palette_runtime_dx/envelope.json
@@ -1,10 +1,11 @@
 {
+  "run_id": "palette_runtime_dx",
   "prompt_id": "palette_runtime_dx",
-  "persona": "palette",
-  "style": "builder",
+  "persona": "Palette",
+  "style": "Builder",
   "primary_shard": "interfaces",
   "allowed_paths": [
-    "crates/tokmd-config/**",
+    "crates/tokmd-settings/**",
     "crates/tokmd-core/**",
     "crates/tokmd/**",
     "docs/reference-cli.md",
@@ -12,5 +13,5 @@
     "crates/tokmd/tests/**"
   ],
   "gate_profile": "core-rust",
-  "allowed_outcomes": ["pr-ready patch", "learning pr"]
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
 }

--- a/.jules/runs/palette_runtime_dx/pr_body.md
+++ b/.jules/runs/palette_runtime_dx/pr_body.md
@@ -1,82 +1,60 @@
 ## 💡 Summary
-Improves the error message hint when an unrecognized subcommand is provided. Instead of giving path-related hints (like "Verify the input path exists"), it now correctly suggests running `tokmd --help` to list available subcommands.
+Aligned the error output for `tokmd check-ignore <nonexistent-path>` to use the standard "Error: Path not found:" prefix instead of "Error: Path '<path>' does not exist".
 
 ## 🎯 Why
-When users mis-type a subcommand (and it's not close enough for the "Did you mean?" fuzzy matching), the CLI falls back to treating it as a bad path and displays path-related hints:
-```
-Error: Unrecognized subcommand 'abc'
-
-Hints:
-- Verify the input path exists and is readable.
-- Use an absolute path to avoid working-directory confusion.
-```
-This is confusing because the error clearly states it was parsed as a subcommand. This change ensures that when the parser definitively interprets the input as a bad subcommand, it provides a relevant hint to check the help menu.
+The `check-ignore` subcommand was emitting a unique error message string ("Path '<path>' does not exist") when asked to check a non-existent file. By aligning this to the standard `Path not found: <path>` message used by other subcommands, we trigger the CLI's global error hint machinery, which appends helpful troubleshooting suggestions (like verifying the path and using absolute paths) to the user.
 
 ## 🔎 Evidence
-Before:
-```bash
-$ cargo run --bin tokmd -- abc
-Error: Unrecognized subcommand 'abc'
+- `crates/tokmd/src/commands/check_ignore.rs`
+- Observed behavior: `cargo run -- check-ignore non-exist.rs` printed `Error: Path 'non-exist.rs' does not exist` without any hints.
+- After change: `cargo run -- check-ignore non-exist.rs`
+```text
+Error: Path not found: non-exist.rs
 
 Hints:
 - Verify the input path exists and is readable.
 - Use an absolute path to avoid working-directory confusion.
-```
-
-After:
-```bash
-$ cargo run --bin tokmd -- abc
-Error: Unrecognized subcommand 'abc'
-
-Hints:
-- Run `tokmd --help` to see a list of available subcommands.
 ```
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- Update `error_hints.rs` to detect when a bare string without path separators is definitively treated as an unrecognized subcommand and return a hint pointing to `--help`, skipping the path-related hints.
-- Why it fits: Directly fixes the confusing output with minimal code changes. Preserves "Did you mean?" suggestions for typos and path-related hints for actual paths.
-- Trade-offs: Low risk, high value DX improvement.
+- what it is: Update `crates/tokmd/src/commands/check_ignore.rs` and the related test string to output "Path not found: <path>".
+- why it fits this repo and shard: It directly improves the runtime developer experience (Palette's goal) by providing clear, consistent context and activating existing hint logic, adhering strictly to the `interfaces` shard.
+- trade-offs:
+  - Structure: Requires modifying the hardcoded string and test assertion.
+  - Velocity: Extremely fast to implement and verify.
+  - Governance: Low risk, purely a UX consistency improvement.
 
 ### Option B
-- Modify clap's parsing to completely separate path arguments from subcommands so they never fall back to each other.
-- When to choose it instead: If the CLI syntax allowed strict positional separation of paths vs subcommands.
-- Trade-offs: High risk. Would require restructuring the CLI syntax and breaking backwards compatibility.
+- what it is: Do not fix `check-ignore` error messages and find another target.
+- when to choose it instead: If the unique error string served a specific contractual purpose (it does not).
+- trade-offs: Leaves a known UX gap unresolved.
 
 ## ✅ Decision
-Option A was chosen because it directly addresses the confusing output at the point of error formatting, preserving the flexible CLI syntax while significantly improving the user experience for simple mistakes.
+Option A was chosen as it aligns perfectly with the goal of improving unclear error messages by using the existing generic hint machinery.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd/src/error_hints.rs`: Updated `suggestions` function to return an early hint `Run \`tokmd --help\` to see a list of available subcommands.` when an unrecognized subcommand is detected and no fuzzy match is found. Updated tests to reflect the new hint.
+- `crates/tokmd/src/commands/check_ignore.rs`
 
 ## 🧪 Verification receipts
 ```text
-$ cargo run --bin tokmd -- abc
-Error: Unrecognized subcommand 'abc'
-
-Hints:
-- Run `tokmd --help` to see a list of available subcommands.
-
-$ cargo run --bin tokmd -- anolyze
-Error: Unrecognized subcommand 'anolyze'
-
-Hints:
-- Did you mean the subcommand `analyze`?
-
-$ cargo run --bin tokmd -- missing/path/to/file
-Error: Path not found: missing/path/to/file
+$ cargo run -- check-ignore non-exist.rs
+Error: Path not found: non-exist.rs
 
 Hints:
 - Verify the input path exists and is readable.
 - Use an absolute path to avoid working-directory confusion.
+
+$ cargo test -p tokmd --test cli_error_paths_w51
+test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.15s
 ```
 
 ## 🧭 Telemetry
-- Change shape: Logic modification
-- Blast radius: Output wording
-- Risk class: Low - Only affects error message formatting
-- Rollback: Revert `error_hints.rs` changes
-- Gates run: `core-rust` (cargo build, CI=true cargo test, cargo fmt, cargo clippy)
+- Change shape: Minor string alignment
+- Blast radius: Output wording for `tokmd check-ignore` on missing paths.
+- Risk class: Low - affects error string matching only (updated test).
+- Rollback: Revert the string in `check_ignore.rs`.
+- Gates run: `core-rust` (test, fmt, clippy, build)
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/palette_runtime_dx/envelope.json`
@@ -86,4 +64,4 @@ Hints:
 - `.jules/runs/palette_runtime_dx/pr_body.md`
 
 ## 🔜 Follow-ups
-None.
+None

--- a/.jules/runs/palette_runtime_dx/receipts.jsonl
+++ b/.jules/runs/palette_runtime_dx/receipts.jsonl
@@ -1,5 +1,2 @@
-{"timestamp": "2023-10-24T00:00:00.000Z", "command": "cargo run --bin tokmd -- abc", "output": "Error: Unrecognized subcommand 'abc'\n\nHints:\n- Run `tokmd --help` to see a list of available subcommands."}
-{"timestamp": "2023-10-24T00:00:00.000Z", "command": "cargo run --bin tokmd -- missing-command", "output": "Error: Unrecognized subcommand 'missing-command'\n\nHints:\n- Run `tokmd --help` to see a list of available subcommands."}
-{"timestamp": "2023-10-24T00:00:00.000Z", "command": "cargo run --bin tokmd -- missing/path/to/file", "output": "Error: Path not found: missing/path/to/file\n\nHints:\n- Verify the input path exists and is readable.\n- Use an absolute path to avoid working-directory confusion."}
-{"timestamp": "2023-10-24T00:00:00.000Z", "command": "cargo run --bin tokmd -- anolyze", "output": "Error: Unrecognized subcommand 'anolyze'\n\nHints:\n- Did you mean the subcommand `analyze`?"}
-{"timestamp": "2023-10-24T00:00:00.000Z", "command": "cargo test -p tokmd", "output": "test result: ok. 506 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.96s"}
+{"command":"cargo run -- check-ignore non-exist.rs","outcome":"Error: Path not found: non-exist.rs\n\nHints:\n- Verify the input path exists and is readable.\n- Use an absolute path to avoid working-directory confusion.\n"}
+{"command":"cargo test -p tokmd --test cli_error_paths_w51","outcome":"test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.15s"}

--- a/.jules/runs/palette_runtime_dx/result.json
+++ b/.jules/runs/palette_runtime_dx/result.json
@@ -1,4 +1,5 @@
 {
   "status": "success",
-  "outcome": "pr-ready patch"
+  "reason": "Aligned check-ignore missing path error to use 'Path not found' format, fixing issue where the general hints for missing path were not being shown.",
+  "outcome_type": "PR-ready patch"
 }

--- a/crates/tokmd/src/commands/check_ignore.rs
+++ b/crates/tokmd/src/commands/check_ignore.rs
@@ -68,7 +68,7 @@ fn check_path(path: &Path, global: &cli::GlobalArgs, verbose: bool) -> Result<Ch
     // keeps access errors distinct from true missing paths.
     match path.try_exists() {
         Ok(true) => {}
-        Ok(false) => return Err(anyhow::anyhow!("Path '{}' does not exist", path_str)),
+        Ok(false) => return Err(anyhow::anyhow!("Path not found: {}", path_str)),
         Err(err) => {
             return Err(err).with_context(|| format!("failed to access path '{}'", path_str));
         }
@@ -366,7 +366,7 @@ mod tests {
             Ok(_) => panic!("missing path should error"),
             Err(err) => err,
         };
-        assert!(err.to_string().contains("does not exist"));
+        assert!(err.to_string().contains("Path not found"));
         Ok(())
     }
 

--- a/crates/tokmd/tests/init_cli_w76.rs
+++ b/crates/tokmd/tests/init_cli_w76.rs
@@ -160,7 +160,7 @@ fn check_ignore_nonexistent_path_reports_not_ignored() {
         .arg(&missing)
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("does not exist"));
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -173,5 +173,5 @@ fn check_ignore_verbose_shows_detail() {
         .arg(&missing)
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("does not exist"));
+        .stderr(predicate::str::contains("Path not found"));
 }


### PR DESCRIPTION
## 💡 Summary
Aligned the error output for `tokmd check-ignore <nonexistent-path>` to use the standard "Error: Path not found:" prefix instead of "Error: Path '<path>' does not exist".

## 🎯 Why
The `check-ignore` subcommand was emitting a unique error message string ("Path '<path>' does not exist") when asked to check a non-existent file. By aligning this to the standard `Path not found: <path>` message used by other subcommands, we trigger the CLI's global error hint machinery, which appends helpful troubleshooting suggestions (like verifying the path and using absolute paths) to the user.

## 🔎 Evidence
- `crates/tokmd/src/commands/check_ignore.rs`
- Observed behavior: `cargo run -- check-ignore non-exist.rs` printed `Error: Path 'non-exist.rs' does not exist` without any hints.
- After change: `cargo run -- check-ignore non-exist.rs`
```text
Error: Path not found: non-exist.rs

Hints:
- Verify the input path exists and is readable.
- Use an absolute path to avoid working-directory confusion.
```

## 🧭 Options considered
### Option A (recommended)
- what it is: Update `crates/tokmd/src/commands/check_ignore.rs` and the related test string to output "Path not found: <path>".
- why it fits this repo and shard: It directly improves the runtime developer experience (Palette's goal) by providing clear, consistent context and activating existing hint logic, adhering strictly to the `interfaces` shard.
- trade-offs: 
  - Structure: Requires modifying the hardcoded string and test assertion.
  - Velocity: Extremely fast to implement and verify.
  - Governance: Low risk, purely a UX consistency improvement.

### Option B
- what it is: Do not fix `check-ignore` error messages and find another target.
- when to choose it instead: If the unique error string served a specific contractual purpose (it does not).
- trade-offs: Leaves a known UX gap unresolved.

## ✅ Decision
Option A was chosen as it aligns perfectly with the goal of improving unclear error messages by using the existing generic hint machinery.

## 🧱 Changes made (SRP)
- `crates/tokmd/src/commands/check_ignore.rs`
- `crates/tokmd/tests/init_cli_w76.rs`

## 🧪 Verification receipts
```text
$ cargo run -- check-ignore non-exist.rs
Error: Path not found: non-exist.rs

Hints:
- Verify the input path exists and is readable.
- Use an absolute path to avoid working-directory confusion.

$ cargo test -p tokmd --test cli_error_paths_w51
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.15s

$ CI=true cargo test --verbose -p tokmd
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.58s
```

## 🧭 Telemetry
- Change shape: Minor string alignment
- Blast radius: Output wording for `tokmd check-ignore` on missing paths.
- Risk class: Low - affects error string matching only (updated test).
- Rollback: Revert the string in `check_ignore.rs`.
- Gates run: `core-rust` (test, fmt, clippy, build)

## 🗂️ .jules artifacts
- `.jules/runs/palette_runtime_dx/envelope.json`
- `.jules/runs/palette_runtime_dx/decision.md`
- `.jules/runs/palette_runtime_dx/receipts.jsonl`
- `.jules/runs/palette_runtime_dx/result.json`
- `.jules/runs/palette_runtime_dx/pr_body.md`

## 🔜 Follow-ups
None

---
*PR created automatically by Jules for task [10497284555060535629](https://jules.google.com/task/10497284555060535629) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI error-string change only; behavior unchanged aside from wording and hints; tests assert the new message.
> 
> **Overview**
> **`tokmd check-ignore`** now reports **`Path not found: <path>`** when the target does not exist, instead of **`Path '<path>' does not exist`**.
> 
> That matches other subcommands and lets the shared **`error_hints`** logic attach the usual troubleshooting hints (verify the path, prefer absolute paths). Unit and CLI integration tests were updated to expect the new text. Jules run metadata under **`.jules/runs/palette_runtime_dx/`** documents the decision and verification receipts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 117f988d77137945f0890d89d0f39cdd7ba82a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->