### PR TITLE
merge(swarm): import strict schema changelog guard (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Hardened the `docs_schema_w72` changelog guard to require the current
+  schema constants in `CONSTANT = value` form: `COCKPIT_SCHEMA_VERSION = 3`,
+  `CONTEXT_SCHEMA_VERSION = 4`, `CONTEXT_BUNDLE_SCHEMA_VERSION = 2`,
+  `HANDOFF_SCHEMA_VERSION = 5`, and `TOOL_SCHEMA_VERSION = 1`. A name-only
+  mention no longer satisfies the guard, so bumping any of these constants
+  now requires a matching changelog entry.
 - Enabled `runtime: container` in the `EffortlessMetrics/tokmd` GitHub Action.
   It anonymously pulls the publication GHCR image
   (`ghcr.io/effortlessmetrics/tokmd`) and runs it against the mounted workspace

--- a/xtask/tests/docs_schema_w72.rs
+++ b/xtask/tests/docs_schema_w72.rs
@@ -895,8 +895,8 @@ fn changelog_documents_extended_schema_versions() {
         assert!(current.is_some(), "{name} not found in source");
         if let Some(current) = current {
             assert!(
-                cl.contains(&format!("{name} = {current}")) || cl.contains(name),
-                "CHANGELOG.md should mention {name} ({current})"
+                cl.contains(&format!("{name} = {current}")),
+                "CHANGELOG.md should mention {name} = {current}"
             );
         }
     }


### PR DESCRIPTION
## Summary
TRUE merge import of swarm keeper **#432** (\6347095a\) on top of import **#2827** / \d8aabc2a\.

- Tightens \changelog_documents_extended_schema_versions\ to require \CONSTANT = value\ in CHANGELOG (drops name-only fallback).
- Adds current schema version pins under \[Unreleased]\.

## Proof (swarm keeper)
- [x] Swarm #432 merged with green CI

## Claim boundary
Test strictness + changelog docs only.

Made with [Cursor](https://cursor.com)