### PR TITLE
palette: Expose error suggestions in JSON envelope 🎨

### DIFF
--- a/.jules/runs/palette_binding_dx/decision.md
+++ b/.jules/runs/palette_binding_dx/decision.md
@@ -1,3 +1,19 @@
-Option A: Fix parse error messages to show the exact path to the failed JSON field (e.g. `inputs[0].path` instead of just `inputs[0]`).
-Option B: Expose a detailed schema response. Takes longer.
-Decision: Option A provides clear developer experience by pointing directly to the invalid field, preventing guessing in JSON FFI integrations.
+# DX Improvement Decision
+
+## Option A: Expose Error Suggestions in Python/Node Bindings (Recommended)
+**What it is:** Update `TokmdError` -> `ErrorDetails` serialization in `tokmd-core` to include the `suggestions` field if present, and update `format_error_message` in `tokmd-envelope` to display them. This will make actionable error hints (like those for missing git) visible in Python, Node, and Web targets.
+**Why it fits:** The task asks to improve runtime DX across target surfaces. `TokmdError` has a `suggestions` field that isn't included in the JSON envelope, meaning bindings like Node/Python just show `[git_not_available] git is not available on PATH` without the help text.
+**Trade-offs:**
+- Structure: Touches core error envelope and envelope parsing logic.
+- Velocity: Simple serialization and formatting additions.
+- Governance: Safe since the `suggestions` field already exists in Rust CLI, just needs exposing.
+
+## Option B: Add custom typed exceptions per error code
+**What it is:** Create specific exception classes for Node/Python (e.g., `TokmdPathNotFoundError`) based on the error code.
+**When to choose it instead:** If bindings users specifically requested fine-grained try/catch error handling.
+**Trade-offs:**
+- Massive API surface increase.
+- Brittle mappings from string error codes to language-specific exceptions.
+
+## Decision
+**Option A**. Exposing `suggestions` directly improves the lowest-context error messages (like `git_not_available` or `path_not_found`) in bindings without changing the API contract.

--- a/.jules/runs/palette_binding_dx/envelope.json
+++ b/.jules/runs/palette_binding_dx/envelope.json
@@ -1,7 +1,7 @@
 {
   "prompt_id": "palette_binding_dx",
-  "persona": "palette",
-  "style": "prover",
+  "persona": "Palette",
+  "style": "Prover",
   "primary_shard": "bindings-targets",
   "allowed_paths": [
     "crates/tokmd-python/**",
@@ -12,9 +12,5 @@
     "docs/**"
   ],
   "gate_profile": "core-rust",
-  "allowed_outcomes": [
-    "proof-improvement patch",
-    "PR-ready patch",
-    "learning PR"
-  ]
+  "allowed_outcomes": ["proof-improvement patch", "PR-ready patch", "learning PR"]
 }

--- a/.jules/runs/palette_binding_dx/pr_body.md
+++ b/.jules/runs/palette_binding_dx/pr_body.md
@@ -1,44 +1,56 @@
 ## 💡 Summary
-Updated `TokmdError::invalid_field` to embed exact field paths into the FFI error response payload under `error.details`. This makes invalid FFI config parameters immediately understandable for Py/Node/WASM bindings.
+Exposed the `suggestions` array inside the `TokmdError` JSON envelope, and updated the `tokmd-envelope` formatter to display them. This drastically improves the developer experience in bindings (Node/Python/Wasm) for low-context errors like `git_not_available` or `path_not_found`.
 
 ## 🎯 Why
-When language bindings (Python, Node, WASM) pass invalid JSON configs to the `run_json` FFI endpoint, they receive an `invalid_settings` error code. Previously, the error message contained the field path, but parsing a localized message string programmatically was poor developer experience. Adding `details` populates the structured `error.details` property natively in JSON with the exact field path (e.g., `inputs[0].path`) out-of-the-box.
+The CLI binary had helpful error messages natively, but `TokmdError` failed to serialize its `suggestions` into the FFI JSON envelope. Because bindings parse errors back using `tokmd_envelope::ffi::format_error_message`, errors without actionable suggestions were confusing and created poor DX for library users.
 
 ## 🔎 Evidence
-- `crates/tokmd-core/src/error.rs` contained `invalid_field` which used `Self::new`, leaving `details: None`.
-- Running `cat crates/tokmd-core/src/error.rs | grep -A 10 "pub fn invalid_field"` confirmed `Self::new` usage.
+Before this change, bindings would fail with:
+`[git_not_available] git is not available on PATH`
+
+After this change, `tokmd-envelope` successfully propagates suggestions, outputting:
+```
+[git_not_available] git is not available on PATH
+
+Suggestions:
+  - Install git from https://git-scm.com/downloads
+  - Ensure git is in your system PATH
+  - Verify installation by running: git --version
+```
+I added targeted tests to `tokmd-core` and `tokmd-envelope` to prove the roundtrip serialization and formatting work correctly.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- what it is: Update `TokmdError::invalid_field` to use `Self::with_details` instead of `Self::new`, passing the `field` string as the `details` field.
-- why it fits this repo and shard: Safely improves the DX for python/node/wasm callers with an immediate programmatic hint inside the shard's bounds without breaking schema layout.
-- trade-offs: Structure / Velocity / Governance - Zero overhead, immediate DX fix.
+- Expose `suggestions` via `ErrorDetails` serialization.
+- This is a non-breaking, minimal-surface addition that fits nicely in the envelope layer without polluting bindings with domain-specific string parsing.
+- Trade-offs: Minor increase to envelope JSON string size.
 
 ### Option B
-- what it is: Expose a detailed schema response or a unified diagnostic endpoint.
-- when to choose it instead: If the FFI schema required sweeping architecture changes for runtime schemas.
-- trade-offs: Takes longer and would overcomplicate the core boundary.
+- Add specific exception classes per target language (Node/Python/Wasm).
+- Trade-offs: Tremendous API surface increase across targets for simple error messages.
 
 ## ✅ Decision
-Option A is safer, within the shard limits, provides immediate DX improvements, and locks down the interface for node/wasm/python callers by ensuring parse errors return [invalid_settings] code with the specific field details.
+Option A was chosen. Reusing the Rust-provided `suggestions` provides the best DX to bindings with the smallest API surface.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd-core/src/error.rs`: Updated `TokmdError::invalid_field` to use `Self::with_details` setting `details` to the field name. Also updated `invalid_field_error` test to assert on `details`.
-- `crates/tokmd-core/tests/error_types.rs`: Updated `invalid_field_error` test to assert on `details`.
+- `crates/tokmd-core/src/error.rs`: Map `suggestions` during `TokmdError` -> `ErrorDetails` serialization.
+- `crates/tokmd-envelope/src/ffi.rs`: Render `suggestions` string in `format_error_message()`.
+- `crates/tokmd-core/tests/error_suggestions.rs`: Verification test for JSON envelope inclusion.
+- `crates/tokmd-envelope/tests/format_error_suggestions.rs`: Verification test for error formatting.
 
 ## 🧪 Verification receipts
 ```text
-grep -A 15 "pub fn invalid_field" crates/tokmd-core/src/error.rs
-CI=true cargo test -p tokmd-core --verbose
-cargo fmt -- --check && cargo clippy -- -D warnings
+cargo test -p tokmd-core --test error_suggestions
+cargo test -p tokmd-envelope --test format_error_suggestions
+cargo clippy -p tokmd-core -p tokmd-envelope -- -D warnings
+cargo test --workspace --all-targets --color=always
 ```
 
 ## 🧭 Telemetry
-- Change shape: Implementation Patch
-- Blast radius: API (safe addition of `details` payload to error envelopes for FFI).
-- Risk class: Low
-- Rollback: Revert the `with_details` change in `invalid_field`.
-- Gates run: `cargo build --verbose`, `CI=true cargo test --verbose`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`
+- Blast radius: API (Bindings string error output), Error format parity
+- Risk class: Low, pure additions to error messages without behavior changes
+- Rollback: Revert `error.rs` and `ffi.rs` changes
+- Gates run: `core-rust` (test, clippy, build)
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/palette_binding_dx/envelope.json`
@@ -48,4 +60,4 @@ cargo fmt -- --check && cargo clippy -- -D warnings
 - `.jules/runs/palette_binding_dx/pr_body.md`
 
 ## 🔜 Follow-ups
-None.
+None

--- a/.jules/runs/palette_binding_dx/receipts.jsonl
+++ b/.jules/runs/palette_binding_dx/receipts.jsonl
@@ -1,3 +1,1 @@
-{"timestamp": "2024-05-11T12:00:00Z", "command": "grep -A 15 \"pub fn invalid_field\" crates/tokmd-core/src/error.rs", "output": "pub fn invalid_field(field: &str, expected: &str) -> Self {\n    Self::new(\n        ErrorCode::InvalidSettings,\n        format!(\"Invalid value for '{}': expected {}\", field, expected),\n    )\n}"}
-{"timestamp": "2024-05-11T12:05:00Z", "command": "CI=true cargo test -p tokmd-core --verbose", "output": "test result: ok. 184 passed; 0 failed"}
-{"timestamp": "2024-05-11T12:10:00Z", "command": "cargo fmt -- --check && cargo clippy -- -D warnings", "output": "Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s"}
+{"command": "cargo test -p tokmd-core --test error_suggestions", "status": "success"}\n{"command": "cargo test -p tokmd-envelope --test format_error_suggestions", "status": "success"}\n

--- a/.jules/runs/palette_binding_dx/result.json
+++ b/.jules/runs/palette_binding_dx/result.json
@@ -1,4 +1,1 @@
-{
-  "status": "success",
-  "summary": "Updated `invalid_field` to embed exact field paths into the FFI error response payload under `error.details`. This makes invalid FFI config parameters immediately understandable for Py/Node/WASM bindings."
-}
+{"status": "success", "outcome": "proof-improvement patch", "story": "Expose `suggestions` field in `TokmdError` across language bindings via JSON envelope."}

--- a/crates/tokmd-core/src/error.rs
+++ b/crates/tokmd-core/src/error.rs
@@ -356,6 +356,9 @@ pub struct ErrorDetails {
     /// Optional additional details.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<String>,
+    /// Optional helpful suggestions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggestions: Option<Vec<String>>,
 }
 
 impl From<&TokmdError> for ErrorDetails {
@@ -364,6 +367,7 @@ impl From<&TokmdError> for ErrorDetails {
             code: err.code.to_string(),
             message: err.message.clone(),
             details: err.details.clone(),
+            suggestions: err.suggestions.clone(),
         }
     }
 }

--- a/crates/tokmd-core/tests/error_suggestions.rs
+++ b/crates/tokmd-core/tests/error_suggestions.rs
@@ -1,5 +1,5 @@
-use tokmd_core::ffi::run_json;
 use serde_json::Value;
+use tokmd_core::ffi::run_json;
 
 #[test]
 fn missing_git_includes_suggestions_in_envelope() {

--- a/crates/tokmd-core/tests/error_suggestions.rs
+++ b/crates/tokmd-core/tests/error_suggestions.rs
@@ -1,0 +1,20 @@
+use tokmd_core::ffi::run_json;
+use serde_json::Value;
+
+#[test]
+fn missing_git_includes_suggestions_in_envelope() {
+    let args = serde_json::json!({
+        "mode": "diff",
+        "from": "missing",
+        "to": "also_missing"
+    });
+    let result = run_json("diff", &args.to_string());
+    let value: Value = serde_json::from_str(&result).unwrap();
+
+    assert_eq!(value["ok"], false);
+
+    let error = &value["error"];
+    assert!(error.get("suggestions").is_some());
+    let suggestions = error["suggestions"].as_array().unwrap();
+    assert!(!suggestions.is_empty());
+}

--- a/crates/tokmd-envelope/src/ffi.rs
+++ b/crates/tokmd-envelope/src/ffi.rs
@@ -92,6 +92,16 @@ pub fn format_error_message(error_obj: Option<&Value>) -> String {
         format!("[{code}] {message}")
     };
 
+    if let Some(suggestions) = error_obj.get("suggestions").and_then(Value::as_array).filter(|a| !a.is_empty()) {
+        formatted.push_str("\n\nSuggestions:");
+        for suggestion in suggestions {
+            if let Some(s) = suggestion.as_str() {
+                use std::fmt::Write;
+                let _ = write!(formatted, "\n  - {s}");
+            }
+        }
+    }
+
     if is_rate_limit_code(code) {
         if let Some(seconds) = retry_after_seconds(error_obj) {
             formatted.push_str(&format!(

--- a/crates/tokmd-envelope/src/ffi.rs
+++ b/crates/tokmd-envelope/src/ffi.rs
@@ -92,7 +92,11 @@ pub fn format_error_message(error_obj: Option<&Value>) -> String {
         format!("[{code}] {message}")
     };
 
-    if let Some(suggestions) = error_obj.get("suggestions").and_then(Value::as_array).filter(|a| !a.is_empty()) {
+    if let Some(suggestions) = error_obj
+        .get("suggestions")
+        .and_then(Value::as_array)
+        .filter(|a| !a.is_empty())
+    {
         formatted.push_str("\n\nSuggestions:");
         for suggestion in suggestions {
             if let Some(s) = suggestion.as_str() {

--- a/crates/tokmd-envelope/tests/format_error_suggestions.rs
+++ b/crates/tokmd-envelope/tests/format_error_suggestions.rs
@@ -1,5 +1,5 @@
-use tokmd_envelope::ffi::format_error_message;
 use serde_json::json;
+use tokmd_envelope::ffi::format_error_message;
 
 #[test]
 fn format_error_message_includes_suggestions() {

--- a/crates/tokmd-envelope/tests/format_error_suggestions.rs
+++ b/crates/tokmd-envelope/tests/format_error_suggestions.rs
@@ -1,0 +1,20 @@
+use tokmd_envelope::ffi::format_error_message;
+use serde_json::json;
+
+#[test]
+fn format_error_message_includes_suggestions() {
+    let err = json!({
+        "code": "git_not_available",
+        "message": "git is not available on PATH",
+        "suggestions": [
+            "Install git",
+            "Ensure git is in PATH"
+        ]
+    });
+
+    let msg = format_error_message(Some(&err));
+    assert!(msg.contains("[git_not_available] git is not available on PATH"));
+    assert!(msg.contains("Suggestions:"));
+    assert!(msg.contains("  - Install git"));
+    assert!(msg.contains("  - Ensure git is in PATH"));
+}


### PR DESCRIPTION
Exposed the `suggestions` array inside the `TokmdError` JSON envelope, and updated the `tokmd-envelope` formatter to display them. This drastically improves the developer experience in bindings (Node/Python/Wasm) for low-context errors like `git_not_available` or `path_not_found`.

---
*PR created automatically by Jules for task [18440883913068128873](https://jules.google.com/task/18440883913068128873) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON field and error-string formatting only; no change to success paths or error codes.
> 
> **Overview**
> **Bindings and FFI callers now get the same actionable hints the CLI already had** by serializing `TokmdError.suggestions` into the JSON error envelope and printing them in formatted error strings.
> 
> `ErrorDetails` gains an optional `suggestions` field, populated in the `From<&TokmdError>` mapping so `run_json` error responses include the array when present. `tokmd-envelope`’s `format_error_message` appends a **Suggestions:** block with bullet lines after the `[code] message` line (unchanged when the array is missing or empty).
> 
> New tests cover a `run_json` round-trip (e.g. missing git) and formatter output for `git_not_available`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ca3c8b98c2360583b44802faf33b4b1fb46025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->