### PR TITLE
palette: validate positive git max commits in analyze and badge commands 🎨

### DIFF
--- a/.jules/runs/palette_runtime_dx/decision.md
+++ b/.jules/runs/palette_runtime_dx/decision.md
@@ -1,16 +1,16 @@
-## 💡 Options A and B
+## Target Selection
+I noticed that the `--max-commits` and `--max-commit-files` arguments for `tokmd analyze` and `tokmd badge` commands lacked validation. While `tokmd context` correctly used `value_parser = super::validate::positive_usize` to prevent a degenerate zero value, `analyze` and `badge` did not, allowing `0` to silently perform no git history scanning or to exit with a non-obvious error deeper down.
 
-### Option A: Improve error message formatting and guidance for Unrecognized subcommand
-- The current message is:
-  `Error: Unrecognized subcommand 'abc'`
-  `Hints:`
-  `- Verify the input path exists and is readable.`
-  `- Use an absolute path to avoid working-directory confusion.`
-- The hints are confusing because they refer to paths, not subcommands. The subcommand logic was added as a fallback to catch mis-parsed subcommands vs paths.
-- I will improve the hint to include listing available subcommands via `tokmd --help` instead of showing path hints when it is definitively interpreted as a subcommand.
+## Options considered
+### Option A (recommended)
+- Add `value_parser = super::validate::positive_usize` to `max_commits` and `max_commit_files` in `crates/tokmd/src/cli/parser/analysis.rs` and `crates/tokmd/src/cli/parser/badge.rs`.
+- Why it fits this repo and shard: It directly improves the runtime developer experience by catching invalid CLI usage (0 commits) at parse time with a clear error message, matching the behavior already implemented for `tokmd context`. It is within the `interfaces` shard (specifically `crates/tokmd/src/cli/parser`).
+- Trade-offs: Small structure change for improved velocity and clarity for end-users.
 
-### Option B: Fix enum value validation error messages
-- `error: invalid value 'xyz' for '--format <FORMAT>'` could provide better hints on how to list all options.
-- This is primarily handled by clap, so changing it might be more involved.
+### Option B
+- Modify the git scanning logic to treat `0` as an error or a no-op instead of validating at the CLI boundary.
+- When to choose it instead: If CLI validation is impossible or if 0 should be a valid configuration value with special semantic meaning.
+- Trade-offs: Poorer UX since the error is delayed and might not attribute directly to the command line argument. It also deviates from the established pattern in `validate.rs`.
 
-Decision: Option A.
+## Decision
+I chose Option A because it provides immediate, clear feedback to the user at the CLI parsing stage, preventing silent failures or confusing downstream errors. This perfectly aligns with the Palette persona's goal of improving runtime developer experience and fixing CLI help/usage sharp edges.

--- a/.jules/runs/palette_runtime_dx/envelope.json
+++ b/.jules/runs/palette_runtime_dx/envelope.json
@@ -1,7 +1,7 @@
 {
   "prompt_id": "palette_runtime_dx",
-  "persona": "palette",
-  "style": "builder",
+  "persona": "Palette",
+  "style": "Builder",
   "primary_shard": "interfaces",
   "allowed_paths": [
     "crates/tokmd-config/**",
@@ -12,5 +12,8 @@
     "crates/tokmd/tests/**"
   ],
   "gate_profile": "core-rust",
-  "allowed_outcomes": ["pr-ready patch", "learning pr"]
+  "allowed_outcomes": [
+    "PR-ready patch",
+    "learning PR"
+  ]
 }

--- a/.jules/runs/palette_runtime_dx/pr_body.md
+++ b/.jules/runs/palette_runtime_dx/pr_body.md
@@ -1,82 +1,43 @@
 ## 💡 Summary
-Improves the error message hint when an unrecognized subcommand is provided. Instead of giving path-related hints (like "Verify the input path exists"), it now correctly suggests running `tokmd --help` to list available subcommands.
+Added parse-time validation to `--max-commits` and `--max-commit-files` in `tokmd analyze` and `tokmd badge` to reject zero values.
 
 ## 🎯 Why
-When users mis-type a subcommand (and it's not close enough for the "Did you mean?" fuzzy matching), the CLI falls back to treating it as a bad path and displays path-related hints:
-```
-Error: Unrecognized subcommand 'abc'
-
-Hints:
-- Verify the input path exists and is readable.
-- Use an absolute path to avoid working-directory confusion.
-```
-This is confusing because the error clearly states it was parsed as a subcommand. This change ensures that when the parser definitively interprets the input as a bad subcommand, it provides a relevant hint to check the help menu.
+Previously, passing `--max-commits 0` to `analyze` or `badge` was allowed by the CLI parser, but it would either silently do nothing or cause confusing errors downstream. `tokmd context` already used `value_parser = super::validate::positive_usize` to catch this at parse time. This change brings `analyze` and `badge` in line with that pattern, providing a clear error message to the user immediately.
 
 ## 🔎 Evidence
-Before:
-```bash
-$ cargo run --bin tokmd -- abc
-Error: Unrecognized subcommand 'abc'
-
-Hints:
-- Verify the input path exists and is readable.
-- Use an absolute path to avoid working-directory confusion.
-```
-
-After:
-```bash
-$ cargo run --bin tokmd -- abc
-Error: Unrecognized subcommand 'abc'
-
-Hints:
-- Run `tokmd --help` to see a list of available subcommands.
-```
+- `crates/tokmd/src/cli/parser/analysis.rs`
+- `crates/tokmd/src/cli/parser/badge.rs`
+- Passing `--max-commits 0` now produces a helpful parse error.
 
 ## 🧭 Options considered
 ### Option A (recommended)
-- Update `error_hints.rs` to detect when a bare string without path separators is definitively treated as an unrecognized subcommand and return a hint pointing to `--help`, skipping the path-related hints.
-- Why it fits: Directly fixes the confusing output with minimal code changes. Preserves "Did you mean?" suggestions for typos and path-related hints for actual paths.
-- Trade-offs: Low risk, high value DX improvement.
+- Add `value_parser = super::validate::positive_usize` to the clap arguments.
+- Matches existing repo patterns (`context.rs`), keeps errors at the system boundary, and provides excellent DX.
+- Trade-offs: Small codebase addition for high user value.
 
 ### Option B
-- Modify clap's parsing to completely separate path arguments from subcommands so they never fall back to each other.
-- When to choose it instead: If the CLI syntax allowed strict positional separation of paths vs subcommands.
-- Trade-offs: High risk. Would require restructuring the CLI syntax and breaking backwards compatibility.
+- Handle `0` deep in the git scanning logic.
+- Delays the error, making it harder for the user to understand which flag caused the problem.
 
 ## ✅ Decision
-Option A was chosen because it directly addresses the confusing output at the point of error formatting, preserving the flexible CLI syntax while significantly improving the user experience for simple mistakes.
+Option A. It's the standard clap way to handle this and aligns perfectly with the goal of improving CLI ergonomics and error messaging.
 
 ## 🧱 Changes made (SRP)
-- `crates/tokmd/src/error_hints.rs`: Updated `suggestions` function to return an early hint `Run \`tokmd --help\` to see a list of available subcommands.` when an unrecognized subcommand is detected and no fuzzy match is found. Updated tests to reflect the new hint.
+- `crates/tokmd/src/cli/parser/analysis.rs`
+- `crates/tokmd/src/cli/parser/badge.rs`
 
 ## 🧪 Verification receipts
 ```text
-$ cargo run --bin tokmd -- abc
-Error: Unrecognized subcommand 'abc'
-
-Hints:
-- Run `tokmd --help` to see a list of available subcommands.
-
-$ cargo run --bin tokmd -- anolyze
-Error: Unrecognized subcommand 'anolyze'
-
-Hints:
-- Did you mean the subcommand `analyze`?
-
-$ cargo run --bin tokmd -- missing/path/to/file
-Error: Path not found: missing/path/to/file
-
-Hints:
-- Verify the input path exists and is readable.
-- Use an absolute path to avoid working-directory confusion.
+$ bash -c "cargo run --bin tokmd -- analyze --max-commits 0"
+error: invalid value '0' for '--max-commits <MAX_COMMITS>': value must be at least 1
 ```
 
 ## 🧭 Telemetry
-- Change shape: Logic modification
-- Blast radius: Output wording
-- Risk class: Low - Only affects error message formatting
-- Rollback: Revert `error_hints.rs` changes
-- Gates run: `core-rust` (cargo build, CI=true cargo test, cargo fmt, cargo clippy)
+- Change shape: CLI argument validation tightening.
+- Blast radius: Low. Only affects users who were passing invalid `0` values to these specific flags.
+- Risk class: Low.
+- Rollback: Revert the added `value_parser` attributes.
+- Gates run: `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`.
 
 ## 🗂️ .jules artifacts
 - `.jules/runs/palette_runtime_dx/envelope.json`

--- a/.jules/runs/palette_runtime_dx/result.json
+++ b/.jules/runs/palette_runtime_dx/result.json
@@ -1,4 +1,20 @@
 {
-  "status": "success",
-  "outcome": "pr-ready patch"
+  "outcome_type": "patch",
+  "reviewer_facing_title": "palette: validate positive git max commits in analyze and badge commands 🎨",
+  "summary": "Added parse-time validation to `--max-commits` and `--max-commit-files` in `tokmd analyze` and `tokmd badge` to reject zero values, matching the behavior of `tokmd context`.",
+  "target_paths": [
+    "crates/tokmd/src/cli/parser/analysis.rs",
+    "crates/tokmd/src/cli/parser/badge.rs"
+  ],
+  "proof_summary": "Attempting to pass `--max-commits 0` now correctly fails with a clap error: `error: invalid value '0' for '--max-commits <MAX_COMMITS>': value must be at least 1`.",
+  "gates_run": [
+    "cargo build",
+    "cargo test -p tokmd",
+    "cargo fmt -- --check",
+    "cargo clippy -- -D warnings"
+  ],
+  "friction_items_created": [],
+  "persona_notes_created": [],
+  "rollback": "Revert changes to `analysis.rs` and `badge.rs`.",
+  "follow_ups": []
 }

--- a/crates/tokmd/src/cli/parser/analysis.rs
+++ b/crates/tokmd/src/cli/parser/analysis.rs
@@ -51,11 +51,11 @@ pub struct CliAnalyzeArgs {
     pub max_file_bytes: Option<u64>,
 
     /// Limit how many commits are scanned for git metrics.
-    #[arg(long)]
+    #[arg(long, value_parser = super::validate::positive_usize)]
     pub max_commits: Option<usize>,
 
     /// Limit files per commit when scanning git history.
-    #[arg(long)]
+    #[arg(long, value_parser = super::validate::positive_usize)]
     pub max_commit_files: Option<usize>,
 
     /// Import graph granularity [default: module].

--- a/crates/tokmd/src/cli/parser/badge.rs
+++ b/crates/tokmd/src/cli/parser/badge.rs
@@ -36,11 +36,11 @@ pub struct BadgeArgs {
     pub no_git: bool,
 
     /// Limit how many commits are scanned for git metrics.
-    #[arg(long)]
+    #[arg(long, value_parser = super::validate::positive_usize)]
     pub max_commits: Option<usize>,
 
     /// Limit files per commit when scanning git history.
-    #[arg(long)]
+    #[arg(long, value_parser = super::validate::positive_usize)]
     pub max_commit_files: Option<usize>,
 
     /// Output file for the badge (defaults to stdout).


### PR DESCRIPTION
Added parse-time validation to `--max-commits` and `--max-commit-files` in `tokmd analyze` and `tokmd badge` to reject zero values, matching the behavior of `tokmd context`.

---
*PR created automatically by Jules for task [11236067683397669771](https://jules.google.com/task/11236067683397669771) started by @EffortlessSteven*