### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-28 (G)

### DIFF
--- a/crates/tokmd-scan/src/in_memory.rs
+++ b/crates/tokmd-scan/src/in_memory.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use tokei::Languages;
 
+use tokmd_io_port::RepoSnapshot;
 use tokmd_settings::ScanOptions;
 
 /// A single logical file supplied from memory rather than the host filesystem.
@@ -67,6 +68,28 @@ impl MaterializedScan {
 /// native and browser callers see the same contract.
 pub fn normalize_in_memory_paths(inputs: &[InMemoryFile]) -> Result<Vec<PathBuf>> {
     normalize_logical_paths(inputs, true)
+}
+
+/// Scan an already-captured [`RepoSnapshot`] instead of the host filesystem.
+///
+/// This is the first `tokmd-scan` consumer of the repo-snapshot portability
+/// seam (see `docs/specs/repo-snapshot.md`). The snapshot's
+/// provider-agnostic [`VirtualFile`](tokmd_io_port::VirtualFile) entries — which
+/// may have been captured from `HostFs`, `MemFs`, or a future archive provider —
+/// are routed through the same [`scan_in_memory`] materialization path. That
+/// reuse gives the snapshot scan host parity for free: the in-scope file set and
+/// aggregated language totals match the equivalent host-backed run.
+///
+/// EXPERIMENTAL / UNSTABLE: the snapshot seam is intentionally narrow and may
+/// change until a stable consumer promotes it. Walking and ignore semantics are
+/// not re-derived from the snapshot; the snapshot supplies the in-scope file set
+/// and bytes only.
+pub fn scan_snapshot(snapshot: &RepoSnapshot, args: &ScanOptions) -> Result<MaterializedScan> {
+    let inputs: Vec<InMemoryFile> = snapshot
+        .files()
+        .map(|file| InMemoryFile::new(file.path(), file.bytes().to_vec()))
+        .collect();
+    scan_in_memory(&inputs, args)
 }
 
 pub fn scan_in_memory(inputs: &[InMemoryFile], args: &ScanOptions) -> Result<MaterializedScan> {

--- a/crates/tokmd-scan/src/lib.rs
+++ b/crates/tokmd-scan/src/lib.rs
@@ -20,7 +20,7 @@ use tokei::{Config, Languages};
 
 use crate::ignore_patterns::ignored_patterns;
 pub use crate::in_memory::{
-    InMemoryFile, MaterializedScan, normalize_in_memory_paths, scan_in_memory,
+    InMemoryFile, MaterializedScan, normalize_in_memory_paths, scan_in_memory, scan_snapshot,
 };
 use crate::roots::{rebase_report_paths, validated_scan_roots};
 use tokmd_settings::ScanOptions;

--- a/crates/tokmd-scan/tests/snapshot_parity.rs
+++ b/crates/tokmd-scan/tests/snapshot_parity.rs
@@ -1,0 +1,102 @@
+//! Parity oracle for the repo-snapshot scan consumer.
+//!
+//! Scanning a fixture through the host filesystem (`scan`) and through a
+//! captured `RepoSnapshot` (`scan_snapshot`) must yield the same per-language
+//! inventory: identical report (file) counts and identical code/comment/blank
+//! totals. This is the snapshot-backed slice of the host/in-memory parity
+//! contract described in `docs/specs/repo-snapshot.md`.
+
+use anyhow::Result;
+use std::fs;
+
+use tokmd_io_port::{MemFs, RepoSnapshot};
+use tokmd_scan::{scan, scan_snapshot};
+use tokmd_settings::{ConfigMode, ScanOptions};
+
+/// Relative path -> contents fixture shared by both scan paths.
+const FIXTURE: &[(&str, &str)] = &[
+    (
+        "src/lib.rs",
+        "// crate root\npub fn alpha() -> usize { 1 }\n\n",
+    ),
+    ("src/util.py", "# helper\nprint('ok')\n"),
+    ("docs/README.md", "# Title\n\nSome prose.\n"),
+];
+
+/// Content-driven scan options: neutralize ambient ignore files so the two
+/// distinct temp roots are compared purely on their captured contents.
+fn parity_scan_options() -> ScanOptions {
+    ScanOptions {
+        excluded: vec![],
+        config: ConfigMode::None,
+        hidden: false,
+        no_ignore: true,
+        no_ignore_parent: true,
+        no_ignore_dot: true,
+        no_ignore_vcs: true,
+        treat_doc_strings_as_comments: false,
+    }
+}
+
+/// Summarize a scan into a deterministic, path-prefix-independent inventory:
+/// `(language name, file count, code, comments, blanks)` sorted by language.
+fn summarize(languages: &tokei::Languages) -> Vec<(String, usize, usize, usize, usize)> {
+    let mut rows: Vec<(String, usize, usize, usize, usize)> = languages
+        .iter()
+        .map(|(lang_type, language)| {
+            (
+                lang_type.name().to_string(),
+                language.reports.len(),
+                language.code,
+                language.comments,
+                language.blanks,
+            )
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+#[test]
+fn host_and_snapshot_scans_produce_equivalent_inventory() -> Result<()> {
+    let opts = parity_scan_options();
+
+    // Host path: materialize the fixture on disk and scan via std::fs/tokei.
+    let dir = tempfile::tempdir()?;
+    for (rel, contents) in FIXTURE {
+        let full = dir.path().join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(full, contents)?;
+    }
+    let host_languages = scan(&[dir.path().to_path_buf()], &opts)?;
+
+    // Snapshot path: capture the same fixture through MemFs into a RepoSnapshot
+    // and scan via the snapshot consumer.
+    let mut mem = MemFs::new();
+    for (rel, contents) in FIXTURE {
+        mem.add_file(*rel, *contents);
+    }
+    let mut builder = RepoSnapshot::builder(&mem, ".");
+    builder
+        .add_paths(FIXTURE.iter().map(|(rel, _)| *rel))
+        .map_err(|err| anyhow::anyhow!("snapshot capture failed: {err}"))?;
+    let snapshot = builder.build();
+    let snapshot_scan = scan_snapshot(&snapshot, &opts)?;
+
+    let host_summary = summarize(&host_languages);
+    let snapshot_summary = summarize(snapshot_scan.languages());
+
+    // Sanity: the fixture really exercised more than one language.
+    assert!(
+        host_summary.len() >= 2,
+        "fixture should produce multiple languages: {host_summary:?}"
+    );
+    assert_eq!(
+        host_summary, snapshot_summary,
+        "snapshot scan inventory must match the host scan inventory"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Import the latest aligned `tokmd-swarm/main` into the publication repository.

## Contents

- `feat(scan): RepoSnapshot scan consumer with host parity test`
  (swarm PR #347) — first `tokmd-scan` consumer of the repo-snapshot
  portability seam (`scan_snapshot`), routing captured `RepoSnapshot`
  `VirtualFile` entries through the existing in-memory materialization path,
  with a host/snapshot per-language inventory parity test.

## Provenance

- Swarm head: `27bc5a0d` (origin/main)
- Prior publication head: `2fb7a4dd` (= merge-base; publication is a strict
  ancestor of the swarm head, swarm ahead by 1 commit)
- No release/tag/publish surface changes; additive library seam only, no new
  dependencies and no CLI flag.

## Proof

- Swarm gate `Tokmd Rust Result` already green on PR #347 prior to merge.
- This import re-runs the publication gate; merge as a merge commit once
  `Tokmd Rust Result` is green here.
