### PR TITLE
merge(swarm): import tokmd-swarm #393

### DIFF
--- a/.github/workflows/ghcr-container-smoke.yml
+++ b/.github/workflows/ghcr-container-smoke.yml
@@ -10,9 +10,10 @@ name: GHCR Container Smoke
 #
 # This workflow only PULLS and RUNS the already-published publication image
 # (ghcr.io/effortlessmetrics/tokmd). It performs no release mutation, no push,
-# no tag/alias change, and does not enable `runtime: container` in action.yml.
-# Public visibility (gate steps 1-5) is verified separately; see
-# docs/releases/1.14-ledger.md and docs/publishing-evidence.md.
+# no tag/alias change. Public visibility (gate steps 1-5) is verified separately;
+# gate steps 6-7 discharge evidence for adding a tag to action.yml's supported
+# set (see docs/specs/packet-ghcr-runtime.md). This workflow does not perform
+# release mutation or change publication tags.
 
 on:
   workflow_dispatch:

--- a/docs/specs/packet-ghcr-runtime.md
+++ b/docs/specs/packet-ghcr-runtime.md
@@ -170,22 +170,18 @@ release tag commit, `image.version` is `1.14.0`). Receipt:
 `target/publishing/ghcr-visibility-1.14.0.md`; ledger copy in
 `docs/releases/1.14-ledger.md`.
 
-Gate steps 6 (container `tokmd --version`) and 7 (mounted-repository `complete`
-packet smoke) were **not run** because they require a Docker exec unavailable on
-the verification host. The OCI `image.version` label is image-declared metadata,
-not a runtime exec, so it does not discharge step 6. The container runtime for
-`1.14.0` therefore stays **pending** under this gate: `action.yml` keeps the
-`runtime: container` hard error until a Docker-capable host completes steps 6-7
-for the tag. Public visibility being verified does not by itself make the
-container runtime supported.
+Gate steps 6 (container `tokmd --version`) and 7 (mounted-repository
+`complete` packet smoke) require a Docker-capable host. The OCI `image.version`
+label is image-declared metadata, not a runtime exec, so it does not discharge
+step 6 on its own.
 
 Steps 6-7 are run by the `GHCR Container Smoke` lane
 (`.github/workflows/ghcr-container-smoke.yml`), a `workflow_dispatch`-only smoke
 that anonymously pulls the published image, runs `tokmd --version`, and
 generates a `complete` packet against a mounted git fixture. See
 [GHCR container smoke runbook](../ci/ghcr-container-smoke.md). The lane only
-pulls and runs the already-published image; it does not enable
-`runtime: container` in `action.yml`.
+pulls and runs the already-published image; it records gate evidence for adding
+a tag to `action.yml`'s supported set. It does not perform release mutation.
 
 On **2026-06-26**, that lane ran on `ubuntu-latest`
 ([run 28262553040](https://github.com/EffortlessMetrics/tokmd-swarm/actions/runs/28262553040))


### PR DESCRIPTION
Import tokmd-swarm checkpoint for #393.

## Contents

- #393 docs(ci): fix stale GHCR container smoke comments

## Topology

- Swarm-Head: 7a9d0dc59ced393c7296252f3d76a2b7670ae30b
- Swarm-Range: fb07668d..7a9d0dc5
- Publication base: fb07668dcac4c1a9cb810e321dd9b2338a9fda94

## Claim boundary

- Docs-only import (CI comment text fix). No code, schema, or behavior change.
- Swarm required check `Tokmd Rust Result` passed on the swarm PR before squash-merge.
- Merge with a merge commit (two-parent) per `docs/ci/swarm-routing.md`; do not squash.
- No tag, release, publish, signing, Docker, or v1 alias action is part of this import.
