### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-27 (CycloneDX test + ub-review docs)

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1240,6 +1240,7 @@ paths = [
   "docs/recipes.md",
   "docs/tutorial.md",
   "docs/troubleshooting.md",
+  "docs/ub-review-integration.md",
   "docs/user-paths.md",
   "docs/workflows.md",
 ]

--- a/crates/tokmd/tests/full_pipeline_w55.rs
+++ b/crates/tokmd/tests/full_pipeline_w55.rs
@@ -15,7 +15,8 @@ use serde_json::Value;
 use tokmd_analysis::derive_report;
 use tokmd_format::{
     badge_svg, compute_diff_rows, compute_diff_totals, create_diff_receipt, write_export_csv_to,
-    write_export_json_to, write_export_jsonl_to, write_lang_report_to, write_module_report_to,
+    write_export_cyclonedx_to, write_export_json_to, write_export_jsonl_to, write_lang_report_to,
+    write_module_report_to,
 };
 use tokmd_model::{create_export_data, create_lang_report, create_module_report};
 use tokmd_scan::scan;
@@ -413,6 +414,26 @@ fn cli_lang_json_full_pipeline() {
     assert!(json["rows"].is_array());
     assert!(json["total"].is_object());
     assert!(json["tool"]["version"].is_string());
+}
+
+#[test]
+fn pipeline_export_cyclonedx_full() {
+    let langs = scan(&[fixture_path()], &default_scan_options()).expect("scan");
+    let data = create_export_data(
+        &langs,
+        &[],
+        2,
+        ChildIncludeMode::Separate,
+        Some(fixture_path().as_path()),
+        0,
+        0,
+    );
+    let mut buf = Vec::new();
+    write_export_cyclonedx_to(&mut buf, &data, RedactMode::None).unwrap();
+    let v: Value = serde_json::from_slice(&buf).unwrap();
+    assert_eq!(v["bomFormat"], "CycloneDX");
+    assert_eq!(v["specVersion"], "1.6");
+    assert!(v["components"].is_array());
 }
 
 #[test]

--- a/docs/packet-consumption.md
+++ b/docs/packet-consumption.md
@@ -221,3 +221,5 @@ See [Review packet contract](review-packet.md#github-action-behavior) and
   producer/verifier contract
 - [Cockpit proof evidence](cockpit-proof-evidence.md) — importing and reading proof
 - [Packet workflows](packet-workflows.md) — Action and CI adoption paths
+- [ub-review ↔ tokmd packet integration](ub-review-integration.md) — consumer-side
+  status taxonomy, cache/receipt, and manifest trust order for the ub-review lane

--- a/docs/ub-review-integration.md
+++ b/docs/ub-review-integration.md
@@ -1,0 +1,146 @@
+# ub-review ↔ tokmd Packet Integration
+
+Status: consumer-side integration guide. This document describes how an
+`ub-review` lane **calls and consumes** a tokmd evidence packet. The
+**producer** recipe (how to run tokmd to write the packet) lives in
+[ub-review tokmd sensor recipe](integrations/ub-review.md). General packet
+reading rules live in [Packet consumption guide](packet-consumption.md).
+
+This doc does not introduce a new command or schema version. It indexes the
+contract that already exists in [Evidence packet](evidence-packet.md) and
+[Evidence packet workflow spec](specs/evidence-packet-workflow.md), narrowed to
+the ub-review consumer.
+
+## Where this fits
+
+`ub-review` runs `tokmd` as a bounded evidence sensor inside an **advisory**
+lane (see [UB-Review single-tight CI gate](specs/ub-review-ci-gate.md)). The
+relationship is one-directional:
+
+```text
+ub-review lane
+  ├─ produces: sensors/tokmd/ packet   (tokmd packet generate / evidence-packet)
+  └─ consumes: sensors/tokmd/manifest.json + receipts   (this doc)
+```
+
+The packet is review evidence, not a verdict. `tokmd` never decides whether
+undefined behavior exists or is absent; ub-review must not present a green
+packet as a UB-absence proof or a merge gate.
+
+## How ub-review calls the packet
+
+The advisory lane attaches the PR evidence packet family at `sensors/tokmd/`
+(schema `tokmd.evidence-packet/v1`). Produce it with the orchestrator:
+
+```bash
+tokmd packet generate \
+  --base "$BASE" \
+  --head "$HEAD" \
+  "$@"
+```
+
+`$@` is the changed review scope (native-boundary paths for Bun UB). See the
+producer recipe for the `bun-ub` preset, the per-step form, and the Windows
+PowerShell UTF-8 write paths. The lane then **consumes** the manifest using the
+trust order below.
+
+## Status taxonomy
+
+ub-review consumers must read two independent axes and never collapse them: the
+packet `status` (is the packet itself valid?) and the per-artifact advisory
+state (was an optional signal produced?).
+
+### Packet status (`manifest.json` `status`)
+
+| `status` | Read as | ub-review action | Exit |
+| --- | --- | --- | --- |
+| `complete` | Required artifacts exist, refs resolved, scoped analysis parsed, `errors` empty. | Attach and review. Not a merge verdict. | `0` |
+| `partial` | Required artifacts exist, but named `warnings` bound the evidence (e.g. optional `syntax.json` missing/degraded). | Attach with the warnings surfaced; treat limits as named, not as failure. | `0` |
+| `failed` | A required artifact is missing, refs did not resolve, or `analyze.json` could not be parsed. | Do **not** attach a valid-looking packet. Regenerate or omit. | non-zero (manifest still written for inspection) |
+
+Required artifacts: `analyze_md`, `analyze_json`, `context_md`. Optional
+advisory artifact: `syntax_json`.
+
+### Advisory artifact state
+
+For optional signals (today: `syntax_json` / `review_priority`), distinguish:
+
+| State | Meaning | ub-review action |
+| --- | --- | --- |
+| **skipped** | Optional artifact was not requested (e.g. binary built without the `ast` feature, syntax step omitted). | Expected. Packet stays `complete`/`partial`; do not call it a failure. |
+| **advisory-missing** | Optional artifact was requested for this run but is absent. | Packet degrades to `partial` with a named warning. Read it as a bounded limit, not a required-proof failure, unless the repo explicitly promoted that signal to required. |
+
+Neither state is a UB finding and neither is a merge blocker. An advisory gap is
+a visible limit, not a red gate. (See the shared evidence-state vocabulary in
+[Packet consumption guide](packet-consumption.md#evidence-state-glossary).)
+
+## Claim boundary: what to trust first in `manifest.json`
+
+Read the manifest top-down in this order; stop and reject early if an upstream
+field invalidates the packet.
+
+1. **`status` + `errors`** — gate validity. `failed` (or any `errors`) means
+   invalid evidence; stop here.
+2. **`schema` + `tokmd_version`** — confirm `tokmd.evidence-packet/v1` and a
+   known binary version before interpreting other fields.
+3. **`base` + `head` + `paths`** — confirm the packet matches the PR's diff
+   window and review scope. A mismatch is **stale** evidence: re-run the
+   `reproduce` commands against the current head before trusting it.
+4. **`warnings` + `non_claims`** — the named limits and the claims the packet
+   explicitly does not make. Surface these in any advisory note.
+5. **`artifacts`** — the indexed receipts. `analyze.json` is the machine
+   receipt for bots/ledgers; `analyze.md` is the first-read human summary;
+   `context.md` shows which source was included, truncated, or skipped.
+6. **`review_priority`** — advisory reading order only. Open the referenced
+   `syntax_json` entries before making any review claim; never treat a priority
+   rank as a finding or verdict.
+
+Fail closed: if a required field is missing, treat the packet as invalid rather
+than guessing. Ignore unknown fields (producers may add non-breaking fields).
+
+## Cache and receipt guidance
+
+- **Receipts are the evidence; the manifest is the index.** Trust `analyze.json`
+  (and `syntax.json` when present) as the receipts; `manifest.json` only points
+  at them and records status/scope.
+- **Cache by identity, not by presence.** A reusable packet is keyed by
+  `(schema, tokmd_version, base, head, paths, preset)`. Reuse a prior
+  `sensors/tokmd/` packet only when all of those match the current run;
+  otherwise it is stale and must be regenerated.
+- **Regenerate from `reproduce`.** The `reproduce` array records copy-ready
+  commands scoped to the same paths. Use it (or `tokmd packet generate` with the
+  same base/head/preset/paths) to refresh evidence rather than hand-editing
+  artifacts.
+- **Never cache a `failed` packet as a pass.** A `failed` manifest is written to
+  disk for inspection, not for reuse as a green signal.
+- **Advisory lane posture.** Because the ub-review tokmd step is
+  `continue-on-error` / advisory, a missing or degraded packet must surface as a
+  what/why/fix note in the job summary, never as a bare red required check. The
+  required floor remains `Tokmd Rust Result`.
+
+## Claim boundary (lane level)
+
+Consuming this packet establishes:
+
+- what changed, whether the requested refs resolved, where review risk
+  concentrates, and what source context was included/skipped;
+- a reproducible, scoped evidence index for the bot, reviewer, and next agent.
+
+It does **not** establish:
+
+- that undefined behavior exists or is absent, or memory safety;
+- merge readiness beyond the deterministic core floor;
+- that LLM review ran (advisory, same-repo only; fork PRs skip it);
+- CI proof, coverage, mutation, fuzz, release, signing, or publish results.
+
+## Related docs
+
+- [ub-review tokmd sensor recipe](integrations/ub-review.md) — producer recipe
+  (how to run tokmd to write the packet)
+- [Packet consumption guide](packet-consumption.md) — reading order, evidence-state
+  glossary, worked examples
+- [Evidence packet](evidence-packet.md) — manifest field reference and status rules
+- [Evidence packet workflow spec](specs/evidence-packet-workflow.md) — normative
+  producer/verifier contract
+- [UB-Review single-tight CI gate](specs/ub-review-ci-gate.md) — advisory lane shape
+- [Bun UB analysis preset](analyze/bun-ub.md) — the `bun-ub` preset signals

--- a/policy/no-panic-baseline-receipt.json
+++ b/policy/no-panic-baseline-receipt.json
@@ -2,14 +2,14 @@
   "schema": "tokmd.no_panic_baseline.v1",
   "generated_at": "2026-06-27T19:52:23.384119300+00:00",
   "allowlist_path": "policy/no-panic-allowlist.toml",
-  "finding_count": 21876,
-  "entry_count": 21876,
+  "finding_count": 21879,
+  "entry_count": 21879,
   "expires": "2026-12-31",
   "by_classification": {
     "ffi": 87,
     "fixture": 4,
     "production": 303,
-    "test_helper": 20319,
+    "test_helper": 20322,
     "tooling": 1163
   },
   "command": "cargo xtask no-panic-baseline"


### PR DESCRIPTION
## Summary

Publication import of two squashed swarm commits on top of the prior import (#2721).

- **#335** `test(export): add CycloneDX full-pipeline integration test` — new SBOM export coverage (`scan -> model -> write_export_cyclonedx_to`) asserting `bomFormat`, `specVersion == "1.6"`, and a `components` array. Append-only no-panic allowlist entries + baseline receipt bump. Narrow successor to the scope-crept #2716.
- **#336** `docs: add ub-review consumer-side packet integration guide` — `docs/ub-review-integration.md` + a cross-link in `docs/packet-consumption.md` + a `ci/proof.toml` mapping line.

Swarm-Head: 3bfd76334dac3cd8565c753f2f56732b0ebc958e
Swarm-Range: 3bce2b75cb7974ffdfce4bdf12cee0369b502ff1..3bfd76334dac3cd8565c753f2f56732b0ebc958e

## New surface to watch

- CycloneDX full-pipeline integration test is new test surface — watch **No-panic Family** and **Tokmd Rust Result**.

## Claim boundary

- Import only; no production logic, schema version, CLI flag, or Action behavior change beyond the two imported commits.
- No release, tag, publish, signing, or alias change.

Co-authored-by: Cursor <cursoragent@cursor.com>
