### PR TITLE
import: overlay stable bootstrap dev dependency

### DIFF
--- a/.github/workflows/recover-stable-crates.yml
+++ b/.github/workflows/recover-stable-crates.yml
@@ -48,9 +48,18 @@ jobs:
           mkdir -p "${RELEASE_SOURCE_DIR}"
           git archive --format=tar "${RELEASE_TAG}" | tar -xf - -C "${RELEASE_SOURCE_DIR}"
           test -f "${RELEASE_SOURCE_DIR}/Cargo.toml"
-          if ! grep -Fqx 'tokmd-format = { path = "crates/tokmd-format" }' "${RELEASE_SOURCE_DIR}/Cargo.toml"; then
-            printf '\ntokmd-format = { path = "crates/tokmd-format" }\n' >> "${RELEASE_SOURCE_DIR}/Cargo.toml"
-          fi
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          manifest = Path(os.environ["RELEASE_SOURCE_DIR"]) / "crates/tokmd-types/Cargo.toml"
+          text = manifest.read_text()
+          old = "tokmd-format.workspace = true"
+          new = 'tokmd-format = { version = "1.14.0" }'
+          if old not in text:
+              raise SystemExit("tokmd-types dev dependency overlay target was not found")
+          manifest.write_text(text.replace(old, new, 1))
+          PY
           git -C "${RELEASE_SOURCE_DIR}" init --quiet
           git -C "${RELEASE_SOURCE_DIR}" config user.name "tokmd release recovery"
           git -C "${RELEASE_SOURCE_DIR}" config user.email "release-recovery@users.noreply.github.com"


### PR DESCRIPTION
## Summary\n- imports the merged swarm recovery overlay\n- resolves tokmd-types dev-only tokmd-format metadata against published 1.14.0 during bootstrap\n- keeps runtime dependencies and the immutable tag unchanged\n\n## Topology\nDeliberate publication import; merge with a normal two-parent merge commit.\n\n## Proof\nSource PR #513 passed exact-head Codex review and Tokmd Rust Result.