### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-28 (F)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +730,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1387,6 +1412,16 @@ checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2233,6 +2268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2729,7 @@ version = "1.14.0"
 dependencies = [
  "proptest",
  "tempfile",
+ "zip",
 ]
 
 [[package]]
@@ -2928,6 +2970,12 @@ dependencies = [
  "cc",
  "tree-sitter-language",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -3692,7 +3740,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/crates/tokmd-io-port/Cargo.toml
+++ b/crates/tokmd-io-port/Cargo.toml
@@ -14,12 +14,22 @@ documentation = "https://docs.rs/tokmd-io-port"
 [features]
 # Archive ingestion admission engine (path-safety + zip-bomb resource limits).
 # Carries ZERO decompression dependencies: this gate exposes the fail-closed
-# entry-admission core only. A concrete codec adapter (e.g. `snapshot_from_zip_bytes`)
-# is a deferred follow-up that selects and pins an audited archive crate via a
-# dedicated dependency-maintenance PR. See docs/specs/repo-snapshot.md.
+# entry-admission core only. See docs/specs/repo-snapshot.md.
 archive = []
+# ZIP codec adapter: layers a concrete decoder (`snapshot_from_zip_bytes`) over
+# the dependency-free admission engine. This is the trust-surface feature that
+# pulls the audited `zip` crate (deflate-only, default features off). The plain
+# `archive` feature stays decompression-dependency-free so the admission engine
+# remains provable without a codec.
+archive-zip = ["archive", "dep:zip"]
 
 [dependencies]
+# Optional ZIP decoder for the `archive-zip` codec adapter only. Deflate-only,
+# default features disabled to keep the trust surface minimal (no aes-crypto,
+# bzip2, lzma, xz, zstd, ppmd). Pure-Rust deflate backend (flate2/zlib-rs).
+zip = { version = "8.6.0", optional = true, default-features = false, features = [
+    "deflate",
+] }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/tokmd-io-port/src/archive.rs
+++ b/crates/tokmd-io-port/src/archive.rs
@@ -189,6 +189,14 @@ pub enum ArchiveError {
         /// The normalized path that failed to capture.
         name: String,
     },
+    /// The container could not be decoded (malformed archive, unsupported
+    /// compression method, or a decompression error). Only produced by a codec
+    /// adapter such as [`snapshot_from_zip_bytes`]; the dependency-free
+    /// admission engine never returns this.
+    MalformedArchive {
+        /// A human-readable description of the decode failure.
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for ArchiveError {
@@ -232,6 +240,9 @@ impl std::fmt::Display for ArchiveError {
             ),
             ArchiveError::Capture { name } => {
                 write!(f, "failed to capture admitted entry: '{name}'")
+            }
+            ArchiveError::MalformedArchive { reason } => {
+                write!(f, "malformed or undecodable archive: {reason}")
             }
         }
     }
@@ -406,6 +417,138 @@ pub fn snapshot_from_entries(
             SnapshotError::Read { path, .. } => ArchiveError::Capture { name: path },
         })?;
     Ok(builder.build())
+}
+
+/// Decode an in-memory ZIP archive into a [`RepoSnapshot`], enforcing all
+/// path-safety and resource limits fail-closed (`feature = "archive-zip"`).
+///
+/// This is the codec adapter described in `docs/specs/repo-snapshot.md`: it
+/// enumerates the ZIP central directory, classifies each entry, **bounded-
+/// inflates** regular files so a hostile declared size cannot force unbounded
+/// allocation, and delegates the authoritative admission policy to
+/// [`snapshot_from_entries`]. The archive is treated as hostile input.
+///
+/// Decoding is buffered (the whole archive is provided as a byte slice) per the
+/// spec's first-implementation choice. Compression support is deflate-only
+/// (plus stored); other methods surface as
+/// [`ArchiveError::MalformedArchive`].
+///
+/// Memory safety against zip bombs is enforced at two layers: each regular
+/// entry is inflated through a reader capped at
+/// [`ArchiveLimits::max_entry_size`] + 1 byte (so an oversized entry is
+/// detected without materializing its full declared payload), and a running
+/// total guard stops decoding before the staged byte buffer can exceed
+/// [`ArchiveLimits::max_total_size`]. [`snapshot_from_entries`] then re-checks
+/// every limit as the single authoritative validator.
+///
+/// # Errors
+///
+/// Returns [`ArchiveError::MalformedArchive`] if the bytes are not a decodable
+/// ZIP (or an entry uses an unsupported compression method), or any other
+/// [`ArchiveError`] surfaced by the admission policy (invalid/traversal/
+/// absolute name, non-regular entry, duplicate, or a breached size/count/ratio
+/// limit).
+#[cfg(feature = "archive-zip")]
+pub fn snapshot_from_zip_bytes(
+    root: impl AsRef<Path>,
+    bytes: &[u8],
+    limits: &ArchiveLimits,
+) -> Result<RepoSnapshot, ArchiveError> {
+    use std::io::{Cursor, Read};
+
+    let reader = Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|err| ArchiveError::MalformedArchive {
+            reason: err.to_string(),
+        })?;
+
+    let mut entries: Vec<RawArchiveEntry> = Vec::new();
+    // Running total guard: bound the staged byte buffer during decode so a
+    // multi-entry bomb cannot accumulate past the total cap before the
+    // admission engine runs. The engine remains authoritative.
+    let mut running_total: u64 = 0;
+    // Per-entry read ceiling: one byte over the cap is enough to detect an
+    // oversized entry without materializing the full declared payload.
+    let read_ceiling = limits.max_entry_size.saturating_add(1);
+
+    for index in 0..archive.len() {
+        let mut file = archive
+            .by_index(index)
+            .map_err(|err| ArchiveError::MalformedArchive {
+                reason: err.to_string(),
+            })?;
+
+        // Raw, untrusted stored name; the admission engine validates it.
+        let name = file.name().to_string();
+
+        // Classify: symlink/device/other (via unix type bits) before directory,
+        // so a symlink whose name lacks a trailing slash is still rejected.
+        let kind = classify_zip_entry(file.unix_mode(), file.is_dir());
+
+        match kind {
+            EntryKind::File => {
+                let compressed_size = file.compressed_size();
+                let mut buf = Vec::new();
+                file.by_ref()
+                    .take(read_ceiling)
+                    .read_to_end(&mut buf)
+                    .map_err(|err| ArchiveError::MalformedArchive {
+                        reason: err.to_string(),
+                    })?;
+
+                let uncompressed = u64::try_from(buf.len()).unwrap_or(u64::MAX);
+                // Early total guard to bound peak memory; the admission engine
+                // re-checks this authoritatively.
+                running_total = running_total.saturating_add(uncompressed);
+                if running_total > limits.max_total_size {
+                    return Err(ArchiveError::TotalTooLarge {
+                        size: running_total,
+                        limit: limits.max_total_size,
+                    });
+                }
+
+                entries.push(RawArchiveEntry::file(name, compressed_size, buf));
+            }
+            EntryKind::Directory => entries.push(RawArchiveEntry::directory(name)),
+            EntryKind::Other => entries.push(RawArchiveEntry {
+                name,
+                kind: EntryKind::Other,
+                compressed_size: 0,
+                bytes: Vec::new(),
+            }),
+        }
+    }
+
+    snapshot_from_entries(root, entries, limits)
+}
+
+/// Classify a ZIP entry into an [`EntryKind`] from its optional unix mode and
+/// the codec's directory flag.
+///
+/// Symlinks and other non-regular unix types (FIFO, block/char device, socket)
+/// are classified as [`EntryKind::Other`] so the admission engine rejects them.
+/// Entries with no unix mode (e.g. archives written on Windows) fall back to
+/// the directory flag, then to a regular file.
+#[cfg(feature = "archive-zip")]
+fn classify_zip_entry(unix_mode: Option<u32>, is_dir: bool) -> EntryKind {
+    const S_IFMT: u32 = 0o170000;
+    const S_IFREG: u32 = 0o100000;
+    const S_IFDIR: u32 = 0o040000;
+
+    if let Some(mode) = unix_mode {
+        match mode & S_IFMT {
+            S_IFREG => return EntryKind::File,
+            S_IFDIR => return EntryKind::Directory,
+            0 => {} // No type bits recorded; fall back to the directory flag.
+            _ => return EntryKind::Other, // symlink, device, fifo, socket, ...
+        }
+    }
+
+    if is_dir {
+        EntryKind::Directory
+    } else {
+        EntryKind::File
+    }
 }
 
 #[cfg(test)]
@@ -611,5 +754,205 @@ mod tests {
         let snap = snapshot_from_entries(".\\nested\\root", entries, &limits())?;
         assert_eq!(snap.root(), "nested/root");
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "archive-zip"))]
+mod zip_tests {
+    use super::*;
+    use crate::VirtualFile;
+    use std::io::{Cursor, Write};
+    use zip::CompressionMethod;
+    use zip::write::{SimpleFileOptions, ZipWriter};
+
+    type ZipResult = zip::result::ZipResult<Vec<u8>>;
+
+    fn stored() -> SimpleFileOptions {
+        SimpleFileOptions::default().compression_method(CompressionMethod::Stored)
+    }
+
+    fn deflated() -> SimpleFileOptions {
+        SimpleFileOptions::default().compression_method(CompressionMethod::Deflated)
+    }
+
+    /// Build an in-memory ZIP via the provided closure.
+    fn build_zip(
+        build: impl FnOnce(&mut ZipWriter<Cursor<Vec<u8>>>) -> zip::result::ZipResult<()>,
+    ) -> ZipResult {
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+        build(&mut writer)?;
+        let cursor = writer.finish()?;
+        Ok(cursor.into_inner())
+    }
+
+    #[test]
+    fn round_trips_stored_and_deflated() -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = build_zip(|w| {
+            w.start_file("src/main.rs", stored())?;
+            w.write_all(b"fn main() {}")?;
+            w.start_file("a/deflated.txt", deflated())?;
+            w.write_all(b"hello deflated world")?;
+            Ok(())
+        })?;
+
+        let snap = snapshot_from_zip_bytes("repo", &bytes, &ArchiveLimits::default())?;
+        let paths: Vec<&str> = snap.paths().collect();
+        assert_eq!(paths, vec!["a/deflated.txt", "src/main.rs"]);
+        assert_eq!(
+            snap.get("src/main.rs").map(VirtualFile::bytes),
+            Some(&b"fn main() {}"[..])
+        );
+        assert_eq!(
+            snap.get("a/deflated.txt").map(VirtualFile::bytes),
+            Some(&b"hello deflated world"[..])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn directory_entries_contribute_no_file() -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = build_zip(|w| {
+            w.add_directory("src/", stored())?;
+            w.start_file("src/lib.rs", stored())?;
+            w.write_all(b"pub fn x() {}")?;
+            Ok(())
+        })?;
+
+        let snap = snapshot_from_zip_bytes("repo", &bytes, &ArchiveLimits::default())?;
+        let paths: Vec<&str> = snap.paths().collect();
+        assert_eq!(paths, vec!["src/lib.rs"]);
+        Ok(())
+    }
+
+    #[test]
+    fn empty_stored_file_is_admitted() -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = build_zip(|w| {
+            w.start_file("empty.txt", stored())?;
+            Ok(())
+        })?;
+
+        let snap = snapshot_from_zip_bytes("repo", &bytes, &ArchiveLimits::default())?;
+        assert_eq!(snap.len(), 1);
+        assert!(
+            snap.get("empty.txt")
+                .map(VirtualFile::is_empty)
+                .unwrap_or(false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_symlink_entry() -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = build_zip(|w| {
+            w.add_symlink("link", "src/main.rs", stored())?;
+            Ok(())
+        })?;
+
+        let err = snapshot_from_zip_bytes("repo", &bytes, &ArchiveLimits::default()).unwrap_err();
+        assert!(matches!(err, ArchiveError::NonRegularEntry { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_traversal_name() -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = build_zip(|w| {
+            w.start_file("../evil.rs", stored())?;
+            w.write_all(b"pwn")?;
+            Ok(())
+        })?;
+
+        let err = snapshot_from_zip_bytes("repo", &bytes, &ArchiveLimits::default()).unwrap_err();
+        assert!(matches!(err, ArchiveError::Traversal { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn enforces_per_entry_size_cap_via_bounded_read() -> Result<(), Box<dyn std::error::Error>> {
+        let small = ArchiveLimits {
+            max_entry_size: 8,
+            ..ArchiveLimits::default()
+        };
+        let bytes = build_zip(|w| {
+            w.start_file("big.bin", stored())?;
+            w.write_all(&[0u8; 64])?;
+            Ok(())
+        })?;
+
+        let err = snapshot_from_zip_bytes("repo", &bytes, &small).unwrap_err();
+        assert!(matches!(err, ArchiveError::EntryTooLarge { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn enforces_compression_ratio_guard() -> Result<(), Box<dyn std::error::Error>> {
+        let strict = ArchiveLimits {
+            max_ratio: 10,
+            ..ArchiveLimits::default()
+        };
+        // 100 KiB of zeros deflates to a tiny payload -> ratio far above 10x.
+        let bytes = build_zip(|w| {
+            w.start_file("bomb.bin", deflated())?;
+            w.write_all(&[0u8; 100_000])?;
+            Ok(())
+        })?;
+
+        let err = snapshot_from_zip_bytes("repo", &bytes, &strict).unwrap_err();
+        assert!(matches!(err, ArchiveError::RatioExceeded { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn enforces_total_size_cap_during_decode() -> Result<(), Box<dyn std::error::Error>> {
+        let small = ArchiveLimits {
+            max_entry_size: 1024,
+            max_total_size: 10,
+            max_ratio: u64::MAX,
+            ..ArchiveLimits::default()
+        };
+        let bytes = build_zip(|w| {
+            w.start_file("a.bin", stored())?;
+            w.write_all(&[0u8; 6])?;
+            w.start_file("b.bin", stored())?;
+            w.write_all(&[0u8; 6])?;
+            Ok(())
+        })?;
+
+        let err = snapshot_from_zip_bytes("repo", &bytes, &small).unwrap_err();
+        assert!(matches!(err, ArchiveError::TotalTooLarge { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_malformed_archive() {
+        let garbage = b"this is definitely not a zip archive";
+        let err = snapshot_from_zip_bytes("repo", garbage, &ArchiveLimits::default()).unwrap_err();
+        assert!(matches!(err, ArchiveError::MalformedArchive { .. }));
+    }
+
+    #[test]
+    fn fails_closed_on_first_hostile_entry() -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = build_zip(|w| {
+            w.start_file("ok.rs", stored())?;
+            w.write_all(b"good")?;
+            w.start_file("nested/../../evil.rs", stored())?;
+            w.write_all(b"evil")?;
+            Ok(())
+        })?;
+
+        let err = snapshot_from_zip_bytes("repo", &bytes, &ArchiveLimits::default()).unwrap_err();
+        assert!(matches!(err, ArchiveError::Traversal { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn classify_falls_back_without_unix_mode() {
+        assert_eq!(classify_zip_entry(None, false), EntryKind::File);
+        assert_eq!(classify_zip_entry(None, true), EntryKind::Directory);
+        assert_eq!(classify_zip_entry(Some(0o100644), false), EntryKind::File);
+        assert_eq!(
+            classify_zip_entry(Some(0o040755), false),
+            EntryKind::Directory
+        );
+        assert_eq!(classify_zip_entry(Some(0o120777), false), EntryKind::Other);
     }
 }

--- a/docs/specs/repo-snapshot.md
+++ b/docs/specs/repo-snapshot.md
@@ -113,7 +113,7 @@ allocation.
 
 #### Incremental implementation status
 
-The archive sub-seam is landing in two deliberately separated steps so the
+The archive sub-seam landed in two deliberately separated steps so the
 security-critical core is provable before any decompression dependency enters
 the workspace:
 
@@ -131,17 +131,27 @@ the workspace:
    the whole build on the first violation. It reuses the existing `MemFs` +
    `RepoSnapshot` builder so admitted entries get host/in-memory parity for
    free.
-2. **Codec adapter (deferred)** — a concrete container decoder (for example a
-   `snapshot_from_zip_bytes` that enumerates a ZIP central directory and
-   bounded-inflates each entry into a `RawArchiveEntry`) is a follow-up. It must
-   select and pin an audited archive crate through a dedicated
-   dependency-maintenance PR (license + security note, `cargo deny` proof) per
-   the Compatibility section. The spec intentionally still treats the concrete
-   crate and container matrix as an open question.
+2. **ZIP codec adapter (landed)** — a concrete ZIP decoder,
+   `snapshot_from_zip_bytes(root, bytes, limits) -> Result<RepoSnapshot, ArchiveError>`,
+   lives in the same module behind a separate `archive-zip` Cargo feature
+   (`archive-zip = ["archive", "dep:zip"]`). The plain `archive` feature stays
+   decompression-dependency-free; `archive-zip` is the trust-surface feature
+   that pulls the audited [`zip`](https://crates.io/crates/zip) crate
+   (deflate-only, `default-features = false`, so no aes-crypto/bzip2/lzma/xz/
+   zstd/ppmd back-ends). The codec enumerates the ZIP central directory,
+   classifies each entry (symlink/device/other via unix type bits → rejected;
+   directory flag → no file; otherwise a regular file), **bounded-inflates**
+   each regular file through a reader capped at `max_entry_size + 1` byte so a
+   hostile declared size cannot force unbounded allocation, runs a running-total
+   guard during decode, and delegates the authoritative admission policy to
+   `snapshot_from_entries`. Malformed containers and unsupported compression
+   methods surface as `ArchiveError::MalformedArchive`. The first
+   implementation is buffered (whole archive supplied as a byte slice).
 
 This split keeps the engine — the part that must be correct against hostile
-input — fully unit-tested without committing the default dependency graph to a
-codec.
+input — fully unit-tested without committing the default `archive` dependency
+graph to a codec, while the optional `archive-zip` feature carries the audited
+decompression surface.
 
 ## Inputs
 
@@ -273,9 +283,11 @@ integration steps, in rough dependency order, are:
   `MemFs` (or, once the codec adapter lands, directly from archive bytes) and
   runs the same aggregation, producing receipts indistinguishable from a
   host-backed run for in-scope files.
-- **Codec adapter (`archive` feature)** — wiring a `snapshot_from_zip_bytes`
-  over the landed admission engine (see the incremental status note above) is
-  the remaining piece needed for the archive-upload story end to end.
+- **ZIP codec adapter (`archive-zip` feature, landed)** —
+  `snapshot_from_zip_bytes` wires a buffered ZIP decoder over the admission
+  engine (see the incremental status note above). The remaining archive-upload
+  work is a consumer (`crates/tokmd-scan` or `crates/tokmd-wasm`) that builds a
+  snapshot from uploaded bytes and runs the existing aggregation.
 
 These are forward-looking seams; none change current behavior. Each should land
 as its own narrow PR behind the experimental marker until a real consumer
@@ -291,9 +303,10 @@ promotes the surface.
   appears? The default promotion ladder favors an internal module first.
 - Does the seam need to carry per-file metadata (size is enough today) such as
   modified time or a content hash, or should that stay in the analysis layer?
-- Which archive crate (and container matrix: ZIP only first, or ZIP plus
-  tar/gzip) best balances audited security, maintenance, and a small dependency
-  surface for the optional feature?
+- Which container matrix beyond ZIP (tar/gzip) is worth supporting? The first
+  codec selected the audited [`zip`](https://crates.io/crates/zip) crate
+  (deflate-only, default features off) behind `archive-zip`; tar-family
+  containers remain an open option behind the same admission engine.
 - What are the right default values for the ingestion limits (per-entry cap,
   total cap, entry-count cap, compression-ratio guard), and should they scale
   with an explicit caller "expected repo size" hint instead of fixed constants?


### PR DESCRIPTION
## Publication import: tokmd-swarm through 2026-06-28 (F)

Merge-commit import of aligned swarm work since the last publication sync.

**Swarm-Head:** `75ffacb1` (feat(io-port): add ZIP codec adapter behind archive-zip feature #346)
**Swarm-Range:** `9475459b..75ffacb1` (1 commit)
**Previous publication sync:** `9475459b` merge(swarm): import tokmd-swarm through 2026-06-28 (E) (#2730)

### Included change

- **#346 / `75ffacb1`** — ZIP codec adapter (`snapshot_from_zip_bytes`) behind `archive-zip` feature on `tokmd-io-port`, with audited `zip` 8.6.0 (deflate-only) dependency and 11 codec unit tests. Spec incremental status updated.

### Checks (swarm)

- Tokmd Rust Result: run `28318362757` — SUCCESS
- Cargo Deny: SUCCESS (new zip/flate2/zlib-rs deps, all allow-listed licenses)

### Claim boundary

Import only; no release/tag/publish. Behavior change is behind optional `archive-zip` Cargo feature; default CLI/build unaffected.
