### PR TITLE
merge(swarm): import tokmd-swarm #394

### DIFF
--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -290,6 +290,26 @@ permissions:
 
 Commenting only runs on `pull_request` events. Set `comment: 'false'` for scheduled jobs, push jobs, private smoke tests, or workflows where comments are not desired.
 
+### Fork pull requests
+
+On fork pull requests the default `GITHUB_TOKEN` is read-only for security, even
+when the base workflow declares `pull-requests: write`. Hosted comment posting
+can therefore be rejected for a fork PR while receipt, packet, and artifact
+generation still succeed. A missing hosted comment on a fork PR is not a packet
+failure: treat the uploaded `tokmd-receipts` artifact (and, for cockpit review
+packets, the packet-local `.tokmd/review/` directory) as the source of truth.
+
+If a repository takes many fork contributions, prefer one of these fork-safe
+patterns over relying on the hosted comment:
+
+- keep `comment: 'false'` and let reviewers read the uploaded artifact, or
+- run generation on the `pull_request` event with `artifact: 'true'`, then post
+  the summary from a separate `workflow_run` job that has write access.
+
+Do not switch the generating job to `pull_request_target` only to expose a write
+token to fork code; that reintroduces the fork-secret exposure the read-only
+token is designed to prevent.
+
 The default flow comments with `tokmd-summary.md`. `sensor` comments with `comment.md`. JSON-only modes such as `gate`, `cockpit`, and `baseline` normally leave the `summary` output empty. `cockpit` with `review-packet: 'true'` comments with the packet summary, using `tokmd-review-packet-comment.md` when hosted packet metadata is added.
 
 For cockpit review packets, the Action copies `.tokmd/review/comment.md` to

--- a/docs/packet-consumption.md
+++ b/docs/packet-consumption.md
@@ -185,7 +185,7 @@ no separate `tokmd review` command.
 | Symptom | Likely cause | What to do |
 | --- | --- | --- |
 | Workflow succeeded but no PR comment | Event is not `pull_request`, or `comment: false` | Expected for `push`, `schedule`, and `workflow_dispatch`. Download the `tokmd-receipts` artifact or read `.tokmd/review/` from the job log path. |
-| Fork PR has artifacts but no comment | Fork-safe comment posting is skipped | Treat the uploaded packet as the source of truth. Do not infer packet failure from the absent comment. |
+| Fork PR has artifacts but no comment | Fork pull requests run with a read-only `GITHUB_TOKEN`, so hosted comment posting can be rejected even when `pull-requests: write` is declared | Expected. Treat the uploaded packet as the source of truth. Do not infer packet failure from the absent comment. For fork-heavy repos, set `comment: false` or post from a separate `workflow_run` job (see [GitHub Action](github-action.md#fork-pull-requests)). |
 | Comment says the packet was not uploaded | `artifact: false` while `comment: true` | Set `artifact: true` when reviewers need hosted links, or run `tokmd cockpit --review-packet-dir .tokmd/review` locally. |
 | Hosted comment text differs from `.tokmd/review/comment.md` | Action copies to `tokmd-review-packet-comment.md` and appends run/artifact links | Normal. Packet-local `comment.md` stays unchanged so `manifest.json` hashes remain valid. |
 | `review-packet-check` rejects a file in `.tokmd/review/` | A hosted comment copy was placed inside the packet directory | Keep hosted copies outside the packet tree. The verifier rejects hosted comment copies in the manifest path set. |

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -477,8 +477,13 @@ behavior.
 ## GitHub Action Behavior
 
 The Action uploads the packet as an artifact when `artifact: 'true'` and
-`review-packet: 'true'` are both set. Comment posting remains fork-safe and is
-not required for packet generation.
+`review-packet: 'true'` are both set. Comment posting is optional and is not
+required for packet generation. On fork pull requests the default `GITHUB_TOKEN`
+is read-only, so the hosted comment can be rejected while the packet and
+artifact still generate; the uploaded `tokmd-receipts` artifact and the
+packet-local `.tokmd/review/` directory remain the source of truth. See
+[GitHub Action fork pull requests](github-action.md#fork-pull-requests) for
+fork-safe comment patterns.
 
 When the composite Action generates a review packet, it copies
 `.tokmd/review/comment.md` to `tokmd-review-packet-comment.md` and appends a


### PR DESCRIPTION
Import tokmd-swarm checkpoint for #394.

## Contents

- #394 docs: fork-safe hosted-comment guidance for review packets

## Topology

- Swarm-Head: 683181a5e7f02f16ab1a6f385e380ffd7204aa3f
- Swarm-Range: 41e28946..683181a5
- Publication base: 41e289460228172c2570b7ea3da1b56a3e4bc5e0

## Claim boundary

- Docs-only import (review-packet fork-comment guidance). No code, schema, or behavior change.
- Swarm required check `Tokmd Rust Result` passed on the swarm PR before squash-merge.
- Merge with a merge commit (two-parent) per `docs/ci/swarm-routing.md`; do not squash.
- No tag, release, publish, signing, Docker, or v1 alias action is part of this import.
