### PR TITLE
merge(swarm): import tokmd-swarm Lane 3 PR F + NOW closeout (#411 + #412)

### DIFF
--- a/crates/tokmd-analysis/src/content/io.rs
+++ b/crates/tokmd-analysis/src/content/io.rs
@@ -35,17 +35,40 @@ mod tags;
 
 pub fn read_head(path: &Path, max_bytes: usize) -> Result<Vec<u8>> {
     // `fuzz_entropy` path-includes this module (crate = tokmd-fuzz), where the
-    // tokmd-analysis-only `io_trace` module does not exist; the fuzz target
-    // never exercises the read helpers, so tracing is compiled out there.
+    // tokmd-analysis-only `io_trace`/`io_cache` modules do not exist; the fuzz
+    // target never exercises the read helpers, so instrumentation is compiled
+    // out there.
     #[cfg(not(fuzzing))]
-    crate::io_trace::record(crate::io_trace::IoReadMode::Head, max_bytes, path);
-    read::read_head(path, max_bytes)
+    {
+        crate::io_trace::record(crate::io_trace::IoReadMode::Head, max_bytes, path);
+        crate::io_cache::get_or_read_bytes(
+            crate::io_trace::IoReadMode::Head,
+            max_bytes,
+            path,
+            || read::read_head(path, max_bytes),
+        )
+    }
+    #[cfg(fuzzing)]
+    {
+        read::read_head(path, max_bytes)
+    }
 }
 
 pub fn read_head_tail(path: &Path, max_bytes: usize) -> Result<Vec<u8>> {
     #[cfg(not(fuzzing))]
-    crate::io_trace::record(crate::io_trace::IoReadMode::HeadTail, max_bytes, path);
-    read::read_head_tail(path, max_bytes)
+    {
+        crate::io_trace::record(crate::io_trace::IoReadMode::HeadTail, max_bytes, path);
+        crate::io_cache::get_or_read_bytes(
+            crate::io_trace::IoReadMode::HeadTail,
+            max_bytes,
+            path,
+            || read::read_head_tail(path, max_bytes),
+        )
+    }
+    #[cfg(fuzzing)]
+    {
+        read::read_head_tail(path, max_bytes)
+    }
 }
 
 pub fn read_lines(path: &Path, max_lines: usize, max_bytes: usize) -> Result<Vec<String>> {

--- a/crates/tokmd-analysis/src/io_cache.rs
+++ b/crates/tokmd-analysis/src/io_cache.rs
@@ -1,0 +1,350 @@
+//! Opt-in per-request read-through cache **prototype** for content file opens.
+//!
+//! This is the measurement instrument for the file-I/O cache decision described
+//! in `docs/plans/file-io-cache-evidence.md`. The plan's PR D trace
+//! ([`crate::io_trace`]) confirmed that a bounded `analyze` pass re-opens the
+//! same `(read_mode, max_bytes, path)` key more than once (health preset:
+//! ~1.54× on self-scan), but a trace counts open *attempts*, not the time
+//! attributable to duplicate opens. This module lets a maintainer run a
+//! health-preset before/after A/B and measure whether serving duplicate reads
+//! from a request-scoped cache actually reduces `analyze total_ms` before any
+//! production cache is proposed (the plan's PR E).
+//!
+//! Like [`crate::io_trace`], the cache is **thread-local and scope-gated**: it
+//! is only active while a [`scope`] is installed on the current thread, and it
+//! is dropped when the scope returns. When no scope is active,
+//! [`get_or_read_bytes`] performs a single thread-local `Option` check and then
+//! calls the reader directly, so the default `analyze` path is byte-for-byte
+//! unchanged. This is a prototype instrument, not a product cache: it is only
+//! ever installed by `cargo xtask perf-smoke --cache-io`.
+//!
+//! ## Scope of caching
+//!
+//! Only the byte-returning read modes ([`IoReadMode::Head`] and
+//! [`IoReadMode::HeadTail`]) are cached, because those are the modes that fire
+//! under the measured `health`/`security` presets and both return `Vec<u8>`.
+//! `read_lines` and `read_text_capped` are intentionally not cached in this
+//! prototype (the health preset never exercises them, and `read_text_capped`
+//! already delegates to the inner head reader). A served value is an exact
+//! clone of the first read for that key, so cached and uncached runs produce
+//! identical bytes.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use std::path::Path;
+
+use crate::io_trace::IoReadMode;
+
+/// Aggregated read-cache statistics for a single [`scope`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IoCacheReport {
+    /// Cache lookups performed (one per cached-mode facade read).
+    pub lookups: u64,
+    /// Lookups served from the cache without opening the file.
+    pub hits: u64,
+    /// Lookups that read the file and populated the cache.
+    pub misses: u64,
+    /// Distinct `(mode, max_bytes, path)` entries retained at scope end.
+    pub entries: u64,
+    /// Total bytes served from the cache on hits (sum of served value lengths).
+    pub bytes_served: u64,
+}
+
+impl IoCacheReport {
+    /// Fraction of lookups served from the cache, or `0.0` when idle.
+    #[must_use]
+    pub fn hit_rate(&self) -> f64 {
+        if self.lookups == 0 {
+            0.0
+        } else {
+            self.hits as f64 / self.lookups as f64
+        }
+    }
+}
+
+#[derive(Default)]
+struct IoCacheState {
+    entries: BTreeMap<(IoReadMode, usize, String), Vec<u8>>,
+    lookups: u64,
+    hits: u64,
+    bytes_served: u64,
+}
+
+impl IoCacheState {
+    fn into_report(self) -> IoCacheReport {
+        let entries = self.entries.len() as u64;
+        IoCacheReport {
+            lookups: self.lookups,
+            hits: self.hits,
+            misses: self.lookups.saturating_sub(self.hits),
+            entries,
+            bytes_served: self.bytes_served,
+        }
+    }
+}
+
+thread_local! {
+    static ACTIVE: RefCell<Option<IoCacheState>> = const { RefCell::new(None) };
+}
+
+fn scope_active() -> bool {
+    ACTIVE.with(|cell| cell.try_borrow().map(|g| g.is_some()).unwrap_or(false))
+}
+
+/// Look up a cached value, recording a lookup and (on hit) a served-bytes count.
+///
+/// The borrow is released before returning so the caller's reader never runs
+/// while the cache is borrowed.
+fn cache_get(key: &(IoReadMode, usize, String)) -> Option<Vec<u8>> {
+    ACTIVE.with(|cell| {
+        let mut guard = cell.try_borrow_mut().ok()?;
+        let state = guard.as_mut()?;
+        state.lookups = state.lookups.saturating_add(1);
+        match state.entries.get(key) {
+            Some(bytes) => {
+                state.hits = state.hits.saturating_add(1);
+                state.bytes_served = state.bytes_served.saturating_add(bytes.len() as u64);
+                Some(bytes.clone())
+            }
+            None => None,
+        }
+    })
+}
+
+fn cache_insert(key: (IoReadMode, usize, String), bytes: &[u8]) {
+    ACTIVE.with(|cell| {
+        if let Ok(mut guard) = cell.try_borrow_mut()
+            && let Some(state) = guard.as_mut()
+        {
+            state.entries.entry(key).or_insert_with(|| bytes.to_vec());
+        }
+    });
+}
+
+/// Serve a byte read from the request-scoped cache when a [`scope`] is active,
+/// otherwise call `read` directly.
+///
+/// On a cache miss the file is read via `read`, the result is cloned into the
+/// cache, and the bytes are returned. On a hit the cached bytes are cloned and
+/// returned without invoking `read`, so the file is not re-opened. The returned
+/// bytes are always identical to a fresh read of the same key.
+pub(crate) fn get_or_read_bytes(
+    mode: IoReadMode,
+    max_bytes: usize,
+    path: &Path,
+    read: impl FnOnce() -> Result<Vec<u8>>,
+) -> Result<Vec<u8>> {
+    if !scope_active() {
+        return read();
+    }
+    let key = (mode, max_bytes, path.to_string_lossy().into_owned());
+    if let Some(bytes) = cache_get(&key) {
+        return Ok(bytes);
+    }
+    let bytes = read()?;
+    cache_insert(key, &bytes);
+    Ok(bytes)
+}
+
+/// Restores the previous scope's state (if any) when a scope returns, even on
+/// an early return from the cached closure.
+struct Installed {
+    previous: Option<IoCacheState>,
+}
+
+impl Drop for Installed {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        ACTIVE.with(|cell| {
+            if let Ok(mut guard) = cell.try_borrow_mut() {
+                *guard = previous;
+            }
+        });
+    }
+}
+
+/// Run `f` with the request-scoped read cache active on the current thread and
+/// return its result alongside the collected [`IoCacheReport`].
+///
+/// Nested scopes are isolated: the enclosing scope's cache is restored when
+/// this scope returns, and reads inside the inner scope populate only the inner
+/// cache.
+pub fn scope<R>(f: impl FnOnce() -> R) -> (R, IoCacheReport) {
+    let guard = Installed {
+        previous: ACTIVE.with(|cell| {
+            cell.try_borrow_mut()
+                .ok()
+                .and_then(|mut g| g.replace(IoCacheState::default()))
+        }),
+    };
+    let result = f();
+    let state = ACTIVE.with(|cell| cell.try_borrow_mut().ok().and_then(|mut g| g.take()));
+    drop(guard);
+    let report = state.map(IoCacheState::into_report).unwrap_or_default();
+    (result, report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_calls(counter: &std::cell::Cell<u32>, payload: &'static [u8]) -> Result<Vec<u8>> {
+        counter.set(counter.get() + 1);
+        Ok(payload.to_vec())
+    }
+
+    #[test]
+    fn idle_passes_through_and_reports_empty() -> Result<()> {
+        let counter = std::cell::Cell::new(0);
+        // No scope active: reader is always called, cache is a no-op.
+        let bytes = get_or_read_bytes(IoReadMode::Head, 16, Path::new("a.rs"), || {
+            read_calls(&counter, b"hello")
+        })?;
+        assert_eq!(bytes, b"hello");
+        assert_eq!(counter.get(), 1);
+
+        let ((), report) = scope(|| {});
+        assert_eq!(report.lookups, 0);
+        assert_eq!(report.hits, 0);
+        assert_eq!(report.misses, 0);
+        assert_eq!(report.entries, 0);
+        assert_eq!(report.hit_rate(), 0.0);
+        Ok(())
+    }
+
+    #[test]
+    fn second_read_of_same_key_is_served_from_cache() -> Result<()> {
+        let counter = std::cell::Cell::new(0);
+        let (bytes_pair, report) = scope(|| -> Result<(Vec<u8>, Vec<u8>)> {
+            let first = get_or_read_bytes(IoReadMode::Head, 16, Path::new("a.rs"), || {
+                read_calls(&counter, b"content")
+            })?;
+            let second = get_or_read_bytes(IoReadMode::Head, 16, Path::new("a.rs"), || {
+                read_calls(&counter, b"content")
+            })?;
+            Ok((first, second))
+        });
+        let (first, second) = bytes_pair?;
+        // The reader ran exactly once; the second lookup was a cache hit.
+        assert_eq!(counter.get(), 1);
+        // Cache parity: served bytes equal the originally-read bytes.
+        assert_eq!(first, b"content");
+        assert_eq!(second, b"content");
+        assert_eq!(report.lookups, 2);
+        assert_eq!(report.hits, 1);
+        assert_eq!(report.misses, 1);
+        assert_eq!(report.entries, 1);
+        assert_eq!(report.bytes_served, b"content".len() as u64);
+        assert_eq!(report.hit_rate(), 0.5);
+        Ok(())
+    }
+
+    #[test]
+    fn different_mode_or_limit_are_distinct_keys() {
+        let counter = std::cell::Cell::new(0);
+        let ((), report) = scope(|| {
+            let _ = get_or_read_bytes(IoReadMode::Head, 16, Path::new("a.rs"), || {
+                read_calls(&counter, b"x")
+            });
+            let _ = get_or_read_bytes(IoReadMode::HeadTail, 16, Path::new("a.rs"), || {
+                read_calls(&counter, b"x")
+            });
+            let _ = get_or_read_bytes(IoReadMode::Head, 32, Path::new("a.rs"), || {
+                read_calls(&counter, b"x")
+            });
+        });
+        // Three distinct keys => three reads, no hits.
+        assert_eq!(counter.get(), 3);
+        assert_eq!(report.lookups, 3);
+        assert_eq!(report.hits, 0);
+        assert_eq!(report.entries, 3);
+    }
+
+    #[test]
+    fn read_error_is_not_cached() {
+        let ((), report) = scope(|| {
+            let first: Result<Vec<u8>> =
+                get_or_read_bytes(IoReadMode::Head, 16, Path::new("missing.rs"), || {
+                    Err(anyhow::anyhow!("open failed"))
+                });
+            assert!(first.is_err());
+        });
+        // A failed read populates no entry, so a later read can retry.
+        assert_eq!(report.lookups, 1);
+        assert_eq!(report.hits, 0);
+        assert_eq!(report.entries, 0);
+    }
+
+    #[test]
+    fn nested_scopes_are_isolated() {
+        let counter = std::cell::Cell::new(0);
+        let ((), outer) = scope(|| {
+            let _ = get_or_read_bytes(IoReadMode::Head, 8, Path::new("outer.rs"), || {
+                read_calls(&counter, b"o")
+            });
+            let ((), inner) = scope(|| {
+                // Inner scope starts empty: this is a miss even though the key
+                // matches an outer entry.
+                let _ = get_or_read_bytes(IoReadMode::Head, 8, Path::new("outer.rs"), || {
+                    read_calls(&counter, b"o")
+                });
+            });
+            assert_eq!(inner.lookups, 1);
+            assert_eq!(inner.hits, 0);
+            assert_eq!(inner.entries, 1);
+            // Back in the outer scope, the original entry is still cached.
+            let _ = get_or_read_bytes(IoReadMode::Head, 8, Path::new("outer.rs"), || {
+                read_calls(&counter, b"o")
+            });
+        });
+        assert_eq!(outer.lookups, 2);
+        assert_eq!(outer.hits, 1);
+        assert_eq!(outer.entries, 1);
+    }
+}
+
+#[cfg(all(test, feature = "content"))]
+mod content_wiring_tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn facade_read_head_is_served_from_cache_on_repeat() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().join("sample.rs");
+        let mut file = std::fs::File::create(&path)?;
+        file.write_all(b"fn main() {}\n")?;
+
+        let (bytes_pair, report) = scope(|| -> Result<(Vec<u8>, Vec<u8>)> {
+            let first = crate::content::io::read_head(&path, 4096)?;
+            let second = crate::content::io::read_head(&path, 4096)?;
+            Ok((first, second))
+        });
+        let (first, second) = bytes_pair?;
+
+        // Byte parity between the read-through and the cached copy.
+        assert_eq!(first, b"fn main() {}\n");
+        assert_eq!(second, first);
+        assert_eq!(report.lookups, 2);
+        assert_eq!(report.hits, 1);
+        assert_eq!(report.misses, 1);
+        assert_eq!(report.entries, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn facade_read_head_matches_uncached_bytes() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().join("parity.rs");
+        let mut file = std::fs::File::create(&path)?;
+        file.write_all(b"// parity check\npub fn f() {}\n")?;
+
+        let uncached = crate::content::io::read_head(&path, 4096)?;
+        let (cached, _report) = scope(|| crate::content::io::read_head(&path, 4096));
+        assert_eq!(cached?, uncached);
+        Ok(())
+    }
+}

--- a/crates/tokmd-analysis/src/lib.rs
+++ b/crates/tokmd-analysis/src/lib.rs
@@ -46,6 +46,7 @@ mod grid;
 mod halstead;
 #[cfg(feature = "content")]
 mod imports;
+pub mod io_cache;
 pub mod io_trace;
 #[cfg(all(feature = "content", feature = "walk"))]
 mod license;

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,7 +1,8 @@
 # NOW / NEXT / LATER
 
-> One-screen operational truth. Updated after the Lane 2/5 closeout batch
-> (swarm #398, #399, publication import #2799 at `1c864623`).
+> One-screen operational truth. Updated after the Lane 3 measured-performance
+> closeout batch (swarm #401–#409, publication imports #2802/#2803 at
+> `14d611cb`; PR F #411 — the file-I/O cache decision — lands in the same batch).
 
 ## Adoption wave closeout (2026-06-30)
 
@@ -75,6 +76,33 @@ Agent-executable adoption/contributor docs work for this batch is at handoff:
 accuracy, and ub-review gate phase-4 documentation. It does not enable badge
 auto-CI (needs org `BADGE_PAT` secret) or change publication merge-commit UI
 settings.
+
+## Lane 3 measured-performance closeout (2026-07-02)
+
+Agent-executable measured-performance work for Lane 3 is at handoff. The lane is
+measurement-led throughout: no optimization landed without a perf-smoke receipt.
+
+- **#401–#404, #406**: `cargo xtask perf-smoke` maintainer guide, the
+  core-workflow baseline receipt, the first measured hot-path fix (PR B —
+  `tokmd-model` line-based byte estimate, export `model_ms` 377 → ~40 ms), and
+  the file-I/O cache evidence plan (PR C). Imported at `41c05d30` (import #2802).
+- **#407, #409**: Lane 3 governance closeout and the opt-in content I/O
+  open-trace (PR D — `tokmd-analysis::io_trace` + `perf-smoke --trace-io`) that
+  measured the duplicate-read rate (health preset re-opens capped files ~1.54×,
+  confirmed). Imported at `14d611cb` (import #2803).
+- **PR F (#411)**: prototype request-scoped read cache + health-preset A/B
+  (`tokmd-analysis::io_cache` + `perf-smoke --cache-io`). The cache serves all
+  268 confirmed duplicate `head` opens (hit_rate 0.349) but changes `analyze
+  total_ms` by only ~0.1% (within run-to-run noise), so **PR E (production cache)
+  is closed as a measured no-go**. Evidence:
+  `docs/ci/perf-smoke-io-cache-2026-07.md`. Lands in this closeout batch.
+
+**Claim boundary**: this lane proves a repeatable perf-smoke measurement spine,
+one low-risk measured core-workflow win (PR B), a confirmed duplicate-read rate
+(PR D), and an evidence-settled file-I/O cache decision (PR F: no-go). It does
+not add persistent caching to the default `analyze` path, change receipt schemas
+or preset defaults, or promote any advisory proof. The trace and cache
+prototypes remain opt-in maintainer instruments.
 
 ## Shipped this wave
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -240,14 +240,17 @@ is consumption: making those artifacts easier to read and triage.
 
 ### Lane 3: Measured Performance and CI Feedback
 
-**Status:** active (2026-07-02). Packets 1-5 shipped and imported into the
+**Status:** complete (2026-07-02). Packets 1-5 shipped and imported into the
 checkpoint (`#403` + `#404` + `#406`, import #2802 @ `41c05d30`): maintainer
 perf-smoke guide, baseline receipt, the first measured hot-path fix (PR B,
 export `model_ms` 377 → ~40 ms), and the I/O cache evidence plan (PR C). Packet
-6 (plan PR D, the content-open trace) then measured the duplicate-read rate:
-duplicates are **confirmed** (health preset re-opens capped files ~1.54×) but
-the timing-reduction threshold is **not** established, so the plan's PR E
-production cache stays deferred (no-go on current evidence).
+6 (plan PR D, the content-open trace) measured the duplicate-read rate
+(**confirmed**: health preset re-opens capped files ~1.54×). Packet 7 (plan PR F,
+the prototype cache A/B) then settled the timing question: a request-scoped read
+cache serves **all** confirmed duplicate opens but changes `analyze total_ms` by
+only ~0.1% (within noise), so the plan's PR E production cache is **closed as a
+measured no-go**. The file-I/O cache lane is decided; the trace and cache
+prototypes remain opt-in maintainer instruments.
 
 | Packet | Shipped in |
 | --- | --- |
@@ -257,6 +260,7 @@ production cache stays deferred (no-go on current evidence).
 | 4. Model row-collection hot path | `tokmd-model` line-based byte estimate (#404) |
 | 5. File I/O cache evidence plan | `docs/plans/file-io-cache-evidence.md` (#406) |
 | 6. File I/O open-trace measurement (plan PR D) | `tokmd-analysis::io_trace` + `cargo xtask perf-smoke --trace-io`; `docs/ci/perf-smoke-io-trace-2026-07.md` |
+| 7. File I/O cache prototype A/B (plan PR F) | `tokmd-analysis::io_cache` + `cargo xtask perf-smoke --cache-io`; `docs/ci/perf-smoke-io-cache-2026-07.md` (PR E closed: measured no-go) |
 
 **Goal:** Improve developer feedback speed and runtime performance only where
 measurement shows a bottleneck.

--- a/docs/ci/perf-smoke-io-cache-2026-07.md
+++ b/docs/ci/perf-smoke-io-cache-2026-07.md
@@ -1,0 +1,125 @@
+# Perf-Smoke I/O Cache Prototype A/B — 2026-07 (Lane 3, PR F)
+
+Health-preset before/after A/B for the file-I/O cache decision described in
+[file-io-cache-evidence.md](../plans/file-io-cache-evidence.md). This is the
+plan's remaining **PR D option** — *"a prototype request-scoped cache measured
+with a health-preset before/after A/B"* — which the
+[PR D open trace](perf-smoke-io-trace-2026-07.md) named as the only instrument
+that can settle the timing-reduction threshold. The trace confirmed duplicate
+opens (~1.54×) but could not measure the *time* attributable to them; this A/B
+measures it directly.
+
+## Instrument
+
+`tokmd-analysis::io_cache` is a request-scoped, thread-local read-through cache
+prototype that mirrors the `io_trace` scope pattern. When installed it serves
+repeated `(read_mode, max_bytes, path)` byte reads (`head` / `head_tail`) from a
+per-request cache instead of re-opening the file. `cargo xtask perf-smoke
+--cache-io` installs one cache scope around each timed `analyze` preset and emits
+an `io_cache` section (`tokmd.io_cache_prototype.v1`) with lookups, hits, misses,
+retained entries, and served bytes.
+
+The cache is **scope-gated and off by default**: when no scope is active the
+content read facade calls the reader directly, so the default `analyze` path is
+byte-for-byte unchanged. Served bytes are an exact clone of the first read for
+each key (proven by `io_cache` unit + facade parity tests), so a cached run
+produces identical analysis input to an uncached run. Only the byte-returning
+modes are cached; under the `health` preset every content open is `head` mode
+(see the PR D trace), so the cache covers 100% of the measured duplicate reads.
+
+## Command
+
+```bash
+# Baseline (cache off), two consecutive receipts
+cargo xtask perf-smoke \
+  --target-repo . \
+  --output xtask/target/perf/health-cache-off-run1.json \
+  --analysis-preset health \
+  --analysis-max-files 500 \
+  --analysis-max-bytes 52428800 \
+  --sha "$(git rev-parse HEAD)"
+
+# Prototype cache (cache on), two consecutive receipts
+cargo xtask perf-smoke \
+  --target-repo . \
+  --output xtask/target/perf/health-cache-on-run1.json \
+  --analysis-preset health \
+  --analysis-max-files 500 \
+  --analysis-max-bytes 52428800 \
+  --cache-io \
+  --sha "$(git rev-parse HEAD)"
+```
+
+Build profile: **debug** `xtask` (local Windows MSVC host), matching
+[perf-smoke-baseline-2026-07.md](perf-smoke-baseline-2026-07.md) and the PR D
+trace. tokmd-swarm self-scan at `14d611cb`, two consecutive receipts per arm.
+
+## Results (health preset, self-scan, 2026-07-02)
+
+| Receipt | `analyze total_ms` | cache `lookups` | `hits` | `misses` | `entries` | `hit_rate` |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| cache off, run 1 | 6235 | — | — | — | — | — |
+| cache off, run 2 | 6447 | — | — | — | — | — |
+| cache on, run 1 | 6493 | 768 | 268 | 500 | 500 | 0.349 |
+| cache on, run 2 | 6175 | 768 | 268 | 500 | 500 | 0.349 |
+
+- **cache off** mean `total_ms` ≈ **6341** (6235, 6447).
+- **cache on** mean `total_ms` ≈ **6334** (6493, 6175).
+- **Difference ≈ 7 ms (~0.1%)**, well inside run-to-run noise: the two cache-off
+  runs alone differ by 212 ms and the two cache-on runs by 318 ms, so the arm
+  means overlap entirely.
+- The cache is doing exactly what the PR D trace predicted: **768 lookups, 500
+  unique keys (entries), 268 hits** — i.e. it serves all 268 duplicate `head`
+  opens (`hit_rate` = 268 / 768 = 0.349), matching the trace's
+  `duplicate_key_opens = 268` and `total_opens = 768`.
+- `warning_count = 0` in all four; `row_count` drifted 1819 → 1822 across the run
+  order (the receipts are written into `xtask/target/` between runs, so each
+  self-scan sees one more file). This is the same scan-edge variance noted in the
+  PR D trace and is present in both arms; it is not caused by the cache, whose
+  byte parity is proven by tests.
+
+## Decision thresholds (from the plan)
+
+| Signal | Threshold | Observed | Met? |
+| --- | --- | --- | --- |
+| Repeated `(path, limit)` opens | ≥ **1.3×** file count | 1.536× (768 / 500) — served as 268 cache hits | **yes** |
+| `analyze total_ms` (health) reduction | ≥ **15%** or ≥ **200 ms** | **~7 ms (~0.1%)**, within noise | **no** |
+| Row / warning parity | identical rows/warnings/reports | `warning_count` identical; byte parity proven; `row_count` scan-edge variance in both arms | parity holds (cache does not change bytes) |
+
+## Outcome: **NO-GO for PR E (production cache)** — now measured, not inferred
+
+The prototype eliminates **100% of the measured duplicate content opens** (all
+268 duplicate `head` reads served from cache) and still produces **no measurable
+`analyze total_ms` improvement**. This is the direct timing evidence the plan
+required and the PR D trace could not provide.
+
+The result confirms the PR D reasoning: `analyze total_ms` (~6.3 s) is dominated
+by analysis compute (complexity landmarks, derived metrics), not file opens. Each
+duplicate is a bounded `head` read of an already-warm small source file
+(sub-millisecond class), so removing all 268 duplicates is lost in run-to-run
+noise. Under the plan's "proceed only when **all** thresholds hold" rule, the
+timing threshold fails and **PR E stays closed**.
+
+The prototype ships as a permanent opt-in measurement instrument (`perf-smoke
+--cache-io`), mirroring `--trace-io`, so this A/B is repeatable by maintainers
+and re-checkable if the analysis compute profile changes materially. It is **not**
+wired into the default `analyze` path.
+
+## Claim boundary
+
+- **Establishes**: a repeatable prototype request-scoped read cache and a direct
+  health-preset A/B on this host/corpus showing that eliminating all confirmed
+  duplicate `head` opens changes `analyze total_ms` by ~0.1% (within noise), i.e.
+  below the plan's ≥ 15% / ≥ 200 ms threshold.
+- **Does not establish**: any release-profile or CI wall-clock effect,
+  cross-platform duplicate-read timing, or behavior for presets that exercise
+  `head_tail` / `lines` / `text_capped` (the `health` preset uses only `head`).
+  It does not change default `analyze` behavior, receipt schemas, or preset
+  defaults.
+
+## See also
+
+- [file-io-cache-evidence.md](../plans/file-io-cache-evidence.md) — plan, thresholds, invalidation sketch, PR E decision
+- [perf-smoke-io-trace-2026-07.md](perf-smoke-io-trace-2026-07.md) — PR D open-count trace
+- [perf-smoke.md](perf-smoke.md) — maintainer workflow and comparison rules
+- [perf-smoke-baseline-2026-07.md](perf-smoke-baseline-2026-07.md) — core-workflow baseline

--- a/docs/plans/file-io-cache-evidence.md
+++ b/docs/plans/file-io-cache-evidence.md
@@ -1,6 +1,7 @@
 # Plan: File I/O Cache Evidence (Lane 3 PR C)
 
-- Status: active
+- Status: complete
+- Decision: no-go for a production read cache, measured by the PR F prototype A/B
 - Related spec: none (plan precedes implementation)
 - Related ADR: none
 - Related issues: Lane 3 queue item 4 in [ROADMAP.md](../ROADMAP.md)
@@ -96,12 +97,26 @@ Any cache must be:
    capped files ~1.54×, ≥ 1.3×), but the timing-reduction threshold is **not
    established** by an open count. The plan's alternate PR D option — a
    prototype request-scoped cache measured with a health-preset before/after
-   A/B — remains available and is the only instrument that can settle the
-   timing threshold.
-3. **Future PR E** — production cache only if a prototype A/B meets **all**
-   thresholds with parity tests. **Status: not started (no-go on current
-   evidence).** The trace confirms duplicates but does not prove a ≥ 15% /
-   ≥ 200 ms `analyze total_ms` win, so PR E stays deferred.
+   A/B — was the only instrument that could settle the timing threshold; see
+   PR F below.
+3. **PR F — prototype cache A/B** — permanent opt-in request-scoped read cache
+   prototype (`tokmd-analysis::io_cache` + `cargo xtask perf-smoke --cache-io`)
+   with a health-preset before/after A/B. **Status: complete.** Measurement
+   receipt and threshold evaluation:
+   [perf-smoke-io-cache-2026-07.md](../ci/perf-smoke-io-cache-2026-07.md).
+   Outcome: the prototype serves **all 268 confirmed duplicate `head` opens**
+   (hit_rate 0.349 over 768 lookups) yet changes `analyze total_ms` by only
+   ~7 ms (~0.1%), well inside run-to-run noise and far below the ≥ 15% /
+   ≥ 200 ms threshold. The timing-reduction threshold is now **measured as not
+   met**, not merely unestablished.
+4. **Future PR E** — production cache only if a prototype A/B meets **all**
+   thresholds with parity tests. **Status: closed — no-go (measured).** The
+   PR F A/B directly measured the timing effect of eliminating every duplicate
+   open and found no ≥ 15% / ≥ 200 ms `analyze total_ms` win, so PR E is not
+   pursued. Reopen only from fresh evidence that the `analyze` compute profile
+   has shifted enough to make bounded content opens a material cost (e.g. a much
+   larger per-file byte cap, a preset dominated by `head_tail`/`lines`, or a
+   cold-cache/network-backed file provider).
 
 ## Validation
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -516,6 +516,18 @@ pub struct PerfSmokeArgs {
     /// `docs/plans/file-io-cache-evidence.md` before any cache is implemented.
     #[arg(long)]
     pub trace_io: bool,
+
+    /// Install the prototype request-scoped read cache for each timed analysis
+    /// preset.
+    ///
+    /// Emits an `io_cache` section (lookups/hits/misses/bytes served) and serves
+    /// duplicate content reads from a request-scoped cache. Use a health-preset
+    /// before/after A/B against `--cache-io` to measure whether eliminating
+    /// duplicate opens reduces `analyze total_ms` per the PR E threshold in
+    /// `docs/plans/file-io-cache-evidence.md`. Cached bytes are identical to a
+    /// fresh read; this is a measurement instrument, not a product cache.
+    #[arg(long)]
+    pub cache_io: bool,
 }
 
 impl Default for PerfSmokeArgs {
@@ -532,6 +544,7 @@ impl Default for PerfSmokeArgs {
             analysis_max_commits: 200,
             analysis_max_commit_files: 200,
             trace_io: false,
+            cache_io: false,
         }
     }
 }

--- a/xtask/src/tasks/perf_smoke.rs
+++ b/xtask/src/tasks/perf_smoke.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::time::Instant;
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokmd_analysis::io_cache::{self, IoCacheReport};
 use tokmd_analysis::io_trace::{self, IoTraceReport};
 use tokmd_core::settings::{
     AnalyzeSettings, ExportSettings, LangSettings, ModuleSettings, ScanSettings,
@@ -19,6 +20,7 @@ use tokmd_core::{
 const PERF_SMOKE_SCHEMA: &str = "tokmd.perf_smoke.v1";
 const ANALYSIS_TIMING_SCHEMA: &str = "tokmd.analysis_workflow_timing.v1";
 const IO_TRACE_SCHEMA: &str = "tokmd.io_open_trace.v1";
+const IO_CACHE_SCHEMA: &str = "tokmd.io_cache_prototype.v1";
 
 #[derive(Debug, Serialize)]
 struct PerfSmokeReceipt {
@@ -62,6 +64,8 @@ struct AnalysisWorkflowTiming {
     total_ms: u128,
     #[serde(skip_serializing_if = "Option::is_none")]
     io_trace: Option<IoTraceSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    io_cache: Option<IoCacheSection>,
 }
 
 #[derive(Debug, Serialize)]
@@ -81,6 +85,33 @@ struct IoTraceSection {
 struct IoTraceModeSection {
     opens: u64,
     unique_keys: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct IoCacheSection {
+    schema: String,
+    schema_version: u32,
+    lookups: u64,
+    hits: u64,
+    misses: u64,
+    entries: u64,
+    bytes_served: u64,
+    hit_rate: f64,
+}
+
+impl From<&IoCacheReport> for IoCacheSection {
+    fn from(report: &IoCacheReport) -> Self {
+        Self {
+            schema: IO_CACHE_SCHEMA.to_string(),
+            schema_version: 1,
+            lookups: report.lookups,
+            hits: report.hits,
+            misses: report.misses,
+            entries: report.entries,
+            bytes_served: report.bytes_served,
+            hit_rate: report.hit_rate(),
+        }
+    }
 }
 
 impl From<&IoTraceReport> for IoTraceSection {
@@ -189,7 +220,7 @@ fn analysis_timings(
 
     args.analysis_presets
         .iter()
-        .map(|preset| analysis_timing(scan, preset, &limits, args.trace_io))
+        .map(|preset| analysis_timing(scan, preset, &limits, args.trace_io, args.cache_io))
         .collect()
 }
 
@@ -198,6 +229,7 @@ fn analysis_timing(
     preset: &str,
     limits: &AnalysisTimingLimits,
     trace_io: bool,
+    cache_io: bool,
 ) -> Result<AnalysisWorkflowTiming> {
     let normalized = preset.trim().to_ascii_lowercase();
     let analyze = AnalyzeSettings {
@@ -210,12 +242,32 @@ fn analysis_timing(
         ..AnalyzeSettings::default()
     };
 
+    let mut io_report = None;
+    let mut cache_report = None;
     let start = Instant::now();
-    let (receipt_result, io_report) = if trace_io {
-        let (result, report) = io_trace::scope(|| analyze_workflow(scan, &analyze));
-        (result, Some(report))
-    } else {
-        (analyze_workflow(scan, &analyze), None)
+    // Trace and cache are independent thread-local scopes. When both are
+    // requested the cache scope nests inside the trace scope: the trace records
+    // every content-open demand while the cache serves duplicate reads, so an
+    // A/B can show demand and hit rate together.
+    let receipt_result = match (trace_io, cache_io) {
+        (false, false) => analyze_workflow(scan, &analyze),
+        (true, false) => {
+            let (result, report) = io_trace::scope(|| analyze_workflow(scan, &analyze));
+            io_report = Some(report);
+            result
+        }
+        (false, true) => {
+            let (result, report) = io_cache::scope(|| analyze_workflow(scan, &analyze));
+            cache_report = Some(report);
+            result
+        }
+        (true, true) => {
+            let ((result, cache), trace) =
+                io_trace::scope(|| io_cache::scope(|| analyze_workflow(scan, &analyze)));
+            io_report = Some(trace);
+            cache_report = Some(cache);
+            result
+        }
     };
     let total_ms = start.elapsed().as_millis();
     let receipt =
@@ -242,6 +294,7 @@ fn analysis_timing(
         limits: limits.clone(),
         total_ms,
         io_trace: io_report.as_ref().map(IoTraceSection::from),
+        io_cache: cache_report.as_ref().map(IoCacheSection::from),
     })
 }
 
@@ -404,6 +457,41 @@ mod tests {
         assert_eq!(timing.limits.max_commits, 7);
         assert_eq!(timing.limits.max_commit_files, 8);
         assert!(timing.io_trace.is_none());
+        assert!(timing.io_cache.is_none());
+        assert!(!serde_json::to_string(&receipt)?.contains(temp.path().to_string_lossy().as_ref()));
+        Ok(())
+    }
+
+    #[test]
+    fn cache_io_records_prototype_cache_section() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join("lib.rs"),
+            "pub fn lib() { /* TODO: keep content enrichers reading this file */ }\n",
+        )?;
+        let args = PerfSmokeArgs {
+            target_repo: temp.path().to_path_buf(),
+            output: temp.path().join("perf.json"),
+            analysis_presets: vec!["health".to_string()],
+            cache_io: true,
+            ..PerfSmokeArgs::default()
+        };
+
+        let receipt = perf_smoke_receipt(&args)?;
+
+        let timing = receipt
+            .analysis_workflows
+            .first()
+            .context("expected one analysis workflow timing")?;
+        assert!(timing.io_trace.is_none());
+        let cache = timing
+            .io_cache
+            .as_ref()
+            .context("cache_io should populate an io_cache section")?;
+        assert_eq!(cache.schema, IO_CACHE_SCHEMA);
+        assert!(cache.lookups >= 1, "expected at least one cache lookup");
+        assert_eq!(cache.misses + cache.hits, cache.lookups);
+        assert!(cache.entries <= cache.lookups);
         assert!(!serde_json::to_string(&receipt)?.contains(temp.path().to_string_lossy().as_ref()));
         Ok(())
     }


### PR DESCRIPTION
## Summary

Deliberate merge-commit import of the tokmd-swarm Lane 3 measured-performance
closeout batch (PR F + NOW.md freshness) into publication.

Swarm-Head: `0f00c2f722d3a0dfc5264dc3b3143a9079078697`
Swarm-Range: `14d611cb..0f00c2f7`

Imported swarm PRs:

- **#411** perf(analysis): prototype request-scoped read cache + health A/B
  (Lane 3 PR F). New `tokmd-analysis::io_cache` + `perf-smoke --cache-io`; the
  health-preset A/B settles the file-I/O cache decision as a **measured no-go**
  (PR E closed). Cache is scope-gated and off by default; default `analyze`
  behavior, receipt schemas, and preset defaults are unchanged.
- **#412** docs(now): Lane 3 measured-performance closeout + alignment refresh.

## Claim boundary

- No release, publish, signing, tag, Docker, `v1` alias, or Nix-full claim is
  made or proven by this import.
- The prototype cache is a maintainer measurement instrument only; it does not
  change default product behavior or any public schema.
- Advisory no-panic strict lane carries 11 pre-existing test-code findings
  (complexity/io_trace/trace_io); this batch adds none.

## Proof (swarm side)

- `Tokmd Rust Result` passed on both #411 and #412 before squash-merge.
- `cargo xtask repo-graph --expect swarm-ahead` = ok (swarm_ahead=2) pre-import.
- Merge with a **merge commit** (not squash); swarm fast-forwards to this merge
  commit after publication CI.
