### PR TITLE
import: retain preflight for stable crate recovery

### DIFF
--- a/scripts/publish-release-crates.sh
+++ b/scripts/publish-release-crates.sh
@@ -44,7 +44,7 @@ expected_crates=(
 
 echo "Running release publish preflight"
 cargo xtask version-consistency
-cargo xtask publish-surface --json --verify-publish >/tmp/tokmd-publish-surface.json
+cargo xtask publish-surface --json
 
 plan_output="$(cargo xtask publish --plan)"
 mapfile -t planned_crates < <(
@@ -118,5 +118,8 @@ publish_one tokmd-cockpit
 publish_one tokmd-core
 publish_one tokmd-wasm
 publish_one tokmd
+
+echo "Verifying the published crate surface"
+cargo xtask publish-surface --json --verify-publish
 
 echo "All publishable tokmd crates are published or already present."


### PR DESCRIPTION
## Summary\n- imports the merged swarm recovery fix\n- retains local publish-surface validation before crate uploads\n- verifies the complete registry-backed surface after all publish attempts\n\n## Topology\nThis is a deliberate publication import from the aligned swarm main. Merge with a normal two-parent merge commit.\n\n## Proof\nThe source PR #507 passed exact-head Codex review and Tokmd Rust Result.