### PR TITLE
mutant: add assertion for saturating_sub safety in ChildrenMode::Separate 🧬

### DIFF
--- a/.jules/runs/run_mutant_01/decision.md
+++ b/.jules/runs/run_mutant_01/decision.md
@@ -1,0 +1,10 @@
+# Decision
+
+## Option A
+Add `separate_drops_parent_when_child_subsumes_all_code` test to `crates/tokmd-model/src/children.rs` to assert that when a child's code exceeds or subsumes its parent's code in `ChildrenMode::Separate`, the parent is safely dropped by `aggregate_lang_rows` rather than underflowing.
+
+## Option B
+Add no new tests. Use a learning PR to record that `children.rs` is mostly covered, which is safe but less impactful given a concrete missing check around saturating subtraction and filtering logic.
+
+## Decision
+Option A. This closes a missed-mutant gap on `saturating_sub` lines where an over-reporting child could cause underflow/panics in older Rust if unchecked, and proves that our current `saturating_sub` coupled with `agg.code == 0` filtering actually prevents negative reporting or panics.

--- a/.jules/runs/run_mutant_01/envelope.json
+++ b/.jules/runs/run_mutant_01/envelope.json
@@ -1,0 +1,17 @@
+{
+  "prompt_id": "mutant_high_value",
+  "persona": "Mutant",
+  "style": "Prover",
+  "primary_shard": "core-pipeline",
+  "allowed_paths": [
+    "crates/tokmd-types/**",
+    "crates/tokmd-scan/**",
+    "crates/tokmd-model/**",
+    "crates/tokmd-format/**"
+  ],
+  "gate_profile": "mutation",
+  "allowed_outcomes": [
+    "proof-improvement patch",
+    "learning PR"
+  ]
+}

--- a/.jules/runs/run_mutant_01/pr_body.md
+++ b/.jules/runs/run_mutant_01/pr_body.md
@@ -1,0 +1,52 @@
+## 💡 Summary
+Added a test to explicitly verify that `aggregate_lang_rows` safely drops a parent row without underflowing when a child's code size subsumes or exceeds the parent's code in `ChildrenMode::Separate`.
+
+## 🎯 Why
+In `aggregate_lang_rows`, when in `ChildrenMode::Separate`, we subtract child code lines from the parent code using `saturating_sub`. Later we filter out rows with `agg.code == 0`. We had no test verifying the combined safety of these operations when a child row reports more code than its parent. This closes a concrete mutation/assertion gap and protects against underflow panics.
+
+## 🔎 Evidence
+- file path: `crates/tokmd-model/src/children.rs`
+- finding: The subtraction logic `row.code.saturating_sub(child_code)` implicitly relied on `agg.code == 0` filtering to prevent rendering invalid rows, but this behavior was untested for edge cases where `child_code > row.code`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Add a new test `separate_drops_parent_when_child_subsumes_all_code` demonstrating that an oversized child row yields a `0` code parent, which is correctly excluded.
+- **Why it fits:** It directly strengthens behavioral assertions around a core model aggregation surface, fulfilling the `mutant` objective.
+- **Trade-offs:** Adds a small amount of test code but ensures safety against regressions or mutating `saturating_sub` to regular subtraction.
+
+### Option B
+- Add no tests and submit a learning PR.
+- **When to choose:** If the target was out of scope or tests were completely saturated.
+- **Trade-offs:** Misses an opportunity to close a concrete assertion gap.
+
+## ✅ Decision
+Option A. It closes a mutation/assertion gap around an arithmetic operation (`saturating_sub`) in a core aggregation path, matching the prompt requirements.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd-model/src/children.rs`: Added `separate_drops_parent_when_child_subsumes_all_code` test.
+
+## 🧪 Verification receipts
+```text
+cargo test -p tokmd-model children
+cargo build
+CI=true cargo test -p tokmd-model
+cargo fmt -- --check
+cargo clippy -- -D warnings
+```
+
+## 🧭 Telemetry
+- Change shape: Test addition.
+- Blast radius: None (tests only).
+- Risk class: Low (does not modify runtime code).
+- Rollback: Revert test addition.
+- Gates run: targeted `cargo test`, `cargo build`, `cargo fmt`, `cargo clippy`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run_mutant_01/envelope.json`
+- `.jules/runs/run_mutant_01/decision.md`
+- `.jules/runs/run_mutant_01/receipts.jsonl`
+- `.jules/runs/run_mutant_01/result.json`
+- `.jules/runs/run_mutant_01/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run_mutant_01/receipts.jsonl
+++ b/.jules/runs/run_mutant_01/receipts.jsonl
@@ -1,0 +1,7 @@
+{"command":"cargo test -p tokmd-model children"}
+{"command":"patch -p0 < fix_test.patch"}
+{"command":"cargo test -p tokmd-model children"}
+{"command":"cargo build"}
+{"command":"CI=true cargo test -p tokmd-model"}
+{"command":"cargo fmt -- --check"}
+{"command":"cargo clippy -- -D warnings"}

--- a/.jules/runs/run_mutant_01/result.json
+++ b/.jules/runs/run_mutant_01/result.json
@@ -1,0 +1,7 @@
+{
+  "status": "success",
+  "outcome": "proof-improvement patch",
+  "files_changed": [
+    "crates/tokmd-model/src/children.rs"
+  ]
+}

--- a/crates/tokmd-model/src/children.rs
+++ b/crates/tokmd-model/src/children.rs
@@ -167,6 +167,19 @@ mod tests {
     }
 
     #[test]
+    fn separate_drops_parent_when_child_subsumes_all_code() {
+        let rows = [
+            row("docs/mixed.md", "Markdown", FileKind::Parent, 10, 20),
+            row("docs/mixed.md", "Rust", FileKind::Child, 15, 25), // exceeds parent
+        ];
+
+        let aggregated = aggregate_lang_rows(&rows, ChildrenMode::Separate);
+
+        // The parent code becomes 0 due to saturating_sub, so the parent is filtered out entirely.
+        assert!(aggregated.iter().find(|r| r.lang == "Markdown").is_none());
+    }
+
+    #[test]
     fn collapse_preserves_orphan_child_without_parent() {
         let rows = [row("orphan.template", "Rust", FileKind::Child, 4, 5)];
 


### PR DESCRIPTION
## 💡 Summary 
Added a test to explicitly verify that `aggregate_lang_rows` safely drops a parent row without underflowing when a child's code size subsumes or exceeds the parent's code in `ChildrenMode::Separate`.

## 🎯 Why 
In `aggregate_lang_rows`, when in `ChildrenMode::Separate`, we subtract child code lines from the parent code using `saturating_sub`. Later we filter out rows with `agg.code == 0`. We had no test verifying the combined safety of these operations when a child row reports more code than its parent. This closes a concrete mutation/assertion gap and protects against underflow panics.

## 🔎 Evidence 
- file path: `crates/tokmd-model/src/children.rs`
- finding: The subtraction logic `row.code.saturating_sub(child_code)` implicitly relied on `agg.code == 0` filtering to prevent rendering invalid rows, but this behavior was untested for edge cases where `child_code > row.code`. 

## 🧭 Options considered 
### Option A (recommended) 
- Add a new test `separate_drops_parent_when_child_subsumes_all_code` demonstrating that an oversized child row yields a `0` code parent, which is correctly excluded.
- **Why it fits:** It directly strengthens behavioral assertions around a core model aggregation surface, fulfilling the `mutant` objective.
- **Trade-offs:** Adds a small amount of test code but ensures safety against regressions or mutating `saturating_sub` to regular subtraction.

### Option B 
- Add no tests and submit a learning PR.
- **When to choose:** If the target was out of scope or tests were completely saturated.
- **Trade-offs:** Misses an opportunity to close a concrete assertion gap.

## ✅ Decision 
Option A. It closes a mutation/assertion gap around an arithmetic operation (`saturating_sub`) in a core aggregation path, matching the prompt requirements.

## 🧱 Changes made (SRP) 
- `crates/tokmd-model/src/children.rs`: Added `separate_drops_parent_when_child_subsumes_all_code` test.

## 🧪 Verification receipts 
```text
cargo test -p tokmd-model children
cargo build
CI=true cargo test -p tokmd-model
cargo fmt -- --check
cargo clippy -- -D warnings
```

## 🧭 Telemetry 
- Change shape: Test addition.
- Blast radius: None (tests only).
- Risk class: Low (does not modify runtime code).
- Rollback: Revert test addition.
- Gates run: targeted `cargo test`, `cargo build`, `cargo fmt`, `cargo clippy`.

## 🗂️ .jules artifacts 
- `.jules/runs/run_mutant_01/envelope.json`
- `.jules/runs/run_mutant_01/decision.md`
- `.jules/runs/run_mutant_01/receipts.jsonl`
- `.jules/runs/run_mutant_01/result.json`
- `.jules/runs/run_mutant_01/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [10109037892698921770](https://jules.google.com/task/10109037892698921770) started by @EffortlessSteven*