### PR TITLE
auditor: remove explicit tokio dependency from Node addon in favor of napi::tokio 🧾

### DIFF
--- a/.jules/runs/auditor-bindings/decision.md
+++ b/.jules/runs/auditor-bindings/decision.md
@@ -1,0 +1,17 @@
+## 🧭 Options considered
+
+### Option A (recommended)
+- Remove the explicit `tokio` dependency in `crates/tokmd-node` and instead use the managed `tokio` runtime provided by the host environment via `napi::tokio` (when the `napi` crate's `async` feature is enabled).
+- **Why it fits:** This aligns directly with the `deps-hygiene` gate profile and the Auditor persona mission. The `tokmd-node` module currently explicitly depends on `tokio = { version = "1", features = ["rt-multi-thread"] }`. However, `napi` already re-exports a managed `tokio` runtime when `async` is enabled, and managing parallel tokio instances in a Node.js context adds unnecessary bloat, redundant dependencies, and complexity to the build surface.
+- **Trade-offs:**
+  - Structure: Improves consistency and prevents multi-runtime collisions in Node environments.
+  - Velocity: High; the change is straightforward and local.
+  - Governance: High signal for the Auditor role; removes a duplicate dependency footprint.
+
+### Option B
+- Tighten `napi` features to reduce compile time.
+- **When to choose it:** If removing the entire explicit tokio dependency isn't possible, we could at least try to drop unused features.
+- **Trade-offs:** Requires deep analysis of napi usage, and doesn't solve the core issue of multiple tokio runtimes being instantiated.
+
+## ✅ Decision
+Option A. I will remove the `tokio` dependency from `crates/tokmd-node/Cargo.toml` and change all occurrences of `tokio::` to `napi::tokio::` in `crates/tokmd-node/src/lib.rs`. The `async` feature is already enabled in `napi` in `crates/tokmd-node/Cargo.toml`. This perfectly aligns with the explicit memory instruction: "In Node.js native addons using `napi-rs` (e.g., `crates/tokmd-node`), avoid declaring an explicit multi-threaded `tokio` dependency. Instead, use the managed `tokio` runtime provided by the host environment via `napi::tokio` (when the `napi` crate's `async` feature is enabled) to prevent parallel unmanaged runtimes and redundant dependencies."

--- a/.jules/runs/auditor-bindings/envelope.json
+++ b/.jules/runs/auditor-bindings/envelope.json
@@ -1,0 +1,14 @@
+{
+  "prompt_id": "auditor_bindings_manifests",
+  "persona": "auditor",
+  "style": "builder",
+  "primary_shard": "bindings-targets",
+  "allowed_paths": [
+    "crates/tokmd-python/**",
+    "crates/tokmd-node/**",
+    "crates/tokmd-wasm/**",
+    "web/runner/**"
+  ],
+  "gate_profile": "deps-hygiene",
+  "allowed_outcomes": ["pr_ready_patch", "learning_pr"]
+}

--- a/.jules/runs/auditor-bindings/pr_body.md
+++ b/.jules/runs/auditor-bindings/pr_body.md
@@ -1,0 +1,57 @@
+## 💡 Summary
+Removed the explicit multi-threaded `tokio` dependency from `tokmd-node` in favor of using `napi::tokio`. This simplifies the build graph and prevents creating parallel, unmanaged runtimes in Node.js addons.
+
+## 🎯 Why
+In Node.js native addons using `napi-rs` (e.g., `crates/tokmd-node`), declaring an explicit multi-threaded `tokio` dependency is an anti-pattern. Instead, we should use the managed `tokio` runtime provided by the host environment via `napi::tokio` (when the `napi` crate's `async` feature is enabled) to prevent parallel unmanaged runtimes and redundant dependencies.
+
+## 🔎 Evidence
+- `crates/tokmd-node/Cargo.toml` explicitly depended on `tokio = { version = "1", features = ["rt-multi-thread"] }`.
+- `crates/tokmd-node/src/lib.rs` instantiated its own runtime with `tokio::runtime::Builder::new_multi_thread()`.
+- Tests pass after migrating to `napi::tokio`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Remove the explicit `tokio` dependency in `crates/tokmd-node` and instead use the managed `tokio` runtime provided by the host environment via `napi::tokio` (when the `napi` crate's `async` feature is enabled).
+- **Why it fits:** This aligns directly with the `deps-hygiene` gate profile and the Auditor persona mission.
+- **Trade-offs:**
+  - Structure: Improves consistency and prevents multi-runtime collisions in Node environments.
+  - Velocity: High; the change is straightforward and local.
+  - Governance: High signal for the Auditor role; removes a duplicate dependency footprint.
+
+### Option B
+- Tighten `napi` features to reduce compile time.
+- **When to choose it:** If removing the entire explicit tokio dependency isn't possible.
+- **Trade-offs:** Requires deep analysis of napi usage, and doesn't solve the core issue of multiple tokio runtimes.
+
+## ✅ Decision
+Option A. Removed the explicit `tokio` dependency and switched to using the `napi::tokio` re-export, which natively provides managed async functionality inside napi contexts.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-node/Cargo.toml`: Removed explicit `tokio` dependency.
+- `crates/tokmd-node/src/lib.rs`: Swapped `tokio::` paths to `napi::tokio::`.
+
+## 🧪 Verification receipts
+```text
+$ cd crates/tokmd-node && CI=true cargo test
+test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+
+$ cd crates/tokmd-node && cargo fmt -- --check && cargo clippy -- -D warnings
+Finished `dev` profile [unoptimized + debuginfo] target(s)
+```
+
+## 🧭 Telemetry
+- Change shape: Dependency removal and code migration
+- Blast radius: API/dependencies (Node.js target only)
+- Risk class: Low (covered by napi bindings tests)
+- Rollback: Revert `Cargo.toml` and `lib.rs`
+- Gates run: `cargo build`, `CI=true cargo test`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/auditor-bindings/envelope.json`
+- `.jules/runs/auditor-bindings/decision.md`
+- `.jules/runs/auditor-bindings/receipts.jsonl`
+- `.jules/runs/auditor-bindings/result.json`
+- `.jules/runs/auditor-bindings/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/auditor-bindings/receipts.jsonl
+++ b/.jules/runs/auditor-bindings/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "cd crates/tokmd-node && CI=true cargo test", "output": "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"}
+{"command": "cd crates/tokmd-node && cargo fmt -- --check && cargo clippy -- -D warnings", "output": "Finished `dev` profile [unoptimized + debuginfo] target(s)"}

--- a/.jules/runs/auditor-bindings/result.json
+++ b/.jules/runs/auditor-bindings/result.json
@@ -1,0 +1,13 @@
+{
+  "outcome": "patch",
+  "files_changed": [
+    "crates/tokmd-node/Cargo.toml",
+    "crates/tokmd-node/src/lib.rs"
+  ],
+  "gates_run": [
+    "cargo build",
+    "CI=true cargo test",
+    "cargo fmt",
+    "cargo clippy"
+  ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,7 +2718,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
  "tokmd-core",
  "tokmd-envelope",
 ]

--- a/crates/tokmd-node/Cargo.toml
+++ b/crates/tokmd-node/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3", features = ["async", "serde-json"] }
 napi-derive = "3"
-tokio = { version = "1", features = ["rt-multi-thread"] }
+
 serde_json.workspace = true
 serde.workspace = true
 tokmd-core = { workspace = true, features = ["analysis", "cockpit"] }

--- a/crates/tokmd-node/src/lib.rs
+++ b/crates/tokmd-node/src/lib.rs
@@ -71,7 +71,7 @@ where
     F: FnOnce() -> String + Send + 'static,
 {
     // Run in a blocking task to not block the event loop
-    tokio::task::spawn_blocking(f)
+    napi::tokio::task::spawn_blocking(f)
         .await
         .map_err(|e| Error::from_reason(format!("Task join error: {}", e)))
 }
@@ -275,7 +275,7 @@ mod tests {
     use std::path::Path;
 
     fn block_on<T>(future: impl Future<Output = Result<T>>) -> Result<T> {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
+        let runtime = napi::tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .build()
             .expect("build tokio runtime");


### PR DESCRIPTION
## 💡 Summary
Removed the explicit multi-threaded `tokio` dependency from `tokmd-node` in favor of using `napi::tokio`. This simplifies the build graph and prevents creating parallel, unmanaged runtimes in Node.js addons.

## 🎯 Why
In Node.js native addons using `napi-rs` (e.g., `crates/tokmd-node`), declaring an explicit multi-threaded `tokio` dependency is an anti-pattern. Instead, we should use the managed `tokio` runtime provided by the host environment via `napi::tokio` (when the `napi` crate's `async` feature is enabled) to prevent parallel unmanaged runtimes and redundant dependencies.

## 🔎 Evidence
- `crates/tokmd-node/Cargo.toml` explicitly depended on `tokio = { version = "1", features = ["rt-multi-thread"] }`.
- `crates/tokmd-node/src/lib.rs` instantiated its own runtime with `tokio::runtime::Builder::new_multi_thread()`.
- Tests pass after migrating to `napi::tokio`.

## 🧭 Options considered
### Option A (recommended)
- Remove the explicit `tokio` dependency in `crates/tokmd-node` and instead use the managed `tokio` runtime provided by the host environment via `napi::tokio` (when the `napi` crate's `async` feature is enabled).
- **Why it fits:** This aligns directly with the `deps-hygiene` gate profile and the Auditor persona mission.
- **Trade-offs:** 
  - Structure: Improves consistency and prevents multi-runtime collisions in Node environments.
  - Velocity: High; the change is straightforward and local.
  - Governance: High signal for the Auditor role; removes a duplicate dependency footprint.

### Option B
- Tighten `napi` features to reduce compile time.
- **When to choose it:** If removing the entire explicit tokio dependency isn't possible.
- **Trade-offs:** Requires deep analysis of napi usage, and doesn't solve the core issue of multiple tokio runtimes.

## ✅ Decision
Option A. Removed the explicit `tokio` dependency and switched to using the `napi::tokio` re-export, which natively provides managed async functionality inside napi contexts.

## 🧱 Changes made (SRP)
- `crates/tokmd-node/Cargo.toml`: Removed explicit `tokio` dependency.
- `crates/tokmd-node/src/lib.rs`: Swapped `tokio::` paths to `napi::tokio::`.

## 🧪 Verification receipts
```text
$ cd crates/tokmd-node && CI=true cargo test
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cd crates/tokmd-node && cargo fmt -- --check && cargo clippy -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## 🧭 Telemetry
- Change shape: Dependency removal and code migration
- Blast radius: API/dependencies (Node.js target only)
- Risk class: Low (covered by napi bindings tests)
- Rollback: Revert `Cargo.toml` and `lib.rs`
- Gates run: `cargo build`, `CI=true cargo test`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`

## 🗂️ .jules artifacts
- `.jules/runs/auditor-bindings/envelope.json`
- `.jules/runs/auditor-bindings/decision.md`
- `.jules/runs/auditor-bindings/receipts.jsonl`
- `.jules/runs/auditor-bindings/result.json`
- `.jules/runs/auditor-bindings/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [17499272768016548622](https://jules.google.com/task/17499272768016548622) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Node-only dependency and import path change; behavior stays the same and is covered by existing tokmd-node tests.
> 
> **Overview**
> Removes the standalone **`tokio`** crate from **`tokmd-node`** and routes async work through **`napi::tokio`**, which **`napi`** already exposes when the **`async`** feature is on. That cuts a duplicate dependency and avoids a second, addon-owned runtime alongside the one napi-rs manages in Node.
> 
> **`run_blocking`** now calls **`napi::tokio::task::spawn_blocking`** instead of **`tokio::task::spawn_blocking`**. Tests build their helper runtime with **`napi::tokio::runtime::Builder`** instead of **`tokio::runtime::Builder`**. **`Cargo.lock`** drops **`tokio`** from the **`tokmd-node`** package list. The PR also adds **`.jules/runs/auditor-bindings/`** decision and verification artifacts for the auditor run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e05dc4517d573ad436f2989158e2da0ea63c604f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->