### PR TITLE
merge(swarm): import tokmd-swarm AST shadow TS/Python corpus

### DIFF
--- a/crates/tokmd-analysis/src/ast/capability.rs
+++ b/crates/tokmd-analysis/src/ast/capability.rs
@@ -1,4 +1,6 @@
+use super::python;
 use super::rust;
+use super::typescript;
 
 pub const AST_SHADOW_SCHEMA_VERSION: &str = "tokmd.ast_shadow.v1";
 pub const SYNTAX_RECEIPT_SCHEMA_VERSION: &str = "tokmd.syntax_receipt.v1";
@@ -52,7 +54,13 @@ impl AstCapability {
 
 #[must_use]
 pub fn capabilities() -> &'static [AstCapability] {
-    rust::CAPABILITIES
+    static CAPABILITIES: &[AstCapability] = &[
+        rust::RUST_CAPABILITY,
+        typescript::TYPESCRIPT_CAPABILITY,
+        typescript::TSX_CAPABILITY,
+        python::PYTHON_CAPABILITY,
+    ];
+    CAPABILITIES
 }
 
 #[cfg(test)]

--- a/crates/tokmd-analysis/src/ast/mod.rs
+++ b/crates/tokmd-analysis/src/ast/mod.rs
@@ -42,17 +42,19 @@ mod tests {
     };
 
     #[test]
-    fn rust_capability_is_shadow_only_and_not_default_receipts() {
+    fn shadow_capabilities_are_parser_backed_and_shadow_only() {
         let capabilities = capabilities();
 
-        assert_eq!(capabilities.len(), 1);
-        assert_eq!(capabilities[0].language, AstLanguage::Rust);
-        assert_eq!(
-            capabilities[0].parser_status,
-            AstParserStatus::ParserBackedShadow
-        );
-        assert!(capabilities[0].shadow_only);
-        assert!(!capabilities[0].changes_default_receipts);
+        assert_eq!(capabilities.len(), 4);
+        for capability in capabilities {
+            assert_eq!(
+                capability.parser_status,
+                AstParserStatus::ParserBackedShadow
+            );
+            assert!(capability.shadow_only);
+            assert!(!capability.changes_default_receipts);
+            assert!(capability.parser_crate.starts_with("tree-sitter-"));
+        }
     }
 
     #[test]
@@ -71,10 +73,24 @@ mod tests {
     }
 
     #[test]
-    fn syntax_registry_is_feature_gated_and_does_not_expand_shadow_capabilities() {
+    fn shadow_capabilities_track_parser_backed_languages() {
         assert_eq!(SYNTAX_RECEIPT_SCHEMA_VERSION, "tokmd.syntax_receipt.v1");
         assert_eq!(syntax_capabilities().len(), 4);
-        assert_eq!(capabilities().len(), 1);
-        assert_eq!(capabilities()[0].language, AstLanguage::Rust);
+        assert_eq!(capabilities().len(), 4);
+        assert!(
+            capabilities()
+                .iter()
+                .any(|capability| capability.language == AstLanguage::Rust)
+        );
+        assert!(
+            capabilities()
+                .iter()
+                .any(|capability| capability.language == AstLanguage::Python)
+        );
+        assert!(
+            capabilities()
+                .iter()
+                .any(|capability| capability.language == AstLanguage::TypeScript)
+        );
     }
 }

--- a/crates/tokmd-analysis/src/ast/python.rs
+++ b/crates/tokmd-analysis/src/ast/python.rs
@@ -1,8 +1,154 @@
+use super::capability::{AstCapability, AstLanguage};
 use super::facts::{
     SyntaxCallSite, SyntaxExport, SyntaxFacts, SyntaxImport, SyntaxRiskSeam, SyntaxSpan,
     SyntaxSymbol,
 };
-use tree_sitter::Node;
+use std::error::Error;
+use std::fmt;
+use tree_sitter::{Node, Parser};
+
+pub const TREE_SITTER_PYTHON_CRATE: &str = "tree-sitter-python";
+pub const PYTHON_CAPABILITY: AstCapability =
+    AstCapability::parser_backed_shadow(AstLanguage::Python, TREE_SITTER_PYTHON_CRATE);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PythonAstShadow {
+    pub has_error: bool,
+    pub landmarks: Vec<PythonLandmark>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PythonLandmark {
+    pub kind: PythonLandmarkKind,
+    pub name: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum PythonLandmarkKind {
+    ControlFlow,
+    Function,
+    Import,
+}
+
+#[derive(Debug)]
+pub enum PythonAstError {
+    Language(tree_sitter::LanguageError),
+    ParseFailed,
+}
+
+impl fmt::Display for PythonAstError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Language(error) => {
+                write!(f, "failed to load Python Tree-sitter language: {error}")
+            }
+            Self::ParseFailed => f.write_str("failed to parse Python source"),
+        }
+    }
+}
+
+impl Error for PythonAstError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Language(error) => Some(error),
+            Self::ParseFailed => None,
+        }
+    }
+}
+
+pub fn parse_python_landmarks(source: &str) -> Result<PythonAstShadow, PythonAstError> {
+    let mut parser = Parser::new();
+    let language = tree_sitter_python::LANGUAGE;
+    parser
+        .set_language(&language.into())
+        .map_err(PythonAstError::Language)?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or(PythonAstError::ParseFailed)?;
+
+    let mut landmarks = Vec::new();
+    collect_python_landmarks(tree.root_node(), source, &mut landmarks);
+    landmarks.sort_by(|left, right| {
+        left.start_line
+            .cmp(&right.start_line)
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    Ok(PythonAstShadow {
+        has_error: tree.root_node().has_error(),
+        landmarks,
+    })
+}
+
+fn collect_python_landmarks(node: Node<'_>, source: &str, landmarks: &mut Vec<PythonLandmark>) {
+    match node.kind() {
+        "function_definition" => {
+            if let Some(name) = python_function_name(node, source) {
+                push_python_landmark(node, PythonLandmarkKind::Function, name, landmarks);
+            }
+        }
+        "import_statement" | "import_from_statement" => {
+            if let Some(name) = import_statement_name(node, source) {
+                push_python_landmark(node, PythonLandmarkKind::Import, name, landmarks);
+            }
+        }
+        kind => {
+            if let Some(name) = python_control_flow_name(kind) {
+                push_python_landmark(
+                    node,
+                    PythonLandmarkKind::ControlFlow,
+                    name.to_owned(),
+                    landmarks,
+                );
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_python_landmarks(child, source, landmarks);
+    }
+}
+
+fn python_function_name(node: Node<'_>, source: &str) -> Option<String> {
+    node.child_by_field_name("name")
+        .and_then(|name| node_text_checked(source, name))
+        .map(compact_text)
+        .or_else(|| first_identifier_text(node, source))
+}
+
+fn import_statement_name(node: Node<'_>, source: &str) -> Option<String> {
+    Some(compact_text(node_text(source, node)))
+}
+
+fn python_control_flow_name(kind: &str) -> Option<&'static str> {
+    match kind {
+        "if_statement" => Some("if"),
+        "for_statement" => Some("for"),
+        "while_statement" => Some("while"),
+        "match_statement" => Some("match"),
+        _ => None,
+    }
+}
+
+fn push_python_landmark(
+    node: Node<'_>,
+    kind: PythonLandmarkKind,
+    name: String,
+    landmarks: &mut Vec<PythonLandmark>,
+) {
+    let start = node.start_position();
+    let end = node.end_position();
+    landmarks.push(PythonLandmark {
+        kind,
+        name,
+        start_line: start.row + 1,
+        end_line: end.row + 1,
+    });
+}
 
 #[must_use]
 pub fn extract_python_facts(root: Node<'_>, source: &str) -> SyntaxFacts {

--- a/crates/tokmd-analysis/src/ast/rust.rs
+++ b/crates/tokmd-analysis/src/ast/rust.rs
@@ -10,7 +10,6 @@ use tree_sitter::{Node, Parser};
 pub const TREE_SITTER_RUST_CRATE: &str = "tree-sitter-rust";
 pub const RUST_CAPABILITY: AstCapability =
     AstCapability::parser_backed_shadow(AstLanguage::Rust, TREE_SITTER_RUST_CRATE);
-pub static CAPABILITIES: &[AstCapability] = &[RUST_CAPABILITY];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RustAstShadow {

--- a/crates/tokmd-analysis/src/ast/shadow.rs
+++ b/crates/tokmd-analysis/src/ast/shadow.rs
@@ -1,6 +1,13 @@
 use super::capability::{AST_SHADOW_SCHEMA_VERSION, AstLanguage, AstParserStatus, capabilities};
+use super::python::{
+    PythonAstError, PythonAstShadow, PythonLandmark, PythonLandmarkKind, parse_python_landmarks,
+};
 use super::rust::{
     RustAstError, RustAstShadow, RustLandmark, RustLandmarkKind, parse_rust_landmarks,
+};
+use super::typescript::{
+    TypeScriptAstError, TypeScriptAstShadow, TypeScriptLandmark, TypeScriptLandmarkKind,
+    parse_typescript_landmarks,
 };
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
@@ -51,7 +58,9 @@ pub struct ShadowArtifactPaths {
 #[derive(Debug)]
 pub enum ShadowArtifactError {
     AbsolutePath(String),
+    PythonAst(PythonAstError),
     RustAst(RustAstError),
+    TypeScriptAst(TypeScriptAstError),
 }
 
 impl fmt::Display for ShadowArtifactError {
@@ -60,7 +69,9 @@ impl fmt::Display for ShadowArtifactError {
             Self::AbsolutePath(path) => {
                 write!(f, "AST shadow artifact paths must be relative: {path}")
             }
+            Self::PythonAst(error) => write!(f, "{error}"),
             Self::RustAst(error) => write!(f, "{error}"),
+            Self::TypeScriptAst(error) => write!(f, "{error}"),
         }
     }
 }
@@ -69,14 +80,28 @@ impl Error for ShadowArtifactError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::AbsolutePath(_) => None,
+            Self::PythonAst(error) => Some(error),
             Self::RustAst(error) => Some(error),
+            Self::TypeScriptAst(error) => Some(error),
         }
+    }
+}
+
+impl From<PythonAstError> for ShadowArtifactError {
+    fn from(error: PythonAstError) -> Self {
+        Self::PythonAst(error)
     }
 }
 
 impl From<RustAstError> for ShadowArtifactError {
     fn from(error: RustAstError) -> Self {
         Self::RustAst(error)
+    }
+}
+
+impl From<TypeScriptAstError> for ShadowArtifactError {
+    fn from(error: TypeScriptAstError) -> Self {
+        Self::TypeScriptAst(error)
     }
 }
 
@@ -148,8 +173,23 @@ pub fn build_shadow_artifacts(
                     AstParserStatus::ParserBackedShadow,
                 )
             }
-            AstLanguage::Python | AstLanguage::TypeScript | AstLanguage::Tsx => {
-                (Vec::new(), false, true, AstParserStatus::Unsupported)
+            AstLanguage::Python => {
+                let ast_shadow = parse_python_landmarks(input.source)?;
+                (
+                    shadow_landmarks_from_python(&ast_shadow),
+                    ast_shadow.has_error,
+                    false,
+                    AstParserStatus::ParserBackedShadow,
+                )
+            }
+            AstLanguage::TypeScript | AstLanguage::Tsx => {
+                let ast_shadow = parse_typescript_landmarks(input.source, input.language)?;
+                (
+                    shadow_landmarks_from_typescript(&ast_shadow),
+                    ast_shadow.has_error,
+                    false,
+                    AstParserStatus::ParserBackedShadow,
+                )
             }
         };
         ast_landmarks.sort();
@@ -271,6 +311,56 @@ fn parser_status_value(status: AstParserStatus) -> &'static str {
     match status {
         AstParserStatus::ParserBackedShadow => "parser_backed_shadow",
         AstParserStatus::Unsupported => "unsupported",
+    }
+}
+
+fn shadow_landmarks_from_python(shadow: &PythonAstShadow) -> Vec<ShadowLandmark> {
+    shadow
+        .landmarks
+        .iter()
+        .map(shadow_landmark_from_python)
+        .collect()
+}
+
+fn shadow_landmark_from_python(landmark: &PythonLandmark) -> ShadowLandmark {
+    ShadowLandmark {
+        kind: python_landmark_kind_value(landmark.kind).to_owned(),
+        name: landmark.name.clone(),
+        start_line: landmark.start_line,
+        end_line: landmark.end_line,
+    }
+}
+
+fn python_landmark_kind_value(kind: PythonLandmarkKind) -> &'static str {
+    match kind {
+        PythonLandmarkKind::ControlFlow => "control_flow",
+        PythonLandmarkKind::Function => "function",
+        PythonLandmarkKind::Import => "import",
+    }
+}
+
+fn shadow_landmarks_from_typescript(shadow: &TypeScriptAstShadow) -> Vec<ShadowLandmark> {
+    shadow
+        .landmarks
+        .iter()
+        .map(shadow_landmark_from_typescript)
+        .collect()
+}
+
+fn shadow_landmark_from_typescript(landmark: &TypeScriptLandmark) -> ShadowLandmark {
+    ShadowLandmark {
+        kind: typescript_landmark_kind_value(landmark.kind).to_owned(),
+        name: landmark.name.clone(),
+        start_line: landmark.start_line,
+        end_line: landmark.end_line,
+    }
+}
+
+fn typescript_landmark_kind_value(kind: TypeScriptLandmarkKind) -> &'static str {
+    match kind {
+        TypeScriptLandmarkKind::ControlFlow => "control_flow",
+        TypeScriptLandmarkKind::Function => "function",
+        TypeScriptLandmarkKind::Import => "import",
     }
 }
 
@@ -477,23 +567,26 @@ mod tests {
     }
 
     #[test]
-    fn marks_non_rust_shadow_inputs_as_unsupported_without_failing() {
-        let heuristic = [ShadowLandmark::function("run", 1, 1)];
+    fn compares_python_shadow_inputs_without_marking_unsupported() -> Result<(), ShadowArtifactError>
+    {
+        let heuristic = [ShadowLandmark::function("run", 1, 2)];
         let files = [ShadowFileInput {
             path: "tools/run.py",
             language: AstLanguage::Python,
-            source: "def run():\n    return 1\n",
+            source: "import os\n\ndef run():\n    if True:\n        return 1\n",
             heuristic_landmarks: &heuristic,
         }];
 
-        let artifacts =
-            build_shadow_artifacts(&files).expect("unsupported shadow language should be advisory");
+        let artifacts = build_shadow_artifacts(&files)?;
 
-        assert_eq!(artifacts.ast["files"][0]["parser_status"], "unsupported");
-        assert_eq!(artifacts.diff["files"][0]["status"], "unsupported");
-        assert_eq!(artifacts.diff["files"][0]["unsupported"], true);
-        assert_eq!(artifacts.diff["summary"]["unsupported"], 1);
-        assert_eq!(artifacts.diff["summary"]["heuristic_only"], 1);
+        assert_eq!(
+            artifacts.ast["files"][0]["parser_status"],
+            "parser_backed_shadow"
+        );
+        assert_eq!(artifacts.diff["files"][0]["status"], "compared");
+        assert_eq!(artifacts.diff["files"][0]["unsupported"], false);
+        assert_eq!(artifacts.diff["summary"]["unsupported"], 0);
+        Ok(())
     }
 
     #[test]

--- a/crates/tokmd-analysis/src/ast/typescript.rs
+++ b/crates/tokmd-analysis/src/ast/typescript.rs
@@ -1,8 +1,169 @@
+use super::capability::{AstCapability, AstLanguage};
 use super::facts::{
     SyntaxCallSite, SyntaxExport, SyntaxFacts, SyntaxImport, SyntaxRiskSeam, SyntaxSpan,
     SyntaxSymbol,
 };
-use tree_sitter::Node;
+use std::error::Error;
+use std::fmt;
+use tree_sitter::{Node, Parser};
+
+pub const TREE_SITTER_TYPESCRIPT_CRATE: &str = "tree-sitter-typescript";
+pub const TYPESCRIPT_CAPABILITY: AstCapability =
+    AstCapability::parser_backed_shadow(AstLanguage::TypeScript, TREE_SITTER_TYPESCRIPT_CRATE);
+pub const TSX_CAPABILITY: AstCapability =
+    AstCapability::parser_backed_shadow(AstLanguage::Tsx, TREE_SITTER_TYPESCRIPT_CRATE);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TypeScriptAstShadow {
+    pub has_error: bool,
+    pub landmarks: Vec<TypeScriptLandmark>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TypeScriptLandmark {
+    pub kind: TypeScriptLandmarkKind,
+    pub name: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum TypeScriptLandmarkKind {
+    ControlFlow,
+    Function,
+    Import,
+}
+
+#[derive(Debug)]
+pub enum TypeScriptAstError {
+    Language(tree_sitter::LanguageError),
+    ParseFailed,
+    UnsupportedLanguage,
+}
+
+impl fmt::Display for TypeScriptAstError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Language(error) => {
+                write!(f, "failed to load TypeScript Tree-sitter language: {error}")
+            }
+            Self::ParseFailed => f.write_str("failed to parse TypeScript source"),
+            Self::UnsupportedLanguage => f.write_str("unsupported TypeScript shadow language"),
+        }
+    }
+}
+
+impl Error for TypeScriptAstError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Language(error) => Some(error),
+            Self::ParseFailed | Self::UnsupportedLanguage => None,
+        }
+    }
+}
+
+pub fn parse_typescript_landmarks(
+    source: &str,
+    language: AstLanguage,
+) -> Result<TypeScriptAstShadow, TypeScriptAstError> {
+    let tree_sitter_language = match language {
+        AstLanguage::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT,
+        AstLanguage::Tsx => tree_sitter_typescript::LANGUAGE_TSX,
+        _ => return Err(TypeScriptAstError::UnsupportedLanguage),
+    };
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_language.into())
+        .map_err(TypeScriptAstError::Language)?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or(TypeScriptAstError::ParseFailed)?;
+
+    let mut landmarks = Vec::new();
+    collect_typescript_landmarks(tree.root_node(), source, &mut landmarks);
+    landmarks.sort_by(|left, right| {
+        left.start_line
+            .cmp(&right.start_line)
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    Ok(TypeScriptAstShadow {
+        has_error: tree.root_node().has_error(),
+        landmarks,
+    })
+}
+
+fn collect_typescript_landmarks(
+    node: Node<'_>,
+    source: &str,
+    landmarks: &mut Vec<TypeScriptLandmark>,
+) {
+    match node.kind() {
+        "function_declaration" | "generator_function_declaration" | "method_definition" => {
+            if let Some(name) = typescript_function_name(node, source) {
+                push_typescript_landmark(node, TypeScriptLandmarkKind::Function, name, landmarks);
+            }
+        }
+        "import_statement" => {
+            if let Some(name) = import_statement_name(node, source) {
+                push_typescript_landmark(node, TypeScriptLandmarkKind::Import, name, landmarks);
+            }
+        }
+        kind => {
+            if let Some(name) = typescript_control_flow_name(kind) {
+                push_typescript_landmark(
+                    node,
+                    TypeScriptLandmarkKind::ControlFlow,
+                    name.to_owned(),
+                    landmarks,
+                );
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_typescript_landmarks(child, source, landmarks);
+    }
+}
+
+fn typescript_function_name(node: Node<'_>, source: &str) -> Option<String> {
+    node.child_by_field_name("name")
+        .and_then(|name| text_if_named(source, name))
+        .or_else(|| first_identifier_text(source, node))
+}
+
+fn import_statement_name(node: Node<'_>, source: &str) -> Option<String> {
+    Some(compact_text(node_text(source, node)))
+}
+
+fn typescript_control_flow_name(kind: &str) -> Option<&'static str> {
+    match kind {
+        "if_statement" => Some("if"),
+        "for_statement" | "for_in_statement" => Some("for"),
+        "while_statement" => Some("while"),
+        "switch_statement" => Some("switch"),
+        _ => None,
+    }
+}
+
+fn push_typescript_landmark(
+    node: Node<'_>,
+    kind: TypeScriptLandmarkKind,
+    name: String,
+    landmarks: &mut Vec<TypeScriptLandmark>,
+) {
+    let start = node.start_position();
+    let end = node.end_position();
+    landmarks.push(TypeScriptLandmark {
+        kind,
+        name,
+        start_line: start.row + 1,
+        end_line: end.row + 1,
+    });
+}
 
 #[must_use]
 pub fn extract_typescript_facts(root: Node<'_>, source: &str) -> SyntaxFacts {

--- a/crates/tokmd-analysis/tests/ast_shadow_backend_taxonomy.rs
+++ b/crates/tokmd-analysis/tests/ast_shadow_backend_taxonomy.rs
@@ -155,10 +155,10 @@ fn ast_syntax_receipt_parser_crate_maps_to_tree_sitter_identity() -> TestResult 
 fn ast_shadow_diff_wire_values_map_to_documented_mismatch_taxonomy() -> TestResult {
     // Exercise every diff-level outcome: agree + backend_only (parser finds an
     // extra function), heuristic_only, parse_degraded (recovered syntax error),
-    // and unsupported (no parser backend for the language).
+    // and a parser-backed Python comparison.
     let agree_landmark = [ShadowLandmark::function("top_level", 1, 1)];
     let heuristic_only_landmark = [ShadowLandmark::function("ghost", 1, 1)];
-    let unsupported_landmark = [ShadowLandmark::function("run", 1, 1)];
+    let python_landmark = [ShadowLandmark::function("run", 1, 2)];
     let files = [
         ShadowFileInput {
             path: "src/agree.rs",
@@ -181,8 +181,8 @@ fn ast_shadow_diff_wire_values_map_to_documented_mismatch_taxonomy() -> TestResu
         ShadowFileInput {
             path: "tools/run.py",
             language: AstLanguage::Python,
-            source: "def run():\n    return 1\n",
-            heuristic_landmarks: &unsupported_landmark,
+            source: "def run():\n    return 1\n\ndef helper():\n    return 2\n",
+            heuristic_landmarks: &python_landmark,
         },
     ];
 
@@ -212,11 +212,6 @@ fn ast_shadow_diff_wire_values_map_to_documented_mismatch_taxonomy() -> TestResu
         observed_statuses
             .iter()
             .any(|status| status == "parse_degraded")
-    );
-    assert!(
-        observed_statuses
-            .iter()
-            .any(|status| status == "unsupported")
     );
 
     assert!(observed_kinds.contains(&"agree"));

--- a/docs/plans/ast-productization.md
+++ b/docs/plans/ast-productization.md
@@ -1,6 +1,6 @@
 # Plan: AST / Syntax Productization
 
-- Status: active
+- Status: complete
 - Related proposal: `docs/proposals/ast-productization.md`
 - Related spec:
   `docs/specs/syntax-receipts.md`,
@@ -41,8 +41,13 @@ public receipts.
 4. **Optional: user-path syntax guide**
    - Add a recipes or workflows section for UB/crash review using
      `review_signals` (no new command).
-5. **Publication import checkpoint**
-   - True merge-commit import after packets 1–2 merge; FF swarm; repo-graph
+5. **Shadow corpus expansion for TS/Python**
+   - Extend `policy/ast-shadow-corpus.toml` with TypeScript and Python fixtures.
+   - Promote `cargo xtask ast-shadow-compare` to infer language, collect
+     heuristics, and emit parser-backed shadow artifacts for `.ts` and `.py`
+     files alongside Rust.
+6. **Publication import checkpoint**
+   - True merge-commit import after lane packets merge; FF swarm; repo-graph
      aligned.
 
 ## Validation
@@ -77,8 +82,9 @@ Required CI: `Tokmd Rust Result` (`cargo test --all-features`).
 | 1 | #368 syntax `--exclude` | merged |
 | 2 | #369 governance reconciliation | merged |
 | 3 | #370 packet exclude forwarding | merged |
-| 4 | user-path syntax guide | in progress |
-| 5 | publication import | after lane packets |
+| 4 | user-path syntax guide | merged |
+| 5 | shadow corpus TS/Python expansion | merged |
+| 6 | publication import | after lane packets |
 
 ## Intentionally deferred
 

--- a/docs/specs/ast-shadow.md
+++ b/docs/specs/ast-shadow.md
@@ -17,8 +17,9 @@ During shadow mode:
 - default `tokmd analyze`, `tokmd cockpit`, `tokmd context`, `tokmd handoff`,
   FFI, Python, Node, and WASM outputs must remain unchanged;
 - AST parsing must stay behind the explicit `ast` feature;
-- Rust is the only parser-backed language until comparison evidence justifies a
-  later language slice;
+- parser-backed shadow comparison covers Rust, TypeScript, TSX, and Python in
+  the repo-owned corpus; other languages remain heuristic-only until a later
+  slice adds parser evidence;
 - generated shadow artifacts are not merge verdicts, proof promotion receipts,
   or evidencebus packets;
 - any future public receipt field that changes meaning because of AST evidence
@@ -30,8 +31,8 @@ The first shadow slice may read:
 
 - normalized repository-relative source paths;
 - a repo-owned corpus manifest such as `policy/ast-shadow-corpus.toml` for
-  repeatable evidence collection;
-- Rust source text for files selected by a future shadow runner;
+  repeatable evidence collection across Rust, TypeScript, and Python files;
+- source text for files selected by the shadow runner;
 - heuristic facts already produced by existing analysis modules;
 - AST capability metadata from `tokmd-analysis` when built with
   `--features ast`.
@@ -65,7 +66,7 @@ comparison, including normalized paths and stable identifiers. The first
 library builder accepts caller-supplied heuristic landmarks; choosing the
 production heuristic source remains a later runner decision.
 
-`ast.json` should record parser-backed Rust facts selected for comparison,
+`ast.json` should record parser-backed facts selected for comparison,
 including parser capability metadata, normalized paths, function/import/simple
 control-flow landmarks, parser status, and recoverable parse-error state.
 

--- a/fixtures/ast-shadow/python/basic.py
+++ b/fixtures/ast-shadow/python/basic.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def compute(value: int) -> int:
+    if value == 0:
+        return 0
+
+    for item in range(value):
+        while item > 1:
+            break
+
+    match value:
+        case 1:
+            return 1
+        case _:
+            return value
+
+
+def load_path(path: Path) -> str:
+    return path.read_text()

--- a/fixtures/ast-shadow/python/parse-degraded.py
+++ b/fixtures/ast-shadow/python/parse-degraded.py
@@ -1,0 +1,5 @@
+def ok() -> None:
+    pass
+
+
+def broken(

--- a/fixtures/ast-shadow/typescript/basic.ts
+++ b/fixtures/ast-shadow/typescript/basic.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+
+export function compute(value: number): number {
+  if (value === 0) {
+    return 0;
+  }
+
+  for (let item = 0; item < value; item += 1) {
+    while (item > 1) {
+      break;
+    }
+  }
+
+  switch (value) {
+    case 1:
+      return 1;
+    default:
+      return value;
+  }
+}

--- a/fixtures/ast-shadow/typescript/parse-degraded.ts
+++ b/fixtures/ast-shadow/typescript/parse-degraded.ts
@@ -1,0 +1,3 @@
+export function ok(): void {}
+
+export function broken(

--- a/policy/ast-shadow-corpus.toml
+++ b/policy/ast-shadow-corpus.toml
@@ -1,12 +1,11 @@
 schema = "tokmd.ast_shadow_corpus.v1"
 status = "draft"
 fact_family = "function_boundary"
-language = "rust"
+language = "multi"
 owner = "analysis_ast_shadow"
 
 [rules]
 path_style = "repo_relative"
-supported_extension = ".rs"
 public_behavior = "none"
 proof_scope = "analysis_ast_shadow"
 
@@ -23,6 +22,30 @@ category = "fixture_parse_degraded"
 expected_signal = "parse_degraded"
 
 [[file]]
+path = "fixtures/ast-shadow/typescript/basic.ts"
+reason = "TypeScript baseline fixture with imports, one function, and simple control-flow landmarks"
+category = "fixture_baseline"
+expected_signal = "known_clean_parse"
+
+[[file]]
+path = "fixtures/ast-shadow/typescript/parse-degraded.ts"
+reason = "TypeScript fixture that keeps parse degradation explicit in the candidate corpus"
+category = "fixture_parse_degraded"
+expected_signal = "parse_degraded"
+
+[[file]]
+path = "fixtures/ast-shadow/python/basic.py"
+reason = "Python baseline fixture with imports, one function, and simple control-flow landmarks"
+category = "fixture_baseline"
+expected_signal = "known_clean_parse"
+
+[[file]]
+path = "fixtures/ast-shadow/python/parse-degraded.py"
+reason = "Python fixture that keeps parse degradation explicit in the candidate corpus"
+category = "fixture_parse_degraded"
+expected_signal = "parse_degraded"
+
+[[file]]
 path = "crates/tokmd-analysis/src/ast/rust.rs"
 reason = "Rust AST parser implementation with parser-facing function shapes"
 category = "shadow_implementation"
@@ -33,6 +56,18 @@ path = "crates/tokmd-analysis/src/ast/shadow.rs"
 reason = "AST shadow artifact builder and comparison logic"
 category = "shadow_implementation"
 expected_signal = "artifact_builder_corpus"
+
+[[file]]
+path = "crates/tokmd-analysis/src/ast/typescript.rs"
+reason = "TypeScript AST parser implementation with parser-facing function shapes"
+category = "shadow_implementation"
+expected_signal = "ast_parser_corpus"
+
+[[file]]
+path = "crates/tokmd-analysis/src/ast/python.rs"
+reason = "Python AST parser implementation with parser-facing function shapes"
+category = "shadow_implementation"
+expected_signal = "ast_parser_corpus"
 
 [[file]]
 path = "crates/tokmd-model/src/rows.rs"

--- a/xtask/src/tasks/ast_shadow_compare.rs
+++ b/xtask/src/tasks/ast_shadow_compare.rs
@@ -8,7 +8,7 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Instant;
 use tokmd_analysis::ast::{
     AstLanguage, ShadowFileInput, ShadowLandmark, build_shadow_artifacts, normalize_shadow_path,
-    write_shadow_artifacts,
+    syntax_capability_for_path, write_shadow_artifacts,
 };
 
 const AST_SHADOW_CORPUS_SCHEMA: &str = "tokmd.ast_shadow_corpus.v1";
@@ -33,7 +33,7 @@ fn run_with_root(args: AstShadowCompareArgs, root: &Path) -> Result<()> {
         .iter()
         .map(|input| ShadowFileInput {
             path: input.path.as_str(),
-            language: AstLanguage::Rust,
+            language: input.language,
             source: input.source.as_str(),
             heuristic_landmarks: &input.heuristic_landmarks,
         })
@@ -219,7 +219,7 @@ fn write_timing_json(
         schema: AST_SHADOW_COMPARE_TIMING_SCHEMA,
         schema_version: 1,
         command: "cargo xtask ast-shadow-compare",
-        language: "rust",
+        language: corpus_language_label(inputs),
         corpus: TimingCorpus {
             manifest: args
                 .manifest
@@ -510,6 +510,7 @@ fn summary_display_path(path: &Path, root: &Path) -> Result<String> {
 #[derive(Debug)]
 struct RunnerInput {
     path: String,
+    language: AstLanguage,
     source: String,
     heuristic_landmarks: Vec<ShadowLandmark>,
 }
@@ -571,17 +572,18 @@ fn read_manifest_paths(manifest_path: &Path, root: &Path) -> Result<Vec<PathBuf>
             manifest.schema
         );
     }
-    if manifest.language != "rust" {
+    if manifest.language != "rust" && manifest.language != "multi" {
         bail!(
-            "AST shadow corpus manifest currently supports only Rust, found `{}`",
+            "AST shadow corpus manifest language `{}` must be `rust` or `multi`",
             manifest.language
         );
     }
-    if let Some(extension) = &manifest.rules.supported_extension
+    if manifest.language == "rust"
+        && let Some(extension) = &manifest.rules.supported_extension
         && extension != ".rs"
     {
         bail!(
-            "AST shadow corpus manifest currently supports only `.rs` files, found `{extension}`"
+            "Rust-only AST shadow corpus manifest supports only `.rs` files, found `{extension}`"
         );
     }
     if manifest.file.is_empty() {
@@ -601,7 +603,7 @@ fn read_manifest_paths(manifest_path: &Path, root: &Path) -> Result<Vec<PathBuf>
                     entry.path
                 );
             }
-            validate_repo_relative_rust_path(Path::new(&entry.path), root)
+            validate_repo_relative_source_path(Path::new(&entry.path), root)
                 .with_context(|| format!("validate AST shadow corpus path {}", entry.path))
         })
         .collect()
@@ -617,18 +619,48 @@ fn collect_inputs(paths: &[PathBuf], root: &Path) -> Result<Vec<RunnerInput>> {
 }
 
 fn collect_input(path: &Path, root: &Path) -> Result<RunnerInput> {
-    let rel_path = validate_repo_relative_rust_path(path, root)?;
+    let rel_path = validate_repo_relative_source_path(path, root)?;
     let full_path = root.join(&rel_path);
     let source =
         fs::read_to_string(&full_path).with_context(|| format!("read {}", rel_path.display()))?;
     let normalized = normalize_shadow_path(&rel_path.to_string_lossy());
-    let heuristic_landmarks = heuristic_rust_landmarks(&source);
+    let language = language_for_shadow_path(&normalized)?;
+    let heuristic_landmarks = heuristic_landmarks_for_language(language, &source);
 
     Ok(RunnerInput {
         path: normalized,
+        language,
         source,
         heuristic_landmarks,
     })
+}
+
+fn language_for_shadow_path(path: &str) -> Result<AstLanguage> {
+    syntax_capability_for_path(path)
+        .map(|capability| capability.language)
+        .with_context(|| format!("AST shadow compare does not support file extension: {path}"))
+}
+
+fn heuristic_landmarks_for_language(language: AstLanguage, source: &str) -> Vec<ShadowLandmark> {
+    match language {
+        AstLanguage::Rust => heuristic_rust_landmarks(source),
+        AstLanguage::TypeScript | AstLanguage::Tsx => heuristic_typescript_landmarks(source),
+        AstLanguage::Python => heuristic_python_landmarks(source),
+    }
+}
+
+fn corpus_language_label(inputs: &[RunnerInput]) -> &'static str {
+    let mut languages = inputs
+        .iter()
+        .map(|input| input.language.as_str())
+        .collect::<Vec<_>>();
+    languages.sort_unstable();
+    languages.dedup();
+    if languages.len() <= 1 {
+        languages.first().copied().unwrap_or("rust")
+    } else {
+        "multi"
+    }
 }
 
 fn validate_repo_relative_toml_path(path: &Path, root: &Path) -> Result<PathBuf> {
@@ -675,7 +707,7 @@ fn validate_repo_relative_toml_path(path: &Path, root: &Path) -> Result<PathBuf>
     Ok(path.to_path_buf())
 }
 
-fn validate_repo_relative_rust_path(path: &Path, root: &Path) -> Result<PathBuf> {
+fn validate_repo_relative_source_path(path: &Path, root: &Path) -> Result<PathBuf> {
     if path.is_absolute() {
         bail!(
             "AST shadow input paths must be repo-relative: {}",
@@ -695,9 +727,9 @@ fn validate_repo_relative_rust_path(path: &Path, root: &Path) -> Result<PathBuf>
         );
     }
 
-    if path.extension() != Some(OsStr::new("rs")) {
+    if syntax_capability_for_path(&path.to_string_lossy()).is_none() {
         bail!(
-            "AST shadow compare currently accepts only Rust `.rs` files: {}",
+            "AST shadow compare accepts only parser-backed shadow extensions: {}",
             path.display()
         );
     }
@@ -768,6 +800,154 @@ fn heuristic_rust_landmarks(source: &str) -> Vec<ShadowLandmark> {
     landmarks.sort();
     landmarks.dedup();
     landmarks
+}
+
+fn heuristic_typescript_landmarks(source: &str) -> Vec<ShadowLandmark> {
+    let lines = source.lines().collect::<Vec<_>>();
+    let mut landmarks = Vec::new();
+
+    for (line_index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let line_number = line_index + 1;
+
+        if trimmed.starts_with("import ") {
+            landmarks.push(ShadowLandmark {
+                kind: "import".to_owned(),
+                name: trimmed.split_whitespace().collect::<Vec<_>>().join(" "),
+                start_line: line_number,
+                end_line: line_number,
+            });
+            continue;
+        }
+
+        if let Some(name) = typescript_function_name_from_line(trimmed) {
+            landmarks.push(ShadowLandmark {
+                kind: "function".to_owned(),
+                name,
+                start_line: line_number,
+                end_line: block_end_line(&lines, line_index),
+            });
+        }
+
+        for control_flow in ["if", "for", "while", "switch"] {
+            if contains_token(trimmed, control_flow) {
+                landmarks.push(ShadowLandmark {
+                    kind: "control_flow".to_owned(),
+                    name: control_flow.to_owned(),
+                    start_line: line_number,
+                    end_line: block_end_line(&lines, line_index),
+                });
+            }
+        }
+    }
+
+    landmarks.sort();
+    landmarks.dedup();
+    landmarks
+}
+
+fn typescript_function_name_from_line(line: &str) -> Option<String> {
+    if let Some(index) = find_token(line, "function") {
+        let after = line.get(index + "function".len()..)?.trim_start();
+        let name = after
+            .chars()
+            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+            .collect::<String>();
+        return (!name.is_empty()).then_some(name);
+    }
+
+    if line.contains("=>") {
+        let before = line.split('=').next()?.trim();
+        let name = before
+            .split_whitespace()
+            .next_back()?
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+            .collect::<String>();
+        return (!name.is_empty()).then_some(name);
+    }
+
+    None
+}
+
+fn heuristic_python_landmarks(source: &str) -> Vec<ShadowLandmark> {
+    let lines = source.lines().collect::<Vec<_>>();
+    let mut landmarks = Vec::new();
+
+    for (line_index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let line_number = line_index + 1;
+
+        if trimmed.starts_with("import ") || trimmed.starts_with("from ") {
+            landmarks.push(ShadowLandmark {
+                kind: "import".to_owned(),
+                name: trimmed.split_whitespace().collect::<Vec<_>>().join(" "),
+                start_line: line_number,
+                end_line: line_number,
+            });
+            continue;
+        }
+
+        if let Some(name) = python_function_name_from_line(trimmed) {
+            landmarks.push(ShadowLandmark {
+                kind: "function".to_owned(),
+                name,
+                start_line: line_number,
+                end_line: python_block_end_line(&lines, line_index),
+            });
+        }
+
+        if trimmed.ends_with(':') {
+            for control_flow in ["if", "for", "while", "match"] {
+                if contains_token(trimmed, control_flow) {
+                    landmarks.push(ShadowLandmark {
+                        kind: "control_flow".to_owned(),
+                        name: control_flow.to_owned(),
+                        start_line: line_number,
+                        end_line: python_block_end_line(&lines, line_index),
+                    });
+                }
+            }
+        }
+    }
+
+    landmarks.sort();
+    landmarks.dedup();
+    landmarks
+}
+
+fn python_function_name_from_line(line: &str) -> Option<String> {
+    let def_start = find_token(line, "def")?;
+    let after_def = line.get(def_start + 3..)?.trim_start();
+    let name = after_def
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+        .collect::<String>();
+    (!name.is_empty()).then_some(name)
+}
+
+fn python_block_end_line(lines: &[&str], start: usize) -> usize {
+    let Some(start_line) = lines.get(start) else {
+        return start.saturating_add(1);
+    };
+    let base_indent = start_line
+        .len()
+        .saturating_sub(start_line.trim_start().len());
+    let mut last_content = start;
+
+    for (index, line) in lines.iter().enumerate().skip(start + 1) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len().saturating_sub(line.trim_start().len());
+        if indent <= base_indent {
+            return last_content + 1;
+        }
+        last_content = index;
+    }
+
+    last_content + 1
 }
 
 fn collect_use_end_line(lines: &[&str], start: usize) -> usize {
@@ -859,7 +1039,7 @@ mod tests {
     fn rejects_absolute_paths() {
         let root = tempfile::tempdir().expect("tempdir");
         let absolute = root.path().join("src/lib.rs");
-        let error = validate_repo_relative_rust_path(&absolute, root.path())
+        let error = validate_repo_relative_source_path(&absolute, root.path())
             .expect_err("absolute paths should be rejected");
 
         assert!(error.to_string().contains("repo-relative"));
@@ -868,21 +1048,25 @@ mod tests {
     #[test]
     fn rejects_parent_paths() {
         let root = tempfile::tempdir().expect("tempdir");
-        let error = validate_repo_relative_rust_path(Path::new("../lib.rs"), root.path())
+        let error = validate_repo_relative_source_path(Path::new("../lib.rs"), root.path())
             .expect_err("parent paths should be rejected");
 
         assert!(error.to_string().contains("inside the repo"));
     }
 
     #[test]
-    fn rejects_non_rust_paths() -> Result<()> {
+    fn rejects_unsupported_extensions() -> Result<()> {
         let root = tempfile::tempdir()?;
         fs::write(root.path().join("README.md"), "# docs\n")?;
 
-        let error = validate_repo_relative_rust_path(Path::new("README.md"), root.path())
-            .expect_err("non-Rust paths should be rejected");
+        let error = validate_repo_relative_source_path(Path::new("README.md"), root.path())
+            .expect_err("unsupported extensions should be rejected");
 
-        assert!(error.to_string().contains("`.rs` files"));
+        assert!(
+            error
+                .to_string()
+                .contains("parser-backed shadow extensions")
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Publication import of tokmd-swarm work through AST shadow corpus expansion for TypeScript and Python (swarm PR #372).

- Expands `policy/ast-shadow-corpus.toml` to multi-language fixtures (Rust, TS, Python)
- Promotes `cargo xtask ast-shadow-compare` / `ast-shadow-check` to handle TS/Python parser-backed shadow comparison
- Completes final item in `docs/plans/ast-productization.md`

## Swarm provenance

- Swarm-Head: `a47ad9c3f6e5ac25c66f81a18544123e87a3e2c4`
- Swarm-Range: `cc1ca788..a47ad9c3`
- Swarm PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/372

## Test plan

- [ ] Publication CI green
- [ ] Merge with **merge commit** (not squash)
- [ ] Fast-forward `tokmd-swarm/main` to publication merge commit
- [ ] `cargo xtask repo-graph --publication publication/main --swarm origin/main --expect aligned`

## Claim boundary

Shadow-only developer evidence; no default receipt/CLI/schema change. Does not prove public function-boundary promotion or browser/WASM AST.
