### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-25 (v1.14.0 prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-06-25
+
+1.14 expands the PR evidence surface into a first-class local and CI workflow.
+It adds the `tokmd render` and `tokmd packet generate` CLIs, ships the
+`mode: packet` GitHub Action, sharpens syntax-receipt and complexity evidence,
+and makes several CLI error and validation paths more actionable. No receipt
+schema versions changed in this release.
+
 ### Added
 
+- Added `tokmd render`, which renders packet presets (including unsafe-review
+  bundles) from analysis/context/syntax inputs, ingests sibling tool bundles,
+  and validates against the `tokmd-packets` JSON Schema at the CLI boundary.
+- Added `tokmd packet generate`, an evidence-packet orchestrator that produces
+  the `sensors/tokmd/` packet (analysis, context, optional syntax, manifest)
+  from a single command.
 - Added `mode: packet` to the `EffortlessMetrics/tokmd` GitHub Action. It runs
   `tokmd packet generate` with the prebuilt-binary runtime as the default,
   shares the cockpit/sensor base-ref inference, uploads the `sensors/tokmd/`
@@ -21,9 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `runtime` Action inputs for `mode: packet`. `fail-on` maps packet status to
   workflow failure (`failed`, `partial`, `never`); `runtime: container` is
   reserved for the pending GHCR runtime and fails fast for now.
+- Added `panic_seam_summary` to syntax receipts, summarizing panic-like seams
+  detected during syntax extraction for packet consumers.
 
 ### Changed
 
+- Syntax evidence ranking now deprioritizes test assertion noise so advisory
+  review signals surface higher-value seams instead of test-only assertions.
 - CI phase 3 (#226, #299): retired the duplicate routed Rust Small frontdoor
   workflow (`em-routed-rust-small.yml`) and its `tokmd_rust_small_*` lane
   catalogue entries. Runner routing is now the advisory `Route CI runner` job of
@@ -31,7 +49,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required `Tokmd Rust Result` gate. Branch protection already required only
   `Tokmd Rust Result`, so no required check changed.
 
+### Fixed
+
+- Aligned `max_cyclomatic` with per-function complexity units so the reported
+  maximum reflects a single function rather than an aggregate.
+- `tokmd diff` `resolve_targets` errors are now actionable, including usage
+  examples that show how to specify valid comparison targets.
+- `tokmd context` and `tokmd handoff` now validate numeric flags and reject
+  invalid values with clear errors instead of silently mishandling them.
+- `tokmd packet generate` / `tokmd evidence-packet` now detect UTF-16 encoded
+  JSON inputs (commonly produced by a bare PowerShell `>` redirect on Windows)
+  and return an actionable error pointing at `--output-dir` / `--output` or
+  `Out-File -Encoding utf8` instead of failing with an opaque parse error.
+
+### Security
+
+- Upgraded `pyo3` (and its transitive PyO3 crate family) from 0.28.3 to 0.29.0
+  in `tokmd-python`, resolving the `RUSTSEC-2026-0176` advisory flagged by
+  `cargo deny`.
+
 ### Documentation
+
+- Added usage example blocks to the `tokmd module`, `tokmd run`, and
+  `tokmd init` command help so `--help` shows common invocations, matching the
+  existing `context` / `handoff` / `analyze` / `cockpit` convention
+  (regenerated `docs/reference-cli.md`).
 
 - Resolved the `v1.13.1` publication GHCR visibility caveat: maintainer
   verification on 2026-06-21 records `ghcr.io/effortlessmetrics/tokmd` as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "blake3",
  "proptest",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "insta",
  "proptest",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3564,7 +3564,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.13.1"
+version = "1.14.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -194,22 +194,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.13.1" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.13.1" }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.13.1" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.13.1" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.13.1" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.13.1" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.13.1" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.13.1" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.13.1" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.13.1" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.13.1" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.13.1" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.13.1" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.13.1" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.13.1" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.13.1" }
+tokmd = { path = "crates/tokmd", version = "1.14.0" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.14.0" }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.14.0" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.14.0" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.14.0" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.14.0" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.14.0" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.14.0" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.14.0" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.14.0" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.14.0" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.14.0" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.14.0" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.14.0" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.14.0" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.14.0" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -82,6 +82,7 @@ kind = "rust"
 paths = [
   ".github/workflows/fuzz.yml",
   "docs/testing.md",
+  "fuzz/build.rs",
   "fuzz/Cargo.toml",
   "fuzz/README.md",
   "fuzz/corpus/**",
@@ -149,6 +150,7 @@ paths = [
   "xtask/src/tasks/affected.rs",
   "xtask/src/tasks/bindings_parity.rs",
   "xtask/src/tasks/boundaries_check.rs",
+  "xtask/src/tasks/build_guard.rs",
   "xtask/src/tasks/bump.rs",
   "xtask/src/tasks/ci_actuals.rs",
   "xtask/src/tasks/ci_gate_contract.rs",
@@ -160,6 +162,7 @@ paths = [
   "xtask/src/tasks/doc_artifacts.rs",
   "xtask/src/tasks/file_policy.rs",
   "xtask/src/tasks/fixture_blobs_check.rs",
+  "xtask/src/tasks/gate.rs",
   "xtask/src/tasks/jules_index.rs",
   "xtask/src/tasks/mutation_scope.rs",
   "xtask/src/tasks/mutation_summary.rs",
@@ -400,6 +403,7 @@ coverage = false
 name = "analysis_orchestration"
 kind = "rust"
 paths = [
+  "crates/tokmd-analysis/build.rs",
   "crates/tokmd-analysis/Cargo.toml",
   "crates/tokmd-analysis/src/analysis.rs",
   "crates/tokmd-analysis/src/analysis/**",
@@ -437,6 +441,7 @@ paths = [
   "crates/tokmd-analysis-types/src/findings.rs",
   "crates/tokmd-analysis-types/src/receipt.rs",
   "crates/tokmd-analysis-types/src/util.rs",
+  "crates/tokmd-analysis-types/src/util/**",
   "crates/tokmd-analysis-types/tests/**",
   "docs/SCHEMA.md",
 ]
@@ -1030,6 +1035,7 @@ paths = [
   "crates/tokmd/src/config/**",
   "crates/tokmd/src/error_hints.rs",
   "crates/tokmd/src/progress.rs",
+  "fixtures/progress-events/**",
   "crates/tokmd/tests/cli_*.rs",
   "crates/tokmd/tests/evidence_packet_*.rs",
   "crates/tokmd/tests/packet_*.rs",

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.13.1"
+        "version": "1.14.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.13.1"
+        "version": "1.14.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.13.1"
+        "version": "1.14.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.13.1"
+        "version": "1.14.0"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.13.1"
+        "version": "1.14.0"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.13.1",
-    "@tokmd/core-darwin-x64": "1.13.1",
-    "@tokmd/core-linux-arm64-gnu": "1.13.1",
-    "@tokmd/core-linux-x64-gnu": "1.13.1",
-    "@tokmd/core-win32-x64-msvc": "1.13.1"
+    "@tokmd/core-darwin-arm64": "1.14.0",
+    "@tokmd/core-darwin-x64": "1.14.0",
+    "@tokmd/core-linux-arm64-gnu": "1.14.0",
+    "@tokmd/core-linux-x64-gnu": "1.14.0",
+    "@tokmd/core-win32-x64-msvc": "1.14.0"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.13.1",
-    "@tokmd/core-darwin-x64": "1.13.1",
-    "@tokmd/core-darwin-arm64": "1.13.1",
-    "@tokmd/core-linux-x64-gnu": "1.13.1",
-    "@tokmd/core-linux-x64-musl": "1.13.1",
-    "@tokmd/core-linux-arm64-gnu": "1.13.1",
-    "@tokmd/core-linux-arm64-musl": "1.13.1",
-    "@tokmd/core-win32-arm64-msvc": "1.13.1"
+    "@tokmd/core-win32-x64-msvc": "1.14.0",
+    "@tokmd/core-darwin-x64": "1.14.0",
+    "@tokmd/core-darwin-arm64": "1.14.0",
+    "@tokmd/core-linux-x64-gnu": "1.14.0",
+    "@tokmd/core-linux-x64-musl": "1.14.0",
+    "@tokmd/core-linux-arm64-gnu": "1.14.0",
+    "@tokmd/core-linux-arm64-musl": "1.14.0",
+    "@tokmd/core-win32-arm64-msvc": "1.14.0"
   }
 }

--- a/docs/releases/1.14-readiness.md
+++ b/docs/releases/1.14-readiness.md
@@ -1,0 +1,153 @@
+# tokmd 1.14 Release Readiness Report
+
+Date: 2026-06-25
+
+Source state checked:
+
+- Workbench repository: `EffortlessMetrics/tokmd-swarm`
+- Local branch: `release/1.14.0-prep`
+- Pull request: [#313](https://github.com/EffortlessMetrics/tokmd-swarm/pull/313)
+- Validation base: `main`
+- Previous published release: `v1.13.1`
+- Candidate release version: `1.14.0`
+
+This report is pre-release evidence only. It does not publish crates, create
+tags, create GitHub releases, move aliases, push images, or mutate the
+publication repository (`EffortlessMetrics/tokmd`).
+
+## Release Thesis
+
+1.14 promotes the PR evidence-packet surface from a manual multi-step recipe
+into a first-class local and CI workflow:
+
+```text
+tokmd render          # render packet presets (incl. unsafe-review bundles)
+tokmd packet generate # one-command evidence-packet orchestrator
+mode: packet          # GitHub Action step that runs packet generate
+```
+
+It also sharpens syntax-receipt and complexity evidence and makes several CLI
+error and validation paths more actionable.
+
+## Semver Classification
+
+`1.14.0` is a minor release: new CLI subcommands (`render`, `packet generate`),
+a new GitHub Action mode, and an additive `panic_seam_summary` field on syntax
+receipts. No receipt schema versions changed:
+
+- `SCHEMA_VERSION = 2`
+- `ANALYSIS_SCHEMA_VERSION = 9`
+- `COCKPIT_SCHEMA_VERSION = 3`
+- `HANDOFF_SCHEMA_VERSION = 5`
+- `CONTEXT_SCHEMA_VERSION = 4`
+- `CONTEXT_BUNDLE_SCHEMA_VERSION = 2`
+
+## Scope
+
+Included (user-facing) — see the `## [1.14.0]` section of `CHANGELOG.md` for the
+full list:
+
+- `tokmd render` packet presets with sibling-bundle ingestion and
+  `tokmd-packets` JSON Schema validation at the CLI boundary;
+- `tokmd packet generate` evidence-packet orchestrator;
+- `mode: packet` GitHub Action with prebuilt-binary runtime, packet outputs, and
+  `fail-on` status mapping;
+- `panic_seam_summary` on syntax receipts;
+- syntax evidence ranking that deprioritizes test-assertion noise;
+- `max_cyclomatic` aligned with per-function complexity units;
+- actionable `tokmd diff` `resolve_targets` errors;
+- numeric-flag validation for `tokmd context` / `tokmd handoff`;
+- UTF-16 input detection for `packet generate` / `evidence-packet`;
+- `pyo3` 0.28.3 → 0.29.0 upgrade in `tokmd-python` resolving `RUSTSEC-2026-0176`;
+- usage examples in `module` / `run` / `init` command help;
+- CI phase 3: retirement of the duplicate routed Rust Small frontdoor.
+
+Not claimed:
+
+- no undefined-behavior detection, reachability proof, safety proof, semantic
+  call-graph coverage, or merge-readiness guarantee;
+- no schema-version change to any receipt family;
+- no release mutation from `tokmd-swarm`.
+
+## Validation Evidence
+
+All commands were run locally on Windows (MSVC, line-table debuginfo per repo
+default) from `release/1.14.0-prep`.
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Full workspace tests | Pass after fix | `cargo test --workspace` / `cargo test --workspace --no-fail-fast`. Initial run surfaced two release-prep blockers (below); after the fixes, the affected surfaces re-ran green. |
+| `tokmd-analysis` suite | Pass | `6005 passed; 0 failed` in the analysis test binary. |
+| `tokmd-format` suite | Pass | full package re-run green, including all CycloneDX snapshot tests. |
+| `xtask` `ci_actuals_w96` | Pass | `5 passed; 0 failed` after aligning the asserted checkout action version. |
+| No-panic family (strict) | Pass | `cargo xtask check-no-panic-family --strict`: `22358 finding(s), 22358 matched, 0 unallowlisted, 0 stale, 0 expired, 0 shape error(s)`. |
+| Workspace formatting | Pass | `cargo fmt-check` (`cargo xtask lint-fix --check --no-clippy`): all steps passed. |
+| Workspace clippy | Pass | `cargo clippy --workspace --all-targets --all-features -- -D warnings`. |
+
+## Release-Prep Blockers Found and Fixed
+
+The version bump and a merged GitHub Actions dependency bump left two stale
+assertions that failed `cargo test --workspace` (and the required
+`Tokmd Rust Result` gate on PR #313, which stopped at the first one):
+
+1. **Stale CycloneDX SBOM version snapshots.** Five `tokmd-format` insta
+   snapshots embedded the tool version `1.13.1`. The SBOM metadata renders the
+   live tool version (`1.14.0`), so the snapshots were updated to match. This is
+   expected version-bump snapshot churn, not a behavior change:
+   - `format_tests__cyclonedx_snapshot_deterministic.snap`
+   - `format_depth_w63__snapshot_w63_cyclonedx_basic.snap`
+   - `deep_format_w47__snapshot_cyclonedx_multi_file.snap`
+   - `snapshot_w45__snapshot_export_cyclonedx_single_file.snap`
+   - `snapshot_w74__w74_export_cyclonedx.snap`
+2. **Stale CI action version assertion.** `xtask/tests/ci_actuals_w96.rs`
+   asserted `actions/checkout@v6.0.2` in the `ci-actuals` job, but the merged
+   github-actions dependency bump (#295) moved every checkout step in `ci.yml`
+   to `actions/checkout@v7.0.0`. The test assertion was aligned to `v7.0.0`, and
+   the matching `policy/no-panic-allowlist.toml` `receiver_fingerprint` was
+   updated in lockstep so the strict no-panic checker stays green.
+
+## CI Status (PR #313)
+
+Pre-fix `Tokmd Rust Result` (required gate) failed on the stale CycloneDX
+snapshot. All other lanes were green or skipped-by-policy:
+
+- Pass: Affected Proof Plan, Cargo Deny, Clippy Exceptions, Docs Check,
+  Feature Boundaries, MSRV Check, No-panic Family, Publish Surface,
+  Version consistency, Typos, PR Cockpit Report, and all advisory lanes.
+- Skipped-by-policy (not failures): Windows/macOS Build & Test, Mutation Testing,
+  Nix PR Package Gate, Proptest Smoke, Wasm Compile & Test, Codecov Coverage.
+
+The pushed fix is expected to turn the required gate green; the post-push CI
+result must be confirmed on PR #313 before publication import.
+
+## Remaining Release Gates
+
+This workbench state is intended for a green hosted check on PR #313, then
+publication import. The release is not ready to tag yet. Still required before
+`v1.14.0`:
+
+1. Confirm `Tokmd Rust Result` is green on PR #313 after the prep fixes.
+2. Merge the release-prep PR into `tokmd-swarm/main`.
+3. Import `tokmd-swarm/main` into `EffortlessMetrics/tokmd` by merge commit.
+4. Fast-forward `tokmd-swarm/main` back to the publication merge commit.
+5. Re-run publication-repo release checks (docs, publish surface, version
+   consistency, cargo deny, Nix package gate).
+6. Tag and publish only from `EffortlessMetrics/tokmd`.
+7. Run installed-artifact smoke after publication.
+
+## Release Decision
+
+```text
+Ready for swarm readiness PR check: yes (fixes pushed to release/1.14.0-prep).
+Ready for publication import: pending green Tokmd Rust Result on PR #313.
+Ready for v1.14.0 tag/publish: no; tagging and publication happen only from
+EffortlessMetrics/tokmd after import.
+```
+
+## Claim Boundary
+
+This report records that local tests, formatting, clippy, and the strict
+no-panic checker passed on `release/1.14.0-prep` after two stale-assertion
+fixes. It does not claim hosted CI is green for the fixed commit (must be
+re-checked on PR #313), does not claim any published artifact, and does not
+prove runtime safety, mutation adequacy, or coverage.

--- a/xtask/tests/ci_actuals_w96.rs
+++ b/xtask/tests/ci_actuals_w96.rs
@@ -154,7 +154,7 @@ fn ci_actuals_uploads_receipt_before_advisory_summary() {
     let ci_actuals = &workflow[ci_actuals_idx..];
 
     let checkout_idx = ci_actuals
-        .find("actions/checkout@v6.0.2")
+        .find("actions/checkout@v7.0.0")
         .expect("CI actuals checkout step");
     let toolchain_idx = ci_actuals
         .find("dtolnay/rust-toolchain@stable")


### PR DESCRIPTION
Merge-commit import of `tokmd-swarm/main` into the publication repo, bringing the 1.14.0 release prep.

This is a **topology import only**. It does NOT tag `v1.14.0`, create a GitHub release, publish to crates.io/npm/PyPI, push images, sign artifacts, or move the `v1` alias. Those remain gated on maintainer approval.

```
merge(swarm): import tokmd-swarm through 2026-06-25 (v1.14.0 prep)

Swarm-Head: 21ffda346dae9489f61b621f8c984966b11f8a2d
Swarm-Range: e71181289ab4550660d2fe07e701ae20bac69e9e..21ffda346dae9489f61b621f8c984966b11f8a2d
Checks (swarm main @ 21ffda34):
- CI: run 28151409423 (success)
- Tokmd Rust Result: success
- Version consistency: success
- Publish Surface: success
- Docs Check: success
- Build & Test (macOS / Windows): success
- Cargo Deny / MSRV / Mutation Testing / Wasm Compile & Test: success
```

## Imported commits (2, swarm_ahead=2, publication_ahead=0)
- `1fafaa4b` Route post-import files into proof scopes (#312)
- `21ffda34` chore(release): prep 1.14.0 (changelog + version bump) — PR #313 squash merge

## Local readiness spot-checks (swarm @ 21ffda34)
- `cargo xtask version-consistency` ✅ all crates / workspace deps / Node packages = 1.14.0
- `cargo xtask publish-surface --json --verify-publish` ✅ `violations: []`
- `cargo xtask doc-artifacts --check` ✅
- `cargo xtask docs --check` ✅ "Documentation is up to date."
- `cargo xtask repo-graph --expect swarm-ahead` ✅ `SwarmAhead publication_ahead=0 swarm_ahead=2 ok=true`

## Merge method
Merge with a **merge commit** (not squash) per `docs/ci/swarm-routing.md`, then fast-forward `tokmd-swarm/main` to the merge commit.

## Claim boundary
Proves: swarm head imports cleanly, version/publish-surface/docs checks green locally, swarm main CI green. Does NOT prove: full 42-min gate, Nix full validation (publication-only, runs on this PR), or any release/publish action.