### PR TITLE
bolt: remove string allocation overhead from cyclonedx exporter ⚡

### DIFF
--- a/.jules/runs/bolt_core_pipeline_refactorer/decision.md
+++ b/.jules/runs/bolt_core_pipeline_refactorer/decision.md
@@ -1,0 +1,19 @@
+### Option A (recommended)
+
+- **What it is:** Update `CycloneDxComponent` logic to use macro formats or `.to_string()` directly if macro not applicable. More specifically, right now, in `crates/tokmd-format/src/export/cyclonedx.rs`, `write_export_cyclonedx_impl` allocates `String`s for property values in every row like this:
+  `value: row.code.to_string()`
+  And for names it uses `name: "tokmd:code".to_string()`.
+
+Wait, actually, I noticed in several places `.to_string()` and `format!` are being called excessively. Let's look closely at `cyclonedx.rs`. The `name` fields of `CycloneDxProperty` are static strings! They don't need to be allocated as `String`. They could be `Cow<'static, str>` or just `String` but initialized more efficiently, though `CycloneDxProperty` struct requires `String` in `crates/tokmd-format/src/export/cyclonedx.rs`. Wait, we can change `CycloneDxProperty` to use `&'static str` for `name` if we own the struct! `CycloneDxProperty` is a private struct.
+
+Let's look at `CycloneDxProperty`:
+```rust
+#[derive(Debug, Clone, Serialize)]
+struct CycloneDxProperty {
+    name: String,
+    value: String,
+}
+```
+We can change `name: &'static str`, which avoids allocating 7 strings per file row.
+
+Let's do a quick structural proof/benchmark of this.

--- a/.jules/runs/bolt_core_pipeline_refactorer/envelope.json
+++ b/.jules/runs/bolt_core_pipeline_refactorer/envelope.json
@@ -1,0 +1,17 @@
+{
+  "run_id": "bolt_core_pipeline_refactorer",
+  "persona": "bolt",
+  "style": "refactorer",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**"
+  ],
+  "gate_profile": "perf-proof",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/bolt_core_pipeline_refactorer/pr_body.md
+++ b/.jules/runs/bolt_core_pipeline_refactorer/pr_body.md
@@ -1,0 +1,50 @@
+## 💡 Summary
+Removed unnecessary `String` allocations for static property names in the CycloneDX exporter. This structural improvement prevents 7+ string allocations per file row during SBOM export.
+
+## 🎯 Why
+During CycloneDX export (`tokmd-format` crate), the `CycloneDxProperty` struct was declaring `name: String`, forcing allocations for static strings like `"tokmd:code"`, `"tokmd:lang"`, etc. For large repos, allocating strings per property per file scales poorly and slows down export while increasing peak memory usage.
+
+## 🔎 Evidence
+Minimal proof:
+- file path: `crates/tokmd-format/src/export/cyclonedx.rs`
+- observed behavior: `CycloneDxProperty` defined `name: String`, and the exporter iterated rows, doing `name: "tokmd:code".to_string()`.
+- The fix correctly changes `name` to `&'static str` for static keys.
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Update `CycloneDxProperty` struct to use `&'static str` for the `name` field, removing `.to_string()` for static keys.
+- why it fits this repo and shard: Direct structural performance win in formatting pipeline, strictly avoiding allocations.
+- trade-offs: Structure / Velocity / Governance - Structure improves, velocity is unchanged, governance stays in line with performance expectations.
+
+### Option B
+- what it is: Use `Cow<'static, str>` instead of `&'static str`.
+- when to choose it instead: If the `name` field needed to be dynamically generated occasionally.
+- trade-offs: More complex code for no added benefit since all properties here use static literal names.
+
+## ✅ Decision
+Chose Option A to strictly eliminate the allocation without complexity overhead.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-format/src/export/cyclonedx.rs`
+
+## 🧪 Verification receipts
+```text
+test result: ok. 144 passed; 0 failed
+```
+
+## 🧭 Telemetry
+- Change shape: Optimization (structural/hot-path reduction)
+- Blast radius: Local to `tokmd-format` CycloneDX serialization. Does not alter JSON schemas structurally, just reduces allocations under the hood before serialization.
+- Risk class + why: Low risk. Serialization outputs identical JSON.
+- Rollback: Revert the PR.
+- Gates run: `cargo check`, `cargo test`, `cargo fmt`, `cargo clippy`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/bolt_core_pipeline_refactorer/envelope.json`
+- `.jules/runs/bolt_core_pipeline_refactorer/decision.md`
+- `.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl`
+- `.jules/runs/bolt_core_pipeline_refactorer/result.json`
+- `.jules/runs/bolt_core_pipeline_refactorer/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl
+++ b/.jules/runs/bolt_core_pipeline_refactorer/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "python3 update_cyclonedx_struct.py", "stdout": ""}
+{"command": "cargo test -p tokmd-format", "stdout": "test result: ok. 144 passed; 0 failed"}

--- a/.jules/runs/bolt_core_pipeline_refactorer/result.json
+++ b/.jules/runs/bolt_core_pipeline_refactorer/result.json
@@ -1,0 +1,7 @@
+{
+  "status": "success",
+  "changed_files": [
+    "crates/tokmd-format/src/export/cyclonedx.rs"
+  ],
+  "message": "Replaced unnecessary String allocations with &'static str in CycloneDX properties."
+}

--- a/crates/tokmd-format/src/export/cyclonedx.rs
+++ b/crates/tokmd-format/src/export/cyclonedx.rs
@@ -52,7 +52,7 @@ struct CycloneDxComponent {
 
 #[derive(Debug, Clone, Serialize)]
 struct CycloneDxProperty {
-    name: String,
+    name: &'static str,
     value: String,
 }
 
@@ -81,38 +81,38 @@ pub(super) fn write_export_cyclonedx_impl<W: Write>(
         .map(|row| {
             let mut properties = vec![
                 CycloneDxProperty {
-                    name: "tokmd:lang".to_string(),
+                    name: "tokmd:lang",
                     value: row.lang.clone(),
                 },
                 CycloneDxProperty {
-                    name: "tokmd:code".to_string(),
+                    name: "tokmd:code",
                     value: row.code.to_string(),
                 },
                 CycloneDxProperty {
-                    name: "tokmd:comments".to_string(),
+                    name: "tokmd:comments",
                     value: row.comments.to_string(),
                 },
                 CycloneDxProperty {
-                    name: "tokmd:blanks".to_string(),
+                    name: "tokmd:blanks",
                     value: row.blanks.to_string(),
                 },
                 CycloneDxProperty {
-                    name: "tokmd:lines".to_string(),
+                    name: "tokmd:lines",
                     value: row.lines.to_string(),
                 },
                 CycloneDxProperty {
-                    name: "tokmd:bytes".to_string(),
+                    name: "tokmd:bytes",
                     value: row.bytes.to_string(),
                 },
                 CycloneDxProperty {
-                    name: "tokmd:tokens".to_string(),
+                    name: "tokmd:tokens",
                     value: row.tokens.to_string(),
                 },
             ];
 
             if row.kind == FileKind::Child {
                 properties.push(CycloneDxProperty {
-                    name: "tokmd:kind".to_string(),
+                    name: "tokmd:kind",
                     value: "child".to_string(),
                 });
             }


### PR DESCRIPTION
Removed unnecessary String allocations for static property names in the CycloneDX exporter. This structural improvement prevents 7+ string allocations per file row during SBOM export.

---
*PR created automatically by Jules for task [11083591166804651553](https://jules.google.com/task/11083591166804651553) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized serialization struct change in `tokmd-format` with identical JSON shape; verified by `tokmd-format` tests.
> 
> **Overview**
> **CycloneDX export** no longer allocates a `String` for each fixed `tokmd:*` property name on every file row. `CycloneDxProperty.name` is now `&'static str`, and the exporter passes string literals instead of calling `.to_string()` on keys like `"tokmd:code"` and `"tokmd:lang"`.
> 
> Property **values** are unchanged (still owned strings where needed). Serialized CycloneDX JSON should match prior output; the win is fewer allocations on large SBOM exports.
> 
> The PR also adds **`.jules/runs/bolt_core_pipeline_refactorer/`** artifacts (envelope, decision, receipts, result, pr body) documenting the Jules perf run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c1405e20c75451ee595b21d000d47fe1e558ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->