### PR TITLE
import: repair RC runtime user identity

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -15,8 +15,8 @@ ARG SOURCE_COMMIT
 RUN apt-get update \
     && apt-get install --no-install-recommends --yes ca-certificates git \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd --gid 1000 tokmd \
-    && useradd --uid 1000 --gid 1000 --create-home --shell /usr/sbin/nologin tokmd
+    && groupadd --system tokmd \
+    && useradd --system --gid tokmd --create-home --shell /usr/sbin/nologin tokmd
 
 COPY ${BINARY} /usr/local/bin/tokmd
 RUN chmod 0755 /usr/local/bin/tokmd \


### PR DESCRIPTION
## Summary

Import the reviewed swarm repair that removes fixed runtime UID/GID assumptions from the Ubuntu 24.04 candidate image.

## Source and proof

- swarm source tip: `a4e028aa` (squash merge of swarm PR #475)
- publication base: `f3faa245`
- the import branch contains the expected two-parent merge of those commits
- swarm PR #475 had `Codex Review Gate=success` on exact head `5aa64baf` and `Tokmd Rust Result=success`
- candidate run `30825498889` confirmed Ubuntu 24.04 solved the libc mismatch, then failed because GID 1000 already existed on both platforms

## Claim boundary

The imported commit still requires public CI and a fresh pre-tag candidate proof. No candidate artifact is claimed verified by this PR alone.