### PR TITLE
merge(swarm): import tokmd-swarm defer FileStatRow perf (#423)

### DIFF
--- a/crates/tokmd-analysis/src/derived/files.rs
+++ b/crates/tokmd-analysis/src/derived/files.rs
@@ -7,47 +7,41 @@ const TOP_N: usize = 10;
 const MIN_DOC_LINES: usize = 50;
 const MIN_DENSE_LINES: usize = 10;
 
-pub(super) fn build_file_stats(rows: &[&FileRow]) -> Vec<FileStatRow> {
-    rows.iter()
-        .map(|r| FileStatRow {
-            path: r.path.clone(),
-            module: r.module.clone(),
-            lang: r.lang.clone(),
-            code: r.code,
-            comments: r.comments,
-            blanks: r.blanks,
-            lines: r.lines,
-            bytes: r.bytes,
-            tokens: r.tokens,
-            doc_pct: if r.code + r.comments == 0 {
-                None
-            } else {
-                Some(safe_ratio(r.comments, r.code + r.comments))
-            },
-            bytes_per_line: if r.lines == 0 {
-                None
-            } else {
-                Some(safe_ratio(r.bytes, r.lines))
-            },
-            depth: path_depth(&r.path),
-        })
-        .collect()
+pub(crate) fn to_stat_row(r: &FileRow) -> FileStatRow {
+    FileStatRow {
+        path: r.path.clone(),
+        module: r.module.clone(),
+        lang: r.lang.clone(),
+        code: r.code,
+        comments: r.comments,
+        blanks: r.blanks,
+        lines: r.lines,
+        bytes: r.bytes,
+        tokens: r.tokens,
+        doc_pct: if r.code + r.comments == 0 {
+            None
+        } else {
+            Some(safe_ratio(r.comments, r.code + r.comments))
+        },
+        bytes_per_line: if r.lines == 0 {
+            None
+        } else {
+            Some(safe_ratio(r.bytes, r.lines))
+        },
+        depth: path_depth(&r.path),
+    }
 }
 
-pub(super) fn build_max_file_report(rows: &[FileStatRow]) -> MaxFileReport {
-    let mut overall = rows
+pub(super) fn build_max_file_report(rows: &[&FileRow]) -> MaxFileReport {
+    let overall = rows
         .iter()
+        .copied()
         .max_by(|a, b| a.lines.cmp(&b.lines).then_with(|| a.path.cmp(&b.path)))
-        .cloned()
+        .map(to_stat_row)
         .unwrap_or_else(empty_file_row);
 
-    if rows.is_empty() {
-        overall = empty_file_row();
-    }
-
-    let mut by_lang: std::collections::BTreeMap<&str, &FileStatRow> =
-        std::collections::BTreeMap::new();
-    let mut by_module: std::collections::BTreeMap<&str, &FileStatRow> =
+    let mut by_lang: std::collections::BTreeMap<&str, &FileRow> = std::collections::BTreeMap::new();
+    let mut by_module: std::collections::BTreeMap<&str, &FileRow> =
         std::collections::BTreeMap::new();
 
     for row in rows {
@@ -55,20 +49,20 @@ pub(super) fn build_max_file_report(rows: &[FileStatRow]) -> MaxFileReport {
             if row.lines > existing.lines
                 || (row.lines == existing.lines && row.path < existing.path)
             {
-                *existing = row;
+                *existing = *row;
             }
         } else {
-            by_lang.insert(row.lang.as_str(), row);
+            by_lang.insert(row.lang.as_str(), *row);
         }
 
         if let Some(existing) = by_module.get_mut(row.module.as_str()) {
             if row.lines > existing.lines
                 || (row.lines == existing.lines && row.path < existing.path)
             {
-                *existing = row;
+                *existing = *row;
             }
         } else {
-            by_module.insert(row.module.as_str(), row);
+            by_module.insert(row.module.as_str(), *row);
         }
     }
 
@@ -78,56 +72,84 @@ pub(super) fn build_max_file_report(rows: &[FileStatRow]) -> MaxFileReport {
             .into_iter()
             .map(|(key, file)| MaxFileRow {
                 key: key.to_string(),
-                file: file.clone(),
+                file: to_stat_row(file),
             })
             .collect(),
         by_module: by_module
             .into_iter()
             .map(|(key, file)| MaxFileRow {
                 key: key.to_string(),
-                file: file.clone(),
+                file: to_stat_row(file),
             })
             .collect(),
     }
 }
 
-pub(super) fn build_top_offenders(rows: &[FileStatRow]) -> TopOffenders {
-    let mut by_lines: Vec<&FileStatRow> = rows.iter().collect();
+pub(super) fn build_top_offenders(rows: &[&FileRow]) -> TopOffenders {
+    let mut by_lines: Vec<&FileRow> = rows.to_vec();
     by_lines.sort_by(|a, b| b.lines.cmp(&a.lines).then_with(|| a.path.cmp(&b.path)));
+    by_lines.truncate(TOP_N);
 
-    let mut by_tokens: Vec<&FileStatRow> = rows.iter().collect();
+    let mut by_tokens: Vec<&FileRow> = rows.to_vec();
     by_tokens.sort_by(|a, b| b.tokens.cmp(&a.tokens).then_with(|| a.path.cmp(&b.path)));
+    by_tokens.truncate(TOP_N);
 
-    let mut by_bytes: Vec<&FileStatRow> = rows.iter().collect();
+    let mut by_bytes: Vec<&FileRow> = rows.to_vec();
     by_bytes.sort_by(|a, b| b.bytes.cmp(&a.bytes).then_with(|| a.path.cmp(&b.path)));
+    by_bytes.truncate(TOP_N);
 
-    let mut least_doc: Vec<&FileStatRow> =
-        rows.iter().filter(|r| r.lines >= MIN_DOC_LINES).collect();
+    let mut least_doc: Vec<&FileRow> = rows
+        .iter()
+        .copied()
+        .filter(|r| r.lines >= MIN_DOC_LINES)
+        .collect();
     least_doc.sort_by(|a, b| {
-        let a_doc = a.doc_pct.unwrap_or(0.0);
-        let b_doc = b.doc_pct.unwrap_or(0.0);
+        let a_doc = if a.code + a.comments == 0 {
+            0.0
+        } else {
+            safe_ratio(a.comments, a.code + a.comments)
+        };
+        let b_doc = if b.code + b.comments == 0 {
+            0.0
+        } else {
+            safe_ratio(b.comments, b.code + b.comments)
+        };
         a_doc
             .partial_cmp(&b_doc)
             .unwrap_or(std::cmp::Ordering::Equal)
             .then_with(|| b.lines.cmp(&a.lines))
             .then_with(|| a.path.cmp(&b.path))
     });
+    least_doc.truncate(TOP_N);
 
-    let mut dense: Vec<&FileStatRow> = rows.iter().filter(|r| r.lines >= MIN_DENSE_LINES).collect();
+    let mut dense: Vec<&FileRow> = rows
+        .iter()
+        .copied()
+        .filter(|r| r.lines >= MIN_DENSE_LINES)
+        .collect();
     dense.sort_by(|a, b| {
-        let a_rate = a.bytes_per_line.unwrap_or(0.0);
-        let b_rate = b.bytes_per_line.unwrap_or(0.0);
+        let a_rate = if a.lines == 0 {
+            0.0
+        } else {
+            safe_ratio(a.bytes, a.lines)
+        };
+        let b_rate = if b.lines == 0 {
+            0.0
+        } else {
+            safe_ratio(b.bytes, b.lines)
+        };
         b_rate
             .partial_cmp(&a_rate)
             .unwrap_or(std::cmp::Ordering::Equal)
             .then_with(|| a.path.cmp(&b.path))
     });
+    dense.truncate(TOP_N);
 
     TopOffenders {
-        largest_lines: by_lines.into_iter().take(TOP_N).cloned().collect(),
-        largest_tokens: by_tokens.into_iter().take(TOP_N).cloned().collect(),
-        largest_bytes: by_bytes.into_iter().take(TOP_N).cloned().collect(),
-        least_documented: least_doc.into_iter().take(TOP_N).cloned().collect(),
-        most_dense: dense.into_iter().take(TOP_N).cloned().collect(),
+        largest_lines: by_lines.into_iter().map(to_stat_row).collect(),
+        largest_tokens: by_tokens.into_iter().map(to_stat_row).collect(),
+        largest_bytes: by_bytes.into_iter().map(to_stat_row).collect(),
+        least_documented: least_doc.into_iter().map(to_stat_row).collect(),
+        most_dense: dense.into_iter().map(to_stat_row).collect(),
     }
 }

--- a/crates/tokmd-analysis/src/derived/mod.rs
+++ b/crates/tokmd-analysis/src/derived/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use tokmd_analysis_types::{
     BoilerplateReport, CocomoReport, ContextWindowReport, DerivedReport, DerivedTotals,
-    FileStatRow, NestingReport, NestingRow, ReadingTimeReport, TestDensityReport,
+    NestingReport, NestingRow, ReadingTimeReport, TestDensityReport,
 };
 use tokmd_analysis_types::{is_infra_lang, is_test_path};
 use tokmd_format::render_analysis_tree;
@@ -17,7 +17,7 @@ mod integrity;
 mod languages;
 mod ratios;
 use distribution::{build_distribution_report, build_histogram};
-use files::{build_file_stats, build_max_file_report, build_top_offenders};
+use files::{build_max_file_report, build_top_offenders};
 use integrity::build_integrity_report;
 use languages::{build_lang_purity_report, build_polyglot_report};
 use ratios::{build_doc_density_report, build_verbosity_report, build_whitespace_report};
@@ -58,13 +58,11 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
 
     let verbosity = build_verbosity_report(&parents, totals.bytes, totals.lines);
 
-    let file_stats = build_file_stats(&parents);
-
-    let max_file = build_max_file_report(&file_stats);
+    let max_file = build_max_file_report(&parents);
 
     let lang_purity = build_lang_purity_report(&parents);
 
-    let nesting = build_nesting_report(&file_stats);
+    let nesting = build_nesting_report(&parents);
 
     let test_density = build_test_density_report(&parents);
 
@@ -76,7 +74,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
 
     let histogram = build_histogram(&parents);
 
-    let top = build_top_offenders(&file_stats);
+    let top = build_top_offenders(&parents);
 
     let reading_time = ReadingTimeReport {
         minutes: round_f64(totals.code as f64 / LINES_PER_MINUTE as f64, 2),
@@ -142,7 +140,7 @@ pub fn derive_report(export: &ExportData, window_tokens: Option<usize>) -> Deriv
     }
 }
 
-fn build_nesting_report(rows: &[FileStatRow]) -> NestingReport {
+fn build_nesting_report(rows: &[&FileRow]) -> NestingReport {
     if rows.is_empty() {
         return NestingReport {
             max: 0,
@@ -156,12 +154,13 @@ fn build_nesting_report(rows: &[FileStatRow]) -> NestingReport {
     let mut by_module: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
 
     for row in rows {
-        total_depth += row.depth;
-        max_depth = max_depth.max(row.depth);
+        let depth = tokmd_analysis_types::path_depth(&row.path);
+        total_depth += depth;
+        max_depth = max_depth.max(depth);
         if let Some(existing) = by_module.get_mut(row.module.as_str()) {
-            existing.push(row.depth);
+            existing.push(depth);
         } else {
-            by_module.insert(row.module.as_str(), vec![row.depth]);
+            by_module.insert(row.module.as_str(), vec![depth]);
         }
     }
 


### PR DESCRIPTION
## Summary

Publication import of swarm PR EffortlessMetrics/tokmd-swarm#423 — defer `FileStatRow` creation to report boundaries.

- Removes `build_file_stats` and its O(N) per-file string clones (`path`, `module`, `lang`); `FileStatRow` values are now materialized only at the report edges (`build_max_file_report`, `build_top_offenders`).
- Output DTOs in `tokmd-analysis-types` are unchanged; this is a behavior-preserving allocation-reduction refactor.

## Provenance

- Swarm squash commit: `c5c5990d` — `perf(analysis): defer FileStatRow creation to report boundaries (#423)`
- Swarm range imported: `2801fd66..c5c5990d`
- Swarm gate `Tokmd Rust Result` (run 28667753698): success

## Merge method

Merge with a **merge commit** (not squash) per `docs/ci/swarm-routing.md`. After merge, `tokmd-swarm/main` fast-forwards to the publication merge commit.

## Supersedes

Closes out publication bolt PR #2780 (already closed as superseded by swarm #423).

## Claim boundary

- Establishes: swarm #423 content imported into publication via merge commit; graph returns to aligned after swarm fast-forward.
- Does NOT establish: any release/tag/publish/signing action; no version bump; no perf measurement is claimed by this import beyond swarm CI green.
