### PR TITLE
merge(swarm): import tokmd-swarm CLI friction docs through 2026-06-26

### DIFF
--- a/crates/tokmd/src/cli/parser/badge.rs
+++ b/crates/tokmd/src/cli/parser/badge.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 use super::AnalysisPreset;
 
 #[derive(Args, Debug, Clone)]
+#[command(
+    after_help = "Examples:\n  tokmd badge --metric lines\n  tokmd badge --metric hotspot --preset risk --output badge.svg"
+)]
 pub struct BadgeArgs {
     /// Inputs to analyze (run dir, receipt.json, export.jsonl, or paths).
     #[arg(value_name = "INPUT", default_value = ".")]

--- a/crates/tokmd/src/cli/parser/cockpit.rs
+++ b/crates/tokmd/src/cli/parser/cockpit.rs
@@ -77,6 +77,9 @@ pub struct CockpitArgs {
 }
 
 #[derive(Args, Debug, Clone)]
+#[command(
+    after_help = "Examples:\n  tokmd baseline\n  tokmd baseline crates --output .tokmd/baseline.json --force"
+)]
 pub struct BaselineArgs {
     /// Target path to analyze.
     #[arg(default_value = ".")]

--- a/crates/tokmd/src/cli/parser/diff.rs
+++ b/crates/tokmd/src/cli/parser/diff.rs
@@ -7,6 +7,9 @@ use clap::{Args, ValueEnum};
 use serde::{Deserialize, Serialize};
 
 #[derive(Args, Debug, Clone)]
+#[command(
+    after_help = "Examples:\n  tokmd diff --from main --to HEAD\n  tokmd diff base.json current.json --format json"
+)]
 pub struct DiffArgs {
     /// Base receipt/run or git ref to compare from.
     #[arg(long)]

--- a/crates/tokmd/src/cli/parser/export.rs
+++ b/crates/tokmd/src/cli/parser/export.rs
@@ -10,6 +10,9 @@ use clap::Args;
 use super::{ChildIncludeMode, ExportFormat, RedactMode};
 
 #[derive(Args, Debug, Clone)]
+#[command(
+    after_help = "Examples:\n  tokmd export --format csv --output inventory.csv\n  tokmd export crates --min-code 10 --redact paths"
+)]
 pub struct CliExportArgs {
     /// Paths to scan (directories, files, or globs). Defaults to "."
     #[arg(value_name = "PATH")]

--- a/crates/tokmd/src/cli/parser/gate.rs
+++ b/crates/tokmd/src/cli/parser/gate.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 use super::AnalysisPreset;
 
 #[derive(Args, Debug, Clone)]
+#[command(
+    after_help = "Examples:\n  tokmd gate analysis.json --policy tokmd-gate.toml\n  tokmd gate . --preset health --format json"
+)]
 pub struct CliGateArgs {
     /// Input analysis receipt or path to scan.
     #[arg(value_name = "INPUT")]

--- a/crates/tokmd/src/cli/parser/lang.rs
+++ b/crates/tokmd/src/cli/parser/lang.rs
@@ -10,6 +10,9 @@ use clap::Args;
 use super::{ChildrenMode, TableFormat};
 
 #[derive(Args, Debug, Clone, Default)]
+#[command(
+    after_help = "Examples:\n  tokmd lang --top 10 --files\n  tokmd lang crates --format json"
+)]
 pub struct CliLangArgs {
     /// Paths to scan (directories, files, or globs). Defaults to "."
     #[arg(value_name = "PATH")]

--- a/crates/tokmd/src/cli/parser/sensor.rs
+++ b/crates/tokmd/src/cli/parser/sensor.rs
@@ -9,6 +9,9 @@ use clap::{Args, ValueEnum};
 use serde::{Deserialize, Serialize};
 
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[command(
+    after_help = "Examples:\n  tokmd sensor --base main --head HEAD\n  tokmd sensor --format md --output report.md"
+)]
 pub struct SensorArgs {
     /// Base reference to compare from (default: main).
     #[arg(long, default_value = "main")]

--- a/crates/tokmd/src/cli/parser/tools.rs
+++ b/crates/tokmd/src/cli/parser/tools.rs
@@ -7,6 +7,9 @@ use crate::tool_schema::ToolSchemaFormat;
 use clap::Args;
 
 #[derive(Args, Debug, Clone)]
+#[command(
+    after_help = "Examples:\n  tokmd tools --format openai --pretty\n  tokmd tools --format anthropic"
+)]
 pub struct ToolsArgs {
     /// Output format for the tool schema.
     #[arg(long, value_enum, default_value_t = ToolSchemaFormat::Jsonschema)]

--- a/crates/tokmd/src/error_hints.rs
+++ b/crates/tokmd/src/error_hints.rs
@@ -267,6 +267,26 @@ fn suggestions(err: &Error) -> Vec<String> {
         );
     }
 
+    // JSON receipt / baseline parse failures (gate, diff, analyze, badge,
+    // baseline) surface a bare serde error. Point the user at a valid source
+    // instead of leaving them to guess what shape the file should have. Scoped
+    // away from TOML so the two parse hints do not both fire.
+    if haystack.contains("failed to parse")
+        && !haystack.contains("toml")
+        && (haystack.contains("receipt")
+            || haystack.contains("json")
+            || haystack.contains("export rows"))
+    {
+        push_hint(
+            &mut out,
+            "Ensure the file is a tokmd JSON receipt (produced by `tokmd run`, `tokmd export`, or `tokmd analyze`).",
+        );
+        push_hint(
+            &mut out,
+            "If it was hand-edited or truncated, regenerate the receipt and retry.",
+        );
+    }
+
     out
 }
 
@@ -458,6 +478,45 @@ mod tests {
         assert!(hints.iter().any(|h| h.contains("limiting requests")));
         assert!(hints.iter().any(|h| h.contains("Retry-After")));
         assert!(hints.iter().any(|h| h.contains("smaller input scope")));
+    }
+
+    #[test]
+    fn suggests_for_json_receipt_parse_failure() {
+        let err = anyhow!("Failed to parse JSON from receipt.json: expected value at line 1");
+        let hints = suggestions(&err);
+        assert!(
+            hints.iter().any(|h| h.contains("tokmd JSON receipt")),
+            "expected receipt-source guidance, got: {hints:?}"
+        );
+        assert!(
+            hints.iter().any(|h| h.contains("regenerate the receipt")),
+            "expected regenerate guidance, got: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn suggests_for_lang_receipt_parse_failure() {
+        let err = anyhow!("Failed to parse lang receipt");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("tokmd JSON receipt")));
+    }
+
+    #[test]
+    fn suggests_for_baseline_json_parse_failure() {
+        let err = anyhow!("Failed to parse baseline JSON from baseline.json");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("tokmd JSON receipt")));
+    }
+
+    #[test]
+    fn toml_parse_failure_does_not_get_receipt_hint() {
+        let err = anyhow!("invalid TOML: failed to parse key at line 3");
+        let hints = suggestions(&err);
+        assert!(hints.iter().any(|h| h.contains("tokmd.toml")));
+        assert!(
+            !hints.iter().any(|h| h.contains("tokmd JSON receipt")),
+            "TOML parse errors must not get the JSON receipt hint, got: {hints:?}"
+        );
     }
 
     #[test]

--- a/crates/tokmd/tests/cli_error_help_w73.rs
+++ b/crates/tokmd/tests/cli_error_help_w73.rs
@@ -264,6 +264,21 @@ fn help_diff_mentions_from_and_to() {
 }
 
 #[test]
+fn help_diff_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["diff", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains("tokmd diff --from main --to HEAD"))
+                .and(predicate::str::contains(
+                    "tokmd diff base.json current.json --format json",
+                )),
+        );
+}
+
+#[test]
 fn help_gate_mentions_policy() {
     let assert = tokmd_cmd().args(["gate", "--help"]).assert().success();
 
@@ -284,6 +299,23 @@ fn help_gate_mentions_policy() {
         !stdout.contains("--validate"),
         "gate help should not advertise nonexistent --validate flag"
     );
+}
+
+#[test]
+fn help_gate_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["gate", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains(
+                    "tokmd gate analysis.json --policy tokmd-gate.toml",
+                ))
+                .and(predicate::str::contains(
+                    "tokmd gate . --preset health --format json",
+                )),
+        );
 }
 
 #[test]
@@ -452,6 +484,23 @@ fn help_init_mentions_practical_examples() {
                 .and(predicate::str::contains("tokmd init --template rust"))
                 .and(predicate::str::contains(
                     "tokmd init --non-interactive --template node --force",
+                )),
+        );
+}
+
+#[test]
+fn help_export_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["export", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains(
+                    "tokmd export --format csv --output inventory.csv",
+                ))
+                .and(predicate::str::contains(
+                    "tokmd export crates --min-code 10 --redact paths",
                 )),
         );
 }

--- a/crates/tokmd/tests/cli_error_help_w73.rs
+++ b/crates/tokmd/tests/cli_error_help_w73.rs
@@ -137,6 +137,19 @@ fn help_lang_mentions_format_and_children() {
 }
 
 #[test]
+fn help_lang_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["lang", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains("tokmd lang --top 10 --files"))
+                .and(predicate::str::contains("tokmd lang crates --format json")),
+        );
+}
+
+#[test]
 fn help_module_mentions_depth_and_format() {
     tokmd_cmd()
         .args(["module", "--help"])
@@ -328,6 +341,21 @@ fn help_badge_exists() {
 }
 
 #[test]
+fn help_badge_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["badge", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains("tokmd badge --metric lines"))
+                .and(predicate::str::contains(
+                    "tokmd badge --metric hotspot --preset risk --output badge.svg",
+                )),
+        );
+}
+
+#[test]
 fn help_run_exists() {
     tokmd_cmd()
         .args(["run", "--help"])
@@ -364,6 +392,21 @@ fn help_tools_exists() {
 }
 
 #[test]
+fn help_tools_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["tools", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains(
+                    "tokmd tools --format openai --pretty",
+                ))
+                .and(predicate::str::contains("tokmd tools --format anthropic")),
+        );
+}
+
+#[test]
 fn help_cockpit_exists() {
     tokmd_cmd()
         .args(["cockpit", "--help"])
@@ -395,12 +438,44 @@ fn help_sensor_exists() {
 }
 
 #[test]
+fn help_sensor_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["sensor", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains(
+                    "tokmd sensor --base main --head HEAD",
+                ))
+                .and(predicate::str::contains(
+                    "tokmd sensor --format md --output report.md",
+                )),
+        );
+}
+
+#[test]
 fn help_baseline_exists() {
     tokmd_cmd()
         .args(["baseline", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn help_baseline_mentions_practical_examples() {
+    tokmd_cmd()
+        .args(["baseline", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Examples:")
+                .and(predicate::str::contains("tokmd baseline"))
+                .and(predicate::str::contains(
+                    "tokmd baseline crates --output .tokmd/baseline.json --force",
+                )),
+        );
 }
 
 // =========================================================================

--- a/crates/tokmd/tests/snapshots/cli_snapshot_golden__help.snap
+++ b/crates/tokmd/tests/snapshots/cli_snapshot_golden__help.snap
@@ -108,3 +108,7 @@ Options:
 
   -V, --version
           Print version
+
+Examples:
+  tokmd lang --top 10 --files
+  tokmd lang crates --format json

--- a/crates/tokmd/tests/snapshots/cli_snapshot_golden__help_ast.snap
+++ b/crates/tokmd/tests/snapshots/cli_snapshot_golden__help_ast.snap
@@ -111,3 +111,7 @@ Options:
 
   -V, --version
           Print version
+
+Examples:
+  tokmd lang --top 10 --files
+  tokmd lang crates --format json

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -260,6 +260,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd export --format csv --output inventory.csv
+  tokmd export crates --min-code 10 --redact paths
 ```
 <!-- /HELP: export -->
 
@@ -727,6 +731,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd diff --from main --to HEAD
+  tokmd diff base.json current.json --format json
 ```
 <!-- /HELP: diff -->
 
@@ -1870,6 +1878,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd gate analysis.json --policy tokmd-gate.toml
+  tokmd gate . --preset health --format json
 ```
 <!-- /HELP: gate -->
 

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -83,6 +83,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd lang --top 10 --files
+  tokmd lang crates --format json
 ```
 <!-- /HELP: lang -->
 
@@ -577,6 +581,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd baseline
+  tokmd baseline crates --output .tokmd/baseline.json --force
 ```
 <!-- /HELP: baseline -->
 
@@ -656,6 +664,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd badge --metric lines
+  tokmd badge --metric hotspot --preset risk --output badge.svg
 ```
 <!-- /HELP: badge -->
 
@@ -1246,6 +1258,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd tools --format openai --pretty
+  tokmd tools --format anthropic
 ```
 <!-- /HELP: tools -->
 
@@ -1504,6 +1520,10 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+Examples:
+  tokmd sensor --base main --head HEAD
+  tokmd sensor --format md --output report.md
 ```
 <!-- /HELP: sensor -->
 


### PR DESCRIPTION
## Summary

Publication import of accumulated CLI friction / help-text work from `tokmd-swarm`. Docs/CLI-text only; no behavior, schema, or release-surface changes.

Imported swarm commits (3):
- `b134c3a1` feat(cli): add practical help examples to diff, gate, and export (#316)
- `c9f28204` feat(cli): add practical help examples to badge, tools, baseline, sensor, lang (#317)
- `75423439` feat(cli): add recovery hint for JSON receipt parse failures (#318)

Swarm-Head: 754234399cb7f83b0c2445c0e732b1042e52d56e
Swarm-Range: b233992e373a214bbc9aa5e83974c9fd4ab6f543..754234399cb7f83b0c2445c0e732b1042e52d56e
Previous-publication-sync: b233992e373a214bbc9aa5e83974c9fd4ab6f543

## Claim boundary

- Proven: each swarm PR (#316, #317, #318) was squash-merged after `Tokmd Rust Small Result` passed; publication CI runs on this import PR.
- This import is docs / CLI-help-text only.
- Not in scope: no tag, no crates.io publish, no Docker push, no signing, no `v1` alias move.

## Merge method

Per `docs/ci/swarm-routing.md`, this import lands as a **merge commit** (not squash) to preserve second-parent swarm history. `allow_merge_commit` may be toggled on temporarily for this merge.

After merge, `tokmd-swarm/main` fast-forwards to the publication merge commit and `cargo xtask repo-graph --expect aligned` must report 0 0.
