### PR TITLE
import: export recovery source path

### DIFF
--- a/.github/workflows/recover-stable-crates.yml
+++ b/.github/workflows/recover-stable-crates.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          RELEASE_SOURCE_DIR="${RUNNER_TEMP}/tokmd-release-source"
+          export RELEASE_SOURCE_DIR="${RUNNER_TEMP}/tokmd-release-source"
           if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::tag must be a stable semantic-version tag such as v1.15.0"
             exit 1


### PR DESCRIPTION
## Summary\n- import the reviewed swarm recovery workflow fix\n- preserve the exact stable-tag publication path\n\n## Source\n- swarm source: 3c58620db81df4e88d071e928c953c9afc1699d5\n- publication merge method: normal two-parent merge\n\n## Proof\n- swarm PR #514 exact-head Codex review: 0 blocking findings\n- swarm required CI: green at 8a2c57eae9184ce4826228dc9d9fc692f72077cd\n- public publication CI is required before merge\n\n## Claim boundary\nThis imports only the workflow execution fix. It does not claim stable crates publication until the recovery workflow completes successfully.