### PR TITLE
merge(swarm): import tokmd-swarm through 2026-06-30

### DIFF
--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -660,6 +660,7 @@ paths = [
   "crates/tokmd-analysis/Cargo.toml",
   "crates/tokmd-analysis/examples/ast_shadow_perf.rs",
   "crates/tokmd-analysis/src/ast/**",
+  "crates/tokmd-analysis/tests/ast_shadow_backend_taxonomy.rs",
   "fixtures/ast-shadow/**",
   "fixtures/syntax/**",
   "policy/ast-shadow-corpus.toml",

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1054,6 +1054,7 @@ paths = [
   "crates/tokmd/tests/cli_*.rs",
   "crates/tokmd/tests/evidence_packet_*.rs",
   "crates/tokmd/tests/packet_*.rs",
+  "crates/tokmd/tests/ub_review_packet_*.rs",
   "crates/tokmd/tests/render_*.rs",
   "crates/tokmd/tests/snapshots/cli_*.snap",
   "crates/tokmd/tests/config_resolution.rs",
@@ -1070,6 +1071,7 @@ proof = [
   "cargo test -p tokmd --test config_resolution --verbose",
   "cargo test -p tokmd --test packet_generate_integration --verbose",
   "cargo test -p tokmd --test render_packets_integration --verbose",
+  "cargo test -p tokmd --test ub_review_packet_consumer --verbose",
 ]
 mutation = true
 coverage = true

--- a/crates/tokmd-analysis/tests/ast_shadow_backend_taxonomy.rs
+++ b/crates/tokmd-analysis/tests/ast_shadow_backend_taxonomy.rs
@@ -1,0 +1,315 @@
+//! Oracle anchoring `docs/specs/ast-shadow-backend.md` to emitted wire values.
+//!
+//! The backend spec defines two documentation-level vocabularies layered over
+//! the artifacts in `docs/specs/ast-shadow.md` and `docs/specs/syntax-receipts.md`:
+//!
+//! 1. a *backend identity* mapping (`heuristic` / `tree-sitter`) derived from the
+//!    `tokmd.ast_shadow.v1` `kind` and the `tree-sitter-*` `parser_crate`; and
+//! 2. a *backend-aware mismatch taxonomy* that unifies the diff comparison
+//!    buckets and the advisory parse statuses under one vocabulary.
+//!
+//! The spec is intentionally additive: it adds no `backend_id` wire field and
+//! changes no default receipt. These tests guard against the spec silently
+//! drifting from the code by asserting that every wire value a real producer
+//! emits maps onto exactly one documented identity / mismatch kind, and that the
+//! documented receipt-status taxonomy is total over `SyntaxParseStatus`.
+//!
+//! Claim boundary: this anchors the spec's *documentation tables* to the wire
+//! strings the shadow and syntax-receipt producers emit. It does not add a
+//! backend identity wire field, does not change default behavior, and asserts
+//! nothing about parse correctness or AST fact accuracy.
+//!
+//! The mapping helpers and JSON accessors are fallible so the oracle stays
+//! panic-free: an undocumented wire value or a missing field surfaces as a test
+//! error rather than a panic-family call.
+#![cfg(feature = "ast")]
+
+use serde_json::Value;
+use tokmd_analysis::ast::{
+    AstLanguage, ShadowFileInput, ShadowLandmark, SyntaxParseOptions, SyntaxParseStatus,
+    build_shadow_artifacts, parse_syntax_receipt,
+};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+const TREE_SITTER_PREFIX: &str = "tree-sitter-";
+
+fn str_field<'a>(value: &'a Value, key: &str) -> Result<&'a str, String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("expected string field `{key}`"))
+}
+
+fn array_field<'a>(value: &'a Value, key: &str) -> Result<&'a Vec<Value>, String> {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("expected array field `{key}`"))
+}
+
+/// Spec "Outputs" backend-identity table (wire value -> backend identity).
+fn backend_identity_for_shadow_kind(kind: &str) -> Result<&'static str, String> {
+    match kind {
+        "heuristic" => Ok("heuristic"),
+        "ast" => Ok("tree-sitter"),
+        other => Err(format!("undocumented tokmd.ast_shadow.v1 kind: {other}")),
+    }
+}
+
+/// Spec "Backend-aware mismatch taxonomy" table for `tokmd.ast_shadow.v1` diff
+/// `status` values. `compared` is the healthy diff state whose per-landmark
+/// buckets carry the `agree` / `heuristic_only` / `backend_only` kinds, so it is
+/// not itself an advisory mismatch kind (modelled as `Ok(None)`).
+fn taxonomy_for_diff_status(status: &str) -> Result<Option<&'static str>, String> {
+    match status {
+        "compared" => Ok(None),
+        "parse_degraded" => Ok(Some("parse_degraded")),
+        "unsupported" => Ok(Some("unsupported")),
+        other => Err(format!("undocumented diff status: {other}")),
+    }
+}
+
+/// Spec "Backend-aware mismatch taxonomy" table for the diff comparison buckets.
+fn taxonomy_for_diff_bucket(bucket: &str) -> Result<&'static str, String> {
+    match bucket {
+        "matches" => Ok("agree"),
+        "heuristic_only" => Ok("heuristic_only"),
+        "ast_only" => Ok("backend_only"),
+        other => Err(format!("undocumented diff bucket: {other}")),
+    }
+}
+
+/// Spec "Backend-aware mismatch taxonomy" table for `tokmd.syntax_receipt.v1`
+/// `status` values. `complete` is the healthy parser-backed state, not an
+/// advisory mismatch kind (modelled as `Ok(None)`).
+fn taxonomy_for_receipt_status(status: &str) -> Result<Option<&'static str>, String> {
+    match status {
+        "complete" => Ok(None),
+        "parse_degraded" => Ok(Some("parse_degraded")),
+        "parser_failed" => Ok(Some("parser_failed")),
+        "unsupported_language" => Ok(Some("unsupported")),
+        "skipped_generated_or_vendor" | "skipped_too_large" => Ok(Some("skipped")),
+        other => Err(format!("undocumented syntax receipt status: {other}")),
+    }
+}
+
+#[test]
+fn ast_shadow_wire_kinds_map_to_documented_backend_identity() -> TestResult {
+    let files = [ShadowFileInput {
+        path: "src/lib.rs",
+        language: AstLanguage::Rust,
+        source: "fn top_level() {}\n",
+        heuristic_landmarks: &[],
+    }];
+
+    let artifacts = build_shadow_artifacts(&files)?;
+
+    let heuristic_kind = str_field(&artifacts.heuristic, "kind")?;
+    assert_eq!(
+        backend_identity_for_shadow_kind(heuristic_kind)?,
+        "heuristic"
+    );
+
+    let ast_kind = str_field(&artifacts.ast, "kind")?;
+    assert_eq!(backend_identity_for_shadow_kind(ast_kind)?, "tree-sitter");
+
+    // Every declared shadow capability is a `tree-sitter-*` crate, so the `ast`
+    // kind maps unambiguously to the `tree-sitter` backend identity.
+    let capabilities = array_field(&artifacts.ast, "capabilities")?;
+    assert!(
+        !capabilities.is_empty(),
+        "ast artifact should declare at least one parser capability"
+    );
+    for capability in capabilities {
+        let parser_crate = str_field(capability, "parser_crate")?;
+        assert!(
+            parser_crate.starts_with(TREE_SITTER_PREFIX),
+            "capability {parser_crate} should map to the tree-sitter backend identity"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn ast_syntax_receipt_parser_crate_maps_to_tree_sitter_identity() -> TestResult {
+    let receipt = parse_syntax_receipt(
+        "src/lib.rs",
+        "fn top_level() {}\n",
+        SyntaxParseOptions::default(),
+    );
+    let value = receipt.to_value();
+
+    assert_eq!(str_field(&value, "schema")?, "tokmd.syntax_receipt.v1");
+    let parser_crate = str_field(&value, "parser_crate")?;
+    assert!(
+        parser_crate.starts_with(TREE_SITTER_PREFIX),
+        "{parser_crate} should map to the tree-sitter backend identity"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ast_shadow_diff_wire_values_map_to_documented_mismatch_taxonomy() -> TestResult {
+    // Exercise every diff-level outcome: agree + backend_only (parser finds an
+    // extra function), heuristic_only, parse_degraded (recovered syntax error),
+    // and unsupported (no parser backend for the language).
+    let agree_landmark = [ShadowLandmark::function("top_level", 1, 1)];
+    let heuristic_only_landmark = [ShadowLandmark::function("ghost", 1, 1)];
+    let unsupported_landmark = [ShadowLandmark::function("run", 1, 1)];
+    let files = [
+        ShadowFileInput {
+            path: "src/agree.rs",
+            language: AstLanguage::Rust,
+            source: "fn top_level() {}\nfn extra() {}\n",
+            heuristic_landmarks: &agree_landmark,
+        },
+        ShadowFileInput {
+            path: "src/heuristic_only.rs",
+            language: AstLanguage::Rust,
+            source: "fn other() {}\n",
+            heuristic_landmarks: &heuristic_only_landmark,
+        },
+        ShadowFileInput {
+            path: "src/degraded.rs",
+            language: AstLanguage::Rust,
+            source: "fn ok() {}\nfn broken(",
+            heuristic_landmarks: &[],
+        },
+        ShadowFileInput {
+            path: "tools/run.py",
+            language: AstLanguage::Python,
+            source: "def run():\n    return 1\n",
+            heuristic_landmarks: &unsupported_landmark,
+        },
+    ];
+
+    let artifacts = build_shadow_artifacts(&files)?;
+    let diff_files = array_field(&artifacts.diff, "files")?;
+
+    let mut observed_statuses = Vec::new();
+    let mut observed_kinds = Vec::new();
+    for file in diff_files {
+        let status = str_field(file, "status")?;
+        observed_statuses.push(status.to_owned());
+        // Errors on any undocumented status; healthy `compared` files carry
+        // their mismatch kinds in the per-landmark buckets.
+        taxonomy_for_diff_status(status)?;
+
+        for bucket in ["matches", "heuristic_only", "ast_only"] {
+            let entries = array_field(file, bucket)?;
+            if !entries.is_empty() {
+                observed_kinds.push(taxonomy_for_diff_bucket(bucket)?);
+            }
+        }
+    }
+
+    // The corpus reaches the advisory diff statuses and each comparison bucket.
+    assert!(observed_statuses.iter().any(|status| status == "compared"));
+    assert!(
+        observed_statuses
+            .iter()
+            .any(|status| status == "parse_degraded")
+    );
+    assert!(
+        observed_statuses
+            .iter()
+            .any(|status| status == "unsupported")
+    );
+
+    assert!(observed_kinds.contains(&"agree"));
+    assert!(observed_kinds.contains(&"heuristic_only"));
+    assert!(observed_kinds.contains(&"backend_only"));
+
+    Ok(())
+}
+
+#[test]
+fn ast_syntax_receipt_status_taxonomy_is_total_over_wire_statuses() -> TestResult {
+    // Constructing every `SyntaxParseStatus` variant makes the documented
+    // receipt-status taxonomy total over the wire vocabulary, including the
+    // `parser_failed` status that cannot be triggered deterministically with a
+    // healthy locked grammar. The mapping errors on any undocumented status.
+    let all_statuses = [
+        SyntaxParseStatus::Complete,
+        SyntaxParseStatus::ParseDegraded,
+        SyntaxParseStatus::ParserFailed,
+        SyntaxParseStatus::SkippedGeneratedOrVendor,
+        SyntaxParseStatus::SkippedTooLarge,
+        SyntaxParseStatus::UnsupportedLanguage,
+    ];
+    for status in all_statuses {
+        taxonomy_for_receipt_status(status.as_str())?;
+    }
+
+    assert_eq!(
+        taxonomy_for_receipt_status(SyntaxParseStatus::ParserFailed.as_str())?,
+        Some("parser_failed")
+    );
+    assert_eq!(
+        taxonomy_for_receipt_status(SyntaxParseStatus::UnsupportedLanguage.as_str())?,
+        Some("unsupported")
+    );
+    assert_eq!(
+        taxonomy_for_receipt_status(SyntaxParseStatus::SkippedTooLarge.as_str())?,
+        Some("skipped")
+    );
+    assert_eq!(
+        taxonomy_for_receipt_status(SyntaxParseStatus::Complete.as_str())?,
+        None
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ast_syntax_receipt_producers_emit_only_documented_statuses() -> TestResult {
+    // Drive the real producer through each deterministically reachable status
+    // and confirm the emitted wire string is part of the documented taxonomy.
+    let huge_limit = SyntaxParseOptions {
+        max_bytes: 4,
+        skip_generated_vendor: false,
+    };
+    let cases = [
+        ("src/lib.rs", "fn ok() {}\n", SyntaxParseOptions::default()),
+        (
+            "src/lib.rs",
+            "fn ok() {}\nfn broken(",
+            SyntaxParseOptions::default(),
+        ),
+        ("README.md", "# docs\n", SyntaxParseOptions::default()),
+        (
+            "vendor/crate/src/lib.rs",
+            "fn ignored() {}\n",
+            SyntaxParseOptions::default(),
+        ),
+        ("src/lib.rs", "fn main() {}\n", huge_limit),
+    ];
+
+    let mut observed = Vec::new();
+    for (path, source, options) in cases {
+        let receipt = parse_syntax_receipt(path, source, options);
+        let value = receipt.to_value();
+        let status = str_field(&value, "status")?.to_owned();
+        // Errors on any undocumented status string.
+        taxonomy_for_receipt_status(&status)?;
+        observed.push(status);
+    }
+
+    for expected in [
+        "complete",
+        "parse_degraded",
+        "unsupported_language",
+        "skipped_generated_or_vendor",
+        "skipped_too_large",
+    ] {
+        assert!(
+            observed.iter().any(|status| status == expected),
+            "expected to observe receipt status {expected}: {observed:?}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/tokmd-core/tests/archive_host_receipt_parity.rs
+++ b/crates/tokmd-core/tests/archive_host_receipt_parity.rs
@@ -1,0 +1,132 @@
+//! Receipt-level archive↔host parity oracle (`feature = "archive-zip"`).
+//!
+//! `docs/specs/repo-snapshot.md` states the archive-ingestion proof obligation
+//! as: a benign archive ingested through the archive provider must yield "the
+//! same normalized file set and **aggregated receipt** as scanning the
+//! equivalent extracted tree through `HostFs`".
+//!
+//! The existing oracles do not, together, anchor the full tokmd *receipt* to a
+//! real host filesystem scan:
+//!
+//! - `tokmd-scan/tests/archive_scan_parity.rs` proves tokei `Languages`
+//!   inventory parity (per-language file/code/comment/blank counts) for
+//!   host-vs-ZIP, but stops at the tokei layer — it never exercises the
+//!   `tokmd-model` aggregation that computes byte and token totals.
+//! - `tokmd-core/tests/archive_zip_bytemode.rs` proves the ZIP-decoded inputs
+//!   match the equivalent `{ path, text }` in-memory inputs, but both sides run
+//!   the in-memory workflow; neither is a host filesystem scan.
+//!
+//! This oracle closes that gap. It scans an extracted fixture through the host
+//! workflow (`lang_workflow`) and the equivalent ZIP through the archive
+//! workflow (`inputs_from_zip_bytes` + `lang_workflow_from_inputs`) and asserts
+//! the aggregated `LangReport` — rows plus totals, **including the model-layer
+//! `bytes` and `tokens`** — is byte-for-byte identical.
+//!
+//! Out of scope (intentionally not asserted here): per-file path strings (host
+//! paths are temp-rooted, the language-level report is path-independent), the
+//! receipt envelope's volatile `generated_at_ms`, and any browser/WASM
+//! capability claim.
+#![cfg(feature = "archive-zip")]
+
+use std::fs;
+use std::io::{Cursor, Write};
+
+use tokmd_core::{
+    InMemoryFile, lang_workflow, lang_workflow_from_inputs,
+    settings::{LangSettings, ScanOptions, ScanSettings},
+};
+use tokmd_scan::{ArchiveLimits, inputs_from_zip_bytes};
+use tokmd_types::ConfigMode;
+use zip::CompressionMethod;
+use zip::write::{SimpleFileOptions, ZipWriter};
+
+type BoxedError = Box<dyn std::error::Error>;
+
+/// Relative path -> contents fixture shared by the host and archive paths.
+const FIXTURE: &[(&str, &str)] = &[
+    (
+        "src/lib.rs",
+        "// crate root\npub fn alpha() -> usize { 1 }\n\n",
+    ),
+    ("src/util.py", "# helper\nprint('ok')\n"),
+    ("docs/README.md", "# Title\n\nSome prose.\n"),
+];
+
+/// Content-driven scan options: neutralize ambient ignore/config discovery so
+/// the host temp root and the archive snapshot are compared purely on their
+/// captured contents.
+fn parity_scan_options() -> ScanOptions {
+    ScanOptions {
+        excluded: vec![],
+        config: ConfigMode::None,
+        hidden: false,
+        no_ignore: true,
+        no_ignore_parent: true,
+        no_ignore_dot: true,
+        no_ignore_vcs: true,
+        treat_doc_strings_as_comments: false,
+    }
+}
+
+/// Build an in-memory ZIP of the shared fixture, deflate-compressed.
+fn fixture_zip() -> Result<Vec<u8>, BoxedError> {
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    for (name, body) in FIXTURE {
+        writer.start_file(*name, options)?;
+        writer.write_all(body.as_bytes())?;
+    }
+    Ok(writer.finish()?.into_inner())
+}
+
+#[test]
+fn archive_lang_report_matches_host_lang_report() -> Result<(), BoxedError> {
+    let lang = LangSettings::default();
+
+    // Host path: materialize the fixture on disk and scan via the host
+    // workflow (`tokmd_scan::scan` + `tokmd_model::create_lang_report`).
+    let dir = tempfile::tempdir()?;
+    for (rel, contents) in FIXTURE {
+        let full = dir.path().join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(full, contents)?;
+    }
+    let host_scan = ScanSettings {
+        paths: vec![dir.path().to_string_lossy().into_owned()],
+        options: parity_scan_options(),
+    };
+    let host = lang_workflow(&host_scan, &lang)?;
+
+    // Archive path: pack the same fixture into a ZIP, admit it fail-closed into
+    // the snapshot input set, and run the in-memory workflow
+    // (`tokmd_model::create_lang_report_from_rows`).
+    let bytes = fixture_zip()?;
+    let inputs: Vec<InMemoryFile> =
+        inputs_from_zip_bytes("repo", &bytes, &ArchiveLimits::default())?;
+    let archive = lang_workflow_from_inputs(&inputs, &parity_scan_options(), &lang)?;
+
+    // Sanity: the fixture really exercised the model layer (bytes + tokens) and
+    // more than one language, so the comparison below is not vacuous.
+    assert!(
+        host.report.rows.len() >= 2,
+        "fixture should produce multiple languages: {:?}",
+        host.report.rows
+    );
+    assert!(
+        host.report.total.bytes > 0,
+        "host report should carry model-layer byte totals"
+    );
+    assert!(
+        host.report.total.tokens > 0,
+        "host report should carry model-layer token totals"
+    );
+
+    assert_eq!(
+        serde_json::to_value(&host.report)?,
+        serde_json::to_value(&archive.report)?,
+        "archive-backed LangReport diverged from the host LangReport"
+    );
+    Ok(())
+}

--- a/crates/tokmd/tests/ub_review_packet_consumer.rs
+++ b/crates/tokmd/tests/ub_review_packet_consumer.rs
@@ -12,12 +12,25 @@
 //! `tokmd_types::EvidencePacketManifest` type, so a drift in the schema, the
 //! type, or the canonical examples is caught.
 //!
-//! Pure parse/validate/assert: no binary, git, or feature gate required.
+//! The synthetic rows above are pure parse/validate/assert: no binary, git, or
+//! feature gate required. The `real_producer_bridge` module at the bottom of
+//! this file additionally drives the real producer (`tokmd evidence-packet`)
+//! and feeds its emitted manifest through the *same* `consume` + `is_attachable`
+//! gate, so the hand-built skeletons cannot silently drift from what the binary
+//! actually writes. That bridge is gated on the `analysis` feature and git
+//! availability.
 
 use std::error::Error;
 
 use serde_json::{Value, json};
 use tokmd_types::{EVIDENCE_PACKET_SCHEMA, EvidencePacketManifest, EvidencePacketStatus};
+
+// Shared git/test helpers, declared at the crate root so the standard
+// `tests/common/mod.rs` resolution works on every platform (a nested-module
+// `#[path]` with `..` is not portable). Only the `analysis`-gated bridge below
+// uses it, so gate the declaration to avoid an unused module warning.
+#[cfg(feature = "analysis")]
+mod common;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -214,4 +227,185 @@ fn consumer_confirms_schema_identity_before_interpreting_fields() -> TestResult 
         "a non-v1 schema id must be rejected by the v1 schema gate"
     );
     Ok(())
+}
+
+/// Realistic-input bridge: run the real producer (`tokmd evidence-packet`) and
+/// feed the manifest it writes through the same consumer gate the synthetic rows
+/// exercise (`consume` + `is_attachable`). This guards the documented trust
+/// order and ADR-0015 ("consume `partial`, reject `failed`") against real binary
+/// output rather than only hand-built fixtures.
+///
+/// Claim boundary: this asserts the producer's emitted `manifest.json` round
+/// trips through the published schema and the public `EvidencePacketManifest`
+/// type and lands on the documented attachability decision. It does not assert
+/// analyze/syntax content correctness, and it does not prove anything about UB.
+#[cfg(feature = "analysis")]
+mod real_producer_bridge {
+    use std::path::Path;
+
+    use assert_cmd::Command;
+    use serde_json::{Value, json};
+    use tempfile::tempdir;
+    use tokmd_types::{EvidencePacketManifest, EvidencePacketStatus};
+
+    use super::{TestResult, consume, is_attachable};
+    use crate::common;
+
+    type SetupResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+    const SCOPE_PATH: &str = "src/runtime/api/MarkdownObject.rs";
+
+    /// Write the canonical complete `analyze.json` the producer validates.
+    fn write_analyze_json(sensor_dir: &Path) -> SetupResult<()> {
+        std::fs::write(
+            sensor_dir.join("analyze.json"),
+            json!({
+                "status": "complete",
+                "warnings": [],
+                "args": { "preset": "bun-ub" },
+                "source": { "inputs": [SCOPE_PATH] }
+            })
+            .to_string(),
+        )?;
+        Ok(())
+    }
+
+    /// Initialise a git repo whose review scope changed between `main` and HEAD,
+    /// matching the diff window the producer resolves. Fallible so the bridge
+    /// stays panic-free.
+    fn init_repo_with_scope() -> SetupResult<tempfile::TempDir> {
+        let dir = tempdir()?;
+        if !common::init_git_repo(dir.path()) {
+            return Err("git init failed".into());
+        }
+        let scope_dir = dir.path().join("src").join("runtime").join("api");
+        std::fs::create_dir_all(&scope_dir)?;
+        std::fs::write(scope_dir.join("MarkdownObject.rs"), "pub fn old() {}\n")?;
+        if !common::git_add_commit(dir.path(), "initial") {
+            return Err("initial commit failed".into());
+        }
+        std::fs::write(
+            scope_dir.join("MarkdownObject.rs"),
+            "pub fn old() {}\npub fn new_boundary() {}\n",
+        )?;
+        if !common::git_add_commit(dir.path(), "change api") {
+            return Err("change commit failed".into());
+        }
+        Ok(dir)
+    }
+
+    /// Write the three required sensor artifacts the producer indexes.
+    fn write_required_artifacts(root: &Path) -> SetupResult<()> {
+        let sensor_dir = root.join("sensors").join("tokmd");
+        std::fs::create_dir_all(&sensor_dir)?;
+        std::fs::write(sensor_dir.join("analyze.md"), "# Bun UB analyze\n")?;
+        write_analyze_json(&sensor_dir)?;
+        std::fs::write(sensor_dir.join("context.md"), "# Context\n")?;
+        Ok(())
+    }
+
+    /// Run the producer and return its emitted `manifest.json` value.
+    fn generate_manifest(root: &Path, extra_args: &[&str]) -> SetupResult<Value> {
+        let mut args = vec!["evidence-packet", "--base", "main", "--head", "HEAD"];
+        args.extend_from_slice(extra_args);
+        args.push(SCOPE_PATH);
+        // The producer exits non-zero for `failed` packets but still writes the
+        // manifest for inspection, so do not assert on the exit status here; the
+        // consumer gate is what this bridge validates.
+        let _ = Command::new(env!("CARGO_BIN_EXE_tokmd"))
+            .current_dir(root)
+            .args(&args)
+            .output()?;
+        let manifest_path = root.join("sensors").join("tokmd").join("manifest.json");
+        let raw = std::fs::read_to_string(manifest_path)?;
+        Ok(serde_json::from_str(&raw)?)
+    }
+
+    #[test]
+    fn real_complete_packet_passes_consumer_gate() -> TestResult {
+        if !common::git_available() {
+            return Ok(());
+        }
+        let dir = init_repo_with_scope()?;
+        write_required_artifacts(dir.path())?;
+
+        let manifest = generate_manifest(dir.path(), &[])?;
+        // Real producer output must round-trip through the published schema and
+        // the public consumer type unchanged.
+        let packet: EvidencePacketManifest = consume(&manifest)?;
+
+        assert_eq!(packet.status, EvidencePacketStatus::Complete);
+        assert!(
+            packet.errors.is_empty(),
+            "complete packet carries no errors"
+        );
+        assert!(
+            is_attachable(&packet),
+            "a real complete packet is valid review evidence"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn real_partial_packet_with_advisory_missing_syntax_is_attachable() -> TestResult {
+        if !common::git_available() {
+            return Ok(());
+        }
+        let dir = init_repo_with_scope()?;
+        write_required_artifacts(dir.path())?;
+
+        // Request an optional syntax artifact that was never written: the
+        // documented "advisory-missing" state. Per ADR-0015 the packet degrades
+        // to `partial` with a named warning and stays attachable.
+        let manifest =
+            generate_manifest(dir.path(), &["--syntax-json", "sensors/tokmd/syntax.json"])?;
+        let packet: EvidencePacketManifest = consume(&manifest)?;
+
+        assert_eq!(packet.status, EvidencePacketStatus::Partial);
+        assert!(
+            packet.errors.is_empty(),
+            "advisory-missing syntax is a bounded limit, not invalid evidence"
+        );
+        assert!(
+            packet
+                .warnings
+                .iter()
+                .any(|w| w.contains("syntax_json") && w.contains("missing")),
+            "advisory-missing must name the absent optional artifact: {:?}",
+            packet.warnings
+        );
+        assert!(
+            is_attachable(&packet),
+            "ADR-0015: ub-review consumes partial packets"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn real_failed_packet_is_rejected_by_consumer_gate() -> TestResult {
+        if !common::git_available() {
+            return Ok(());
+        }
+        let dir = init_repo_with_scope()?;
+        // Omit the required analyze.md / context.md so the producer marks the
+        // packet `failed` and records errors, while still writing the manifest.
+        let sensor_dir = dir.path().join("sensors").join("tokmd");
+        std::fs::create_dir_all(&sensor_dir)?;
+        write_analyze_json(&sensor_dir)?;
+
+        let manifest = generate_manifest(dir.path(), &[])?;
+        // A failed manifest is still schema-valid and typed for inspection.
+        let packet: EvidencePacketManifest = consume(&manifest)?;
+
+        assert_eq!(packet.status, EvidencePacketStatus::Failed);
+        assert!(
+            !packet.errors.is_empty(),
+            "failed status must record at least one error for the consumer"
+        );
+        assert!(
+            !is_attachable(&packet),
+            "a real failed packet must be rejected, not attached"
+        );
+        Ok(())
+    }
 }

--- a/docs/specs/ast-shadow-backend.md
+++ b/docs/specs/ast-shadow-backend.md
@@ -119,6 +119,15 @@ their per-file entries, as the existing diff summary already requires.
 
 ## Proof Requirements
 
+The backend-identity and mismatch-taxonomy tables above are anchored to the
+emitted wire values by
+`crates/tokmd-analysis/tests/ast_shadow_backend_taxonomy.rs`: it asserts that
+every `tokmd.ast_shadow.v1` and `tokmd.syntax_receipt.v1` wire value a real
+producer emits maps onto exactly one documented backend identity / mismatch
+kind, and that the receipt-status taxonomy is total over `SyntaxParseStatus`.
+That oracle guards the documentation tables against silent drift; it adds no
+`backend_id` wire field and changes no default behavior.
+
 This spec documents identity meaning for behavior already covered by the AST
 shadow proof scope. When the backend identity vocabulary, the mismatch taxonomy,
 or the underlying artifact contracts change, run the `analysis_ast_shadow` scope

--- a/docs/specs/repo-snapshot.md
+++ b/docs/specs/repo-snapshot.md
@@ -262,7 +262,12 @@ implemented:
   compression-ratio guard and fail closed without unbounded allocation.
 - Archive/host parity: a benign archive fixture ingested through the
   `ArchiveProvider` must yield the same normalized file set and aggregated
-  receipt as scanning the equivalent extracted tree through `HostFs`.
+  receipt as scanning the equivalent extracted tree through `HostFs`. The
+  tokei-`Languages` inventory layer of this is covered by
+  `crates/tokmd-scan/tests/archive_scan_parity.rs`; the full tokmd
+  `LangReport` (including the `tokmd-model` byte and token totals) is anchored
+  to a host filesystem scan by
+  `crates/tokmd-core/tests/archive_host_receipt_parity.rs`.
 - Fail-closed semantics: a single rejected entry fails the whole snapshot build
   rather than silently dropping the entry and reporting `complete`.
 


### PR DESCRIPTION
## Summary

Deliberate publication import of three squashed swarm commits via **true merge commit** (not squash), per `docs/ci/swarm-routing.md`.

Imported swarm commits:
- `0db6f2bc` test(core): anchor archive ZIP LangReport to host filesystem scan (#364)
- `7db053f1` test(analysis): anchor AST shadow backend identity + mismatch taxonomy to wire values (#365)
- `f6d4c062` test(tokmd): bridge real evidence-packet producer through ub-review consumer gate (#366)

```
Swarm-Head: f6d4c062f12a4d176ed5b11b5e89b32026788c41
Swarm-Range: 9f3e37f0f20ca0941e80c4eb9eddbc899d41cce8..f6d4c062f12a4d176ed5b11b5e89b32026788c41
Pre-import repo-graph: SwarmAhead publication_ahead=0 swarm_ahead=3
```

## Claim boundary

This is a topology import only. It does **not** move release tags, publish crates, sign artifacts, update the `v1` alias, push Docker images, or bump versions. The three swarm commits are test/docs-anchoring changes already green on swarm via `Tokmd Rust Small Result`.

## Merge method

MUST be merged with a **merge commit** (`gh pr merge --merge`) so the second parent preserves the squashed swarm history. Squash would destroy the ahead/behind graph shape. See `docs/ci/swarm-routing.md`.
