### PR TITLE
import: repair RC runtime libc

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,7 +3,10 @@
 # Release images receive a platform-specific binary built by the release
 # matrix. Keeping Rust compilation outside Docker avoids serial workspace
 # builds under emulated ARM64 while preserving a multi-architecture image.
-FROM debian:bookworm-slim AS runtime
+# The release runners build against Ubuntu 24.04's glibc 2.39; keep the
+# runtime at that compatibility floor instead of copying the binary into
+# Debian Bookworm's older glibc 2.36.
+FROM ubuntu:24.04 AS runtime
 
 ARG BINARY=artifacts/tokmd
 ARG VERSION


### PR DESCRIPTION
## Summary

Import the reviewed swarm repair that aligns the release candidate container runtime with the hosted release binary libc floor.

## Source and proof

- swarm source tip: `358e9613` (squash merge of swarm PR #474)
- import is a deliberate two-parent merge from publication `main`
- swarm PR #474 had `Codex Review Gate=success` on exact head `ea96cbd3` and `Tokmd Rust Result=success`
- the prior candidate run `30821362677` built both platform jobs but failed at the runtime self-check because Debian Bookworm provided GLIBC_2.36 while the amd64 binary required GLIBC_2.39

## Claim boundary

This import does not claim the candidate is verified. After merge, the exact imported commit must pass the pre-tag candidate workflow: both platform builds, manifest assembly, anonymous pull, exact version, mounted packet content, digest, and verification marker.