### PR TITLE
merge(swarm): import archive module/export receipt parity

### DIFF
--- a/crates/tokmd-core/src/workflows/mod.rs
+++ b/crates/tokmd-core/src/workflows/mod.rs
@@ -32,5 +32,5 @@ pub use timing::{
 
 pub(crate) use support::{
     collect_pure_in_memory_rows, deterministic_in_memory_scan_options, scan_paths_or_current_dir,
-    settings_to_scan_options, strip_virtual_export_prefix,
+    settings_to_scan_options, single_scan_root_strip_prefix, strip_virtual_export_prefix,
 };

--- a/crates/tokmd-core/src/workflows/module.rs
+++ b/crates/tokmd-core/src/workflows/module.rs
@@ -9,7 +9,7 @@ use crate::{InMemoryFile, build_module_receipt};
 
 use super::{
     collect_pure_in_memory_rows, deterministic_in_memory_scan_options, scan_paths_or_current_dir,
-    settings_to_scan_options,
+    settings_to_scan_options, single_scan_root_strip_prefix,
 };
 
 /// Runs the module summary workflow with pure settings types.
@@ -40,10 +40,18 @@ use super::{
 pub fn module_workflow(scan: &ScanSettings, module: &ModuleSettings) -> Result<ModuleReceipt> {
     let scan_opts = settings_to_scan_options(scan);
     let paths = scan_paths_or_current_dir(scan);
+    let strip_prefix = single_scan_root_strip_prefix(&paths);
 
     let languages = tokmd_scan::scan(&paths, &scan_opts)?;
-    let report = tokmd_model::create_module_report(
+    let file_rows = tokmd_model::collect_file_rows(
         &languages,
+        &module.module_roots,
+        module.module_depth,
+        module.children,
+        strip_prefix,
+    );
+    let report = tokmd_model::create_module_report_from_rows(
+        &file_rows,
         &module.module_roots,
         module.module_depth,
         module.children,

--- a/crates/tokmd-core/src/workflows/support.rs
+++ b/crates/tokmd-core/src/workflows/support.rs
@@ -23,6 +23,16 @@ pub(crate) fn scan_paths_or_current_dir(scan: &ScanSettings) -> Vec<PathBuf> {
     }
 }
 
+/// When exactly one scan root is provided, strip it from host file paths before
+/// module-key aggregation so single-root scans match archive/virtual relative paths.
+pub(crate) fn single_scan_root_strip_prefix(paths: &[PathBuf]) -> Option<&Path> {
+    if paths.len() == 1 {
+        paths.first().map(|path| path.as_path())
+    } else {
+        None
+    }
+}
+
 pub(crate) fn deterministic_in_memory_scan_options(scan_opts: &ScanOptions) -> ScanOptions {
     let mut effective = scan_opts.clone();
     // Explicit in-memory inputs are authoritative; they should not depend on
@@ -79,6 +89,17 @@ pub(crate) fn strip_virtual_export_prefix(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn single_scan_root_strip_prefix_uses_only_root() {
+        let one = vec![PathBuf::from("/repo")];
+        assert_eq!(
+            single_scan_root_strip_prefix(&one),
+            Some(Path::new("/repo"))
+        );
+        let many = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        assert_eq!(single_scan_root_strip_prefix(&many), None);
+    }
 
     #[test]
     fn settings_to_scan_options_preserves_values() {

--- a/crates/tokmd-core/tests/archive_host_receipt_parity.rs
+++ b/crates/tokmd-core/tests/archive_host_receipt_parity.rs
@@ -16,11 +16,13 @@
 //!   match the equivalent `{ path, text }` in-memory inputs, but both sides run
 //!   the in-memory workflow; neither is a host filesystem scan.
 //!
-//! This oracle closes that gap. It scans an extracted fixture through the host
-//! workflow (`lang_workflow`) and the equivalent ZIP through the archive
-//! workflow (`inputs_from_zip_bytes` + `lang_workflow_from_inputs`) and asserts
-//! the aggregated `LangReport` — rows plus totals, **including the model-layer
-//! `bytes` and `tokens`** — is byte-for-byte identical.
+//! This oracle closes that gap for `lang`, `module`, and `export` receipts. It
+//! scans an extracted fixture through the host workflow and the equivalent ZIP
+//! through the archive workflow (`inputs_from_zip_bytes` + `*_workflow_from_inputs`)
+//! and asserts the aggregated reports are byte-for-byte identical. Host `module`
+//! scans strip a single scan root automatically; host `export` scans use
+//! `strip_prefix` equal to the materialized fixture root so paths align with
+//! archive-relative virtual paths.
 //!
 //! Out of scope (intentionally not asserted here): per-file path strings (host
 //! paths are temp-rooted, the language-level report is path-independent), the
@@ -32,8 +34,9 @@ use std::fs;
 use std::io::{Cursor, Write};
 
 use tokmd_core::{
-    InMemoryFile, lang_workflow, lang_workflow_from_inputs,
-    settings::{LangSettings, ScanOptions, ScanSettings},
+    InMemoryFile, export_workflow, export_workflow_from_inputs, lang_workflow,
+    lang_workflow_from_inputs, module_workflow, module_workflow_from_inputs,
+    settings::{ExportSettings, LangSettings, ModuleSettings, ScanOptions, ScanSettings},
 };
 use tokmd_scan::{ArchiveLimits, inputs_from_zip_bytes};
 use tokmd_types::ConfigMode;
@@ -82,30 +85,9 @@ fn fixture_zip() -> Result<Vec<u8>, BoxedError> {
 #[test]
 fn archive_lang_report_matches_host_lang_report() -> Result<(), BoxedError> {
     let lang = LangSettings::default();
-
-    // Host path: materialize the fixture on disk and scan via the host
-    // workflow (`tokmd_scan::scan` + `tokmd_model::create_lang_report`).
-    let dir = tempfile::tempdir()?;
-    for (rel, contents) in FIXTURE {
-        let full = dir.path().join(rel);
-        if let Some(parent) = full.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(full, contents)?;
-    }
-    let host_scan = ScanSettings {
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        options: parity_scan_options(),
-    };
+    let (_dir, host_scan) = materialize_fixture_host_scan()?;
     let host = lang_workflow(&host_scan, &lang)?;
-
-    // Archive path: pack the same fixture into a ZIP, admit it fail-closed into
-    // the snapshot input set, and run the in-memory workflow
-    // (`tokmd_model::create_lang_report_from_rows`).
-    let bytes = fixture_zip()?;
-    let inputs: Vec<InMemoryFile> =
-        inputs_from_zip_bytes("repo", &bytes, &ArchiveLimits::default())?;
-    let archive = lang_workflow_from_inputs(&inputs, &parity_scan_options(), &lang)?;
+    let archive = lang_workflow_from_inputs(&archive_inputs()?, &parity_scan_options(), &lang)?;
 
     // Sanity: the fixture really exercised the model layer (bytes + tokens) and
     // more than one language, so the comparison below is not vacuous.
@@ -129,4 +111,87 @@ fn archive_lang_report_matches_host_lang_report() -> Result<(), BoxedError> {
         "archive-backed LangReport diverged from the host LangReport"
     );
     Ok(())
+}
+
+#[test]
+fn archive_module_report_matches_host_module_report() -> Result<(), BoxedError> {
+    let module = ModuleSettings::default();
+    let (_dir, host_scan) = materialize_fixture_host_scan()?;
+    let host = module_workflow(&host_scan, &module)?;
+
+    let inputs = archive_inputs()?;
+    let archive = module_workflow_from_inputs(&inputs, &parity_scan_options(), &module)?;
+
+    assert!(
+        host.report.rows.len() >= 2,
+        "fixture should produce multiple modules: {:?}",
+        host.report.rows
+    );
+    assert!(
+        host.report.total.bytes > 0,
+        "host report should carry model-layer byte totals"
+    );
+
+    assert_eq!(
+        serde_json::to_value(&host.report)?,
+        serde_json::to_value(&archive.report)?,
+        "archive-backed ModuleReport diverged from the host ModuleReport"
+    );
+    Ok(())
+}
+
+#[test]
+fn archive_export_report_matches_host_export_report() -> Result<(), BoxedError> {
+    let (_dir, host_scan) = materialize_fixture_host_scan()?;
+    let strip = _dir.path().to_string_lossy().into_owned();
+    let export = ExportSettings {
+        strip_prefix: Some(strip),
+        ..Default::default()
+    };
+    let host = export_workflow(&host_scan, &export)?;
+
+    let inputs = archive_inputs()?;
+    let archive = export_workflow_from_inputs(&inputs, &parity_scan_options(), &export)?;
+
+    assert!(
+        host.data.rows.len() >= 2,
+        "fixture should produce multiple file rows: {:?}",
+        host.data.rows
+    );
+    assert!(
+        host.data.rows.iter().any(|row| row.bytes > 0),
+        "host export rows should carry model-layer byte totals"
+    );
+
+    assert_eq!(
+        serde_json::to_value(&host.data)?,
+        serde_json::to_value(&archive.data)?,
+        "archive-backed ExportData diverged from the host ExportData"
+    );
+    Ok(())
+}
+
+fn materialize_fixture_host_scan() -> Result<(tempfile::TempDir, ScanSettings), BoxedError> {
+    let dir = tempfile::tempdir()?;
+    for (rel, contents) in FIXTURE {
+        let full = dir.path().join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(full, contents)?;
+    }
+    let scan = ScanSettings {
+        paths: vec![dir.path().to_string_lossy().into_owned()],
+        options: parity_scan_options(),
+    };
+    Ok((dir, scan))
+}
+
+fn archive_inputs() -> Result<Vec<InMemoryFile>, BoxedError> {
+    let bytes = fixture_zip()?;
+    Ok(inputs_from_zip_bytes(
+        "repo",
+        &bytes,
+        &ArchiveLimits::default(),
+    )?)
 }

--- a/docs/specs/repo-snapshot.md
+++ b/docs/specs/repo-snapshot.md
@@ -265,9 +265,11 @@ implemented:
   receipt as scanning the equivalent extracted tree through `HostFs`. The
   tokei-`Languages` inventory layer of this is covered by
   `crates/tokmd-scan/tests/archive_scan_parity.rs`; the full tokmd
-  `LangReport` (including the `tokmd-model` byte and token totals) is anchored
-  to a host filesystem scan by
-  `crates/tokmd-core/tests/archive_host_receipt_parity.rs`.
+  `LangReport`, `ModuleReport`, and `ExportData` receipts (including the
+  `tokmd-model` byte and token totals) are anchored to a host filesystem scan
+  by `crates/tokmd-core/tests/archive_host_receipt_parity.rs`. Host `module`
+  scans auto-strip a single scan root; host `export` parity uses explicit
+  `strip_prefix` matching the fixture root.
 - Fail-closed semantics: a single rejected entry fails the whole snapshot build
   rather than silently dropping the entry and reporting `complete`.
 

--- a/docs/specs/wasm-ffi-byte-mode.md
+++ b/docs/specs/wasm-ffi-byte-mode.md
@@ -159,10 +159,14 @@ capability promotion.
   tests in the same file. Broader hostile-fixture coverage
   (absolute/drive-prefix/NUL/non-regular) is already proven at the admission
   engine in `crates/tokmd-io-port`.
-- Byte/host parity (PENDING): scanning a benign archive fixture through the byte
-  mode must yield the same normalized file set and aggregated receipt as
-  scanning the equivalent extracted tree through the host path, reusing the
-  parity oracle the snapshot seam defines.
+- Byte/host parity (MET, lang/module/export): scanning a benign archive fixture
+  through the byte mode must yield the same normalized file set and aggregated
+  receipt as scanning the equivalent extracted tree through the host path,
+  reusing the parity oracle the snapshot seam defines. Covered by
+  `archive_lang_report_matches_host_lang_report`,
+  `archive_module_report_matches_host_module_report`, and
+  `archive_export_report_matches_host_export_report` in
+  `crates/tokmd-core/tests/archive_host_receipt_parity.rs`.
 - WASM boundary coverage (MET): a `wasm-bindgen-test` exercises the
   `Uint8Array` binding end to end and asserts the browser payload matches the
   core payload, in the same style as the existing boundary tests in


### PR DESCRIPTION
## Summary

Publication import of tokmd-swarm portable-core archive parity work (swarm PR #373).

- Extends `archive_host_receipt_parity` with module and export receipt oracles
- Auto-strips a single scan root in `module_workflow` for host/archive module-key alignment
- Updates `docs/specs/repo-snapshot.md` and `docs/specs/wasm-ffi-byte-mode.md` proof obligations

## Swarm provenance

- Swarm-Head: `f895826b5df841becc7c065aefc611df3e3d5ff3`
- Swarm-Range: `18e113eb..f895826b`
- Swarm PR: https://github.com/EffortlessMetrics/tokmd-swarm/pull/373

## Test plan

- [ ] Publication CI green
- [ ] Merge with **merge commit** (not squash)
- [ ] Fast-forward `tokmd-swarm/main` to publication merge commit
- [ ] `cargo xtask repo-graph --publication publication/main --swarm origin/main --expect aligned`

## Claim boundary

Proof/oracle + narrow `module_workflow` path normalization only. No schema bump, no release mutation, no default receipt behavior change beyond single-root module scans via `tokmd-core`.