### PR TITLE
merge(swarm): import tokmd-swarm as_text single-pass UTF-8 (#424)

### DIFF
--- a/crates/tokmd-analysis/src/api_surface/report.rs
+++ b/crates/tokmd-analysis/src/api_surface/report.rs
@@ -71,12 +71,10 @@ pub(crate) fn build_api_surface_report(
         };
         total_bytes += bytes.len() as u64;
 
-        if !crate::content::io::is_text_like(&bytes) {
+        let Some(text) = crate::content::io::as_text(&bytes) else {
             continue;
-        }
-
-        let text = String::from_utf8_lossy(&bytes);
-        let symbols = symbols::extract_symbols(&row.lang, &text);
+        };
+        let symbols = symbols::extract_symbols(&row.lang, text);
 
         if symbols.is_empty() {
             continue;

--- a/crates/tokmd-analysis/src/complexity/mod.rs
+++ b/crates/tokmd-analysis/src/complexity/mod.rs
@@ -88,19 +88,17 @@ pub(crate) fn build_complexity_report(
         };
         total_bytes += bytes.len() as u64;
 
-        if !crate::content::io::is_text_like(&bytes) {
+        let Some(text) = crate::content::io::as_text(&bytes) else {
             continue;
-        }
-
-        let text = String::from_utf8_lossy(&bytes);
+        };
         let lang_mapped = map_language_for_complexity(&row.lang);
-        let (function_count, max_function_length) = count_functions(&row.lang, &text);
+        let (function_count, max_function_length) = count_functions(&row.lang, text);
         let cyclomatic_analysis =
-            crate::content::complexity::estimate_cyclomatic_complexity(&text, lang_mapped);
+            crate::content::complexity::estimate_cyclomatic_complexity(text, lang_mapped);
         let (cyclomatic, max_function_cyclomatic) = if cyclomatic_analysis.function_count > 0 {
             (cyclomatic_analysis.total_cc, cyclomatic_analysis.max_cc)
         } else if function_count > 0 {
-            let file_level = estimate_cyclomatic(&row.lang, &text);
+            let file_level = estimate_cyclomatic(&row.lang, text);
             (file_level, file_level)
         } else {
             (0, 0)
@@ -108,8 +106,8 @@ pub(crate) fn build_complexity_report(
 
         // Compute cognitive complexity and nesting depth
         let cognitive_result =
-            crate::content::complexity::estimate_cognitive_complexity(&text, lang_mapped);
-        let nesting_result = crate::content::complexity::analyze_nesting_depth(&text, lang_mapped);
+            crate::content::complexity::estimate_cognitive_complexity(text, lang_mapped);
+        let nesting_result = crate::content::complexity::analyze_nesting_depth(text, lang_mapped);
 
         let cognitive_complexity = if cognitive_result.function_count > 0 {
             Some(cognitive_result.total)
@@ -131,7 +129,7 @@ pub(crate) fn build_complexity_report(
         );
 
         let functions = if detail_functions {
-            Some(extract_function_details(&row.lang, &text))
+            Some(extract_function_details(&row.lang, text))
         } else {
             None
         };

--- a/crates/tokmd-analysis/src/content/io.rs
+++ b/crates/tokmd-analysis/src/content/io.rs
@@ -83,6 +83,22 @@ pub fn read_text_capped(path: &Path, max_bytes: usize) -> Result<String> {
     read::read_text_capped(path, max_bytes)
 }
 
+/// Borrow the bytes as text (`&str`) when text-like, else `None`.
+///
+/// Single-pass alternative to `is_text_like` + `String::from_utf8_lossy`: it
+/// validates UTF-8 once and returns a borrow, avoiding the redundant second
+/// validation and the `Cow` allocation at analysis enricher call sites.
+pub fn as_text(bytes: &[u8]) -> Option<&str> {
+    bytes::as_text(bytes)
+}
+
+#[cfg_attr(
+    not(any(test, fuzzing)),
+    expect(
+        dead_code,
+        reason = "text-like predicate now backed by as_text; retained for tests and fuzz_entropy"
+    )
+)]
 pub fn is_text_like(bytes: &[u8]) -> bool {
     bytes::is_text_like(bytes)
 }

--- a/crates/tokmd-analysis/src/content/io/bytes.rs
+++ b/crates/tokmd-analysis/src/content/io/bytes.rs
@@ -4,11 +4,21 @@ use std::path::Path;
 
 use anyhow::Result;
 
-pub fn is_text_like(bytes: &[u8]) -> bool {
+/// Borrow `bytes` as text when they are text-like: no interior NUL byte and
+/// valid UTF-8. Returns `None` otherwise.
+///
+/// This performs a single UTF-8 validation pass and returns a borrowed `&str`,
+/// letting callers avoid the `is_text_like` (validate) + `from_utf8_lossy`
+/// (validate again and allocate a `Cow`) double scan on the analysis hot path.
+pub fn as_text(bytes: &[u8]) -> Option<&str> {
     if bytes.contains(&0) {
-        return false;
+        return None;
     }
-    std::str::from_utf8(bytes).is_ok()
+    std::str::from_utf8(bytes).ok()
+}
+
+pub fn is_text_like(bytes: &[u8]) -> bool {
+    as_text(bytes).is_some()
 }
 
 pub fn hash_bytes(bytes: &[u8]) -> String {
@@ -46,6 +56,53 @@ mod tests {
     use std::io::Write;
 
     use super::*;
+
+    #[test]
+    fn as_text_borrows_valid_utf8_without_null() {
+        let bytes = "héllo wörld".as_bytes();
+        let text = as_text(bytes);
+        assert_eq!(text, Some("héllo wörld"));
+        assert_eq!(
+            text.map(str::as_ptr),
+            Some(bytes.as_ptr()),
+            "as_text must borrow, not copy"
+        );
+    }
+
+    #[test]
+    fn as_text_rejects_interior_null() {
+        assert!(as_text(b"hello\x00world").is_none());
+    }
+
+    #[test]
+    fn as_text_rejects_invalid_utf8() {
+        assert!(as_text(&[0xFF, 0xFE, 0x41]).is_none());
+    }
+
+    #[test]
+    fn as_text_empty_is_some_empty() {
+        assert_eq!(as_text(b""), Some(""));
+    }
+
+    #[test]
+    fn as_text_some_iff_is_text_like() {
+        // as_text must agree with the is_text_like predicate it now backs.
+        let cases: &[&[u8]] = &[
+            b"plain ascii",
+            "日本語".as_bytes(),
+            b"",
+            b"has\x00null",
+            &[0x89, 0x50, 0x4E, 0x47],
+            &[0xFF, 0xFE, 0x00, 0x41],
+        ];
+        for bytes in cases {
+            assert_eq!(
+                as_text(bytes).is_some(),
+                is_text_like(bytes),
+                "as_text/is_text_like disagreement for {bytes:?}"
+            );
+        }
+    }
 
     #[test]
     fn hash_file_returns_correct_blake3_hash() {

--- a/crates/tokmd-analysis/src/content/mod.rs
+++ b/crates/tokmd-analysis/src/content/mod.rs
@@ -48,11 +48,10 @@ pub(crate) fn build_todo_report(
         let path = root.join(rel);
         let bytes = crate::content::io::read_head(&path, per_file_limit)?;
         total_bytes += bytes.len() as u64;
-        if !crate::content::io::is_text_like(&bytes) {
+        let Some(text) = crate::content::io::as_text(&bytes) else {
             continue;
-        }
-        let text = String::from_utf8_lossy(&bytes);
-        for (tag, count) in crate::content::io::count_delimited_tags(&text, &tags) {
+        };
+        for (tag, count) in crate::content::io::count_delimited_tags(text, &tags) {
             *counts.entry(tag).or_insert(0) += count;
         }
     }

--- a/crates/tokmd-analysis/src/halstead/mod.rs
+++ b/crates/tokmd-analysis/src/halstead/mod.rs
@@ -63,13 +63,11 @@ pub(crate) fn build_halstead_report(
         };
         total_bytes += bytes.len() as u64;
 
-        if !crate::content::io::is_text_like(&bytes) {
+        let Some(text) = crate::content::io::as_text(&bytes) else {
             continue;
-        }
-
-        let text = String::from_utf8_lossy(&bytes);
+        };
         let lang_lower = row.lang.to_lowercase();
-        let counts = tokenize_for_halstead(&text, &lang_lower);
+        let counts = tokenize_for_halstead(text, &lang_lower);
 
         for (op, count) in counts.operators {
             *all_operators.entry(op).or_insert(0) += count;


### PR DESCRIPTION
## Summary

Import the swarm `as_text` single-pass UTF-8 change into publication via
merge commit, per the shared-history topology in
`docs/ci/swarm-routing.md`.

Swarm PR #424 (`perf(analysis): borrow file text via as_text to drop
double UTF-8 pass`) removes a redundant UTF-8 validation pass and a `Cow`
allocation per text file across four content enrichers, routing them
through the new `content::io::as_text` borrow helper. This is the swarm
implementation of the intent behind publication bolt PR #2752 (now
closed superseded); publication only receives swarm work via
merge-commit imports.

## Provenance

- Swarm-Head: `4d4af4251b96c18292bd92b1a27a8203c1e663af`
- Swarm-Range: `72dee2589ec9448347daafe5f4fbb9381baca277..4d4af4251b96c18292bd92b1a27a8203c1e663af`
- Swarm PR: EffortlessMetrics/tokmd-swarm#424 (squash merge)

## Checks

- Swarm `Tokmd Rust Result`: pass (run 28671222707)
- Swarm No-panic Family: pass (fixed test-only panic-family finding
  before merge)

## Claim boundary

- Establishes: behavior-preserving import of the swarm perf change into
  publication first-parent history with the squashed swarm commit as
  second parent.
- Does NOT establish: release, publish, signing, tag, Docker, or `v1`
  alias movement. This is a topology import only.
