### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-28

### DIFF
--- a/crates/tokmd-io-port/src/lib.rs
+++ b/crates/tokmd-io-port/src/lib.rs
@@ -173,6 +173,231 @@ impl ReadFs for MemFs {
 }
 
 // ---------------------------------------------------------------------------
+// RepoSnapshot / VirtualFile (experimental portability seam)
+// ---------------------------------------------------------------------------
+//
+// These types implement the minimal slice of the repo-snapshot portability
+// seam described in `docs/specs/repo-snapshot.md`. They capture a
+// provider-agnostic, deterministic view of in-scope files read through any
+// [`ReadFs`] backend (`HostFs`, `MemFs`, or a future host-supplied provider),
+// so scan/aggregation logic can later operate on the snapshot instead of
+// touching `std::fs` directly.
+//
+// EXPERIMENTAL / UNSTABLE: this is the first landing of the seam. The spec
+// keeps it intentionally narrow (eager byte capture, no directory walking, no
+// archive ingestion, no serialized format). The surface may change until a
+// real consumer promotes it; do not treat it as a stable support promise.
+
+/// Normalize a path to the forward-slash rule shared with `tokmd-model`.
+///
+/// `tokmd-model::normalize_path` is the canonical rule, but it lives in a
+/// higher tier; this tier-0 crate mirrors the core of that rule (backslash to
+/// forward slash, strip a leading `./`, trim leading `/`) without taking a
+/// dependency on `tokmd-model`.
+fn normalize_snapshot_path(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    let owned;
+    let mut slice: &str = if raw.contains('\\') {
+        owned = raw.replace('\\', "/");
+        &owned
+    } else {
+        &raw
+    };
+
+    if let Some(stripped) = slice.strip_prefix("./") {
+        slice = stripped;
+    }
+    slice = slice.trim_start_matches('/');
+    if let Some(stripped) = slice.strip_prefix("./") {
+        slice = stripped;
+    }
+    slice.trim_start_matches('/').to_string()
+}
+
+/// A single provider-agnostic file entry: a normalized forward-slash path plus
+/// its eagerly captured bytes.
+///
+/// EXPERIMENTAL: part of the repo-snapshot seam (see module note).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VirtualFile {
+    path: String,
+    bytes: Vec<u8>,
+}
+
+impl VirtualFile {
+    /// The normalized forward-slash path of this entry.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The captured file contents.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// The byte length of the captured contents.
+    pub fn len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    /// Whether the captured contents are empty.
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+/// Error raised while building a [`RepoSnapshot`].
+///
+/// EXPERIMENTAL: part of the repo-snapshot seam (see module note).
+#[derive(Debug)]
+pub enum SnapshotError<E> {
+    /// Reading an in-scope path through the provider failed.
+    Read {
+        /// The normalized path that failed to read.
+        path: String,
+        /// The provider-specific read error.
+        source: E,
+    },
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for SnapshotError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SnapshotError::Read { path, source } => {
+                write!(f, "failed to read snapshot entry '{path}': {source}")
+            }
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for SnapshotError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SnapshotError::Read { source, .. } => Some(source),
+        }
+    }
+}
+
+/// A deterministic, captured set of [`VirtualFile`] entries rooted at a logical
+/// repository root, built from any [`ReadFs`] provider.
+///
+/// Entries are keyed by their normalized path in a sorted map, so enumeration
+/// order is stable and independent of insertion order.
+///
+/// EXPERIMENTAL: part of the repo-snapshot seam (see module note).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RepoSnapshot {
+    root: String,
+    files: BTreeMap<String, VirtualFile>,
+}
+
+impl RepoSnapshot {
+    /// Start building a snapshot rooted at `root`, reading entries through `fs`.
+    pub fn builder<F: ReadFs>(fs: &F, root: impl AsRef<Path>) -> RepoSnapshotBuilder<'_, F> {
+        RepoSnapshotBuilder {
+            fs,
+            root: normalize_snapshot_path(root.as_ref()),
+            files: BTreeMap::new(),
+        }
+    }
+
+    /// The normalized logical repository root.
+    pub fn root(&self) -> &str {
+        &self.root
+    }
+
+    /// The number of captured entries.
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Whether the snapshot captured no entries.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Whether a normalized path is present in the snapshot.
+    pub fn contains(&self, path: impl AsRef<Path>) -> bool {
+        self.files
+            .contains_key(&normalize_snapshot_path(path.as_ref()))
+    }
+
+    /// Look up a captured entry by path.
+    pub fn get(&self, path: impl AsRef<Path>) -> Option<&VirtualFile> {
+        self.files.get(&normalize_snapshot_path(path.as_ref()))
+    }
+
+    /// Iterate captured entries in deterministic (sorted-path) order.
+    pub fn files(&self) -> impl Iterator<Item = &VirtualFile> {
+        self.files.values()
+    }
+
+    /// Iterate captured paths in deterministic (sorted) order.
+    pub fn paths(&self) -> impl Iterator<Item = &str> {
+        self.files.keys().map(String::as_str)
+    }
+}
+
+/// Builder that reads in-scope paths through a [`ReadFs`] provider and captures
+/// them into a [`RepoSnapshot`].
+///
+/// EXPERIMENTAL: part of the repo-snapshot seam (see module note).
+pub struct RepoSnapshotBuilder<'fs, F: ReadFs> {
+    fs: &'fs F,
+    root: String,
+    files: BTreeMap<String, VirtualFile>,
+}
+
+impl<F: ReadFs> RepoSnapshotBuilder<'_, F> {
+    /// Read one in-scope path through the provider and capture it.
+    ///
+    /// The path is normalized to the forward-slash rule before capture, so the
+    /// same logical file produces the same key regardless of the host
+    /// separator. Re-adding an already-captured path overwrites it.
+    pub fn add_path(
+        &mut self,
+        path: impl AsRef<Path>,
+    ) -> Result<&mut Self, SnapshotError<F::Error>> {
+        let path = path.as_ref();
+        let normalized = normalize_snapshot_path(path);
+        let bytes = self
+            .fs
+            .read_bytes(path)
+            .map_err(|source| SnapshotError::Read {
+                path: normalized.clone(),
+                source,
+            })?;
+        self.files.insert(
+            normalized.clone(),
+            VirtualFile {
+                path: normalized,
+                bytes,
+            },
+        );
+        Ok(self)
+    }
+
+    /// Read every path in `paths`, failing closed on the first read error.
+    pub fn add_paths<P: AsRef<Path>>(
+        &mut self,
+        paths: impl IntoIterator<Item = P>,
+    ) -> Result<&mut Self, SnapshotError<F::Error>> {
+        for path in paths {
+            self.add_path(path)?;
+        }
+        Ok(self)
+    }
+
+    /// Finish building, yielding a deterministic snapshot.
+    pub fn build(self) -> RepoSnapshot {
+        RepoSnapshot {
+            root: self.root,
+            files: self.files,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/crates/tokmd-io-port/tests/repo_snapshot.rs
+++ b/crates/tokmd-io-port/tests/repo_snapshot.rs
@@ -1,0 +1,235 @@
+//! Tests for the experimental [`RepoSnapshot`] portability seam.
+//!
+//! These cover the minimal proof obligations from
+//! `docs/specs/repo-snapshot.md` that this slice implements:
+//! host/in-memory parity, deterministic enumeration independent of insertion
+//! order, path normalization to the forward-slash rule, reading bytes, and
+//! listing files through the snapshot view.
+//!
+//! Each test returns `Result` and uses `?` / fallible accessors instead of
+//! panic-family calls, per the repo no-panic policy.
+
+use std::error::Error;
+use std::path::PathBuf;
+
+use tokmd_io_port::{HostFs, MemFs, RepoSnapshot};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+// ---------------------------------------------------------------------------
+// Path normalization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn normalizes_backslash_root_to_forward_slashes() -> TestResult {
+    let fs = MemFs::new();
+    // Root normalization is pure string work, so a Windows-style backslash root
+    // is normalized deterministically on every platform.
+    let snapshot = RepoSnapshot::builder(&fs, "repo\\nested\\root").build();
+    assert_eq!(snapshot.root(), "repo/nested/root");
+    assert!(snapshot.is_empty());
+    Ok(())
+}
+
+#[test]
+fn snapshot_paths_use_forward_slashes() -> TestResult {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("src/a.rs"), "a");
+
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    builder.add_path("src/a.rs")?;
+    let snapshot = builder.build();
+
+    let only = snapshot.paths().collect::<Vec<_>>();
+    assert_eq!(only, vec!["src/a.rs"]);
+    let first = only.first().ok_or("expected one path")?;
+    assert!(!first.contains('\\'));
+    Ok(())
+}
+
+#[test]
+fn strips_leading_dot_slash_and_root_slash() -> TestResult {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("./x.txt"), "x");
+
+    let mut builder = RepoSnapshot::builder(&fs, "./root");
+    builder.add_path("./x.txt")?;
+    let snapshot = builder.build();
+
+    assert_eq!(snapshot.root(), "root");
+    assert_eq!(snapshot.paths().collect::<Vec<_>>(), vec!["x.txt"]);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Read bytes / list files via snapshot view
+// ---------------------------------------------------------------------------
+
+#[test]
+fn captures_bytes_and_length() -> TestResult {
+    let mut fs = MemFs::new();
+    fs.add_bytes(PathBuf::from("blob.bin"), vec![0xDE, 0xAD, 0xBE, 0xEF]);
+
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    builder.add_path("blob.bin")?;
+    let snapshot = builder.build();
+
+    let entry = snapshot.get("blob.bin").ok_or("entry missing")?;
+    assert_eq!(entry.bytes(), &[0xDE, 0xAD, 0xBE, 0xEF]);
+    assert_eq!(entry.len(), 4);
+    assert!(!entry.is_empty());
+    Ok(())
+}
+
+#[test]
+fn empty_file_is_empty() -> TestResult {
+    let mut fs = MemFs::new();
+    fs.add_bytes(PathBuf::from("empty"), Vec::<u8>::new());
+
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    builder.add_path("empty")?;
+    let snapshot = builder.build();
+
+    let entry = snapshot.get("empty").ok_or("entry missing")?;
+    assert_eq!(entry.len(), 0);
+    assert!(entry.is_empty());
+    Ok(())
+}
+
+#[test]
+fn lists_files_in_sorted_order_independent_of_insertion() -> TestResult {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("z.rs"), "z");
+    fs.add_file(PathBuf::from("a.rs"), "a");
+    fs.add_file(PathBuf::from("m.rs"), "m");
+
+    // Insert in reverse-sorted order; enumeration must still be sorted.
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    builder.add_paths(["z.rs", "m.rs", "a.rs"])?;
+    let snapshot = builder.build();
+
+    assert_eq!(snapshot.len(), 3);
+    assert_eq!(
+        snapshot.paths().collect::<Vec<_>>(),
+        vec!["a.rs", "m.rs", "z.rs"]
+    );
+    Ok(())
+}
+
+#[test]
+fn re_adding_path_overwrites_entry() -> TestResult {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("f.txt"), "first");
+
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    builder.add_path("f.txt")?;
+    let snapshot = builder.build();
+    assert_eq!(snapshot.get("f.txt").ok_or("missing")?.bytes(), b"first");
+
+    // A fresh builder over updated provider state captures the new bytes, and
+    // re-adding the same path within one build keeps a single entry.
+    fs.add_file(PathBuf::from("f.txt"), "second");
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    builder.add_path("f.txt")?;
+    builder.add_path("f.txt")?;
+    let snapshot = builder.build();
+
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot.get("f.txt").ok_or("missing")?.bytes(), b"second");
+    Ok(())
+}
+
+#[test]
+fn contains_uses_normalized_lookup() -> TestResult {
+    let mut fs = MemFs::new();
+    fs.add_file(PathBuf::from("src/lib.rs"), "x");
+
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    builder.add_path("src/lib.rs")?;
+    let snapshot = builder.build();
+
+    assert!(snapshot.contains("src/lib.rs"));
+    assert!(snapshot.contains("./src/lib.rs"));
+    assert!(!snapshot.contains("src/main.rs"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed on missing entry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_path_fails_closed_with_named_error() -> TestResult {
+    let fs = MemFs::new();
+    let mut builder = RepoSnapshot::builder(&fs, ".");
+    let msg = match builder.add_path("nope.rs") {
+        Ok(_) => return Err("expected fail-closed error for missing path".into()),
+        Err(err) => err.to_string(),
+    };
+    assert!(msg.contains("nope.rs"), "error names the path: {msg}");
+    assert!(msg.contains("not found"), "error names the cause: {msg}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Host / in-memory parity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn host_and_mem_snapshots_match_for_same_fixture() -> TestResult {
+    // Fixture: a small tree of files with identical contents in both backends.
+    let fixture: &[(&str, &[u8])] = &[
+        ("src/main.rs", b"fn main() {}"),
+        ("src/util/helpers.rs", b"pub fn h() {}"),
+        ("README.md", b"# demo"),
+        ("data/blob.bin", &[0x00, 0x01, 0x02, 0xFF]),
+    ];
+
+    // MemFs snapshot, rooted logically at ".".
+    let mut mem = MemFs::new();
+    for (path, bytes) in fixture {
+        mem.add_bytes(PathBuf::from(*path), bytes.to_vec());
+    }
+    let mut mem_builder = RepoSnapshot::builder(&mem, ".");
+    mem_builder.add_paths(fixture.iter().map(|(p, _)| *p))?;
+    let mem_snapshot = mem_builder.build();
+
+    // HostFs snapshot over the same fixture written to a temp dir.
+    let dir = tempfile::tempdir()?;
+    let mut host_paths = Vec::new();
+    for (path, bytes) in fixture {
+        let full = dir.path().join(path);
+        let parent = full.parent().ok_or("fixture path has no parent")?;
+        std::fs::create_dir_all(parent)?;
+        std::fs::write(&full, bytes)?;
+        host_paths.push(full);
+    }
+    let host = HostFs;
+    let mut host_builder = RepoSnapshot::builder(&host, dir.path());
+    for full in &host_paths {
+        host_builder.add_path(full)?;
+    }
+    let host_snapshot = host_builder.build();
+
+    for (logical, bytes) in fixture {
+        // MemFs side: exact normalized key.
+        let mem_entry = mem_snapshot
+            .get(logical)
+            .ok_or_else(|| format!("mem missing {logical}"))?;
+        assert_eq!(mem_entry.bytes(), *bytes);
+
+        // HostFs side: find the entry whose normalized path ends with the
+        // logical suffix (temp dir prefix differs per run).
+        let host_entry = host_snapshot
+            .files()
+            .find(|f| f.path().ends_with(logical))
+            .ok_or_else(|| format!("host missing {logical}"))?;
+        assert_eq!(host_entry.bytes(), *bytes);
+        assert_eq!(host_entry.len(), mem_entry.len());
+    }
+
+    // Same number of files captured in both backends.
+    assert_eq!(host_snapshot.len(), mem_snapshot.len());
+    assert_eq!(host_snapshot.len(), fixture.len());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Import the latest squashed swarm development commit into publication.

This batch imports the experimental `RepoSnapshot` portability seam (swarm PR #342), the smallest useful code slice of `docs/specs/repo-snapshot.md`: a deterministic, provider-agnostic snapshot built on the existing `ReadFs` backends in `tokmd-io-port`. No zip/archive dependency, no schema bump, no CLI surface change. New types are experimental/internal-by-intent.

Swarm-Head: 3dd429054e22ab26d18e055a564ce69a5f1763da
Swarm-Range: 6c5240923a53a8f60a6727286be4a3e5505efadb..3dd429054e22ab26d18e055a564ce69a5f1763da

Checks:
- Tokmd Rust Result (swarm PR #342): run 28308697228 — success
- Publication CI: pending on this PR

## Claim boundary

- Topology import only; no release, tag, publish, signing, Docker, or v1 alias action.
- No schema version change. Imported types are experimental and not yet a stable support promise.
