### PR TITLE
import: RC3 WASM archive-control fix

### DIFF
--- a/web/runner/main.js
+++ b/web/runner/main.js
@@ -730,6 +730,7 @@ function setCapabilities(message) {
     };
     renderWorkerCapabilities(message);
     renderRepoCapabilities();
+    updateRepoLoadControls();
     updateRunControls();
     updateDownloadButtonState();
     cancelButton.disabled = true;

--- a/web/runner/main.test.mjs
+++ b/web/runner/main.test.mjs
@@ -668,6 +668,40 @@ test("main page constrains mode controls to worker capabilities", async (t) => {
     assert.equal(modeInput.options.find((option) => option.value === "analyze").disabled, true);
 });
 
+test("ready capabilities enable archive controls", async (t) => {
+    const harness = installBrowserHarness(t, {
+        storage: createMemoryStorage(),
+        fetchImpl: async () => {
+            throw new Error("fetch should not run");
+        },
+    });
+
+    await import(`./main.js?zipControls=${Date.now()}`);
+
+    const worker = FakeWorker.instances[0];
+    worker.emit({
+        type: "ready",
+        protocolVersion: 2,
+        capabilities: {
+            modes: ["lang", "module", "export", "analyze"],
+            analyzePresets: ["receipt", "estimate"],
+            wasm: true,
+            downloads: true,
+            progress: true,
+            cancel: false,
+            zipball: true,
+        },
+        engine: {
+            version: "test",
+            schemaVersion: 2,
+            analysisSchemaVersion: 9,
+        },
+    });
+
+    assert.equal(harness.element("[data-zip-archive]").disabled, false);
+    assert.equal(harness.element("[data-load-zip]").disabled, false);
+});
+
 test("repo load uses the loaded wasm analyze preset fallback", async (t) => {
     const harness = installBrowserHarness(t, {
         storage: createMemoryStorage(),


### PR DESCRIPTION
## Summary

Import the merged swarm fix for the RC2 released-WASM browser failure.

The exact RC2 consumer smoke showed that the archive-enabled WASM worker reported `zipball: yes`, but the ZIP input and load controls remained disabled. The swarm fix refreshes repository-load controls when worker capabilities arrive and adds a regression test.

This is a deliberate publication import and must merge as a normal two-parent merge commit. The RC2 tag remains immutable; this source is for RC3 preparation.

## Proof

- Swarm PR #495 merged at `f8a569127dc7c4ea6d1abfb70c81acf803497d4b`.
- Swarm exact-head Codex review: `blocking_findings=0`.
- `Tokmd Rust Result=success` on the exact swarm head.
- Publication import source has parents `959560fb` and `f8a56912`.

## Claim boundary

This import carries the product fix only. RC3 release preparation and exact published-artifact consumer proof remain required before stable.