### PR TITLE
merge(swarm): import steward docs manifest fix

### DIFF
--- a/crates/tokmd-cockpit/Cargo.toml
+++ b/crates/tokmd-cockpit/Cargo.toml
@@ -22,7 +22,7 @@ ignore = "0.4.23"
 serde.workspace = true
 serde_json.workspace = true
 time = { version = "0.3.41", features = ["formatting"] }
-tokmd-analysis = { path = "../tokmd-analysis", version = "1.11.0", default-features = false }
+tokmd-analysis = { path = "../tokmd-analysis", version = ">=1.9, <2", default-features = false }
 tokmd-analysis-types.workspace = true
 tokmd-envelope.workspace = true
 tokmd-types.workspace = true

--- a/docs/ci/swarm-routing.md
+++ b/docs/ci/swarm-routing.md
@@ -419,6 +419,13 @@ the gate's `runs-on`. The advisory `CI Actuals (Advisory)` job writes
 `target/ci/ci-actuals.json` with per-job results and best-effort timing for the
 run; open it for observed required-job results behind the `Tokmd Rust Result`
 check. There is no longer a separate normalized routed result receipt or
+
+The routed result receipt formerly contained `router.target`, `router.reason`,
+`router.receipt_path`, `selected.job/result`, `telemetry.duration_seconds`,
+`telemetry.queue_seconds`, `telemetry.cache_note`, `run.run_attempt`, and
+`run.rerun_count` fields. Open the receipt before reading runner logs if
+reviewing historical CI runs.
+
 mutually-exclusive implementation jobs.
 
 Runner health and quarantine operations are documented in


### PR DESCRIPTION
## Summary
TRUE merge import of swarm steward restack at `ab489870` (narrow replacement for superseded publication draft #2826 / swarm #433).

- Documents historical `router.*` receipt fields in `docs/ci/swarm-routing.md`.
- Aligns `tokmd-cockpit` `tokmd-analysis` dependency with workspace `>=1.9, <2` pattern.
- Graph proof target: `repo-graph --expect aligned` after swarm fast-forward.

## Swarm state
- Swarm-Head: `ab489870a0a3fd6c6addfd8f71d2f0a7031c2a3b`
- Swarm-Range: `79c99739..ab489870`
- Merge parents: `79c99739` + `ab489870`

## Checks
- Tokmd Rust Result: https://github.com/EffortlessMetrics/tokmd-swarm/actions/runs/28722320062 (PR #433)

## Claim boundary
Docs + dependency bound alignment only. No behavior, schema, release, tag, or badge changes.
