### PR TITLE
gatekeeper: Fix strict file-policy check by allowlisting new syntax fixtures and scripts ✅

### DIFF
--- a/.jules/runs/gatekeeper_contracts/decision.md
+++ b/.jules/runs/gatekeeper_contracts/decision.md
@@ -1,17 +1,16 @@
 # Option A (recommended)
-Use the `xtask docs --update` tool logic by replacing hardcoded command parameter tables in `docs/reference-cli.md` with auto-updating `<!-- HELP: <command> -->` markers. The xtask command automatically pulls the current `tokmd` help text.
-
-- **Structure**: Automatically synchronizes docs with command changes, removing drift.
-- **Velocity**: Speeds up doc updates since CLI parameters will always stay in sync.
-- **Governance**: Ensures reference documentation acts as a deterministically correct reflection of the program options. Fits well within the 'Gatekeeper' persona and the `tooling-governance` shard.
+- Add missing policy globs to `policy/non-rust-allowlist.toml` to cover `fixtures/syntax/python/**/*.py`, `fixtures/syntax/typescript/**/*.ts`, `fixtures/syntax/typescript/**/*.tsx`, and `scripts/*.sh`.
+- This fits the `tooling-governance` shard and the `Gatekeeper` persona perfectly by enforcing the deterministic file policy check (`cargo xtask check-file-policy --strict`).
+- The unallowlisted files were causing the strict file policy checker to fail, breaking CI or pre-commit deterministic guarantees.
+- **Trade-offs**:
+  - Structure: High. Enforces the invariant that all non-Rust files must be tracked and allowlisted.
+  - Velocity: Low impact.
+  - Governance: High. Locks in the policy for new fixtures.
 
 # Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand, matching them against `cargo run --bin tokmd -- <cmd> --help`.
-
-- **When to choose it**: Only if you strictly want specialized tables with custom columns or manually edited parameter groups that rust `clap` output does not provide.
-- **Trade-offs**: Extreme risk of drift and maintenance burden. Requires a developer to manually verify changes on every new parameter addition.
+- Ignore the file-policy check and only run other contract checks.
+- Choose this if file policy is not considered part of the core determinant loop.
+- **Trade-offs**: Violates deterministic build policies by allowing untracked or unrecognized files to slip into the repo without an owner or justification.
 
 # Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables (from `.jules/policy/shards.json` or general run memory). The final restack replaces the remaining manual command tables with `<!-- HELP: <command> -->` markers, then makes `cargo xtask docs --check` fail if any expected marker pair is missing. This keeps the deterministic docs path inside `cargo xtask docs --update` / `cargo xtask docs --check` instead of relying on ad hoc post-processing scripts.
-
-The restack also aligns the xtask gate regression test with the current repository rule that Jules provenance under `.jules/**` may be intentional PR state. Gate still blocks cache/transcript/runtime/tmp paths, but it does not blanket-block `.jules/runs/**` provenance packets.
+Option A. The `Gatekeeper` persona's mission is to protect contract-bearing surfaces and deterministic behavior. The `check-file-policy --strict` failure is a direct violation of repository governance. Fixing the allowlist restores the gate.

--- a/.jules/runs/gatekeeper_contracts/envelope.json
+++ b/.jules/runs/gatekeeper_contracts/envelope.json
@@ -17,7 +17,6 @@
   "gate_profile": "contracts-determinism",
   "allowed_outcomes": [
     "PR-ready patch",
-    "proof-improvement patch",
     "learning PR"
   ]
 }

--- a/.jules/runs/gatekeeper_contracts/pr_body.md
+++ b/.jules/runs/gatekeeper_contracts/pr_body.md
@@ -1,58 +1,43 @@
 ## 💡 Summary
-Removed manual markdown parameter tables from `docs/reference-cli.md` and replaced them with `<!-- HELP: <command> -->` markers. This delegates documentation generation to `cargo xtask docs`, locks in deterministic CLI usage tracking, and closes the silent-skip case where a missing marker pair could make docs checks pass without checking a command.
-
-The restack also updates the xtask gate regression test to match the current queue policy: Jules provenance under `.jules/**` can be intentional PR state, so gate should not blanket-block `.jules/runs/**` while still guarding actual runtime/cache/transcript directories.
+Added missing file-policy allowlist entries for `fixtures/syntax/python`, `fixtures/syntax/typescript`, and `scripts/*.sh`. This resolves strict file-policy checker failures and locks in governance for these new fixture and script files.
 
 ## 🎯 Why
-Manual parameter tables in documentation frequently become outdated when CLI arguments change. `tokmd` provides `cargo xtask docs --update` which relies on `<!-- HELP: <command> -->` markers. Several commands were still using hand-maintained markdown tables, meaning updates to CLI args could easily be missed by the xtask check. The final patch also makes missing marker pairs an explicit docs-check failure.
+The `cargo xtask check-file-policy --strict` gate was failing due to 4 unallowlisted non-Rust files (`fixtures/syntax/python/native_boundary.py`, `fixtures/syntax/typescript/component.tsx`, `fixtures/syntax/typescript/native_boundary.ts`, and `scripts/check-no-bare-self-hosted.sh`). The Gatekeeper persona enforces deterministic policy invariants; all non-Rust files must be mapped to an owner, kind, and reason.
 
 ## 🔎 Evidence
-- File: `docs/reference-cli.md`
-- Observation: Many subcommands like `module`, `export`, `run`, `handoff` did not have `<!-- HELP: <command> -->` markers and used manual `| Argument | Description |` tables.
-- Verification: Running `cargo xtask docs --check` before the change ignored drift in these subcommands because they had no markers.
+- `policy/non-rust-allowlist.toml`
+- Running the file policy checker in strict mode failed on the new test fixtures and scripts.
+- `cargo xtask check-file-policy --strict` failure output.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-Replace manual parameter tables with `<!-- HELP: <command> -->` markers for all commands, letting `cargo xtask docs --update` populate them correctly from the clap help output. Also fail `cargo xtask docs --check` when an expected marker pair is absent.
-- Trade-offs:
-  - **Structure**: Eliminates duplication of parameter details.
-  - **Velocity**: Developers no longer have to manually edit markdown tables when updating CLI parameters.
-  - **Governance**: Fits perfectly within the `tooling-governance` shard.
+- Add explicit `[[allow]]` blocks in `policy/non-rust-allowlist.toml` for the new syntax fixtures and scripts.
+- Why it fits this repo and shard: Directly aligns with the `tooling-governance` shard's mandate to maintain deterministic workspace policies.
+- Trade-offs: Structure is improved by enforcing invariants. No velocity penalty. Enhances governance.
 
 ### Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand.
-- When to choose it: Only if custom columns are needed that clap does not output.
-- Trade-offs: Extreme risk of drift and maintenance burden.
+- Wait for the authors of the test fixtures to fix it themselves.
+- When to choose it instead: If the files were temporary or mistakenly committed.
+- Trade-offs: Leaves the `check-file-policy --strict` gate broken in the meantime, violating the Gatekeeper mandate to lock in invariants.
 
 ## ✅ Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables. The final patch keeps all synchronization in `cargo xtask docs --update` / `cargo xtask docs --check` and verifies that every expected command marker exists.
+Option A. Enforcing the file policy allowlist is exactly the kind of deterministic governance fix the Gatekeeper is designed for.
 
 ## 🧱 Changes made (SRP)
-- `docs/reference-cli.md`: Removed manual parameter tables for the CLI command surface and replaced them with `<!-- HELP: <command> -->` markers.
-- `xtask/src/tasks/docs.rs`: Treats missing marker pairs as documentation drift instead of silently skipping those commands.
-- `xtask/src/tasks/gate.rs`, `xtask/tests/xtask_deep_w74.rs`: Document and test that `.jules/runs/**` is not treated as forbidden runtime state because it may be intentional PR provenance.
+- `policy/non-rust-allowlist.toml`
 
 ## 🧪 Verification receipts
 ```text
-$ cargo xtask docs --update
-Updated docs/reference-cli.md
-
-$ cargo xtask docs --check
-Documentation is up to date.
-
-$ cargo test -p tokmd --test docs
-test result: ok
-
-$ cargo test -p xtask
-test result: ok
+$ cargo xtask check-file-policy --strict
+file-policy OK: 87 entries, 1157 non-Rust files covered, 1309 Rust files skipped
 ```
 
 ## 🧭 Telemetry
-- Change shape: Replacement of manual documentation content with auto-generated sync blocks plus docs-check and provenance-policy guardrails.
-- Blast radius: Docs and xtask validation only.
-- Risk class: Low - Does not change application runtime behavior.
-- Rollback: Revert the commit.
-- Gates run: `cargo xtask docs --update`, `cargo xtask docs --check`, `cargo test -p xtask`, `cargo test -p tokmd --test docs`, `cargo fmt-check`, `git diff --check`
+- Change shape: Policy ledger update
+- Blast radius: build / policy (No API or production changes).
+- Risk class: Low. Restores CI gate.
+- Rollback: Revert the PR.
+- Gates run: `cargo xtask check-file-policy --strict`
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/gatekeeper_contracts/envelope.json`
@@ -62,4 +47,4 @@ test result: ok
 - `.jules/runs/gatekeeper_contracts/pr_body.md`
 
 ## 🔜 Follow-ups
-None. All CLI references are now correctly managed via xtask.
+None.

--- a/.jules/runs/gatekeeper_contracts/receipts.jsonl
+++ b/.jules/runs/gatekeeper_contracts/receipts.jsonl
@@ -1,4 +1,3 @@
-{"command": "cargo xtask docs --update", "result": "updated docs/reference-cli.md from tokmd help markers"}
-{"command": "cargo xtask docs --check", "result": "documentation is up to date and all expected marker pairs exist"}
-{"command": "cargo test -p xtask", "result": "xtask docs guard covered by task tests"}
-{"command": "cargo test -p tokmd --test docs", "result": "CLI docs integration tests passed"}
+{"command": "cargo xtask check-file-policy --strict", "result": "Error: file-policy: 4 finding(s) (strict)"}
+{"command": "cat << 'EOF' >> policy/non-rust-allowlist.toml ...", "result": "Added missing globs."}
+{"command": "cargo xtask check-file-policy --strict", "result": "file-policy OK: 87 entries, 1157 non-Rust files covered, 1309 Rust files skipped"}

--- a/.jules/runs/gatekeeper_contracts/result.json
+++ b/.jules/runs/gatekeeper_contracts/result.json
@@ -1,17 +1,5 @@
 {
-  "summary": "Fixed documentation drift by replacing manual parameter tables with `<!-- HELP: <command> -->` markers and failing docs checks when expected marker pairs are missing",
-  "files_changed": [
-    "docs/reference-cli.md",
-    "xtask/src/tasks/docs.rs",
-    "xtask/src/tasks/gate.rs",
-    "xtask/tests/xtask_deep_w74.rs"
-  ],
-  "gates_run": [
-    "cargo xtask docs --update",
-    "cargo xtask docs --check",
-    "cargo test -p xtask",
-    "cargo test -p tokmd --test docs",
-    "cargo fmt-check",
-    "git diff --check"
-  ]
+  "summary": "Fixed `check-file-policy --strict` failures by adding missing allowlist entries for `fixtures/syntax` and `scripts/*.sh`.",
+  "status": "success",
+  "files_changed": ["policy/non-rust-allowlist.toml"]
 }

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -800,3 +800,39 @@ surface = "vendor"
 classification = "production"
 reason = "Pinned patched dependency required until upstream fallback exists."
 covered_by = ["cargo check --workspace --locked"]
+
+[[allow]]
+glob = "fixtures/syntax/python/**/*.py"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "Python fixtures for syntax boundary tests."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "fixtures/syntax/typescript/**/*.ts"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "TypeScript fixtures for syntax boundary tests."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "fixtures/syntax/typescript/**/*.tsx"
+kind = "test_fixture"
+owner = "testing/oracle"
+surface = "test"
+classification = "test_fixture"
+reason = "TSX fixtures for syntax boundary tests."
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "scripts/*.sh"
+kind = "script"
+owner = "core/policy"
+surface = "build"
+classification = "config"
+reason = "Shell scripts for CI or utility tasks."
+covered_by = []


### PR DESCRIPTION
Added missing file-policy allowlist entries for `fixtures/syntax/python`, `fixtures/syntax/typescript`, and `scripts/*.sh`. This resolves strict file-policy checker failures and locks in governance for these new fixture and script files.

The `cargo xtask check-file-policy --strict` gate was failing due to 4 unallowlisted non-Rust files. The Gatekeeper persona enforces deterministic policy invariants; all non-Rust files must be mapped to an owner, kind, and reason.

---
*PR created automatically by Jules for task [4498475976377584978](https://jules.google.com/task/4498475976377584978) started by @EffortlessSteven*