### PR TITLE
merge(swarm): import strip_prefix redaction fix (#428)

### DIFF
--- a/crates/tokmd-core/src/receipts.rs
+++ b/crates/tokmd-core/src/receipts.rs
@@ -107,7 +107,7 @@ pub(crate) fn build_export_receipt(
                 export
                     .strip_prefix
                     .as_ref()
-                    .map(|p| tokmd_format::redact_path(p))
+                    .map(|p| tokmd_format::short_hash(p))
             } else {
                 export.strip_prefix.clone()
             },

--- a/crates/tokmd-format/src/export/json.rs
+++ b/crates/tokmd-format/src/export/json.rs
@@ -13,7 +13,7 @@ use tokmd_types::{
     ExportArgs, ExportArgsMeta, ExportData, ExportReceipt, RedactMode, ScanStatus, ToolInfo,
 };
 
-use crate::{now_ms, redact_module_roots, redact_path, scan_args};
+use crate::{now_ms, redact_module_roots, scan_args, short_hash};
 
 use super::redact_rows;
 
@@ -48,7 +48,7 @@ pub(super) fn write_export_json<W: Write>(
                 strip_prefix: if should_redact {
                     args.strip_prefix
                         .as_ref()
-                        .map(|p| redact_path(&p.display().to_string().replace('\\', "/")))
+                        .map(|p| short_hash(&p.display().to_string().replace('\\', "/")))
                 } else {
                     args.strip_prefix
                         .as_ref()

--- a/crates/tokmd-format/src/export/jsonl.rs
+++ b/crates/tokmd-format/src/export/jsonl.rs
@@ -16,7 +16,7 @@ use tokmd_types::{
     ExportArgs, ExportArgsMeta, ExportData, FileRow, RedactMode, ScanArgs, ScanStatus, ToolInfo,
 };
 
-use crate::{now_ms, redact_module_roots, redact_path, scan_args};
+use crate::{now_ms, redact_module_roots, scan_args, short_hash};
 
 use super::redact_rows;
 
@@ -74,7 +74,7 @@ pub(super) fn write_export_jsonl<W: Write>(
                 strip_prefix: if should_redact {
                     args.strip_prefix
                         .as_ref()
-                        .map(|p| redact_path(&p.display().to_string().replace('\\', "/")))
+                        .map(|p| short_hash(&p.display().to_string().replace('\\', "/")))
                 } else {
                     args.strip_prefix
                         .as_ref()

--- a/crates/tokmd-format/tests/test_redaction_leak.rs
+++ b/crates/tokmd-format/tests/test_redaction_leak.rs
@@ -1,4 +1,4 @@
-use tokmd_format::redact_path;
+use tokmd_format::{redact_path, short_hash};
 
 #[test]
 fn test_redact_path_leak() {
@@ -45,4 +45,22 @@ fn redaction_normalizes_known_compound_archive_suffix_case() {
     let redacted = redact_path("archive.TAR.GZ");
     assert!(redacted.ends_with(".tar.gz"));
     assert!(!redacted.ends_with(".TAR.GZ"));
+}
+
+#[test]
+fn strip_prefix_redaction_must_use_short_hash_not_redact_path() {
+    let prefix = "src/secret.rs";
+    let via_redact_path = redact_path(prefix);
+    let via_short_hash = short_hash(prefix);
+
+    assert!(
+        via_redact_path.ends_with(".rs"),
+        "redact_path preserves a file extension that must not leak for strip_prefix: {via_redact_path}"
+    );
+    assert_eq!(via_short_hash.len(), 16);
+    assert!(!via_short_hash.contains('.'));
+    assert_ne!(
+        via_redact_path, via_short_hash,
+        "strip_prefix redaction must use short_hash semantics, not redact_path"
+    );
 }


### PR DESCRIPTION
## Summary
- Deliberate merge-commit import of tokmd-swarm #428 (strip_prefix redaction hardening)
- Swarm head: 0b67f750; publication base: 6f8e6c50
- Merge commit: 5dbfb4eb

## Imported change
- Use short_hash instead of redact_path for export strip_prefix under Paths/All redaction
- Regression test in test_redaction_leak.rs

## Routing
- Supersedes direct-publication Jules draft #2819 (closed with routing comment)

## Test plan
- [x] Swarm Tokmd Rust Result passed on #428
- [x] Swarm strict no-panic gate green
- [ ] Publication CI on this import PR

## Claim boundary
Topology/import only. No tag, publish, release alias, or AST default promotion.

Made with [Cursor](https://cursor.com)