### PR TITLE
librarian: fix CLI argument drift in debugging examples 📚

### DIFF
--- a/.jules/runs/librarian_docs_examples_01/decision.md
+++ b/.jules/runs/librarian_docs_examples_01/decision.md
@@ -1,0 +1,23 @@
+# Decision
+
+## Option A (recommended)
+Update the `debugging.md` documentation to fix CLI option usage for debugging commands.
+
+Currently `docs/debugging.md` uses outdated CLI arguments like `--path` and `--out` for `run`, `analyze`, and `cockpit` commands. The CLI has shifted to positional arguments for inputs and `--output-dir`/`--artifacts-dir` for outputs. Updating these ensures that developers following the debugging guide do not encounter parse errors when trying to debug receipts.
+
+- **Why it fits:** The Librarian persona targets docs/examples drifting from actual behavior.
+- **Trade-offs:**
+  - *Structure:* Aligns documentation with CLI struct definitions.
+  - *Velocity:* Small, direct fix that doesn't modify underlying logic.
+  - *Governance:* Reduces friction for maintainers running debug commands.
+
+## Option B
+Create a learning PR to document the drift and add a friction item.
+
+Instead of making the fix directly, we could record that `debugging.md` is drifting from actual CLI argument parsing and propose it as future work.
+
+- **When to choose:** If the drift was intentional or part of a larger CLI rework that isn't finalized.
+- **Trade-offs:** Misses the opportunity to fix a clear, factual drift in execution instructions.
+
+## Decision
+**Option A**. The drift in `debugging.md` is an objective mismatch between executable docs and CLI definition. Fixing it directly addresses the Librarian's top ranking goal: "README/example drift from actual behavior".

--- a/.jules/runs/librarian_docs_examples_01/envelope.json
+++ b/.jules/runs/librarian_docs_examples_01/envelope.json
@@ -1,0 +1,21 @@
+{
+  "prompt_id": "librarian_docs_examples",
+  "persona": "Librarian",
+  "style": "Builder",
+  "primary_shard": "tooling-governance",
+  "allowed_paths": [
+    "xtask/**",
+    ".github/workflows/**",
+    "docs/**",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "Cargo.toml",
+    "Cargo.lock"
+  ],
+  "adjacent_paths": [
+    "crates/**/Cargo.toml",
+    ".cargo/**"
+  ],
+  "gate_profile": "docs-executable",
+  "allowed_outcomes": ["PR-ready patch", "proof-improvement patch", "learning PR"]
+}

--- a/.jules/runs/librarian_docs_examples_01/pr_body.md
+++ b/.jules/runs/librarian_docs_examples_01/pr_body.md
@@ -1,0 +1,65 @@
+## 💡 Summary
+Fixed executable example commands in `docs/debugging.md` that drifted from actual CLI parsing rules. The debugging instructions now use valid positional arguments and current output flags (`--output-dir`, `--artifacts-dir`).
+
+## 🎯 Why
+The receipt debugging guide instructed maintainers to run commands using removed flags like `--path` and `--out`. Running these commands exactly as written caused `clap` parsing failures, blocking local troubleshooting workflows and creating friction during evidence review.
+
+## 🔎 Evidence
+- `docs/debugging.md` contained `cargo run -p tokmd -- run --path . --out target/tokmd-debug`.
+- The current CLI definitions (verified via `cargo run -p tokmd -- run --help`) expect paths as positional inputs `[PATH]...` and outputs via `--output-dir`.
+- `cargo run -p tokmd -- cockpit --help` expects `--artifacts-dir` instead of `--out`.
+
+## 🧭 Options considered
+### Option A (recommended)
+- what it is: Update `docs/debugging.md` to reflect the correct CLI schema.
+- why it fits this repo and shard: Directly targets example/docs drift for the librarian persona in the tooling-governance shard.
+- trade-offs:
+  - Structure: Aligns docs with CLI structs.
+  - Velocity: Quick, direct documentation fix.
+  - Governance: Removes maintainer friction when debugging PR evidence.
+
+### Option B
+- what it is: Produce a learning PR proposing a friction item without fixing the text.
+- when to choose it instead: If the CLI syntax was in the middle of an active redesign.
+- trade-offs: Misses the opportunity to fix clear factual drift in executable examples.
+
+## ✅ Decision
+Option A. Fixing executable docs drift directly addresses the Librarian's top ranking goal and prevents developers from copy-pasting failing commands.
+
+## 🧱 Changes made (SRP)
+- `docs/debugging.md`: Updated arguments for `tokmd run`, `tokmd analyze`, and `tokmd cockpit` receipt debugging examples.
+
+## 🧪 Verification receipts
+```text
+cargo xtask docs --check
+Documentation is up to date.
+doc artifacts ok: 2 required doc(s), 73 family file(s), 1 active goal(s), 26 spec-index artifact(s), 0 spec-index lane(s)
+
+cargo fmt -- --check
+
+cargo clippy -- -D warnings
+  Downloaded ...
+  Compiling ...
+  Finished `dev` profile [unoptimized + debuginfo] target(s)
+
+bash -c 'CI=true cargo test -p tokmd --verbose'
+...
+test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
+```
+
+## 🧭 Telemetry
+- Change shape: Docs/Markdown only.
+- Blast radius: `docs/`. No API, IO, or concurrency risk.
+- Risk class: Low + docs-only change to executable instructions.
+- Rollback: Revert the documentation commit.
+- Gates run: `cargo xtask docs --check`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test -p tokmd --verbose`.
+
+## 🗂️ .jules artifacts
+- `.jules/runs/librarian_docs_examples_01/envelope.json`
+- `.jules/runs/librarian_docs_examples_01/decision.md`
+- `.jules/runs/librarian_docs_examples_01/receipts.jsonl`
+- `.jules/runs/librarian_docs_examples_01/result.json`
+- `.jules/runs/librarian_docs_examples_01/pr_body.md`
+
+## 🔜 Follow-ups
+None.

--- a/.jules/runs/librarian_docs_examples_01/receipts.jsonl
+++ b/.jules/runs/librarian_docs_examples_01/receipts.jsonl
@@ -1,0 +1,12 @@
+{"cmd": "mkdir -p .jules/runs/librarian_docs_examples_01", "status": "success"}
+{"cmd": "cat << 'EOF' > .jules/runs/librarian_docs_examples_01/envelope.json", "status": "success"}
+{"cmd": "sed -i 's/cargo run -p tokmd -- run --path . --out target\\/tokmd-debug/cargo run -p tokmd -- run . --output-dir target\\/tokmd-debug/g' docs/debugging.md", "status": "success"}
+{"cmd": "sed -i 's/cargo run -p tokmd -- analyze --path . --format json/cargo run -p tokmd -- analyze . --format json/g' docs/debugging.md", "status": "success"}
+{"cmd": "sed -i 's/cargo run -p tokmd -- cockpit --base origin\\/main --head HEAD --out target\\/cockpit-debug/cargo run -p tokmd -- cockpit --base origin\\/main --head HEAD --artifacts-dir target\\/cockpit-debug/g' docs/debugging.md", "status": "success"}
+{"cmd": "sed -i 's/cargo run -p tokmd -- run --path . --out target\\/perf-debug/cargo run -p tokmd -- run . --output-dir target\\/perf-debug/g' docs/debugging.md", "status": "success"}
+{"cmd": "cargo xtask docs --check", "status": "success"}
+{"cmd": "cargo fmt -- --check", "status": "success"}
+{"cmd": "cargo clippy -- -D warnings", "status": "success"}
+{"cmd": "bash -c 'CI=true cargo test -p tokmd --verbose'", "status": "success"}
+{"cmd": "cat << \'EOF\' > .jules/runs/librarian_docs_examples_01/result.json\n{\n  \"status\": \"success\",\n  \"chosen_option\": \"Option A\",\n  \"findings\": \"The docs/debugging.md file contained outdated CLI option usage for debugging commands. They were using --path and --out which have been replaced by positional arguments and --output-dir/--artifacts-dir. The CLI commands in the debugging guide were failing to parse.\",\n  \"outcome_type\": \"PR-ready patch\"\n}\nEOF", "status": "success"}
+{"cmd": "cat << \'EOF\' > .jules/runs/librarian_docs_examples_01/pr_body.md ...", "status": "success"}

--- a/.jules/runs/librarian_docs_examples_01/result.json
+++ b/.jules/runs/librarian_docs_examples_01/result.json
@@ -1,0 +1,6 @@
+{
+  "status": "success",
+  "chosen_option": "Option A",
+  "findings": "The docs/debugging.md file contained outdated CLI option usage for debugging commands. They were using --path and --out which have been replaced by positional arguments and --output-dir/--artifacts-dir. The CLI commands in the debugging guide were failing to parse.",
+  "outcome_type": "PR-ready patch"
+}

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -89,9 +89,9 @@ terminal logs. Write artifacts to `target/` and inspect the machine-readable
 form first:
 
 ```bash
-cargo run -p tokmd -- run --path . --out target/tokmd-debug
-cargo run -p tokmd -- analyze --path . --format json
-cargo run -p tokmd -- cockpit --base origin/main --head HEAD --out target/cockpit-debug
+cargo run -p tokmd -- run . --output-dir target/tokmd-debug
+cargo run -p tokmd -- analyze . --format json
+cargo run -p tokmd -- cockpit --base origin/main --head HEAD --artifacts-dir target/cockpit-debug
 ```
 
 When changing a receipt shape, update the owning types, schema docs, and tests
@@ -129,7 +129,7 @@ Start from a fresh timing receipt before optimizing:
 
 ```bash
 cargo xtask perf-smoke --sha "$(git rev-parse HEAD)"
-cargo run -p tokmd -- run --path . --out target/perf-debug
+cargo run -p tokmd -- run . --output-dir target/perf-debug
 ```
 
 See [ci/perf-smoke.md](ci/perf-smoke.md) for the maintainer baseline workflow,


### PR DESCRIPTION
Fixed executable example commands in `docs/debugging.md` that drifted from actual CLI parsing rules. The debugging instructions now use valid positional arguments and current output flags (`--output-dir`, `--artifacts-dir`).

---
*PR created automatically by Jules for task [7859171925986409061](https://jules.google.com/task/7859171925986409061) started by @EffortlessSteven*