### PR TITLE
import: release consumer browser smoke fix

### DIFF
--- a/.github/workflows/release-consumer-smoke.yml
+++ b/.github/workflows/release-consumer-smoke.yml
@@ -424,9 +424,12 @@ jobs:
           EXPECTED_VERSION: ${{ inputs.expected_version }}
         run: |
           set -euo pipefail
+          mkdir -p consumer-smoke
+          cp scripts/release-consumer-smoke-browser.spec.mjs \
+            consumer-smoke/release-consumer-smoke-browser.spec.mjs
           npx --no-install playwright install --with-deps chromium
           npx --no-install playwright test \
-            scripts/release-consumer-smoke-browser.spec.mjs \
+            consumer-smoke/release-consumer-smoke-browser.spec.mjs \
             --reporter=line
       - name: Write WASM receipt
         if: always()

--- a/scripts/release-consumer-smoke-browser.spec.mjs
+++ b/scripts/release-consumer-smoke-browser.spec.mjs
@@ -62,7 +62,9 @@ test("released archive-enabled WASM supports browser ZIP workflows", async ({ pa
     }
 
     await page.goto(baseUrl, { waitUntil: "networkidle" });
-    await expect(page.locator("[data-worker-capabilities]")).toContainText(expectedVersion);
+    const workerCapabilities = page.locator("[data-worker-capabilities]");
+    await expect(workerCapabilities).toContainText(expectedVersion);
+    await expect(workerCapabilities).toContainText("zipball: yes");
 
     await page.locator("[data-zip-archive]").setInputFiles(zipPath);
     await expect(page.locator("[data-load-zip]")).toBeEnabled();


### PR DESCRIPTION
## Summary

Import the merged swarm proof fix at `8db75929d2c4` into the publication repository.

The publication-side consumer workflow will execute the current browser smoke spec exactly once from a unique temporary directory while serving the exact tagged checkout and released WASM archive. The smoke also requires the worker to advertise `zipball: yes` before ZIP operations.

## Proof

- Swarm PR #494 was squash-merged at `8db75929d2c4`.
- `Codex Review Gate=success` on `0631f726`.
- `Tokmd Rust Result=success` on `0631f726`.
- `actionlint`, `node --check`, aggregate fixture tests (6 passed), and `git diff --check` passed locally.

## Topology

This is a deliberate publication import. Merge normally to preserve the two-parent publication merge, then fast-forward `tokmd-swarm/main` and prove graph alignment.
