### PR TITLE
specsmith: add export children flag tests 🧪

### DIFF
--- a/crates/tokmd/tests/bdd_export_scenarios_w50.rs
+++ b/crates/tokmd/tests/bdd_export_scenarios_w50.rs
@@ -258,3 +258,49 @@ fn given_empty_dir_when_export_json_then_empty_rows() {
         .expect("JSON output rows field should be an array");
     assert!(rows.is_empty(), "empty dir should produce no export rows");
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 9: Export with --children separate records the mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_export_children_separate_then_mode_recorded() {
+    // Given: a project with source files
+    // When: I run `tokmd export --format json --children separate`
+    let output = tokmd_cmd()
+        .args(["export", "--format", "json", "--children", "separate"])
+        .output()
+        .expect("failed to execute tokmd export --children separate");
+
+    // Then: the children mode is recorded in args
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["args"]["children"].as_str().unwrap(),
+        "separate",
+        "args should record children=separate"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 10: Export with --children parents-only records the mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn given_project_when_export_children_parents_only_then_mode_recorded() {
+    // Given: a project with source files
+    // When: I run `tokmd export --format json --children parents-only`
+    let output = tokmd_cmd()
+        .args(["export", "--format", "json", "--children", "parents-only"])
+        .output()
+        .expect("failed to execute tokmd export --children parents-only");
+
+    // Then: the children mode is recorded in args
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["args"]["children"].as_str().unwrap(),
+        "parents-only",
+        "args should record children=parents-only"
+    );
+}

--- a/policy/no-panic-baseline-receipt.json
+++ b/policy/no-panic-baseline-receipt.json
@@ -1,15 +1,15 @@
 {
   "schema": "tokmd.no_panic_baseline.v1",
-  "generated_at": "2026-06-27T12:24:23.119278783+00:00",
+  "generated_at": "2026-06-27T19:52:23.384119300+00:00",
   "allowlist_path": "policy/no-panic-allowlist.toml",
-  "finding_count": 21872,
-  "entry_count": 21872,
+  "finding_count": 21876,
+  "entry_count": 21876,
   "expires": "2026-12-31",
   "by_classification": {
     "ffi": 87,
     "fixture": 4,
     "production": 303,
-    "test_helper": 20315,
+    "test_helper": 20319,
     "tooling": 1163
   },
   "command": "cargo xtask no-panic-baseline"


### PR DESCRIPTION
Added missing BDD scenarios for the `export` command to verify the behavior of the `--children parents-only` and `--children separate` flags.

The `module` and `lang` commands had BDD test coverage for the `--children` flag, but the `export` command lacked these scenarios. This PR fills that gap, locking in the expected behavior and preventing regressions.

---
*PR created automatically by Jules for task [11916391434917666363](https://jules.google.com/task/11916391434917666363) started by @EffortlessSteven*