### PR TITLE
import: verify alias digests through pulls

### DIFF
--- a/.github/workflows/promote-release-aliases.yml
+++ b/.github/workflows/promote-release-aliases.yml
@@ -50,7 +50,13 @@ jobs:
             echo "::error::expected_digest must be a sha256 digest"
             exit 1
           fi
-          actual="$(docker buildx imagetools inspect "${IMAGE}:${version}" | awk '$1 == "Digest:" { print $2; exit }')"
+          pull_output="$(docker pull "${IMAGE}:${version}" 2>&1 | tee /tmp/tokmd-release-pull.log)"
+          printf '%s\n' "${pull_output}"
+          actual="$(printf '%s\n' "${pull_output}" | awk '$1 == "Digest:" { print $2; exit }')"
+          if [[ -z "${actual}" ]]; then
+            echo "::error::exact release pull did not report a manifest digest"
+            exit 1
+          fi
           if [[ "${actual}" != "${EXPECTED_DIGEST}" ]]; then
             echo "::error::exact release digest ${actual} did not match ${EXPECTED_DIGEST}"
             exit 1
@@ -65,7 +71,13 @@ jobs:
           IFS=. read -r major minor _ <<< "${version}"
           for alias in "${major}" "${major}.${minor}" latest; do
             docker buildx imagetools create --tag "${IMAGE}:${alias}" "${IMAGE}:${version}"
-            actual="$(docker buildx imagetools inspect "${IMAGE}:${alias}" | awk '$1 == "Digest:" { print $2; exit }')"
+            pull_output="$(docker pull "${IMAGE}:${alias}" 2>&1 | tee /tmp/tokmd-alias-pull.log)"
+            printf '%s\n' "${pull_output}"
+            actual="$(printf '%s\n' "${pull_output}" | awk '$1 == "Digest:" { print $2; exit }')"
+            if [[ -z "${actual}" ]]; then
+              echo "::error::alias ${alias} pull did not report a manifest digest"
+              exit 1
+            fi
             if [[ "${actual}" != "${EXPECTED_DIGEST}" ]]; then
               echo "::error::alias ${alias} resolved to ${actual}, expected ${EXPECTED_DIGEST}"
               exit 1


### PR DESCRIPTION
## Summary\nImport the reviewed fix that verifies exact and mutable GHCR digests through authenticated docker pulls, with fail-closed empty-digest handling.\n\n## Topology\n- public base: 049e6bfd469020f4a047360dc3f370733d948f9d\n- reviewed swarm fix: 98c65f90770fc751b14b1a8e5b225f3da1497df7\n- import branch head is a two-parent merge\n\n## Proof\n- swarm PR #520 exact-head Codex review: blocking_findings=0\n- swarm Tokmd Rust Result: passed\n- actionlint: passed\n- prior runs 30960945751 and 30962915500 failed before promotion because hosted digest inspection returned no usable result; this fixes that path\n\nNo release tag or alias is moved by this import PR.