### PR TITLE
import: finalize RC consumer smoke runtime fixes

### DIFF
--- a/.github/workflows/release-consumer-smoke.yml
+++ b/.github/workflows/release-consumer-smoke.yml
@@ -256,7 +256,7 @@ jobs:
           printf '%s' "$analyze_json" | python3 -c 'import json, sys; json.load(sys.stdin)'
           (
             cd "$fixture"
-            "$bin" packet generate --no-syntax .
+            "$bin" packet generate --base HEAD --head HEAD --no-syntax .
           )
           test -s "$fixture/sensors/tokmd/manifest.json"
           python3 - "$fixture/sensors/tokmd/manifest.json" <<'PY'
@@ -340,8 +340,8 @@ jobs:
             echo "nix=unavailable (Nix installer did not provide an executable)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          nix build "github:${RELEASE_REPOSITORY}?rev=${TAG_SHA}"
-          version_output="$(nix run "github:${RELEASE_REPOSITORY}?rev=${TAG_SHA}" -- --version)"
+          nix build --no-write-lock-file "github:${RELEASE_REPOSITORY}?rev=${TAG_SHA}"
+          version_output="$(nix run --no-write-lock-file "github:${RELEASE_REPOSITORY}?rev=${TAG_SHA}" -- --version)"
           grep -qx "tokmd ${EXPECTED_VERSION}" <<< "$version_output"
           status=passed
           echo "- Nix exact-tag build and version: passed" >> "$GITHUB_STEP_SUMMARY"
@@ -415,6 +415,7 @@ jobs:
             exit 1
           fi
       - name: Run browser smoke against released archive
+        id: browser
         shell: bash
         env:
           BASE_URL: http://127.0.0.1:4173/index.html
@@ -427,6 +428,15 @@ jobs:
           npx --no-install playwright test \
             scripts/release-consumer-smoke-browser.spec.mjs \
             --reporter=line
+      - name: Write WASM receipt
+        if: always()
+        shell: bash
+        env:
+          RECEIPT_STATUS: ${{ steps.browser.outcome == 'success' && 'passed' || 'failed' }}
+          TAG: ${{ inputs.tag }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+        run: |
+          set -euo pipefail
           mkdir -p receipt
           python3 - <<'PY'
           import json
@@ -438,7 +448,7 @@ jobs:
               "kind": "wasm",
               "tag": os.environ["TAG"],
               "expected_version": os.environ["EXPECTED_VERSION"],
-              "status": "passed",
+              "status": os.environ["RECEIPT_STATUS"],
           }, indent=2) + "\n", encoding="utf-8")
           PY
       - name: Upload WASM receipt
@@ -465,6 +475,7 @@ jobs:
         continue-on-error: true
         with:
           mode: packet
+          base: HEAD
           syntax: 'false'
           artifact: 'false'
           comment: 'false'
@@ -545,6 +556,7 @@ jobs:
         continue-on-error: true
         with:
           mode: packet
+          base: HEAD
           version: ${{ inputs.expected_version }}
           runtime: container
           syntax: 'false'


### PR DESCRIPTION
## Summary\n\nImport the exact-head consumer-smoke fixes from swarm 47f71514e into publication.\n\n- explicit HEAD base/head for binary and Action packet proofs;\n- read-only Nix flake evaluation;\n- always-present WASM receipt on browser failure.\n\nThis is a normal two-parent publication import. It does not modify the published RC or create a tag. The next consumer run will be dispatched against the unchanged 1.15.0-rc.1 to separate workflow correctness from its artifact capability.\n\n## Proof\n\n- swarm PR #492 exact-head required checks green\n- Codex Review Gate fcfaf78, blocking_findings=0\n- local actionlint, aggregate fixtures, policy, docs, and no-panic checks pass