### PR TITLE
import: finalize stable release after consumer proof

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,9 @@ jobs:
           files: artifacts/**/*
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
-          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
+          # Stable releases become latest only after crates and exact consumer
+          # proof pass in finalize-release below. RCs remain prereleases.
+          make_latest: false
 
   publish-crates:
     name: Publish to crates.io
@@ -385,9 +387,36 @@ jobs:
       expected_version: ${{ needs.create-release.outputs.release_version }}
       release_kind: ${{ needs.create-release.outputs.release_kind }}
 
+  finalize-release:
+    name: Finalize stable GitHub Release
+    needs: [publish-crates, verify-container, verify-action]
+    if: ${{ github.repository == 'EffortlessMetrics/tokmd' && !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Finalize stable release as latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          release="$(gh api "repos/${REPOSITORY}/releases/tags/${TAG}")"
+          test "$(jq -r '.draft' <<<"${release}")" = false
+          test "$(jq -r '.prerelease' <<<"${release}")" = false
+          gh release edit "${TAG}" --repo "${REPOSITORY}" --draft=false --latest
+          latest="$(gh api "repos/${REPOSITORY}/releases/latest" --jq '.tag_name')"
+          test "${latest}" = "${TAG}"
+          {
+            echo "- stable_release: finalized"
+            echo "- latest_tag: ${latest}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   promote-aliases:
     name: Promote stable aliases
-    needs: [publish-crates, verify-container, verify-action]
+    needs: finalize-release
     if: ${{ github.repository == 'EffortlessMetrics/tokmd' && !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     permissions:

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -951,6 +951,26 @@ review_after     = "2026-08-02"
 expires          = "2027-02-02"
 
 [[lane]]
+id               = "release_finalize"
+workflow         = ".github/workflows/release.yml"
+job              = "Finalize stable GitHub Release"
+kind             = "release"
+tier             = "deep"
+default_pr       = false
+blocking         = true
+runner           = "ubuntu_latest"
+base_lem         = 5
+owner            = "release/publish"
+intent           = "Finalize a stable GitHub Release as latest only after registry and exact consumer proof pass."
+failure_mode     = "A partial stable publication is presented as the latest release before registry completion."
+proof_obligation = "Verify the release is non-draft and non-prerelease, finalize it as latest, and verify the latest tag points at the expected stable tag."
+evidence         = ["release workflow logs", "GitHub latest release tag"]
+allowed_triggers = ["push"]
+duplicate_of     = []
+review_after     = "2026-08-05"
+expires          = "2027-02-05"
+
+[[lane]]
 id               = "release_promote_aliases"
 workflow         = ".github/workflows/release.yml"
 job              = "Promote stable aliases"
@@ -963,7 +983,7 @@ base_lem         = 4
 owner            = "release/publish"
 intent           = "Move v1 and mutable GHCR aliases only after exact release, crate, container, and Action gates pass."
 failure_mode     = "Mutable consumer aliases move before the release surfaces are proven."
-proof_obligation = "Require publish-crates, exact-container verification, and exact-tag Action verification before moving aliases."
+proof_obligation = "Require finalized stable release, exact-container verification, and exact-tag Action verification before moving aliases."
 evidence         = ["release workflow logs", "GitHub tag ref", "GHCR manifest tags"]
 allowed_triggers = ["push"]
 duplicate_of     = []


### PR DESCRIPTION
History-preserving publication import of the reviewed 1.15.1 stable-release ordering fix. Merge with an explicit two-parent merge commit; do not squash or rebase.