### PR TITLE
test(xtask): cover fixture blob allowlist prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,9 +3389,9 @@ dependencies = [
  "tokmd-analysis-types",
  "tokmd-analysis-util",
  "tokmd-git",
+ "tokmd-test-support",
  "tokmd-types",
  "tokmd-walk",
- "uselesskey",
 ]
 
 [[package]]
@@ -3499,8 +3499,8 @@ dependencies = [
  "tokmd-analysis-types",
  "tokmd-analysis-util",
  "tokmd-content",
+ "tokmd-test-support",
  "tokmd-types",
- "uselesskey",
 ]
 
 [[package]]
@@ -4023,6 +4023,14 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokmd-test-support"
+version = "1.9.0"
+dependencies = [
+ "tempfile",
+ "uselesskey",
 ]
 
 [[package]]
@@ -5154,6 +5162,7 @@ dependencies = [
  "petgraph",
  "semver",
  "serde_json",
+ "tempfile",
  "toml 1.0.7+spec-1.1.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "crates/tokmd-sensor",
     "crates/tokmd-settings",
     "crates/tokmd-substrate",
+    "crates/tokmd-test-support",
     "crates/tokmd-tokeignore",
     "crates/tokmd-tool-schema",
     "crates/tokmd-types",
@@ -110,6 +111,7 @@ default-members = [
     "crates/tokmd-sensor",
     "crates/tokmd-settings",
     "crates/tokmd-substrate",
+    "crates/tokmd-test-support",
     "crates/tokmd-tokeignore",
     "crates/tokmd-tool-schema",
     "crates/tokmd-types",
@@ -185,6 +187,7 @@ tokmd-scan-args = { path = "crates/tokmd-scan-args", version = "1.9.0" }
 tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.9.0" }
 tokmd-substrate = { path = "crates/tokmd-substrate", version = "1.9.0" }
 tokmd-settings = { path = "crates/tokmd-settings", version = "1.9.0" }
+tokmd-test-support = { path = "crates/tokmd-test-support", version = "1.9.0" }
 tokmd-tokeignore = { path = "crates/tokmd-tokeignore", version = "1.9.0" }
 tokmd-tool-schema = { path = "crates/tokmd-tool-schema", version = "1.9.0" }
 tokmd-types = { path = "crates/tokmd-types", version = "1.9.0" }

--- a/crates/tokmd-analysis-entropy/Cargo.toml
+++ b/crates/tokmd-analysis-entropy/Cargo.toml
@@ -22,4 +22,4 @@ tokmd-types.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-uselesskey.workspace = true
+tokmd-test-support.workspace = true

--- a/crates/tokmd-analysis-entropy/tests/uselesskey_runtime_fixtures.rs
+++ b/crates/tokmd-analysis-entropy/tests/uselesskey_runtime_fixtures.rs
@@ -1,12 +1,11 @@
-use std::fs;
 use std::path::PathBuf;
 
 use tempfile::tempdir;
 use tokmd_analysis_entropy::build_entropy_report;
 use tokmd_analysis_types::EntropyClass;
 use tokmd_analysis_util::AnalysisLimits;
+use tokmd_test_support::crypto;
 use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
-use uselesskey::{Factory, RsaFactoryExt, RsaSpec, Seed};
 
 fn export_for_paths(paths: &[&str]) -> ExportData {
     let rows = paths
@@ -37,50 +36,21 @@ fn export_for_paths(paths: &[&str]) -> ExportData {
     }
 }
 
-fn deterministic_factory() -> Factory {
-    let seed = Seed::from_env_value(module_path!()).expect("module path should be a valid seed");
-    Factory::deterministic(seed)
-}
-
 #[test]
 fn uselesskey_generates_reproducible_rsa_der_fixtures() {
-    let first_factory = deterministic_factory();
-    let second_factory = deterministic_factory();
+    let first = crypto::rsa_private_key_pkcs8_der(crypto::label::ENTROPY_PRIMARY);
+    let second = crypto::rsa_private_key_pkcs8_der(crypto::label::ENTROPY_PRIMARY);
+    let different = crypto::rsa_private_key_pkcs8_der(crypto::label::ENTROPY_ALTERNATE);
 
-    let first = first_factory.rsa("entropy-fixture", RsaSpec::rs256());
-    let second = second_factory.rsa("entropy-fixture", RsaSpec::rs256());
-
-    assert_eq!(
-        first.private_key_pkcs8_der(),
-        second.private_key_pkcs8_der()
-    );
-
-    let different = first_factory.rsa("entropy-fixture-alt", RsaSpec::rs256());
-
-    assert_ne!(
-        first.private_key_pkcs8_der(),
-        different.private_key_pkcs8_der()
-    );
+    assert_eq!(first, second);
+    assert_ne!(first, different);
 }
 
 #[test]
 fn entropy_report_detects_uselesskey_generated_private_key_der() {
     let dir = tempdir().expect("tempdir should be created");
-    let relative_path = "fixtures/generated/private-key.pk8";
-    let output_path = dir
-        .path()
-        .join("fixtures")
-        .join("generated")
-        .join("private-key.pk8");
-    fs::create_dir_all(
-        output_path
-            .parent()
-            .expect("generated fixture file should have a parent directory"),
-    )
-    .expect("fixture directory should be created");
-
-    let fixture = deterministic_factory().rsa("entropy-report-fixture", RsaSpec::rs256());
-    fs::write(&output_path, fixture.private_key_pkcs8_der())
+    let relative_path = crypto::GENERATED_PRIVATE_KEY_RELATIVE_PATH;
+    crypto::write_generated_private_key(dir.path(), crypto::label::ENTROPY_REPORT)
         .expect("rsa fixture bytes should be written");
 
     let export = export_for_paths(&[relative_path]);

--- a/crates/tokmd-analysis/Cargo.toml
+++ b/crates/tokmd-analysis/Cargo.toml
@@ -79,5 +79,5 @@ tokmd-analysis-effort = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
-uselesskey.workspace = true
 serde.workspace = true
+tokmd-test-support.workspace = true

--- a/crates/tokmd-analysis/tests/uselesskey_security_pipeline.rs
+++ b/crates/tokmd-analysis/tests/uselesskey_security_pipeline.rs
@@ -1,6 +1,5 @@
 #![cfg(all(feature = "content", feature = "walk"))]
 
-use std::fs;
 use std::path::Path;
 
 use tokmd_analysis::{
@@ -8,13 +7,8 @@ use tokmd_analysis::{
     NearDupScope, analyze,
 };
 use tokmd_analysis_types::{AnalysisArgsMeta, AnalysisSource, EntropyClass};
+use tokmd_test_support::crypto;
 use tokmd_types::{ChildIncludeMode, ExportData, FileKind, FileRow};
-use uselesskey::{Factory, RsaFactoryExt, RsaSpec, Seed};
-
-fn deterministic_factory() -> Factory {
-    let seed = Seed::from_env_value(module_path!()).expect("module path should be a valid seed");
-    Factory::deterministic(seed)
-}
 
 fn make_request(preset: AnalysisPreset) -> AnalysisRequest {
     AnalysisRequest {
@@ -88,21 +82,8 @@ fn export_for_private_key_fixture(path: &str) -> ExportData {
 #[test]
 fn security_preset_detects_uselesskey_generated_private_key() {
     let dir = tempfile::tempdir().expect("tempdir should be created");
-    let relative_path = "fixtures/generated/private-key.pk8";
-    let output_path = dir
-        .path()
-        .join("fixtures")
-        .join("generated")
-        .join("private-key.pk8");
-    fs::create_dir_all(
-        output_path
-            .parent()
-            .expect("generated fixture file should have a parent directory"),
-    )
-    .expect("fixture directory should be created");
-
-    let fixture = deterministic_factory().rsa("security-preset-fixture", RsaSpec::rs256());
-    fs::write(&output_path, fixture.private_key_pkcs8_der())
+    let relative_path = crypto::GENERATED_PRIVATE_KEY_RELATIVE_PATH;
+    crypto::write_generated_private_key(dir.path(), crypto::label::SECURITY_SUSPECT)
         .expect("rsa fixture bytes should be written");
 
     let receipt = analyze(

--- a/crates/tokmd-test-support/Cargo.toml
+++ b/crates/tokmd-test-support/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tokmd-test-support"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = false
+description = "Shared deterministic test support for tokmd workspace tests."
+
+[dependencies]
+uselesskey.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/tokmd-test-support/src/crypto.rs
+++ b/crates/tokmd-test-support/src/crypto.rs
@@ -1,0 +1,81 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec, Seed};
+
+const SEED_NAMESPACE: &str = "tokmd/uselesskey/v1";
+
+pub const GENERATED_PRIVATE_KEY_RELATIVE_PATH: &str = "fixtures/generated/private-key.pk8";
+
+pub mod label {
+    pub const ENTROPY_PRIMARY: &str = "entropy-private-key-primary";
+    pub const ENTROPY_ALTERNATE: &str = "entropy-private-key-alternate";
+    pub const ENTROPY_REPORT: &str = "entropy-private-key-report";
+    pub const SECURITY_SUSPECT: &str = "security-private-key-suspect";
+}
+
+pub fn factory() -> &'static Factory {
+    static FACTORY: OnceLock<Factory> = OnceLock::new();
+
+    FACTORY.get_or_init(|| {
+        let seed =
+            Seed::from_env_value(SEED_NAMESPACE).expect("seed namespace should remain valid");
+        Factory::deterministic(seed)
+    })
+}
+
+pub fn rsa_private_key_pkcs8_der(label: &str) -> Vec<u8> {
+    factory()
+        .rsa(label, RsaSpec::rs256())
+        .private_key_pkcs8_der()
+        .to_vec()
+}
+
+pub fn generated_private_key_output_path(root: &Path) -> PathBuf {
+    root.join("fixtures")
+        .join("generated")
+        .join("private-key.pk8")
+}
+
+pub fn write_generated_private_key(root: &Path, label: &str) -> io::Result<PathBuf> {
+    let output_path = generated_private_key_output_path(root);
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&output_path, rsa_private_key_pkcs8_der(label))?;
+    Ok(output_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{factory, generated_private_key_output_path, label, write_generated_private_key};
+    use uselesskey::RsaFactoryExt;
+
+    #[test]
+    fn factory_is_deterministic_for_stable_labels() {
+        let first = factory().rsa(label::ENTROPY_PRIMARY, uselesskey::RsaSpec::rs256());
+        let second = factory().rsa(label::ENTROPY_PRIMARY, uselesskey::RsaSpec::rs256());
+        let different = factory().rsa(label::ENTROPY_ALTERNATE, uselesskey::RsaSpec::rs256());
+
+        assert_eq!(
+            first.private_key_pkcs8_der(),
+            second.private_key_pkcs8_der()
+        );
+        assert_ne!(
+            first.private_key_pkcs8_der(),
+            different.private_key_pkcs8_der()
+        );
+    }
+
+    #[test]
+    fn write_generated_private_key_uses_shared_fixture_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output_path =
+            write_generated_private_key(dir.path(), label::ENTROPY_PRIMARY).expect("write key");
+
+        assert_eq!(output_path, generated_private_key_output_path(dir.path()));
+        assert!(output_path.exists());
+    }
+}

--- a/crates/tokmd-test-support/src/lib.rs
+++ b/crates/tokmd-test-support/src/lib.rs
@@ -1,0 +1,3 @@
+#![forbid(unsafe_code)]
+
+pub mod crypto;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,4 +19,5 @@ serde_json = "1"
 
 [dev-dependencies]
 serde_json = "1"
+tempfile.workspace = true
 toml = "1.0.6"

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -22,6 +22,8 @@ pub enum Commands {
     VersionConsistency(VersionConsistencyArgs),
     /// Verify dependency boundaries for analysis microcrates
     BoundariesCheck(BoundariesCheckArgs),
+    /// Reject committed crypto fixture blobs outside approved paths
+    FixtureBlobsCheck(FixtureBlobsCheckArgs),
     /// Run pre-merge quality gate (fmt, check, clippy, test-compile)
     Gate(GateArgs),
     /// Auto-fix lint issues (fmt + clippy --fix) then verify
@@ -155,6 +157,9 @@ pub struct BumpArgs {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct BoundariesCheckArgs {}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct FixtureBlobsCheckArgs {}
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct GateArgs {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,7 @@ fn main() -> Result<()> {
         Some(cli::Commands::Docs(args)) => tasks::docs::run(args),
         Some(cli::Commands::VersionConsistency(args)) => tasks::version_consistency::run(args),
         Some(cli::Commands::BoundariesCheck(args)) => tasks::boundaries_check::run(args),
+        Some(cli::Commands::FixtureBlobsCheck(args)) => tasks::fixture_blobs_check::run(args),
         Some(cli::Commands::Gate(args)) => tasks::gate::run(args),
         Some(cli::Commands::LintFix(args)) => tasks::lint_fix::run(args),
         Some(cli::Commands::Sccache(args)) => tasks::sccache::run(args),

--- a/xtask/src/tasks/fixture_blobs_check.rs
+++ b/xtask/src/tasks/fixture_blobs_check.rs
@@ -1,10 +1,11 @@
 use crate::cli::FixtureBlobsCheckArgs;
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 
 const ALLOWLIST_PREFIXES: &[&str] = &[".claude/", ".jules/", "vendor/"];
+const ALLOWLIST_PATHS: &[&str] = &["xtask/src/tasks/fixture_blobs_check.rs"];
 const FORBIDDEN_EXTENSIONS: &[&str] = &[
     "cer", "crt", "der", "jwk", "jwks", "key", "p12", "p8", "pem", "pfx", "pk8",
 ];
@@ -23,6 +24,10 @@ struct Violation {
 }
 
 fn is_allowlisted(path: &str) -> bool {
+    if ALLOWLIST_PATHS.contains(&path) {
+        return true;
+    }
+
     ALLOWLIST_PREFIXES
         .iter()
         .any(|prefix| path.starts_with(prefix))
@@ -161,6 +166,16 @@ mod tests {
 
         assert_eq!(violation.path, "docs/example.md");
         assert!(violation.reason.contains("BEGIN PRIVATE KEY"));
+    }
+
+    #[test]
+    fn allows_checker_source_file() {
+        let dir = tempdir().expect("tempdir");
+
+        let violation = evaluate_candidate(dir.path(), "xtask/src/tasks/fixture_blobs_check.rs")
+            .expect("check");
+
+        assert!(violation.is_none());
     }
 
     #[test]

--- a/xtask/src/tasks/fixture_blobs_check.rs
+++ b/xtask/src/tasks/fixture_blobs_check.rs
@@ -1,0 +1,181 @@
+use crate::cli::FixtureBlobsCheckArgs;
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const ALLOWLIST_PREFIXES: &[&str] = &[".claude/", ".jules/", "vendor/"];
+const FORBIDDEN_EXTENSIONS: &[&str] = &[
+    "cer", "crt", "der", "jwk", "jwks", "key", "p12", "p8", "pem", "pfx", "pk8",
+];
+const FORBIDDEN_MARKERS: &[&str] = &[
+    "BEGIN CERTIFICATE",
+    "BEGIN EC PRIVATE KEY",
+    "BEGIN OPENSSH PRIVATE KEY",
+    "BEGIN PRIVATE KEY",
+    "BEGIN RSA PRIVATE KEY",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Violation {
+    path: String,
+    reason: String,
+}
+
+fn is_allowlisted(path: &str) -> bool {
+    ALLOWLIST_PREFIXES
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+}
+
+fn forbidden_extension(path: &str) -> Option<String> {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .filter(|ext| FORBIDDEN_EXTENSIONS.contains(&ext.as_str()))
+}
+
+fn contains_forbidden_marker(path: &Path) -> Result<Option<&'static str>> {
+    let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let text = String::from_utf8_lossy(&bytes);
+    Ok(FORBIDDEN_MARKERS
+        .iter()
+        .copied()
+        .find(|marker| text.contains(marker)))
+}
+
+fn evaluate_candidate(repo_root: &Path, rel_path: &str) -> Result<Option<Violation>> {
+    if is_allowlisted(rel_path) {
+        return Ok(None);
+    }
+
+    if let Some(ext) = forbidden_extension(rel_path) {
+        return Ok(Some(Violation {
+            path: rel_path.to_string(),
+            reason: format!(
+                "committed crypto fixture blob extension .{ext} is forbidden; generate fixtures at runtime or explicitly whitelist the path"
+            ),
+        }));
+    }
+
+    let abs_path = repo_root.join(rel_path);
+    if let Some(marker) = contains_forbidden_marker(&abs_path)? {
+        return Ok(Some(Violation {
+            path: rel_path.to_string(),
+            reason: format!(
+                "committed crypto fixture marker '{marker}' is forbidden; generate fixtures at runtime or explicitly whitelist the path"
+            ),
+        }));
+    }
+
+    Ok(None)
+}
+
+fn tracked_files() -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["ls-files", "-z"])
+        .output()
+        .context("failed to list tracked files with git ls-files")?;
+
+    if !output.status.success() {
+        bail!("git ls-files did not succeed");
+    }
+
+    Ok(output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| String::from_utf8_lossy(entry).to_string())
+        .collect())
+}
+
+fn collect_violations(repo_root: &Path, tracked: &[String]) -> Result<Vec<Violation>> {
+    let mut violations = Vec::new();
+
+    for rel_path in tracked {
+        if let Some(violation) = evaluate_candidate(repo_root, rel_path)? {
+            violations.push(violation);
+        }
+    }
+
+    Ok(violations)
+}
+
+pub fn run(_args: FixtureBlobsCheckArgs) -> Result<()> {
+    let repo_root = std::env::current_dir()?;
+    let tracked = tracked_files()?;
+    let violations = collect_violations(&repo_root, &tracked)?;
+
+    if violations.is_empty() {
+        println!("No committed crypto fixture blobs found");
+        return Ok(());
+    }
+
+    eprintln!("Committed crypto fixture blobs detected:");
+    for violation in &violations {
+        eprintln!("  - {} ({})", violation.path, violation.reason);
+        eprintln!("::error file={}::{}", violation.path, violation.reason);
+    }
+
+    bail!(
+        "found {} committed crypto fixture blob(s); use deterministic runtime fixtures instead",
+        violations.len()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_violations, evaluate_candidate, forbidden_extension};
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detects_forbidden_extension() {
+        assert_eq!(forbidden_extension("fixtures/key.pem"), Some("pem".into()));
+        assert_eq!(forbidden_extension("fixtures/key.PK8"), Some("pk8".into()));
+        assert_eq!(forbidden_extension("src/lib.rs"), None);
+    }
+
+    #[test]
+    fn skips_allowlisted_vendor_paths() {
+        let dir = tempdir().expect("tempdir");
+        let vendor_file = dir.path().join("vendor").join("fixture.pem");
+        fs::create_dir_all(vendor_file.parent().unwrap()).expect("vendor dir");
+        fs::write(&vendor_file, "BEGIN PRIVATE KEY").expect("write");
+
+        let violation = evaluate_candidate(dir.path(), "vendor/fixture.pem").expect("check");
+        assert!(violation.is_none());
+    }
+
+    #[test]
+    fn detects_forbidden_marker_in_text_file() {
+        let dir = tempdir().expect("tempdir");
+        let manifest = dir.path().join("docs").join("example.md");
+        fs::create_dir_all(manifest.parent().unwrap()).expect("docs dir");
+        fs::write(&manifest, "-----BEGIN PRIVATE KEY-----").expect("write");
+
+        let violation = evaluate_candidate(dir.path(), "docs/example.md")
+            .expect("check")
+            .expect("violation");
+
+        assert_eq!(violation.path, "docs/example.md");
+        assert!(violation.reason.contains("BEGIN PRIVATE KEY"));
+    }
+
+    #[test]
+    fn collects_violations_across_multiple_paths() {
+        let dir = tempdir().expect("tempdir");
+        let pem = dir.path().join("fixtures").join("bad.pem");
+        let readme = dir.path().join("README.md");
+        fs::create_dir_all(pem.parent().unwrap()).expect("fixtures dir");
+        fs::write(&pem, "ignored due to extension").expect("write pem");
+        fs::write(&readme, "no secrets here").expect("write readme");
+
+        let tracked = vec!["fixtures/bad.pem".to_string(), "README.md".to_string()];
+        let violations = collect_violations(dir.path(), &tracked).expect("collect");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].path, "fixtures/bad.pem");
+    }
+}

--- a/xtask/src/tasks/fixture_blobs_check.rs
+++ b/xtask/src/tasks/fixture_blobs_check.rs
@@ -179,6 +179,27 @@ mod tests {
     }
 
     #[test]
+    fn skips_allowlisted_prefix_paths() {
+        let dir = tempdir().expect("tempdir");
+
+        for rel_path in [".claude/fixture.pem", ".jules/key.pem"] {
+            let path = dir.path().join(rel_path);
+            fs::create_dir_all(
+                path.parent()
+                    .expect("parent dir should exist"),
+            )
+            .expect("create allowlist prefix parent");
+            fs::write(&path, "BEGIN PRIVATE KEY").expect("write allowlisted file");
+
+            let violation = evaluate_candidate(dir.path(), rel_path).expect("check");
+            assert!(
+                violation.is_none(),
+                "{rel_path} should be allowlisted and not flagged"
+            );
+        }
+    }
+
+    #[test]
     fn collects_violations_across_multiple_paths() {
         let dir = tempdir().expect("tempdir");
         let pem = dir.path().join("fixtures").join("bad.pem");

--- a/xtask/src/tasks/gate.rs
+++ b/xtask/src/tasks/gate.rs
@@ -1,4 +1,6 @@
+use crate::cli::FixtureBlobsCheckArgs;
 use crate::cli::GateArgs;
+use crate::tasks::fixture_blobs_check;
 use crate::tasks::workspace::run_workspace_fmt;
 use anyhow::{Result, bail};
 use std::process::Command;
@@ -117,6 +119,7 @@ fn ensure_no_tracked_agent_runtime_state() -> Result<()> {
 
 pub fn run(args: GateArgs) -> Result<()> {
     ensure_no_tracked_agent_runtime_state()?;
+    fixture_blobs_check::run(FixtureBlobsCheckArgs::default())?;
 
     let total = STEPS.len();
     let mut failures = Vec::new();

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -2,6 +2,7 @@ pub mod boundaries_check;
 pub mod bump;
 pub mod cockpit;
 pub mod docs;
+pub mod fixture_blobs_check;
 pub mod gate;
 pub mod lint_fix;
 pub mod publish;

--- a/xtask/tests/fixture_blobs_w83.rs
+++ b/xtask/tests/fixture_blobs_w83.rs
@@ -1,0 +1,52 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.parent().unwrap().to_path_buf()
+}
+
+fn run_xtask(args: &[&str]) -> (String, String, bool) {
+    let root = workspace_root();
+    let output = Command::new("cargo")
+        .arg("run")
+        .arg("-q")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .args(args)
+        .current_dir(&root)
+        .output()
+        .expect("failed to run cargo xtask");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (stdout, stderr, output.status.success())
+}
+
+#[test]
+fn fixture_blobs_check_passes_on_clean_repo() {
+    let (stdout, stderr, success) = run_xtask(&["fixture-blobs-check"]);
+    assert!(success, "fixture-blobs-check failed. stderr: {stderr}");
+    assert!(stdout.contains("No committed crypto fixture blobs found"));
+}
+
+#[test]
+fn xtask_help_mentions_fixture_blobs_check() {
+    let (stdout, stderr, success) = run_xtask(&["--help"]);
+    assert!(success, "xtask --help failed. stderr: {stderr}");
+    assert!(stdout.contains("fixture-blobs-check"));
+}
+
+#[test]
+fn gate_invokes_fixture_blob_guardrail() {
+    let src = std::fs::read_to_string(
+        workspace_root()
+            .join("xtask")
+            .join("src")
+            .join("tasks")
+            .join("gate.rs"),
+    )
+    .expect("read gate.rs");
+
+    assert!(src.contains("fixture_blobs_check::run"));
+}


### PR DESCRIPTION
Add focused tests for allowlisted .claude and .jules fixture paths in fixture blob checker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture helpers and CI/xtask guardrails; no production analysis or runtime behavior changes beyond stricter repo hygiene checks.
> 
> **Overview**
> Introduces **`tokmd-test-support`** so entropy and security integration tests share deterministic RSA PKCS#8 generation and a single runtime path (`fixtures/generated/private-key.pk8`) instead of duplicating `uselesskey` setup per test crate.
> 
> Adds **`cargo xtask fixture-blobs-check`**, which fails if tracked files use forbidden key/cert extensions or PEM-style markers outside allowlisted prefixes (`.claude/`, `.jules/`, `vendor/`) and paths. The pre-merge **gate** runs this check first; unit tests cover vendor paths, marker detection, and **`.claude` / `.jules` prefix allowlisting**, plus smoke tests that the command passes on a clean repo and is wired into gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dba88a1830f1cf76903a8c3dc0710f58dd7a4702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->