### PR TITLE
specsmith: standardize missing path errors to trigger hints 🧪

### DIFF
--- a/.jules/runs/specsmith_interfaces/decision.md
+++ b/.jules/runs/specsmith_interfaces/decision.md
@@ -1,18 +1,16 @@
-## Options Considered
+## 🧭 Options considered
 
-### Option A: Add integration test for `resolve_lang_with_config` (Recommended)
-- **What it is**: Implement `test_resolve_lang_with_config` in `crates/tokmd/tests/config_resolution.rs`.
-- **Why it fits this repo and shard**: The `interfaces` shard explicitly covers `crates/tokmd-config` and `crates/tokmd/src/config.rs`. Adding missing BDD/integration coverage for this critical path addresses the highest ranked target ("1) missing BDD/integration coverage for an important path") for the Specsmith persona.
-- **Trade-offs**:
-  - Structure: High. Ensures that CLI overrides of `lang` command settings correctly take precedence over TOML and JSON configurations.
-  - Velocity: High. A straightforward addition that plugs a direct gap in `tokmd`'s testing matrix.
-  - Governance: High. Locks in determinism for how configuration sources are prioritized.
+### Option A (recommended)
+Fix bug in `check_ignore` where it printed the wrong error message format for non-existent files.
+- what it is: Update `crates/tokmd/src/commands/check_ignore.rs` and `crates/tokmd/src/commands/diff.rs` to correctly output "Path not found: ..." for missing paths. Also update `crates/tokmd-scan/src/tokeignore/mod.rs` to be aligned.
+- why it fits this repo and shard: It aligns error messages to the expected format so that `error_hints` correctly triggers. This fits the `interfaces` shard and the `Specsmith` persona's objective to fix edge case regressions and improve polish around CLI interfaces.
+- trade-offs: Structure / Velocity / Governance: Low risk change that improves the CLI error handling.
 
-### Option B: Add unit test for `resolve_profile`
-- **What it is**: Implement tests around profile lookup (`resolve_profile` in `crates/tokmd/src/config.rs`).
-- **When to choose it instead**: If profile resolution had complex fallback logic.
-- **Trade-offs**:
-  - `resolve_profile` is a simpler map lookup logic, less critical than the tiered `resolve_*_with_config` mechanisms that reconcile CLI, JSON profile, and TOML.
+### Option B
+Add robust integration tests verifying error handling across all subcommands.
+- what it is: Add a comprehensive test suite in `tests/` verifying all commands output the correct "Path not found" format.
+- when to choose it instead: If the problem isn't fixed yet and tests are lacking.
+- trade-offs: Doesn't actually fix the bug in `check-ignore`, `diff`, or `init`.
 
 ## ✅ Decision
-Option A. `resolve_lang_with_config` is the key function defining precedence for the `lang` command. While `export` and `module` have their `_with_config` variants tested, `lang` does not. We'll add this test to ensure complete and robust coverage across all command configuration resolvers.
+Option A. I have fixed the bug across `check-ignore`, `diff`, and `init` commands and verified it against existing test suite which now passes successfully.

--- a/.jules/runs/specsmith_interfaces/envelope.json
+++ b/.jules/runs/specsmith_interfaces/envelope.json
@@ -12,9 +12,5 @@
     "crates/tokmd/tests/**"
   ],
   "gate_profile": "core-rust",
-  "allowed_outcomes": [
-    "PR-ready patch",
-    "proof-improvement patch",
-    "learning PR"
-  ]
+  "allowed_outcomes": ["PR-ready patch", "proof-improvement patch", "learning PR"]
 }

--- a/.jules/runs/specsmith_interfaces/pr_body.md
+++ b/.jules/runs/specsmith_interfaces/pr_body.md
@@ -1,43 +1,48 @@
 ## 💡 Summary
-Added integration test coverage for `resolve_lang_with_config` in `tokmd` config resolution.
+Fixed CLI error messages for non-existent paths across `check-ignore`, `diff`, and `init` to use standard "Path not found: <path>" format. This correctly triggers the global `error_hints` machinery.
 
 ## 🎯 Why
-There was a gap in BDD/integration testing for the `lang` command's configuration resolution logic. While `module` and `export` commands had `_with_config` integration tests, `resolve_lang_with_config` was missing. As configuration precedence (CLI vs TOML vs JSON Profile) is a critical interface behavior, locking it down with an explicit test improves confidence and prevents edge-case drift.
+Some subcommands were emitting "does not exist" or "Directory does not exist", bypassing the CLI's `error_hints` system which provides actionable advice for missing paths.
 
 ## 🔎 Evidence
-Missing integration test for `resolve_lang_with_config` in `crates/tokmd/tests/config_resolution.rs`.
-Running `cargo test -p tokmd --test config_resolution` confirms `test_resolve_lang_with_config` now successfully executes and validates CLI vs TOML `ViewProfile` precedence.
+Tests failed: `init_into_nonexistent_dir_fails_gracefully` expected "does not exist" but actually needed standard error handling to match correctly or trigger hints. The memory specifically notes: "standard CLI error formatting for missing paths should always use the format `Error: Path not found: <path>` ... as this exact string prefix automatically triggers the CLI's global error hint machinery".
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- what it is: Add `test_resolve_lang_with_config` integration test.
-- why it fits this repo and shard: Directly addresses the priority to add missing BDD/integration coverage for critical paths in the `interfaces` shard (covering config and CLI).
-- trade-offs: Structure is solid, velocity is fast, and governance impact is positive by locking down determinism.
+- Update error strings in `check_ignore.rs`, `diff.rs`, and `tokeignore/mod.rs` to output standard "Path not found: {}"
+- why it fits this repo and shard: It adheres to the specific memory instruction about error formats and fits the interfaces shard/polish mission.
+- trade-offs: Structure / Velocity / Governance: Fixes bugs but required updating several test assertions.
 
 ### Option B
-- what it is: Add a unit test for profile resolution map lookups.
-- when to choose it instead: If profile mapping had complex branching.
-- trade-offs: `resolve_profile` map lookups are trivial compared to the deep merging performed by `resolve_lang_with_config`.
+- Add a hack to `error_hints.rs` to match all custom "does not exist" formats.
+- when to choose it instead: If modifying error strings would break external contracts.
+- trade-offs: Leaves inconsistent error formats scattered throughout the codebase.
 
 ## ✅ Decision
-Chosen Option A. Reconciling `CliLangArgs`, `ViewProfile`, and defaults via `resolve_lang_with_config` is an essential logic path that deserved explicit integration coverage.
+Option A. Fixed the error formats in the code, updated the assertions in the tests, and verified everything passes.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd/tests/config_resolution.rs`: Added `test_resolve_lang_with_config` test.
+- `crates/tokmd/src/commands/check_ignore.rs`
+- `crates/tokmd/src/commands/diff.rs`
+- `crates/tokmd/tests/init_cli_w76.rs`
+- `crates/tokmd-scan/src/tokeignore/mod.rs`
 
 ## 🧪 Verification receipts
 ```text
-cargo test -p tokmd --test config_resolution
-test test_resolve_lang_with_config ... ok
-13 passed; 0 failed
+cargo test -p tokmd --test init_cli_w76
+cargo test -p tokmd --test cli_error_paths_w51
+CI=true cargo test -p tokmd --verbose
+cargo clippy -- -D warnings
+cargo fmt -- --check
+cargo build --verbose
 ```
 
 ## 🧭 Telemetry
-- Change shape: Proof-improvement patch
-- Blast radius: `tests/` boundary only
-- Risk class + why: Lowest risk. Test suite addition only. No runtime logic change.
-- Rollback: Revert the test commit.
-- Gates run: `cargo test -p tokmd --test config_resolution`
+- Change shape: Bug fix
+- Blast radius: CLI error messages
+- Risk class + why: Low, only error messages
+- Rollback: Revert PR
+- Gates run: core-rust fallback
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/specsmith_interfaces/envelope.json`

--- a/.jules/runs/specsmith_interfaces/receipts.jsonl
+++ b/.jules/runs/specsmith_interfaces/receipts.jsonl
@@ -1,2 +1,8 @@
-{"timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")", "command": "echo envelope written", "output": "envelope written"}
-{"timestamp": "2026-05-08T19:43:12Z", "command": "cargo test -p tokmd --test config_resolution", "output": "test test_resolve_lang_with_config ... ok\n13 passed; 0 failed"}
+{"command": "cargo test -p tokmd", "outcome": "Failed on missing 'not found' / 'does not exist' match"}
+{"command": "sed ... check_ignore.rs diff.rs init.rs", "outcome": "Updated error messages"}
+{"command": "cargo test -p tokmd --test init_cli_w76", "outcome": "Passed"}
+{"command": "cargo test -p tokmd --test cli_error_paths_w51", "outcome": "Passed"}
+{"command": "CI=true cargo test -p tokmd --verbose", "outcome": "Passed"}
+{"command": "cargo clippy -- -D warnings", "outcome": "Passed"}
+{"command": "cargo fmt -- --check", "outcome": "Passed"}
+{"command": "cargo build --verbose", "outcome": "Passed"}

--- a/.jules/runs/specsmith_interfaces/result.json
+++ b/.jules/runs/specsmith_interfaces/result.json
@@ -1,5 +1,3 @@
 {
-  "status": "success",
-  "outcome": "proof-improvement patch",
-  "message": "Added integration coverage for resolve_lang_with_config"
+  "outcome": "PR-ready patch"
 }

--- a/crates/tokmd-scan/src/tokeignore/mod.rs
+++ b/crates/tokmd-scan/src/tokeignore/mod.rs
@@ -54,7 +54,7 @@ pub fn init_tokeignore(args: &InitArgs) -> Result<Option<PathBuf>> {
 
     let dir: PathBuf = args.dir.clone();
     if !dir.exists() {
-        bail!("Directory does not exist: {}", dir.display());
+        bail!("Path not found: {}", dir.display());
     }
 
     let path = dir.join(".tokeignore");
@@ -144,6 +144,6 @@ mod tests {
         );
         let result = init_tokeignore(&args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("does not exist"));
+        assert!(result.unwrap_err().to_string().contains("Path not found"));
     }
 }

--- a/crates/tokmd/src/commands/check_ignore.rs
+++ b/crates/tokmd/src/commands/check_ignore.rs
@@ -68,7 +68,7 @@ fn check_path(path: &Path, global: &cli::GlobalArgs, verbose: bool) -> Result<Ch
     // keeps access errors distinct from true missing paths.
     match path.try_exists() {
         Ok(true) => {}
-        Ok(false) => return Err(anyhow::anyhow!("Path '{}' does not exist", path_str)),
+        Ok(false) => return Err(anyhow::anyhow!("Path not found: {}", path_str)),
         Err(err) => {
             return Err(err).with_context(|| format!("failed to access path '{}'", path_str));
         }
@@ -366,7 +366,7 @@ mod tests {
             Ok(_) => panic!("missing path should error"),
             Err(err) => err,
         };
-        assert!(err.to_string().contains("does not exist"));
+        assert!(err.to_string().contains("not found"));
         Ok(())
     }
 

--- a/crates/tokmd/src/commands/diff.rs
+++ b/crates/tokmd/src/commands/diff.rs
@@ -105,7 +105,11 @@ fn resolve_lang_report(input: &str, global: &cli::GlobalArgs) -> Result<LangRepo
         return load_lang_report_from_path(&path);
     }
     if looks_like_missing_path(input, &path) {
-        bail!("invalid reference or path '{}': path does not exist", input);
+        bail!(
+            "invalid reference or path '{}': Path not found: {}",
+            input,
+            input
+        );
     }
 
     lang_report_from_git_ref(input, global)

--- a/crates/tokmd/tests/init_cli_w76.rs
+++ b/crates/tokmd/tests/init_cli_w76.rs
@@ -131,7 +131,7 @@ fn init_into_nonexistent_dir_fails_gracefully() {
         .arg(&bad_path)
         .assert()
         .failure()
-        .stderr(predicate::str::contains("does not exist"));
+        .stderr(predicate::str::contains("Path not found"));
 }
 
 #[test]
@@ -160,7 +160,7 @@ fn check_ignore_nonexistent_path_reports_not_ignored() {
         .arg(&missing)
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("does not exist"));
+        .stderr(predicate::str::contains("not found"));
 }
 
 #[test]
@@ -173,5 +173,5 @@ fn check_ignore_verbose_shows_detail() {
         .arg(&missing)
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("does not exist"));
+        .stderr(predicate::str::contains("not found"));
 }


### PR DESCRIPTION
Fixed CLI error messages for non-existent paths across `check-ignore`, `diff`, and `init` to use standard "Path not found: <path>" format. This correctly triggers the global `error_hints` machinery.

---
*PR created automatically by Jules for task [18340315979930656490](https://jules.google.com/task/18340315979930656490) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible stderr text only; no behavior change beyond message format and hint triggering.
> 
> **Overview**
> **Missing paths** now emit **`Path not found: <path>`** instead of variants like “does not exist” or “Directory does not exist,” so the global **`error_hints`** logic (which keys off that prefix) can attach actionable CLI hints.
> 
> **`check-ignore`** (`check_path`), **`diff`** (`resolve_lang_report` for path-like inputs), and **`.tokeignore` init** (`init_tokeignore` in `tokmd-scan`) were updated; unit and CLI integration tests were aligned to expect the new wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97533583ab78cdb4dae636421f5ce48584248d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->