### PR TITLE
merge(swarm): import docs children defaults and schema changelog tests (#431)

### DIFF
--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -100,7 +100,7 @@ Examples:
 | :--- | :--- | :--- |
 | `-f, --format <FMT>` | Output format: `md` (Markdown table), `tsv`, `json`. | `md` |
 | `-t, --top <N>` | Only show the top N languages (by lines of code). Others grouped as "Other". | `0` (all) |
-| `--children <MODE>` | How to handle embedded languages (e.g., JS inside HTML). | `collapse` |
+| `--children <MODE>` | How to handle embedded languages (e.g., JS inside HTML). | `collapse` (`lang`), `separate` (`module`, `export`) |
 | | `collapse`: Embedded code counts toward the parent file's language. | |
 | | `separate`: Embedded code is counted separately under its own language. | |
 

--- a/xtask/tests/docs_schema_w72.rs
+++ b/xtask/tests/docs_schema_w72.rs
@@ -867,6 +867,41 @@ fn changelog_follows_keepachangelog() {
     );
 }
 
+#[test]
+fn changelog_documents_extended_schema_versions() {
+    let cl = changelog_md();
+    let cases = [
+        (
+            "crates/tokmd-types/src/cockpit.rs",
+            "COCKPIT_SCHEMA_VERSION",
+        ),
+        (
+            "crates/tokmd-types/src/context.rs",
+            "CONTEXT_SCHEMA_VERSION",
+        ),
+        (
+            "crates/tokmd-types/src/context.rs",
+            "CONTEXT_BUNDLE_SCHEMA_VERSION",
+        ),
+        (
+            "crates/tokmd-types/src/context.rs",
+            "HANDOFF_SCHEMA_VERSION",
+        ),
+        ("crates/tokmd/src/tool_schema.rs", "TOOL_SCHEMA_VERSION"),
+    ];
+
+    for (path, name) in cases {
+        let current = read_const_u32(path, name);
+        assert!(current.is_some(), "{name} not found in source");
+        if let Some(current) = current {
+            assert!(
+                cl.contains(&format!("{name} = {current}")) || cl.contains(name),
+                "CHANGELOG.md should mention {name} ({current})"
+            );
+        }
+    }
+}
+
 // ===========================================================================
 // 8. Cross-doc consistency
 // ===========================================================================


### PR DESCRIPTION
## Summary
TRUE merge import of swarm keeper **#431** (\c28ca359\).

- Restack publication **#2766**: \docs/reference-cli.md\ \--children\ default column notes subcommand-specific defaults.
- Restack publication **#2825**: consolidated \changelog_documents_extended_schema_versions\ xtask test (no new no-panic allowlist churn).

## Proof (swarm keeper)
- [x] \cargo test -p xtask --test docs_schema_w72 changelog_documents_extended\
- [x] \cargo xtask docs --check\
- [x] \cargo xtask check-no-panic-family --strict\
- [x] Swarm CI green (Tokmd Rust Result + No-panic Family)

## Claim boundary
Docs + contract-determinism tests only. No runtime, release, badge, or AST default changes.

Made with [Cursor](https://cursor.com)