### PR TITLE
palette: Improve error UX for missing paths 🎨

### DIFF
--- a/.jules/runs/palette-1/decision.md
+++ b/.jules/runs/palette-1/decision.md
@@ -1,0 +1,18 @@
+## Options Considered
+
+### Option A: Improve "Path not found" errors and clarify implicit subcommands (Recommended)
+
+When a user runs `tokmd my_repo`, this actually parses into the implicit `lang` subcommand, because clap puts `my_repo` into the `[PATH]...` argument. Since `tokmd` defaults to `lang` when no subcommand is given, but then `lang` fails to find the path `my_repo`, the system generates an error: `Path not found: my_repo`.
+
+Then `error_hints.rs` contains logic that says "if the path doesn't contain slashes or dots, it's probably a typo'd subcommand" and rewrites the error to `Error: Unrecognized subcommand 'my_repo'`. This is incredibly confusing if the user meant a directory path like `tokmd src` but there's no `src` folder (e.g. they typed `srs` or are in the wrong folder). The user expects it to tell them the path doesn't exist, not that `srs` is a subcommand.
+
+I will improve this by refining the `missing_path_as_unrecognized_subcommand` heuristic to recognize when a user is calling `tokmd <path>` and give a more intelligent error that tells them whether it's an unrecognized command or a missing path, and add better suggestions when a missing path is encountered.
+
+I'll remove or dial back the aggressive `missing_path_as_unrecognized_subcommand` rewrite so that paths without slashes are still reported as missing paths if they aren't close to a known subcommand, but maybe include "did you mean the subcommand..." in the hints.
+
+### Option B: Fix the default mode parser
+
+Try to change clap so that it parses subcommands properly, instead of relying on `[PATH]...`. This is harder because it involves re-architecting the CLI schema. The current setup is a design choice to allow `tokmd <path>` to default to `tokmd lang <path>`. The DX issue is purely in the error string rewriting.
+
+## Decision
+I choose **Option A**. The heuristic in `error_hints.rs` that rewrites `Path not found: <token>` to `Unrecognized subcommand '<token>'` is flawed because valid directory names (like `src`, `lib`, `test`) have no slashes or dots. I will change the logic to keep the original `Path not found` error but add a hint: "If this was intended as a subcommand..." or similar, rather than fully replacing the error message.

--- a/.jules/runs/palette-1/envelope.json
+++ b/.jules/runs/palette-1/envelope.json
@@ -1,0 +1,1 @@
+{"prompt_id":"palette_runtime_dx","persona":"palette","style":"builder","primary_shard":"interfaces","allowed_paths":["crates/tokmd-config/**","crates/tokmd-core/**","crates/tokmd/**","docs/reference-cli.md","docs/tutorial.md","crates/tokmd/tests/**"],"gate_profile":"core-rust","allowed_outcomes":["PR-ready patch","learning PR"]}

--- a/.jules/runs/palette-1/pr_body.md
+++ b/.jules/runs/palette-1/pr_body.md
@@ -1,0 +1,70 @@
+## 💡 Summary
+This PR stops rewriting "Path not found: xxx" to "Unrecognized subcommand 'xxx'". Instead, missing paths are reported honestly, and suggestions for subcommands are properly contained in the hint block, avoiding significant confusion for users with typos in directory names.
+
+## 🎯 Why
+When a user typos a path or specifies a missing file (e.g., `tokmd srrc/` or `tokmd test`), the system was rewriting the error to say `Unrecognized subcommand 'srrc'` or `Unrecognized subcommand 'test'`. This creates severe developer friction because the user did not intend to invoke a subcommand. It masks the actual error ("the path doesn't exist").
+
+## 🔎 Evidence
+- **File:** `crates/tokmd/src/error_hints.rs`
+- **Observed behavior:** `cargo run -- missing_path` returned `Error: Unrecognized subcommand 'missing_path'`.
+- **Receipt:** Before changes: `cargo run -- src` returned `Error: Unrecognized subcommand 'src'`. After changes: `cargo run -- src` returns `Error: Path not found: src` with a helpful hint: `Did you mean the subcommand...` or `Run tokmd --help`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Retain the base "Path not found" error, removing `missing_path_as_unrecognized_subcommand` which forcibly rewrites the string. Move subcommand typo corrections directly into the `Hints:` section.
+- **Why it fits:** It's honest to what the CLI parser does (it parsed it as an implicit `lang` `[PATH]`) while still providing subcommand typo correction.
+- **Trade-offs:** Changes CLI error message structure, requiring updates to 4 test files.
+
+### Option B
+- Attempt to rewrite the `clap` parser to separate the implicit `lang` path parsing from command parsing.
+- **When to choose:** If we want strict clap-level rejection.
+- **Trade-offs:** Significantly more complex and might break intentional default-to-lang behaviors.
+
+## ✅ Decision
+Chosen **Option A**. Modifying the DX string rewrite in `error_hints.rs` avoids lying to the user about what the parser did, keeping "Path not found" and pushing the subcommand suggestions to the hints.
+
+## 🧱 Changes made (SRP)
+- Modified `crates/tokmd/src/error_hints.rs` to remove the forced rewriting of missing path errors to unrecognized subcommands.
+- Updated tests in `crates/tokmd/tests/cli_e2e_w65.rs`, `crates/tokmd/tests/cli_error_paths_w51.rs`, `crates/tokmd/tests/cli_errors_w66.rs`, and `crates/tokmd/tests/error_handling_w70.rs` to expect the more accurate `Path not found` base error.
+
+## 🧪 Verification receipts
+```text
+$ cargo run -- src/
+Error: Path not found: src/
+
+Hints:
+- Verify the input path exists and is readable.
+- Use an absolute path to avoid working-directory confusion.
+
+$ cargo run -- anolyze
+Error: Path not found: anolyze
+
+Hints:
+- Did you mean the subcommand `analyze`?
+
+$ cargo run -- frobnicate
+Error: Path not found: frobnicate
+
+Hints:
+- Run `tokmd --help` to see a list of available subcommands.
+
+$ cargo test -p tokmd
+test result: ok. 99 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+## 🧭 Telemetry
+- Change shape: Core CLI error message generation and e2e test assertions.
+- Blast radius: API (error formatting only). Safe change.
+- Risk class: Low risk. Modifies only string formatting for error hints on already-failed executions.
+- Rollback: Revert the PR.
+- Gates run: `core-rust` (test, build).
+
+## 🗂️ .jules artifacts
+- `.jules/runs/palette-1/envelope.json`
+- `.jules/runs/palette-1/decision.md`
+- `.jules/runs/palette-1/receipts.jsonl`
+- `.jules/runs/palette-1/result.json`
+- `.jules/runs/palette-1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/palette-1/receipts.jsonl
+++ b/.jules/runs/palette-1/receipts.jsonl
@@ -1,0 +1,1 @@
+{"command":"cargo test -p tokmd --verbose","exit_code":0}

--- a/.jules/runs/palette-1/result.json
+++ b/.jules/runs/palette-1/result.json
@@ -1,0 +1,11 @@
+{
+  "summary": "Improved DX for unknown subcommands / missing paths.",
+  "outcome": "success",
+  "files_changed": [
+    "crates/tokmd/src/error_hints.rs",
+    "crates/tokmd/tests/cli_e2e_w65.rs",
+    "crates/tokmd/tests/cli_error_paths_w51.rs",
+    "crates/tokmd/tests/cli_errors_w66.rs",
+    "crates/tokmd/tests/error_handling_w70.rs"
+  ]
+}

--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -1,18 +1,8 @@
 use anyhow::Error;
 
 pub(crate) fn format(err: &Error) -> String {
-    let mut out = if let Some(token) = missing_path_as_unrecognized_subcommand(err) {
-        format!("Error: Unrecognized subcommand '{token}'")
-    } else {
-        format!("Error: {err:#}")
-    };
-    let mut hints = suggestions(err);
-    if out.starts_with("Error: Unrecognized subcommand ") {
-        hints.retain(|h| {
-            !h.contains("was intended as a subcommand")
-                && !h.contains("was meant to be a subcommand")
-        });
-    }
+    let mut out = format!("Error: {err:#}");
+    let hints = suggestions(err);
     if !hints.is_empty() {
         out.push_str("\n\nHints:\n");
         for hint in hints {
@@ -22,24 +12,6 @@ pub(crate) fn format(err: &Error) -> String {
         }
     }
     out
-}
-
-fn missing_path_as_unrecognized_subcommand(err: &Error) -> Option<String> {
-    for entry in err.chain() {
-        let message = entry.to_string();
-        let token = message
-            .strip_prefix("Path not found: ")
-            .or_else(|| message.strip_prefix("Input path does not exist: "));
-
-        if let Some(token) = token {
-            let token = token.trim();
-            if looks_like_bare_subcommand_token(token) {
-                return Some(token.to_string());
-            }
-        }
-    }
-
-    None
 }
 
 fn looks_like_bare_subcommand_token(token: &str) -> bool {
@@ -346,14 +318,11 @@ mod tests {
     }
 
     #[test]
-    fn format_rewrites_bare_missing_path_as_unrecognized_subcommand() {
+    fn format_no_longer_rewrites_bare_missing_path() {
         let err = anyhow!("Path not found: frobnicate");
         let rendered = format(&err);
-        assert!(rendered.contains("Error: Unrecognized subcommand 'frobnicate'"));
-        assert!(!rendered.contains("Error: Path not found: frobnicate"));
-        assert!(!rendered.contains("was intended as a subcommand"));
+        assert!(rendered.contains("Error: Path not found: frobnicate"));
         assert!(rendered.contains("Run `tokmd --help` to see a list of available subcommands."));
-        assert!(!rendered.contains("Verify the input path exists and is readable."));
     }
 
     #[test]
@@ -361,7 +330,7 @@ mod tests {
         let err = anyhow!("Path not found: missing/file.rs");
         let rendered = format(&err);
         assert!(rendered.contains("Error: Path not found: missing/file.rs"));
-        assert!(!rendered.contains("Unrecognized subcommand"));
+        assert!(rendered.contains("Verify the input path exists and is readable."));
     }
 
     #[test]

--- a/crates/tokmd/tests/cli_e2e_w65.rs
+++ b/crates/tokmd/tests/cli_e2e_w65.rs
@@ -543,9 +543,7 @@ fn err_typo_subcommand_fails() {
         .arg("lnag")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "Error: Unrecognized subcommand 'lnag'",
-        ))
+        .stderr(predicate::str::contains("Error: Path not found: lnag"))
         .stderr(predicate::str::contains(
             "Did you mean the subcommand `lang`?",
         ));
@@ -700,12 +698,12 @@ fn frobnicate_unknown_subcommand_has_stable_error_output() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Error: Unrecognized subcommand 'frobnicate'"),
-        "stderr should include the unrecognized subcommand error, got: {stderr}"
+        stderr.contains("Error: Path not found: frobnicate"),
+        "stderr should report a bare unknown token as a path error, got: {stderr}"
     );
     assert!(
-        !stderr.contains("Error: Path not found: frobnicate"),
-        "stderr should not report a bare unknown token as only a path error, got: {stderr}"
+        stderr.contains("Run `tokmd --help` to see a list of available subcommands"),
+        "stderr should suggest the help command, got: {stderr}"
     );
     assert!(
         stderr.contains("Hints:"),

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -250,7 +250,7 @@ fn unknown_subcommand_fails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Error: Unrecognized subcommand 'nonexistent-subcommand'",
+            "Error: Path not found: nonexistent-subcommand",
         ));
 }
 
@@ -260,9 +260,7 @@ fn typo_subcommand_suggests_correction() {
         .arg("anolyze")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "Error: Unrecognized subcommand 'anolyze'",
-        ))
+        .stderr(predicate::str::contains("Error: Path not found: anolyze"))
         .stderr(predicate::str::contains(
             "Did you mean the subcommand `analyze`?",
         ));

--- a/crates/tokmd/tests/cli_errors_w66.rs
+++ b/crates/tokmd/tests/cli_errors_w66.rs
@@ -259,7 +259,7 @@ fn unknown_subcommand_produces_helpful_error() {
         .arg("not-a-real-command")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Unrecognized subcommand"));
+        .stderr(predicate::str::contains("Error: Path not found"));
 }
 
 #[test]

--- a/crates/tokmd/tests/error_handling_w70.rs
+++ b/crates/tokmd/tests/error_handling_w70.rs
@@ -159,7 +159,7 @@ fn unknown_subcommand_fails_with_stderr() {
         .arg("nonexistent_subcommand_w70")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Unrecognized subcommand"));
+        .stderr(predicate::str::contains("Error: Path not found"));
 }
 
 // ===========================================================================


### PR DESCRIPTION
This PR stops rewriting "Path not found: xxx" to "Unrecognized subcommand 'xxx'". Instead, missing paths are reported honestly, and suggestions for subcommands are properly contained in the hint block, avoiding significant confusion for users with typos in directory names.

---
*PR created automatically by Jules for task [914190697224641560](https://jules.google.com/task/914190697224641560) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible stderr text only on already-failing invocations; no parser or execution-path changes beyond error formatting.
> 
> **Overview**
> **CLI error formatting** no longer rewrites bare `Path not found: <token>` failures into `Unrecognized subcommand '<token>'`. The primary line stays `Error: {err:#}` (typically **Path not found**), matching implicit default-`lang` parsing when users run `tokmd <bare-token>`.
> 
> In `error_hints.rs`, **`missing_path_as_unrecognized_subcommand`** and the hint-stripping tied to that rewrite are removed. Existing **`suggestions`** logic still adds **Did you mean the subcommand** (Levenshtein) or **`tokmd --help`** in the **Hints:** section for path-shaped tokens; path-like errors with slashes still get verify-path hints.
> 
> Four CLI integration test suites were updated to assert **Path not found** (and hint text) instead of **Unrecognized subcommand**. Jules run artifacts under `.jules/runs/palette-1/` document the decision and verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42628956c530b943d896d459a99e7ce26a9489c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->