### PR TITLE
archivist: fix index drift in RUNS_ROLLUP.md 🗃️

### DIFF
--- a/.jules/index/generated/RUNS_ROLLUP.md
+++ b/.jules/index/generated/RUNS_ROLLUP.md
@@ -25,6 +25,7 @@ It rolls up metadata from all run packets in `.jules/runs/` and historical ledge
 | `palette_binding_dx` | palette | prover | bindings-targets | success | 0 | live |
 | `palette_runtime_dx` | palette | builder | interfaces | success | 0 | live |
 | `palette_runtime_dx_interfaces` | Palette 🎨 | Builder | interfaces | in-progress | 0 | live |
+| `run-archivist-001` | Archivist 🗃️ | Builder | workspace-wide | in-progress | 0 | live |
 | `run-sentinel-redact-1` | Sentinel | Stabilizer | core-pipeline | in-progress | 0 | live |
 | `run-specsmith-1` | Specsmith | Builder | analysis-stack | in-progress | 3 | live |
 | `run_mutant_01` | Mutant | Prover | core-pipeline | success | 0 | live |

--- a/.jules/runs/run-archivist-001/decision.md
+++ b/.jules/runs/run-archivist-001/decision.md
@@ -1,0 +1,13 @@
+## 🧭 Options considered
+
+### Option A (recommended)
+- Run `cargo xtask jules-index` to regenerate the `.jules/index/generated/RUNS_ROLLUP.md` and related index files, which are currently drifting because new run metadata exists in `.jules/runs/`.
+- Commit the result as a standard patch update.
+- Fit for the Archivist persona's mission to "summarize per-run packets into generated indexes/rollups".
+
+### Option B
+- Ignore the drift and create a learning PR documenting that it exists.
+- This is not recommended because the drift is easily fixable with an existing tool and aligns perfectly with the target ranking: "summarize per-run packets into generated indexes/rollups".
+
+## ✅ Decision
+Option A. This is the exact task expected of the Archivist persona, the drift is easily verifiable with `cargo xtask jules-index --check`, and fixable with `cargo xtask jules-index`. This provides a clean, coherent story that improves Jules's indexing.

--- a/.jules/runs/run-archivist-001/envelope.json
+++ b/.jules/runs/run-archivist-001/envelope.json
@@ -1,0 +1,9 @@
+{
+  "prompt_id": "archivist_jules",
+  "persona": "Archivist 🗃️",
+  "style": "Builder",
+  "primary_shard": "workspace-wide",
+  "allowed_paths": ["**"],
+  "gate_profile": "governance-release",
+  "allowed_outcomes": ["PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/run-archivist-001/pr_body.md
+++ b/.jules/runs/run-archivist-001/pr_body.md
@@ -1,0 +1,52 @@
+## 💡 Summary
+Updated the Jules run rollup indexes. This resolves the index drift caused by newly added run packets.
+
+## 🎯 Why
+The `cargo xtask jules-index --check` validation failed, indicating that `.jules/index/generated/RUNS_ROLLUP.md` was out of sync with the actual contents of `.jules/runs/`. Regenerating the indexes ensures our run history is accurately reflected in the summary documents.
+
+## 🔎 Evidence
+- `.jules/index/generated/RUNS_ROLLUP.md`
+- `cargo xtask jules-index --check` output showed: `Error: Jules index drift detected in /app/.jules/index/generated/RUNS_ROLLUP.md. Run cargo xtask jules-index to update.`
+
+## 🧭 Options considered
+### Option A (recommended)
+- Run `cargo xtask jules-index` to regenerate the `.jules/index/generated/RUNS_ROLLUP.md` and related index files.
+- This directly aligns with the Archivist mission to "summarize per-run packets into generated indexes/rollups".
+- Trade-offs:
+  - Structure: Improves consistency.
+  - Velocity: Low effort, high signal fix.
+  - Governance: Ensures metadata rollups remain accurate.
+
+### Option B
+- Document the drift as a learning PR instead of fixing it.
+- Choose this only if the xtask generation was broken or required out-of-scope changes.
+- Trade-offs: Leaves known, fixable drift in the repository.
+
+## ✅ Decision
+Option A. The index drift was straightforward to fix using the provided `cargo xtask jules-index` tool, maintaining the accuracy of our generated rollups without risking any product code stability.
+
+## 🧱 Changes made (SRP)
+- `.jules/index/generated/RUNS_ROLLUP.md`
+
+## 🧪 Verification receipts
+```text
+cargo xtask jules-index
+cargo xtask jules-index --check
+```
+
+## 🧭 Telemetry
+- Change shape: Metadata regeneration
+- Blast radius: None (docs only)
+- Risk class: Low - touches only generated `.jules` artifacts
+- Rollback: Revert the commit
+- Gates run: `cargo xtask jules-index --check`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-archivist-001/envelope.json`
+- `.jules/runs/run-archivist-001/decision.md`
+- `.jules/runs/run-archivist-001/receipts.jsonl`
+- `.jules/runs/run-archivist-001/result.json`
+- `.jules/runs/run-archivist-001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-archivist-001/receipts.jsonl
+++ b/.jules/runs/run-archivist-001/receipts.jsonl
@@ -1,0 +1,2 @@
+cargo xtask jules-index
+cargo xtask jules-index --check

--- a/.jules/runs/run-archivist-001/result.json
+++ b/.jules/runs/run-archivist-001/result.json
@@ -1,0 +1,4 @@
+{
+  "outcome": "success",
+  "patch_type": "PR-ready patch"
+}


### PR DESCRIPTION
Updated the Jules run rollup indexes. This resolves the index drift caused by newly added run packets.

The `cargo xtask jules-index --check` validation failed, indicating that `.jules/index/generated/RUNS_ROLLUP.md` was out of sync with the actual contents of `.jules/runs/`. Regenerating the indexes ensures our run history is accurately reflected in the summary documents.

---
*PR created automatically by Jules for task [1909106212431820898](https://jules.google.com/task/1909106212431820898) started by @EffortlessSteven*