### PR TITLE
import: prepare tokmd 1.15.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes recorded after the 1.15.0-rc.2 preparation point.
+RC2 consumer proof rejected the released WASM browser ZIP flow; RC3 preparation
+is in progress.
+
+## [1.15.0-rc.3] - 2026-08-04
+
+### Fixed
+
+- Refresh the browser repository-load controls when the WASM worker reports
+  archive ZIP capability, so the released ZIP workflow is actionable.
 
 ## [1.15.0-rc.2] - 2026-08-04
 
@@ -1330,6 +1338,7 @@ Stable release following `v1.10.0-rc.1` validation.
 [Unreleased]: https://github.com/EffortlessMetrics/tokmd/compare/v1.14.0...main
 [1.15.0-rc.1]: https://github.com/EffortlessMetrics/tokmd/compare/v1.14.0...v1.15.0-rc.1
 [1.15.0-rc.2]: https://github.com/EffortlessMetrics/tokmd/compare/v1.15.0-rc.1...v1.15.0-rc.2
+[1.15.0-rc.3]: https://github.com/EffortlessMetrics/tokmd/compare/v1.15.0-rc.2...v1.15.0-rc.3
 [1.14.0]: https://github.com/EffortlessMetrics/tokmd/compare/v1.13.1...v1.14.0
 [1.13.1]: https://github.com/EffortlessMetrics/tokmd/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/EffortlessMetrics/tokmd/compare/v1.12.0...v1.13.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 title: tokmd
 message: "If you use this software, please cite it as below."
 type: software
-version: 1.15.0-rc.2
+version: 1.15.0-rc.3
 date-released: 2026-08-04
 authors:
   - family-names: Zimmerman

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-analysis-types"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "chrono",
  "js-sys",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-cockpit"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-core"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-envelope"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "blake3",
  "proptest",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-format"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-gate"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "proptest",
  "serde",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-git"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-io-port"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "proptest",
  "tempfile",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-model"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "insta",
  "proptest",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-node"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-python"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "proptest",
  "pyo3",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-scan"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-sensor"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-settings"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "proptest",
  "serde",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-types"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "insta",
  "proptest",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "tokmd-wasm"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -3404,7 +3404,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 # xtask is a workspace member but excluded from default-members
 
 [workspace.package]
-version = "1.15.0-rc.2"
+version = "1.15.0-rc.3"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -194,22 +194,22 @@ name = "tokmd-workspace"
 
 [workspace.dependencies]
 # Internal crates - centralized for "bump once" version management
-tokmd = { path = "crates/tokmd", version = "1.15.0-rc.2" }
-tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.15.0-rc.2", default-features = false }
-tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.15.0-rc.2" }
-tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.15.0-rc.2" }
-tokmd-core = { path = "crates/tokmd-core", version = "1.15.0-rc.2" }
-tokmd-format = { path = "crates/tokmd-format", version = "1.15.0-rc.2" }
-tokmd-git = { path = "crates/tokmd-git", version = "1.15.0-rc.2" }
-tokmd-model = { path = "crates/tokmd-model", version = "1.15.0-rc.2" }
-tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.15.0-rc.2" }
-tokmd-scan = { path = "crates/tokmd-scan", version = "1.15.0-rc.2" }
-tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.15.0-rc.2" }
-tokmd-settings = { path = "crates/tokmd-settings", version = "1.15.0-rc.2" }
-tokmd-types = { path = "crates/tokmd-types", version = "1.15.0-rc.2" }
-tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.15.0-rc.2" }
-tokmd-gate = { path = "crates/tokmd-gate", version = "1.15.0-rc.2" }
-tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.15.0-rc.2" }
+tokmd = { path = "crates/tokmd", version = "1.15.0-rc.3" }
+tokmd-analysis = { path = "crates/tokmd-analysis", version = "1.15.0-rc.3", default-features = false }
+tokmd-analysis-types = { path = "crates/tokmd-analysis-types", version = "1.15.0-rc.3" }
+tokmd-envelope = { path = "crates/tokmd-envelope", version = "1.15.0-rc.3" }
+tokmd-core = { path = "crates/tokmd-core", version = "1.15.0-rc.3" }
+tokmd-format = { path = "crates/tokmd-format", version = "1.15.0-rc.3" }
+tokmd-git = { path = "crates/tokmd-git", version = "1.15.0-rc.3" }
+tokmd-model = { path = "crates/tokmd-model", version = "1.15.0-rc.3" }
+tokmd-wasm = { path = "crates/tokmd-wasm", version = "1.15.0-rc.3" }
+tokmd-scan = { path = "crates/tokmd-scan", version = "1.15.0-rc.3" }
+tokmd-sensor = { path = "crates/tokmd-sensor", version = "1.15.0-rc.3" }
+tokmd-settings = { path = "crates/tokmd-settings", version = "1.15.0-rc.3" }
+tokmd-types = { path = "crates/tokmd-types", version = "1.15.0-rc.3" }
+tokmd-io-port = { path = "crates/tokmd-io-port", version = "1.15.0-rc.3" }
+tokmd-gate = { path = "crates/tokmd-gate", version = "1.15.0-rc.3" }
+tokmd-cockpit = { path = "crates/tokmd-cockpit", version = "1.15.0-rc.3" }
 
 # External crates - centralized for consistent versioning
 anyhow = "1.0.102"

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: ''
   version:
     description: 'Version of tokmd to install. Defaults to the workspace release version.'
-    default: '1.15.0-rc.2'
+    default: '1.15.0-rc.3'
   paths:
     description: 'Paths to scan'
     default: '.'
@@ -151,7 +151,7 @@ runs:
             # 1-7 via the GHCR Container Smoke lane). Mutable tags ('latest',
             # major/minor aliases) are intentionally excluded so the recorded
             # tokmd-version output stays reproducible.
-            container_supported_tags="1.14.0 1.15.0-rc.2"
+            container_supported_tags="1.14.0 1.15.0-rc.3"
             tag_supported="false"
             for supported in $container_supported_tags; do
               if [ "$normalized_version" = "$supported" ]; then

--- a/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
+++ b/crates/tokmd-format/tests/snapshots/deep_format_w47__snapshot_cyclonedx_multi_file.snap
@@ -14,7 +14,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.15.0-rc.2"
+        "version": "1.15.0-rc.3"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_depth_w63__snapshot_w63_cyclonedx_basic.snap
@@ -13,7 +13,7 @@ expression: out
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.15.0-rc.2"
+        "version": "1.15.0-rc.3"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
+++ b/crates/tokmd-format/tests/snapshots/format_tests__cyclonedx_snapshot_deterministic.snap
@@ -47,7 +47,7 @@ expression: pretty
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.15.0-rc.2"
+        "version": "1.15.0-rc.3"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w45__snapshot_export_cyclonedx_single_file.snap
@@ -13,7 +13,7 @@ expression: "String::from_utf8(buf).unwrap()"
       {
         "vendor": "tokmd",
         "name": "tokmd",
-        "version": "1.15.0-rc.2"
+        "version": "1.15.0-rc.3"
       }
     ]
   },

--- a/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
+++ b/crates/tokmd-format/tests/snapshots/snapshot_w74__w74_export_cyclonedx.snap
@@ -117,7 +117,7 @@ expression: "serde_json::to_string_pretty(&pretty).unwrap()"
       {
         "name": "tokmd",
         "vendor": "tokmd",
-        "version": "1.15.0-rc.2"
+        "version": "1.15.0-rc.3"
       }
     ]
   },

--- a/crates/tokmd-node/npm/package.json
+++ b/crates/tokmd-node/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.15.0-rc.2",
+  "version": "1.15.0-rc.3",
   "description": "Code inventory receipts and analytics - Node.js bindings",
   "main": "index.js",
   "types": "index.d.ts",
@@ -19,11 +19,11 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@tokmd/core-darwin-arm64": "1.15.0-rc.2",
-    "@tokmd/core-darwin-x64": "1.15.0-rc.2",
-    "@tokmd/core-linux-arm64-gnu": "1.15.0-rc.2",
-    "@tokmd/core-linux-x64-gnu": "1.15.0-rc.2",
-    "@tokmd/core-win32-x64-msvc": "1.15.0-rc.2"
+    "@tokmd/core-darwin-arm64": "1.15.0-rc.3",
+    "@tokmd/core-darwin-x64": "1.15.0-rc.3",
+    "@tokmd/core-linux-arm64-gnu": "1.15.0-rc.3",
+    "@tokmd/core-linux-x64-gnu": "1.15.0-rc.3",
+    "@tokmd/core-win32-x64-msvc": "1.15.0-rc.3"
   },
   "repository": {
     "type": "git",

--- a/crates/tokmd-node/package.json
+++ b/crates/tokmd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokmd/core",
-  "version": "1.15.0-rc.2",
+  "version": "1.15.0-rc.3",
   "description": "Node.js bindings for tokmd - code inventory and analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -60,13 +60,13 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "@tokmd/core-win32-x64-msvc": "1.15.0-rc.2",
-    "@tokmd/core-darwin-x64": "1.15.0-rc.2",
-    "@tokmd/core-darwin-arm64": "1.15.0-rc.2",
-    "@tokmd/core-linux-x64-gnu": "1.15.0-rc.2",
-    "@tokmd/core-linux-x64-musl": "1.15.0-rc.2",
-    "@tokmd/core-linux-arm64-gnu": "1.15.0-rc.2",
-    "@tokmd/core-linux-arm64-musl": "1.15.0-rc.2",
-    "@tokmd/core-win32-arm64-msvc": "1.15.0-rc.2"
+    "@tokmd/core-win32-x64-msvc": "1.15.0-rc.3",
+    "@tokmd/core-darwin-x64": "1.15.0-rc.3",
+    "@tokmd/core-darwin-arm64": "1.15.0-rc.3",
+    "@tokmd/core-linux-x64-gnu": "1.15.0-rc.3",
+    "@tokmd/core-linux-x64-musl": "1.15.0-rc.3",
+    "@tokmd/core-linux-arm64-gnu": "1.15.0-rc.3",
+    "@tokmd/core-linux-arm64-musl": "1.15.0-rc.3",
+    "@tokmd/core-win32-arm64-msvc": "1.15.0-rc.3"
   }
 }

--- a/docs/packet-workflows.md
+++ b/docs/packet-workflows.md
@@ -8,7 +8,7 @@ into one `sensors/tokmd/` packet from a single command. The root
 `mode: packet`, downloading a prebuilt `tokmd` binary by default. This page
 defines the one-command CLI path and the `mode: packet` Action path. The GHCR
 container runtime is implemented for verification-gated tags. `1.14.0` is
-verified; `1.15.0-rc.2` is staged in the release-prep contract and remains
+verified; `1.15.0-rc.3` is staged in the release-prep contract and remains
 pending its exact candidate and anonymous runtime gate. Downstream `ub-review`
 consumption remains planned.
 
@@ -256,7 +256,7 @@ The Action's `runtime: container` path:
 
 - requires a Linux runner with Docker available;
 - accepts only verification-gated tags. The unreleased RC-prep source stages
-  `1.15.0-rc.2` for candidate verification; it is not a supported tag until
+  `1.15.0-rc.3` for candidate verification; it is not a supported tag until
   that gate passes. Any other tag,
   including mutable aliases such as `latest`, `1.14`, and `1`, is a hard error
   pointing at the spec;
@@ -325,7 +325,7 @@ A packet workflow does not:
    [GitHub Action reference](github-action.md) and the packet job summary)
 6. ~~Harden publication GHCR as a secondary runtime.~~ (done: `runtime:
    container` wired in `action.yml` for verification-gated tags; `1.14.0` is
-   verified and `1.15.0-rc.2` is staged for RC proof.) Re-verify on each
+   verified and `1.15.0-rc.3` is staged for RC proof.) Re-verify on each
    release and extend the supported-tag set only after the gate passes.
 7. Wire downstream `ub-review` consumption after the Action path is stable.
 

--- a/docs/releases/1.15-ledger.md
+++ b/docs/releases/1.15-ledger.md
@@ -1,15 +1,15 @@
 # tokmd 1.15 Release Ledger
 
-Status: `v1.15.0-rc.1` consumer proof rejected; `v1.15.0-rc.2` preparation is
-in progress. Pending and failed entries are intentionally explicit; a
-placeholder is not a release receipt.
+Status: `v1.15.0-rc.1` and `v1.15.0-rc.2` consumer proof rejected; `v1.15.0-rc.3`
+preparation is in progress. Pending and failed entries are intentionally
+explicit; a placeholder is not a release receipt.
 
 ## Source and topology
 
 | Field | Receipt |
 | --- | --- |
 | Previous stable | `v1.14.0` |
-| RC target | `v1.15.0-rc.2` |
+| RC target | `v1.15.0-rc.3` |
 | Stable target | `v1.15.0` |
 | Candidate proof source | `b02c6a4bd1f9948df4a8763fc053cdff23fb8c57` |
 | Final source commit | `b02c6a4bd1f9948df4a8763fc053cdff23fb8c57` |

--- a/docs/releases/1.15-readiness.md
+++ b/docs/releases/1.15-readiness.md
@@ -2,12 +2,13 @@
 
 Status: `v1.15.0-rc.1` was published as a GitHub prerelease, but its exact
 consumer proof was rejected: run `30879928050` failed closed because the
-released WASM archive did not support ZIP ingestion. RC2 preparation is in
-progress; no stable-release claim is made.
+released WASM archive did not support ZIP ingestion, and run `30894225008`
+failed because the exact RC2 browser UI left ZIP controls disabled. RC3
+preparation is in progress; no stable-release claim is made.
 
 ## Release boundary
 
-- Target: `v1.15.0-rc.2`, followed by `v1.15.0` if the complete consumer proof
+- Target: `v1.15.0-rc.3`, followed by `v1.15.0` if the complete consumer proof
   passes.
 - Previous stable: `v1.14.0`.
 - Preparation repository: `EffortlessMetrics/tokmd-swarm`.

--- a/docs/releases/1.15.md
+++ b/docs/releases/1.15.md
@@ -1,7 +1,7 @@
 # tokmd 1.15
 
-Status: `v1.15.0-rc.2` preparation record; stable release remains pending RC
-consumer proof.
+Status: `v1.15.0-rc.3` preparation record after RC1 and RC2 consumer-proof
+rejection; stable release remains pending RC3 consumer proof.
 
 ## Release thesis
 

--- a/docs/specs/packet-ghcr-runtime.md
+++ b/docs/specs/packet-ghcr-runtime.md
@@ -173,7 +173,7 @@ release ledger, per `docs/specs/publishing-evidence.md`.
 | Tag | Visibility (steps 1-5) | Runtime exec (steps 6-7) | Container runtime |
 | --- | --- | --- | --- |
 | `1.14.0` (concrete patch tag) | verified-public (2026-06-26) | verified (2026-06-26) | **gate-passed and wired**; accepted by `action.yml` `runtime: container` |
-| `1.15.0-rc.2` (RC candidate tag) | pending candidate proof | pending exact-tag runtime proof | **staged, not yet supported**; do not tag until the candidate gate passes |
+| `1.15.0-rc.3` (RC candidate tag) | pending candidate proof | pending exact-tag runtime proof | **staged, not yet supported**; do not tag until the candidate gate passes |
 | `1.14` / `1` / `latest` (mutable aliases) | verified-public (2026-06-26) | n/a | **rejected** by `action.yml`; mutable tags are not accepted for the container runtime |
 
 On **2026-06-26**, anonymous registry-API verification (no Docker on the
@@ -219,7 +219,7 @@ pattern). The published Action currently supports `1.14.0`; mutable tags
 (`latest`, `1.14`, `1`) and any non-gated tag remain hard errors pointing at this
 spec. The container-runtime test in `.github/workflows/test-action.yml` exercises
 both the supported-tag success path and the unverified/mutable rejection paths.
-The `1.15.0-rc.2` entry is staged by the unreleased RC-prep commit but remains
+The `1.15.0-rc.3` entry is staged by the unreleased RC-prep commit but remains
 unsupported until the pre-tag candidate and exact-tag verification receipts pass.
 Each new stable tag must re-enter the verification gate and be added to the
 Action's supported-tag set before its container runtime is called supported.


### PR DESCRIPTION
## Summary

Import the exact green swarm RC3 preparation into the publication repository.

This carries the RC3 version propagation, version-bearing lock/snapshot updates, staged RC3 container tag, and explicit RC2 rejection/RC3 readiness records. It follows the merged product fix that made the browser ZIP controls respond to released WASM capabilities.

This is a deliberate publication import and must merge as a normal two-parent merge commit. It does not tag or publish; RC3 candidate proof and release operations remain separate.

## Proof

- Swarm PR #500 merged at `161534a04170d0edc210446f712edc0015ebdd0c`.
- Swarm exact-head Codex review: `blocking_findings=0`.
- `Tokmd Rust Result=success` and all required swarm checks passed.
- Import head parents: `b15f85ff` and `161534a0`.

## Claim boundary

RC2 remains immutable and rejected by the released browser consumer proof. This import stages RC3; it does not establish RC3 artifact or consumer success.