### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-28 (K)

### DIFF
--- a/crates/tokmd-core/src/ffi/byte_mode.rs
+++ b/crates/tokmd-core/src/ffi/byte_mode.rs
@@ -1,0 +1,135 @@
+//! Byte-mode FFI entrypoint for archive (ZIP) uploads (`feature = "archive-zip"`).
+//!
+//! This is the transport seam named by `docs/specs/wasm-ffi-byte-mode.md`. It
+//! lets a host hand raw archive bytes plus a small JSON options object into
+//! tokmd and receive the same response envelope the JSON `{ path, text }` modes
+//! return.
+//!
+//! Untrusted archive bytes are admitted fail-closed by the single authoritative
+//! admission engine (`tokmd_scan::inputs_from_zip_bytes`, which delegates to
+//! `tokmd_io_port::archive`), and the resulting ordered inputs are routed
+//! through the existing mode dispatch. There is no second scan path and no
+//! second admission path, so byte/JSON-mode parity holds by construction.
+
+use serde_json::Value;
+use tokmd_scan::{ArchiveLimits, inputs_from_zip_bytes};
+
+use super::envelope::json_response;
+use super::modes::run_mode;
+use super::parse::{parse_optional_string, parse_optional_u64, parse_optional_usize};
+use super::settings_parse::parse_scan_settings;
+use crate::error::TokmdError;
+
+/// Logical repository root the admitted archive entries are rooted under when
+/// the caller omits the `root` option.
+const DEFAULT_ARCHIVE_ROOT: &str = "repo";
+
+/// Run a tokmd scan over an in-memory archive (currently ZIP) byte buffer.
+///
+/// This is the byte-mode counterpart to [`run_json`](super::run_json): instead
+/// of `{ path, text }` inputs or host paths, the input source is the archive
+/// `archive_bytes` buffer. The `options_json` object carries the same scan and
+/// per-mode settings the JSON modes accept, plus two byte-mode-only options:
+///
+/// * `root` — the logical repository root admitted entries are rooted under
+///   (default `"repo"`).
+/// * `archive_limits` — an optional object overriding any of the conservative
+///   ingestion caps (`max_entry_size`, `max_total_size`, `max_entries`,
+///   `max_ratio`); omitted fields keep the engine defaults.
+///
+/// # Arguments
+///
+/// * `mode` — one of `"lang"`, `"module"`, `"export"`, or `"analyze"`. Host-only
+///   modes (`diff`/`cockpit`/`version`) have no archive meaning and are rejected.
+/// * `options_json` — JSON options object (must not carry `inputs` or `paths`).
+/// * `archive_bytes` — the raw archive buffer, copied/owned by the caller.
+///
+/// # Returns
+///
+/// The same envelope shape [`run_json`](super::run_json) returns:
+/// `{"ok": true, "data": {...receipt...}}` on success, or
+/// `{"ok": false, "error": {...}}` on failure. A rejected archive fails closed
+/// with no partial receipt.
+///
+/// # Example
+///
+/// ```ignore
+/// use tokmd_core::ffi::run_json_bytes;
+///
+/// let result = run_json_bytes("lang", r#"{"lang": {"files": true}}"#, &zip_bytes);
+/// let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+/// assert_eq!(parsed["data"]["mode"], "lang");
+/// ```
+pub fn run_json_bytes(mode: &str, options_json: &str, archive_bytes: &[u8]) -> String {
+    json_response(run_json_bytes_inner(mode, options_json, archive_bytes))
+}
+
+fn run_json_bytes_inner(
+    mode: &str,
+    options_json: &str,
+    archive_bytes: &[u8],
+) -> Result<Value, TokmdError> {
+    let args: Value = serde_json::from_str(options_json)
+        .map_err(|err| TokmdError::invalid_json(err.to_string()))?;
+    if !args.is_object() {
+        return Err(TokmdError::invalid_json(
+            "Top-level JSON value must be an object",
+        ));
+    }
+
+    // The archive is the sole input source. The `{ path, text }` and host-path
+    // conventions are mutually exclusive with byte mode, mirroring the existing
+    // "paths cannot be combined with in-memory inputs" rule in ffi/inputs.rs.
+    if args.get("inputs").is_some_and(|value| !value.is_null()) {
+        return Err(TokmdError::invalid_field(
+            "inputs",
+            "must not be combined with archive bytes; the archive is the input source",
+        ));
+    }
+    if args.get("paths").is_some_and(|value| !value.is_null()) {
+        return Err(TokmdError::invalid_field(
+            "paths",
+            "cannot be combined with archive bytes",
+        ));
+    }
+
+    // Byte mode only serves the input-consuming scan modes.
+    if !matches!(mode, "lang" | "module" | "export" | "analyze") {
+        return Err(TokmdError::invalid_field(
+            "mode",
+            "one of 'lang', 'module', 'export', or 'analyze' for archive byte mode",
+        ));
+    }
+
+    let root =
+        parse_optional_string(&args, "root")?.unwrap_or_else(|| DEFAULT_ARCHIVE_ROOT.to_string());
+    let limits = parse_archive_limits(&args)?;
+
+    // Untrusted bytes cross the trust boundary here: all path-safety and
+    // zip-bomb admission is delegated to the single authoritative engine, which
+    // fails closed on the first violated entry.
+    let inputs = inputs_from_zip_bytes(&root, archive_bytes, &limits)?;
+
+    let scan = parse_scan_settings(&args)?;
+    run_mode(mode, &args, &scan, Some(&inputs))
+}
+
+/// Build [`ArchiveLimits`] from an optional `archive_limits` options object,
+/// keeping the conservative engine defaults for any omitted field.
+fn parse_archive_limits(args: &Value) -> Result<ArchiveLimits, TokmdError> {
+    let defaults = ArchiveLimits::default();
+    let obj = match args.get("archive_limits") {
+        None | Some(Value::Null) => return Ok(defaults),
+        Some(value) if value.is_object() => value,
+        Some(_) => return Err(TokmdError::invalid_field("archive_limits", "a JSON object")),
+    };
+
+    Ok(ArchiveLimits {
+        max_entry_size: parse_optional_u64(obj, "max_entry_size")?
+            .unwrap_or(defaults.max_entry_size),
+        max_total_size: parse_optional_u64(obj, "max_total_size")?
+            .unwrap_or(defaults.max_total_size),
+        max_entries: parse_optional_usize(obj, "max_entries")?.unwrap_or(defaults.max_entries),
+        max_ratio: parse_optional_u64(obj, "max_ratio")?.unwrap_or(defaults.max_ratio),
+    })
+}

--- a/crates/tokmd-core/src/ffi/mod.rs
+++ b/crates/tokmd-core/src/ffi/mod.rs
@@ -17,6 +17,8 @@
 
 use serde_json::Value;
 
+#[cfg(feature = "archive-zip")]
+mod byte_mode;
 mod envelope;
 mod inputs;
 mod modes;
@@ -24,6 +26,8 @@ mod parse;
 mod settings_parse;
 
 use crate::error::TokmdError;
+#[cfg(feature = "archive-zip")]
+pub use byte_mode::run_json_bytes;
 use envelope::json_response;
 use inputs::parse_in_memory_inputs;
 use modes::run_mode;

--- a/crates/tokmd-core/tests/archive_zip_ffi_bytemode.rs
+++ b/crates/tokmd-core/tests/archive_zip_ffi_bytemode.rs
@@ -1,0 +1,183 @@
+//! Public FFI byte-entrypoint coverage for the WASM FFI byte-mode seam.
+//!
+//! These tests prove the public-entrypoint slice of
+//! `docs/specs/wasm-ffi-byte-mode.md`: the `tokmd_core::ffi::run_json_bytes`
+//! transport entrypoint admits ZIP bytes through the single authoritative
+//! engine and routes them through the existing mode dispatch, so the byte-mode
+//! envelope matches the equivalent `{ path, text }` JSON-mode envelope and
+//! hostile/malformed archives fail closed with no partial receipt.
+//!
+//! Out of scope for this slice (intentionally untested here): the `tokmd-wasm`
+//! `Uint8Array` binding + `wasm-bindgen-test` coverage, and any browser
+//! capability promotion.
+#![cfg(feature = "archive-zip")]
+
+use std::io::{Cursor, Write};
+
+use serde_json::{Value, json};
+use tokmd_core::ffi::{run_json, run_json_bytes};
+use zip::CompressionMethod;
+use zip::write::{SimpleFileOptions, ZipWriter};
+
+type BoxedError = Box<dyn std::error::Error>;
+
+/// Fixture entries in normalized-sorted path order, matching the order the ZIP
+/// admission engine yields so the JSON-mode parity inputs line up exactly.
+const FIXTURE: &[(&str, &str)] = &[
+    ("src/lib.rs", "pub fn alpha() -> usize { 1 }\n"),
+    ("src/main.rs", "fn main() {}\n"),
+    ("tests/basic.py", "# TODO: keep smoke\nprint('ok')\n"),
+];
+
+fn fixture_zip() -> Result<Vec<u8>, BoxedError> {
+    build_zip(|writer| {
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        for (name, body) in FIXTURE {
+            writer.start_file(*name, options)?;
+            writer.write_all(body.as_bytes())?;
+        }
+        Ok(())
+    })
+}
+
+fn build_zip(
+    build: impl FnOnce(&mut ZipWriter<Cursor<Vec<u8>>>) -> zip::result::ZipResult<()>,
+) -> Result<Vec<u8>, BoxedError> {
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    build(&mut writer)?;
+    Ok(writer.finish()?.into_inner())
+}
+
+/// Equivalent JSON-mode options carrying the same logical file set as inline
+/// `{ path, text }` inputs, in the same normalized order.
+fn json_mode_options() -> Value {
+    let inputs: Vec<Value> = FIXTURE
+        .iter()
+        .map(|(name, body)| json!({ "path": name, "text": body }))
+        .collect();
+    json!({ "lang": { "files": true }, "inputs": inputs })
+}
+
+fn byte_mode_options() -> String {
+    json!({ "lang": { "files": true } }).to_string()
+}
+
+fn parse_envelope(raw: &str) -> Result<Value, BoxedError> {
+    Ok(serde_json::from_str(raw)?)
+}
+
+/// Strip the volatile `generated_at_ms` field so two otherwise-identical
+/// receipts compare equal.
+fn scrub_timestamp(envelope: &mut Value) {
+    if let Some(data) = envelope.get_mut("data")
+        && let Some(obj) = data.as_object_mut()
+    {
+        obj.remove("generated_at_ms");
+    }
+}
+
+#[test]
+fn byte_mode_lang_envelope_matches_json_mode_inputs() -> Result<(), BoxedError> {
+    let bytes = fixture_zip()?;
+
+    let mut from_zip = parse_envelope(&run_json_bytes("lang", &byte_mode_options(), &bytes))?;
+    let mut from_json = parse_envelope(&run_json("lang", &json_mode_options().to_string()))?;
+
+    assert_eq!(from_zip["ok"], json!(true), "byte-mode call should succeed");
+    assert_eq!(
+        from_json["ok"],
+        json!(true),
+        "json-mode call should succeed"
+    );
+    assert_eq!(from_zip["data"]["mode"], json!("lang"));
+    // `LangReceipt.report` is `#[serde(flatten)]`, so its `total` sits directly
+    // on `data`.
+    assert_eq!(from_zip["data"]["total"]["files"], json!(3));
+
+    scrub_timestamp(&mut from_zip);
+    scrub_timestamp(&mut from_json);
+    assert_eq!(
+        from_zip, from_json,
+        "byte-mode envelope diverged from the equivalent JSON-mode envelope"
+    );
+    Ok(())
+}
+
+#[test]
+fn byte_mode_rejects_inline_inputs_option() -> Result<(), BoxedError> {
+    let bytes = fixture_zip()?;
+    let options = json!({ "inputs": [{ "path": "a.rs", "text": "fn a() {}" }] }).to_string();
+
+    let envelope = parse_envelope(&run_json_bytes("lang", &options, &bytes))?;
+    assert_eq!(envelope["ok"], json!(false));
+    assert_eq!(envelope["error"]["code"], json!("invalid_settings"));
+    Ok(())
+}
+
+#[test]
+fn byte_mode_rejects_paths_option() -> Result<(), BoxedError> {
+    let bytes = fixture_zip()?;
+    let options = json!({ "paths": ["."] }).to_string();
+
+    let envelope = parse_envelope(&run_json_bytes("lang", &options, &bytes))?;
+    assert_eq!(envelope["ok"], json!(false));
+    assert_eq!(envelope["error"]["code"], json!("invalid_settings"));
+    Ok(())
+}
+
+#[test]
+fn byte_mode_rejects_host_only_mode() -> Result<(), BoxedError> {
+    let bytes = fixture_zip()?;
+
+    let envelope = parse_envelope(&run_json_bytes("diff", &byte_mode_options(), &bytes))?;
+    assert_eq!(envelope["ok"], json!(false));
+    assert_eq!(envelope["error"]["code"], json!("invalid_settings"));
+    Ok(())
+}
+
+#[test]
+fn byte_mode_fails_closed_on_hostile_entry() -> Result<(), BoxedError> {
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let bytes = build_zip(|writer| {
+        writer.start_file("ok.rs", stored)?;
+        writer.write_all(b"fn ok() {}\n")?;
+        writer.start_file("nested/../../evil.rs", stored)?;
+        writer.write_all(b"pwn")?;
+        Ok(())
+    })?;
+
+    let envelope = parse_envelope(&run_json_bytes("lang", &byte_mode_options(), &bytes))?;
+    assert_eq!(
+        envelope["ok"],
+        json!(false),
+        "a traversal entry must fail closed with no partial receipt"
+    );
+    assert!(
+        envelope.get("data").is_none() || envelope["data"].is_null(),
+        "a rejected archive must not produce a receipt"
+    );
+    Ok(())
+}
+
+#[test]
+fn byte_mode_rejects_malformed_archive() -> Result<(), BoxedError> {
+    let envelope = parse_envelope(&run_json_bytes("lang", &byte_mode_options(), b"not a zip"))?;
+    assert_eq!(envelope["ok"], json!(false));
+    Ok(())
+}
+
+#[test]
+fn byte_mode_enforces_archive_limits() -> Result<(), BoxedError> {
+    let bytes = fixture_zip()?;
+    // The fixture has three entries; a one-entry cap must fail closed.
+    let options =
+        json!({ "lang": { "files": true }, "archive_limits": { "max_entries": 1 } }).to_string();
+
+    let envelope = parse_envelope(&run_json_bytes("lang", &options, &bytes))?;
+    assert_eq!(
+        envelope["ok"],
+        json!(false),
+        "exceeding the entry-count cap must fail closed"
+    );
+    Ok(())
+}

--- a/docs/specs/wasm-ffi-byte-mode.md
+++ b/docs/specs/wasm-ffi-byte-mode.md
@@ -1,7 +1,11 @@
 # Spec: WASM FFI Byte Mode for Archive Upload
 
-- Status: draft
-- Schema family, if any: none yet (no new serialized receipt schema is introduced by this stub)
+- Status: active
+- Implementation state: the core byte FFI entrypoint
+  (`tokmd_core::ffi::run_json_bytes`, behind the `archive-zip` feature) has
+  landed with core-level parity and fail-closed coverage; the WASM `Uint8Array`
+  binding and the capability promotion remain pending.
+- Schema family, if any: none yet (no new serialized receipt schema is introduced by this seam)
 - Related ADRs: none yet
 - Related proof scopes: `scan`, `model`, `io_port`
 - Related crates: `crates/tokmd-core`, `crates/tokmd-wasm`, `crates/tokmd-scan`, `crates/tokmd-io-port`
@@ -35,14 +39,20 @@ this as the standing blocker for browser ZIP upload.
 This spec fixes the byte-mode contract that closes that gap. Three roles make up
 the seam.
 
-- **Byte FFI mode (proposed)** — a core entrypoint that accepts an archive byte
-  buffer plus a small JSON options object (logical root, scan options, ingestion
-  limits, output mode) and returns the same envelope shape
+- **Byte FFI mode (landed)** — `tokmd_core::ffi::run_json_bytes(mode,
+  options_json, archive_bytes)` accepts an archive byte buffer plus a small JSON
+  options object (logical `root`, scan options, `archive_limits` ingestion caps,
+  per-mode settings) and returns the same envelope shape
   (`{ "ok": ..., "data": ..., "error": ... }`) that the JSON modes already
-  return. It composes the landed ZIP→scan consumer; it does not introduce a new
-  scan path. The byte mode is gated by the same decompression-dependency feature
-  (`archive-zip`) so the default core/binding surface stays free of
-  decompression dependencies.
+  return. It decodes the bytes through the landed
+  `tokmd_scan::inputs_from_zip_bytes` consumer and routes the admitted inputs
+  through the existing `run_mode` dispatch, so it introduces no new scan path
+  and no second admission path. The byte mode is gated by the same
+  decompression-dependency feature (`archive-zip`) so the default core/binding
+  surface stays free of decompression dependencies. It serves the
+  input-consuming scan modes (`lang`/`module`/`export`/`analyze`); host-only
+  modes (`diff`/`cockpit`/`version`) are rejected, and the `inputs`/`paths`
+  conventions are mutually exclusive with the archive byte source.
 
 - **WASM byte binding (proposed)** — a thin wasm-bindgen function that accepts a
   JS byte view (`Uint8Array`) plus options and forwards to the core byte mode,
@@ -129,27 +139,36 @@ get its own schema version and a follow-on spec; this stub does not define one.
 
 ## Proof Requirements
 
-These are the proof obligations a future implementing PR must satisfy; this stub
-asserts none of them as already met.
+These are the proof obligations for the full seam. Items met by the landed core
+byte entrypoint are marked; the remaining items gate the WASM binding and
+capability promotion.
 
-- Byte/host parity: scanning a benign archive fixture through the byte mode must
-  yield the same normalized file set and aggregated receipt as scanning the
-  equivalent extracted tree through the host path, reusing the parity oracle the
-  snapshot seam defines.
-- Byte/JSON-mode parity: for the same logical file set, the byte-mode receipt
-  must match the receipt produced by the existing `{ path, text }` JSON mode
-  (same `schema_version`, same payload modulo volatile timestamps).
-- Fail-closed admission: traversal/absolute/drive-prefix/NUL/non-regular and
-  zip-bomb fixtures must each be rejected with a named error and produce no
-  partial receipt, with no second admission path bypassing
-  `crates/tokmd-io-port/src/archive.rs`.
-- WASM boundary coverage: a `wasm-bindgen-test` must exercise the `Uint8Array`
-  binding end to end and assert the browser payload matches the core payload, in
-  the same style as the existing boundary tests in
+- Byte/JSON-mode parity (MET, core): for the same logical file set, the
+  byte-mode envelope must match the envelope produced by the existing
+  `{ path, text }` JSON mode (same `schema_version`, same payload modulo
+  volatile timestamps). Covered by the
+  `byte_mode_lang_envelope_matches_json_mode_inputs` test in
+  `crates/tokmd-core/tests/archive_zip_ffi_bytemode.rs` and the `tokmd-scan`
+  decode parity in `crates/tokmd-core/tests/archive_zip_bytemode.rs`.
+- Fail-closed admission (MET, core): a traversal entry, a malformed archive, and
+  a breached ingestion cap each fail closed with no partial receipt, with no
+  second admission path bypassing `crates/tokmd-io-port/src/archive.rs`. Covered
+  by the `byte_mode_fails_closed_on_hostile_entry`,
+  `byte_mode_rejects_malformed_archive`, and `byte_mode_enforces_archive_limits`
+  tests in the same file. Broader hostile-fixture coverage
+  (absolute/drive-prefix/NUL/non-regular) is already proven at the admission
+  engine in `crates/tokmd-io-port`.
+- Byte/host parity (PENDING): scanning a benign archive fixture through the byte
+  mode must yield the same normalized file set and aggregated receipt as
+  scanning the equivalent extracted tree through the host path, reusing the
+  parity oracle the snapshot seam defines.
+- WASM boundary coverage (PENDING): a `wasm-bindgen-test` must exercise the
+  `Uint8Array` binding end to end and assert the browser payload matches the
+  core payload, in the same style as the existing boundary tests in
   `crates/tokmd-wasm/src/lib.rs`.
-- Default-surface guard: a build/test of the default (non-`archive-zip`) feature
-  set must confirm no decompression dependency entered the default core or WASM
-  surface.
+- Default-surface guard (PENDING): a build/test of the default
+  (non-`archive-zip`) feature set must confirm no decompression dependency
+  entered the default core or WASM surface.
 
 Doc-shape checks for this spec stub itself:
 
@@ -160,11 +179,14 @@ cargo xtask docs --check
 
 ## Open Questions
 
-- Should the byte mode be a new `run_json`-style mode discriminator (e.g. an
-  `archive-zip` mode whose JSON args carry a base64 byte field) or a separate
-  byte-taking entrypoint alongside `run_json`? A dedicated byte entrypoint avoids
-  base64 inflation across the FFI boundary; a mode discriminator reuses the
-  existing dispatch and envelope plumbing. The browser matrix notes both options.
+- RESOLVED: the byte mode is a separate byte-taking entrypoint
+  (`run_json_bytes(mode, options_json, archive_bytes)`) alongside `run_json`,
+  not a base64 mode discriminator. This avoids base64 inflation across the FFI
+  boundary while still reusing the existing `run_mode` dispatch and envelope
+  plumbing by decoding the bytes into the in-memory input list first. The `mode`
+  argument selects the scan mode, leaving room for the WASM binding to expose
+  either one archive function per mode or a single mode-taking entrypoint (see
+  the next question).
 - Should the WASM binding expose one archive function per scan mode
   (mirroring `runLang`/`runModule`/`runExport`) or a single archive entrypoint
   that takes the mode as an argument?


### PR DESCRIPTION
Import the swarm workbench head into publication via merge commit.

Swarm-Head: 5fba3cbc1ef60f6e5eec18f906976f4fe3e41125
Swarm-Range: 9a7a326866c37c5110d0b39b863c33dbbf2f9aff..5fba3cbc1ef60f6e5eec18f906976f4fe3e41125

Imports swarm PR #352 (feat(core): add archive-zip byte-mode FFI entrypoint):
the public `tokmd_core::ffi::run_json_bytes` byte-mode entrypoint behind the
`archive-zip` feature, its byte/JSON-mode parity and fail-closed tests, and the
updated `docs/specs/wasm-ffi-byte-mode.md` status/proof matrix.

Claim boundary: core entrypoint only. No `tokmd-wasm` binding,
`wasm-bindgen-test`, or browser capability promotion is included.

Checks:
- Tokmd Rust Result (swarm #352): pass (merge-gate green before squash-merge)
- Publication CI: pending on this PR
