### PR TITLE
import: stabilize RC manifest proof

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -172,15 +172,15 @@ jobs:
           MANIFEST="$(mktemp)"
           export DOCKER_CONFIG
           trap 'rm -rf "${DOCKER_CONFIG}" "${FIXTURE}" "${MANIFEST}"' EXIT
-          docker --config "${DOCKER_CONFIG}" pull "${REF}"
-          docker --config "${DOCKER_CONFIG}" buildx imagetools inspect --raw "${REF}" > "${MANIFEST}"
+          PULL_OUTPUT="$(docker --config "${DOCKER_CONFIG}" pull "${REF}" 2>&1 | tee /dev/stderr)"
+          docker --config "${DOCKER_CONFIG}" manifest inspect "${REF}" > "${MANIFEST}"
           jq -e '[.manifests[] | select(.platform != null) | "\(.platform.os)/\(.platform.architecture)"] as $p | ($p | index("linux/amd64") != null and index("linux/arm64") != null)' "${MANIFEST}" > /dev/null
           OUT="$(docker --config "${DOCKER_CONFIG}" run --rm "${REF}" --version)"
           if ! grep -qxE "tokmd ${EXPECTED_VERSION}([[:space:]]|$)" <<<"${OUT}"; then
             echo "::error::candidate reported an unexpected version: ${OUT}"
             exit 1
           fi
-          DIGEST="$(DOCKER_CONFIG="${DOCKER_CONFIG}" docker buildx imagetools inspect "${REF}" | awk '$1 == "Digest:" { print $2; exit }')"
+          DIGEST="$(awk '$1 == "Digest:" { print $2; exit }' <<<"${PULL_OUTPUT}")"
           if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "::error::candidate digest was not immutable: ${DIGEST}"
             exit 1
@@ -240,7 +240,8 @@ jobs:
           docker buildx imagetools create \
             --tag "${IMAGE}:verified-candidate-${COMMIT}" \
             "${IMAGE}@${DIGEST}"
-          VERIFIED="$(docker buildx imagetools inspect "${IMAGE}:verified-candidate-${COMMIT}" | awk '$1 == "Digest:" { print $2; exit }')"
+          VERIFIED_PULL="$(docker pull "${IMAGE}:verified-candidate-${COMMIT}" 2>&1 | tee /dev/stderr)"
+          VERIFIED="$(awk '$1 == "Digest:" { print $2; exit }' <<<"${VERIFIED_PULL}")"
           if [[ "${VERIFIED}" != "${DIGEST}" ]]; then
             echo "::error::verified candidate marker resolved to ${VERIFIED}, expected ${DIGEST}"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,13 +238,15 @@ jobs:
           IMAGE="ghcr.io/${OWNER}/tokmd"
           CANDIDATE="${IMAGE}:verified-candidate-${GITHUB_SHA}"
           EXACT="${IMAGE}:${VERSION}"
-          DIGEST="$(docker buildx imagetools inspect "${CANDIDATE}" | awk '$1 == "Digest:" { print $2; exit }')"
+          CANDIDATE_PULL="$(docker pull "${CANDIDATE}" 2>&1 | tee /dev/stderr)"
+          DIGEST="$(awk '$1 == "Digest:" { print $2; exit }' <<<"${CANDIDATE_PULL}")"
           if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "::error::no immutable candidate digest found for ${CANDIDATE}"
             exit 1
           fi
           docker buildx imagetools create --tag "${EXACT}" "${IMAGE}@${DIGEST}"
-          PROMOTED="$(docker buildx imagetools inspect "${EXACT}" | awk '$1 == "Digest:" { print $2; exit }')"
+          PROMOTED_PULL="$(docker pull "${EXACT}" 2>&1 | tee /dev/stderr)"
+          PROMOTED="$(awk '$1 == "Digest:" { print $2; exit }' <<<"${PROMOTED_PULL}")"
           if [[ "${PROMOTED}" != "${DIGEST}" ]]; then
             echo "::error::exact release tag resolved to ${PROMOTED}, expected ${DIGEST}"
             exit 1


### PR DESCRIPTION
## Summary

Import the reviewed release-proof stabilization from swarm.

## Source and proof

- swarm source tip: `fbee6743` (squash merge of swarm PR #477)
- public base: `8af20bef`
- this branch is a deliberate two-parent import
- swarm PR #477 passed exact-head Codex review, Droid review, and required CI
- candidate run `30833747207` built both platform images and pulled the candidate anonymously, but Buildx raw inspection exited 255 before verification

## Claim boundary

The imported commit still requires public CI and a fresh candidate run to prove platform inspection, exact version, packet content, digest, and verification marker.