### PR TITLE
specsmith: lock in missing path CLI error edge cases 🧪

### DIFF
--- a/.jules/runs/specsmith_interfaces_01/decision.md
+++ b/.jules/runs/specsmith_interfaces_01/decision.md
@@ -1,0 +1,24 @@
+# Decision
+
+## Option A (recommended)
+Add an explicit integration test validating the exact behavior of `tokmd <nonexistent-file.rs>`, proving that `tokmd` defaults to the `lang` subcommand, interprets the bare token as a path, and correctly emits the "Error: Path not found: <bad-path>" global error fallback. We can add this to `crates/tokmd/tests/cli_error_paths_w51.rs` or `crates/tokmd/tests/cli_errors_w66.rs`.
+
+**Why it fits:**
+The `interfaces` shard covers the CLI interface. Memory emphasizes that an unrecognized bare string argument (like `tokmd unknown_word`) defaults to the `lang` subcommand and is interpreted as a `PATH` argument, resulting in a "Path not found" error. If that token looks like a bare subcommand (no slash, no dot, no hyphen), the hint machinery kicks in and rewrites it to an unrecognized subcommand error. However, if it's a file path like `missing/file.rs`, it outputs "Path not found: missing/file.rs". Currently, there are unit tests in `src/error_hints.rs` proving the internal rendering behavior, and some e2e tests like `lang_nonexistent_path_fails` (which passes `tokmd /tmp/...`). But we don't have a specific test explicitly passing `tokmd missing/file.rs` (a bare non-existent path that looks like a path, not a bare token).
+
+**Trade-offs:**
+- Structure: High alignment with Specsmith (improve edge-case polish and regression coverage).
+- Velocity: Quick to implement, solidifying behavior lock.
+- Governance: Meets `core-rust` gating.
+
+## Option B
+Find missing edge cases around `--help` flags and add tests for them.
+
+**When to choose:**
+If we find missing tests for help.
+
+**Trade-offs:**
+- Slower, less targeted than Option A.
+
+## Decision
+Option A. Adding an explicit BDD-style or integration test that ensures `tokmd missing/file.rs` outputs `Path not found: missing/file.rs` without being rewritten to `Unrecognized subcommand 'missing/file.rs'`.

--- a/.jules/runs/specsmith_interfaces_01/envelope.json
+++ b/.jules/runs/specsmith_interfaces_01/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "specsmith_interfaces",
+  "persona": "Specsmith",
+  "style": "Explorer",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "core-rust",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/specsmith_interfaces_01/pr_body.md
+++ b/.jules/runs/specsmith_interfaces_01/pr_body.md
@@ -1,0 +1,58 @@
+## 💡 Summary
+This PR adds edge-case integration tests locking in the behavior of the `tokmd` CLI when provided a non-existent file path without an explicit subcommand. It proves that the path is evaluated correctly as a "Path not found" error, instead of being inaccurately swallowed by the typo/unknown-subcommand logic.
+
+## 🎯 Why
+While the internal hint resolution logic in `error_hints.rs` is covered by unit tests, there was missing end-to-end regression coverage to prove that `tokmd missing/file.rs` implicitly defaults to the `lang` subcommand and surfaces the correct "Path not found" error instead of rewriting the error to "Unrecognized subcommand". Locking this behavior down prevents regressions where path-like arguments get swallowed by over-eager subcommand typo correctors.
+
+## 🔎 Evidence
+- File paths: `crates/tokmd/tests/cli_e2e_w65.rs`, `crates/tokmd/tests/cli_error_paths_w51.rs`
+- Missing coverage for `tokmd <non-existent-path>` (with slash) as an implicit `lang` fallback.
+- Test `nonexistent_file_path_keeps_path_not_found_error_output` successfully runs the CLI process and asserts the correct error boundaries.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add explicit integration/BDD-style tests ensuring `tokmd missing/file.rs` outputs `Path not found: missing/file.rs` without being rewritten to `Unrecognized subcommand`.
+- Fits the `interfaces` shard by increasing CLI edge-case polish and regression coverage (Specsmith core directive).
+- Trade-offs: Structure is solid, high velocity, strictly local to `crates/tokmd/tests`.
+
+### Option B
+- Add unit tests inside `crates/tokmd/src/error_hints.rs` rather than e2e process tests.
+- When to choose: If the failure is deep in the string manipulation and doesn't depend on `clap` routing.
+- Trade-offs: Doesn't prove the full path through `clap` to the default `lang` subcommand error fallback.
+
+## ✅ Decision
+Option A was chosen because proving the full integration path from CLI args to standard error stream is the strongest guarantee against regressions for bare paths.
+
+## 🧱 Changes made (SRP)
+- Added `implicit_lang_mode_with_nonexistent_file_path_shows_path_not_found` to `crates/tokmd/tests/cli_error_paths_w51.rs`
+- Added `nonexistent_file_path_keeps_path_not_found_error_output` to `crates/tokmd/tests/cli_e2e_w65.rs`
+
+## 🧪 Verification receipts
+```text
+running 1 test
+test implicit_lang_mode_with_nonexistent_file_path_shows_path_not_found ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.01s
+
+running 1 test
+test nonexistent_file_path_keeps_path_not_found_error_output ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 99 filtered out; finished in 0.01s
+```
+
+## 🧭 Telemetry
+- Change shape: Test additions
+- Blast radius: `tests` only, no risk to prod behavior.
+- Risk class: Low, purely regression lock-in tests.
+- Rollback: Revert the test additions.
+- Gates run: `cargo test --test cli_e2e_w65`, `cargo test --test cli_error_paths_w51`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/specsmith_interfaces_01/envelope.json`
+- `.jules/runs/specsmith_interfaces_01/decision.md`
+- `.jules/runs/specsmith_interfaces_01/receipts.jsonl`
+- `.jules/runs/specsmith_interfaces_01/result.json`
+- `.jules/runs/specsmith_interfaces_01/pr_body.md`
+
+## 🔜 Follow-ups
+None

--- a/.jules/runs/specsmith_interfaces_01/receipts.jsonl
+++ b/.jules/runs/specsmith_interfaces_01/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "cargo test --test cli_e2e_w65 nonexistent_file_path_keeps_path_not_found_error_output", "output": "test nonexistent_file_path_keeps_path_not_found_error_output ... ok"}
+{"command": "cargo test --test cli_error_paths_w51 implicit_lang_mode_with_nonexistent_file_path_shows_path_not_found", "output": "test implicit_lang_mode_with_nonexistent_file_path_shows_path_not_found ... ok"}

--- a/.jules/runs/specsmith_interfaces_01/result.json
+++ b/.jules/runs/specsmith_interfaces_01/result.json
@@ -1,0 +1,1 @@
+{"status": "success", "files_changed": ["crates/tokmd/tests/cli_e2e_w65.rs", "crates/tokmd/tests/cli_error_paths_w51.rs"]}

--- a/crates/tokmd/tests/cli_e2e_w65.rs
+++ b/crates/tokmd/tests/cli_e2e_w65.rs
@@ -1249,3 +1249,25 @@ fn check_ignore_help_shows_usage() {
         .success()
         .stdout(predicate::str::is_empty().not());
 }
+
+#[test]
+fn nonexistent_file_path_keeps_path_not_found_error_output() {
+    let output = tokmd_bare().arg("missing/file.rs").output().expect("run");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty(), "stdout should be empty");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: Path not found: missing/file.rs"),
+        "stderr should include the path not found error, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Unrecognized subcommand"),
+        "stderr should not report a path-like token as an unrecognized subcommand, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hints:"),
+        "stderr should include the stable hints block, got: {stderr}"
+    );
+}

--- a/crates/tokmd/tests/cli_error_paths_w51.rs
+++ b/crates/tokmd/tests/cli_error_paths_w51.rs
@@ -300,3 +300,15 @@ fn cockpit_subcommand_responds_to_help() {
         .success()
         .stdout(predicate::str::contains("Usage"));
 }
+
+#[test]
+fn implicit_lang_mode_with_nonexistent_file_path_shows_path_not_found() {
+    tokmd_cmd()
+        .arg("missing/file.rs")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Error: Path not found: missing/file.rs",
+        ))
+        .stderr(predicate::str::contains("Unrecognized subcommand").not());
+}


### PR DESCRIPTION
This PR adds edge-case integration tests locking in the behavior of the `tokmd` CLI when provided a non-existent file path without an explicit subcommand. It proves that the path is evaluated correctly as a "Path not found" error, instead of being inaccurately swallowed by the typo/unknown-subcommand logic.

---
*PR created automatically by Jules for task [13402270295825664602](https://jules.google.com/task/13402270295825664602) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and documentation artifacts; no runtime behavior is modified.
> 
> **Overview**
> Adds **integration regression tests** for bare invocations like `tokmd missing/file.rs` (no explicit `lang` subcommand). The tests assert stderr shows **`Error: Path not found: missing/file.rs`**, does **not** contain **`Unrecognized subcommand`**, and (in the e2e case) still includes the stable **`Hints:`** block.
> 
> Coverage lands in `cli_error_paths_w51.rs` (`implicit_lang_mode_with_nonexistent_file_path_shows_path_not_found`) and `cli_e2e_w65.rs` (`nonexistent_file_path_keeps_path_not_found_error_output`), complementing existing nonexistent-path tests that use temp paths or explicit subcommands.
> 
> The diff also adds **`.jules/runs/specsmith_interfaces_01/`** artifacts (decision, envelope, receipts, PR body) documenting the Specsmith run; **no production CLI or hint logic changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c6798c21a3835f54d4f661e3a426fc632ec40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->