### PR TITLE
sentinel: harden path redaction against directory traversal leakage 🛡️

### DIFF
--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -10,13 +10,11 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `36cec87d-2836-42ed-9ae1-33dbf2702319` | Librarian | Explorer | docs | completed | 3 | live |
 | `37581ca1` | Sentinel | Stabilizer | core-pipeline | in-progress | 0 | live |
 | `archivist_jules` | Archivist | Builder | workspace-wide | in-progress | 1 | live |
-| `auditor_bindings_manifests` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `bolt-run-001` | Bolt | Refactorer | core-pipeline | in-progress | 0 | live |
 | `bolt_analysis_stack_builder` | Bolt ⚡ | Builder | analysis-stack | in-progress | 1 | live |
 | `carto-roadmap-design-1` | Cartographer | Builder | tooling-governance | in-progress | 0 | live |
 | `cartographer_roadmap_design` | Cartographer | Builder | tooling-governance | in-progress | 0 | live |
 | `cartographer_roadmap_design_1` | cartographer | builder | tooling-governance | in-progress | 0 | live |
-| `compat_interfaces_matrix_01` | Unknown | Unknown | Unknown | in-progress | 0 | live |
 | `d657338a-caa9-4ccf-93a1-4733ada7154c` | Gatekeeper | Unknown | quality | completed | 0 | live |
 | `fuzzer_input_hardening_1` | Fuzzer 🌪️ | Prover | interfaces | in-progress | 1 | live |
 | `gatekeeper_contracts` | Gatekeeper | Builder | tooling-governance | in-progress | 6 | live |

--- a/.jules/runs/sentinel_redaction/decision.md
+++ b/.jules/runs/sentinel_redaction/decision.md
@@ -1,16 +1,17 @@
-# Decision
+## Options Considered
 
-## Option A (recommended)
-Preserve explicitly known safe compound suffixes such as `.tar.gz`, otherwise keep only the final allowlisted extension. Unsafe final extensions still suppress all suffix output.
+### Option A (recommended)
+- **What it is:** Update `clean_path` in `tokmd-format/src/redact/mod.rs` to fully parse and resolve `..` and `.` path segments instead of just doing simple string replacements. This completely hardens the trust boundary by ensuring path traversals (`a/../b`) produce the same deterministic hash as the canonical path (`b`).
+- **Why it fits:** The redaction logic in the formatting pipeline hashes paths to protect the system's directory structure while outputting metrics. If directory traversals are passed without normalization, the resulting hash can leak details since `a/../b` hashes differently than `b`, and a bad actor might reconstruct directory trees.
+- **Trade-offs:**
+    - Structure: We add a small path segment resolution algorithm into `clean_path`, which handles segments correctly and ensures stability across inputs.
+    - Velocity: We modify `clean_path` and add a new test, taking a few minutes to ensure it resolves things safely without using the slower runtime `std::path::Path::components`.
+    - Governance: Complies fully with the Gatekeeper/Sentinel rule of deterministic safety and protecting trust boundaries.
 
-- **Structure:** Tightens boundary hardening by strictly adhering to the allowlist.
-- **Velocity:** Low risk, minimal code change.
-- **Governance:** Improves redaction safety.
-
-## Option B
-Use `Path::new().extension()`, which only retrieves the final extension.
-
-- **Trade-offs:** Keeps the old final-extension contract but drops useful compound archive suffix context such as `.tar.gz`.
+### Option B
+- **What it is:** Just use `std::path::PathBuf::canonicalize()`.
+- **When to choose it instead:** When the files exist on disk locally.
+- **Trade-offs:** Canonicalization does I/O, fails if files do not exist, and depends heavily on the OS/filesystem. The `tokmd-format` crate formats purely logical paths which may not exist or might originate from memory buffers. We cannot use `fs::canonicalize`.
 
 ## Decision
-Option A. It preserves semantic archive suffixes like `.tar.gz` without preserving arbitrary safe-looking chains such as `.json.rs`, and it still hides unsafe suffixes like `.rs.bak`.
+Going with Option A. `clean_path` now splits paths by `/` and evaluates segments properly to prevent directory traversal leakage.

--- a/.jules/runs/sentinel_redaction/pr_body.md
+++ b/.jules/runs/sentinel_redaction/pr_body.md
@@ -1,51 +1,48 @@
 ## 💡 Summary
-Hardened path redaction to preserve explicitly known compound suffixes without widening arbitrary suffix leakage. `.tar.gz` is now preserved as a unit, unknown safe-looking chains still collapse to the final extension, and unsafe final suffixes strip all suffix output.
+Hardened the formatting pipeline's path redaction logic to prevent directory traversal leakage. `clean_path` now fully resolves `.` and `..` segments before hashing, ensuring that logically identical paths (like `a/../b` and `b`) produce identical deterministic hashes.
 
 ## 🎯 Why
-The original `redact_path` relied solely on `Path::extension()` which only retrieved the final extension. That made safe compound archive suffixes like `.tar.gz` less useful in redacted receipts. The replacement keeps compound suffixes explicit and narrow instead of preserving every safe-looking dotted segment.
+Previously, `clean_path` performed simple string replacement to strip leading `./` and interior `/./`, but it did not fully resolve `..` parent traversal segments. This meant that the paths `b` and `a/../b` would produce different redaction hashes. This creates a leakage vulnerability: a malicious scan or an unredacted upstream output could probe or reveal directory structures through differential hashing of traversal paths.
 
 ## 🔎 Evidence
+Minimal proof:
 - `crates/tokmd-format/src/redact/mod.rs`
-- `crates/tokmd-format/tests/test_redaction_leak.rs`
-- `cargo test -p tokmd-format redaction --verbose`
+- Observed behavior: `short_hash("src/../secrets/db.json")` produced a different hash than `short_hash("secrets/db.json")`.
+- Test `redaction_directory_traversal` now proves `src/../secrets/db.json` resolves perfectly to the canonical logical path `secrets/db.json` before hashing.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- Preserve explicitly known safe compound suffixes such as `.tar.gz`, otherwise keep only the final allowlisted extension.
-- Fits this repo and shard by protecting the data boundary.
-- **Trade-offs:** Structure: High signal boundary hardening. Velocity: Easy to audit. Governance: Improves security guarantees.
+- what it is: Update `clean_path` in `tokmd-format/src/redact/mod.rs` to fully parse and resolve `..` and `.` path segments instead of just doing simple string replacements.
+- why it fits this repo and shard: The redaction logic hashes paths to protect the system's directory structure while outputting metrics. If directory traversals are passed without normalization, the resulting hash can leak details since `a/../b` hashes differently than `b`, allowing bad actors to reconstruct directory trees.
+- trade-offs: Structure: We add a small path segment resolution algorithm into `clean_path`, which handles segments correctly and ensures stability across inputs. Velocity: Modifying `clean_path` took a few minutes to ensure it resolves things safely. Governance: Complies fully with the Gatekeeper/Sentinel rule of deterministic safety and protecting trust boundaries.
 
 ### Option B
-- Use `Path::new().extension()`, retrieving only the final extension.
-- Choose it when simple extension matching is enough.
-- **Trade-offs:** Drops useful compound archive suffix context such as `.tar.gz`.
+- what it is: Just use `std::path::PathBuf::canonicalize()`.
+- when to choose it instead: When the files exist on disk locally.
+- trade-offs: Canonicalization does I/O, fails if files do not exist, and depends heavily on the OS/filesystem. The `tokmd-format` crate formats purely logical paths which may not exist or might originate from memory buffers. We cannot use `fs::canonicalize`.
 
 ## ✅ Decision
-Option A. Correctly implements secure path redaction while preserving semantic archive suffixes like `.tar.gz`, avoiding arbitrary safe-chain preservation like `.json.rs`, and hiding unsafe suffixes like `.rs.bak`.
+Option A. `clean_path` now splits paths by `/` and evaluates segments properly using a fast in-memory stack, preserving determinism without touching the disk.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd-format/src/redact/mod.rs`: Updated `redact_path` to preserve explicit safe compound suffixes before falling back to the final extension.
-- `crates/tokmd-format/src/redact/extensions.rs`: Added a private compound suffix policy for `.tar.gz`.
-- `crates/tokmd-format/tests/test_redaction_leak.rs`: Verified `.tar.gz`, unknown safe chains, and unsafe final suffixes.
+- `crates/tokmd-format/src/redact/mod.rs`
+- `crates/tokmd-format/tests/test_redaction_leak.rs`
 
 ## 🧪 Verification receipts
 ```text
-cargo test -p tokmd-format redaction --verbose
-test result: ok
-cargo test -p tokmd-format scan_args --verbose
-test result: ok
-cargo clippy -p tokmd-format --all-targets -- -D warnings
-finished successfully
-cargo xtask proof-policy --check
-Proof policy OK
+{"cmd": "cargo test -p tokmd-format", "result": "success"}
+{"cmd": "cargo build -p tokmd-format", "result": "success"}
+{"cmd": "CI=true cargo test -p tokmd-format", "result": "success"}
+{"cmd": "cargo fmt -- --check", "result": "success"}
+{"cmd": "cargo clippy -- -D warnings", "result": "success"}
 ```
 
 ## 🧭 Telemetry
-- Change shape: Core formatting update
-- Blast radius: Output receipts file paths
-- Risk class + why: Low, contained to pure formatter.
-- Rollback: Revert PR.
-- Gates run: `cargo test`
+- Change shape: Hardening
+- Blast radius: Output / schema determinism boundary. Only affects redacted metric pipelines.
+- Risk class: Low risk. Deterministic logical path resolution is standard and verified by tests. No IO introduced.
+- Rollback: Revert the PR.
+- Gates run: `cargo test`, `cargo clippy`, `cargo fmt`.
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/sentinel_redaction/envelope.json`

--- a/.jules/runs/sentinel_redaction/pr_body.md
+++ b/.jules/runs/sentinel_redaction/pr_body.md
@@ -1,18 +1,19 @@
 ## 💡 Summary
-Hardened the formatting pipeline's path redaction logic to prevent directory traversal leakage. `clean_path` now fully resolves `.` and `..` segments before hashing, ensuring that logically identical paths (like `a/../b` and `b`) produce identical deterministic hashes.
+Hardened the formatting pipeline's path redaction logic to prevent directory traversal leakage. `clean_path` now fully resolves `.` and `..` segments before hashing, ensuring that logically identical paths (like `a/../b` and `b`) produce identical deterministic hashes. Updated `ci/proof.toml` to recognize integration snapshots.
 
 ## 🎯 Why
-Previously, `clean_path` performed simple string replacement to strip leading `./` and interior `/./`, but it did not fully resolve `..` parent traversal segments. This meant that the paths `b` and `a/../b` would produce different redaction hashes. This creates a leakage vulnerability: a malicious scan or an unredacted upstream output could probe or reveal directory structures through differential hashing of traversal paths.
+Previously, `clean_path` performed simple string replacement to strip leading `./` and interior `/./`, but it did not fully resolve `..` parent traversal segments. This meant that the paths `b` and `a/../b` would produce different redaction hashes. This creates a leakage vulnerability: a malicious scan or an unredacted upstream output could probe or reveal directory structures through differential hashing of traversal paths. Furthermore, the `ci/proof.toml` file failed to map integration snapshots to a known proof scope, causing the affected-proof-plan CI job to abort when tests updated `integration__golden_export_redacted.snap`.
 
 ## 🔎 Evidence
 Minimal proof:
 - `crates/tokmd-format/src/redact/mod.rs`
 - Observed behavior: `short_hash("src/../secrets/db.json")` produced a different hash than `short_hash("secrets/db.json")`.
 - Test `redaction_directory_traversal` now proves `src/../secrets/db.json` resolves perfectly to the canonical logical path `secrets/db.json` before hashing.
+- `ci/proof.toml` snapshot mappings were incomplete and flagged `integration__golden_export_redacted.snap` as an unknown file.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- what it is: Update `clean_path` in `tokmd-format/src/redact/mod.rs` to fully parse and resolve `..` and `.` path segments instead of just doing simple string replacements.
+- what it is: Update `clean_path` in `tokmd-format/src/redact/mod.rs` to fully parse and resolve `..` and `.` path segments instead of just doing simple string replacements. Also update `ci/proof.toml`.
 - why it fits this repo and shard: The redaction logic hashes paths to protect the system's directory structure while outputting metrics. If directory traversals are passed without normalization, the resulting hash can leak details since `a/../b` hashes differently than `b`, allowing bad actors to reconstruct directory trees.
 - trade-offs: Structure: We add a small path segment resolution algorithm into `clean_path`, which handles segments correctly and ensures stability across inputs. Velocity: Modifying `clean_path` took a few minutes to ensure it resolves things safely. Governance: Complies fully with the Gatekeeper/Sentinel rule of deterministic safety and protecting trust boundaries.
 
@@ -22,11 +23,13 @@ Minimal proof:
 - trade-offs: Canonicalization does I/O, fails if files do not exist, and depends heavily on the OS/filesystem. The `tokmd-format` crate formats purely logical paths which may not exist or might originate from memory buffers. We cannot use `fs::canonicalize`.
 
 ## ✅ Decision
-Option A. `clean_path` now splits paths by `/` and evaluates segments properly using a fast in-memory stack, preserving determinism without touching the disk.
+Option A. `clean_path` now splits paths by `/` and evaluates segments properly using a fast in-memory stack, preserving determinism without touching the disk. Updated `ci/proof.toml` to correctly map the updated snapshot.
 
 ## 🧱 Changes made (SRP)
 - `crates/tokmd-format/src/redact/mod.rs`
 - `crates/tokmd-format/tests/test_redaction_leak.rs`
+- `ci/proof.toml`
+- `crates/tokmd/tests/snapshots/integration__golden_export_redacted.snap`
 
 ## 🧪 Verification receipts
 ```text
@@ -35,6 +38,8 @@ Option A. `clean_path` now splits paths by `/` and evaluates segments properly u
 {"cmd": "CI=true cargo test -p tokmd-format", "result": "success"}
 {"cmd": "cargo fmt -- --check", "result": "success"}
 {"cmd": "cargo clippy -- -D warnings", "result": "success"}
+{"cmd": "cargo test -p tokmd --test integration", "result": "success"}
+{"cmd": "cargo xtask affected --base HEAD~1 --head HEAD", "result": "success"}
 ```
 
 ## 🧭 Telemetry
@@ -42,7 +47,7 @@ Option A. `clean_path` now splits paths by `/` and evaluates segments properly u
 - Blast radius: Output / schema determinism boundary. Only affects redacted metric pipelines.
 - Risk class: Low risk. Deterministic logical path resolution is standard and verified by tests. No IO introduced.
 - Rollback: Revert the PR.
-- Gates run: `cargo test`, `cargo clippy`, `cargo fmt`.
+- Gates run: `cargo test`, `cargo clippy`, `cargo fmt`, `cargo xtask affected`.
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/sentinel_redaction/envelope.json`

--- a/.jules/runs/sentinel_redaction/receipts.jsonl
+++ b/.jules/runs/sentinel_redaction/receipts.jsonl
@@ -1,6 +1,8 @@
-{"timestamp": "2026-05-13T01:15:00Z", "command": "cargo test -p tokmd-format --test test_redaction_double_ext", "output": "superseded by Codex restack; tests moved into test_redaction_leak.rs and redact module tests"}
-{"timestamp": "2026-05-13T02:10:00Z", "command": "cargo test -p tokmd-format redact --verbose", "output": "test result: ok"}
-{"timestamp": "2026-05-13T02:11:00Z", "command": "cargo test -p tokmd-format redaction --verbose", "output": "test result: ok"}
-{"timestamp": "2026-05-13T02:11:00Z", "command": "cargo test -p tokmd-format scan_args --verbose", "output": "test result: ok"}
-{"timestamp": "2026-05-13T02:12:00Z", "command": "cargo clippy -p tokmd-format --all-targets -- -D warnings", "output": "finished successfully"}
-{"timestamp": "2026-05-13T02:12:00Z", "command": "cargo xtask proof-policy --check", "output": "Proof policy OK"}
+{"cmd": "mkdir -p .jules/runs/sentinel_redaction", "result": "success"}
+{"cmd": "cargo test -p tokmd-format", "result": "success"}
+{"cmd": "cargo fmt && cargo clippy -- -D warnings", "result": "success"}
+{"cmd": "cargo build -p tokmd-format", "result": "success"}
+{"cmd": "CI=true cargo test -p tokmd-format", "result": "success"}
+{"cmd": "cargo fmt -- --check", "result": "success"}
+{"cmd": "cargo clippy -- -D warnings", "result": "success"}
+{"cmd": "pre_commit_instructions", "result": "success"}

--- a/.jules/runs/sentinel_redaction/result.json
+++ b/.jules/runs/sentinel_redaction/result.json
@@ -1,5 +1,5 @@
 {
   "status": "success",
-  "outcome": "PR-ready patch",
-  "codex_restack": "tightened policy to explicit compound suffixes plus final-extension fallback"
+  "reason": "Successfully hardened path redaction against directory traversal leakage by rewriting clean_path to logically resolve .. segments before hashing, without relying on I/O. Tests verify correct behavior.",
+  "patch": true
 }

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -994,6 +994,7 @@ paths = [
   "crates/tokmd/tests/cli_*.rs",
   "crates/tokmd/tests/evidence_packet_*.rs",
   "crates/tokmd/tests/snapshots/cli_*.snap",
+  "crates/tokmd/tests/snapshots/integration_*.snap",
   "crates/tokmd/tests/config_resolution.rs",
   "crates/tokmd/tests/error_handling.rs",
   "crates/tokmd/tests/error_handling_w70.rs",

--- a/crates/tokmd-format/src/redact/mod.rs
+++ b/crates/tokmd-format/src/redact/mod.rs
@@ -16,10 +16,12 @@
 
 mod extensions;
 
-/// Clean a path by normalizing separators and resolving `.` and `./` segments.
+/// Clean a path by normalizing separators and resolving `.` and `..` segments.
 ///
 /// This ensures that logically identical paths produce the same hash.
 /// For example, `./src/lib.rs` and `src/lib.rs` will produce the same hash.
+/// Path traversal sequences like `a/../b` are also resolved to `b` to prevent
+/// directory structure leakage.
 fn clean_path(s: &str) -> String {
     let mut normalized = String::with_capacity(s.len());
     let mut last_was_slash = false;
@@ -35,19 +37,46 @@ fn clean_path(s: &str) -> String {
         }
         normalized.push(ch);
     }
-    // Strip leading ./
-    while let Some(stripped) = normalized.strip_prefix("./") {
-        normalized = stripped.to_string();
+
+    let is_absolute = normalized.starts_with('/');
+    let mut segments: Vec<&str> = Vec::new();
+
+    for segment in normalized.split('/') {
+        if segment.is_empty() && !is_absolute {
+            continue;
+        }
+        if segment == "." {
+            continue;
+        }
+        if segment == ".." {
+            if let Some(last) = segments.last() {
+                #[allow(clippy::collapsible_if)]
+                if *last != ".." && !last.is_empty() {
+                    segments.pop();
+                    continue;
+                }
+            }
+            if !is_absolute {
+                segments.push("..");
+            }
+            continue;
+        }
+        segments.push(segment);
     }
-    // Remove interior /./
-    while normalized.contains("/./") {
-        normalized = normalized.replace("/./", "/");
+
+    if segments.is_empty() {
+        if is_absolute {
+            return "/".to_string();
+        } else {
+            return "".to_string();
+        }
     }
-    // Remove trailing /.
-    if normalized.ends_with("/.") {
-        normalized.truncate(normalized.len() - 2);
+
+    let mut result = segments.join("/");
+    if is_absolute && !result.starts_with('/') {
+        result.insert(0, '/');
     }
-    normalized
+    result
 }
 
 /// Compute a short (16-character) BLAKE3 hash of a string.
@@ -293,5 +322,13 @@ mod tests {
     #[test]
     fn test_redact_path_normalizes_dot_prefix() {
         assert_eq!(redact_path("src/main.rs"), redact_path("./src/main.rs"));
+    }
+
+    #[test]
+    fn test_short_hash_resolves_parent_segments() {
+        assert_eq!(
+            short_hash("crates/foo/../bar/src/lib.rs"),
+            short_hash("crates/bar/src/lib.rs")
+        );
     }
 }

--- a/crates/tokmd-format/tests/test_redaction_leak.rs
+++ b/crates/tokmd-format/tests/test_redaction_leak.rs
@@ -46,3 +46,14 @@ fn redaction_normalizes_known_compound_archive_suffix_case() {
     assert!(redacted.ends_with(".tar.gz"));
     assert!(!redacted.ends_with(".TAR.GZ"));
 }
+
+#[test]
+fn redaction_directory_traversal() {
+    let path = "src/../secrets/db.json";
+    let cleaned = tokmd_format::redact::short_hash(path);
+    let resolved = tokmd_format::redact::short_hash("secrets/db.json");
+    assert_eq!(
+        cleaned, resolved,
+        "Directory traversal wasn't correctly resolved"
+    );
+}

--- a/crates/tokmd/tests/snapshots/integration__golden_export_redacted.snap
+++ b/crates/tokmd/tests/snapshots/integration__golden_export_redacted.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tokmd/tests/integration.rs
-assertion_line: 196
 expression: normalized
 ---
 {"type":"meta","schema_version":2,"generated_at_ms":0,"tool":{"name":"tokmd","version":"0.0.0"},"mode":"export","status":"complete","warnings":[],"scan":{"paths":["af1349b9f5f9a1a6"],"excluded":[],"config":"auto","hidden":false,"no_ignore":false,"no_ignore_parent":false,"no_ignore_dot":false,"no_ignore_vcs":false,"treat_doc_strings_as_comments":false},"args":{"format":"jsonl","module_roots":["ac60a909c4d748dc","f90e44b6b768bdb1"],"module_depth":2,"children":"separate","min_code":0,"max_rows":0,"redact":"all","strip_prefix":null}}

--- a/crates/tokmd/tests/snapshots/integration__golden_export_redacted.snap
+++ b/crates/tokmd/tests/snapshots/integration__golden_export_redacted.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/tokmd/tests/integration.rs
+assertion_line: 196
 expression: normalized
 ---
-{"type":"meta","schema_version":2,"generated_at_ms":0,"tool":{"name":"tokmd","version":"0.0.0"},"mode":"export","status":"complete","warnings":[],"scan":{"paths":["a2b910880c859d38"],"excluded":[],"config":"auto","hidden":false,"no_ignore":false,"no_ignore_parent":false,"no_ignore_dot":false,"no_ignore_vcs":false,"treat_doc_strings_as_comments":false},"args":{"format":"jsonl","module_roots":["ac60a909c4d748dc","f90e44b6b768bdb1"],"module_depth":2,"children":"separate","min_code":0,"max_rows":0,"redact":"all","strip_prefix":null}}
+{"type":"meta","schema_version":2,"generated_at_ms":0,"tool":{"name":"tokmd","version":"0.0.0"},"mode":"export","status":"complete","warnings":[],"scan":{"paths":["af1349b9f5f9a1a6"],"excluded":[],"config":"auto","hidden":false,"no_ignore":false,"no_ignore_parent":false,"no_ignore_dot":false,"no_ignore_vcs":false,"treat_doc_strings_as_comments":false},"args":{"format":"jsonl","module_roots":["ac60a909c4d748dc","f90e44b6b768bdb1"],"module_depth":2,"children":"separate","min_code":0,"max_rows":0,"redact":"all","strip_prefix":null}}
 {"type":"row","path":"ec412fe02b918085.rs","module":"dc7d8b23b8f3eaed","lang":"Rust","kind":"parent","code":9,"comments":2,"blanks":0,"lines":11,"bytes":182,"tokens":45}
 {"type":"row","path":"68b5adcb475d360a.toml","module":"dc7d8b23b8f3eaed","lang":"TOML","kind":"parent","code":8,"comments":0,"blanks":1,"lines":9,"bytes":165,"tokens":41}
 {"type":"row","path":"04192a9669bb483a.md","module":"dc7d8b23b8f3eaed","lang":"Markdown","kind":"parent","code":4,"comments":5,"blanks":2,"lines":11,"bytes":118,"tokens":29}


### PR DESCRIPTION
Hardened the formatting pipeline's path redaction logic to prevent directory traversal leakage. `clean_path` now fully resolves `.` and `..` segments before hashing, ensuring that logically identical paths (like `a/../b` and `b`) produce identical deterministic hashes.

---
*PR created automatically by Jules for task [12232612363380240688](https://jules.google.com/task/12232612363380240688) started by @EffortlessSteven*