### PR TITLE
merge(swarm): import tokmd-swarm determinism + FileRow property tests (#421 + #422)

### DIFF
--- a/crates/tokmd-model/tests/proptest_w42.rs
+++ b/crates/tokmd-model/tests/proptest_w42.rs
@@ -6,7 +6,14 @@
 use proptest::prelude::*;
 use std::path::Path;
 use tokmd_model::{avg, module_key, normalize_path};
-use tokmd_types::{LangRow, ModuleRow};
+use tokmd_types::{FileKind, FileRow, LangRow, ModuleRow};
+
+/// Sort `FileRow`s the same way the model does: descending by code, then
+/// ascending by path. Mirrors `tokmd_model::sorting::sort_file_rows`, which is
+/// crate-private, so the invariant is asserted against the exact comparator.
+fn sort_file_rows_like_model(rows: &mut [FileRow]) {
+    rows.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.path.cmp(&b.path)));
+}
 
 // ============================================================================
 // Strategies
@@ -60,6 +67,41 @@ fn arb_module_row() -> impl Strategy<Value = ModuleRow> {
                 avg_lines,
             }
         })
+}
+
+fn arb_file_kind() -> impl Strategy<Value = FileKind> {
+    prop_oneof![Just(FileKind::Parent), Just(FileKind::Child)]
+}
+
+fn arb_file_row() -> impl Strategy<Value = FileRow> {
+    (
+        "[a-z][a-z0-9_/]{1,20}\\.[a-z]{1,4}", // path
+        "[a-z][a-z0-9_/]{0,10}",              // module
+        "[A-Z][a-z]{2,10}",                   // lang
+        arb_file_kind(),
+        0usize..50_000,    // code
+        0usize..50_000,    // comments
+        0usize..50_000,    // blanks
+        0usize..5_000_000, // bytes
+        0usize..500_000,   // tokens
+    )
+        .prop_map(
+            |(path, module, lang, kind, code, comments, blanks, bytes, tokens)| {
+                let lines = code + comments + blanks;
+                FileRow {
+                    path,
+                    module,
+                    lang,
+                    kind,
+                    code,
+                    comments,
+                    blanks,
+                    lines,
+                    bytes,
+                    tokens,
+                }
+            },
+        )
 }
 
 // ============================================================================
@@ -208,6 +250,96 @@ proptest! {
         sorted.sort_by(|a, b| b.code.cmp(&a.code).then_with(|| a.module.cmp(&b.module)));
         let sum_after: usize = sorted.iter().map(|r| r.code).sum();
         prop_assert_eq!(sum_before, sum_after);
+    }
+}
+
+// ============================================================================
+// FileRow aggregation and sorting invariants
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// A well-formed FileRow keeps `lines == code + comments + blanks`.
+    #[test]
+    fn file_row_lines_equal_component_sum(row in arb_file_row()) {
+        prop_assert_eq!(row.lines, row.code + row.comments + row.blanks);
+    }
+
+    /// lines >= code for well-formed FileRows.
+    #[test]
+    fn file_row_lines_ge_code(row in arb_file_row()) {
+        prop_assert!(row.lines >= row.code,
+            "lines ({}) must be >= code ({})", row.lines, row.code);
+    }
+
+    /// Sorting FileRows by (code desc, path asc) is idempotent.
+    #[test]
+    fn file_row_sort_idempotent(rows in prop::collection::vec(arb_file_row(), 0..30)) {
+        let mut once = rows.clone();
+        sort_file_rows_like_model(&mut once);
+        let mut twice = once.clone();
+        sort_file_rows_like_model(&mut twice);
+        prop_assert_eq!(once, twice);
+    }
+
+    /// Sorting preserves the number of rows.
+    #[test]
+    fn file_row_sort_preserves_count(rows in prop::collection::vec(arb_file_row(), 0..30)) {
+        let mut sorted = rows.clone();
+        sort_file_rows_like_model(&mut sorted);
+        prop_assert_eq!(sorted.len(), rows.len());
+    }
+
+    /// Sorted FileRows are in descending code order, ties broken by path asc.
+    #[test]
+    fn file_row_sorted_descending(rows in prop::collection::vec(arb_file_row(), 2..20)) {
+        let mut sorted = rows;
+        sort_file_rows_like_model(&mut sorted);
+        // Slice-pattern binding avoids unchecked indexing (no-panic policy).
+        for w in sorted.windows(2) {
+            let [a, b] = w else { continue };
+            prop_assert!(
+                a.code > b.code || (a.code == b.code && a.path <= b.path),
+                "Sort order violated: {a:?} before {b:?}"
+            );
+        }
+    }
+
+    /// Sorting preserves the sum of code across all rows (no rows dropped).
+    #[test]
+    fn file_row_sort_preserves_code_sum(rows in prop::collection::vec(arb_file_row(), 0..30)) {
+        let sum_before: usize = rows.iter().map(|r| r.code).sum();
+        let mut sorted = rows;
+        sort_file_rows_like_model(&mut sorted);
+        let sum_after: usize = sorted.iter().map(|r| r.code).sum();
+        prop_assert_eq!(sum_before, sum_after);
+    }
+
+    /// Sorting is a permutation: the multiset of rows is unchanged.
+    #[test]
+    fn file_row_sort_is_permutation(rows in prop::collection::vec(arb_file_row(), 0..25)) {
+        // FileRow is not Ord; compare multisets via a canonical full-field key.
+        let key = |r: &FileRow| {
+            (
+                r.code,
+                r.path.clone(),
+                r.module.clone(),
+                r.lang.clone(),
+                r.kind,
+                r.comments,
+                r.blanks,
+                r.lines,
+                r.bytes,
+                r.tokens,
+            )
+        };
+        let mut sorted = rows.clone();
+        sort_file_rows_like_model(&mut sorted);
+        let mut before = rows;
+        before.sort_by_key(key);
+        sorted.sort_by_key(key);
+        prop_assert_eq!(before, sorted);
     }
 }
 

--- a/crates/tokmd/tests/determinism.rs
+++ b/crates/tokmd/tests/determinism.rs
@@ -13,6 +13,21 @@ fn tokmd_cmd() -> Command {
     cmd
 }
 
+/// Assert a completed command exited successfully, surfacing stderr on failure.
+///
+/// Without this guard a failing command (for example an unsupported `--format`
+/// value) prints nothing to stdout and exits non-zero, so comparing two empty
+/// outputs passes trivially and masks regressions. `assert!` is not a tracked
+/// panic-family construct, so this helper adds no no-panic debt.
+fn assert_cmd_ok(o: &std::process::Output) {
+    assert!(
+        o.status.success(),
+        "command exited with {:?}: {}",
+        o.status.code(),
+        String::from_utf8_lossy(&o.stderr)
+    );
+}
+
 /// Normalize non-deterministic fields (timestamps, tool version) so we can
 /// compare outputs byte-for-byte.
 fn normalize_envelope(output: &str) -> String {
@@ -36,6 +51,7 @@ fn lang_json_is_deterministic() {
             .args(["lang", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     let a = run();
@@ -52,6 +68,7 @@ fn lang_md_is_deterministic() {
             .args(["lang", "--format", "md"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).to_string()
     };
     assert_eq!(
@@ -68,6 +85,7 @@ fn lang_tsv_is_deterministic() {
             .args(["lang", "--format", "tsv"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).to_string()
     };
     assert_eq!(run(), run(), "lang TSV must be byte-stable across runs");
@@ -80,6 +98,7 @@ fn module_json_is_deterministic() {
             .args(["module", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     let a = run();
@@ -96,6 +115,7 @@ fn module_md_is_deterministic() {
             .args(["module", "--format", "md"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).to_string()
     };
     assert_eq!(
@@ -112,6 +132,7 @@ fn module_tsv_is_deterministic() {
             .args(["module", "--format", "tsv"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).to_string()
     };
     assert_eq!(run(), run(), "module TSV must be byte-stable across runs");
@@ -124,6 +145,7 @@ fn export_jsonl_is_deterministic() {
             .args(["export", "--format", "jsonl"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     assert_eq!(run(), run(), "export JSONL must be byte-stable across runs");
@@ -136,6 +158,7 @@ fn export_csv_is_deterministic() {
             .args(["export", "--format", "csv"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).to_string()
     };
     assert_eq!(run(), run(), "export CSV must be byte-stable across runs");
@@ -148,6 +171,7 @@ fn export_json_is_deterministic() {
             .args(["export", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     assert_eq!(run(), run(), "export JSON must be byte-stable across runs");
@@ -163,6 +187,7 @@ fn lang_json_keys_are_sorted() {
         .args(["lang", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
 
     // Verify any nested maps in row objects have sorted keys.
@@ -187,6 +212,7 @@ fn export_json_keys_are_sorted() {
         .args(["export", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     if let Some(rows) = json.get("rows").and_then(|v| v.as_array()) {
         for row in rows {
@@ -210,6 +236,7 @@ fn lang_rows_sorted_by_code_desc_then_name_asc() {
         .args(["lang", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json
         .get("rows")
@@ -236,6 +263,7 @@ fn module_rows_sorted_by_code_desc_then_name_asc() {
         .args(["module", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json
         .get("rows")
@@ -262,6 +290,7 @@ fn export_rows_sorted_by_code_desc_then_path_asc() {
         .args(["export", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json
         .get("rows")
@@ -292,6 +321,7 @@ fn lang_receipt_has_required_envelope_fields() {
         .args(["lang", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     assert!(
         json.get("schema_version").is_some(),
@@ -313,6 +343,7 @@ fn module_receipt_has_required_envelope_fields() {
         .args(["module", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     assert!(
         json.get("schema_version").is_some(),
@@ -328,6 +359,7 @@ fn export_json_receipt_has_required_envelope_fields() {
         .args(["export", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     assert!(
         json.get("schema_version").is_some(),
@@ -347,6 +379,7 @@ fn export_paths_use_forward_slashes() {
         .args(["export", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json
         .get("rows")
@@ -365,6 +398,7 @@ fn export_modules_use_forward_slashes() {
         .args(["export", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json
         .get("rows")
@@ -427,6 +461,7 @@ fn lang_row_count_is_stable() {
             .args(["lang", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
         json.get("rows")
             .and_then(|v| v.as_array())
@@ -443,6 +478,7 @@ fn export_row_count_is_stable() {
             .args(["export", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
         json.get("rows")
             .and_then(|v| v.as_array())
@@ -463,6 +499,7 @@ fn redacted_export_is_deterministic() {
             .args(["export", "--format", "json", "--redact", "paths"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     assert_eq!(
@@ -478,6 +515,7 @@ fn redacted_paths_are_hashed_not_plaintext() {
         .args(["export", "--format", "json", "--redact", "paths"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json
         .get("rows")
@@ -505,6 +543,7 @@ fn export_jsonl_meta_record_is_deterministic() {
             .args(["export", "--format", "jsonl"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         let stdout = String::from_utf8_lossy(&o.stdout).to_string();
         let first_line = stdout.lines().next().unwrap_or("").to_string();
         normalize_envelope(&first_line)
@@ -526,6 +565,7 @@ fn lang_totals_match_row_sums() {
         .args(["lang", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
 
     let rows = json["rows"].as_array().expect("rows array");
@@ -571,6 +611,7 @@ fn module_json_keys_use_forward_slashes() {
         .args(["module", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: serde_json::Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json
         .get("rows")
@@ -598,6 +639,7 @@ fn export_jsonl_all_lines_valid_json() {
         .args(["export", "--format", "jsonl"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let stdout = String::from_utf8_lossy(&o.stdout);
     for (i, line) in stdout.lines().enumerate() {
         assert!(
@@ -617,6 +659,7 @@ fn export_csv_consistent_column_count() {
         .args(["export", "--format", "csv"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let stdout = String::from_utf8_lossy(&o.stdout);
     let lines: Vec<&str> = stdout.lines().collect();
     assert!(!lines.is_empty(), "CSV output must not be empty");

--- a/crates/tokmd/tests/determinism_regression.rs
+++ b/crates/tokmd/tests/determinism_regression.rs
@@ -20,6 +20,21 @@ fn tokmd_cmd() -> Command {
     cmd
 }
 
+/// Assert a completed command exited successfully, surfacing stderr on failure.
+///
+/// A command that fails (for example an unsupported `--format` value) prints
+/// nothing to stdout and exits non-zero, so comparing two empty outputs passes
+/// trivially and masks regressions. `assert!` is not a tracked panic-family
+/// construct, so this helper adds no no-panic debt.
+fn assert_cmd_ok(o: &std::process::Output) {
+    assert!(
+        o.status.success(),
+        "command exited with {:?}: {}",
+        o.status.code(),
+        String::from_utf8_lossy(&o.stderr)
+    );
+}
+
 /// Normalize non-deterministic fields (timestamps, tool version) for
 /// byte-level comparison of serialized output.
 fn normalize_envelope(output: &str) -> String {
@@ -69,6 +84,7 @@ fn lang_json_byte_identical_across_runs() {
             .args(["lang", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     let a = run();
@@ -86,6 +102,7 @@ fn module_json_byte_identical_across_runs() {
             .args(["module", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     let a = run();
@@ -103,6 +120,7 @@ fn export_jsonl_byte_identical_across_runs() {
             .args(["export", "--format", "jsonl"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         normalize_envelope(&String::from_utf8_lossy(&o.stdout))
     };
     let a = run();
@@ -145,6 +163,7 @@ fn export_json_no_backslash_in_path_or_module() {
         .args(["export", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json["rows"].as_array().expect("rows");
 
@@ -165,6 +184,7 @@ fn module_json_no_backslash_in_module_keys() {
         .args(["module", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json["rows"].as_array().expect("rows");
 
@@ -222,6 +242,7 @@ fn lang_json_no_backslash_in_path_fields() {
         .args(["lang", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
 
     let mut strings = Vec::new();
@@ -247,6 +268,7 @@ fn lang_timestamp_is_only_nondeterministic_field() {
             .args(["lang", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         serde_json::from_slice::<Value>(&o.stdout).expect("valid JSON")
     };
     let mut a = run();
@@ -273,6 +295,7 @@ fn module_timestamp_is_only_nondeterministic_field() {
             .args(["module", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         serde_json::from_slice::<Value>(&o.stdout).expect("valid JSON")
     };
     let mut a = run();
@@ -296,6 +319,7 @@ fn export_timestamp_is_only_nondeterministic_field() {
             .args(["export", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         serde_json::from_slice::<Value>(&o.stdout).expect("valid JSON")
     };
     let mut a = run();
@@ -346,6 +370,7 @@ fn lang_rows_descending_code_ascending_name() {
         .args(["lang", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json["rows"].as_array().expect("rows");
 
@@ -368,6 +393,7 @@ fn module_rows_descending_code_ascending_module() {
         .args(["module", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json["rows"].as_array().expect("rows");
 
@@ -390,6 +416,7 @@ fn export_rows_descending_code_ascending_path() {
         .args(["export", "--format", "json"])
         .output()
         .expect("run");
+    assert_cmd_ok(&o);
     let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
     let rows = json["rows"].as_array().expect("rows");
 
@@ -453,24 +480,13 @@ fn analyze_receipt_markdown_deterministic() {
 }
 
 #[test]
-fn lang_csv_byte_identical() {
-    let run = || {
-        let o = tokmd_cmd()
-            .args(["lang", "--format", "csv"])
-            .output()
-            .expect("run");
-        String::from_utf8_lossy(&o.stdout).to_string()
-    };
-    assert_eq!(run(), run(), "lang CSV must be byte-identical");
-}
-
-#[test]
 fn module_tsv_byte_identical() {
     let run = || {
         let o = tokmd_cmd()
             .args(["module", "--format", "tsv"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).to_string()
     };
     assert_eq!(run(), run(), "module TSV must be byte-identical");
@@ -483,6 +499,7 @@ fn export_csv_byte_identical() {
             .args(["export", "--format", "csv"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).to_string()
     };
     assert_eq!(run(), run(), "export CSV must be byte-identical");
@@ -496,6 +513,7 @@ fn export_csv_byte_identical() {
 fn row_counts_stable_across_all_commands() {
     let count = |args: &[&str]| -> usize {
         let o = tokmd_cmd().args(args).output().expect("run");
+        assert_cmd_ok(&o);
         let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
         json["rows"].as_array().map(|a| a.len()).unwrap_or(0)
     };
@@ -523,6 +541,7 @@ fn export_jsonl_line_count_stable() {
             .args(["export", "--format", "jsonl"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         String::from_utf8_lossy(&o.stdout).lines().count()
     };
     let a = count();
@@ -541,6 +560,7 @@ fn json_keys_alphabetically_sorted_in_receipt_rows() {
 
     for cmd in commands {
         let o = tokmd_cmd().args(*cmd).output().expect("run");
+        assert_cmd_ok(&o);
         let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
 
         if let Some(rows) = json["rows"].as_array() {
@@ -596,6 +616,7 @@ fn module_keys_deterministic_across_runs() {
             .args(["module", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
         json["rows"]
             .as_array()
@@ -618,6 +639,7 @@ fn export_module_keys_match_module_command() {
             .args(["module", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
         let mut mods: Vec<String> = json["rows"]
             .as_array()
@@ -635,6 +657,7 @@ fn export_module_keys_match_module_command() {
             .args(["export", "--format", "json"])
             .output()
             .expect("run");
+        assert_cmd_ok(&o);
         let json: Value = serde_json::from_slice(&o.stdout).expect("valid JSON");
         let mut mods: Vec<String> = json["rows"]
             .as_array()


### PR DESCRIPTION
Deliberate merge-commit import of the current `tokmd-swarm/main` head into publication, per `docs/ci/swarm-routing.md`.

## Batch

Swarm-Head: `37495ddc`
Swarm-Range: `a44304c4..37495ddc`

Imported squashed swarm commits:

- `71ef2eb1` test(determinism): guard against silent CLI failures (#421)
- `37495ddc` test(model): add FileRow sorting and aggregation properties (#422)

Both are test-only / determinism-guard changes. No production behavior, schema, or public API changes.

## Notes

- Publication Jules PR #2774 (FileRow property tests) was closed as superseded by swarm #422, which carries the same invariants through this import.

## Proof boundary

- Swarm gate `Tokmd Rust Result` passed on both source PRs (#421, #422) before squash merge.
- Publication CI on this import PR proves the imported batch is release-safe on the shared commit.
- This is a topology/import step only. It does not move tags, publish packages, sign artifacts, update the `v1` alias, or run release workflows.
