### PR TITLE
merge(swarm): import tokmd-swarm #395

### DIFF
--- a/crates/tokmd-wasm/src/lib.rs
+++ b/crates/tokmd-wasm/src/lib.rs
@@ -342,6 +342,17 @@ mod archive_fixture {
         serde_json::json!({ "lang": { "files": true }, "inputs": inputs }).to_string()
     }
 
+    /// Equivalent inline `{ path, text }` options with no mode-specific
+    /// settings, used as the JSON-mode parity oracle for byte-mode `module` and
+    /// `export` (whose byte call carries empty options `{}`).
+    pub(crate) fn inline_bare_options_json() -> String {
+        let inputs: Vec<serde_json::Value> = ENTRIES
+            .iter()
+            .map(|(name, text)| serde_json::json!({ "path": name, "text": text }))
+            .collect();
+        serde_json::json!({ "inputs": inputs }).to_string()
+    }
+
     /// Equivalent inline `{ path, text }` analyze options for rootless presets.
     #[cfg(feature = "analysis")]
     pub(crate) fn inline_analyze_options_json(preset: &str) -> String {
@@ -707,6 +718,89 @@ mod tests {
         assert_eq!(
             from_zip, from_json,
             "byte-mode envelope diverged from the equivalent inline-inputs envelope"
+        );
+    }
+
+    /// Recursively remove volatile timestamp keys so byte-mode and inline-mode
+    /// envelopes can be compared for full structural equality.
+    #[cfg(feature = "archive-zip")]
+    fn scrub_volatile_timestamps(value: &mut Value) {
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    scrub_volatile_timestamps(item);
+                }
+            }
+            Value::Object(map) => {
+                map.remove("generated_at_ms");
+                map.remove("export_generated_at_ms");
+                for nested in map.values_mut() {
+                    scrub_volatile_timestamps(nested);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[cfg(feature = "archive-zip")]
+    #[test]
+    fn core_run_json_bytes_module_matches_inline_inputs() {
+        use crate::archive_fixture::{inline_bare_options_json, tiny_zip};
+
+        let bytes = tiny_zip();
+        let from_zip_raw = tokmd_core::ffi::run_json_bytes("module", "{}", &bytes);
+        let from_json_raw = tokmd_core::ffi::run_json("module", &inline_bare_options_json());
+
+        let mut from_zip: Value = serde_json::from_str(&from_zip_raw).expect("byte-mode envelope");
+        let mut from_json: Value =
+            serde_json::from_str(&from_json_raw).expect("json-mode envelope");
+
+        assert_eq!(from_zip["ok"], json!(true), "byte-mode call should succeed");
+        assert_eq!(from_zip["data"]["mode"], json!("module"));
+        assert!(
+            from_zip["data"]["rows"].as_array().is_some(),
+            "module receipt should carry rows"
+        );
+
+        scrub_volatile_timestamps(&mut from_zip);
+        scrub_volatile_timestamps(&mut from_json);
+        assert_eq!(
+            from_zip, from_json,
+            "byte-mode module envelope diverged from the equivalent inline-inputs envelope"
+        );
+    }
+
+    #[cfg(feature = "archive-zip")]
+    #[test]
+    fn core_run_json_bytes_export_matches_inline_inputs() {
+        use crate::archive_fixture::{inline_bare_options_json, tiny_zip};
+
+        let bytes = tiny_zip();
+        let from_zip_raw = tokmd_core::ffi::run_json_bytes("export", "{}", &bytes);
+        let from_json_raw = tokmd_core::ffi::run_json("export", &inline_bare_options_json());
+
+        let mut from_zip: Value = serde_json::from_str(&from_zip_raw).expect("byte-mode envelope");
+        let mut from_json: Value =
+            serde_json::from_str(&from_json_raw).expect("json-mode envelope");
+
+        assert_eq!(from_zip["ok"], json!(true), "byte-mode call should succeed");
+        assert_eq!(from_zip["data"]["mode"], json!("export"));
+        let paths: Vec<&str> = from_zip["data"]["rows"]
+            .as_array()
+            .expect("export rows array")
+            .iter()
+            .filter_map(|row| row["path"].as_str())
+            .collect();
+        assert!(
+            paths.contains(&"src/lib.rs") && paths.contains(&"tests/basic.py"),
+            "expected fixture paths, got {paths:?}"
+        );
+
+        scrub_volatile_timestamps(&mut from_zip);
+        scrub_volatile_timestamps(&mut from_json);
+        assert_eq!(
+            from_zip, from_json,
+            "byte-mode export envelope diverged from the equivalent inline-inputs envelope"
         );
     }
 
@@ -1175,6 +1269,79 @@ mod wasm_tests {
         assert!(
             values_match_js_boundary(&from_zip, &from_json),
             "byte-mode envelope diverged from inline-inputs envelope\nzip: {from_zip}\njson: {from_json}"
+        );
+    }
+
+    #[cfg(feature = "archive-zip")]
+    #[wasm_bindgen_test]
+    fn run_json_bytes_module_matches_inline_inputs_over_js_boundary() {
+        use crate::archive_fixture::{inline_bare_options_json, tiny_zip};
+
+        let bytes = tiny_zip();
+        let view = Uint8Array::from(bytes.as_slice());
+        let from_zip_raw = run_json_bytes("module", "{}", view);
+        let from_json_raw = tokmd_core::ffi::run_json("module", &inline_bare_options_json());
+
+        let mut from_zip: Value =
+            serde_json::from_str(&from_zip_raw).expect("byte-mode envelope json");
+        let mut from_json: Value =
+            serde_json::from_str(&from_json_raw).expect("json-mode envelope json");
+
+        assert_eq!(
+            from_zip["ok"],
+            Value::Bool(true),
+            "byte-mode module should succeed"
+        );
+        assert_eq!(from_zip["data"]["mode"], "module");
+        assert!(from_zip["data"]["rows"].as_array().is_some());
+        assert_generated_at_ms_nonzero("byte-mode module wasm payload", &from_zip["data"]);
+
+        normalize_volatile_timestamps(&mut from_zip);
+        normalize_volatile_timestamps(&mut from_json);
+        assert!(
+            values_match_js_boundary(&from_zip, &from_json),
+            "byte-mode module envelope diverged from inline-inputs envelope\nzip: {from_zip}\njson: {from_json}"
+        );
+    }
+
+    #[cfg(feature = "archive-zip")]
+    #[wasm_bindgen_test]
+    fn run_json_bytes_export_matches_inline_inputs_over_js_boundary() {
+        use crate::archive_fixture::{inline_bare_options_json, tiny_zip};
+
+        let bytes = tiny_zip();
+        let view = Uint8Array::from(bytes.as_slice());
+        let from_zip_raw = run_json_bytes("export", "{}", view);
+        let from_json_raw = tokmd_core::ffi::run_json("export", &inline_bare_options_json());
+
+        let mut from_zip: Value =
+            serde_json::from_str(&from_zip_raw).expect("byte-mode envelope json");
+        let mut from_json: Value =
+            serde_json::from_str(&from_json_raw).expect("json-mode envelope json");
+
+        assert_eq!(
+            from_zip["ok"],
+            Value::Bool(true),
+            "byte-mode export should succeed"
+        );
+        assert_eq!(from_zip["data"]["mode"], "export");
+        let paths: Vec<&str> = from_zip["data"]["rows"]
+            .as_array()
+            .expect("export rows array")
+            .iter()
+            .filter_map(|row| row["path"].as_str())
+            .collect();
+        assert!(
+            paths.contains(&"src/lib.rs") && paths.contains(&"tests/basic.py"),
+            "expected fixture paths, got {paths:?}"
+        );
+        assert_generated_at_ms_nonzero("byte-mode export wasm payload", &from_zip["data"]);
+
+        normalize_volatile_timestamps(&mut from_zip);
+        normalize_volatile_timestamps(&mut from_json);
+        assert!(
+            values_match_js_boundary(&from_zip, &from_json),
+            "byte-mode export envelope diverged from inline-inputs envelope\nzip: {from_zip}\njson: {from_json}"
         );
     }
 

--- a/docs/browser-capability-matrix.md
+++ b/docs/browser-capability-matrix.md
@@ -32,12 +32,21 @@ The `runJsonBytes` binding (`tokmd-wasm`, `feature = archive-zip`) accepts a
 browser `Uint8Array` of raw ZIP bytes plus a JSON options object and forwards to
 `tokmd_core::ffi::run_json_bytes`. Untrusted bytes are admitted fail-closed by
 the single authoritative engine in `tokmd-io-port` / `tokmd-scan`; there is no
-second admission path. Coverage:
+second admission path. Every browser-supported byte-mode is proven to match the
+equivalent inline `{ path, text }` envelope, both natively and across the JS
+boundary. Coverage (all in `crates/tokmd-wasm/src/lib.rs`):
 
-- native parity: `core_run_json_bytes_lang_matches_inline_inputs` in
-  `crates/tokmd-wasm/src/lib.rs`
-- `wasm-bindgen-test` boundary: `run_json_bytes_lang_matches_inline_inputs_over_js_boundary`
-  in the same file
+- native parity: `core_run_json_bytes_lang_matches_inline_inputs`,
+  `core_run_json_bytes_module_matches_inline_inputs`,
+  `core_run_json_bytes_export_matches_inline_inputs`,
+  `core_run_json_bytes_analyze_receipt_matches_inline_inputs`,
+  `core_run_json_bytes_analyze_estimate_matches_inline_inputs`
+- `wasm-bindgen-test` boundary:
+  `run_json_bytes_lang_matches_inline_inputs_over_js_boundary`,
+  `run_json_bytes_module_matches_inline_inputs_over_js_boundary`,
+  `run_json_bytes_export_matches_inline_inputs_over_js_boundary`,
+  `run_json_bytes_analyze_receipt_matches_inline_inputs_over_js_boundary`,
+  `run_json_bytes_analyze_estimate_matches_inline_inputs_over_js_boundary`
 
 The underlying snapshot/scan seams remain host-free infrastructure; they are
 now reachable from the browser through this binding when the `archive-zip`


### PR DESCRIPTION
Import tokmd-swarm checkpoint for #395.

## Contents

- #395 test(wasm): prove runJsonBytes module/export byte-mode parity

## Topology

- Swarm-Head: 2bc41bcd2092b8a32486834c8dd69d98108fd38d
- Swarm-Range: 3716f370..2bc41bcd
- Publication base: 3716f3706dee63e093eba686fccfc83b2ad3cb6e

## Claim boundary

- Test + policy allowlist + docs import. No library behavior, schema, or receipt change.
- Swarm required check `Tokmd Rust Result` passed on the swarm PR before squash-merge.
- Merge with a merge commit (two-parent) per `docs/ci/swarm-routing.md`; do not squash.
- No tag, release, publish, signing, Docker, or v1 alias action is part of this import.
