### PR TITLE
auditor: remove unused serde dependency from tokmd-model 🧾

### DIFF
--- a/.jules/runs/auditor_core_manifests/decision.md
+++ b/.jules/runs/auditor_core_manifests/decision.md
@@ -1,0 +1,11 @@
+## Options considered
+
+### Option A (recommended)
+- what it is: Remove the unused `serde` dependency from `crates/tokmd-model`.
+- why it fits this repo and shard: It directly targets the primary mission of landing a boring, high-signal dependency hygiene improvement in the core-pipeline shard. `serde` is a direct dependency in `tokmd-model` but isn't used by the actual library code (only in tests where `serde_json` is used).
+- trade-offs: Structure / Velocity / Governance. Minimal impact; improves dependency hygiene.
+
+### Option B
+- what it is: Remove unused `tokmd-scan`, `tokmd-format`, `tokmd-model` dev-dependencies from `crates/tokmd-types`.
+- when to choose it instead: If they were actually unused. However, they are used in `crates/tokmd-types/tests/`.
+- trade-offs: Would require migrating tests, which goes against the "boring" mandate.

--- a/.jules/runs/auditor_core_manifests/envelope.json
+++ b/.jules/runs/auditor_core_manifests/envelope.json
@@ -1,0 +1,20 @@
+{
+  "prompt_id": "auditor_core_manifests",
+  "persona": "Auditor",
+  "style": "Builder",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**",
+    "docs/schema.json",
+    "docs/SCHEMA.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "deps-hygiene",
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/auditor_core_manifests/pr_body.md
+++ b/.jules/runs/auditor_core_manifests/pr_body.md
@@ -1,0 +1,68 @@
+## 💡 Summary
+Removed the unused `serde` dependency from `crates/tokmd-model` to improve dependency hygiene within the `core-pipeline` shard.
+
+## 🎯 Why
+During a review of the dependency graph and manifest files for the core data and model pipeline, `serde` was identified as an unused direct dependency in `tokmd-model`. Although `tokmd-model` types implement Serde traits, the types themselves and their Serde annotations live in `tokmd-types`. The `tokmd-model` implementation code does not directly use `serde`, and tests only require `serde` to serialize/deserialize outputs using `serde_json`. Cleaning up this dependency tightens the manifest surface and reduces the build graph slightly for this crate.
+
+## 🔎 Evidence
+- `crates/tokmd-model/Cargo.toml`
+- Searching `crates/tokmd-model/src` for `serde` yielded no results.
+- Removing `serde` from `[dependencies]` and running `cargo check -p tokmd-model` was successful. (Note: `serde` was added to `[dev-dependencies]` as it is used by test utility code via `serde_json`).
+
+## 🧭 Options considered
+### Option A (recommended)
+- Remove `serde` from `[dependencies]` in `tokmd-model` (moving it to `[dev-dependencies]` for test usage).
+- Why it fits: Aligns perfectly with the Auditor persona's mandate for boring, high-signal dependency hygiene improvements, specifically targeting "remove an unused direct dependency".
+- Trade-offs: Zero velocity or architectural trade-offs. Minor positive governance impact by tightening the dependency surface.
+
+### Option B
+- Investigate removing the unused dev-dependencies (`tokmd-scan`, `tokmd-format`, `tokmd-model`) listed in `tokmd-types`.
+- When to choose: If they were truly unused. However, they are used by tests in `tokmd-types`, so removing them would break the test suite.
+- Trade-offs: Negative impact on velocity as it would require migrating tests.
+
+## ✅ Decision
+Option A was selected. Removing the unused `serde` dependency from `tokmd-model` provides a concrete, safe hygiene improvement within the assigned shard.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-model/Cargo.toml`
+  - Removed `serde.workspace = true` from `[dependencies]`.
+  - Added `serde.workspace = true` to `[dev-dependencies]` for test-only serialization requirements.
+
+## 🧪 Verification receipts
+```text
+$ cargo check -p tokmd-model
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
+
+$ CI=true cargo test -p tokmd-model
+   ...
+   Doc-tests tokmd_model
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 23.94s
+
+$ cargo clippy -- -D warnings
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 30.69s
+
+$ cargo xtask publish --plan --verbose
+=== Publish Plan ===
+
+Workspace version: 1.13.1
+...
+To execute this plan:
+  cargo xtask publish --yes --verbose
+```
+
+## 🧭 Telemetry
+- Change shape: Manifest update
+- Blast radius: Internal crate dependencies only. No API, IO, docs, schema, concurrency, or compatibility risks.
+- Risk class: Low risk. Modifying crate dependencies. Build and test gates provide complete confidence.
+- Rollback: Revert the `Cargo.toml` change.
+- Gates run: `cargo check`, `cargo test`, `cargo fmt`, `cargo clippy`, `cargo build`, `cargo xtask publish --plan`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/auditor_core_manifests/envelope.json`
+- `.jules/runs/auditor_core_manifests/decision.md`
+- `.jules/runs/auditor_core_manifests/receipts.jsonl`
+- `.jules/runs/auditor_core_manifests/result.json`
+- `.jules/runs/auditor_core_manifests/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/auditor_core_manifests/receipts.jsonl
+++ b/.jules/runs/auditor_core_manifests/receipts.jsonl
@@ -1,0 +1,9 @@
+{"command": "Write envelope.json", "outcome": "Success"}
+{"command": "cargo check -p tokmd-model", "outcome": "Success"}
+{"command": "cargo test -p tokmd-model", "outcome": "Success"}
+{"command": "cargo fmt -- --check", "outcome": "Success"}
+{"command": "cargo clippy -- -D warnings", "outcome": "Success"}
+{"command": "cargo build --verbose", "outcome": "Success"}
+{"command": "CI=true cargo test -p tokmd-model --verbose", "outcome": "Success"}
+{"command": "cargo xtask publish --plan --verbose", "outcome": "Success"}
+{"command": "Write PR body and result", "outcome": "Success"}

--- a/.jules/runs/auditor_core_manifests/result.json
+++ b/.jules/runs/auditor_core_manifests/result.json
@@ -1,0 +1,4 @@
+{
+  "status": "success",
+  "outcome": "PR-ready patch"
+}

--- a/crates/tokmd-model/Cargo.toml
+++ b/crates/tokmd-model/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["development-tools"]
 documentation = "https://docs.rs/tokmd-model"
 
 [dependencies]
-serde.workspace = true
 tokei = { version = "14.0.0", default-features = false }
 tokmd-types.workspace = true
 
@@ -22,3 +21,4 @@ proptest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 
+serde.workspace = true


### PR DESCRIPTION
## 💡 Summary
Removed the unused `serde` dependency from `crates/tokmd-model` to improve dependency hygiene within the `core-pipeline` shard.

## 🎯 Why
During a review of the dependency graph and manifest files for the core data and model pipeline, `serde` was identified as an unused direct dependency in `tokmd-model`. Although `tokmd-model` types implement Serde traits, the types themselves and their Serde annotations live in `tokmd-types`. The `tokmd-model` implementation code does not directly use `serde`, and tests only require `serde` to serialize/deserialize outputs using `serde_json`. Cleaning up this dependency tightens the manifest surface and reduces the build graph slightly for this crate.

## 🔎 Evidence
- `crates/tokmd-model/Cargo.toml`
- Searching `crates/tokmd-model/src` for `serde` yielded no results.
- Removing `serde` from `[dependencies]` and running `cargo check -p tokmd-model` was successful. (Note: `serde` was added to `[dev-dependencies]` as it is used by test utility code via `serde_json`).

## 🧭 Options considered
### Option A (recommended)
- Remove `serde` from `[dependencies]` in `tokmd-model` (moving it to `[dev-dependencies]` for test usage).
- Why it fits: Aligns perfectly with the Auditor persona's mandate for boring, high-signal dependency hygiene improvements, specifically targeting "remove an unused direct dependency".
- Trade-offs: Zero velocity or architectural trade-offs. Minor positive governance impact by tightening the dependency surface.

### Option B
- Investigate removing the unused dev-dependencies (`tokmd-scan`, `tokmd-format`, `tokmd-model`) listed in `tokmd-types`.
- When to choose: If they were truly unused. However, they are used by tests in `tokmd-types`, so removing them would break the test suite.
- Trade-offs: Negative impact on velocity as it would require migrating tests.

## ✅ Decision
Option A was selected. Removing the unused `serde` dependency from `tokmd-model` provides a concrete, safe hygiene improvement within the assigned shard.

## 🧱 Changes made (SRP)
- `crates/tokmd-model/Cargo.toml`
  - Removed `serde.workspace = true` from `[dependencies]`.
  - Added `serde.workspace = true` to `[dev-dependencies]` for test-only serialization requirements.

## 🧪 Verification receipts
```text
$ cargo check -p tokmd-model
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s

$ CI=true cargo test -p tokmd-model
   ...
   Doc-tests tokmd_model
    Finished `test` profile [unoptimized + debuginfo] target(s) in 23.94s

$ cargo clippy -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 30.69s

$ cargo xtask publish --plan --verbose
=== Publish Plan ===

Workspace version: 1.13.1
...
To execute this plan:
  cargo xtask publish --yes --verbose
```

## 🧭 Telemetry
- Change shape: Manifest update
- Blast radius: Internal crate dependencies only. No API, IO, docs, schema, concurrency, or compatibility risks.
- Risk class: Low risk. Modifying crate dependencies. Build and test gates provide complete confidence.
- Rollback: Revert the `Cargo.toml` change.
- Gates run: `cargo check`, `cargo test`, `cargo fmt`, `cargo clippy`, `cargo build`, `cargo xtask publish --plan`

## 🗂️ .jules artifacts
- `.jules/runs/auditor_core_manifests/envelope.json`
- `.jules/runs/auditor_core_manifests/decision.md`
- `.jules/runs/auditor_core_manifests/receipts.jsonl`
- `.jules/runs/auditor_core_manifests/result.json`
- `.jules/runs/auditor_core_manifests/pr_body.md`

## 🔜 Follow-ups
None.

---
*PR created automatically by Jules for task [3329742810193518980](https://jules.google.com/task/3329742810193518980) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only change with no API or runtime behavior changes; tests retain `serde` for dev builds.
> 
> **Overview**
> **Dependency hygiene** for `tokmd-model`: `serde` is removed from `[dependencies]` and added under `[dev-dependencies]` so the library no longer declares a runtime `serde` edge—library `src` does not reference it; tests still get it via `serde_json`.
> 
> The PR also adds **Jules auditor run artifacts** under `.jules/runs/auditor_core_manifests/` (envelope, decision log, receipts, PR body copy, result JSON) documenting the deps-hygiene gate and verification commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab7860c2f1baead817473870317814e5b290b952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->