### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-26 (GHCR verified-public receipt)

### DIFF
--- a/docs/releases/1.14-ledger.md
+++ b/docs/releases/1.14-ledger.md
@@ -45,7 +45,7 @@ captured during post-release housekeeping on 2026-06-25.
 | GitHub release | Published | <https://github.com/EffortlessMetrics/tokmd/releases/tag/v1.14.0> (not draft, not prerelease; published `2026-06-25T18:42:02Z`). |
 | Release workflow | Success | <https://github.com/EffortlessMetrics/tokmd/actions/runs/28192117926> (`release.yml`, branch `v1.14.0`, head `f5f810eb`, conclusion `success`). |
 | crates.io | Published | `tokmd` `1.14.0` present and not yanked (`created_at 2026-06-25T18:48:13Z`, `crate_size 163974` bytes) via the crates.io API. Lockstep workspace crates publish at the same version. |
-| GHCR (publication) | Advisory pass | `ghcr.io/effortlessmetrics/tokmd:1.14.0` returned HTTP 200 to an unauthenticated registry pull token. Manifest is an OCI image index, digest `sha256:bd214464eb9c8df734e88dd64e81fab072021e39ec1b3a23b69eebbfb914b096`. |
+| GHCR (publication) | Verified-public (visibility) | `ghcr.io/effortlessmetrics/tokmd:1.14.0` (and `1.14`, `1`, `latest`) resolve to HTTP 200 from an anonymous registry pull token, same OCI image index digest `sha256:bd214464eb9c8df734e88dd64e81fab072021e39ec1b3a23b69eebbfb914b096`. Anonymous config-blob fetch confirms public visibility; `image.revision` matches the release tag commit. Container-runtime exec smokes (steps 6-7) not yet run. See receipt below. |
 | npm | Not published | `@tokmd/*` was intentionally **not** published this cycle. |
 | PyPI | Not published | `tokmd` (PyPI) was intentionally **not** published this cycle. |
 | Install smoke | Pass | `cargo install tokmd --version 1.14.0` from crates.io built and installed `tokmd v1.14.0`; the installed binary reports `tokmd 1.14.0` and exposes the new `render` and `packet generate` commands in the default feature set. |
@@ -57,19 +57,49 @@ repository's lockstep microcrate model, so the publishable workspace crates
 share the `1.14.0` version. This receipt confirms the top-level `tokmd` crate;
 it does not independently re-verify every dependent crate page.
 
-### GHCR visibility receipt (advisory)
+### GHCR visibility receipt (verified-public)
 
-The GHCR row records an **advisory** unauthenticated manifest fetch only. A
-fresh anonymous pull token from `ghcr.io/token` resolved
-`ghcr.io/effortlessmetrics/tokmd:1.14.0` to an OCI image index (HTTP 200,
-digest `sha256:bd214464eb9c8df734e88dd64e81fab072021e39ec1b3a23b69eebbfb914b096`).
+Maintainer-requested anonymous verification on **2026-06-26** records the
+publication GHCR image as **verified-public** for `v1.14.0`. The verification
+used the GHCR registry HTTP API from an unauthenticated context (no Docker on
+the verification host), which is the same anonymous-token + manifest fetch that
+`docker manifest inspect` performs. An anonymous pull token from
+`https://ghcr.io/token` resolved all four tags to HTTP 200 with one shared OCI
+image index digest
+`sha256:bd214464eb9c8df734e88dd64e81fab072021e39ec1b3a23b69eebbfb914b096`:
 
-This is the post-release advisory signal described in
-[release readiness — Post-Release GHCR Visibility](../release-readiness.md#post-release-ghcr-visibility).
-Recording the formal `verified-public` maintainer receipt for the GHCR package
-(per the
+| Tag | Anonymous manifest inspect | Digest |
+| --- | --- | --- |
+| `1.14.0` | HTTP 200 | `sha256:bd214464…b914b096` |
+| `1.14` | HTTP 200 | same |
+| `1` | HTTP 200 | same |
+| `latest` | HTTP 200 | same (currently aliases `1.14.0`) |
+
+The multi-arch index advertises `linux/amd64`, `linux/arm64`, and two
+attestation manifests. The `linux/amd64` sub-manifest and its config blob were
+fetched anonymously, confirming the registry serves blobs without credentials
+(public package). The config reports `entrypoint: tokmd`, `workingdir: /repo`,
+`org.opencontainers.image.version: 1.14.0`, and
+`org.opencontainers.image.revision: f5f810eb24de214aee19da2f902bd1a829d2d9d0`
+(matching the `v1.14.0` release tag commit).
+
+This receipt is recorded per the
 [Publishing evidence — Post-Release GHCR Visibility Checks](../publishing-evidence.md#post-release-ghcr-visibility-checks)
-template) remains a maintainer-only action. The swarm workbench GHCR surface
+template; the filled receipt is saved at
+`target/publishing/ghcr-visibility-1.14.0.md` (under the gitignored `target/`
+tree). It supersedes the prior advisory-only signal described in
+[release readiness — Post-Release GHCR Visibility](../release-readiness.md#post-release-ghcr-visibility).
+
+**Claim boundary.** This receipt verifies anonymous **public visibility** of the
+publication GHCR image for `v1.14.0` and its `1.14` / `1` / `latest` aliases. It
+does **not** satisfy the container-runtime verification gate in
+[packet GHCR runtime spec](../specs/packet-ghcr-runtime.md#verification-gate)
+steps 6-7 (running container `tokmd --version` and a mounted-repository
+`complete` packet smoke), which require a Docker exec not available on the
+verification host. The OCI version label is image-declared metadata, not a
+runtime `tokmd --version` exec. The `runtime: container` path in `action.yml`
+therefore stays a hard error until a Docker-capable host runs steps 6-7 for this
+tag. The swarm workbench GHCR surface
 (`ghcr.io/effortlessmetrics/tokmd-swarm`) is tracked separately (issue #264).
 
 ### Post-release install smoke
@@ -142,16 +172,21 @@ No receipt schema version changed in `1.14.0`:
 - add undefined-behavior detection, reachability proof, safety proof, or a
   semantic call graph;
 - publish npm or PyPI artifacts;
-- claim a formal GHCR `verified-public` maintainer receipt (the GHCR row here is
-  an advisory unauthenticated fetch only);
+- claim a verified `runtime: container` Action path (the GHCR receipt verifies
+  anonymous public visibility only; container-runtime gate steps 6-7 remain
+  unrun);
 - perform tag, GitHub release, crates.io, image, or alias mutation from
   `tokmd-swarm`.
 
 ## Claim Boundary
 
 This ledger records the published `v1.14.0` distribution surface and the
-post-release receipts captured on 2026-06-25: the GitHub release, the successful
-release workflow run, the crates.io `1.14.0` version, and an advisory
-unauthenticated GHCR manifest fetch. It does not claim a formal GHCR
-maintainer receipt, does not claim npm/PyPI publication (intentionally skipped),
-and does not prove runtime safety, mutation adequacy, or coverage.
+post-release receipts captured on 2026-06-25, plus the anonymous GHCR
+visibility verification recorded on 2026-06-26: the GitHub release, the
+successful release workflow run, the crates.io `1.14.0` version, and a
+**verified-public** anonymous GHCR visibility receipt for `1.14.0` / `1.14` /
+`1` / `latest`. The GHCR receipt proves anonymous public visibility only; it
+does not satisfy the container-runtime verification gate (`tokmd --version` and
+mounted-repository packet smoke), does not claim a verified `runtime: container`
+Action path, does not claim npm/PyPI publication (intentionally skipped), and
+does not prove runtime safety, mutation adequacy, or coverage.

--- a/docs/specs/packet-ghcr-runtime.md
+++ b/docs/specs/packet-ghcr-runtime.md
@@ -142,6 +142,31 @@ Maintainer outcomes are recorded as publication GHCR visibility receipts under
 `target/publishing/ghcr-visibility-<version>.md` and copied into the matching
 release ledger, per `docs/specs/publishing-evidence.md`.
 
+### Verification Status
+
+| Tag | Visibility (steps 1-5) | Runtime exec (steps 6-7) | Container runtime |
+| --- | --- | --- | --- |
+| `1.14.0` (and `1.14` / `1` / `latest`) | verified-public (2026-06-26) | not run | **pending** |
+
+On **2026-06-26**, anonymous registry-API verification (no Docker on the
+verification host) confirmed gate steps 1-4 and the registry-level portion of
+step 5 for `1.14.0` and its `1.14` / `1` / `latest` aliases: an unauthenticated
+pull token resolved every tag to HTTP 200 with one shared OCI image index
+digest `sha256:bd214464…b914b096`, and the `linux/amd64` config blob was
+fetched anonymously (public package; `image.revision` matches the `v1.14.0`
+release tag commit, `image.version` is `1.14.0`). Receipt:
+`target/publishing/ghcr-visibility-1.14.0.md`; ledger copy in
+`docs/releases/1.14-ledger.md`.
+
+Gate steps 6 (container `tokmd --version`) and 7 (mounted-repository `complete`
+packet smoke) were **not run** because they require a Docker exec unavailable on
+the verification host. The OCI `image.version` label is image-declared metadata,
+not a runtime exec, so it does not discharge step 6. The container runtime for
+`1.14.0` therefore stays **pending** under this gate: `action.yml` keeps the
+`runtime: container` hard error until a Docker-capable host completes steps 6-7
+for the tag. Public visibility being verified does not by itself make the
+container runtime supported.
+
 ## Claim Boundary
 
 When implemented and verified for a tag, the container runtime proves only that:


### PR DESCRIPTION
## Summary

Imports the single swarm commit landed after the prior 2026-06-26 import: the verified-public GHCR visibility receipt for `1.14.0` (swarm PR #328). This is a docs-only import (release ledger + packet-ghcr-runtime spec verification status), no code or schema change.

Swarm-Head: a43617e0af08a6f13d3c1e38dc27f41abe8b7324
Swarm-Range: ef6b08006eafd616e055d20bc8a6d47404ea3cb2..a43617e0af08a6f13d3c1e38dc27f41abe8b7324

## Changes
- `docs/releases/1.14-ledger.md`: GHCR distribution row + verified-public visibility receipt section; container-runtime gate steps 6-7 explicitly recorded as not run.
- `docs/specs/packet-ghcr-runtime.md`: verification status table marks `1.14.0` steps 1-5 verified-public (2026-06-26), steps 6-7 not run, container runtime stays **pending**.

## Claim boundary
Anonymous **public visibility** of the publication GHCR image only. Does NOT satisfy container-runtime gate steps 6-7 (`tokmd --version` exec + mounted-repository `complete` packet smoke), which require a Docker-capable host. `runtime: container` in `action.yml` remains a hard error. No tag/release/publish/alias mutation.

## Checks
- Swarm PR #328: `Tokmd Rust Result` green (squash-merged to swarm/main).
- Publication CI: see this PR's required checks.

Made with [Cursor](https://cursor.com)