### PR TITLE
import: repair exact release consumer smoke runtime

### DIFF
--- a/.github/workflows/release-consumer-smoke.yml
+++ b/.github/workflows/release-consumer-smoke.yml
@@ -81,23 +81,23 @@ jobs:
           mkdir -p release-assets receipt
           write_receipt() {
             python3 - "$status" "$checksum_status" "$attestation_status" <<'PY'
-            import json
-            import os
-            import sys
-            from pathlib import Path
+          import json
+          import os
+          import sys
+          from pathlib import Path
 
-            status, checksums, attestations = sys.argv[1:]
-            Path("receipt/release-assets.json").write_text(json.dumps({
-                "schema": "tokmd.release_consumer_smoke.v1",
-                "kind": "release-assets",
-                "tag": os.environ["TAG"],
-                "expected_version": os.environ["EXPECTED_VERSION"],
-                "release_kind": os.environ["RELEASE_KIND"],
-                "status": status,
-                "checksums": checksums,
-                "attestations": attestations,
-            }, indent=2) + "\n", encoding="utf-8")
-            PY
+          status, checksums, attestations = sys.argv[1:]
+          Path("receipt/release-assets.json").write_text(json.dumps({
+              "schema": "tokmd.release_consumer_smoke.v1",
+              "kind": "release-assets",
+              "tag": os.environ["TAG"],
+              "expected_version": os.environ["EXPECTED_VERSION"],
+              "release_kind": os.environ["RELEASE_KIND"],
+              "status": status,
+              "checksums": checksums,
+              "attestations": attestations,
+          }, indent=2) + "\n", encoding="utf-8")
+          PY
           }
           trap write_receipt EXIT
 
@@ -207,25 +207,25 @@ jobs:
           mkdir -p release receipt
           write_receipt() {
             python3 - "$status" "$observed_version" <<'PY'
-            import json
-            import os
-            import sys
-            from pathlib import Path
+          import json
+          import os
+          import sys
+          from pathlib import Path
 
-            status, observed = sys.argv[1:]
-            Path(f"receipt/binary-{os.environ['MATRIX_ID']}.json").write_text(json.dumps({
-                "schema": "tokmd.release_consumer_smoke.v1",
-                "kind": "binary",
-                "surface": os.environ["MATRIX_SURFACE"],
-                "artifact": os.environ["MATRIX_ARTIFACT"],
-                "runner": os.environ.get("RUNNER_NAME", "unknown"),
-                "architecture": os.environ["MATRIX_ARCHITECTURE"],
-                "tag": os.environ["TAG"],
-                "expected_version": os.environ["EXPECTED_VERSION"],
-                "observed_version": observed,
-                "status": status,
-            }, indent=2) + "\n", encoding="utf-8")
-            PY
+          status, observed = sys.argv[1:]
+          Path(f"receipt/binary-{os.environ['MATRIX_ID']}.json").write_text(json.dumps({
+              "schema": "tokmd.release_consumer_smoke.v1",
+              "kind": "binary",
+              "surface": os.environ["MATRIX_SURFACE"],
+              "artifact": os.environ["MATRIX_ARTIFACT"],
+              "runner": os.environ.get("RUNNER_NAME", "unknown"),
+              "architecture": os.environ["MATRIX_ARCHITECTURE"],
+              "tag": os.environ["TAG"],
+              "expected_version": os.environ["EXPECTED_VERSION"],
+              "observed_version": observed,
+              "status": status,
+          }, indent=2) + "\n", encoding="utf-8")
+          PY
           }
           trap write_receipt EXIT
 
@@ -319,19 +319,19 @@ jobs:
           mkdir -p receipt
           write_receipt() {
             python3 - "$status" <<'PY'
-            import json
-            import os
-            import sys
-            from pathlib import Path
+          import json
+          import os
+          import sys
+          from pathlib import Path
 
-            Path("receipt/nix.json").write_text(json.dumps({
-                "schema": "tokmd.release_consumer_smoke.v1",
-                "kind": "nix",
-                "tag": os.environ["TAG"],
-                "expected_version": os.environ["EXPECTED_VERSION"],
-                "status": sys.argv[1],
-            }, indent=2) + "\n", encoding="utf-8")
-            PY
+          Path("receipt/nix.json").write_text(json.dumps({
+              "schema": "tokmd.release_consumer_smoke.v1",
+              "kind": "nix",
+              "tag": os.environ["TAG"],
+              "expected_version": os.environ["EXPECTED_VERSION"],
+              "status": sys.argv[1],
+          }, indent=2) + "\n", encoding="utf-8")
+          PY
           }
           trap write_receipt EXIT
 
@@ -625,6 +625,8 @@ jobs:
     env:
       NEEDS_RESULTS: ${{ toJSON(needs) }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: always()
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Summary\n\nImport the reviewed runtime repair for the exact-artifact consumer-smoke workflow.\n\n- Source swarm head: 74c08af2ec\n- Public base: a8e1951a1\n- Fixes the receipt heredoc execution failure found by RC run 30875250238.\n- Checks out source before running the aggregate script.\n\nThis must merge as a normal publication import; no tag or release mutation is included. After merge, rerun the RC consumer smoke against the unchanged published 1.15.0-rc.1.\n\n## Proof\n\n- PR #491 exact-head required CI green\n- exact-head Codex gate 6ccf725, blocking_findings=0\n- actionlint, aggregator fixtures, strict policy gates, docs, affected proof, and no-panic checks pass locally.