### PR TITLE
steward: update ROADMAP.md to reflect v1.12.0, v1.13.0, and v1.13.1 releases 🚢

### DIFF
--- a/.jules/runs/run-steward-1/decision.md
+++ b/.jules/runs/run-steward-1/decision.md
@@ -1,0 +1,18 @@
+# Decision
+
+## Option A (recommended)
+Update the `ROADMAP.md` table to include the 1.12.0, 1.13.0, and 1.13.1 releases, fixing the publishing-evidence drift where the latest releases are entirely missing from the historical summary table in the roadmap. This aligns perfectly with the "Steward 🚢" persona targeting "release metadata or changelog mismatch" and docs drift.
+
+- **Structure**: High. Fixes an obvious drift in the documentation artifact.
+- **Velocity**: High. Simple markdown fix.
+- **Governance**: High. Maintains consistency in project metadata.
+
+## Option B
+Find another small documentation fix, like ensuring all URLs in `docs/` point to the correct places or checking for other mismatches.
+
+- **Structure**: Medium.
+- **Velocity**: Medium. Requires more search to find targets.
+- **Governance**: Medium.
+
+## Decision
+I'll go with Option A. `ROADMAP.md` is clearly missing the 1.12.0, 1.13.0, and 1.13.1 versions in its "Status Summary" table. I'll add them based on the CHANGELOG.md contents.

--- a/.jules/runs/run-steward-1/envelope.json
+++ b/.jules/runs/run-steward-1/envelope.json
@@ -1,0 +1,19 @@
+{
+  "prompt_id": "steward_release",
+  "persona": "Steward",
+  "style": "Stabilizer",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/**/Cargo.toml",
+    ".cargo/**"
+  ],
+  "gate_profile": "governance-release",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/run-steward-1/pr_body.md
+++ b/.jules/runs/run-steward-1/pr_body.md
@@ -1,0 +1,57 @@
+## 💡 Summary
+Updated the `ROADMAP.md` table to include the v1.12.0, v1.13.0, and v1.13.1 releases.
+
+## 🎯 Why
+The "Status Summary" table in `ROADMAP.md` drifted from the actual releases, completely missing versions 1.12 and 1.13. This change keeps our design and planning docs aligned with the real system as targeted by the Steward persona.
+
+## 🔎 Evidence
+- File path: `ROADMAP.md`
+- Observed behavior: Missing versions in the `Status Summary` table when comparing against `CHANGELOG.md` and repo state.
+- Command receipt:
+```text
+awk '/\| \*\*v1.11.0\*\*/ {print; print "| **v1.12.0** | ✅ Complete | Bun UB evidence-readiness and tokmd-swarm workbench. |\n| **v1.13.0** | ✅ Complete | Syntax-aware evidence packet surface. |\n| **v1.13.1** | ✅ Complete | Correction release for the syntax-aware evidence packet surface. |"; next} 1' ROADMAP.md > tmp_roadmap.md && mv tmp_roadmap.md ROADMAP.md
+```
+
+## 🧭 Options considered
+### Option A (recommended)
+- Update the `ROADMAP.md` table to include the 1.12.0, 1.13.0, and 1.13.1 releases.
+- Fits the repo and shard perfectly because it targets release metadata or changelog mismatch.
+- Structure: High. Velocity: High. Governance: High.
+
+### Option B
+- Look for another mismatched doc or configuration.
+- Choose if ROADMAP.md was actually up-to-date or we wanted to make bigger refactoring changes.
+- Trade-offs: Increases search time unnecessarily when a perfect target is available.
+
+## ✅ Decision
+Chose Option A to keep the release surface documents aligned, fixing the obvious version drift in the `ROADMAP.md` file.
+
+## 🧱 Changes made (SRP)
+- `ROADMAP.md`: Inserted v1.12.0, v1.13.0, and v1.13.1 into the `Status Summary` table.
+
+## 🧪 Verification receipts
+```text
+cargo xtask publish --plan --verbose
+cargo xtask version-consistency
+cargo xtask docs --check
+cargo fmt -- --check
+cargo clippy --workspace --all-features --tests --benches -- -D warnings
+```
+All passed.
+
+## 🧭 Telemetry
+- Change shape: Documentation update.
+- Blast radius: Docs. Zero logic impact.
+- Risk class: None. Simple Markdown change.
+- Rollback: Revert the commit.
+- Gates run: `governance-release` fallback commands run.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-steward-1/envelope.json`
+- `.jules/runs/run-steward-1/decision.md`
+- `.jules/runs/run-steward-1/receipts.jsonl`
+- `.jules/runs/run-steward-1/result.json`
+- `.jules/runs/run-steward-1/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-steward-1/receipts.jsonl
+++ b/.jules/runs/run-steward-1/receipts.jsonl
@@ -1,0 +1,6 @@
+{"command": "cargo xtask publish --plan --verbose", "status": "success"}
+{"command": "cargo xtask version-consistency", "status": "success"}
+{"command": "cargo xtask docs --check", "status": "success"}
+{"command": "cargo fmt -- --check", "status": "success"}
+{"command": "cargo clippy --workspace --all-features --tests --benches -- -D warnings", "status": "success"}
+{"command": "awk '/\\| \\*\\*v1.11.0\\*\\*/ {print; print \"| **v1.12.0** | ✅ Complete | Bun UB evidence-readiness and tokmd-swarm workbench. |\\n| **v1.13.0** | ✅ Complete | Syntax-aware evidence packet surface. |\\n| **v1.13.1** | ✅ Complete | Correction release for the syntax-aware evidence packet surface. |\"; next} 1' ROADMAP.md > tmp_roadmap.md && mv tmp_roadmap.md ROADMAP.md", "status": "success"}

--- a/.jules/runs/run-steward-1/result.json
+++ b/.jules/runs/run-steward-1/result.json
@@ -1,0 +1,7 @@
+{
+  "outcome": "PR-ready patch",
+  "files_changed": [
+    "ROADMAP.md"
+  ],
+  "reasoning": "ROADMAP.md Status Summary table drifted from CHANGELOG.md; updated it to include 1.12.0, 1.13.0, and 1.13.1 releases."
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,9 @@ context for humans, machines, CI, and agents.
 | **v1.10.0-rc.1** | ✅ Complete | Release-candidate proof for CI control plane, bounded trust hardening, WASM truth, and proof stability. |
 | **v1.10.0** | ✅ Complete | Stable CI control plane, trust hardening, WASM truth, Action release, and proof stability. |
 | **v1.11.0** | ✅ Complete | Browser runtime polish: explicit cache behavior, progress events, retry/rate-limit UX, and authenticated fetch. |
+| **v1.12.0** | ✅ Complete | Bun UB evidence-readiness and tokmd-swarm workbench. |
+| **v1.13.0** | ✅ Complete | Syntax-aware evidence packet surface. |
+| **v1.13.1** | ✅ Complete | Correction release for the syntax-aware evidence packet surface. |
 | **v2.0.0** | 🔭 Planned  | MCP server, streaming analysis, plugin system.               |
 | **v3.0.0** | 🚧 Active (Shadow) | Tree-sitter AST foundation in-tree behind feature flag. |
 


### PR DESCRIPTION
steward: update ROADMAP.md to reflect v1.12.0, v1.13.0, and v1.13.1 releases 🚢

The "Status Summary" table in `ROADMAP.md` drifted from the actual releases, completely missing versions 1.12 and 1.13. This change keeps our design and planning docs aligned with the real system as targeted by the Steward persona.

---
*PR created automatically by Jules for task [4707471949587034894](https://jules.google.com/task/4707471949587034894) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and automation metadata only; no runtime, schema, or release pipeline behavior changes.
> 
> **Overview**
> The **Status Summary** table in `ROADMAP.md` jumped from **v1.11.0** to **v2.0.0**, so shipped **v1.12.0**, **v1.13.0**, and **v1.13.1** were missing from the historical release index. This PR inserts three **✅ Complete** rows with one-line focus text aligned to `CHANGELOG.md` (Bun UB / swarm workbench, syntax-aware evidence packet surface, and the 1.13.1 install/syntax correction).
> 
> It also adds **Steward** Jules run artifacts under `.jules/runs/run-steward-1/` (envelope, decision, receipts, PR body template, result) recording the governance-release gates run for this docs-only patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecff980f02b63e110005bdb1dc4253d8247445f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->