### PR TITLE
import: repair RC multi-architecture candidate proof

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -14,12 +14,102 @@ permissions:
   packages: write
 
 jobs:
-  candidate:
-    name: Build and verify pre-tag candidate image
+  build-platform:
+    name: Build ${{ matrix.platform }} candidate image
     if: github.repository == 'EffortlessMetrics/tokmd'
     runs-on: ubuntu-latest
-    # Multi-architecture candidate builds must finish before the digest can be verified.
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            suffix: amd64
+            target: x86_64-unknown-linux-gnu
+            cross: false
+          - platform: linux/arm64
+            suffix: arm64
+            target: aarch64-unknown-linux-gnu
+            cross: true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Resolve source commit and version
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          COMMIT="$(git rev-parse HEAD)"
+          VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tokmd") | .version' | head -n 1)"
+          if [[ -z "${VERSION}" || "${VERSION}" == "null" ]]; then
+            echo "::error::workspace tokmd version could not be resolved"
+            exit 1
+          fi
+          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build platform binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          if [[ "${{ matrix.cross }}" == "true" ]]; then
+            cross build --release --locked --target "${{ matrix.target }}" --bin tokmd
+          else
+            cargo build --release --locked --target "${{ matrix.target }}" --bin tokmd
+          fi
+          cp "target/${{ matrix.target }}/release/tokmd" artifacts/tokmd
+          test -x artifacts/tokmd
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push platform candidate image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: Dockerfile.release
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ghcr.io/effortlessmetrics/tokmd:candidate-${{ steps.source.outputs.commit }}-${{ matrix.suffix }}
+          build-args: |
+            BINARY=artifacts/tokmd
+            VERSION=${{ steps.source.outputs.version }}
+            SOURCE_COMMIT=${{ steps.source.outputs.commit }}
+          cache-from: type=gha,scope=tokmd-candidate-${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=tokmd-candidate-${{ matrix.suffix }}
+
+  assemble-and-verify:
+    name: Assemble and verify pre-tag candidate image
+    needs: build-platform
+    if: github.repository == 'EffortlessMetrics/tokmd'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -44,9 +134,6 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "candidate_tag=candidate-${COMMIT}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
@@ -57,18 +144,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push candidate image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/effortlessmetrics/tokmd:${{ steps.source.outputs.candidate_tag }}
-          labels: |
-            org.opencontainers.image.revision=${{ steps.source.outputs.commit }}
-            org.opencontainers.image.version=${{ steps.source.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Assemble multi-architecture candidate manifest
+        shell: bash
+        env:
+          COMMIT: ${{ steps.source.outputs.commit }}
+          CANDIDATE_TAG: ${{ steps.source.outputs.candidate_tag }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/effortlessmetrics/tokmd"
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${CANDIDATE_TAG}" \
+            "${IMAGE}:${CANDIDATE_TAG}-amd64" \
+            "${IMAGE}:${CANDIDATE_TAG}-arm64"
 
       - name: Verify candidate anonymously and record digest
         shell: bash
@@ -82,9 +169,12 @@ jobs:
           REF="${IMAGE}:${CANDIDATE_TAG}"
           DOCKER_CONFIG="$(mktemp -d)"
           FIXTURE="$(mktemp -d)"
+          MANIFEST="$(mktemp)"
           export DOCKER_CONFIG
-          trap 'rm -rf "${DOCKER_CONFIG}" "${FIXTURE}"' EXIT
+          trap 'rm -rf "${DOCKER_CONFIG}" "${FIXTURE}" "${MANIFEST}"' EXIT
           docker --config "${DOCKER_CONFIG}" pull "${REF}"
+          docker --config "${DOCKER_CONFIG}" buildx imagetools inspect --raw "${REF}" > "${MANIFEST}"
+          jq -e '[.manifests[] | select(.platform != null) | "\(.platform.os)/\(.platform.architecture)"] as $p | ($p | index("linux/amd64") != null and index("linux/arm64") != null)' "${MANIFEST}" > /dev/null
           OUT="$(docker --config "${DOCKER_CONFIG}" run --rm "${REF}" --version)"
           if ! grep -qxE "tokmd ${EXPECTED_VERSION}([[:space:]]|$)" <<<"${OUT}"; then
             echo "::error::candidate reported an unexpected version: ${OUT}"
@@ -115,13 +205,14 @@ jobs:
             --arg version "${EXPECTED_VERSION}" \
             --arg candidate "${REF}" \
             --arg digest "${DIGEST}" \
-            '{schema:$schema, source_commit:$commit, version:$version, candidate_ref:$candidate, digest:$digest, anonymous_pull:true, version_smoke:true, mounted_packet:{schema:"tokmd.evidence-packet/v1", status:"complete", content:true}}' \
+            '{schema:$schema, source_commit:$commit, version:$version, candidate_ref:$candidate, digest:$digest, platforms:["linux/amd64","linux/arm64"], anonymous_pull:true, version_smoke:true, mounted_packet:{schema:"tokmd.evidence-packet/v1", status:"complete", content:true}}' \
             > "artifacts/container-candidate-${COMMIT}.json"
           {
             echo "## Pre-tag container candidate proof"
             echo "- source_commit: ${COMMIT}"
             echo "- candidate_ref: ${REF}"
             echo "- version: ${EXPECTED_VERSION}"
+            echo "- platforms: linux/amd64, linux/arm64"
             echo "- digest: ${DIGEST}"
             echo "- anonymous_pull: pass"
             echo "- version_smoke: pass"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+# Release images receive a platform-specific binary built by the release
+# matrix. Keeping Rust compilation outside Docker avoids serial workspace
+# builds under emulated ARM64 while preserving a multi-architecture image.
+FROM debian:bookworm-slim AS runtime
+
+ARG BINARY=artifacts/tokmd
+ARG VERSION
+ARG SOURCE_COMMIT
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes ca-certificates git \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 1000 tokmd \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /usr/sbin/nologin tokmd
+
+COPY ${BINARY} /usr/local/bin/tokmd
+RUN chmod 0755 /usr/local/bin/tokmd \
+    && tokmd --version
+
+USER tokmd
+WORKDIR /repo
+
+LABEL org.opencontainers.image.title="tokmd" \
+      org.opencontainers.image.description="AI-native code inventory receipts and analytics for LLM workflows" \
+      org.opencontainers.image.url="https://github.com/EffortlessMetrics/tokmd" \
+      org.opencontainers.image.source="https://github.com/EffortlessMetrics/tokmd" \
+      org.opencontainers.image.documentation="https://github.com/EffortlessMetrics/tokmd#readme" \
+      org.opencontainers.image.vendor="EffortlessMetrics" \
+      org.opencontainers.image.licenses="MIT OR Apache-2.0" \
+      org.opencontainers.image.revision="${SOURCE_COMMIT}" \
+      org.opencontainers.image.version="${VERSION}"
+
+ENTRYPOINT ["tokmd"]
+CMD ["--help"]

--- a/ci/proof.toml
+++ b/ci/proof.toml
@@ -1569,6 +1569,7 @@ paths = [
   # The Dockerfile pins the builder toolchain, and version-consistency now
   # verifies that pin against the workspace MSRV.
   "Dockerfile",
+  "Dockerfile.release",
   "winget/manifests/e/EffortlessMetrics/tokmd/1.3.1/**",
   "xtask/src/tasks/version_consistency.rs",
 ]
@@ -1577,7 +1578,7 @@ proof = [
   "cargo xtask publish-surface --json --verify-publish",
   "cargo xtask docs --check",
 ]
-reason = "CHANGELOG, citation metadata, release workflow, Dockerfile toolchain pin, and the version-consistency task itself are release artifacts; proof routes to version consistency, publish-surface verification, and docs checks."
+reason = "CHANGELOG, citation metadata, release workflow, release runtime Dockerfile, Dockerfile toolchain pin, and the version-consistency task itself are release artifacts; proof routes to version consistency, publish-surface verification, and docs checks."
 mutation = false
 coverage = false
 

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -871,9 +871,9 @@ review_after     = "2026-08-02"
 expires          = "2027-02-02"
 
 [[lane]]
-id               = "release_candidate_container"
+id               = "release_candidate_platform"
 workflow         = ".github/workflows/release-candidate.yml"
-job              = "Build and verify pre-tag candidate image"
+job              = "Build ${{ matrix.platform }} candidate image"
 kind             = "release"
 tier             = "deep"
 default_pr       = false
@@ -881,9 +881,29 @@ blocking         = true
 runner           = "ubuntu_latest"
 base_lem         = 30
 owner            = "release/publish"
-intent           = "Prove the final source commit's candidate container before a release tag exists."
+intent           = "Build each exact-source platform image before assembling the release candidate manifest."
 failure_mode     = "A release tag points at a container image that was never proven from the exact source commit."
-proof_obligation = "Build candidate-<commit-sha>, anonymously pull it, assert tokmd --version, run mounted packet content checks, and record the immutable digest."
+proof_obligation = "Build the exact source commit's platform binary and push its immutable candidate image for manifest assembly."
+evidence         = ["release workflow logs", "candidate-<commit-sha>-<platform>"]
+allowed_triggers = ["workflow_dispatch"]
+duplicate_of     = []
+review_after     = "2026-08-03"
+expires          = "2027-02-03"
+
+[[lane]]
+id               = "release_candidate_assemble"
+workflow         = ".github/workflows/release-candidate.yml"
+job              = "Assemble and verify pre-tag candidate image"
+kind             = "release"
+tier             = "deep"
+default_pr       = false
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 10
+owner            = "release/publish"
+intent           = "Prove the multi-architecture candidate manifest from the exact source commit before a release tag exists."
+failure_mode     = "A release tag points at a container image that was never proven from the exact source commit."
+proof_obligation = "Assemble candidate-<commit-sha>, prove both Linux platforms, anonymously pull it, assert tokmd --version, run mounted packet content checks, and record the immutable digest and verified marker."
 evidence         = ["release workflow logs", "container-candidate-<commit-sha>", "GITHUB_STEP_SUMMARY"]
 allowed_triggers = ["workflow_dispatch"]
 duplicate_of     = []


### PR DESCRIPTION
Import the exact swarm tip b46e04056d62476e6b3190e518e25194a156d295. This carries the reviewed candidate proof repair: parallel release-style platform binary builds, runtime-only image packaging, multi-architecture manifest assembly, platform assertions, and whitelist/proof scope updates. It replaces the two exact-source candidate build timeouts recorded on public main. Merge only as a true two-parent publication commit; no tag, release, alias, or publish mutation is included.