### PR TITLE
sentinel: tighten FFI trust boundaries by enforcing JSON object types on config blocks 🛡️

### DIFF
--- a/.jules/runs/run_sentinel_001/decision.md
+++ b/.jules/runs/run_sentinel_001/decision.md
@@ -1,0 +1,20 @@
+# Decision
+
+## Problem
+In `tokmd-core/src/ffi/settings_parse.rs`, JSON configuration blocks for modes like `lang`, `module`, `export`, etc. were retrieved using `args.get("field").unwrap_or(args)`. This fallback logic allowed a non-object value (like a string or array) passed in the `field` key to bypass validation and cause a panic when trying to parse the actual parameters, or quietly fallback to parsing the root object when it shouldn't.
+
+## Options Considered
+
+### Option A: Use strict object validation
+Write a `get_config_block` helper that explicitly checks if the block exists, and if it does, ensures it is an object (`v.is_object()`). If not an object, it returns a validation error instead of panicking or falling back to the root `args`.
+
+- Fits this repo and shard because the `interfaces` shard has a strong emphasis on trust boundaries, FFI correctness, and avoiding panics.
+- Trade-offs: Increases code slightly but dramatically improves robustness.
+
+### Option B: Panic safely
+Instead of returning a validation error, unwrap an error or let `serde_json` fail earlier.
+
+- Trade-offs: The FFI should never panic. A soft validation error is the correct approach.
+
+## Decision
+Option A was chosen. I implemented a `get_config_block` helper in `parse.rs` and replaced all the `args.get(field).unwrap_or(args)` instances in `settings_parse.rs` with `get_config_block(args, field)?`. This fixes the non-object validation bypass at the FFI trust boundary.

--- a/.jules/runs/run_sentinel_001/envelope.json
+++ b/.jules/runs/run_sentinel_001/envelope.json
@@ -1,0 +1,16 @@
+{
+  "prompt_id": "sentinel_boundaries",
+  "persona": "Sentinel",
+  "style": "Builder",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-config/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**",
+    "docs/reference-cli.md",
+    "docs/tutorial.md",
+    "crates/tokmd/tests/**"
+  ],
+  "gate_profile": "security-boundary",
+  "allowed_outcomes": ["PR-ready patch", "proof-improvement patch", "learning PR"]
+}

--- a/.jules/runs/run_sentinel_001/pr_body.md
+++ b/.jules/runs/run_sentinel_001/pr_body.md
@@ -1,0 +1,53 @@
+## 💡 Summary
+Tightened FFI trust boundary validation by strictly enforcing JSON object types on configuration blocks. This prevents a validation bypass where non-object values (like strings or arrays) would fall back to the root `args` or cause a panic during argument parsing.
+
+## 🎯 Why
+In `tokmd-core/src/ffi/settings_parse.rs`, JSON configuration blocks (e.g., `scan`, `lang`, `module`) were fetched using `args.get(field).unwrap_or(args)`. If a caller passed a non-object value, `unwrap_or` wouldn't trigger, returning the non-object which later would either fail unpredictably or cause the system to ignore the actual settings. This strengthens the `security-boundary` gate by guaranteeing the shape of the config object.
+
+## 🔎 Evidence
+- `crates/tokmd-core/src/ffi/settings_parse.rs`
+- Observed behavior: `unwrap_or` relies on the key missing to fallback, but an invalid type present at that key circumvents the fallback logic and proceeds with a malformed value.
+- Added `ffi_rejects_non_object_config_blocks` test in `ffi_trust_boundary.rs` demonstrating the fix correctly returns an error instead of a panic/success.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add `get_config_block` helper that explicitly checks if the block is an object.
+- Fits this repo and shard because it directly addresses the FFI trust boundary for `tokmd-core`.
+- Trade-offs: Minor code change, significantly improves structural safety of the FFI interface.
+
+### Option B
+- Change `serde_json` parsing to fail immediately on any invalid type.
+- This would break backward compatibility if some parameters casually allow nulls or fallbacks. Option A specifically targets the configuration blocks.
+
+## ✅ Decision
+Implemented Option A. A new `get_config_block` helper ensures nested configuration objects are actually objects or fall back securely to the root.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-core/src/ffi/parse.rs`: Added `get_config_block` and tests.
+- `crates/tokmd-core/src/ffi/settings_parse.rs`: Updated all configuration block retrievals to use `get_config_block`.
+- `crates/tokmd-core/tests/ffi_trust_boundary.rs`: Added validation test.
+
+## 🧪 Verification receipts
+```text
+cargo test --test ffi_trust_boundary
+cargo test -p tokmd-core
+cargo fmt -- --check
+cargo clippy -- -D warnings
+```
+
+## 🧭 Telemetry
+- Change shape: Structural hardening in FFI parse layer.
+- Blast radius: API/schema. Safe fallback to default object structure.
+- Risk class: Low risk. Fixes a clear validation hole.
+- Rollback: Revert the PR.
+- Gates run: `security-boundary`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run_sentinel_001/envelope.json`
+- `.jules/runs/run_sentinel_001/decision.md`
+- `.jules/runs/run_sentinel_001/receipts.jsonl`
+- `.jules/runs/run_sentinel_001/result.json`
+- `.jules/runs/run_sentinel_001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run_sentinel_001/receipts.jsonl
+++ b/.jules/runs/run_sentinel_001/receipts.jsonl
@@ -1,0 +1,4 @@
+{"command": "cargo test --test ffi_trust_boundary", "outcome": "Failed before patch, succeeded after patch."}
+{"command": "cargo test -p tokmd-core", "outcome": "All tests pass successfully."}
+{"command": "cargo fmt -- --check", "outcome": "Formatted correctly."}
+{"command": "cargo clippy -- -D warnings", "outcome": "No warnings or errors."}

--- a/.jules/runs/run_sentinel_001/result.json
+++ b/.jules/runs/run_sentinel_001/result.json
@@ -1,0 +1,9 @@
+{
+  "outcome": "PR-ready patch",
+  "files_changed": [
+    "crates/tokmd-core/src/ffi/parse.rs",
+    "crates/tokmd-core/src/ffi/settings_parse.rs",
+    "crates/tokmd-core/tests/ffi_trust_boundary.rs"
+  ],
+  "verification": "Tests passed"
+}

--- a/crates/tokmd-core/src/ffi/parse.rs
+++ b/crates/tokmd-core/src/ffi/parse.rs
@@ -8,8 +8,12 @@ use serde_json::Value;
 use crate::error::TokmdError;
 use crate::settings::{ChildIncludeMode, ChildrenMode, ConfigMode, ExportFormat, RedactMode};
 
-pub(super) fn scan_arg_object(args: &Value) -> &Value {
-    args.get("scan").unwrap_or(args)
+pub(super) fn get_config_block<'a>(args: &'a Value, field: &str) -> Result<&'a Value, TokmdError> {
+    match args.get(field) {
+        None => Ok(args),
+        Some(v) if v.is_object() => Ok(v),
+        _ => Err(TokmdError::invalid_field(field, "a JSON object")),
+    }
 }
 
 /// Parse a boolean field strictly: missing/null -> default, non-bool -> error.
@@ -262,20 +266,27 @@ mod tests {
     use crate::error::ErrorCode;
     use serde_json::json;
 
-    // ---- scan_arg_object --------------------------------------------------
+    // ---- get_config_block --------------------------------------------------
 
     #[test]
-    fn scan_arg_object_returns_nested_when_present() {
+    fn get_config_block_returns_nested_when_present() {
         let args = json!({"scan": {"root": "."}, "other": 1});
-        let inner = scan_arg_object(&args);
+        let inner = get_config_block(&args, "scan").unwrap();
         assert_eq!(inner, &json!({"root": "."}));
     }
 
     #[test]
-    fn scan_arg_object_returns_args_when_missing() {
+    fn get_config_block_returns_args_when_missing() {
         let args = json!({"root": "."});
-        let inner = scan_arg_object(&args);
+        let inner = get_config_block(&args, "scan").unwrap();
         assert_eq!(inner, &args);
+    }
+
+    #[test]
+    fn get_config_block_rejects_non_object() {
+        let args = json!({"scan": "not-an-object"});
+        let err = get_config_block(&args, "scan").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidSettings);
     }
 
     // ---- parse_bool -------------------------------------------------------

--- a/crates/tokmd-core/src/ffi/settings_parse.rs
+++ b/crates/tokmd-core/src/ffi/settings_parse.rs
@@ -6,11 +6,11 @@
 use serde_json::Value;
 
 use super::parse::{
-    parse_analyze_preset, parse_bool, parse_child_include_mode, parse_children_mode,
-    parse_config_mode, parse_effort_layer, parse_effort_model, parse_export_format,
-    parse_import_granularity, parse_optional_bool, parse_optional_redact_mode,
+    get_config_block, parse_analyze_preset, parse_bool, parse_child_include_mode,
+    parse_children_mode, parse_config_mode, parse_effort_layer, parse_effort_model,
+    parse_export_format, parse_import_granularity, parse_optional_bool, parse_optional_redact_mode,
     parse_optional_string, parse_optional_u64, parse_optional_usize, parse_redact_mode,
-    parse_required_string, parse_string, parse_string_array, parse_usize, scan_arg_object,
+    parse_required_string, parse_string, parse_string_array, parse_usize,
 };
 use crate::error::TokmdError;
 use crate::settings::{
@@ -19,7 +19,7 @@ use crate::settings::{
 };
 
 pub(super) fn parse_scan_settings(args: &Value) -> Result<ScanSettings, TokmdError> {
-    let obj = scan_arg_object(args);
+    let obj = get_config_block(args, "scan")?;
     if obj.get("paths").is_some_and(Value::is_null) {
         return Err(TokmdError::invalid_field("paths", "an array of strings"));
     }
@@ -40,7 +40,7 @@ pub(super) fn parse_scan_settings(args: &Value) -> Result<ScanSettings, TokmdErr
 }
 
 pub(super) fn parse_lang_settings(args: &Value) -> Result<LangSettings, TokmdError> {
-    let obj = args.get("lang").unwrap_or(args);
+    let obj = get_config_block(args, "lang")?;
 
     Ok(LangSettings {
         top: parse_usize(obj, "top", 0)?,
@@ -51,7 +51,7 @@ pub(super) fn parse_lang_settings(args: &Value) -> Result<LangSettings, TokmdErr
 }
 
 pub(super) fn parse_module_settings(args: &Value) -> Result<ModuleSettings, TokmdError> {
-    let obj = args.get("module").unwrap_or(args);
+    let obj = get_config_block(args, "module")?;
 
     Ok(ModuleSettings {
         top: parse_usize(obj, "top", 0)?,
@@ -67,7 +67,7 @@ pub(super) fn parse_module_settings(args: &Value) -> Result<ModuleSettings, Tokm
 }
 
 pub(super) fn parse_export_settings(args: &Value) -> Result<ExportSettings, TokmdError> {
-    let obj = args.get("export").unwrap_or(args);
+    let obj = get_config_block(args, "export")?;
 
     Ok(ExportSettings {
         format: parse_export_format(obj, ExportFormat::Jsonl)?,
@@ -88,7 +88,7 @@ pub(super) fn parse_export_settings(args: &Value) -> Result<ExportSettings, Tokm
 
 #[allow(dead_code)]
 pub(super) fn parse_analyze_settings(args: &Value) -> Result<AnalyzeSettings, TokmdError> {
-    let obj = args.get("analyze").unwrap_or(args);
+    let obj = get_config_block(args, "analyze")?;
 
     let effort_base_ref = parse_optional_string(obj, "effort_base_ref")?;
     let effort_head_ref = parse_optional_string(obj, "effort_head_ref")?;
@@ -133,7 +133,7 @@ pub(super) fn parse_analyze_settings(args: &Value) -> Result<AnalyzeSettings, To
 pub(super) fn parse_cockpit_settings(
     args: &Value,
 ) -> Result<crate::settings::CockpitSettings, TokmdError> {
-    let obj = args.get("cockpit").unwrap_or(args);
+    let obj = get_config_block(args, "cockpit")?;
 
     Ok(crate::settings::CockpitSettings {
         base: parse_string(obj, "base", "main")?,
@@ -144,7 +144,7 @@ pub(super) fn parse_cockpit_settings(
 }
 
 pub(super) fn parse_diff_settings(args: &Value) -> Result<DiffSettings, TokmdError> {
-    let obj = args.get("diff").unwrap_or(args);
+    let obj = get_config_block(args, "diff")?;
 
     let from = parse_required_string(obj, "from")?;
     let to = parse_required_string(obj, "to")?;

--- a/crates/tokmd-core/tests/ffi_trust_boundary.rs
+++ b/crates/tokmd-core/tests/ffi_trust_boundary.rs
@@ -1,0 +1,18 @@
+use serde_json::json;
+use tokmd_core::ffi::run_json;
+
+#[test]
+fn ffi_rejects_non_object_config_blocks() {
+    let bad_args = json!({
+        "mode": "lang",
+        "scan": "should-be-object-or-missing",
+        "lang": "should-be-object-or-missing"
+    });
+    let result = run_json("lang", &bad_args.to_string());
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert!(
+        parsed.get("error").is_some(),
+        "Expected error when configuration block is not an object, got success: {}",
+        result
+    );
+}


### PR DESCRIPTION
## 💡 Summary 
Tightened FFI trust boundary validation by strictly enforcing JSON object types on configuration blocks. This prevents a validation bypass where non-object values (like strings or arrays) would fall back to the root `args` or cause a panic during argument parsing.

## 🎯 Why 
In `tokmd-core/src/ffi/settings_parse.rs`, JSON configuration blocks (e.g., `scan`, `lang`, `module`) were fetched using `args.get(field).unwrap_or(args)`. If a caller passed a non-object value, `unwrap_or` wouldn't trigger, returning the non-object which later would either fail unpredictably or cause the system to ignore the actual settings. This strengthens the `security-boundary` gate by guaranteeing the shape of the config object.

## 🔎 Evidence 
- `crates/tokmd-core/src/ffi/settings_parse.rs`
- Observed behavior: `unwrap_or` relies on the key missing to fallback, but an invalid type present at that key circumvents the fallback logic and proceeds with a malformed value.
- Added `ffi_rejects_non_object_config_blocks` test in `ffi_trust_boundary.rs` demonstrating the fix correctly returns an error instead of a panic/success.

## 🧭 Options considered 
### Option A (recommended) 
- Add `get_config_block` helper that explicitly checks if the block is an object.
- Fits this repo and shard because it directly addresses the FFI trust boundary for `tokmd-core`.
- Trade-offs: Minor code change, significantly improves structural safety of the FFI interface.

### Option B 
- Change `serde_json` parsing to fail immediately on any invalid type.
- This would break backward compatibility if some parameters casually allow nulls or fallbacks. Option A specifically targets the configuration blocks.

## ✅ Decision 
Implemented Option A. A new `get_config_block` helper ensures nested configuration objects are actually objects or fall back securely to the root.

## 🧱 Changes made (SRP) 
- `crates/tokmd-core/src/ffi/parse.rs`: Added `get_config_block` and tests.
- `crates/tokmd-core/src/ffi/settings_parse.rs`: Updated all configuration block retrievals to use `get_config_block`.
- `crates/tokmd-core/tests/ffi_trust_boundary.rs`: Added validation test.

## 🧪 Verification receipts 
```text
cargo test --test ffi_trust_boundary
cargo test -p tokmd-core
cargo fmt -- --check
cargo clippy -- -D warnings
```

## 🧭 Telemetry 
- Change shape: Structural hardening in FFI parse layer.
- Blast radius: API/schema. Safe fallback to default object structure.
- Risk class: Low risk. Fixes a clear validation hole.
- Rollback: Revert the PR.
- Gates run: `security-boundary`

## 🗂️ .jules artifacts 
- `.jules/runs/run_sentinel_001/envelope.json`
- `.jules/runs/run_sentinel_001/decision.md`
- `.jules/runs/run_sentinel_001/receipts.jsonl`
- `.jules/runs/run_sentinel_001/result.json`
- `.jules/runs/run_sentinel_001/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [11819175541608924284](https://jules.google.com/task/11819175541608924284) started by @EffortlessSteven*