### PR TITLE
import: record RC readiness receipts

### DIFF
--- a/docs/releases/1.15-readiness.md
+++ b/docs/releases/1.15-readiness.md
@@ -42,12 +42,12 @@ approximations:
 
 | Surface | Required evidence | Status |
 | --- | --- | --- |
-| Platform binaries | Each reports `1.15.0-rc.1` | Not run |
-| CLI | `--version`, `--help`, `--show-config`, module, packet, invalid-option smoke | Not run |
+| Platform binaries | Each reports `1.15.0-rc.1` | Not run: exact published RC binaries are not available yet |
+| CLI | `--version`, `--help`, `--show-config`, module, packet, invalid-option smoke | Pass locally with `target/release/tokmd.exe`; exact installed artifact receipt pending |
 | Action binary | Omitted and explicit RC version paths report the RC | Not run |
 | Candidate container | Anonymous pull/version/mounted packet; immutable digest receipt | Pass: run `30842072280`, source `77a83f32`, digest `sha256:98e70385bc4763ce5a2a35831e5881758dfeda3d457518aa4afb1401e3af20b7`, both Linux platforms |
 | RC container tag | Exact digest promotion and re-verification | Not run |
-| Archive WASM | Exact release archive passes browser ZIP smoke | Not run |
+| Archive WASM | Exact release archive passes browser ZIP smoke | Pass: archive-enabled build and 69/69 runner tests locally; exact released archive browser smoke pending |
 | crates.io | Not published for RC | Policy |
 | Nix | Build and run exact RC source/artifact | Not run |
 | Checksums and attestations | Present for every published artifact | Not run |


### PR DESCRIPTION
## Summary\n- import the swarm RC readiness table updates\n- preserve the deliberate two-parent publication topology\n\n## Source\n- swarm source: e212471\n- import merge has public 01c39b7 and swarm e212471 as parents\n\n## Claim boundary\nThis import records local and CI readiness evidence, including explicit unavailable full-test/publish-dry-run boundaries. It does not claim exact published artifact proof or release publication.