### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-28 (O)

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -14,8 +14,9 @@
   ZIP upload when the loaded bundle exposes `runJsonBytes`. Proof: `tokmd-wasm`
   native + `wasm-bindgen-test` byte-parity tests and `web/runner` npm tests (65 pass,
   1 skip for an absent local wasm bundle). **Claim boundary**: manual browser smoke
-  against a real archive, streaming upload, and tar-family containers are not yet
-  established (see `docs/browser-capability-matrix.md`).
+  against a real archive is not yet established; maintainer recipe at
+  `docs/browser-zip-smoke.md` (streaming upload and tar-family containers remain
+  out of scope; see `docs/browser-capability-matrix.md`).
 - **PR evidence packet workflow shipped in `v1.14.0`**: `sensors/tokmd/`
   evidence packets are now boring to generate from one local command
   (`tokmd packet generate`) and one GitHub Action step (`mode: packet`), with

--- a/docs/browser-capability-matrix.md
+++ b/docs/browser-capability-matrix.md
@@ -90,10 +90,13 @@ the boundaries in [browser.md](browser.md#native-only-boundaries) and the
   with `archive-zip`, and an honest experimental/native-only split for git and
   filesystem capabilities.
 - **Does not establish**: in-browser git history, manual browser smoke of the
-  runner ZIP upload path, streaming upload, or tar-family containers.
+  runner ZIP upload path (see [browser-zip-smoke.md](browser-zip-smoke.md) for
+  the maintainer recipe), streaming upload, or tar-family containers.
 
 ## See also
 
+- [browser-zip-smoke.md](browser-zip-smoke.md) — manual browser verification
+  steps for ZIP archive upload with an `archive-zip` WASM build.
 - [browser.md](browser.md) — narrative browser runner overview and boundaries.
 - [browser-to-native.md](browser-to-native.md) — bridge from browser receipts to
   native review packets, handoff bundles, and CI evidence.

--- a/docs/browser-zip-smoke.md
+++ b/docs/browser-zip-smoke.md
@@ -1,0 +1,168 @@
+# Browser ZIP Archive Manual Smoke
+
+Manual verification recipe for the shipped `archive-zip` byte-mode chain:
+`tokmd_core::ffi::run_json_bytes` → `tokmd-wasm::runJsonBytes` → `web/runner`
+ZIP upload UI.
+
+Use this when you need human-observed evidence that a real browser can load an
+`archive-zip` WASM bundle, upload a ZIP file, and receive a successful receipt.
+Automated coverage already exercises the worker/runtime protocol and byte-mode
+parity in Rust tests; this doc closes the remaining **manual browser** gap called
+out in [`browser-capability-matrix.md`](browser-capability-matrix.md) and
+[`NOW.md`](NOW.md).
+
+## Claim boundary
+
+- **Establishes**: a maintainer can reproduce browser ZIP upload end-to-end with
+  a locally built `archive-zip` WASM bundle and a hand-made ZIP fixture.
+- **Does not establish**: streaming/large-archive upload, tar-family containers,
+  release-artifact parity without rebuilding with `archive-zip`, or CI automation
+  of browser UI tests.
+
+Record outcomes in PR comments or release notes only after completing the browser
+steps below; passing `npm test` or `cargo test -p tokmd-wasm --features archive-zip`
+alone does not discharge this lane.
+
+## Prerequisites
+
+From the repository root:
+
+- Rust stable with the `wasm32-unknown-unknown` target:
+  `rustup target add wasm32-unknown-unknown`
+- [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/) on `PATH`
+- Node.js 20+ (for `npm --prefix web/runner test` and optional static server)
+
+## 1. Build the `archive-zip` WASM bundle
+
+The default `build:wasm` script builds analysis support **without**
+decompression dependencies. ZIP upload requires the explicit feature gate:
+
+```bash
+npm --prefix web/runner run build:wasm:archive-zip
+```
+
+This writes the browser bundle to `web/runner/vendor/tokmd-wasm/` (same layout
+expected by `worker.js`).
+
+Optional pre-check (does not replace manual browser smoke):
+
+```bash
+npm --prefix web/runner test
+cargo test -p tokmd-wasm --features analysis,archive-zip run_json_bytes
+```
+
+## 2. Create a ZIP fixture
+
+The repo does not commit binary `.zip` files. Build a small fixture locally.
+The entries below mirror `tokmd-wasm` archive parity tests (`src/lib.rs`,
+`src/main.rs`, `tests/basic.py`) so a successful `lang` run should report
+**3 files** and include Rust plus Python rows.
+
+### Bash / macOS / Linux
+
+```bash
+ROOT="$(mktemp -d)/tokmd-smoke"
+mkdir -p "${ROOT}/src" "${ROOT}/tests"
+printf 'pub fn alpha() -> usize { 1 }\n' > "${ROOT}/src/lib.rs"
+printf 'fn main() {}\n' > "${ROOT}/src/main.rs"
+printf '# TODO: keep smoke\nprint('"'"'ok'"'"')\n' > "${ROOT}/tests/basic.py"
+( cd "${ROOT}" && zip -r ../tokmd-smoke.zip . )
+echo "fixture: ${ROOT%/tokmd-smoke}/tokmd-smoke.zip"
+```
+
+### PowerShell (Windows)
+
+```powershell
+$root = Join-Path $env:TEMP "tokmd-smoke"
+New-Item -ItemType Directory -Force -Path "$root\src", "$root\tests" | Out-Null
+Set-Content -NoNewline "$root\src\lib.rs" "pub fn alpha() -> usize { 1 }`n"
+Set-Content -NoNewline "$root\src\main.rs" "fn main() {}`n"
+Set-Content -NoNewline "$root/tests/basic.py" "# TODO: keep smoke`nprint('ok')`n"
+$zip = Join-Path $env:TEMP "tokmd-smoke.zip"
+if (Test-Path $zip) { Remove-Item $zip }
+Compress-Archive -Path "$root\*" -DestinationPath $zip
+Write-Host "fixture: $zip"
+```
+
+## 3. Serve the browser runner
+
+WASM workers require HTTP(S); opening `index.html` via `file://` will fail.
+
+From the repository root:
+
+```bash
+npx --yes serve web/runner -p 8080
+```
+
+Or, from `web/runner/`:
+
+```bash
+python -m http.server 8080
+```
+
+Open `http://localhost:8080/` in a current Chromium, Firefox, or Safari build.
+
+## 4. Manual browser steps
+
+1. Wait for the status panel to report the WASM worker initialized.
+2. Confirm capability hints show **`zipball: yes`** (or equivalent log line
+   `zipballCapability: wasm runJsonBytes`). If **`zipball: no`**, the loaded
+   bundle was not built with `archive-zip`; rebuild step 1.
+3. Under **ZIP Archive**, choose the fixture from step 2.
+4. Click **Load ZIP Archive**. Expect a success status with the byte size and
+   `strategy: zip-archive-bytes` in the load log.
+5. Set **Mode** to `lang`. The args JSON should be byte-mode (no `inputs` or
+   `paths` keys).
+6. Click **Run**. Expect progress phases including **Decoding ZIP archive
+   bytes**, then a completed run.
+7. Inspect the result pane:
+   - envelope `ok: true`
+   - `data.mode` is `lang`
+   - `data.total.files` is **3**
+   - language rows include Rust and Python
+8. Download the JSON artifact and keep it as optional smoke evidence.
+
+Repeat once with **Mode** `export` if you want extra confidence; the load path
+is the same and only the receipt shape changes.
+
+## 5. Failure signals
+
+| Symptom | Likely cause |
+| --- | --- |
+| ZIP controls disabled | WASM bundle lacks `runJsonBytes`; rebuild with `archive-zip` |
+| `loaded wasm bundle does not expose runJsonBytes` | Same as above |
+| `ZIP load failed` / decode error in run | corrupt fixture or unsupported compression; recreate fixture |
+| `archive runs require byte-mode options without inputs or paths` | args JSON still contains `inputs`/`paths`; reload ZIP to reset args |
+| Worker init error / blank page | served over `file://` or missing `vendor/tokmd-wasm` build output |
+
+## 6. Optional native parity check
+
+After a successful browser run, compare against the Rust byte-mode entrypoint
+using the same ZIP bytes (base64-free file read):
+
+```bash
+# Requires archive-zip enabled in tokmd-core (same feature chain as tokmd-wasm).
+python - <<'PY'
+import json, pathlib, subprocess, sys
+zip_path = pathlib.Path("/tmp/tokmd-smoke.zip")  # adjust if needed
+b = zip_path.read_bytes()
+# Use cargo test helper path only when integrating into CI; for manual smoke,
+# rely on the browser receipt from step 4.
+print(f"zip bytes: {len(b)}")
+PY
+```
+
+For strict parity during development, prefer:
+
+```bash
+cargo test -p tokmd-wasm --features analysis,archive-zip core_run_json_bytes_lang_matches_inline_inputs -- --nocapture
+```
+
+## See also
+
+- [`browser-capability-matrix.md`](browser-capability-matrix.md) — capability
+  honesty map including ZIP upload status.
+- [`browser.md`](browser.md) — browser runner overview and native boundaries.
+- [`specs/wasm-ffi-byte-mode.md`](specs/wasm-ffi-byte-mode.md) — FFI byte-mode
+  contract.
+- [`web/runner/README.md`](../web/runner/README.md) — runner integration notes.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -48,9 +48,9 @@ converted to normalized `{ path, text }` rows in memory.
 When the loaded `tokmd-wasm` bundle exposes `runJsonBytes` (built with
 `archive-zip`), the runner also accepts a user-selected ZIP archive. The main
 thread reads the file into a `Uint8Array`, stores byte-mode options JSON (no
-`inputs` or `paths`), and forwards the archive to the worker. Manual browser
-smoke against a real archive is still required before claiming full ZIP parity
-with native `archive-zip` workflows.
+`inputs` or `paths`), and forwards the archive to the worker. Manual browser smoke against a real archive is still required before claiming
+full ZIP parity with native `archive-zip` workflows. Follow
+[browser-zip-smoke.md](browser-zip-smoke.md) for the maintainer recipe.
 
 ## Artifacts
 

--- a/web/runner/README.md
+++ b/web/runner/README.md
@@ -40,6 +40,15 @@ npm --prefix web/runner run build:wasm
 npm --prefix web/runner test
 ```
 
+ZIP archive upload requires the `archive-zip` feature at build time:
+
+```bash
+npm --prefix web/runner run build:wasm:archive-zip
+```
+
+Manual browser verification steps live in
+[`docs/browser-zip-smoke.md`](../../docs/browser-zip-smoke.md).
+
 The browser bundle loads `web/runner/vendor/tokmd-wasm` and expects the wasm
 package layout produced by the build script.
 

--- a/web/runner/package.json
+++ b/web/runner/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build:wasm": "wasm-pack build ../../crates/tokmd-wasm --target web --out-dir ../../web/runner/vendor/tokmd-wasm --features analysis",
+    "build:wasm:archive-zip": "wasm-pack build ../../crates/tokmd-wasm --target web --out-dir ../../web/runner/vendor/tokmd-wasm --features analysis,archive-zip",
     "check": "node --check ./main.js && node --check ./worker.js",
     "test": "node --test ./*.test.mjs"
   }


### PR DESCRIPTION
## Summary
Publication import O: brings swarm `#356` (manual browser ZIP smoke recipe + `build:wasm:archive-zip` script) into publication as a TRUE merge commit.

- Docs-only commit: `319891a6` `docs(browser): manual ZIP archive smoke recipe (#356)`
- Parent is current publication `main` (`bf8455c5` import N)

## Claim boundary
- Docs-only; no code/schema/CI/release changes
- Merge strategy MUST be merge commit (2 parents)

## Follow-up
- Fast-forward `tokmd-swarm/main` to publication merge commit after merge
