### PR TITLE
import: carry RC candidate timeout proof fix

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -18,7 +18,8 @@ jobs:
     name: Build and verify pre-tag candidate image
     if: github.repository == 'EffortlessMetrics/tokmd'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Multi-architecture candidate builds must finish before the digest can be verified.
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Import the single post-RC-prep swarm fix b9dac6486f9daa945805b5dbcb795239dbab5761. It increases the pre-tag multi-architecture candidate image proof timeout from 30 to 60 minutes after exact publication commit eca73b3e timed out before verification. No product, version, tag, alias, or release changes are included. Merge this import as a true two-parent commit.