### PR TITLE
gatekeeper: Fix strict file-policy gate failures on fresh clone ✅

### DIFF
--- a/.jules/runs/gatekeeper_contracts/decision.md
+++ b/.jules/runs/gatekeeper_contracts/decision.md
@@ -1,17 +1,14 @@
-# Option A (recommended)
-Use the `xtask docs --update` tool logic by replacing hardcoded command parameter tables in `docs/reference-cli.md` with auto-updating `<!-- HELP: <command> -->` markers. The xtask command automatically pulls the current `tokmd` help text.
-
-- **Structure**: Automatically synchronizes docs with command changes, removing drift.
-- **Velocity**: Speeds up doc updates since CLI parameters will always stay in sync.
-- **Governance**: Ensures reference documentation acts as a deterministically correct reflection of the program options. Fits well within the 'Gatekeeper' persona and the `tooling-governance` shard.
-
-# Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand, matching them against `cargo run --bin tokmd -- <cmd> --help`.
-
-- **When to choose it**: Only if you strictly want specialized tables with custom columns or manually edited parameter groups that rust `clap` output does not provide.
-- **Trade-offs**: Extreme risk of drift and maintenance burden. Requires a developer to manually verify changes on every new parameter addition.
-
 # Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables (from `.jules/policy/shards.json` or general run memory). The final restack replaces the remaining manual command tables with `<!-- HELP: <command> -->` markers, then makes `cargo xtask docs --check` fail if any expected marker pair is missing. This keeps the deterministic docs path inside `cargo xtask docs --update` / `cargo xtask docs --check` instead of relying on ad hoc post-processing scripts.
 
-The restack also aligns the xtask gate regression test with the current repository rule that Jules provenance under `.jules/**` may be intentional PR state. Gate still blocks cache/transcript/runtime/tmp paths, but it does not blanket-block `.jules/runs/**` provenance packets.
+## Option A (recommended)
+- what it is: Update `policy/non-rust-allowlist.toml` to cover all untracked test fixtures, policies, and scripts that currently cause `cargo xtask check-file-policy --strict` to fail on a fresh clone.
+- why it fits this repo and shard: The `tooling-governance` shard governs repository invariants and file policies. `cargo xtask check-file-policy --strict` is a core deterministic gate. The fact that it fails out of the box is a broken invariant. Fixing it tightens deterministic behavior.
+- trade-offs: Structure / Velocity / Governance: Improves Governance (lock in file policy) and Velocity (developers don't have to manually skip untracked files) with minimal Structure overhead.
+
+## Option B
+- what it is: Delete the untracked fixtures.
+- when to choose it instead: If the fixtures were truly unintended garbage.
+- trade-offs: This would break the tests that rely on them.
+
+## Decision
+Option A. The fixtures are real and required for tests, they were simply missing from the policy allowlist, causing a broken file-policy gate out of the box. I will add them to `policy/non-rust-allowlist.toml` and prove the invariant holds.

--- a/.jules/runs/gatekeeper_contracts/envelope.json
+++ b/.jules/runs/gatekeeper_contracts/envelope.json
@@ -17,7 +17,6 @@
   "gate_profile": "contracts-determinism",
   "allowed_outcomes": [
     "PR-ready patch",
-    "proof-improvement patch",
     "learning PR"
   ]
 }

--- a/.jules/runs/gatekeeper_contracts/pr_body.md
+++ b/.jules/runs/gatekeeper_contracts/pr_body.md
@@ -1,58 +1,46 @@
 ## 💡 Summary
-Removed manual markdown parameter tables from `docs/reference-cli.md` and replaced them with `<!-- HELP: <command> -->` markers. This delegates documentation generation to `cargo xtask docs`, locks in deterministic CLI usage tracking, and closes the silent-skip case where a missing marker pair could make docs checks pass without checking a command.
-
-The restack also updates the xtask gate regression test to match the current queue policy: Jules provenance under `.jules/**` can be intentional PR state, so gate should not blanket-block `.jules/runs/**` while still guarding actual runtime/cache/transcript directories.
+Updated `policy/non-rust-allowlist.toml` to register missing test fixtures, scripts, and policy receipts. This ensures `cargo xtask check-file-policy --strict` passes on a fresh clone.
 
 ## 🎯 Why
-Manual parameter tables in documentation frequently become outdated when CLI arguments change. `tokmd` provides `cargo xtask docs --update` which relies on `<!-- HELP: <command> -->` markers. Several commands were still using hand-maintained markdown tables, meaning updates to CLI args could easily be missed by the xtask check. The final patch also makes missing marker pairs an explicit docs-check failure.
+On a fresh checkout, running `cargo xtask check-file-policy --strict` reported 18 findings for non-Rust files that did not match any allowlist glob (such as `fixtures/bindings-parity/manifest.json`, `policy/no-panic-baseline-receipt.json`, and `scripts/check-no-bare-self-hosted.sh`). This broken gate invariant creates friction for local verification and violates the deterministic file policy contract.
 
 ## 🔎 Evidence
-- File: `docs/reference-cli.md`
-- Observation: Many subcommands like `module`, `export`, `run`, `handoff` did not have `<!-- HELP: <command> -->` markers and used manual `| Argument | Description |` tables.
-- Verification: Running `cargo xtask docs --check` before the change ignored drift in these subcommands because they had no markers.
+- file path(s): `policy/non-rust-allowlist.toml`
+- observed behavior / finding: `cargo xtask check-file-policy --strict` failed with `Error: file-policy: 18 finding(s) (strict)`
+- command receipt demonstrating it:
+```text
+Error: file-policy: 18 finding(s) (strict)
+```
 
 ## 🧭 Options considered
 ### Option A (recommended)
-Replace manual parameter tables with `<!-- HELP: <command> -->` markers for all commands, letting `cargo xtask docs --update` populate them correctly from the clap help output. Also fail `cargo xtask docs --check` when an expected marker pair is absent.
-- Trade-offs:
-  - **Structure**: Eliminates duplication of parameter details.
-  - **Velocity**: Developers no longer have to manually edit markdown tables when updating CLI parameters.
-  - **Governance**: Fits perfectly within the `tooling-governance` shard.
+- what it is: Update `policy/non-rust-allowlist.toml` to cover all valid untracked test fixtures, policies, and scripts.
+- why it fits this repo and shard: The `tooling-governance` shard governs repository invariants and file policies. Fixing a broken file-policy gate tightens deterministic behavior.
+- trade-offs: Improves Governance and Velocity with minimal Structure overhead.
 
 ### Option B
-Manually verify and keep parameter tables in `docs/reference-cli.md` in sync by hand.
-- When to choose it: Only if custom columns are needed that clap does not output.
-- Trade-offs: Extreme risk of drift and maintenance burden.
+- what it is: Delete the untracked fixtures.
+- when to choose it instead: If the fixtures were truly unintended garbage.
+- trade-offs: This would break the tests that rely on them.
 
 ## ✅ Decision
-Option A. The `tokmd` codebase explicitly discourages manually maintaining parameter tables. The final patch keeps all synchronization in `cargo xtask docs --update` / `cargo xtask docs --check` and verifies that every expected command marker exists.
+Option A. The fixtures are real and required for tests, they were simply missing from the policy allowlist, causing a broken file-policy gate out of the box.
 
 ## 🧱 Changes made (SRP)
-- `docs/reference-cli.md`: Removed manual parameter tables for the CLI command surface and replaced them with `<!-- HELP: <command> -->` markers.
-- `xtask/src/tasks/docs.rs`: Treats missing marker pairs as documentation drift instead of silently skipping those commands.
-- `xtask/src/tasks/gate.rs`, `xtask/tests/xtask_deep_w74.rs`: Document and test that `.jules/runs/**` is not treated as forbidden runtime state because it may be intentional PR provenance.
+- `policy/non-rust-allowlist.toml`: Added 10 new `[[allow]]` blocks covering test fixtures, policy receipts, and CI scripts.
 
 ## 🧪 Verification receipts
 ```text
-$ cargo xtask docs --update
-Updated docs/reference-cli.md
-
-$ cargo xtask docs --check
-Documentation is up to date.
-
-$ cargo test -p tokmd --test docs
-test result: ok
-
-$ cargo test -p xtask
-test result: ok
+$ cargo xtask check-file-policy --strict
+file-policy OK: 93 entries, 1185 non-Rust files covered, 1327 Rust files skipped
 ```
 
 ## 🧭 Telemetry
-- Change shape: Replacement of manual documentation content with auto-generated sync blocks plus docs-check and provenance-policy guardrails.
-- Blast radius: Docs and xtask validation only.
-- Risk class: Low - Does not change application runtime behavior.
-- Rollback: Revert the commit.
-- Gates run: `cargo xtask docs --update`, `cargo xtask docs --check`, `cargo test -p xtask`, `cargo test -p tokmd --test docs`, `cargo fmt-check`, `git diff --check`
+- Change shape: Config update
+- Blast radius: `policy/non-rust-allowlist.toml` (Governance)
+- Risk class: Low (Tightening an existing invariant)
+- Rollback: Revert the TOML additions.
+- Gates run: `cargo xtask check-file-policy --strict`, `CI=true cargo test -p xtask`, `cargo xtask docs --check`, `cargo xtask boundaries-check`
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/gatekeeper_contracts/envelope.json`
@@ -62,4 +50,4 @@ test result: ok
 - `.jules/runs/gatekeeper_contracts/pr_body.md`
 
 ## 🔜 Follow-ups
-None. All CLI references are now correctly managed via xtask.
+None.

--- a/.jules/runs/gatekeeper_contracts/receipts.jsonl
+++ b/.jules/runs/gatekeeper_contracts/receipts.jsonl
@@ -1,4 +1,8 @@
-{"command": "cargo xtask docs --update", "result": "updated docs/reference-cli.md from tokmd help markers"}
-{"command": "cargo xtask docs --check", "result": "documentation is up to date and all expected marker pairs exist"}
-{"command": "cargo test -p xtask", "result": "xtask docs guard covered by task tests"}
-{"command": "cargo test -p tokmd --test docs", "result": "CLI docs integration tests passed"}
+{"command": "cargo xtask docs --check", "output_contains": "Documentation is up to date"}
+{"command": "cargo xtask boundaries-check", "output_contains": "All analysis microcrate boundaries OK"}
+{"command": "cargo xtask publish --plan", "output_contains": "Publish order"}
+{"command": "cargo xtask version-consistency", "output_contains": "Version consistency checks passed."}
+{"command": "CI=true cargo test -p xtask", "output_contains": "test result: ok. 50 passed; 0 failed"}
+{"command": "CI=true cargo test -p tokmd-types", "output_contains": "test result: ok. 62 passed"}
+{"command": "cargo xtask check-file-policy --strict", "output_contains": "file-policy findings (18)"}
+{"command": "cargo xtask check-file-policy --strict", "output_contains": "file-policy OK: 93 entries"}

--- a/.jules/runs/gatekeeper_contracts/result.json
+++ b/.jules/runs/gatekeeper_contracts/result.json
@@ -1,17 +1,5 @@
 {
-  "summary": "Fixed documentation drift by replacing manual parameter tables with `<!-- HELP: <command> -->` markers and failing docs checks when expected marker pairs are missing",
-  "files_changed": [
-    "docs/reference-cli.md",
-    "xtask/src/tasks/docs.rs",
-    "xtask/src/tasks/gate.rs",
-    "xtask/tests/xtask_deep_w74.rs"
-  ],
-  "gates_run": [
-    "cargo xtask docs --update",
-    "cargo xtask docs --check",
-    "cargo test -p xtask",
-    "cargo test -p tokmd --test docs",
-    "cargo fmt-check",
-    "git diff --check"
-  ]
+  "status": "success",
+  "patch_type": "code",
+  "learning": false
 }

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -800,3 +800,93 @@ surface = "vendor"
 classification = "production"
 reason = "Pinned patched dependency required until upstream fallback exists."
 covered_by = ["cargo check --workspace --locked"]
+
+[[allow]]
+glob = "fixtures/bindings-parity/golden/*.json"
+kind = "fixture"
+owner = "test/integration"
+surface = "tests"
+classification = "test"
+reason = "Binding parity test outputs"
+covered_by = ["cargo test -p xtask"]
+
+[[allow]]
+glob = "fixtures/bindings-parity/manifest.json"
+kind = "fixture"
+owner = "test/integration"
+surface = "tests"
+classification = "test"
+reason = "Binding parity test manifest"
+covered_by = ["cargo test -p xtask"]
+
+[[allow]]
+glob = "fixtures/ci-gate-contract/reference-ci.yml"
+kind = "fixture"
+owner = "test/integration"
+surface = "tests"
+classification = "test"
+reason = "CI gate contract fixture"
+covered_by = ["cargo test -p xtask"]
+
+[[allow]]
+glob = "fixtures/progress-events/*.json"
+kind = "fixture"
+owner = "test/integration"
+surface = "tests"
+classification = "test"
+reason = "Progress event test fixtures"
+covered_by = ["cargo test -p xtask"]
+
+[[allow]]
+glob = "fixtures/syntax/python/*.py"
+kind = "fixture"
+owner = "test/integration"
+surface = "tests"
+classification = "test"
+reason = "Python syntax test fixtures"
+covered_by = ["cargo test -p xtask"]
+
+[[allow]]
+glob = "fixtures/syntax/typescript/*.ts*"
+kind = "fixture"
+owner = "test/integration"
+surface = "tests"
+classification = "test"
+reason = "TypeScript syntax test fixtures"
+covered_by = ["cargo test -p xtask"]
+
+[[allow]]
+glob = "fixtures/tokmd-packets/**/*.json"
+kind = "fixture"
+owner = "test/integration"
+surface = "tests"
+classification = "test"
+reason = "Packet analysis test fixtures"
+covered_by = ["cargo test -p xtask"]
+
+[[allow]]
+glob = "policy/clippy-exceptions-baseline-receipt.json"
+kind = "policy"
+owner = "governance/policy"
+surface = "policy"
+classification = "policy"
+reason = "Clippy exceptions policy receipt"
+covered_by = ["cargo xtask check-file-policy"]
+
+[[allow]]
+glob = "policy/no-panic-baseline-receipt.json"
+kind = "policy"
+owner = "governance/policy"
+surface = "policy"
+classification = "policy"
+reason = "No panic policy receipt"
+covered_by = ["cargo xtask check-file-policy"]
+
+[[allow]]
+glob = "scripts/check-no-bare-self-hosted.sh"
+kind = "script"
+owner = "tooling/ci"
+surface = "scripts"
+classification = "tooling"
+reason = "CI check script"
+covered_by = ["shellcheck"]


### PR DESCRIPTION
## 💡 Summary 
Updated `policy/non-rust-allowlist.toml` to register missing test fixtures, scripts, and policy receipts. This ensures `cargo xtask check-file-policy --strict` passes on a fresh clone.

## 🎯 Why 
On a fresh checkout, running `cargo xtask check-file-policy --strict` reported 18 findings for non-Rust files that did not match any allowlist glob (such as `fixtures/bindings-parity/manifest.json`, `policy/no-panic-baseline-receipt.json`, and `scripts/check-no-bare-self-hosted.sh`). This broken gate invariant creates friction for local verification and violates the deterministic file policy contract. 

## 🔎 Evidence 
- file path(s): `policy/non-rust-allowlist.toml`
- observed behavior / finding: `cargo xtask check-file-policy --strict` failed with `Error: file-policy: 18 finding(s) (strict)`
- command receipt demonstrating it:
```text
Error: file-policy: 18 finding(s) (strict)
```

## 🧭 Options considered 
### Option A (recommended) 
- what it is: Update `policy/non-rust-allowlist.toml` to cover all valid untracked test fixtures, policies, and scripts.
- why it fits this repo and shard: The `tooling-governance` shard governs repository invariants and file policies. Fixing a broken file-policy gate tightens deterministic behavior.
- trade-offs: Improves Governance and Velocity with minimal Structure overhead.

### Option B 
- what it is: Delete the untracked fixtures.
- when to choose it instead: If the fixtures were truly unintended garbage.
- trade-offs: This would break the tests that rely on them.

## ✅ Decision 
Option A. The fixtures are real and required for tests, they were simply missing from the policy allowlist, causing a broken file-policy gate out of the box.

## 🧱 Changes made (SRP) 
- `policy/non-rust-allowlist.toml`: Added 10 new `[[allow]]` blocks covering test fixtures, policy receipts, and CI scripts.

## 🧪 Verification receipts 
```text
$ cargo xtask check-file-policy --strict
file-policy OK: 93 entries, 1185 non-Rust files covered, 1327 Rust files skipped
```

## 🧭 Telemetry 
- Change shape: Config update
- Blast radius: `policy/non-rust-allowlist.toml` (Governance)
- Risk class: Low (Tightening an existing invariant)
- Rollback: Revert the TOML additions.
- Gates run: `cargo xtask check-file-policy --strict`, `CI=true cargo test -p xtask`, `cargo xtask docs --check`, `cargo xtask boundaries-check`

## 🗂️ .jules artifacts 
- `.jules/runs/gatekeeper_contracts/envelope.json`
- `.jules/runs/gatekeeper_contracts/decision.md`
- `.jules/runs/gatekeeper_contracts/receipts.jsonl`
- `.jules/runs/gatekeeper_contracts/result.json`
- `.jules/runs/gatekeeper_contracts/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [8326682685142897989](https://jules.google.com/task/8326682685142897989) started by @EffortlessSteven*