### PR TITLE
fuzzer: add deterministic fuzz regression test for CLI parser invalid UTF-8 🌪️

### DIFF
--- a/.jules/runs/run-fuzzer-001/decision.md
+++ b/.jules/runs/run-fuzzer-001/decision.md
@@ -1,0 +1,25 @@
+# Fuzzer Decision: CLI Input Hardening
+
+## Background
+The Fuzzer persona is tasked with improving input hardening or fuzzability, particularly around parser/config/input surfaces. I surveyed the `interfaces` shard (crates/tokmd-config, crates/tokmd-core, crates/tokmd).
+
+Fuzzing tooling (`cargo fuzz`) is not available in the environment, so the gate profile and runbook dictate providing deterministic regressions extracted from fuzzable surfaces.
+
+I found a property test suite for the CLI parser (`crates/tokmd/tests/cli_parser_properties.rs`). This suite explicitly states that the `tokmd::cli::Cli` parser should *never panic when fed arbitrary string arguments*.
+
+I created a deterministic regression test (`crates/tokmd/tests/cli_parser_fuzz_regression.rs`) mimicking a fuzzing mutation: feeding invalid UTF-8 bytes to an argument expecting valid strings (e.g. `--exclude`). The test verifies that `clap` handles this safely by rejecting it with an `ErrorKind::InvalidUtf8` rather than crashing/panicking. This directly serves the `fuzz` gate profile and Fuzzer persona's goal of locking in deterministic proof of parser input hardening.
+
+## Option A (Recommended)
+Land the deterministic regression test for the CLI parser demonstrating safe rejection of invalid UTF-8 byte arrays, expanding the property test suite's coverage of input hardening.
+
+*   **Structure:** Minimal disruption. Fits neatly alongside existing property tests.
+*   **Velocity:** Fast. The test works, proves safe rejection of fuzzed/malformed inputs, and does not require changes to core code (since clap handles this).
+*   **Governance:** Perfectly aligns with the `fuzz` profile fallback expectations.
+
+## Option B
+Attempt to implement manual fuzzer stubs (e.g., AFL, libfuzzer-sys manually).
+
+*   **Trade-offs:** High friction, violates instructions (cargo-fuzz is unsupported, do not fix it), high chance of build errors.
+
+## Decision
+Option A. It's safe, proven, and explicitly meets the Fuzzer requirements to provide deterministic input hardening proof when fuzzers are unavailable.

--- a/.jules/runs/run-fuzzer-001/envelope.json
+++ b/.jules/runs/run-fuzzer-001/envelope.json
@@ -1,0 +1,13 @@
+{
+  "prompt_id": "fuzzer_input_hardening",
+  "persona": "Fuzzer",
+  "style": "Prover",
+  "primary_shard": "interfaces",
+  "allowed_paths": [
+    "crates/tokmd-settings/**",
+    "crates/tokmd-core/**",
+    "crates/tokmd/**"
+  ],
+  "gate_profile": "fuzz",
+  "allowed_outcomes": ["proof-improvement patch", "PR-ready patch", "learning PR"]
+}

--- a/.jules/runs/run-fuzzer-001/pr_body.md
+++ b/.jules/runs/run-fuzzer-001/pr_body.md
@@ -1,0 +1,51 @@
+## 💡 Summary
+Added a deterministic fuzzer regression test for the CLI parser to prove safe handling of invalid UTF-8 inputs. This expands the input hardening guarantees without needing `cargo fuzz`.
+
+## 🎯 Why
+The Fuzzer persona is tasked with improving input hardening and fuzzability of interface surfaces. Since `cargo fuzz` is unavailable in the environment, we must lock in deterministic behavior for fuzzed/malformed inputs. We want to guarantee that feeding arbitrary malformed byte sequences (like invalid UTF-8 in OsString) to string-expecting CLI arguments (e.g., `--exclude`) safely returns a parser error rather than causing a panic.
+
+## 🔎 Evidence
+- `crates/tokmd/tests/cli_parser_properties.rs` (Existing property tests proving parser safety)
+- The newly created `cli_parser_fuzz_regression` test confirms that providing `[0x66, 0x6f, 0x80, 0x6f]` to `--exclude` correctly yields a clap `InvalidUtf8` error without crashing.
+- `cargo test --test cli_parser_fuzz_regression` succeeds.
+
+## 🧭 Options considered
+### Option A (recommended)
+- Land the deterministic regression test for the CLI parser demonstrating safe rejection of invalid UTF-8.
+- Fits the repo and shard by reinforcing `crates/tokmd/tests` interface guarantees.
+- trade-offs: Structure (clean), Velocity (fast), Governance (satisfies fuzz fallback expectations).
+
+### Option B
+- Attempt to implement manual fuzzer stubs (e.g., libfuzzer-sys).
+- when to choose it instead: If fuzzing infrastructure was natively supported and reliable.
+- trade-offs: High friction, likely build errors.
+
+## ✅ Decision
+Option A. It's safe, proven, and explicitly meets the Fuzzer requirements to provide deterministic input hardening proof when fuzzers are unavailable.
+
+## 🧱 Changes made (SRP)
+- `crates/tokmd/tests/cli_parser_fuzz_regression.rs`
+
+## 🧪 Verification receipts
+```text
+$ CI=true cargo test --test cli_parser_fuzz_regression --verbose
+running 1 test
+test cli_parser_fuzz_regression_invalid_utf8 ... ok
+```
+
+## 🧭 Telemetry
+- Change shape: Test addition
+- Blast radius: None (tests only)
+- Risk class: Low - pure proof improvement.
+- Rollback: Revert test file.
+- Gates run: `CI=true cargo test --verbose`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`
+
+## 🗂️ .jules artifacts
+- `.jules/runs/run-fuzzer-001/envelope.json`
+- `.jules/runs/run-fuzzer-001/decision.md`
+- `.jules/runs/run-fuzzer-001/receipts.jsonl`
+- `.jules/runs/run-fuzzer-001/result.json`
+- `.jules/runs/run-fuzzer-001/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/run-fuzzer-001/receipts.jsonl
+++ b/.jules/runs/run-fuzzer-001/receipts.jsonl
@@ -1,0 +1,2 @@
+{"command": "cargo test --test cli_parser_properties", "status": "success", "note": "Verified existing property test suite for CLI"}
+{"command": "cargo test --test cli_parser_fuzz_regression", "status": "success", "note": "Proved safe rejection of invalid UTF-8 without panicking"}

--- a/.jules/runs/run-fuzzer-001/result.json
+++ b/.jules/runs/run-fuzzer-001/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "success",
+  "patch_type": "proof-improvement",
+  "decision": "Option A"
+}

--- a/crates/tokmd/tests/cli_parser_fuzz_regression.rs
+++ b/crates/tokmd/tests/cli_parser_fuzz_regression.rs
@@ -1,0 +1,28 @@
+use clap::Parser;
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+use tokmd::cli::Cli;
+
+#[test]
+fn cli_parser_fuzz_regression_invalid_utf8() {
+    #[cfg(unix)]
+    {
+        // An invalid UTF-8 byte sequence
+        let invalid_utf8 = OsString::from_vec(vec![0x66, 0x6f, 0x80, 0x6f]);
+        // The parser should safely reject the invalid UTF-8 without panicking
+        // Since `lang` subcommand paths argument allows invalid UTF-8 (via PathBuf),
+        // we test a flag that requires string validation instead (e.g., --exclude)
+        let result = Cli::try_parse_from(vec![
+            OsString::from("tokmd"),
+            OsString::from("--exclude"),
+            invalid_utf8,
+        ]);
+        assert!(
+            result.is_err(),
+            "Parser should safely reject invalid UTF-8 without panicking"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidUtf8);
+    }
+}


### PR DESCRIPTION
## 💡 Summary 
Added a deterministic fuzzer regression test for the CLI parser to prove safe handling of invalid UTF-8 inputs. This expands the input hardening guarantees without needing `cargo fuzz`.

## 🎯 Why 
The Fuzzer persona is tasked with improving input hardening and fuzzability of interface surfaces. Since `cargo fuzz` is unavailable in the environment, we must lock in deterministic behavior for fuzzed/malformed inputs. We want to guarantee that feeding arbitrary malformed byte sequences (like invalid UTF-8 in OsString) to string-expecting CLI arguments (e.g., `--exclude`) safely returns a parser error rather than causing a panic.

## 🔎 Evidence 
- `crates/tokmd/tests/cli_parser_properties.rs` (Existing property tests proving parser safety)
- The newly created `cli_parser_fuzz_regression` test confirms that providing `[0x66, 0x6f, 0x80, 0x6f]` to `--exclude` correctly yields a clap `InvalidUtf8` error without crashing.
- `cargo test --test cli_parser_fuzz_regression` succeeds.

## 🧭 Options considered 
### Option A (recommended) 
- Land the deterministic regression test for the CLI parser demonstrating safe rejection of invalid UTF-8.
- Fits the repo and shard by reinforcing `crates/tokmd/tests` interface guarantees.
- trade-offs: Structure (clean), Velocity (fast), Governance (satisfies fuzz fallback expectations).

### Option B 
- Attempt to implement manual fuzzer stubs (e.g., libfuzzer-sys).
- when to choose it instead: If fuzzing infrastructure was natively supported and reliable.
- trade-offs: High friction, likely build errors.

## ✅ Decision 
Option A. It's safe, proven, and explicitly meets the Fuzzer requirements to provide deterministic input hardening proof when fuzzers are unavailable.

## 🧱 Changes made (SRP) 
- `crates/tokmd/tests/cli_parser_fuzz_regression.rs`

## 🧪 Verification receipts 
```text
$ CI=true cargo test --test cli_parser_fuzz_regression --verbose
running 1 test
test cli_parser_fuzz_regression_invalid_utf8 ... ok
```

## 🧭 Telemetry 
- Change shape: Test addition
- Blast radius: None (tests only)
- Risk class: Low - pure proof improvement.
- Rollback: Revert test file.
- Gates run: `CI=true cargo test --verbose`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`

## 🗂️ .jules artifacts 
- `.jules/runs/run-fuzzer-001/envelope.json`
- `.jules/runs/run-fuzzer-001/decision.md`
- `.jules/runs/run-fuzzer-001/receipts.jsonl`
- `.jules/runs/run-fuzzer-001/result.json`
- `.jules/runs/run-fuzzer-001/pr_body.md`

## 🔜 Follow-ups 
None.

---
*PR created automatically by Jules for task [17451022193359502164](https://jules.google.com/task/17451022193359502164) started by @EffortlessSteven*