### PR TITLE
merge(swarm): import tokmd-swarm CLI progress + --show-config through 2026-06-26 (lane1 batch)

### DIFF
--- a/.tokmd-spec/index.toml
+++ b/.tokmd-spec/index.toml
@@ -130,6 +130,12 @@ path = "docs/specs/progress-events.md"
 status = "active"
 
 [[artifact]]
+id = "config-explainability-spec"
+kind = "spec"
+path = "docs/specs/config-explainability.md"
+status = "active"
+
+[[artifact]]
 id = "spec-rails-contributor-guide"
 kind = "contributor-guide"
 path = "docs/contributing/spec-rails.md"

--- a/crates/tokmd/src/cli/parser.rs
+++ b/crates/tokmd/src/cli/parser.rs
@@ -110,6 +110,10 @@ pub struct Cli {
     /// Configuration profile to use (e.g., "llm_safe", "ci").
     #[arg(long, visible_alias = "view", global = true)]
     pub profile: Option<String>,
+
+    /// Print the resolved configuration sources and values, then exit.
+    #[arg(long = "show-config", global = true)]
+    pub show_config: bool,
 }
 
 // =============================================================================

--- a/crates/tokmd/src/commands/cockpit.rs
+++ b/crates/tokmd/src/commands/cockpit.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 
 use crate::cli;
 #[cfg(feature = "git")]
+use crate::progress::Progress;
+#[cfg(feature = "git")]
 use anyhow::Context;
 use anyhow::{Result, bail};
 
@@ -22,10 +24,11 @@ pub use tokmd_types::cockpit::*;
 pub use tokmd_cockpit::compute_cockpit;
 
 /// Handle the cockpit command.
-pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Result<()> {
+pub(crate) fn handle(args: cli::CockpitArgs, global: &cli::GlobalArgs) -> Result<()> {
     #[cfg(not(feature = "git"))]
     {
         let _ = &args; // Silence unused warning
+        let _ = global;
         bail!("The cockpit command requires the 'git' feature. Rebuild with --features git");
     }
 
@@ -35,9 +38,16 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
             bail!("git is not available on PATH");
         }
 
+        // Cockpit is a multi-step orchestrator (git diff + scan + render). The
+        // spinner stays on stderr and machine-readable progress events are
+        // emitted alongside it when TOKMD_PROGRESS_EVENTS is set; stdout stays
+        // reserved for the cockpit receipt/report.
+        let progress = Progress::new(!global.no_progress);
+
         let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
         let repo_root = tokmd_git::repo_root(&cwd)
             .ok_or_else(|| anyhow::anyhow!("not inside a git repository"))?;
+        progress.set_message("Loading proof evidence inputs...");
         let proof_evidence_inputs = load_proof_evidence_inputs(&args)?;
         let doc_artifacts_evidence = load_doc_artifacts_evidence_input(&args)?;
 
@@ -46,6 +56,7 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
             cli::DiffRangeMode::ThreeDot => tokmd_git::GitRangeMode::ThreeDot,
         };
 
+        progress.set_message("Resolving base reference...");
         let resolved_base =
             tokmd_git::resolve_base_ref(&repo_root, &args.base).ok_or_else(|| {
                 anyhow::anyhow!(
@@ -55,6 +66,7 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
                 )
             })?;
 
+        progress.set_message("Computing cockpit metrics (git diff + scan)...");
         let mut receipt = tokmd_cockpit::compute_cockpit(
             &repo_root,
             &resolved_base,
@@ -65,11 +77,17 @@ pub(crate) fn handle(args: cli::CockpitArgs, _global: &cli::GlobalArgs) -> Resul
 
         // Load baseline and compute trend if provided
         if let Some(baseline_path) = &args.baseline {
+            progress.set_message("Computing trend comparison...");
             receipt.trend = Some(tokmd_cockpit::load_and_compute_trend(
                 baseline_path,
                 &receipt,
             )?);
         }
+
+        // Clear the spinner before any stdout/file output so progress noise on
+        // stderr never interleaves with the machine-readable receipt.
+        progress.set_message("Rendering report...");
+        progress.finish_and_clear();
 
         // In sensor mode, write envelope to artifacts_dir
         if args.sensor_mode {

--- a/crates/tokmd/src/commands/export.rs
+++ b/crates/tokmd/src/commands/export.rs
@@ -6,6 +6,7 @@ use tokmd_scan as scan;
 use tokmd_settings::ScanOptions;
 
 use crate::config::{self, ResolvedConfig};
+use crate::progress::Progress;
 
 pub(crate) fn handle(
     cli_args: cli::CliExportArgs,
@@ -14,7 +15,12 @@ pub(crate) fn handle(
 ) -> Result<()> {
     let args = config::resolve_export_with_config(&cli_args, resolved);
     let scan_opts = ScanOptions::from(global);
+
+    let progress = Progress::new(!global.no_progress);
+    progress.set_message("Scanning codebase...");
     let languages = scan::scan(&args.paths, &scan_opts)?;
+
+    progress.set_message("Building file inventory...");
     let strip_prefix = args.strip_prefix.as_deref();
     let export = model::create_export_data(
         &languages,
@@ -25,6 +31,10 @@ pub(crate) fn handle(
         args.min_code,
         args.max_rows,
     );
+    // Clear the stderr spinner before machine-readable output is written so the
+    // inventory on stdout stays clean.
+    progress.finish_and_clear();
+
     format::write_export(&export, &scan_opts, &args)?;
     Ok(())
 }

--- a/crates/tokmd/src/commands/lang.rs
+++ b/crates/tokmd/src/commands/lang.rs
@@ -6,6 +6,7 @@ use tokmd_scan as scan;
 use tokmd_settings::ScanOptions;
 
 use crate::config::{self, ResolvedConfig};
+use crate::progress::Progress;
 
 pub(crate) fn handle(
     cli_args: cli::CliLangArgs,
@@ -14,8 +15,14 @@ pub(crate) fn handle(
 ) -> Result<()> {
     let args = config::resolve_lang_with_config(&cli_args, resolved);
     let scan_opts = ScanOptions::from(global);
+
+    let progress = Progress::new(!global.no_progress);
+    progress.set_message("Scanning codebase...");
     let languages = scan::scan(&args.paths, &scan_opts)?;
     let report = model::create_lang_report(&languages, args.top, args.files, args.children);
+    // Clear the stderr spinner before the report is written to stdout.
+    progress.finish_and_clear();
+
     format::print_lang_report(&report, &scan_opts, &args)?;
     Ok(())
 }

--- a/crates/tokmd/src/commands/module.rs
+++ b/crates/tokmd/src/commands/module.rs
@@ -6,6 +6,7 @@ use tokmd_scan as scan;
 use tokmd_settings::ScanOptions;
 
 use crate::config::{self, ResolvedConfig};
+use crate::progress::Progress;
 
 pub(crate) fn handle(
     cli_args: cli::CliModuleArgs,
@@ -14,6 +15,9 @@ pub(crate) fn handle(
 ) -> Result<()> {
     let args = config::resolve_module_with_config(&cli_args, resolved);
     let scan_opts = ScanOptions::from(global);
+
+    let progress = Progress::new(!global.no_progress);
+    progress.set_message("Scanning codebase...");
     let languages = scan::scan(&args.paths, &scan_opts)?;
     let report = model::create_module_report(
         &languages,
@@ -22,6 +26,9 @@ pub(crate) fn handle(
         args.children,
         args.top,
     );
+    // Clear the stderr spinner before the report is written to stdout.
+    progress.finish_and_clear();
+
     format::print_module_report(&report, &scan_opts, &args)?;
     Ok(())
 }

--- a/crates/tokmd/src/commands/packet.rs
+++ b/crates/tokmd/src/commands/packet.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 use crate::analysis_utils;
 use crate::cli;
 use crate::commands::{analyze, context, evidence_packet};
+use crate::progress;
 
 pub(crate) fn handle(args: cli::PacketArgs, global: &cli::GlobalArgs) -> Result<()> {
     match args.command {
@@ -41,8 +42,15 @@ fn generate_packet(args: cli::PacketGenerateArgs, global: &cli::GlobalArgs) -> R
             .with_context(|| format!("failed to clear stale {}", syntax_json.display()))?;
     }
 
+    // Orchestrator-level progress: the live spinner is owned by each delegated
+    // sub-command (analyze/context each create their own), so the packet frames
+    // every stage with machine-readable `tokmd.progress` events on stderr only
+    // (subject to TOKMD_PROGRESS_EVENTS) without drawing a competing spinner.
+    // stdout stays reserved for the evidence-packet manifest.
+
     // 1. analyze: one analysis pass, rendered to both the JSON and Markdown
     //    artifacts so the receipts cannot disagree.
+    progress::emit_stage("Generating analysis receipt...");
     let analyze_args = analyze_args(&args);
     let receipt = analyze::build_receipt(&analyze_args, global)
         .context("failed to build analysis receipt for packet")?;
@@ -56,6 +64,7 @@ fn generate_packet(args: cli::PacketGenerateArgs, global: &cli::GlobalArgs) -> R
         .with_context(|| format!("failed to write {}", analyze_md.display()))?;
 
     // 2. context: reuse the context command with output redirected to the packet.
+    progress::emit_stage("Generating context artifact...");
     context::handle(context_args(&args, &context_md), global)
         .context("failed to generate packet context artifact")?;
 
@@ -66,6 +75,7 @@ fn generate_packet(args: cli::PacketGenerateArgs, global: &cli::GlobalArgs) -> R
     //    `complete`. The stale-clear above guarantees the referenced file
     //    reflects only this run.
     let syntax_arg = if args.want_syntax() {
+        progress::emit_stage("Generating syntax evidence...");
         if let Err(err) = write_syntax(&args, &syntax_json) {
             eprintln!("warning: syntax evidence unavailable: {err}");
         }
@@ -76,6 +86,7 @@ fn generate_packet(args: cli::PacketGenerateArgs, global: &cli::GlobalArgs) -> R
 
     // 4. evidence-packet: index and validate the artifacts. This prints the
     //    manifest JSON and exits nonzero when the packet status is `failed`.
+    progress::emit_stage("Indexing evidence packet...");
     let packet_args = cli::EvidencePacketArgs {
         preset: args.preset,
         base: args.base.clone(),
@@ -88,7 +99,9 @@ fn generate_packet(args: cli::PacketGenerateArgs, global: &cli::GlobalArgs) -> R
         context_budget: args.context_budget.clone(),
         paths: args.paths.clone(),
     };
-    evidence_packet::handle(packet_args)
+    evidence_packet::handle(packet_args)?;
+    progress::emit_stage_finish();
+    Ok(())
 }
 
 /// Build analyze arguments scoped to the packet request.

--- a/crates/tokmd/src/config.rs
+++ b/crates/tokmd/src/config.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use tokmd_settings::{Profile, TomlConfig, UserConfig, ViewProfile};
 
+pub mod explain;
 mod resolve;
 
 pub use resolve::{

--- a/crates/tokmd/src/config/explain.rs
+++ b/crates/tokmd/src/config/explain.rs
@@ -1,0 +1,214 @@
+//! Human-readable rendering of resolved configuration for `--show-config`.
+//!
+//! This surface is diagnostic only. It reports the configuration sources and
+//! profile-layered values that `tokmd` already resolves at startup, so users
+//! can see which `tokmd.toml`, legacy JSON config, or profile is actually in
+//! effect. It must not emit or alter any receipt or machine-readable output.
+
+use std::io::Write;
+
+use anyhow::Result;
+
+use super::{ConfigContext, ResolvedConfig};
+
+/// Where the active profile/view name was selected from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileSource {
+    /// Selected via the `--profile` / `--view` CLI flag.
+    Cli,
+    /// Selected via the `TOKMD_PROFILE` environment variable.
+    Env,
+    /// No profile selector was provided.
+    None,
+}
+
+impl ProfileSource {
+    fn label(self) -> &'static str {
+        match self {
+            ProfileSource::Cli => "--profile",
+            ProfileSource::Env => "TOKMD_PROFILE",
+            ProfileSource::None => "(none)",
+        }
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn opt_str(value: Option<&str>) -> String {
+    value.map_or_else(|| "(default)".to_string(), str::to_string)
+}
+
+fn opt_display<T: std::fmt::Display>(value: Option<T>) -> String {
+    value.map_or_else(|| "(default)".to_string(), |v| v.to_string())
+}
+
+fn opt_list(value: Option<Vec<String>>) -> String {
+    match value {
+        Some(v) if !v.is_empty() => v.join(", "),
+        Some(_) => "(empty)".to_string(),
+        None => "(default)".to_string(),
+    }
+}
+
+/// Render the resolved configuration report to the given sink.
+///
+/// This is the testable core; [`print_config_report`] is the thin stdout
+/// wrapper used by the CLI.
+pub fn write_config_report<W: Write>(
+    out: &mut W,
+    ctx: &ConfigContext,
+    profile_name: Option<&str>,
+    profile_source: ProfileSource,
+    resolved: &ResolvedConfig,
+) -> Result<()> {
+    writeln!(out, "tokmd configuration")?;
+    writeln!(out)?;
+    writeln!(out, "Config sources (in precedence order):")?;
+    match &ctx.toml_path {
+        Some(path) => writeln!(out, "  TOML config:    {}", path.display())?,
+        None => writeln!(out, "  TOML config:    (none found)")?,
+    }
+    writeln!(
+        out,
+        "  Legacy JSON:    {}",
+        if ctx.json.is_some() {
+            "loaded (~/.config/tokmd/config.json)"
+        } else {
+            "(none)"
+        }
+    )?;
+
+    writeln!(out)?;
+    writeln!(out, "Active profile:")?;
+    match profile_name {
+        Some(name) => {
+            writeln!(
+                out,
+                "  name:           {name} (from {})",
+                profile_source.label()
+            )?;
+            let matched_view = resolved.toml_view.is_some();
+            let matched_json = resolved.json_profile.is_some();
+            writeln!(out, "  matched TOML view:     {}", yes_no(matched_view))?;
+            writeln!(out, "  matched JSON profile:  {}", yes_no(matched_json))?;
+            if !matched_view && !matched_json {
+                writeln!(
+                    out,
+                    "  note: profile \"{name}\" did not match any TOML view or JSON profile"
+                )?;
+            }
+        }
+        None => writeln!(out, "  name:           (none)")?,
+    }
+
+    writeln!(out)?;
+    writeln!(out, "Resolved values:")?;
+    writeln!(out, "  format:         {}", opt_str(resolved.format()))?;
+    writeln!(out, "  top:            {}", opt_display(resolved.top()))?;
+    writeln!(out, "  files:          {}", opt_display(resolved.files()))?;
+    writeln!(
+        out,
+        "  module_roots:   {}",
+        opt_list(resolved.module_roots())
+    )?;
+    writeln!(
+        out,
+        "  module_depth:   {}",
+        opt_display(resolved.module_depth())
+    )?;
+    writeln!(out, "  children:       {}", opt_str(resolved.children()))?;
+    writeln!(
+        out,
+        "  min_code:       {}",
+        opt_display(resolved.min_code())
+    )?;
+    writeln!(
+        out,
+        "  max_rows:       {}",
+        opt_display(resolved.max_rows())
+    )?;
+    writeln!(out, "  redact:         {}", opt_str(resolved.redact()))?;
+    writeln!(out, "  meta:           {}", opt_display(resolved.meta()))?;
+
+    Ok(())
+}
+
+/// Print the resolved configuration report to stdout.
+pub fn print_config_report(
+    ctx: &ConfigContext,
+    profile_name: Option<&str>,
+    profile_source: ProfileSource,
+    resolved: &ResolvedConfig,
+) -> Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    write_config_report(&mut stdout, ctx, profile_name, profile_source, resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use tokmd_settings::Profile;
+
+    fn render(
+        ctx: &ConfigContext,
+        name: Option<&str>,
+        source: ProfileSource,
+        resolved: &ResolvedConfig,
+    ) -> Result<String> {
+        let mut buf = Vec::new();
+        write_config_report(&mut buf, ctx, name, source, resolved)?;
+        Ok(String::from_utf8(buf)?)
+    }
+
+    #[test]
+    fn config_explain_reports_no_sources() -> Result<()> {
+        let ctx = ConfigContext::default();
+        let resolved = ResolvedConfig::default();
+        let out = render(&ctx, None, ProfileSource::None, &resolved)?;
+        assert!(out.contains("TOML config:    (none found)"), "{out}");
+        assert!(out.contains("Legacy JSON:    (none)"), "{out}");
+        assert!(out.contains("name:           (none)"), "{out}");
+        assert!(out.contains("format:         (default)"), "{out}");
+        assert!(out.contains("module_roots:   (default)"), "{out}");
+        Ok(())
+    }
+
+    #[test]
+    fn config_explain_flags_unmatched_profile() -> Result<()> {
+        let ctx = ConfigContext::default();
+        let resolved = ResolvedConfig::default();
+        let out = render(&ctx, Some("ci"), ProfileSource::Cli, &resolved)?;
+        assert!(out.contains("name:           ci (from --profile)"), "{out}");
+        assert!(out.contains("matched TOML view:     no"), "{out}");
+        assert!(out.contains("did not match"), "{out}");
+        Ok(())
+    }
+
+    #[test]
+    fn config_explain_shows_resolved_profile_values() -> Result<()> {
+        let profile = Profile {
+            format: Some("json".to_string()),
+            top: Some(5),
+            ..Profile::default()
+        };
+        let resolved = ResolvedConfig {
+            toml_view: None,
+            json_profile: Some(&profile),
+            toml: None,
+        };
+        let ctx = ConfigContext::default();
+        let out = render(&ctx, Some("default"), ProfileSource::Env, &resolved)?;
+        assert!(
+            out.contains("name:           default (from TOKMD_PROFILE)"),
+            "{out}"
+        );
+        assert!(out.contains("matched JSON profile:  yes"), "{out}");
+        assert!(out.contains("format:         json"), "{out}");
+        assert!(out.contains("top:            5"), "{out}");
+        assert!(!out.contains("did not match"), "{out}");
+        Ok(())
+    }
+}

--- a/crates/tokmd/src/lib.rs
+++ b/crates/tokmd/src/lib.rs
@@ -52,6 +52,19 @@ pub fn run() -> Result<()> {
     let config_ctx = config::load_config();
     let profile_name = config::get_profile_name(cli.profile.as_ref());
     let resolved = config::resolve_config(&config_ctx, profile_name.as_deref());
+    if cli.show_config {
+        let source = match (cli.profile.as_ref(), profile_name.as_ref()) {
+            (Some(_), Some(_)) => config::explain::ProfileSource::Cli,
+            (None, Some(_)) => config::explain::ProfileSource::Env,
+            _ => config::explain::ProfileSource::None,
+        };
+        return config::explain::print_config_report(
+            &config_ctx,
+            profile_name.as_deref(),
+            source,
+            &resolved,
+        );
+    }
     commands::dispatch(cli, &resolved)
 }
 

--- a/crates/tokmd/src/progress.rs
+++ b/crates/tokmd/src/progress.rs
@@ -26,6 +26,29 @@ fn emit_progress_event(kind: &str, message: &str) {
     }
 }
 
+/// Emit a single orchestrator-stage progress event without managing an
+/// interactive spinner.
+///
+/// Multi-step orchestrators such as `packet generate` delegate the live spinner
+/// to the sub-commands they call (each sub-command owns its own [`Progress`]).
+/// They still frame each stage for `tokmd.progress` consumers, so this emits one
+/// `update` event to stderr (subject to `TOKMD_PROGRESS_EVENTS`) without drawing
+/// a second spinner that would conflict with the active sub-command's spinner.
+#[cfg(feature = "analysis")]
+pub(crate) fn emit_stage(message: &str) {
+    emit_progress_event("update", message);
+}
+
+/// Emit the orchestrator completion event (a `finish` event to stderr, subject
+/// to `TOKMD_PROGRESS_EVENTS`).
+///
+/// Pairs with [`emit_stage`] for orchestrators that do not own an interactive
+/// spinner. The default completion message matches the spinner-based finish.
+#[cfg(feature = "analysis")]
+pub(crate) fn emit_stage_finish() {
+    emit_progress_event("finish", "done");
+}
+
 /// Check if we should show interactive output.
 #[cfg(feature = "ui")]
 fn is_interactive() -> bool {
@@ -292,6 +315,15 @@ mod tests {
         progress.set_length(20);
         progress.finish_with_message("done");
         progress.finish_and_clear();
+    }
+
+    #[cfg(feature = "analysis")]
+    #[test]
+    fn stage_event_helpers_do_not_panic_when_disabled() {
+        // Stage helpers are gated by TOKMD_PROGRESS_EVENTS like the spinner
+        // emitters; calling them without the env var set must be a no-op.
+        emit_stage("Generating analysis receipt...");
+        emit_stage_finish();
     }
 
     #[test]

--- a/crates/tokmd/tests/progress_events.rs
+++ b/crates/tokmd/tests/progress_events.rs
@@ -1,0 +1,89 @@
+//! Integration tests for machine-readable progress events on the scan-summary
+//! command family (`lang`, `module`, `export`).
+//!
+//! See `docs/specs/progress-events.md` for the behavior contract. These tests
+//! assert that, when `TOKMD_PROGRESS_EVENTS` is set, each command emits
+//! `tokmd.progress` events to **stderr** while keeping **stdout** free of
+//! progress noise, and that the events are absent when the variable is unset.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+const UPDATE_LINE: &str = r#"{"event":"tokmd.progress","kind":"update","message":"Scanning codebase...","schema_version":1}"#;
+const FINISH_LINE: &str =
+    r#"{"event":"tokmd.progress","kind":"finish","message":"done","schema_version":1}"#;
+
+fn fixture_dir() -> Result<tempfile::TempDir, Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    std::fs::write(tmp.path().join("main.rs"), "fn main() {\n    // body\n}\n")?;
+    Ok(tmp)
+}
+
+fn tokmd_in(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir)
+        .env_remove("TOKMD_PROFILE")
+        .env_remove("TOKMD_CONFIG")
+        .env_remove("TOKMD_NO_PROGRESS");
+    cmd
+}
+
+/// The progress contract is identical across the scan-summary family, so assert
+/// it uniformly: events on stderr, no progress noise on stdout.
+fn assert_emits_progress(subcommand: &str) -> TestResult {
+    let tmp = fixture_dir()?;
+    tokmd_in(tmp.path())
+        .arg(subcommand)
+        .arg("--no-progress")
+        .arg(".")
+        .env("TOKMD_PROGRESS_EVENTS", "1")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(UPDATE_LINE))
+        .stderr(predicate::str::contains(FINISH_LINE))
+        .stdout(predicate::str::contains("tokmd.progress").not());
+    Ok(())
+}
+
+#[test]
+fn lang_emits_progress_events_on_stderr() -> TestResult {
+    assert_emits_progress("lang")
+}
+
+#[test]
+fn module_emits_progress_events_on_stderr() -> TestResult {
+    assert_emits_progress("module")
+}
+
+#[test]
+fn export_emits_progress_events_on_stderr() -> TestResult {
+    assert_emits_progress("export")
+}
+
+#[test]
+fn lang_emits_no_progress_events_when_unset() -> TestResult {
+    let tmp = fixture_dir()?;
+    tokmd_in(tmp.path())
+        .arg("lang")
+        .arg(".")
+        .env_remove("TOKMD_PROGRESS_EVENTS")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("tokmd.progress").not());
+    Ok(())
+}
+
+#[test]
+fn export_emits_no_progress_events_when_unset() -> TestResult {
+    let tmp = fixture_dir()?;
+    tokmd_in(tmp.path())
+        .arg("export")
+        .arg(".")
+        .env_remove("TOKMD_PROGRESS_EVENTS")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("tokmd.progress").not());
+    Ok(())
+}

--- a/crates/tokmd/tests/progress_events.rs
+++ b/crates/tokmd/tests/progress_events.rs
@@ -1,10 +1,13 @@
 //! Integration tests for machine-readable progress events on the scan-summary
-//! command family (`lang`, `module`, `export`).
+//! command family (`lang`, `module`, `export`) and the multi-step orchestrators
+//! (`cockpit`, `packet generate`).
 //!
 //! See `docs/specs/progress-events.md` for the behavior contract. These tests
 //! assert that, when `TOKMD_PROGRESS_EVENTS` is set, each command emits
 //! `tokmd.progress` events to **stderr** while keeping **stdout** free of
 //! progress noise, and that the events are absent when the variable is unset.
+
+mod common;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -82,6 +85,185 @@ fn export_emits_no_progress_events_when_unset() -> TestResult {
         .arg("export")
         .arg(".")
         .env_remove("TOKMD_PROGRESS_EVENTS")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("tokmd.progress").not());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Multi-step orchestrators: `cockpit` and `packet generate`.
+//
+// These commands delegate or sequence several steps. They must frame their
+// orchestrator-level stages as `tokmd.progress` events on stderr (when
+// TOKMD_PROGRESS_EVENTS is set) while keeping the machine-readable receipt /
+// manifest on stdout. They are git-backed, so each gates on git availability.
+// ---------------------------------------------------------------------------
+
+/// Build a two-branch git repo (main + feature with one added file) so cockpit
+/// has a real diff to analyze. Returns `None` when git is unavailable so the
+/// caller can skip gracefully.
+#[cfg(feature = "git")]
+fn cockpit_repo() -> Result<Option<tempfile::TempDir>, Box<dyn std::error::Error>> {
+    if !common::git_available() {
+        eprintln!("Skipping: git not available");
+        return Ok(None);
+    }
+    let dir = tempfile::tempdir()?;
+    if !common::init_git_repo(dir.path()) {
+        eprintln!("Skipping: git init failed");
+        return Ok(None);
+    }
+    std::fs::write(dir.path().join("lib.rs"), "fn lib() {}\n")?;
+    if !common::git_add_commit(dir.path(), "initial") {
+        eprintln!("Skipping: initial commit failed");
+        return Ok(None);
+    }
+    let checked_out = std::process::Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(dir.path())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !checked_out {
+        eprintln!("Skipping: feature branch checkout failed");
+        return Ok(None);
+    }
+    std::fs::write(dir.path().join("new.rs"), "fn new() {}\n")?;
+    if !common::git_add_commit(dir.path(), "add new file") {
+        eprintln!("Skipping: second commit failed");
+        return Ok(None);
+    }
+    Ok(Some(dir))
+}
+
+#[cfg(feature = "git")]
+#[test]
+fn cockpit_emits_progress_events_on_stderr() -> TestResult {
+    let Some(dir) = cockpit_repo()? else {
+        return Ok(());
+    };
+    Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(dir.path())
+        .args([
+            "cockpit",
+            "--base",
+            "main",
+            "--head",
+            "HEAD",
+            "--no-progress",
+        ])
+        .env("TOKMD_PROGRESS_EVENTS", "1")
+        .env_remove("TOKMD_NO_PROGRESS")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(r#""event":"tokmd.progress""#))
+        .stderr(predicate::str::contains("Computing cockpit metrics"))
+        .stderr(predicate::str::contains(FINISH_LINE))
+        .stdout(predicate::str::contains("tokmd.progress").not());
+    Ok(())
+}
+
+#[cfg(feature = "git")]
+#[test]
+fn cockpit_emits_no_progress_events_when_unset() -> TestResult {
+    let Some(dir) = cockpit_repo()? else {
+        return Ok(());
+    };
+    Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(dir.path())
+        .args(["cockpit", "--base", "main", "--head", "HEAD"])
+        .env_remove("TOKMD_PROGRESS_EVENTS")
+        .env_remove("TOKMD_NO_PROGRESS")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("tokmd.progress").not());
+    Ok(())
+}
+
+/// Build a git repo whose feature change touches a single scoped file, matching
+/// the `packet generate` integration fixtures.
+#[cfg(feature = "analysis")]
+fn packet_repo() -> Result<Option<tempfile::TempDir>, Box<dyn std::error::Error>> {
+    if !common::git_available() {
+        eprintln!("Skipping: git not available");
+        return Ok(None);
+    }
+    let dir = tempfile::tempdir()?;
+    if !common::init_git_repo(dir.path()) {
+        eprintln!("Skipping: git init failed");
+        return Ok(None);
+    }
+    let scope_dir = dir.path().join("src").join("runtime").join("api");
+    std::fs::create_dir_all(&scope_dir)?;
+    std::fs::write(scope_dir.join("MarkdownObject.rs"), "pub fn old() {}\n")?;
+    if !common::git_add_commit(dir.path(), "initial") {
+        eprintln!("Skipping: initial commit failed");
+        return Ok(None);
+    }
+    std::fs::write(
+        scope_dir.join("MarkdownObject.rs"),
+        "pub fn old() {}\npub fn new_boundary() {}\n",
+    )?;
+    if !common::git_add_commit(dir.path(), "change api") {
+        eprintln!("Skipping: second commit failed");
+        return Ok(None);
+    }
+    Ok(Some(dir))
+}
+
+#[cfg(feature = "analysis")]
+#[test]
+fn packet_generate_emits_orchestrator_progress_events_on_stderr() -> TestResult {
+    let Some(dir) = packet_repo()? else {
+        return Ok(());
+    };
+    Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(dir.path())
+        .args([
+            "packet",
+            "generate",
+            "--base",
+            "main",
+            "--head",
+            "HEAD",
+            "--no-syntax",
+            "--no-progress",
+            "src/runtime/api/MarkdownObject.rs",
+        ])
+        .env("TOKMD_PROGRESS_EVENTS", "1")
+        .env_remove("TOKMD_NO_PROGRESS")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Generating analysis receipt"))
+        .stderr(predicate::str::contains("Generating context artifact"))
+        .stderr(predicate::str::contains("Indexing evidence packet"))
+        .stderr(predicate::str::contains(FINISH_LINE))
+        .stdout(predicate::str::contains("tokmd.progress").not());
+    Ok(())
+}
+
+#[cfg(feature = "analysis")]
+#[test]
+fn packet_generate_emits_no_progress_events_when_unset() -> TestResult {
+    let Some(dir) = packet_repo()? else {
+        return Ok(());
+    };
+    Command::new(env!("CARGO_BIN_EXE_tokmd"))
+        .current_dir(dir.path())
+        .args([
+            "packet",
+            "generate",
+            "--base",
+            "main",
+            "--head",
+            "HEAD",
+            "--no-syntax",
+            "--no-progress",
+            "src/runtime/api/MarkdownObject.rs",
+        ])
+        .env_remove("TOKMD_PROGRESS_EVENTS")
+        .env_remove("TOKMD_NO_PROGRESS")
         .assert()
         .success()
         .stderr(predicate::str::contains("tokmd.progress").not());

--- a/crates/tokmd/tests/show_config.rs
+++ b/crates/tokmd/tests/show_config.rs
@@ -1,0 +1,71 @@
+//! Integration tests for the global `--show-config` diagnostic surface.
+//!
+//! See `docs/specs/config-explainability.md` for the behavior contract.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn tokmd_in(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokmd"));
+    cmd.current_dir(dir)
+        .env_remove("TOKMD_PROFILE")
+        .env_remove("TOKMD_CONFIG");
+    cmd
+}
+
+#[test]
+fn show_config_prints_report_and_exits_without_scanning() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    tokmd_in(tmp.path())
+        .arg("--show-config")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd configuration"))
+        .stdout(predicate::str::contains(
+            "Config sources (in precedence order):",
+        ))
+        .stdout(predicate::str::contains("Active profile:"))
+        .stdout(predicate::str::contains("Resolved values:"));
+    Ok(())
+}
+
+#[test]
+fn show_config_flags_unmatched_profile() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    tokmd_in(tmp.path())
+        .arg("--show-config")
+        .arg("--profile")
+        .arg("tokmd-no-such-profile-xyz")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "name:           tokmd-no-such-profile-xyz (from --profile)",
+        ))
+        .stdout(predicate::str::contains("did not match"));
+    Ok(())
+}
+
+#[test]
+fn show_config_is_available_after_subcommand() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    tokmd_in(tmp.path())
+        .arg("module")
+        .arg("--show-config")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd configuration"));
+    Ok(())
+}
+
+#[test]
+fn normal_run_does_not_print_config_report() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    tokmd_in(tmp.path())
+        .arg("lang")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tokmd configuration").not());
+    Ok(())
+}

--- a/crates/tokmd/tests/snapshots/cli_snapshot_golden__help.snap
+++ b/crates/tokmd/tests/snapshots/cli_snapshot_golden__help.snap
@@ -103,6 +103,9 @@ Options:
           
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/tokmd/tests/snapshots/cli_snapshot_golden__help_ast.snap
+++ b/crates/tokmd/tests/snapshots/cli_snapshot_golden__help_ast.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tokmd/tests/cli_snapshot_golden.rs
-assertion_line: 35
 expression: normalize(stdout)
 ---
 tokmd — code awareness for AI contexts
@@ -105,6 +104,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
           
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -23,6 +23,7 @@ These arguments apply when you invoke `tokmd` directly without an explicit subco
 | `--files` | Include file counts and average lines per file. |
 | `--children <CHILDREN>` | How to handle embedded languages (`collapse`, `separate`). Default is `collapse`. |
 | `--profile <PROFILE>` | Configuration profile to use (e.g., `llm_safe`, `ci`). Alias: `--view`. |
+| `--show-config` | Print the resolved configuration sources and profile-layered values, then exit without scanning. See [`docs/specs/config-explainability.md`](specs/config-explainability.md). |
 
 > **Note**: Paths to scan are specified as positional arguments on each subcommand (e.g., `tokmd lang ./src`), not as global flags.
 
@@ -80,6 +81,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -165,6 +169,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -262,6 +269,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -329,6 +339,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -491,6 +504,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -579,6 +595,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -662,6 +681,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -741,6 +763,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -810,6 +835,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -973,6 +1001,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -1135,6 +1166,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -1191,6 +1225,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -1255,6 +1292,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -1379,6 +1419,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -1410,6 +1453,7 @@ Examples:
 | `--sensor-mode` | Run in sensor mode for CI integration (see below). | `false` |
 | `--no-progress` | Disable progress spinners. | `false` |
 | `--profile <PROFILE>` | Configuration profile to use. | `(none)` |
+| `--show-config` | Print resolved config sources and values, then exit. | `false` |
 
 **Output Formats**:
 
@@ -1517,6 +1561,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -1693,6 +1740,9 @@ Options:
 
           [aliases: --view]
 
+      --show-config
+          Print the resolved configuration sources and values, then exit
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -1754,6 +1804,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -1895,6 +1948,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')
@@ -2081,6 +2137,9 @@ Options:
           Configuration profile to use (e.g., "llm_safe", "ci")
 
           [aliases: --view]
+
+      --show-config
+          Print the resolved configuration sources and values, then exit
 
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/specs/config-explainability.md
+++ b/docs/specs/config-explainability.md
@@ -1,0 +1,87 @@
+# Spec: Config Explainability (`--show-config`)
+
+- Status: active
+- Schema family, if any: n/a (human-readable diagnostic surface)
+- Related ADRs: n/a
+- Related proof scopes: `tokmd_cli`, `project_truth_docs`
+
+## Contract
+
+`tokmd` resolves runtime options from several layered sources. The layering is
+intentional but not visible to users: a `tokmd.toml` discovered by walking up
+from the current directory can silently shadow a different file, a legacy
+`~/.config/tokmd/config.json` profile can still apply, and `TOKMD_CONFIG` /
+`TOKMD_PROFILE` environment variables can change which file or profile is
+active without any on-screen indication.
+
+The global `--show-config` flag makes that resolution observable. When present,
+`tokmd` prints a human-readable report of the discovered configuration sources
+and the values they resolve to, then exits `0` **without scanning** any paths or
+running the selected subcommand.
+
+`--show-config` is a diagnostic surface only. It must not:
+
+- change command stdout for normal runs,
+- emit or alter any receipt, JSON, JSONL, or CSV output,
+- change exit-code policy for normal commands,
+- read or write files beyond the existing config-discovery reads.
+
+The report is written to **stdout** because it is the requested output of the
+invocation (the same way `--help` and `--version` own stdout). It is
+human-readable text, not a machine contract; its exact wording may change
+between releases.
+
+## Inputs
+
+| Input | Owner | Effect |
+| --- | --- | --- |
+| `--show-config` | CLI flag (global) | Print the config report and exit `0` before dispatching any subcommand. |
+| `TOKMD_CONFIG` | Process environment | Explicit `tokmd.toml` path; highest-precedence TOML source. Reported as the active TOML path when it resolves. |
+| `tokmd.toml` (cwd walk-up) | Filesystem | TOML config discovered from the current directory upward to the filesystem root. |
+| `~/.config/tokmd/tokmd.toml` | Filesystem | User-level TOML config fallback. |
+| `~/.config/tokmd/config.json` | Filesystem | Legacy JSON profile config fallback. |
+| `--profile` / `--view` | CLI flag (global) | Selects a named profile/view. Highest-precedence profile selector. |
+| `TOKMD_PROFILE` | Process environment | Profile/view name used when `--profile` is absent. |
+
+`--show-config` reports exactly the sources that `tokmd` already resolves at
+startup. It does not introduce a new discovery path.
+
+## Outputs
+
+The report names, in resolution order:
+
+1. The active TOML config path, or that none was found.
+2. Whether a legacy JSON config was loaded.
+3. The active profile/view name and where it came from (`--profile`,
+   `TOKMD_PROFILE`, or none), plus whether it matched a TOML view and/or a
+   legacy JSON profile.
+4. The resolved profile-layered values (`format`, `top`, `files`,
+   `module_roots`, `module_depth`, `children`, `min_code`, `max_rows`,
+   `redact`, `meta`), each shown as its resolved value or `(default)` when no
+   source set it.
+
+A profile name that resolves to no matching TOML view and no JSON profile is
+reported as unmatched so users can detect typos or missing config files.
+
+## Compatibility
+
+`--show-config` is additive. It introduces no schema and does not change the
+behavior of any existing command when the flag is absent. Removing the flag
+would only remove the diagnostic surface; no receipt or machine output depends
+on it.
+
+## Proof Requirements
+
+```bash
+cargo test -p tokmd config_explain --verbose
+cargo test -p tokmd show_config --verbose
+cargo fmt-check
+cargo clippy -p tokmd -- -D warnings
+git diff --check
+```
+
+## Open Questions
+
+- Whether a `--show-config --format json` machine projection is worth adding if
+  a tool or agent consumer is named. Until then the surface stays
+  human-readable only.


### PR DESCRIPTION
## Summary

Publication import of three squash-merged tokmd-swarm development commits, per `docs/ci/swarm-routing.md`. Swarm is 3 commits ahead of publication; this PR imports them by merge commit.

Imported swarm commits (oldest to newest):

- `94530dc5` feat(cli): add `--show-config` to explain resolved configuration (#320)
- `3fa36407` feat(cli): emit stderr progress events for lang, module, export (#321)
- `2311ffb5` feat(cli): emit stderr progress events for cockpit and packet generate (#322)

## Graph state

`cargo xtask repo-graph --publication publication/main --swarm origin/main` reports:

- relation = `SwarmAhead`
- publication_ahead = 0
- swarm_ahead = 3
- merge_base = `b0e2bfe4` (current publication/main)

Swarm head `2311ffb5` descends cleanly from publication `b0e2bfe4`.

## Proof boundary

- This is a topology/import PR. It moves no release tag, publishes no package, signs no artifact, pushes no image, and does not move the `v1` alias.
- After merge, `tokmd-swarm/main` fast-forwards to this publication merge commit and `repo-graph --expect aligned` must report aligned.
- Publication CI on this PR is the import gate.

Made with [Cursor](https://cursor.com)