### PR TITLE
import: repair RC analysis proof

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -197,7 +197,7 @@ jobs:
           test "$(jq -r '.status' "${FIXTURE}/sensors/tokmd/manifest.json")" = 'complete'
           test -s "${FIXTURE}/sensors/tokmd/analyze.json"
           test "$(jq -r '.artifacts | length' "${FIXTURE}/sensors/tokmd/manifest.json")" -gt 0
-          jq -e '.mode == "analysis" and .status == "complete" and (.source.paths | length > 0) and (.derived != null)' \
+          jq -e '.mode == "analysis" and .status == "complete" and (.source.inputs | length > 0) and (.derived != null)' \
             "${FIXTURE}/sensors/tokmd/analyze.json" > /dev/null
           jq -n \
             --arg schema 'tokmd.release-candidate/v1' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
           jq -e '
             .mode == "analysis" and
             .status == "complete" and
-            (.source.paths | length > 0) and
+            (.source.inputs | length > 0) and
             (.derived != null)
           ' "${FIXTURE}/sensors/tokmd/analyze.json" > /dev/null
           {


### PR DESCRIPTION
## Summary

Import the schema-correct analysis proof repair for the RC and stable release workflows.

## Source and proof

- swarm source tip: `3c585f44` (squash merge of swarm PR #476)
- publication base: `9078e57f`
- this branch is a deliberate two-parent import
- swarm PR #476 passed exact-head Codex review and required CI
- candidate run `30829558358` built both platform images, pulled the assembled image anonymously, reported `1.15.0-rc.1`, and generated a complete packet before the invalid `.source.paths` assertion failed

## Claim boundary

This import does not claim the candidate is verified. Public CI and a fresh candidate run against the resulting import head are required.