### PR TITLE
import: fix stable tag normalization for alias promotion

### DIFF
--- a/.github/workflows/promote-release-aliases.yml
+++ b/.github/workflows/promote-release-aliases.yml
@@ -45,11 +45,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          version="${RELEASE_TAG#v}"
           if [[ ! "${EXPECTED_DIGEST}" =~ ^sha256:[0-9a-fA-F]{64}$ ]]; then
             echo "::error::expected_digest must be a sha256 digest"
             exit 1
           fi
-          actual="$(docker buildx imagetools inspect "${IMAGE}:${RELEASE_TAG}" | awk '$1 == "Digest:" { print $2; exit }')"
+          actual="$(docker buildx imagetools inspect "${IMAGE}:${version}" | awk '$1 == "Digest:" { print $2; exit }')"
           if [[ "${actual}" != "${EXPECTED_DIGEST}" ]]; then
             echo "::error::exact release digest ${actual} did not match ${EXPECTED_DIGEST}"
             exit 1
@@ -63,7 +64,7 @@ jobs:
           version="${RELEASE_TAG#v}"
           IFS=. read -r major minor _ <<< "${version}"
           for alias in "${major}" "${major}.${minor}" latest; do
-            docker buildx imagetools create --tag "${IMAGE}:${alias}" "${IMAGE}:${RELEASE_TAG}"
+            docker buildx imagetools create --tag "${IMAGE}:${alias}" "${IMAGE}:${version}"
             actual="$(docker buildx imagetools inspect "${IMAGE}:${alias}" | awk '$1 == "Digest:" { print $2; exit }')"
             if [[ "${actual}" != "${EXPECTED_DIGEST}" ]]; then
               echo "::error::alias ${alias} resolved to ${actual}, expected ${EXPECTED_DIGEST}"


### PR DESCRIPTION
## Summary\nImport the reviewed swarm fix that strips the v prefix for GHCR lookup and promotion while retaining the GitHub release tag for v1 ref resolution.\n\n## Topology\n- public base: 2b463b855c1d2f54a9e2acf8d010b6b18e276e2e\n- reviewed swarm fix: 007661b7a88ca267390ec0ad93cc81af36d1e81b\n- import branch head is a two-parent merge\n\n## Proof\n- swarm PR #519 exact-head Codex review: blocking_findings=0\n- swarm Tokmd Rust Result: passed\n- actionlint: passed\n- workflow run 30960945751 reproduced the original v-prefix failure; this fixes that path\n\nNo release tag or alias is moved by this import PR.